### PR TITLE
feat(outputs.execd): Add option for batch format

### DIFF
--- a/plugins/outputs/execd/README.md
+++ b/plugins/outputs/execd/README.md
@@ -34,7 +34,13 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## Flag to determine whether execd should throw error when part of metrics is unserializable
   ## Setting this to true will skip the unserializable metrics and process the rest of metrics
   ## Setting this to false will throw error when encountering unserializable metrics and none will be processed
+  ## This setting is ignored if use_batch_format is true.
   # ignore_serialization_error = false
+
+  ## Use batch serialization format instead of line based delimiting.  The
+  ## batch format allows for the production of non line based output formats and
+  ## may more efficiently encode and write metrics.
+  # use_batch_format = false
 
   ## Data format to export.
   ## Each data format has its own unique set of configuration options, read

--- a/plugins/outputs/execd/README.md
+++ b/plugins/outputs/execd/README.md
@@ -34,12 +34,11 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## Flag to determine whether execd should throw error when part of metrics is unserializable
   ## Setting this to true will skip the unserializable metrics and process the rest of metrics
   ## Setting this to false will throw error when encountering unserializable metrics and none will be processed
-  ## This setting is ignored if use_batch_format is true.
+  ## This setting does not apply when use_batch_format is set.
   # ignore_serialization_error = false
 
-  ## Use batch serialization format instead of line based delimiting.  The
-  ## batch format allows for the production of non line based output formats and
-  ## may more efficiently encode and write metrics.
+  ## Use batch serialization instead of per metric. The batch format allows for the
+  ## production of batch output formats and may more efficiently encode and write metrics.
   # use_batch_format = false
 
   ## Data format to export.

--- a/plugins/outputs/execd/sample.conf
+++ b/plugins/outputs/execd/sample.conf
@@ -16,7 +16,13 @@
   ## Flag to determine whether execd should throw error when part of metrics is unserializable
   ## Setting this to true will skip the unserializable metrics and process the rest of metrics
   ## Setting this to false will throw error when encountering unserializable metrics and none will be processed
+  ## This setting is ignored if use_batch_format is true.
   # ignore_serialization_error = false
+
+  ## Use batch serialization format instead of line based delimiting.  The
+  ## batch format allows for the production of non line based output formats and
+  ## may more efficiently encode and write metrics.
+  # use_batch_format = false
 
   ## Data format to export.
   ## Each data format has its own unique set of configuration options, read

--- a/plugins/outputs/execd/sample.conf
+++ b/plugins/outputs/execd/sample.conf
@@ -16,12 +16,11 @@
   ## Flag to determine whether execd should throw error when part of metrics is unserializable
   ## Setting this to true will skip the unserializable metrics and process the rest of metrics
   ## Setting this to false will throw error when encountering unserializable metrics and none will be processed
-  ## This setting is ignored if use_batch_format is true.
+  ## This setting does not apply when use_batch_format is set.
   # ignore_serialization_error = false
 
-  ## Use batch serialization format instead of line based delimiting.  The
-  ## batch format allows for the production of non line based output formats and
-  ## may more efficiently encode and write metrics.
+  ## Use batch serialization instead of per metric. The batch format allows for the
+  ## production of batch output formats and may more efficiently encode and write metrics.
   # use_batch_format = false
 
   ## Data format to export.


### PR DESCRIPTION
# Required for all PRs

<!-- Before opening a pull request you should run the following checks locally to make sure the CI will pass.

make lint
make check
make check-deps
make test
make docs

-->

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

refs #13654

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->

Adds `use_batch_format` option to execd output plugin. This allows user to specify that the serializer should use the batch format when serializing metrics. Most useful for `json` serializer, and upcoming `template` serializer, as they can create completely different payloads when in batch mode.
