### PR TITLE
chore: Spell endianness correctly

### DIFF
--- a/internal/host_endianness_be.go
+++ b/internal/host_endianness_be.go
@@ -4,4 +4,4 @@ package internal
 
 import "encoding/binary"
 
-var HostEndianess = binary.BigEndian
+var HostEndianness = binary.BigEndian

--- a/internal/host_endianness_le.go
+++ b/internal/host_endianness_le.go
@@ -4,4 +4,4 @@ package internal
 
 import "encoding/binary"
 
-var HostEndianess = binary.LittleEndian
+var HostEndianness = binary.LittleEndian

--- a/plugins/inputs/modbus/type_conversions16.go
+++ b/plugins/inputs/modbus/type_conversions16.go
@@ -9,7 +9,7 @@ import (
 
 type convert16 func([]byte) uint16
 
-func endianessConverter16(byteOrder string) (convert16, error) {
+func endiannessConverter16(byteOrder string) (convert16, error) {
 	switch byteOrder {
 	case "ABCD", "CDAB": // Big endian (Motorola)
 		return binary.BigEndian.Uint16, nil
@@ -21,7 +21,7 @@ func endianessConverter16(byteOrder string) (convert16, error) {
 
 // I16 - no scale
 func determineConverterI16(outType, byteOrder string) (fieldConverterFunc, error) {
-	tohost, err := endianessConverter16(byteOrder)
+	tohost, err := endiannessConverter16(byteOrder)
 	if err != nil {
 		return nil, err
 	}
@@ -49,7 +49,7 @@ func determineConverterI16(outType, byteOrder string) (fieldConverterFunc, error
 
 // U16 - no scale
 func determineConverterU16(outType, byteOrder string) (fieldConverterFunc, error) {
-	tohost, err := endianessConverter16(byteOrder)
+	tohost, err := endiannessConverter16(byteOrder)
 	if err != nil {
 		return nil, err
 	}
@@ -77,7 +77,7 @@ func determineConverterU16(outType, byteOrder string) (fieldConverterFunc, error
 
 // F16 - no scale
 func determineConverterF16(outType, byteOrder string) (fieldConverterFunc, error) {
-	tohost, err := endianessConverter16(byteOrder)
+	tohost, err := endiannessConverter16(byteOrder)
 	if err != nil {
 		return nil, err
 	}
@@ -100,7 +100,7 @@ func determineConverterF16(outType, byteOrder string) (fieldConverterFunc, error
 
 // I16 - scale
 func determineConverterI16Scale(outType, byteOrder string, scale float64) (fieldConverterFunc, error) {
-	tohost, err := endianessConverter16(byteOrder)
+	tohost, err := endiannessConverter16(byteOrder)
 	if err != nil {
 		return nil, err
 	}
@@ -132,7 +132,7 @@ func determineConverterI16Scale(outType, byteOrder string, scale float64) (field
 
 // U16 - scale
 func determineConverterU16Scale(outType, byteOrder string, scale float64) (fieldConverterFunc, error) {
-	tohost, err := endianessConverter16(byteOrder)
+	tohost, err := endiannessConverter16(byteOrder)
 	if err != nil {
 		return nil, err
 	}
@@ -164,7 +164,7 @@ func determineConverterU16Scale(outType, byteOrder string, scale float64) (field
 
 // F16 - scale
 func determineConverterF16Scale(outType, byteOrder string, scale float64) (fieldConverterFunc, error) {
-	tohost, err := endianessConverter16(byteOrder)
+	tohost, err := endiannessConverter16(byteOrder)
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/inputs/modbus/type_conversions32.go
+++ b/plugins/inputs/modbus/type_conversions32.go
@@ -18,7 +18,7 @@ func binaryLSWBEU32(b []byte) uint32 {
 	return uint32(binary.BigEndian.Uint16(b[2:]))<<16 | uint32(binary.BigEndian.Uint16(b[0:]))
 }
 
-func endianessConverter32(byteOrder string) (convert32, error) {
+func endiannessConverter32(byteOrder string) (convert32, error) {
 	switch byteOrder {
 	case "ABCD": // Big endian (Motorola)
 		return binary.BigEndian.Uint32, nil
@@ -34,7 +34,7 @@ func endianessConverter32(byteOrder string) (convert32, error) {
 
 // I32 - no scale
 func determineConverterI32(outType, byteOrder string) (fieldConverterFunc, error) {
-	tohost, err := endianessConverter32(byteOrder)
+	tohost, err := endiannessConverter32(byteOrder)
 	if err != nil {
 		return nil, err
 	}
@@ -62,7 +62,7 @@ func determineConverterI32(outType, byteOrder string) (fieldConverterFunc, error
 
 // U32 - no scale
 func determineConverterU32(outType, byteOrder string) (fieldConverterFunc, error) {
-	tohost, err := endianessConverter32(byteOrder)
+	tohost, err := endiannessConverter32(byteOrder)
 	if err != nil {
 		return nil, err
 	}
@@ -90,7 +90,7 @@ func determineConverterU32(outType, byteOrder string) (fieldConverterFunc, error
 
 // F32 - no scale
 func determineConverterF32(outType, byteOrder string) (fieldConverterFunc, error) {
-	tohost, err := endianessConverter32(byteOrder)
+	tohost, err := endiannessConverter32(byteOrder)
 	if err != nil {
 		return nil, err
 	}
@@ -113,7 +113,7 @@ func determineConverterF32(outType, byteOrder string) (fieldConverterFunc, error
 
 // I32 - scale
 func determineConverterI32Scale(outType, byteOrder string, scale float64) (fieldConverterFunc, error) {
-	tohost, err := endianessConverter32(byteOrder)
+	tohost, err := endiannessConverter32(byteOrder)
 	if err != nil {
 		return nil, err
 	}
@@ -145,7 +145,7 @@ func determineConverterI32Scale(outType, byteOrder string, scale float64) (field
 
 // U32 - scale
 func determineConverterU32Scale(outType, byteOrder string, scale float64) (fieldConverterFunc, error) {
-	tohost, err := endianessConverter32(byteOrder)
+	tohost, err := endiannessConverter32(byteOrder)
 	if err != nil {
 		return nil, err
 	}
@@ -177,7 +177,7 @@ func determineConverterU32Scale(outType, byteOrder string, scale float64) (field
 
 // F32 - scale
 func determineConverterF32Scale(outType, byteOrder string, scale float64) (fieldConverterFunc, error) {
-	tohost, err := endianessConverter32(byteOrder)
+	tohost, err := endiannessConverter32(byteOrder)
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/inputs/modbus/type_conversions64.go
+++ b/plugins/inputs/modbus/type_conversions64.go
@@ -20,7 +20,7 @@ func binaryLSWBEU64(b []byte) uint64 {
 		uint64(binary.BigEndian.Uint16(b[2:]))<<16 | uint64(binary.BigEndian.Uint16(b[0:]))
 }
 
-func endianessConverter64(byteOrder string) (convert64, error) {
+func endiannessConverter64(byteOrder string) (convert64, error) {
 	switch byteOrder {
 	case "ABCD": // Big endian (Motorola)
 		return binary.BigEndian.Uint64, nil
@@ -36,7 +36,7 @@ func endianessConverter64(byteOrder string) (convert64, error) {
 
 // I64 - no scale
 func determineConverterI64(outType, byteOrder string) (fieldConverterFunc, error) {
-	tohost, err := endianessConverter64(byteOrder)
+	tohost, err := endiannessConverter64(byteOrder)
 	if err != nil {
 		return nil, err
 	}
@@ -62,7 +62,7 @@ func determineConverterI64(outType, byteOrder string) (fieldConverterFunc, error
 
 // U64 - no scale
 func determineConverterU64(outType, byteOrder string) (fieldConverterFunc, error) {
-	tohost, err := endianessConverter64(byteOrder)
+	tohost, err := endiannessConverter64(byteOrder)
 	if err != nil {
 		return nil, err
 	}
@@ -86,7 +86,7 @@ func determineConverterU64(outType, byteOrder string) (fieldConverterFunc, error
 
 // F64 - no scale
 func determineConverterF64(outType, byteOrder string) (fieldConverterFunc, error) {
-	tohost, err := endianessConverter64(byteOrder)
+	tohost, err := endiannessConverter64(byteOrder)
 	if err != nil {
 		return nil, err
 	}
@@ -103,7 +103,7 @@ func determineConverterF64(outType, byteOrder string) (fieldConverterFunc, error
 
 // I64 - scale
 func determineConverterI64Scale(outType, byteOrder string, scale float64) (fieldConverterFunc, error) {
-	tohost, err := endianessConverter64(byteOrder)
+	tohost, err := endiannessConverter64(byteOrder)
 	if err != nil {
 		return nil, err
 	}
@@ -135,7 +135,7 @@ func determineConverterI64Scale(outType, byteOrder string, scale float64) (field
 
 // U64 - scale
 func determineConverterU64Scale(outType, byteOrder string, scale float64) (fieldConverterFunc, error) {
-	tohost, err := endianessConverter64(byteOrder)
+	tohost, err := endiannessConverter64(byteOrder)
 	if err != nil {
 		return nil, err
 	}
@@ -167,7 +167,7 @@ func determineConverterU64Scale(outType, byteOrder string, scale float64) (field
 
 // F64 - scale
 func determineConverterF64Scale(outType, byteOrder string, scale float64) (fieldConverterFunc, error) {
-	tohost, err := endianessConverter64(byteOrder)
+	tohost, err := endiannessConverter64(byteOrder)
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/inputs/modbus/type_conversions8.go
+++ b/plugins/inputs/modbus/type_conversions8.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 )
 
-func endianessIndex8(byteOrder string, low bool) (int, error) {
+func endiannessIndex8(byteOrder string, low bool) (int, error) {
 	switch byteOrder {
 	case "ABCD": // Big endian (Motorola)
 		if low {
@@ -22,7 +22,7 @@ func endianessIndex8(byteOrder string, low bool) (int, error) {
 
 // I8 lower byte - no scale
 func determineConverterI8L(outType, byteOrder string) (fieldConverterFunc, error) {
-	idx, err := endianessIndex8(byteOrder, true)
+	idx, err := endiannessIndex8(byteOrder, true)
 	if err != nil {
 		return nil, err
 	}
@@ -50,7 +50,7 @@ func determineConverterI8L(outType, byteOrder string) (fieldConverterFunc, error
 
 // I8 higher byte - no scale
 func determineConverterI8H(outType, byteOrder string) (fieldConverterFunc, error) {
-	idx, err := endianessIndex8(byteOrder, false)
+	idx, err := endiannessIndex8(byteOrder, false)
 	if err != nil {
 		return nil, err
 	}
@@ -78,7 +78,7 @@ func determineConverterI8H(outType, byteOrder string) (fieldConverterFunc, error
 
 // U8 lower byte - no scale
 func determineConverterU8L(outType, byteOrder string) (fieldConverterFunc, error) {
-	idx, err := endianessIndex8(byteOrder, true)
+	idx, err := endiannessIndex8(byteOrder, true)
 	if err != nil {
 		return nil, err
 	}
@@ -106,7 +106,7 @@ func determineConverterU8L(outType, byteOrder string) (fieldConverterFunc, error
 
 // U8 higher byte - no scale
 func determineConverterU8H(outType, byteOrder string) (fieldConverterFunc, error) {
-	idx, err := endianessIndex8(byteOrder, false)
+	idx, err := endiannessIndex8(byteOrder, false)
 	if err != nil {
 		return nil, err
 	}
@@ -134,7 +134,7 @@ func determineConverterU8H(outType, byteOrder string) (fieldConverterFunc, error
 
 // I8 lower byte - scale
 func determineConverterI8LScale(outType, byteOrder string, scale float64) (fieldConverterFunc, error) {
-	idx, err := endianessIndex8(byteOrder, true)
+	idx, err := endiannessIndex8(byteOrder, true)
 	if err != nil {
 		return nil, err
 	}
@@ -166,7 +166,7 @@ func determineConverterI8LScale(outType, byteOrder string, scale float64) (field
 
 // I8 higher byte - scale
 func determineConverterI8HScale(outType, byteOrder string, scale float64) (fieldConverterFunc, error) {
-	idx, err := endianessIndex8(byteOrder, false)
+	idx, err := endiannessIndex8(byteOrder, false)
 	if err != nil {
 		return nil, err
 	}
@@ -198,7 +198,7 @@ func determineConverterI8HScale(outType, byteOrder string, scale float64) (field
 
 // U8 lower byte - scale
 func determineConverterU8LScale(outType, byteOrder string, scale float64) (fieldConverterFunc, error) {
-	idx, err := endianessIndex8(byteOrder, true)
+	idx, err := endiannessIndex8(byteOrder, true)
 	if err != nil {
 		return nil, err
 	}
@@ -226,7 +226,7 @@ func determineConverterU8LScale(outType, byteOrder string, scale float64) (field
 
 // U8 higher byte - scale
 func determineConverterU8HScale(outType, byteOrder string, scale float64) (fieldConverterFunc, error) {
-	idx, err := endianessIndex8(byteOrder, false)
+	idx, err := endiannessIndex8(byteOrder, false)
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/inputs/powerdns_recursor/protocol_commons.go
+++ b/plugins/inputs/powerdns_recursor/protocol_commons.go
@@ -53,9 +53,9 @@ func writeNativeUIntToConn(conn net.Conn, value uint) error {
 
 	switch uintSizeInBytes {
 	case 4:
-		internal.HostEndianess.PutUint32(intData, uint32(value))
+		internal.HostEndianness.PutUint32(intData, uint32(value))
 	case 8:
-		internal.HostEndianess.PutUint64(intData, uint64(value))
+		internal.HostEndianness.PutUint64(intData, uint64(value))
 	default:
 		return fmt.Errorf("unsupported system configuration")
 	}
@@ -79,9 +79,9 @@ func readNativeUIntFromConn(conn net.Conn) (uint, error) {
 
 	switch uintSizeInBytes {
 	case 4:
-		return uint(internal.HostEndianess.Uint32(intData)), nil
+		return uint(internal.HostEndianness.Uint32(intData)), nil
 	case 8:
-		return uint(internal.HostEndianess.Uint64(intData)), nil
+		return uint(internal.HostEndianness.Uint64(intData)), nil
 	default:
 		return 0, fmt.Errorf("unsupported system configuration")
 	}

--- a/plugins/inputs/socket_listener/socket_listener.go
+++ b/plugins/inputs/socket_listener/socket_listener.go
@@ -88,7 +88,7 @@ func (sl *SocketListener) Init() error {
 		case "le":
 			order = binary.LittleEndian
 		default:
-			return fmt.Errorf("invalid 'endianess' %q", sl.SplittingLengthField.Endianness)
+			return fmt.Errorf("invalid 'endianness' %q", sl.SplittingLengthField.Endianness)
 		}
 
 		switch sl.SplittingLengthField.Bytes {

--- a/plugins/parsers/binary/README.md
+++ b/plugins/parsers/binary/README.md
@@ -21,7 +21,7 @@ user-specified configurations.
   ## Specify the endianness of the data.
   ## Available values are "be" (big-endian), "le" (little-endian) and "host",
   ## where "host" means the same endianness as the machine running Telegraf.
-  # endianess = "host"
+  # endianness = "host"
 
   ## Interpret input as string containing hex-encoded data.
   # hex_encoding = false
@@ -282,7 +282,7 @@ you can use the following configuration
 [[inputs.file]]
   files = ["messageA.bin", "messageB.bin", "messageC.bin"]
   data_format = "binary"
-  endianess = "le"
+  endianness = "le"
 
   [[inputs.file.binary]]
     metric_name = "messageA"

--- a/plugins/parsers/binary/entry_test.go
+++ b/plugins/parsers/binary/entry_test.go
@@ -20,7 +20,7 @@ func TestEntryConvertType(t *testing.T) {
 	testdata := []byte{0x01, 0x02, 0x03, 0x04}
 
 	e := &Entry{Type: "garbage"}
-	_, err := e.convertType(testdata, internal.HostEndianess)
+	_, err := e.convertType(testdata, internal.HostEndianness)
 	require.EqualError(t, err, `cannot handle type "garbage"`)
 }
 
@@ -28,16 +28,16 @@ func TestEntryConvertTimeType(t *testing.T) {
 	testdata := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09}
 
 	e := &Entry{Type: "unix_ns", location: time.UTC}
-	_, err := e.convertTimeType(testdata, internal.HostEndianess)
+	_, err := e.convertTimeType(testdata, internal.HostEndianness)
 	require.EqualError(t, err, `too many bytes 9 vs 8`)
 }
 
 func TestConvertNumericType(t *testing.T) {
 	testdata := []byte{0x01, 0x02, 0x03, 0x04}
 
-	_, err := convertNumericType(testdata, "garbage", internal.HostEndianess)
+	_, err := convertNumericType(testdata, "garbage", internal.HostEndianness)
 	require.EqualError(t, err, `cannot determine length for type "garbage"`)
 
-	_, err = convertNumericType(testdata, "uint8", internal.HostEndianess)
+	_, err = convertNumericType(testdata, "uint8", internal.HostEndianness)
 	require.EqualError(t, err, `too many bytes 4 vs 1`)
 }

--- a/plugins/parsers/binary/parser.go
+++ b/plugins/parsers/binary/parser.go
@@ -15,7 +15,8 @@ import (
 
 type Parser struct {
 	AllowNoMatch bool            `toml:"allow_no_match"`
-	Endianess    string          `toml:"endianess"`
+	Endianess    string          `toml:"endianess" deprecated:"1.27.4;use 'endianness' instead"`
+	Endianness   string          `toml:"endianness"`
 	Configs      []Config        `toml:"binary"`
 	HexEncoding  bool            `toml:"hex_encoding"`
 	Log          telegraf.Logger `toml:"-"`
@@ -26,15 +27,19 @@ type Parser struct {
 }
 
 func (p *Parser) Init() error {
-	switch p.Endianess {
+	if p.Endianess != "" && p.Endianness == "" {
+		p.Endianness = p.Endianess
+	}
+
+	switch p.Endianness {
 	case "le":
 		p.converter = binary.LittleEndian
 	case "be":
 		p.converter = binary.BigEndian
 	case "", "host":
-		p.converter = internal.HostEndianess
+		p.converter = internal.HostEndianness
 	default:
-		return fmt.Errorf("unknown endianess %q", p.Endianess)
+		return fmt.Errorf("unknown endianness %q", p.Endianness)
 	}
 
 	// Pre-process the configurations

--- a/plugins/parsers/binary/parser_test.go
+++ b/plugins/parsers/binary/parser_test.go
@@ -50,43 +50,43 @@ func generateBinary(data []interface{}, order binary.ByteOrder) ([]byte, error) 
 	return buf.Bytes(), nil
 }
 
-func determineEndianess(endianess string) binary.ByteOrder {
-	switch endianess {
+func determineEndianness(endianness string) binary.ByteOrder {
+	switch endianness {
 	case "le":
 		return binary.LittleEndian
 	case "be":
 		return binary.BigEndian
 	case "host":
-		return internal.HostEndianess
+		return internal.HostEndianness
 	}
-	panic(fmt.Errorf("unknown endianess %q", endianess))
+	panic(fmt.Errorf("unknown endianness %q", endianness))
 }
 
 func TestInitInvalid(t *testing.T) {
 	var tests = []struct {
-		name      string
-		metric    string
-		config    []Config
-		endianess string
-		expected  string
+		name       string
+		metric     string
+		config     []Config
+		endianness string
+		expected   string
 	}{
 		{
-			name:      "wrong endianess",
-			metric:    "binary",
-			endianess: "garbage",
-			expected:  `unknown endianess "garbage"`,
+			name:       "wrong endianness",
+			metric:     "binary",
+			endianness: "garbage",
+			expected:   `unknown endianness "garbage"`,
 		},
 		{
-			name:      "empty configuration",
-			metric:    "binary",
-			endianess: "host",
-			expected:  `no configuration given`,
+			name:       "empty configuration",
+			metric:     "binary",
+			endianness: "host",
+			expected:   `no configuration given`,
 		},
 		{
-			name:      "no metric name",
-			config:    []Config{{}},
-			endianess: "host",
-			expected:  `config 0 invalid: no metric name given`,
+			name:       "no metric name",
+			config:     []Config{{}},
+			endianness: "host",
+			expected:   `config 0 invalid: no metric name given`,
 		},
 		{
 			name:     "no field",
@@ -128,7 +128,7 @@ func TestInitInvalid(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			parser := &Parser{
-				Endianess:  tt.endianess,
+				Endianness: tt.endianness,
 				Log:        testutil.Logger{Name: "parsers.binary"},
 				metricName: tt.metric,
 			}
@@ -219,7 +219,7 @@ func TestFilterNoMatch(t *testing.T) {
 		}
 		require.NoError(t, parser.Init())
 
-		data, err := generateBinary(testdata, internal.HostEndianess)
+		data, err := generateBinary(testdata, internal.HostEndianness)
 		require.NoError(t, err)
 
 		_, err = parser.Parse(data)
@@ -240,7 +240,7 @@ func TestFilterNoMatch(t *testing.T) {
 		}
 		require.NoError(t, parser.Init())
 
-		data, err := generateBinary(testdata, internal.HostEndianess)
+		data, err := generateBinary(testdata, internal.HostEndianness)
 		require.NoError(t, err)
 
 		metrics, err := parser.Parse(data)
@@ -259,53 +259,53 @@ func TestFilterNone(t *testing.T) {
 	}
 
 	var tests = []struct {
-		name      string
-		data      []interface{}
-		filter    *Filter
-		endianess string
+		name       string
+		data       []interface{}
+		filter     *Filter
+		endianness string
 	}{
 		{
-			name:      "no filter (BE)",
-			data:      testdata,
-			filter:    nil,
-			endianess: "be",
+			name:       "no filter (BE)",
+			data:       testdata,
+			filter:     nil,
+			endianness: "be",
 		},
 		{
-			name:      "no filter (LE)",
-			data:      testdata,
-			filter:    nil,
-			endianess: "le",
+			name:       "no filter (LE)",
+			data:       testdata,
+			filter:     nil,
+			endianness: "le",
 		},
 		{
-			name:      "no filter (host)",
-			data:      testdata,
-			filter:    nil,
-			endianess: "host",
+			name:       "no filter (host)",
+			data:       testdata,
+			filter:     nil,
+			endianness: "host",
 		},
 		{
-			name:      "empty filter (BE)",
-			data:      testdata,
-			filter:    &Filter{},
-			endianess: "be",
+			name:       "empty filter (BE)",
+			data:       testdata,
+			filter:     &Filter{},
+			endianness: "be",
 		},
 		{
-			name:      "empty filter (LE)",
-			data:      testdata,
-			filter:    &Filter{},
-			endianess: "le",
+			name:       "empty filter (LE)",
+			data:       testdata,
+			filter:     &Filter{},
+			endianness: "le",
 		},
 		{
-			name:      "empty filter (host)",
-			data:      testdata,
-			filter:    &Filter{},
-			endianess: "host",
+			name:       "empty filter (host)",
+			data:       testdata,
+			filter:     &Filter{},
+			endianness: "host",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			parser := &Parser{
-				Endianess: tt.endianess,
+				Endianness: tt.endianness,
 				Configs: []Config{
 					{
 						Filter:  tt.filter,
@@ -317,7 +317,7 @@ func TestFilterNone(t *testing.T) {
 			}
 			require.NoError(t, parser.Init())
 
-			order := determineEndianess(tt.endianess)
+			order := determineEndianness(tt.endianness)
 			data, err := generateBinary(tt.data, order)
 			require.NoError(t, err)
 
@@ -390,7 +390,7 @@ func TestFilterLength(t *testing.T) {
 			}
 			require.NoError(t, parser.Init())
 
-			data, err := generateBinary(tt.data, internal.HostEndianess)
+			data, err := generateBinary(tt.data, internal.HostEndianness)
 			require.NoError(t, err)
 
 			metrics, err := parser.Parse(data)
@@ -652,18 +652,18 @@ func TestParseLineInvalid(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		for _, endianess := range []string{"be", "le", "host"} {
-			name := fmt.Sprintf("%s (%s)", tt.name, endianess)
+		for _, endianness := range []string{"be", "le", "host"} {
+			name := fmt.Sprintf("%s (%s)", tt.name, endianness)
 			t.Run(name, func(t *testing.T) {
 				parser := &Parser{
-					Endianess:  endianess,
+					Endianness: endianness,
 					Configs:    tt.configs,
 					Log:        testutil.Logger{Name: "parsers.binary"},
 					metricName: "binary",
 				}
 				require.NoError(t, parser.Init())
 
-				order := determineEndianess(endianess)
+				order := determineEndianness(endianness)
 				data, err := generateBinary(tt.data, order)
 				require.NoError(t, err)
 
@@ -738,12 +738,12 @@ func TestParseLine(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		for _, endianess := range []string{"be", "le", "host"} {
-			name := fmt.Sprintf("%s (%s)", tt.name, endianess)
+		for _, endianness := range []string{"be", "le", "host"} {
+			name := fmt.Sprintf("%s (%s)", tt.name, endianness)
 			t.Run(name, func(t *testing.T) {
 				parser := &Parser{
 					AllowNoMatch: true,
-					Endianess:    endianess,
+					Endianness:   endianness,
 					Configs: []Config{{
 						Filter:  tt.filter,
 						Entries: tt.entries,
@@ -753,7 +753,7 @@ func TestParseLine(t *testing.T) {
 				}
 				require.NoError(t, parser.Init())
 
-				order := determineEndianess(endianess)
+				order := determineEndianness(endianness)
 				data, err := generateBinary(tt.data, order)
 				require.NoError(t, err)
 
@@ -851,18 +851,18 @@ func TestParseInvalid(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		for _, endianess := range []string{"be", "le", "host"} {
-			name := fmt.Sprintf("%s (%s)", tt.name, endianess)
+		for _, endianness := range []string{"be", "le", "host"} {
+			name := fmt.Sprintf("%s (%s)", tt.name, endianness)
 			t.Run(name, func(t *testing.T) {
 				parser := &Parser{
-					Endianess:  endianess,
+					Endianness: endianness,
 					Configs:    []Config{{Entries: tt.entries}},
 					Log:        testutil.Logger{Name: "parsers.binary"},
 					metricName: "binary",
 				}
 				require.NoError(t, parser.Init())
 
-				order := determineEndianess(endianess)
+				order := determineEndianness(endianness)
 				data, err := generateBinary(tt.data, order)
 				require.NoError(t, err)
 
@@ -1376,18 +1376,18 @@ func TestParse(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		for _, endianess := range []string{"be", "le", "host"} {
-			name := fmt.Sprintf("%s (%s)", tt.name, endianess)
+		for _, endianness := range []string{"be", "le", "host"} {
+			name := fmt.Sprintf("%s (%s)", tt.name, endianness)
 			t.Run(name, func(t *testing.T) {
 				parser := &Parser{
-					Endianess:  endianess,
+					Endianness: endianness,
 					Configs:    []Config{{Entries: tt.entries}},
 					Log:        testutil.Logger{Name: "parsers.binary"},
 					metricName: "binary",
 				}
 				require.NoError(t, parser.Init())
 
-				order := determineEndianess(endianess)
+				order := determineEndianness(endianness)
 				data, err := generateBinary(tt.data, order)
 				require.NoError(t, err)
 
@@ -1478,7 +1478,7 @@ func TestHexEncoding(t *testing.T) {
 	}
 
 	parser := &Parser{
-		Endianess:   "be",
+		Endianness:  "be",
 		HexEncoding: true,
 		Configs: []Config{
 			{

--- a/plugins/parsers/binary/testcases/multiple_messages/telegraf.conf
+++ b/plugins/parsers/binary/testcases/multiple_messages/telegraf.conf
@@ -1,7 +1,7 @@
 [[inputs.file]]
   files = ["./testcases/multiple_messages/messageA.bin", "./testcases/multiple_messages/messageB.bin", "./testcases/multiple_messages/messageC.bin"]
   data_format = "binary"
-  endianess = "le"
+  endianness = "le"
 
   [[inputs.file.binary]]
     metric_name = "metricA"

--- a/plugins/processors/parser/parser.go
+++ b/plugins/processors/parser/parser.go
@@ -164,7 +164,7 @@ func (p *Parser) toBytes(value interface{}) ([]byte, error) {
 	}
 
 	var buf bytes.Buffer
-	if err := gobin.Write(&buf, internal.HostEndianess, value); err != nil {
+	if err := gobin.Write(&buf, internal.HostEndianness, value); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
A forums user tried using `endianness` as a setting for the binary plugin. However, that is not what the plugin is using, instead, it is using `endianess` (one less `n`).

This PR changes all internal uses to use `endianness` and deprecates the binary parser's current `endianess` setting in favor of `endianness`.