### PR TITLE
chore: Update permissions on new installs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -472,6 +472,7 @@ windows_i386.zip windows_amd64.zip windows_arm64.zip: export EXEEXT := .exe
 %.deb: export localstatedir := /var
 %.rpm: export pkg := rpm
 %.rpm: export prefix := /usr
+%.rpm: export conf_suffix := .sample
 %.rpm: export sysconfdir := /etc
 %.rpm: export localstatedir := /var
 %.tar.gz: export pkg := tar

--- a/Makefile
+++ b/Makefile
@@ -356,7 +356,7 @@ $(include_packages):
 			--url https://github.com/influxdata/telegraf \
 			--license MIT \
 			--maintainer support@influxdb.com \
-			--config-files /etc/telegraf/telegraf.conf \
+			--config-files /etc/telegraf/telegraf.conf.sample \
 			--config-files /etc/telegraf/telegraf.d/.ignore \
 			--config-files /etc/logrotate.d/telegraf \
 			--after-install scripts/rpm/post-install.sh \

--- a/scripts/deb/post-install.sh
+++ b/scripts/deb/post-install.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-LOG_DIR=/var/log/telegraf
 SCRIPT_DIR=/usr/lib/telegraf/scripts
 
 function install_init {
@@ -45,11 +44,16 @@ fi
 # If 'telegraf.conf' is not present use package's sample (fresh install)
 if [[ ! -f /etc/telegraf/telegraf.conf ]] && [[ -f /etc/telegraf/telegraf.conf.sample ]]; then
    cp /etc/telegraf/telegraf.conf.sample /etc/telegraf/telegraf.conf
+   chmod 640 /etc/telegraf/telegraf.conf
+   chmod 750 /etc/telegraf/telegraf.d
 fi
 
-test -d $LOG_DIR || mkdir -p $LOG_DIR
-chown -R -L telegraf:telegraf $LOG_DIR
-chmod 755 $LOG_DIR
+LOG_DIR=/var/log/telegraf
+test -d $LOG_DIR || {
+    mkdir -p $LOG_DIR
+    chown -R -L telegraf:telegraf $LOG_DIR
+    chmod 755 $LOG_DIR
+}
 
 STATE_DIR=/var/lib/telegraf
 test -d "$STATE_DIR" || {

--- a/scripts/rpm/post-install.sh
+++ b/scripts/rpm/post-install.sh
@@ -23,11 +23,10 @@ fi
 if [[ ! -f /etc/telegraf/telegraf.conf ]] && [[ -f /etc/telegraf/telegraf.conf.sample ]]; then
    cp /etc/telegraf/telegraf.conf.sample /etc/telegraf/telegraf.conf
    chmod 640 /etc/telegraf/telegraf.conf
-   chown root:telegraf /etc/telegraf/telegraf.conf
    chmod 750 /etc/telegraf/telegraf.d
-   chown root:telegraf /etc/telegraf/telegraf.d
 fi
 
+# Set up log directories
 LOG_DIR=/var/log/telegraf
 test -d $LOG_DIR || {
     mkdir -p $LOG_DIR

--- a/scripts/rpm/post-install.sh
+++ b/scripts/rpm/post-install.sh
@@ -22,13 +22,18 @@ fi
 # If 'telegraf.conf' is not present use package's sample (fresh install)
 if [[ ! -f /etc/telegraf/telegraf.conf ]] && [[ -f /etc/telegraf/telegraf.conf.sample ]]; then
    cp /etc/telegraf/telegraf.conf.sample /etc/telegraf/telegraf.conf
+   chmod 640 /etc/telegraf/telegraf.conf
+   chown root:telegraf /etc/telegraf/telegraf.conf
+   chmod 750 /etc/telegraf/telegraf.d
+   chown root:telegraf /etc/telegraf/telegraf.d
 fi
 
-# Set up log directories
 LOG_DIR=/var/log/telegraf
-test -d $LOG_DIR || mkdir -p $LOG_DIR
-chown -R -L telegraf:telegraf $LOG_DIR
-chmod 755 $LOG_DIR
+test -d $LOG_DIR || {
+    mkdir -p $LOG_DIR
+    chown -R -L telegraf:telegraf $LOG_DIR
+    chmod 755 $LOG_DIR
+}
 
 STATE_DIR=/var/lib/telegraf
 test -d "$STATE_DIR" || {


### PR DESCRIPTION
Permissions on /etc/telegraf and /etc/telegraf.d will now be 750 and on the initial configuration file 640. This would only be if these files do not exist, for new installs, or if the user removed them.

fixes: #8685