### PR TITLE
chore(tools): Fix doc inclusion tools on Windows

### DIFF
--- a/tools/config_includer/generator.go
+++ b/tools/config_includer/generator.go
@@ -91,7 +91,7 @@ func main() {
 
 		newUnresolved := make(map[string]string)
 		for name, fn := range unresolved {
-			if strings.HasPrefix(fn, string(filepath.Separator)) || strings.HasPrefix(fn, "/") {
+			if strings.HasPrefix(filepath.ToSlash(fn), "/") {
 				fn = filepath.Join(root, fn)
 			}
 

--- a/tools/config_includer/generator.go
+++ b/tools/config_includer/generator.go
@@ -91,7 +91,7 @@ func main() {
 
 		newUnresolved := make(map[string]string)
 		for name, fn := range unresolved {
-			if filepath.IsAbs(fn) {
+			if strings.HasPrefix(fn, string(filepath.Separator)) || strings.HasPrefix(fn, "/") {
 				fn = filepath.Join(root, fn)
 			}
 
@@ -121,7 +121,7 @@ func main() {
 			pwd = string(filepath.Separator) + pwd
 			for _, iname := range extractIncludes(tmpl) {
 				ifn := iname
-				if !filepath.IsAbs(ifn) {
+				if !strings.HasPrefix(ifn, "/") {
 					ifn = filepath.Join(pwd, ifn)
 				}
 				newUnresolved[iname] = ifn

--- a/tools/readme_config_includer/generator.go
+++ b/tools/readme_config_includer/generator.go
@@ -52,10 +52,9 @@ func extractIncludeBlock(txt []byte, includesEx *regexp.Regexp, root string) *in
 		if len(inc) != 2 {
 			continue
 		}
-		include := filepath.FromSlash(string(inc[1]))
+		include := string(inc[1])
 		// Make absolute paths relative to the include-root if any
-		// Check original value to avoid platform specific slashes
-		if string(inc[1][0]) == "/" {
+		if strings.HasPrefix(include, "/") {
 			if root == "" {
 				log.Printf("Ignoring absolute include %q without include root...", include)
 				continue

--- a/tools/readme_config_includer/generator.go
+++ b/tools/readme_config_includer/generator.go
@@ -55,7 +55,7 @@ func extractIncludeBlock(txt []byte, includesEx *regexp.Regexp, root string) *in
 		include := filepath.FromSlash(string(inc[1]))
 		// Make absolute paths relative to the include-root if any
 		// Check original value to avoid platform specific slashes
-		if filepath.IsAbs(string(inc[1])) {
+		if string(inc[1][0]) == "/" {
 			if root == "" {
 				log.Printf("Ignoring absolute include %q without include root...", include)
 				continue


### PR DESCRIPTION
resolves #13681

`config_includer` and `config_readme_includer` currently don't work on Windows. This fixes that.

The underlying issue is that the tools test for 'absolute' includes, which are relative to the telegraf directory rather than the directory of the current file. Using `filepath.IsAbs` does not work for this test on Windows, and Go doesn't provide a way to do posix path tests/manipulation when running on Windows.