### PR TITLE
feat(inputs.jti_openconfig_telemetry): Add keep-alive setting

### DIFF
--- a/plugins/inputs/jti_openconfig_telemetry/README.md
+++ b/plugins/inputs/jti_openconfig_telemetry/README.md
@@ -84,6 +84,10 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## Failed streams/calls will not be retried if 0 is provided
   retry_delay = "1000ms"
 
+  ## Period for sending keep-alive packets on idle connections
+  ## This is helpful to identify broken connections to the server
+  # keep_alive_period = "10s"
+
   ## To treat all string values as tags, set this to true
   str_as_tags = false
 ```

--- a/plugins/inputs/jti_openconfig_telemetry/sample.conf
+++ b/plugins/inputs/jti_openconfig_telemetry/sample.conf
@@ -52,5 +52,9 @@
   ## Failed streams/calls will not be retried if 0 is provided
   retry_delay = "1000ms"
 
+  ## Period for sending keep-alive packets on idle connections
+  ## This is helpful to identify broken connections to the server
+  # keep_alive_period = "10s"
+
   ## To treat all string values as tags, set this to true
   str_as_tags = false


### PR DESCRIPTION
- [x] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #12017

This PR adds a setting to define a keep-alive period for the GRPC connection to detect broken connections.