### PR TITLE
chore: Cache rework for `.circleci` jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,32 +37,29 @@ commands:
         default: "gotestsum"
       cache_version:
         type: string
-        default: "v3"
+        default: "v1"
     steps:
       - checkout
       - check-changed-files-or-halt
+      - restore_cache:
+        name: "Restore binaries from cache"
+        key: << parameters.os >>-<< parameters.arch >>-go-bin-<< parameters.cache_version >>-{{ checksum "go.sum" }}
       - when:
           condition:
             equal: [ linux, << parameters.os >> ]
           steps:
-            - restore_cache:
-                key: linux2-<< parameters.arch >>-go-<< parameters.cache_version >>-{{ checksum "go.sum" }}
             - attach_workspace:
                 at: '/go'
       - when:
           condition:
             equal: [ darwin, << parameters.os >> ]
           steps:
-            - restore_cache:
-                key: darwin2-<< parameters.arch >>-go-<< parameters.cache_version >>-{{ checksum "go.sum" }}
             - run: 'sh ./scripts/installgo_mac.sh'
       - when:
           condition:
             equal: [ windows, << parameters.os >> ]
           steps:
             - run: choco feature enable -n allowGlobalConfirmation
-            - restore_cache:
-                key: windows3-<< parameters.arch >>-go-<< parameters.cache_version >>-{{ checksum "go.sum" }}
             - run: 'sh ./scripts/installgo_windows.sh'
             - run: choco install mingw
       - run: go env
@@ -126,25 +123,19 @@ commands:
             equal: [ linux, << parameters.os >> ]
           steps:
             - save_cache:
-                name: 'Saving cache'
-                key: linux2-<< parameters.arch >>-go-<< parameters.cache_version >>-{{ checksum "go.sum" }}
+                name: 'Saving binaries to cache'
+                key: << parameters.os >>-<< parameters.arch >>-go-bin-<< parameters.cache_version >>-{{ checksum "go.sum" }}
                 paths:
                   - '/go/src/github.com/influxdata/telegraf/gotestsum'
-                  - '/go/pkg/mod'
-                  - '~/.cache/golangci-lint'
-                  - '~/.cache/go-build'
       - when:
           condition:
             equal: [ darwin, << parameters.os >> ]
           steps:
             - save_cache:
-                name: 'Saving cache'
-                key: darwin2-<< parameters.arch >>-go-<< parameters.cache_version >>-{{ checksum "go.sum" }}
+                name: 'Saving binaries to cache'
+                key: << parameters.os >>-<< parameters.arch >>-go-bin-<< parameters.cache_version >>-{{ checksum "go.sum" }}
                 paths:
                   - '~/go/src/github.com/influxdata/telegraf/gotestsum'
-                  - '~/go/pkg/mod'
-                  - '~/Library/Caches/golangci-lint'
-                  - '~/Library/Caches/go-build'
                   - '/usr/local/Cellar/go'
                   - '/usr/local/bin/go'
                   - '/usr/local/bin/gofmt'
@@ -153,13 +144,10 @@ commands:
             equal: [ windows, << parameters.os >> ]
           steps:
             - save_cache:
-                name: 'Saving cache'
-                key: windows3-<< parameters.arch >>-go-<< parameters.cache_version >>-{{ checksum "go.sum" }}
+                name: 'Saving binaries to cache'
+                key: << parameters.os >>-<< parameters.arch >>-go-bin-<< parameters.cache_version >>-{{ checksum "go.sum" }}
                 paths:
                   - '~\project\gotestsum.exe'
-                  - '~\go\pkg\mod'
-                  - '~\AppData\Local\golangci-lint'
-                  - '~\AppData\Local\go-build'
                   - 'C:\Program Files\Go'
   package-build:
     parameters:
@@ -206,7 +194,8 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: go-mod-v1-{{ checksum "go.sum" }}
+          name: "Restore Go caches"
+          key: linux-amd64-go-cache-v1-{{ checksum "go.sum" }}
       - check-changed-files-or-halt
       - run: ./scripts/make_docs.sh
       - run: 'make deps'
@@ -215,10 +204,12 @@ jobs:
       - run: 'make check-deps'
       - test-go
       - save_cache:
