### PR TITLE
fix(inputs.amqp_consumer): Print error on connection failure

### DIFF
--- a/plugins/inputs/amqp_consumer/amqp_consumer.go
+++ b/plugins/inputs/amqp_consumer/amqp_consumer.go
@@ -226,7 +226,7 @@ func (a *AMQPConsumer) connect(amqpConf *amqp.Config) (<-chan amqp.Delivery, err
 			a.Log.Debugf("Connected to %q", broker)
 			break
 		}
-		a.Log.Debugf("Error connecting to %q", broker)
+		a.Log.Errorf("Error connecting to %q: %s", broker, err)
 	}
 
 	if a.conn == nil {


### PR DESCRIPTION
Actually print the error to the user when an error occurs during a connection attempt. This should actually aid the user into what might be going on.