### PR TITLE
fix(inputs.opcua_listener): Avoid segfault if subscription was not successful

### DIFF
--- a/plugins/inputs/opcua_listener/subscribe_client.go
+++ b/plugins/inputs/opcua_listener/subscribe_client.go
@@ -83,10 +83,11 @@ func (o *SubscribeClient) Connect() error {
 }
 
 func (o *SubscribeClient) Stop(ctx context.Context) <-chan struct{} {
-	o.Log.Debugf("Opc Subscribe Stopped")
-	err := o.sub.Cancel(ctx)
-	if err != nil {
-		o.Log.Warn("Cancelling OPC UA subscription failed with error ", err)
+	o.Log.Debugf("Stopping OPC subscription...")
+	if o.sub != nil {
+		if err := o.sub.Cancel(ctx); err != nil {
+			o.Log.Warn("Cancelling OPC UA subscription failed with error ", err)
+		}
 	}
 	closing := o.OpcUAInputClient.Stop(ctx)
 	o.processingCancel()


### PR DESCRIPTION
- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

Fix case where the client stops without finishing the subscription
```
023-08-09T12:39:47Z D! [inputs.opcua_listener] Opc Subscribe Stopped
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x40 pc=0x2fb91ec]

goroutine 27 [running]:
github.com/gopcua/opcua.(*Subscription).Cancel(0x0, {0x80afc80, 0xc0024351d0})
        /home/sven/go/pkg/mod/github.com/gopcua/opcua@v0.4.0/subscription.go:86 +0x4c
github.com/influxdata/telegraf/plugins/inputs/opcua_listener.(*SubscribeClient).Stop(0xc000782340, {0x80afc80, 0xc0024351d0})
        /home/sven/Development/InfluxData/telegraf/plugins/inputs/opcua_listener/subscribe_client.go:82 +0x72
github.com/influxdata/telegraf/plugins/inputs/opcua_listener.(*OpcUaListener).Stop(0xc000330900)
        /home/sven/Development/InfluxData/telegraf/plugins/inputs/opcua_listener/opcua_listener.go:62 +0x6f
github.com/influxdata/telegraf/agent.stopServiceInputs({0xc000012170, 0x1, 0x0?})
        /home/sven/Development/InfluxData/telegraf/agent/agent.go:529 +0x66
github.com/influxdata/telegraf/agent.(*Agent).testRunInputs(0xc0007b22a8, {0x80afc10, 0xc002376690}, 0x0?, 0xc000de3aa0)
        /home/sven/Development/InfluxData/telegraf/agent/agent.go:519 +0x27f
github.com/influxdata/telegraf/agent.(*Agent).runTest.func4()
        /home/sven/Development/InfluxData/telegraf/agent/agent.go:1053 +0x6c
created by github.com/influxdata/telegraf/agent.(*Agent).runTest
        /home/sven/Development/InfluxData/telegraf/agent/agent.go:1051 +0x665
```