-          name: 'go module cache'
-          key: go-mod-v1-{{ checksum "go.sum" }}
+          name: "Save Go caches"
+          key: linux-amd64-go-cache-v1-{{ checksum "go.sum" }}
           paths:
             - '/go/pkg/mod'
+            - '~/.cache/golangci-lint'
+            - '~/.cache/go-build'
       - persist_to_workspace:
           root: '/go'
           paths:
@@ -228,13 +219,21 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: go-mod-v1-{{ checksum "go.sum" }}
+          name: "Restore Go caches"
+          key: linux-386-go-cache-v1-{{ checksum "go.sum" }}
       - check-changed-files-or-halt
       - run: 'GOARCH=386 make deps'
       - run: 'GOARCH=386 make tidy'
       - run: 'GOARCH=386 make check'
       - test-go:
           arch: "386"
+      - save_cache:
+          name: "Save Go caches"
+          key: linux-386-go-cache-v1-{{ checksum "go.sum" }}
+          paths:
+            - '/go/pkg/mod'
+            - '~/.cache/golangci-lint'
+            - '~/.cache/go-build'
   test-integration:
     machine:
       image: ubuntu-2204:current
@@ -248,32 +247,55 @@ jobs:
   test-go-mac:
     executor: mac
     steps:
+      - restore_cache:
+          name: "Restore Go caches"
+          key: darwin-amd64-go-cache-v1-{{ checksum "go.sum" }}
       - test-go:
           os: darwin
+      - save_cache:
+          name: "Save Go caches"
+          key: darwin-amd64-go-cache-v1-{{ checksum "go.sum" }}
+          paths:
+            - '~/go/pkg/mod'
+            - '~/Library/Caches/golangci-lint'
+            - '~/Library/Caches/go-build'
   test-go-windows:
     executor:
         name: win/default
         shell: bash.exe
         size: xlarge
     steps:
+      - restore_cache:
+          name: "Restore Go caches"
+          key: windows-amd64-go-cache-v1-{{ checksum "go.sum" }}
       - test-go:
           os: windows
           gotestsum: "gotestsum.exe"
+      - save_cache:
+          name: "Save Go caches"
+          key: windows-amd64-go-cache-v1-{{ checksum "go.sum" }}
+          paths:
+            - '~\go\pkg\mod'
+            - '~\AppData\Local\golangci-lint'
+            - '~\AppData\Local\go-build'
 
   test-licenses:
     executor: telegraf-ci
     steps:
       - checkout
       - restore_cache:
-          key: go-mod-v1-{{ checksum "go.sum" }}
+          name: "Restore Go caches"
+          key: linux-amd64-go-cache-v1-{{ checksum "go.sum" }}
       - check-changed-files-or-halt
       - run: 'make build_tools'
       - run: './tools/license_checker/license_checker -whitelist ./tools/license_checker/data/whitelist'
       - save_cache:
-          name: 'go module cache'
-          key: go-mod-v1-{{ checksum "go.sum" }}
+          name: "Save Go caches"
+          key: linux-amd64-go-cache-v1-{{ checksum "go.sum" }}
           paths:
             - '/go/pkg/mod'
+            - '~/.cache/golangci-lint'
+            - '~/.cache/go-build'
 
   windows-package:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,8 +42,8 @@ commands:
       - checkout
       - check-changed-files-or-halt
       - restore_cache:
-        name: "Restore binaries from cache"
-        key: << parameters.os >>-<< parameters.arch >>-go-bin-<< parameters.cache_version >>-{{ checksum "go.sum" }}
+          name: "Restore binaries from cache"
+          key: << parameters.os >>-<< parameters.arch >>-go-bin-<< parameters.cache_version >>-{{ checksum "go.sum" }}
       - when:
           condition:
             equal: [ linux, << parameters.os >> ]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,6 +66,7 @@ commands:
                 key: windows2-<< parameters.arch >>-go-<< parameters.cache_version >>-{{ checksum "go.sum" }}
             - run: 'sh ./scripts/installgo_windows.sh'
             - run: choco install mingw
+
       - run: go env
       - run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.53.2
       - when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,6 @@ commands:
     steps:
       - checkout
       - check-changed-files-or-halt
-      - run: go env
       - when:
           condition:
             equal: [ linux, << parameters.os >> ]
