### PR TITLE
fix(outputs.stackdriver): regenerate time interval for unkown metrics

### DIFF
--- a/plugins/outputs/stackdriver/stackdriver.go
+++ b/plugins/outputs/stackdriver/stackdriver.go
@@ -370,10 +370,7 @@ func getStackdriverIntervalEndpoints(
 	f *telegraf.Field,
 	cc *counterCache,
 ) (*timestamppb.Timestamp, *timestamppb.Timestamp) {
-	fmt.Println(kind)
-	fmt.Printf("metric timestamp: %s\n", m.Time())
 	endTime := timestamppb.New(m.Time())
-	fmt.Printf("generated end time: %s\n", endTime.String())
 	var startTime *timestamppb.Timestamp
 	if kind == metricpb.MetricDescriptor_CUMULATIVE {
 		// Interval starts for stackdriver CUMULATIVE metrics must reset any time
@@ -381,10 +378,6 @@ func getStackdriverIntervalEndpoints(
 		// observed values for each counter in the batch.
 		startTime = cc.GetStartTime(GetCounterCacheKey(m, f), value, endTime)
 	}
-
-	fmt.Printf("startTime: %s\n", startTime.String())
-	fmt.Printf("endTime:   %s\n", endTime.String())
-	fmt.Println()
 	return startTime, endTime
 }
 


### PR DESCRIPTION
fixes: #13725