### PR TITLE
feat(outputs.postgresql): Add option to rename time column

### DIFF
--- a/plugins/outputs/postgresql/README.md
+++ b/plugins/outputs/postgresql/README.md
@@ -54,6 +54,10 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## Store all fields as a JSONB object in a single 'fields' column.
   # fields_as_jsonb = false
 
+  ## Name of the timestamp column
+  ## NOTE: Some tools (e.g. Grafana) require the default name so be careful!
+  # timestamp_column_name = "time"
+
   ## Templated statements to execute when creating a new table.
   # create_templates = [
   #   '''CREATE TABLE {{ .table }} ({{ .columns }})''',

--- a/plugins/outputs/postgresql/columns.go
+++ b/plugins/outputs/postgresql/columns.go
@@ -2,22 +2,12 @@ package postgresql
 
 import "github.com/influxdata/telegraf/plugins/outputs/postgresql/utils"
 
-// Column names and data types for standard fields (time, tag_id, tags, and fields)
-const (
-	timeColumnDataType   = PgTimestampWithoutTimeZone
-	tagIDColumnName      = "tag_id"
-	tagIDColumnDataType  = PgBigInt
-	tagsJSONColumnName   = "tags"
-	fieldsJSONColumnName = "fields"
-	jsonColumnDataType   = PgJSONb
-)
-
+// Define standard column types
 var (
-	timeColumnName   = "time"
-	timeColumn       = utils.Column{Name: timeColumnName, Type: timeColumnDataType, Role: utils.TimeColType}
-	tagIDColumn      = utils.Column{Name: tagIDColumnName, Type: tagIDColumnDataType, Role: utils.TagsIDColType}
-	fieldsJSONColumn = utils.Column{Name: fieldsJSONColumnName, Type: jsonColumnDataType, Role: utils.FieldColType}
-	tagsJSONColumn   = utils.Column{Name: tagsJSONColumnName, Type: jsonColumnDataType, Role: utils.TagColType}
+	timeColumn       = utils.Column{Name: "time", Type: PgTimestampWithoutTimeZone, Role: utils.TimeColType}
+	tagIDColumn      = utils.Column{Name: "tag_id", Type: PgBigInt, Role: utils.TagsIDColType}
+	fieldsJSONColumn = utils.Column{Name: "fields", Type: PgJSONb, Role: utils.FieldColType}
+	tagsJSONColumn   = utils.Column{Name: "tags", Type: PgJSONb, Role: utils.TagColType}
 )
 
 func (p *Postgresql) columnFromTag(key string, value interface{}) utils.Column {
@@ -25,11 +15,4 @@ func (p *Postgresql) columnFromTag(key string, value interface{}) utils.Column {
 }
 func (p *Postgresql) columnFromField(key string, value interface{}) utils.Column {
 	return utils.Column{Name: key, Type: p.derivePgDatatype(value), Role: utils.FieldColType}
-}
-
-func (p *Postgresql) initTimeColumn() {
-	if p.TimestampColumnName != "" {
-		timeColumnName = p.TimestampColumnName
-		timeColumn = utils.Column{Name: timeColumnName, Type: timeColumnDataType, Role: utils.TimeColType}
-	}
 }

--- a/plugins/outputs/postgresql/columns.go
+++ b/plugins/outputs/postgresql/columns.go
@@ -2,14 +2,6 @@ package postgresql
 
 import "github.com/influxdata/telegraf/plugins/outputs/postgresql/utils"
 
-// Define standard column types
-var (
-	timeColumn       = utils.Column{Name: "time", Type: PgTimestampWithoutTimeZone, Role: utils.TimeColType}
-	tagIDColumn      = utils.Column{Name: "tag_id", Type: PgBigInt, Role: utils.TagsIDColType}
-	fieldsJSONColumn = utils.Column{Name: "fields", Type: PgJSONb, Role: utils.FieldColType}
-	tagsJSONColumn   = utils.Column{Name: "tags", Type: PgJSONb, Role: utils.TagColType}
-)
-
 func (p *Postgresql) columnFromTag(key string, value interface{}) utils.Column {
 	return utils.Column{Name: key, Type: p.derivePgDatatype(value), Role: utils.TagColType}
 }

--- a/plugins/outputs/postgresql/columns.go
+++ b/plugins/outputs/postgresql/columns.go
@@ -4,7 +4,6 @@ import "github.com/influxdata/telegraf/plugins/outputs/postgresql/utils"
 
 // Column names and data types for standard fields (time, tag_id, tags, and fields)
 const (
-	timeColumnName       = "time"
 	timeColumnDataType   = PgTimestampWithoutTimeZone
 	tagIDColumnName      = "tag_id"
 	tagIDColumnDataType  = PgBigInt
@@ -13,14 +12,24 @@ const (
 	jsonColumnDataType   = PgJSONb
 )
 
-var timeColumn = utils.Column{Name: timeColumnName, Type: timeColumnDataType, Role: utils.TimeColType}
-var tagIDColumn = utils.Column{Name: tagIDColumnName, Type: tagIDColumnDataType, Role: utils.TagsIDColType}
-var fieldsJSONColumn = utils.Column{Name: fieldsJSONColumnName, Type: jsonColumnDataType, Role: utils.FieldColType}
-var tagsJSONColumn = utils.Column{Name: tagsJSONColumnName, Type: jsonColumnDataType, Role: utils.TagColType}
+var (
+	timeColumnName   = "time"
+	timeColumn       = utils.Column{Name: timeColumnName, Type: timeColumnDataType, Role: utils.TimeColType}
+	tagIDColumn      = utils.Column{Name: tagIDColumnName, Type: tagIDColumnDataType, Role: utils.TagsIDColType}
+	fieldsJSONColumn = utils.Column{Name: fieldsJSONColumnName, Type: jsonColumnDataType, Role: utils.FieldColType}
+	tagsJSONColumn   = utils.Column{Name: tagsJSONColumnName, Type: jsonColumnDataType, Role: utils.TagColType}
+)
 
 func (p *Postgresql) columnFromTag(key string, value interface{}) utils.Column {
 	return utils.Column{Name: key, Type: p.derivePgDatatype(value), Role: utils.TagColType}
 }
 func (p *Postgresql) columnFromField(key string, value interface{}) utils.Column {
 	return utils.Column{Name: key, Type: p.derivePgDatatype(value), Role: utils.FieldColType}
+}
+
+func (p *Postgresql) initTimeColumn() {
+	if p.TimestampColumnName != "" {
+		timeColumnName = p.TimestampColumnName
+		timeColumn = utils.Column{Name: timeColumnName, Type: timeColumnDataType, Role: utils.TimeColType}
+	}
 }

--- a/plugins/outputs/postgresql/postgresql.go
+++ b/plugins/outputs/postgresql/postgresql.go
@@ -129,7 +129,11 @@ func (p *Postgresql) Init() error {
 	default:
 		return fmt.Errorf("invalid uint64_type")
 	}
-	p.initTimeColumn()
+
+	// Rename the time-column if requested by the user
+	if p.TimestampColumnName != "" {
+		timeColumn.Name = p.TimestampColumnName
+	}
 
 	return nil
 }

--- a/plugins/outputs/postgresql/postgresql.go
+++ b/plugins/outputs/postgresql/postgresql.go
@@ -41,6 +41,7 @@ type Postgresql struct {
 	ForeignTagConstraint       bool                    `toml:"foreign_tag_constraint"`
 	TagsAsJsonb                bool                    `toml:"tags_as_jsonb"`
 	FieldsAsJsonb              bool                    `toml:"fields_as_jsonb"`
+	TimestampColumnName        string                  `toml:"timestamp_column_name"`
 	CreateTemplates            []*sqltemplate.Template `toml:"create_templates"`
 	AddColumnTemplates         []*sqltemplate.Template `toml:"add_column_templates"`
 	TagTableCreateTemplates    []*sqltemplate.Template `toml:"tag_table_create_templates"`
@@ -128,6 +129,7 @@ func (p *Postgresql) Init() error {
 	default:
 		return fmt.Errorf("invalid uint64_type")
 	}
+	p.initTimeColumn()
 
 	return nil
 }

--- a/plugins/outputs/postgresql/sample.conf
+++ b/plugins/outputs/postgresql/sample.conf
@@ -37,6 +37,10 @@
   ## Store all fields as a JSONB object in a single 'fields' column.
   # fields_as_jsonb = false
 
+  ## Name of the timestamp column
+  ## NOTE: Some tools (e.g. Grafana) require the default name so be careful!
+  # timestamp_column_name = "time"
+
   ## Templated statements to execute when creating a new table.
   # create_templates = [
   #   '''CREATE TABLE {{ .table }} ({{ .columns }})''',

--- a/plugins/outputs/postgresql/table_manager.go
+++ b/plugins/outputs/postgresql/table_manager.go
@@ -318,13 +318,13 @@ func (tm *TableManager) getColumns(ctx context.Context, db dbh, name string) (ma
 
 		role := utils.FieldColType
 		switch colName {
-		case timeColumn.Name:
+		case tm.timeColumn.Name:
 			role = utils.TimeColType
-		case tagIDColumn.Name:
+		case tm.tagIDColumn.Name:
 			role = utils.TagsIDColType
-		case tagsJSONColumn.Name:
+		case tm.tagsJSONColumn.Name:
 			role = utils.TagColType
-		case fieldsJSONColumn.Name:
+		case tm.fieldsJSONColumn.Name:
 			role = utils.FieldColType
 		default:
 			// We don't want to monopolize the column comment (preventing user from storing other information there),

--- a/plugins/outputs/postgresql/table_manager.go
+++ b/plugins/outputs/postgresql/table_manager.go
@@ -318,16 +318,17 @@ func (tm *TableManager) getColumns(ctx context.Context, db dbh, name string) (ma
 
 		role := utils.FieldColType
 		switch colName {
-		case timeColumnName:
+		case timeColumn.Name:
 			role = utils.TimeColType
-		case tagIDColumnName:
+		case tagIDColumn.Name:
 			role = utils.TagsIDColType
-		case tagsJSONColumnName:
+		case tagsJSONColumn.Name:
 			role = utils.TagColType
-		case fieldsJSONColumnName:
+		case fieldsJSONColumn.Name:
 			role = utils.FieldColType
 		default:
-			// We don't want to monopolize the column comment (preventing user from storing other information there), so just look at the first word
+			// We don't want to monopolize the column comment (preventing user from storing other information there),
+			// so just look at the first word
 			if desc != nil {
 				descWords := strings.Split(*desc, " ")
 				if descWords[0] == "tag" {

--- a/plugins/outputs/postgresql/table_source.go
+++ b/plugins/outputs/postgresql/table_source.go
@@ -133,7 +133,7 @@ func (tsrc *TableSource) TagColumns() []utils.Column {
 	var cols []utils.Column
 
 	if tsrc.postgresql.TagsAsJsonb {
-		cols = append(cols, tagsJSONColumn)
+		cols = append(cols, tsrc.postgresql.tagsJSONColumn)
 	} else {
 		cols = append(cols, tsrc.tagColumns.columns...)
 	}
@@ -149,17 +149,17 @@ func (tsrc *TableSource) FieldColumns() []utils.Column {
 // MetricTableColumns returns the full column list, including time, tag id or tags, and fields.
 func (tsrc *TableSource) MetricTableColumns() []utils.Column {
 	cols := []utils.Column{
-		timeColumn,
+		tsrc.postgresql.timeColumn,
 	}
 
 	if tsrc.postgresql.TagsAsForeignKeys {
-		cols = append(cols, tagIDColumn)
+		cols = append(cols, tsrc.postgresql.tagIDColumn)
 	} else {
 		cols = append(cols, tsrc.TagColumns()...)
 	}
 
 	if tsrc.postgresql.FieldsAsJsonb {
-		cols = append(cols, fieldsJSONColumn)
+		cols = append(cols, tsrc.postgresql.fieldsJSONColumn)
 	} else {
 		cols = append(cols, tsrc.FieldColumns()...)
 	}
@@ -169,7 +169,7 @@ func (tsrc *TableSource) MetricTableColumns() []utils.Column {
 
 func (tsrc *TableSource) TagTableColumns() []utils.Column {
 	cols := []utils.Column{
-		tagIDColumn,
+		tsrc.postgresql.tagIDColumn,
 	}
 
 	cols = append(cols, tsrc.TagColumns()...)


### PR DESCRIPTION
- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #13744 

This PR adds an option to specify the name of the column used for storing the metric timestamp.