### PR TITLE
fix(inputs.opcua): Register node IDs again on reconnect

### DIFF
--- a/plugins/common/opcua/input/input_client.go
+++ b/plugins/common/opcua/input/input_client.go
@@ -79,8 +79,7 @@ func (o *InputClientConfig) Validate() error {
 }
 
 func (o *InputClientConfig) CreateInputClient(log telegraf.Logger) (*OpcUAInputClient, error) {
-	err := o.Validate()
-	if err != nil {
+	if err := o.Validate(); err != nil {
 		return nil, err
 	}
 
@@ -97,15 +96,13 @@ func (o *InputClientConfig) CreateInputClient(log telegraf.Logger) (*OpcUAInputC
 	}
 
 	log.Debug("Initialising node to metric mapping")
-	err = c.InitNodeMetricMapping()
-	if err != nil {
+	if err := c.InitNodeMetricMapping(); err != nil {
 		return nil, err
 	}
 
 	c.initLastReceivedValues()
 
-	err = c.initNodeIDs()
-	return c, err
+	return c, nil
 }
 
 // NodeMetricMapping mapping from a single node to a metric
@@ -327,7 +324,7 @@ func (o *OpcUAInputClient) InitNodeMetricMapping() error {
 	return nil
 }
 
-func (o *OpcUAInputClient) initNodeIDs() error {
+func (o *OpcUAInputClient) InitNodeIDs() error {
 	o.NodeIDs = make([]*ua.NodeID, 0, len(o.NodeMetricMapping))
 	for _, node := range o.NodeMetricMapping {
 		nid, err := ua.ParseNodeID(node.Tag.NodeID())

--- a/plugins/common/opcua/input/input_client.go
+++ b/plugins/common/opcua/input/input_client.go
@@ -102,8 +102,7 @@ func (o *InputClientConfig) CreateInputClient(log telegraf.Logger) (*OpcUAInputC
 
 	c.initLastReceivedValues()
 
-	err = c.InitNodeIDs()
-	return c, err
+	return c, nil
 }
 
 // NodeMetricMapping mapping from a single node to a metric

--- a/plugins/common/opcua/input/input_client.go
+++ b/plugins/common/opcua/input/input_client.go
@@ -102,7 +102,8 @@ func (o *InputClientConfig) CreateInputClient(log telegraf.Logger) (*OpcUAInputC
 
 	c.initLastReceivedValues()
 
-	return c, nil
+	err = c.InitNodeIDs()
+	return c, err
 }
 
 // NodeMetricMapping mapping from a single node to a metric

--- a/plugins/inputs/opcua_listener/subscribe_client.go
+++ b/plugins/inputs/opcua_listener/subscribe_client.go
@@ -37,6 +37,11 @@ func (sc *SubscribeClientConfig) CreateSubscribeClient(log telegraf.Logger) (*Su
 	if err != nil {
 		return nil, err
 	}
+
+	if err := client.InitNodeIDs(); err != nil {
+		return nil, err
+	}
+
 	subClient := &SubscribeClient{
 		OpcUAInputClient:   client,
 		Config:             *sc,


### PR DESCRIPTION
- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #13594 

Issue #13594 suggests that the node IDs of a OPCUA connections are not longer valid if the server was restarted. As we cannot decide if the connection was lost due to client or server side, we re-initialize the node IDs on reconnect to be on the safe side.