@@ -67,6 +66,7 @@ commands:
                 key: windows-<< parameters.arch >>-go-<< parameters.cache_version >>-{{ checksum "go.sum" }}
             - run: 'sh ./scripts/installgo_windows.sh'
             - run: choco install mingw
+      - run: go env
       - run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.53.2
       - when:
           condition:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,6 @@ commands:
         type: string
         default: "v1"
     steps:
-      - checkout
       - check-changed-files-or-halt
       - restore_cache:
           name: "Restore binaries from cache"
@@ -247,6 +246,7 @@ jobs:
   test-go-mac:
     executor: mac
     steps:
+      - checkout
       - restore_cache:
           name: "Restore Go caches"
           key: darwin-amd64-go-cache-v1-{{ checksum "go.sum" }}
@@ -265,6 +265,7 @@ jobs:
         shell: bash.exe
         size: xlarge
     steps:
+      - checkout
       - restore_cache:
           name: "Restore Go caches"
           key: windows-amd64-go-cache-v1-{{ checksum "go.sum" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,12 +41,13 @@ commands:
     steps:
       - checkout
       - check-changed-files-or-halt
+      - run: go env
       - when:
           condition:
             equal: [ linux, << parameters.os >> ]
           steps:
             - restore_cache:
-                key: linux-go-<< parameters.cache_version >>-{{ checksum "go.sum" }}
+                key: linux-<< parameters.arch >>-go-<< parameters.cache_version >>-{{ checksum "go.sum" }}
             - attach_workspace:
                 at: '/go'
       - when:
@@ -54,7 +55,7 @@ commands:
             equal: [ darwin, << parameters.os >> ]
           steps:
             - restore_cache:
-                key: darwin-go-<< parameters.cache_version >>-{{ checksum "go.sum" }}
+                key: darwin-<< parameters.arch >>-go-<< parameters.cache_version >>-{{ checksum "go.sum" }}
             - run: 'sh ./scripts/installgo_mac.sh'
       - when:
           condition:
@@ -63,7 +64,7 @@ commands:
             - run: rm -rf /c/Go
             - run: choco feature enable -n allowGlobalConfirmation
             - restore_cache:
-                key: windows-go-<< parameters.cache_version >>-{{ checksum "go.sum" }}
+                key: windows-<< parameters.arch >>-go-<< parameters.cache_version >>-{{ checksum "go.sum" }}
             - run: 'sh ./scripts/installgo_windows.sh'
             - run: choco install mingw
       - run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.53.2
@@ -81,12 +82,22 @@ commands:
           condition:
             equal: [ darwin, << parameters.os >> ]
           steps:
-            - run: $HOME/go/bin/golangci-lint run --verbose
+            - run:
+                name: golangci-lint cache status
+                command: $HOME/go/bin/golangci-lint cache status
+            - run:
+                name: golangci-lint run
+                command: $HOME/go/bin/golangci-lint run --verbose
       - when:
           condition:
             equal: [ windows, << parameters.os >> ]
           steps:
-            - run: $HOME/go/bin/golangci-lint.exe run --verbose
+            - run:
+                name: golangci-lint cache status
+                command: $HOME/go/bin/golangci-lint.exe cache status
+            - run:
+                name: golangci-lint run
+                command: $HOME/go/bin/golangci-lint.exe run --verbose
       - run: ./scripts/install_gotestsum.sh << parameters.os >> << parameters.gotestsum >>
       - unless:
           condition:
@@ -117,18 +128,20 @@ commands:
           steps:
             - save_cache:
                 name: 'Saving cache'
-                key: linux-go-<< parameters.cache_version >>-{{ checksum "go.sum" }}
+                key: linux-<< parameters.arch >>-go-<< parameters.cache_version >>-{{ checksum "go.sum" }}
                 paths:
-                  - '~/go/src/github.com/influxdata/telegraf/gotestsum'
+                  - '/go/src/github.com/influxdata/telegraf/gotestsum'
+                  - '/go/pkg/mod'
+                  - '~/.cache/golangci-lint'
       - when:
           condition:
             equal: [ darwin, << parameters.os >> ]
           steps:
             - save_cache:
                 name: 'Saving cache'
-                key: darwin-go-<< parameters.cache_version >>-{{ checksum "go.sum" }}
+                key: darwin-<< parameters.arch >>-go-<< parameters.cache_version >>-{{ checksum "go.sum" }}
                 paths:
-                  - '/go/src/github.com/influxdata/telegraf/gotestsum'
+                  - '~/go/src/github.com/influxdata/telegraf/gotestsum'
                   - '/usr/local/Cellar/go'
                   - '/usr/local/bin/go'
                   - '/usr/local/bin/gofmt'
@@ -138,7 +151,7 @@ commands:
           steps:
             - save_cache:
                 name: 'Saving cache'
-                key: windows-go-<< parameters.cache_version >>-{{ checksum "go.sum" }}
+                key: windows-<< parameters.arch >>-go-<< parameters.cache_version >>-{{ checksum "go.sum" }}
                 paths:
                   - 'C:\Go'
                   - 'C:\Users\circleci\project\gotestsum.exe'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -187,6 +187,7 @@ commands:
           root: './build'
           paths:
             - 'dist'
+
 jobs:
   test-go-linux:
     executor: telegraf-ci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ commands:
             equal: [ linux, << parameters.os >> ]
           steps:
             - restore_cache:
-                key: linux1-<< parameters.arch >>-go-<< parameters.cache_version >>-{{ checksum "go.sum" }}
+                key: linux2-<< parameters.arch >>-go-<< parameters.cache_version >>-{{ checksum "go.sum" }}
             - attach_workspace:
                 at: '/go'
       - when:
@@ -54,7 +54,7 @@ commands:
             equal: [ darwin, << parameters.os >> ]
           steps:
             - restore_cache:
-                key: darwin1-<< parameters.arch >>-go-<< parameters.cache_version >>-{{ checksum "go.sum" }}
+                key: darwin2-<< parameters.arch >>-go-<< parameters.cache_version >>-{{ checksum "go.sum" }}
             - run: 'sh ./scripts/installgo_mac.sh'
       - when:
           condition:
@@ -63,7 +63,7 @@ commands:
             - run: rm -rf /c/Go
             - run: choco feature enable -n allowGlobalConfirmation
             - restore_cache:
-                key: windows1-<< parameters.arch >>-go-<< parameters.cache_version >>-{{ checksum "go.sum" }}
+                key: windows2-<< parameters.arch >>-go-<< parameters.cache_version >>-{{ checksum "go.sum" }}
             - run: 'sh ./scripts/installgo_windows.sh'
             - run: choco install mingw
       - run: go env
@@ -128,7 +128,7 @@ commands:
           steps:
             - save_cache:
                 name: 'Saving cache'
-                key: linux1-<< parameters.arch >>-go-<< parameters.cache_version >>-{{ checksum "go.sum" }}
+                key: linux2-<< parameters.arch >>-go-<< parameters.cache_version >>-{{ checksum "go.sum" }}
                 paths:
                   - '/go/src/github.com/influxdata/telegraf/gotestsum'
                   - '/go/pkg/mod'
@@ -140,7 +140,7 @@ commands:
           steps:
             - save_cache:
                 name: 'Saving cache'
-                key: darwin1-<< parameters.arch >>-go-<< parameters.cache_version >>-{{ checksum "go.sum" }}
+                key: darwin2-<< parameters.arch >>-go-<< parameters.cache_version >>-{{ checksum "go.sum" }}
                 paths:
                   - '~/go/src/github.com/influxdata/telegraf/gotestsum'
                   - '~/go/pkg/mod'
@@ -155,11 +155,11 @@ commands:
           steps:
             - save_cache:
                 name: 'Saving cache'
-                key: windows1-<< parameters.arch >>-go-<< parameters.cache_version >>-{{ checksum "go.sum" }}
+                key: windows2-<< parameters.arch >>-go-<< parameters.cache_version >>-{{ checksum "go.sum" }}
                 paths:
-                  - '~\gotestsum.exe'
+                  - '~\project\gotestsum.exe'
                   - '~\go\pkg\mod'
-                  - '~\AppData\Local\AppData\Local\golangci-lint'
+                  - '~\AppData\Local\golangci-lint'
                   - '~\AppData\Local\go-build'
                   - 'C:\Go'
   package-build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ commands:
             equal: [ linux, << parameters.os >> ]
           steps:
             - restore_cache:
-                key: linux-<< parameters.arch >>-go-<< parameters.cache_version >>-{{ checksum "go.sum" }}
+                key: linux1-<< parameters.arch >>-go-<< parameters.cache_version >>-{{ checksum "go.sum" }}
             - attach_workspace:
                 at: '/go'
       - when:
@@ -54,7 +54,7 @@ commands:
             equal: [ darwin, << parameters.os >> ]
           steps:
             - restore_cache:
-                key: darwin-<< parameters.arch >>-go-<< parameters.cache_version >>-{{ checksum "go.sum" }}
+                key: darwin1-<< parameters.arch >>-go-<< parameters.cache_version >>-{{ checksum "go.sum" }}
             - run: 'sh ./scripts/installgo_mac.sh'
       - when:
           condition:
@@ -63,7 +63,7 @@ commands:
             - run: rm -rf /c/Go
             - run: choco feature enable -n allowGlobalConfirmation
             - restore_cache:
-                key: windows-<< parameters.arch >>-go-<< parameters.cache_version >>-{{ checksum "go.sum" }}
+                key: windows1-<< parameters.arch >>-go-<< parameters.cache_version >>-{{ checksum "go.sum" }}
             - run: 'sh ./scripts/installgo_windows.sh'
             - run: choco install mingw
       - run: go env
@@ -128,7 +128,7 @@ commands:
           steps:
             - save_cache:
                 name: 'Saving cache'
-                key: linux-<< parameters.arch >>-go-<< parameters.cache_version >>-{{ checksum "go.sum" }}
+                key: linux1-<< parameters.arch >>-go-<< parameters.cache_version >>-{{ checksum "go.sum" }}
                 paths:
                   - '/go/src/github.com/influxdata/telegraf/gotestsum'
                   - '/go/pkg/mod'
@@ -140,7 +140,7 @@ commands:
           steps:
             - save_cache:
                 name: 'Saving cache'
-                key: darwin-<< parameters.arch >>-go-<< parameters.cache_version >>-{{ checksum "go.sum" }}
+                key: darwin1-<< parameters.arch >>-go-<< parameters.cache_version >>-{{ checksum "go.sum" }}
                 paths:
                   - '~/go/src/github.com/influxdata/telegraf/gotestsum'
                   - '~/go/pkg/mod'
@@ -155,10 +155,13 @@ commands:
           steps:
             - save_cache:
                 name: 'Saving cache'
-                key: windows-<< parameters.arch >>-go-<< parameters.cache_version >>-{{ checksum "go.sum" }}
+                key: windows1-<< parameters.arch >>-go-<< parameters.cache_version >>-{{ checksum "go.sum" }}
                 paths:
+                  - '~\gotestsum.exe'
+                  - '~\go\pkg\mod'
+                  - '~\AppData\Local\AppData\Local\golangci-lint'
+                  - '~\AppData\Local\go-build'
                   - 'C:\Go'
-                  - 'C:\Users\circleci\project\gotestsum.exe'
   package-build:
     parameters:
       type:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,12 @@ commands:
           condition:
             equal: [ linux, << parameters.os >> ]
           steps:
-            - run: GOGC=20 /go/bin/golangci-lint run --verbose
+            - run:
+                name: golangci-lint cache status
+                command: GOGC=20 /go/bin/golangci-lint cache status
+            - run:
+                name: golangci-lint run
+                command: GOGC=20 /go/bin/golangci-lint run --verbose
       - when:
           condition:
             equal: [ darwin, << parameters.os >> ]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,10 +60,9 @@ commands:
           condition:
             equal: [ windows, << parameters.os >> ]
           steps:
-            - run: rm -rf /c/Go
             - run: choco feature enable -n allowGlobalConfirmation
             - restore_cache:
-                key: windows2-<< parameters.arch >>-go-<< parameters.cache_version >>-{{ checksum "go.sum" }}
+                key: windows3-<< parameters.arch >>-go-<< parameters.cache_version >>-{{ checksum "go.sum" }}
             - run: 'sh ./scripts/installgo_windows.sh'
             - run: choco install mingw
 
@@ -156,13 +155,13 @@ commands:
           steps:
             - save_cache:
                 name: 'Saving cache'
-                key: windows2-<< parameters.arch >>-go-<< parameters.cache_version >>-{{ checksum "go.sum" }}
+                key: windows3-<< parameters.arch >>-go-<< parameters.cache_version >>-{{ checksum "go.sum" }}
                 paths:
                   - '~\project\gotestsum.exe'
                   - '~\go\pkg\mod'
                   - '~\AppData\Local\golangci-lint'
                   - '~\AppData\Local\go-build'
-                  - 'C:\Go'
+                  - 'C:\Program Files\Go'
   package-build:
     parameters:
       type:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,6 @@ commands:
                 key: windows3-<< parameters.arch >>-go-<< parameters.cache_version >>-{{ checksum "go.sum" }}
             - run: 'sh ./scripts/installgo_windows.sh'
             - run: choco install mingw
-
       - run: go env
       - run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.53.2
       - when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,6 +133,7 @@ commands:
                   - '/go/src/github.com/influxdata/telegraf/gotestsum'
                   - '/go/pkg/mod'
                   - '~/.cache/golangci-lint'
+                  - '~/.cache/go-build'
       - when:
           condition:
             equal: [ darwin, << parameters.os >> ]
@@ -142,6 +143,9 @@ commands:
                 key: darwin-<< parameters.arch >>-go-<< parameters.cache_version >>-{{ checksum "go.sum" }}
                 paths:
                   - '~/go/src/github.com/influxdata/telegraf/gotestsum'
+                  - '~/go/pkg/mod'
+                  - '~/Library/Caches/golangci-lint'
+                  - '~/Library/Caches/go-build'
                   - '/usr/local/Cellar/go'
                   - '/usr/local/bin/go'
                   - '/usr/local/bin/gofmt'

--- a/scripts/installgo_windows.sh
+++ b/scripts/installgo_windows.sh
@@ -8,8 +8,6 @@ setup_go () {
     choco upgrade golang --allow-downgrade --version=${GO_VERSION}
     choco install make
     git config --system core.longpaths true
-    rm -rf /c/Go
-    cp -r /c/Program\ Files/Go /c/
 }
 
 if command -v go >/dev/null 2>&1; then


### PR DESCRIPTION
Caches are grouped by os/arch (`linux-amd64`, `linux-386`, `darwin-amd64`, `windows-amd64`) and by type (`Go caches` and `binaries`).
- `Go caches` contains:
  - downloaded dependencies: `go\pkg\mod`
  - `GOCACHE` directory: `go-build` dir
  - caches for `golangci-lint`
- `binaries` contains;
  - `gotestsum` binary (for all OSes)
  - `Go` directory (for `darwin` and `windows`)
  - `go`/`gofmt` binaries (for `darwin`)

Cache contains right now 8 entries with total size around: **8-9 GB**.

Fixes/improvements made:
- Incorrect `~/go/src/github.com/influxdata/telegraf/gotestsum` path corrected to valid `/go/src/github.com/influxdata/telegraf/gotestsum` (for `linux`)
- Incorrect `/go/src/github.com/influxdata/telegraf/gotestsum` path corrected to valid `~/go/src/github.com/influxdata/telegraf/gotestsum` (for `darwin`)
- Incorrect `C:\Users\circleci\project\gotestsum.exe` path corrected to valid `~\project\gotestsum.exe` (for `windows`)
- It seems that copying `C:\Program Files\Go` to `C:\Go` (for `windows`) didn't make much sense (or maybe I'm missing something?)
  - `C:\Go` was cached and restored but this restored go directory hadn't been used in `installgo_windows.sh` script (it uses `go` from `PATH` system variable, which is `C:\Program Files\Go`, to check `go version` and decide if newer `go` needs to be downloaded and installed). `go1.20.7` was cached in `C:\Go`, `go1.20.6` was always found in `C:\Program Files\Go` so `go` has been always upgraded.
  - So `C:\Go` was removed from script and job, `C:\Program Files\Go` is cached instead.


In addition to that:
- `go env` is run (to see `go` directories for each OS - may help debugging)
- `golangci-lint cache status` is run (to show status of `golangci-lint` cache)


Ale mention changes speed up following jobs in scenario in which cache is used "perfectly" (no changes in code between runs), jobs may be of course a little slower when code is slightly changed:
- `make check` (for both: `linux-amd64`, `linux-386`)
- `golangci-lint run` (for all OSes)
- `gotestsum` - running tests (for all OSes)
- Install go (mainly for `windows`)