### PR TITLE
fix(inputs.cisco_telemetry_mdt): Check for slice length

### DIFF
--- a/plugins/inputs/cisco_telemetry_mdt/cisco_telemetry_mdt.go
+++ b/plugins/inputs/cisco_telemetry_mdt/cisco_telemetry_mdt.go
@@ -416,6 +416,10 @@ func (c *CiscoTelemetryMDT) handleTelemetry(data []byte) {
 		if content != nil {
 			// Parse values
 			for _, subfield := range content.Fields {
+				if len(subfield.Fields) == 0 {
+					continue
+				}
+
 				prefix := ""
 				switch subfield.Name {
 				case "operation-metric":


### PR DESCRIPTION
fixes: #13789
