### PR TITLE
feat(inputs.procstat): new option to select fields and tcp info

### DIFF
--- a/docs/LICENSE_OF_DEPENDENCIES.md
+++ b/docs/LICENSE_OF_DEPENDENCIES.md
@@ -121,6 +121,7 @@ following works:
 - github.com/eapache/queue [MIT License](https://github.com/eapache/queue/blob/master/LICENSE)
 - github.com/eclipse/paho.golang [Eclipse Public License - v 2.0](https://github.com/eclipse/paho.golang/blob/master/LICENSE)
 - github.com/eclipse/paho.mqtt.golang [Eclipse Public License - v 2.0](https://github.com/eclipse/paho.mqtt.golang/blob/master/LICENSE)
+- github.com/elastic/gosigar [Apache License 2.0](https://github.com/elastic/gosigar/blob/master/LICENSE)
 - github.com/emicklei/go-restful [MIT License](https://github.com/emicklei/go-restful/blob/v3/LICENSE)
 - github.com/fatih/color [MIT License](https://github.com/fatih/color/blob/master/LICENSE.md)
 - github.com/form3tech-oss/jwt-go [MIT License](https://github.com/form3tech-oss/jwt-go/blob/master/LICENSE)

--- a/go.mod
+++ b/go.mod
@@ -213,6 +213,8 @@ require (
 	modernc.org/sqlite v1.24.0
 )
 
+require github.com/elastic/gosigar v0.14.2
+
 require (
 	cloud.google.com/go v0.110.4 // indirect
 	cloud.google.com/go/compute v1.20.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -494,6 +494,8 @@ github.com/eclipse/paho.golang v0.11.0 h1:6Avu5dkkCfcB61/y1vx+XrPQ0oAl4TPYtY0uw3
 github.com/eclipse/paho.golang v0.11.0/go.mod h1:rhrV37IEwauUyx8FHrvmXOKo+QRKng5ncoN1vJiJMcs=
 github.com/eclipse/paho.mqtt.golang v1.4.2 h1:66wOzfUHSSI1zamx7jR6yMEI5EuHnT1G6rNA5PM12m4=
 github.com/eclipse/paho.mqtt.golang v1.4.2/go.mod h1:JGt0RsEwEX+Xa/agj90YJ9d9DH2b7upDZMK9HRbFvCA=
+github.com/elastic/gosigar v0.14.2 h1:Dg80n8cr90OZ7x+bAax/QjoW/XqTI11RmA79ZwIm9/4=
+github.com/elastic/gosigar v0.14.2/go.mod h1:iXRIGg2tLnu7LBdpqzyQfGDEidKCfWcCMS0WKyPWoMs=
 github.com/emicklei/go-restful/v3 v3.10.1 h1:rc42Y5YTp7Am7CS630D7JmhRjq4UlEUuEKfrDac4bSQ=
 github.com/emicklei/go-restful/v3 v3.10.1/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
@@ -1779,6 +1781,7 @@ golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.3.0 h1:ftCYgMx6zT/asHUrPw8BLLscYtGznsLAnjq5RH9P66E=
 golang.org/x/sync v0.3.0/go.mod h1:FU7BRWz2tNW+3quACPkgCx/L+uEAv1htQ0V83Z9Rj+Y=
+golang.org/x/sys v0.0.0-20180810173357-98c5dad5d1a0/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/plugins/inputs/procstat/README.md
+++ b/plugins/inputs/procstat/README.md
@@ -71,6 +71,33 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## the native finder performs the search directly in a manor dependent on the
   ## platform.  Default is 'pgrep'
   # pid_finder = "pgrep"
+
+  ## Select which extra metrics should be added:
+  ##  - "threads": to enable collection of number of file descriptors
+  ##  - "fds": to enable collection of context switches
+  ##  - "ctx_switches": to enable collection of page faults
+  ##  - "page_faults": to enable collection of IO
+  ##  - "io": to enable collection of proc creation time
+  ##  - "create_time": to enable collection of CPU time used
+  ##  - "cpu": to enable collection of percentage of CPU used
+  ##  - "cpu_percent": to enable collection of memory used
+  ##  - "mem": to enable collection of memory percentage used
+  ##  - "mem_percent": to enable collection of procs' limits
+  ##  - "limits": to enable collection of procs' limits
+  ## Default value:
+  # metrics_include = [
+  #  "threads",
+  #  "fds",
+  #  "ctx_switches",
+  #  "page_faults",
+  #  "io",
+  #  "create_time",
+  #  "cpu",
+  #  "cpu_percent",
+  #  "mem",
+  #  "mem_percent",
+  #  "limits",
+  # ]
 ```
 
 ### Windows support

--- a/plugins/inputs/procstat/README.md
+++ b/plugins/inputs/procstat/README.md
@@ -84,6 +84,8 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ##  - "mem": to enable collection of memory percentage used
   ##  - "mem_percent": to enable collection of procs' limits
   ##  - "limits": to enable collection of procs' limits
+  ##  - "tcp_stats": tcp_* and upd_socket metrics
+  ##  - "connections_endpoints": new metric procstat_tcp with connections and listeners endpoints
   ## Default value:
   # metrics_include = [
   #  "threads",
@@ -198,6 +200,46 @@ the `win_perf_counters` input plugin as a more mature alternative.
     - running (int)
     - result_code (int, success = 0, lookup_error = 1)
 
+If ``tcp_stats`` enabled, added fields:
+
+- procstat
+  - fields:
+    - tcp_close (int)
+    - tcp_close_wait (int)
+    - tcp_closing (int)
+    - tcp_established (int)
+    - tcp_fin_wait1 (int)
+    - tcp_fin_wait2 (int)
+    - tcp_last_ack (int)
+    - tcp_listen (int)
+    - tcp_none (int)
+    - tcp_syn_recv (int)
+    - tcp_syn_sent (int)
+
+If ``connections_endpoints`` enabled, added fields:
+
+- procstat_tcp
+  - tags:
+    - pid (when `pid_tag` is true)
+    - cmdline (when 'cmdline_tag' is true)
+    - process_name
+    - pidfile (when defined)
+    - exe (when defined)
+    - pattern (when defined)
+    - user (when selected)
+    - systemd_unit (when defined)
+    - cgroup (when defined)
+  - fields:
+    - conn (string)
+    - listen (string)
+
+To gather connection info, if Telegraf is not run as root, it needs the
+following capabilities:
+
+```text
+sudo setcap "CAP_DAC_READ_SEARCH,CAP_SYS_PTRACE+ep" telegraf
+```
+
 *NOTE: Resource limit > 2147483647 will be reported as 2147483647.*
 
 ## Example Output
@@ -205,4 +247,6 @@ the `win_perf_counters` input plugin as a more mature alternative.
 ```text
 procstat_lookup,host=prash-laptop,pattern=influxd,pid_finder=pgrep,result=success pid_count=1i,running=1i,result_code=0i 1582089700000000000
 procstat,host=prash-laptop,pattern=influxd,process_name=influxd,user=root involuntary_context_switches=151496i,child_minor_faults=1061i,child_major_faults=8i,cpu_time_user=2564.81,cpu_time_idle=0,cpu_time_irq=0,cpu_time_guest=0,pid=32025i,major_faults=8609i,created_at=1580107536000000000i,voluntary_context_switches=1058996i,cpu_time_system=616.98,cpu_time_steal=0,cpu_time_guest_nice=0,memory_swap=0i,memory_locked=0i,memory_usage=1.7797634601593018,num_threads=18i,cpu_time_nice=0,cpu_time_iowait=0,cpu_time_soft_irq=0,memory_rss=148643840i,memory_vms=1435688960i,memory_data=0i,memory_stack=0i,minor_faults=1856550i 1582089700000000000
+procstat,host=laptop,pattern=httpd,process_name=httpd,user=root child_major_faults=0i,child_minor_faults=70i,cpu_time=0i,cpu_time_guest=0,cpu_time_guest_nice=0,cpu_time_idle=0,cpu_time_iowait=0,cpu_time_irq=0,cpu_time_nice=0,cpu_time_soft_irq=0,cpu_time_steal=0,cpu_time_system=0.01,cpu_time_user=0.02,cpu_usage=0,created_at=1611738400000000000i,involuntary_context_switches=15i,listen=1i,major_faults=0i,memory_data=999424i,memory_locked=0i,memory_rss=4677632i,memory_stack=135168i,memory_swap=0i,memory_usage=0.013990458101034164,memory_vms=6078464i,minor_faults=1636i,nice_priority=20i,num_fds=8i,num_threads=1i,pid=1738811i,read_bytes=0i,read_count=4397i,realtime_priority=0i,rlimit_cpu_time_hard=2147483647i,rlimit_cpu_time_soft=2147483647i,rlimit_file_locks_hard=2147483647i,rlimit_file_locks_soft=2147483647i,rlimit_memory_data_hard=2147483647i,rlimit_memory_data_soft=2147483647i,rlimit_memory_locked_hard=65536i,rlimit_memory_locked_soft=65536i,rlimit_memory_rss_hard=2147483647i,rlimit_memory_rss_soft=2147483647i,rlimit_memory_stack_hard=2147483647i,rlimit_memory_stack_soft=8388608i,rlimit_memory_vms_hard=2147483647i,rlimit_memory_vms_soft=2147483647i,rlimit_nice_priority_hard=0i,rlimit_nice_priority_soft=0i,rlimit_num_fds_hard=1048576i,rlimit_num_fds_soft=1048576i,rlimit_realtime_priority_hard=0i,rlimit_realtime_priority_soft=0i,rlimit_signals_pending_hard=127473i,rlimit_signals_pending_soft=127473i,signals_pending=0i,tcp_close=0i,tcp_close_wait=0i,tcp_closing=0i,tcp_established=0i,tcp_fin_wait1=0i,tcp_fin_wait2=0i,tcp_last_ack=0i,tcp_listen=1i,tcp_syn_recv=0i,tcp_syn_sent=0i,voluntary_context_switches=169i,write_bytes=53248i,write_count=10i 1611738522000000000
+procstat_tcp,host=laptop,pattern=httpd,process_name=httpd,user=root conn="",listen="192.168.1.35:80,192.168.1.48:80,[da01:beef:234:3830:aeda:f001:a00c:0091]:80,[aa01:beef:234:3830:e8e:0000:000a:6b0f]:80" 1611738522000000000
 ```

--- a/plugins/inputs/procstat/connections.go
+++ b/plugins/inputs/procstat/connections.go
@@ -1,0 +1,36 @@
+package procstat
+
+import (
+	"fmt"
+	"net"
+)
+
+const (
+	// dockerMACPrefix https://macaddress.io/faq/how-to-recognise-a-docker-container-by-its-mac-address
+	dockerMACPrefix = "02:42"
+	//nolint:lll // avoid splitting the link
+	// virtualBoxMACPrefix https://github.com/mdaniel/virtualbox-org-svn-vbox-trunk/blob/2d259f948bc352ee400f9fd41c4a08710cd9138a/src/VBox/HostDrivers/VBoxNetAdp/VBoxNetAdp.c#L93
+	virtualBoxMACPrefix = "0a:00:27"
+	// hardwareAddrLength is the number of bytes of a MAC address
+	hardwareAddrLength = 6
+)
+
+// errPIDNotFound is the error generated when the pid does not have network info
+var errPIDNotFound = fmt.Errorf("pid not found")
+
+// inodeInfo represents information of a proc associated with an inode
+type inodeInfo struct {
+	pid uint32
+}
+
+// networkInfo implements networkInfo using the netlink calls and parsing /proc to map sockets to PIDs
+type networkInfo struct {
+	// tcp contains the connection info for each pid
+	tcp map[uint32][]connInfo
+	// listenPorts is a map with the listen ports in the host, used to ignore inbound connections
+	listenPorts map[uint32]interface{}
+	// publicIPs list of IPs considered "public" (used to connect to other hosts)
+	publicIPs []net.IP
+	// privateIPs list of IPs considered "private" (loopback, virtual interfaces, point2point, etc)
+	privateIPs []net.IP
+}

--- a/plugins/inputs/procstat/connections.go
+++ b/plugins/inputs/procstat/connections.go
@@ -3,6 +3,8 @@ package procstat
 import (
 	"fmt"
 	"net"
+
+	"github.com/influxdata/telegraf"
 )
 
 const (
@@ -25,6 +27,7 @@ type inodeInfo struct {
 
 // networkInfo implements networkInfo using the netlink calls and parsing /proc to map sockets to PIDs
 type networkInfo struct {
+	log telegraf.Logger
 	// tcp contains the connection info for each pid
 	tcp map[uint32][]connInfo
 	// listenPorts is a map with the listen ports in the host, used to ignore inbound connections

--- a/plugins/inputs/procstat/connections_fallback.go
+++ b/plugins/inputs/procstat/connections_fallback.go
@@ -1,0 +1,46 @@
+//go:build !linux
+// +build !linux
+
+package procstat
+
+import (
+	"fmt"
+	"net"
+)
+
+type connInfo struct{}
+
+func (n *networkInfo) IsAListenPort(_ uint32) bool {
+	return false
+}
+
+func (n *networkInfo) Fetch() error {
+	return nil
+}
+
+func (n *networkInfo) GetConnectionsByPid(_ uint32) (conn []connInfo, err error) {
+	// Avoid "unused" errors
+	_ = dockerMACPrefix
+	_ = virtualBoxMACPrefix
+	_ = hardwareAddrLength
+	i := inodeInfo{}
+	_ = i.pid
+	_ = n.tcp
+	_ = n.listenPorts
+	_ = n.publicIPs
+	_ = n.privateIPs
+
+	return conn, fmt.Errorf("platform not supported")
+}
+
+func (n *networkInfo) GetPublicIPs() []net.IP {
+	return []net.IP{}
+}
+
+func (n *networkInfo) GetPrivateIPs() []net.IP {
+	return []net.IP{}
+}
+
+func (n *networkInfo) IsPidListeningInAddr(_ uint32, _ net.IP, _ uint32) bool {
+	return false
+}

--- a/plugins/inputs/procstat/connections_linux.go
+++ b/plugins/inputs/procstat/connections_linux.go
@@ -1,0 +1,235 @@
+//go:build linux
+// +build linux
+
+package procstat
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/elastic/gosigar/sys/linux"
+)
+
+// connInfo represents a single proc's connection and the parent pid (for practical purpouses)
+type connInfo struct {
+	state   linux.TCPState
+	srcIP   net.IP
+	srcPort uint32
+	dstIP   net.IP
+	dstPort uint32
+}
+
+// IsAListenPort returns true if the port param is associated with a listener found in the host connections
+func (n *networkInfo) IsAListenPort(port uint32) bool {
+	_, ok := n.listenPorts[port]
+	return ok
+}
+
+// Fetch fetches network info: TCP connections and hosts' IPs.
+// Parameter getConnections is the function that will be used to obtain TCP connections
+// Parameter getLocalIPs is the function that will be used to get IPs.
+// It is passed as a parameter to facilitate testing
+func (n *networkInfo) Fetch() error {
+	var err error
+	n.tcp, n.listenPorts, err = getTCPProcInfo()
+	if err != nil {
+		return fmt.Errorf("gathering host TCP info: %w", err)
+	}
+
+	// Get IPs, to be able to resolve procs listening in 0.0.0.0 or ::
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return fmt.Errorf("getting network interfaces: %w", err)
+	}
+
+	n.publicIPs, n.privateIPs, err = getLocalIPs(ifaces)
+	if err != nil {
+		return fmt.Errorf("procstat getting local IPs: %w", err)
+	}
+
+	return nil
+}
+
+// GetConnectionsByPid return connection info for a particular PID
+func (n *networkInfo) GetConnectionsByPid(pid uint32) (conn []connInfo, err error) {
+	conn, ok := n.tcp[pid]
+	if !ok {
+		return conn, errPIDNotFound
+	}
+	return conn, nil
+}
+
+// GetPublicIPs return the list of public IPs (used to connect to others hosts)
+func (n *networkInfo) GetPublicIPs() []net.IP {
+	return n.publicIPs
+}
+
+// GetPrivateIPs return the list of private IPs (loopback devices, virtual, point2point)
+func (n *networkInfo) GetPrivateIPs() []net.IP {
+	return n.privateIPs
+}
+
+// IsPidListeningInAddr returns true if the pid has a listener in that ip and port
+// Return false is pid=0
+func (n *networkInfo) IsPidListeningInAddr(pid uint32, ip net.IP, port uint32) bool {
+	if pid == 0 {
+		return false
+	}
+
+	for _, c := range n.tcp[pid] {
+		if c.srcIP.Equal(ip) && c.srcPort == port {
+			return true
+		}
+	}
+
+	return false
+}
+
+// getLocalIPs return the IPv4/v6 addresses active in the current host divided in two groups:
+// "publicIPs" contains addresses to connect with other external hosts.
+// "privateIPs" contains loopback addreses, virtual interfaces, etc.
+// This division is a best effort and probably does not contains all the possibilities.
+// It should extract the information from a list of interfaces passed as a parameter.
+func getLocalIPs(ifaces []net.Interface) (publicIPs, privateIPs []net.IP, err error) {
+	for _, i := range ifaces {
+		// Ignore down interfaces
+		if i.Flags&net.FlagUp == 0 {
+			continue
+		}
+
+		addresses, err := i.Addrs()
+		if err != nil {
+			return nil, nil, fmt.Errorf("getting addresses from interfaces: %w", err)
+		}
+
+		ips, err := extractIPs(addresses)
+		if err != nil {
+			return nil, nil, fmt.Errorf("getting IPs from interface addresses: %w", err)
+		}
+
+		if i.Flags&net.FlagLoopback != 0 || // Ignore loopback interfaces
+			i.Flags&net.FlagPointToPoint != 0 || // ignore VPN interfaces
+			len(i.HardwareAddr) != hardwareAddrLength || // ignore interfaces without a MAC address
+			strings.HasPrefix(i.HardwareAddr.String(), dockerMACPrefix) || // ignore docker virtual interfaces
+			strings.HasPrefix(i.HardwareAddr.String(), virtualBoxMACPrefix) { // ignore VirtualBox virtual interfaces
+			privateIPs = append(privateIPs, ips...)
+		} else {
+			for _, i := range ips {
+				if i.IsLinkLocalUnicast() {
+					// Do not add link-local IPs: 169.254.0.0/16 or fe80::/10
+					continue
+				}
+				publicIPs = append(publicIPs, i)
+			}
+		}
+	}
+
+	return publicIPs, privateIPs, nil
+}
+
+// getTCPProcInfo return the connections grouped by pid and a map of listening ports.
+// Both results are for IPv4 and IPv6
+func getTCPProcInfo() (connectionsByPid map[uint32][]connInfo, listeners map[uint32]interface{}, err error) {
+	req := linux.NewInetDiagReq()
+	var diagWriter io.Writer
+	msgs, err := linux.NetlinkInetDiagWithBuf(req, nil, diagWriter)
+	if err != nil {
+		return nil, nil, fmt.Errorf("calling netlink to get sockets: %w", err)
+	}
+
+	listeners = map[uint32]interface{}{}
+	connectionsByPid = map[uint32][]connInfo{}
+
+	inodeToPid, err := mapInodesToPid()
+	if err != nil {
+		return nil, nil, fmt.Errorf("mapping inodes to pid: %w", err)
+	}
+
+	for _, diag := range msgs {
+		inodeInfo := inodeToPid[diag.Inode]
+
+		for _, proc := range inodeInfo {
+			if linux.TCPState(diag.State) == linux.TCP_LISTEN {
+				listeners[uint32(diag.SrcPort())] = nil
+			}
+
+			connectionsByPid[proc.pid] = append(connectionsByPid[proc.pid], connInfo{
+				state:   linux.TCPState(diag.State),
+				srcIP:   diag.SrcIP(),
+				srcPort: uint32(diag.SrcPort()),
+				dstIP:   diag.DstIP(),
+				dstPort: uint32(diag.DstPort()),
+			})
+		}
+	}
+
+	return connectionsByPid, listeners, nil
+}
+
+// mapInodesToPid return a map with the procs associated to each inode.
+func mapInodesToPid() (map[uint32][]inodeInfo, error) {
+	ret := map[uint32][]inodeInfo{}
+
+	fd, err := os.Open("/proc")
+	if err != nil {
+		return nil, fmt.Errorf("opening /proc: %w", err)
+	}
+	defer fd.Close()
+
+	dirContents, err := fd.Readdirnames(0)
+	if err != nil {
+		return nil, fmt.Errorf("reading /proc files: %w", err)
+	}
+
+	for _, pidStr := range dirContents {
+		readPidFDs(pidStr, ret)
+	}
+
+	return ret, nil
+}
+
+// readPidFDs given a PID, add to the ret map info about its inodes
+func readPidFDs(pidStr string, ret map[uint32][]inodeInfo) {
+	pid, err := strconv.ParseUint(pidStr, 10, 32)
+	if err != nil {
+		// exclude files with a not numeric name. We only want to access pid directories
+		return
+	}
+
+	pidDir, err := os.Open("/proc/" + pidStr + "/fd/")
+	if err != nil {
+		// ignore errors:
+		//   - missing directory, pid has already finished
+		//   - permission denied
+		return
+	}
+	defer pidDir.Close()
+
+	fds, err := pidDir.Readdirnames(0)
+	if err != nil {
+		return
+	}
+
+	for _, fd := range fds {
+		link, err := os.Readlink("/proc/" + pidStr + "/fd/" + fd)
+		if err != nil {
+			continue
+		}
+
+		var inode uint32
+
+		_, err = fmt.Sscanf(link, "socket:[%d]", &inode)
+		if err != nil {
+			// this inode is not a socket
+			continue
+		}
+
+		ret[inode] = append(ret[inode], inodeInfo{
+			pid: uint32(pid),
+		})
+	}
+}

--- a/plugins/inputs/procstat/connections_linux.go
+++ b/plugins/inputs/procstat/connections_linux.go
@@ -1,6 +1,19 @@
 //go:build linux
 // +build linux
 
+/*
+* The functions in this file are desgined to help input plugin procstat to gather informatión
+* about procs networking.
+* The main idea is to add outgoing and listeners for each process.
+* Procs in others network namespaces other than the default are taked into account just for outgoing
+* connections, as listeners are not accessible, so ignored.
+* The main flow of this functions is:
+*   - read all /proc/ pid directories to get inodes and network namespaces
+*   - for each network NS, call Netlink to get all connections
+*   - map those connections to procs (using inode)
+*   - return also the list of listeners ports (only in the default network ns)
+ */
+
 package procstat
 
 import (
@@ -8,14 +21,34 @@ import (
 	"io"
 	"net"
 	"os"
+	"runtime"
 	"strconv"
 	"strings"
 
 	"github.com/elastic/gosigar/sys/linux"
+	"github.com/vishvananda/netns"
 )
 
-// connInfo represents a single proc's connection and the parent pid (for practical purpouses)
+// inode numeric representation of inodes
+type inode uint32
+
+// netNSProcInfo stores proc info grouped by network namespace
+type netNSProcInfo struct {
+	data map[string]netNSProcs
+}
+
+// netNSProcs store for each network namespace, a link to its path and the list
+// of procs under it
+type netNSProcs struct {
+	id string
+	// inodeToProc map each inode to a list of procs (pid + ppid)
+	inodeToProc map[inode][]inodeInfo
+}
+
+// connInfo represents a single proc's connection and the parent pid (for
+// practical purposes ).
 type connInfo struct {
+	netNs   string
 	state   linux.TCPState
 	srcIP   net.IP
 	srcPort uint32
@@ -23,39 +56,41 @@ type connInfo struct {
 	dstPort uint32
 }
 
-// IsAListenPort returns true if the port param is associated with a listener found in the host connections
+// IsAListenPort returns true if the port param is associated with a listener
+// found in the host connections
 func (n *networkInfo) IsAListenPort(port uint32) bool {
 	_, ok := n.listenPorts[port]
 	return ok
 }
 
 // Fetch fetches network info: TCP connections and hosts' IPs.
-// Parameter getConnections is the function that will be used to obtain TCP connections
+// Parameter getConnections is the function that will be used to obtain TCP
+// connections.
 // Parameter getLocalIPs is the function that will be used to get IPs.
-// It is passed as a parameter to facilitate testing
+// It is passed as a parameter to facilitate testing.
 func (n *networkInfo) Fetch() error {
 	var err error
-	n.tcp, n.listenPorts, err = getTCPProcInfo()
+	n.tcp, n.listenPorts, err = n.getTCPProcInfo()
 	if err != nil {
-		return fmt.Errorf("gathering host TCP info: %w", err)
+		return fmt.Errorf("TCP info: %w", err)
 	}
 
 	// Get IPs, to be able to resolve procs listening in 0.0.0.0 or ::
 	ifaces, err := net.Interfaces()
 	if err != nil {
-		return fmt.Errorf("getting network interfaces: %w", err)
+		return fmt.Errorf("network interfaces: %w", err)
 	}
 
 	n.publicIPs, n.privateIPs, err = getLocalIPs(ifaces)
 	if err != nil {
-		return fmt.Errorf("procstat getting local IPs: %w", err)
+		return fmt.Errorf("local IPs: %w", err)
 	}
 
 	return nil
 }
 
 // GetConnectionsByPid return connection info for a particular PID
-func (n *networkInfo) GetConnectionsByPid(pid uint32) (conn []connInfo, err error) {
+func (n *networkInfo) GetConnectionsByPid(pid uint32) ([]connInfo, error) {
 	conn, ok := n.tcp[pid]
 	if !ok {
 		return conn, errPIDNotFound
@@ -68,13 +103,15 @@ func (n *networkInfo) GetPublicIPs() []net.IP {
 	return n.publicIPs
 }
 
-// GetPrivateIPs return the list of private IPs (loopback devices, virtual, point2point)
+// GetPrivateIPs return the list of private IPs (loopback devices, virtual,
+// point2point)
 func (n *networkInfo) GetPrivateIPs() []net.IP {
 	return n.privateIPs
 }
 
-// IsPidListeningInAddr returns true if the pid has a listener in that ip and port
-// Return false is pid=0
+// IsPidListeningInAddr returns true if the pid has a listener in that ip and
+// port.
+// Return false is pid=0.
 func (n *networkInfo) IsPidListeningInAddr(pid uint32, ip net.IP, port uint32) bool {
 	if pid == 0 {
 		return false
@@ -89,12 +126,19 @@ func (n *networkInfo) IsPidListeningInAddr(pid uint32, ip net.IP, port uint32) b
 	return false
 }
 
-// getLocalIPs return the IPv4/v6 addresses active in the current host divided in two groups:
+// getLocalIPs return the IPv4/v6 addresses active in the current host divided
+// in two groups:
 // "publicIPs" contains addresses to connect with other external hosts.
 // "privateIPs" contains loopback addreses, virtual interfaces, etc.
-// This division is a best effort and probably does not contains all the possibilities.
-// It should extract the information from a list of interfaces passed as a parameter.
-func getLocalIPs(ifaces []net.Interface) (publicIPs, privateIPs []net.IP, err error) {
+// This division is a best effort and probably does not contains all the
+// possibilities.
+// It should extract the information from a list of interfaces passed as a
+// parameter.
+func getLocalIPs(ifaces []net.Interface) (
+	publicIPs,
+	privateIPs []net.IP,
+	err error,
+) {
 	for _, i := range ifaces {
 		// Ignore down interfaces
 		if i.Flags&net.FlagUp == 0 {
@@ -103,19 +147,26 @@ func getLocalIPs(ifaces []net.Interface) (publicIPs, privateIPs []net.IP, err er
 
 		addresses, err := i.Addrs()
 		if err != nil {
-			return nil, nil, fmt.Errorf("getting addresses from interfaces: %w", err)
+			return nil, nil,
+				fmt.Errorf("getting addresses from interfaces: %w", err)
 		}
 
 		ips, err := extractIPs(addresses)
 		if err != nil {
-			return nil, nil, fmt.Errorf("getting IPs from interface addresses: %w", err)
+			return nil, nil,
+				fmt.Errorf("getting IPs from interface addresses: %w", err)
 		}
 
-		if i.Flags&net.FlagLoopback != 0 || // Ignore loopback interfaces
-			i.Flags&net.FlagPointToPoint != 0 || // ignore VPN interfaces
-			len(i.HardwareAddr) != hardwareAddrLength || // ignore interfaces without a MAC address
-			strings.HasPrefix(i.HardwareAddr.String(), dockerMACPrefix) || // ignore docker virtual interfaces
-			strings.HasPrefix(i.HardwareAddr.String(), virtualBoxMACPrefix) { // ignore VirtualBox virtual interfaces
+		// Ignore loopback interfaces
+		if i.Flags&net.FlagLoopback != 0 ||
+			// ignore VPN interfaces
+			i.Flags&net.FlagPointToPoint != 0 ||
+			// ignore interfaces without a MAC address
+			len(i.HardwareAddr) != hardwareAddrLength ||
+			// ignore docker virtual interfaces
+			strings.HasPrefix(i.HardwareAddr.String(), dockerMACPrefix) ||
+			// ignore VirtualBox virtual interfaces
+			strings.HasPrefix(i.HardwareAddr.String(), virtualBoxMACPrefix) {
 			privateIPs = append(privateIPs, ips...)
 		} else {
 			for _, i := range ips {
@@ -131,72 +182,140 @@ func getLocalIPs(ifaces []net.Interface) (publicIPs, privateIPs []net.IP, err er
 	return publicIPs, privateIPs, nil
 }
 
-// getTCPProcInfo return the connections grouped by pid and a map of listening ports.
+// getTCPProcInfo return the connections grouped by pid and a map of listening
+// ports.
 // Both results are for IPv4 and IPv6
-func getTCPProcInfo() (connectionsByPid map[uint32][]connInfo, listeners map[uint32]interface{}, err error) {
-	req := linux.NewInetDiagReq()
+// Ignore listeners inside non-default network namespace
+func (n *networkInfo) getTCPProcInfo() (map[uint32][]connInfo, map[uint32]interface{}, error) {
 	var diagWriter io.Writer
-	msgs, err := linux.NetlinkInetDiagWithBuf(req, nil, diagWriter)
+
+	netNSProcInfo := netNSProcInfo{}
+	err := netNSProcInfo.gatherData()
 	if err != nil {
-		return nil, nil, fmt.Errorf("calling netlink to get sockets: %w", err)
+		return nil, nil, fmt.Errorf("gathering net info: %w", err)
 	}
 
-	listeners = map[uint32]interface{}{}
-	connectionsByPid = map[uint32][]connInfo{}
-
-	inodeToPid, err := mapInodesToPid()
+	defaultNetNs, err := netns.Get()
 	if err != nil {
-		return nil, nil, fmt.Errorf("mapping inodes to pid: %w", err)
+		return nil, nil,
+			fmt.Errorf("unable to get current net namespace: %w", err)
 	}
+	defer defaultNetNs.Close()
 
-	for _, diag := range msgs {
-		inodeInfo := inodeToPid[diag.Inode]
+	listeners := map[uint32]interface{}{}
+	connectionsByPid := map[uint32][]connInfo{}
 
-		for _, proc := range inodeInfo {
-			if linux.TCPState(diag.State) == linux.TCP_LISTEN {
-				listeners[uint32(diag.SrcPort())] = nil
-			}
-
-			connectionsByPid[proc.pid] = append(connectionsByPid[proc.pid], connInfo{
-				state:   linux.TCPState(diag.State),
-				srcIP:   diag.SrcIP(),
-				srcPort: uint32(diag.SrcPort()),
-				dstIP:   diag.DstIP(),
-				dstPort: uint32(diag.DstPort()),
-			})
+	for _, netNs := range netNSProcInfo.GetNS() {
+		nsHandle, err := netNs.GetNSHandle()
+		if err != nil {
+			// ignore error, unable to get the handler for the net ns, probably
+			// it was a short lived proc
+			continue
 		}
+
+		// We force this goroutine to an OS thread.
+		// It also prevents other threads to inherit the namespace change.
+		// https://github.com/golang/go/commit/2595fe7fb6f272f9204ca3ef0b0c55e66fb8d90f
+		// What we want to achieve is to get the connections from another
+		// network namespace without affecting the operation of the rest of the
+		// goroutines.
+		// While we are within the modified network ns, we prevent this
+		// goroutine from creating others threads, which would inherit the
+		// namespace change.
+		// We must also leave the default ns in this thread, so that other
+		// goroutines using this thread do not have the modified network ns.
+		runtime.LockOSThread()
+
+		// Move the process to a different ns to get its connections
+		err = netns.Set(nsHandle)
+		if err != nil {
+			nsHandle.Close()
+			n.log.Errorf("unable to change net namespace: %v\n", err)
+			continue
+		}
+
+		req := linux.NewInetDiagReq()
+		msgs, err := linux.NetlinkInetDiagWithBuf(req, nil, diagWriter)
+		if err != nil {
+			nsHandle.Close()
+			n.log.Errorf("calling netlink to get sockets: %v\n", err)
+			continue
+		}
+
+		// Move back the process to its original net ns
+		err = netns.Set(defaultNetNs)
+		if err != nil {
+			nsHandle.Close()
+			n.log.Errorf("unable to change net namespace back to the default: %v\n", err)
+			continue
+		}
+		runtime.UnlockOSThread()
+
+		for _, diag := range msgs {
+			inodeInfo := netNs.inodeToProc[inode(diag.Inode)]
+
+			for _, proc := range inodeInfo {
+				if linux.TCPState(diag.State) == linux.TCP_LISTEN {
+					if !nsHandle.Equal(defaultNetNs) {
+						// Ignore listener outside of the default net NS
+						nsHandle.Close()
+						continue
+					}
+					listeners[uint32(diag.SrcPort())] = nil
+				}
+
+				connectionsByPid[proc.pid] = append(connectionsByPid[proc.pid], connInfo{
+					netNs:   netNs.id,
+					state:   linux.TCPState(diag.State),
+					srcIP:   diag.SrcIP(),
+					srcPort: uint32(diag.SrcPort()),
+					dstIP:   diag.DstIP(),
+					dstPort: uint32(diag.DstPort()),
+				})
+			}
+		}
+		nsHandle.Close()
 	}
 
 	return connectionsByPid, listeners, nil
 }
 
-// mapInodesToPid return a map with the procs associated to each inode.
-func mapInodesToPid() (map[uint32][]inodeInfo, error) {
-	ret := map[uint32][]inodeInfo{}
+// gatherData parse /proc to get procs info grouped by network namespace
+func (n *netNSProcInfo) gatherData() error {
+	n.data = map[string]netNSProcs{}
 
 	fd, err := os.Open("/proc")
 	if err != nil {
-		return nil, fmt.Errorf("opening /proc: %w", err)
+		return fmt.Errorf("opening /proc: %w", err)
 	}
 	defer fd.Close()
 
 	dirContents, err := fd.Readdirnames(0)
 	if err != nil {
-		return nil, fmt.Errorf("reading /proc files: %w", err)
+		return fmt.Errorf("reading /proc: %w", err)
 	}
 
 	for _, pidStr := range dirContents {
-		readPidFDs(pidStr, ret)
+		n.readPidInfo(pidStr)
 	}
 
-	return ret, nil
+	return nil
 }
 
-// readPidFDs given a PID, add to the ret map info about its inodes
-func readPidFDs(pidStr string, ret map[uint32][]inodeInfo) {
+// readPidInfo for each PID, get network namespace and associated inodes
+func (n *netNSProcInfo) readPidInfo(pidStr string) {
 	pid, err := strconv.ParseUint(pidStr, 10, 32)
 	if err != nil {
 		// exclude files with a not numeric name. We only want to access pid directories
+		return
+	}
+
+	// Get process net namespace
+	netNs, err := os.Readlink("/proc/" + pidStr + "/ns/net")
+	if err != nil {
+		// ignore errors:
+		//   - missing directory, pid has already finished
+		//   - permission denied
 		return
 	}
 
@@ -211,25 +330,71 @@ func readPidFDs(pidStr string, ret map[uint32][]inodeInfo) {
 
 	fds, err := pidDir.Readdirnames(0)
 	if err != nil {
+		// ignore errors:
+		//   - missing directory, pid has already finished
 		return
 	}
 
 	for _, fd := range fds {
 		link, err := os.Readlink("/proc/" + pidStr + "/fd/" + fd)
 		if err != nil {
+			// ignore errors:
+			//   - missing file, fd disappeared
 			continue
 		}
 
-		var inode uint32
+		var procInode uint32
 
-		_, err = fmt.Sscanf(link, "socket:[%d]", &inode)
+		_, err = fmt.Sscanf(link, "socket:[%d]", &procInode)
 		if err != nil {
 			// this inode is not a socket
 			continue
 		}
 
-		ret[inode] = append(ret[inode], inodeInfo{
-			pid: uint32(pid),
-		})
+		n.AddProc(netNs, uint32(pid), inode(procInode))
 	}
+}
+
+// AddProc store pid with its associated network namespace an inode
+func (n *netNSProcInfo) AddProc(netNs string, pid uint32, procInode inode) {
+	netNsData, ok := n.data[netNs]
+	if !ok {
+		netNsData = netNSProcs{
+			id:          netNs,
+			inodeToProc: map[inode][]inodeInfo{},
+		}
+	}
+
+	procInfo, ok := netNsData.inodeToProc[procInode]
+	if ok {
+		procInfo = append(procInfo, inodeInfo{pid: pid})
+		netNsData.inodeToProc[procInode] = procInfo
+	} else {
+		netNsData.inodeToProc[procInode] = []inodeInfo{{pid: pid}}
+	}
+
+	n.data[netNs] = netNsData
+}
+
+// GetNS return the list of network namespaces discovered in the /proc
+func (n *netNSProcInfo) GetNS() (ret []netNSProcs) {
+	for _, ns := range n.data {
+		ret = append(ret, ns)
+	}
+	return ret
+}
+
+// GetNSHandle return the file descriptor for the given network namespace.
+// It will use the first proc path available in the procs under this net ns
+func (n *netNSProcs) GetNSHandle() (ret netns.NsHandle, err error) {
+	for _, procs := range n.inodeToProc {
+		for _, p := range procs {
+			ret, err = netns.GetFromPath(fmt.Sprintf("/proc/%d/ns/net", p.pid))
+			if err == nil {
+				return ret, nil
+			}
+		}
+	}
+
+	return ret, fmt.Errorf("net ns not longer available in analyzed procs")
 }

--- a/plugins/inputs/procstat/procstat.go
+++ b/plugins/inputs/procstat/procstat.go
@@ -165,12 +165,12 @@ func (p *Procstat) Gather(acc telegraf.Accumulator) error {
 
 	// Initialize the conn object. Gather info about all TCP connections organized per PID
 	// Avoid repeating this task for each proc
-	netInfo := networkInfo{}
+	netInfo := networkInfo{log: p.Log}
 	// Only collect this info if we are going to use it (avoid reading all /proc/N/fd dirs)
 	if (p.metricEnabled(metricsTCPStats) || p.metricEnabled(metricsConnectionsEndpoints)) && len(p.procs) > 0 {
 		err := netInfo.Fetch()
 		if err != nil {
-			acc.AddError(fmt.Errorf("getting TCP network info: %w", err))
+			acc.AddError(fmt.Errorf("gather network info: %w", err))
 		}
 	}
 

--- a/plugins/inputs/procstat/procstat_fallback.go
+++ b/plugins/inputs/procstat/procstat_fallback.go
@@ -1,0 +1,28 @@
+//go:build !linux
+// +build !linux
+
+package procstat
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/influxdata/telegraf"
+)
+
+func addConnectionStats(_ []connInfo, _ map[string]interface{}, _ string) {
+}
+
+func addConnectionEndpoints(_ telegraf.Accumulator, _ Process, _ networkInfo) error {
+	// Avoid "unused" errors
+	_ = metricNameTCPConnections
+	_ = tcpConnectionKey
+	_ = tcpListenKey
+	_, _ = extractIPs([]net.Addr{})
+	_ = containsIP([]net.IP{}, net.IP{})
+	_ = isIPV4(net.IP{})
+	_ = isIPV6(net.IP{})
+	_ = endpointString(net.IP{}, uint32(0))
+
+	return fmt.Errorf("platform not supported")
+}

--- a/plugins/inputs/procstat/procstat_linux.go
+++ b/plugins/inputs/procstat/procstat_linux.go
@@ -1,0 +1,110 @@
+//go:build linux
+// +build linux
+
+package procstat
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/elastic/gosigar/sys/linux"
+	"github.com/influxdata/telegraf"
+)
+
+// addConnectionStats count the number of connections in each TCP state and add those values to the metric
+func addConnectionStats(pidConnections []connInfo, fields map[string]interface{}, prefix string) {
+	counts := make(map[linux.TCPState]int)
+	for _, netcon := range pidConnections {
+		counts[netcon.state]++
+	}
+
+	fields[prefix+"tcp_established"] = counts[linux.TCP_ESTABLISHED]
+	fields[prefix+"tcp_syn_sent"] = counts[linux.TCP_SYN_SENT]
+	fields[prefix+"tcp_syn_recv"] = counts[linux.TCP_SYN_RECV]
+	fields[prefix+"tcp_fin_wait1"] = counts[linux.TCP_FIN_WAIT1]
+	fields[prefix+"tcp_fin_wait2"] = counts[linux.TCP_FIN_WAIT2]
+	// Do not add TIME-WAIT as connections does not have a pid associated
+	fields[prefix+"tcp_close"] = counts[linux.TCP_CLOSE]
+	fields[prefix+"tcp_close_wait"] = counts[linux.TCP_CLOSE_WAIT]
+	fields[prefix+"tcp_last_ack"] = counts[linux.TCP_LAST_ACK]
+	fields[prefix+"tcp_listen"] = counts[linux.TCP_LISTEN]
+	fields[prefix+"tcp_closing"] = counts[linux.TCP_CLOSING]
+}
+
+// addConnectionEndpoints add listen and connection endpoints to the procstat_tcp metric.
+// If listen is 0.0.0.0 or ::, it will be added one value for each of the IP addresses of the host.
+// Listeners in private IPs are ignored (maybe a flag could be added, but now the reasoning is matching connections between hosts).
+// Connections made to this server are ignored (the local port is one of the listening ports).
+func addConnectionEndpoints(acc telegraf.Accumulator, proc Process, netInfo networkInfo) error {
+	tcpListen := map[string]interface{}{}
+	tcpConn := map[string]interface{}{}
+
+	pidConnections, err := netInfo.GetConnectionsByPid(uint32(proc.PID()))
+	if err != nil {
+		if errors.Is(err, errPIDNotFound) {
+			return nil
+		}
+
+		return fmt.Errorf("not able to get connections for pid=%v: %w", proc.PID(), err)
+	}
+
+	// In case of error, ppid=0 and will be ignored in IsPidListeningInPort
+	ppid, _ := proc.Ppid()
+
+	for _, c := range pidConnections {
+		// Ignore listeners or connections in/to localhost or private IPs
+		if c.srcIP.IsLoopback() || containsIP(netInfo.GetPrivateIPs(), c.srcIP) {
+			continue
+		}
+
+		if c.state == linux.TCP_LISTEN {
+			if netInfo.IsPidListeningInAddr(uint32(ppid), c.srcIP, c.srcPort) {
+				continue
+			}
+
+			if c.srcIP.IsUnspecified() {
+				// 0.0.0.0 listen in all IPv4 addresses
+				// :: listen in all IPv4 + IPv6 addresses
+				for _, ip := range netInfo.GetPublicIPs() {
+					if isIPV4(ip) || isIPV6(c.srcIP) {
+						tcpListen[endpointString(ip, c.srcPort)] = nil
+					}
+				}
+			} else {
+				tcpListen[endpointString(c.srcIP, c.srcPort)] = nil
+			}
+		} else if c.state != linux.TCP_SYN_SENT { // All TCP states except LISTEN (already processed) and SYN_SENT imply a connection between the hosts
+			// Ignore connections from outside hosts to listeners in this host (status != LISTEN and localPort in listenPorts)
+			if !netInfo.IsAListenPort(c.srcPort) {
+				tcpConn[endpointString(c.dstIP, c.dstPort)] = nil
+			}
+		}
+	}
+
+	// Only add metrics if we have data
+	if len(tcpConn) > 0 || len(tcpListen) > 0 {
+		tcpConnections := []string{}
+		tcpListeners := []string{}
+
+		for k := range tcpConn {
+			tcpConnections = append(tcpConnections, k)
+		}
+		sort.Strings(tcpConnections) // sort to make testing simplier
+
+		for k := range tcpListen {
+			tcpListeners = append(tcpListeners, k)
+		}
+		sort.Strings(tcpListeners)
+
+		fields := map[string]interface{}{
+			tcpConnectionKey: strings.Join(tcpConnections, ","),
+			tcpListenKey:     strings.Join(tcpListeners, ","),
+		}
+
+		acc.AddFields(metricNameTCPConnections, fields, proc.Tags())
+	}
+
+	return nil
+}

--- a/plugins/inputs/procstat/procstat_linux.go
+++ b/plugins/inputs/procstat/procstat_linux.go
@@ -60,6 +60,7 @@ func addConnectionEndpoints(acc telegraf.Accumulator, proc Process, netInfo netw
 		}
 
 		if c.state == linux.TCP_LISTEN {
+			// Ignore is parent pid is listening in the same address:port
 			if netInfo.IsPidListeningInAddr(uint32(ppid), c.srcIP, c.srcPort) {
 				continue
 			}

--- a/plugins/inputs/procstat/procstat_linux_test.go
+++ b/plugins/inputs/procstat/procstat_linux_test.go
@@ -1,0 +1,624 @@
+package procstat
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/elastic/gosigar/sys/linux"
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAddConnectionEndpoints(t *testing.T) {
+	tests := []struct {
+		name        string
+		pid         PID
+		ppid        int32
+		listenPorts map[uint32]interface{}
+		tcp         map[uint32][]connInfo
+		publicIPs   []net.IP
+		privateIPs  []net.IP
+		metrics     []telegraf.Metric
+		err         string
+	}{
+		{
+			name: "no connections, no metrics",
+		},
+		{
+			name:        "outside connection",
+			pid:         100,
+			listenPorts: map[uint32]interface{}{},
+			tcp: map[uint32][]connInfo{
+				100: {
+					{
+						srcIP:   net.ParseIP("192.168.0.2"),
+						srcPort: 34567,
+						dstIP:   net.ParseIP("1.1.1.1"),
+						dstPort: 80,
+						state:   linux.TCP_ESTABLISHED,
+					},
+				},
+			},
+			publicIPs:  []net.IP{},
+			privateIPs: []net.IP{},
+			metrics: []telegraf.Metric{
+				testutil.MustMetric(
+					metricNameTCPConnections,
+					map[string]string{},
+					map[string]interface{}{
+						tcpConnectionKey: "1.1.1.1:80",
+					},
+					time.Now(),
+				),
+			},
+		},
+		{
+			name:        "TCP states except SYN_SENT are used for connections",
+			pid:         100,
+			listenPorts: map[uint32]interface{}{},
+			tcp: map[uint32][]connInfo{
+				100: {
+					{
+						srcIP:   net.ParseIP("192.168.0.2"),
+						srcPort: 10000,
+						dstIP:   net.ParseIP("1.1.1.1"),
+						dstPort: 80,
+						state:   linux.TCP_ESTABLISHED,
+					},
+					{ // this is ignore, is a host trying to connect but the other end has not replied
+						srcIP:   net.ParseIP("192.168.0.2"),
+						srcPort: 10001,
+						dstIP:   net.ParseIP("1.1.1.1"),
+						dstPort: 81,
+						state:   linux.TCP_SYN_SENT,
+					},
+					{
+						srcIP:   net.ParseIP("192.168.0.2"),
+						srcPort: 10002,
+						dstIP:   net.ParseIP("1.1.1.1"),
+						dstPort: 82,
+						state:   linux.TCP_SYN_RECV,
+					},
+					{
+						srcIP:   net.ParseIP("192.168.0.2"),
+						srcPort: 10003,
+						dstIP:   net.ParseIP("1.1.1.1"),
+						dstPort: 83,
+						state:   linux.TCP_FIN_WAIT1,
+					},
+					{
+						srcIP:   net.ParseIP("192.168.0.2"),
+						srcPort: 10004,
+						dstIP:   net.ParseIP("1.1.1.1"),
+						dstPort: 84,
+						state:   linux.TCP_FIN_WAIT2,
+					},
+					{
+						srcIP:   net.ParseIP("192.168.0.2"),
+						srcPort: 10005,
+						dstIP:   net.ParseIP("1.1.1.1"),
+						dstPort: 85,
+						state:   linux.TCP_TIME_WAIT,
+					},
+					{
+						srcIP:   net.ParseIP("192.168.0.2"),
+						srcPort: 10006,
+						dstIP:   net.ParseIP("1.1.1.1"),
+						dstPort: 86,
+						state:   linux.TCP_CLOSE,
+					},
+					{
+						srcIP:   net.ParseIP("192.168.0.2"),
+						srcPort: 10007,
+						dstIP:   net.ParseIP("1.1.1.1"),
+						dstPort: 87,
+						state:   linux.TCP_CLOSE_WAIT,
+					},
+					{
+						srcIP:   net.ParseIP("192.168.0.2"),
+						srcPort: 10008,
+						dstIP:   net.ParseIP("1.1.1.1"),
+						dstPort: 88,
+						state:   linux.TCP_LAST_ACK,
+					},
+					{
+						srcIP:   net.ParseIP("192.168.0.2"),
+						srcPort: 10009,
+						dstIP:   net.ParseIP("1.1.1.1"),
+						dstPort: 89,
+						state:   linux.TCP_CLOSING,
+					},
+				},
+			},
+			publicIPs:  []net.IP{},
+			privateIPs: []net.IP{},
+			metrics: []telegraf.Metric{
+				testutil.MustMetric(
+					metricNameTCPConnections,
+					map[string]string{},
+					map[string]interface{}{
+						tcpConnectionKey: "1.1.1.1:80,1.1.1.1:82,1.1.1.1:83,1.1.1.1:84,1.1.1.1:85,1.1.1.1:86,1.1.1.1:87,1.1.1.1:88,1.1.1.1:89",
+					},
+					time.Now(),
+				),
+			},
+		},
+		{
+			name:        "IPv4 listener",
+			pid:         100,
+			listenPorts: map[uint32]interface{}{80: nil},
+			tcp: map[uint32][]connInfo{
+				100: {
+					{
+						srcIP:   net.ParseIP("192.168.0.2"),
+						srcPort: 80,
+						state:   linux.TCP_LISTEN,
+					},
+				},
+			},
+			publicIPs:  []net.IP{net.ParseIP("192.168.0.2")},
+			privateIPs: []net.IP{},
+			metrics: []telegraf.Metric{
+				testutil.MustMetric(
+					metricNameTCPConnections,
+					map[string]string{},
+					map[string]interface{}{
+						tcpListenKey: "192.168.0.2:80",
+					},
+					time.Now(),
+				),
+			},
+		},
+		{
+			name:        "process listening in a IP not present in the local IPs will generate metric anyway",
+			pid:         100,
+			listenPorts: map[uint32]interface{}{80: nil},
+			tcp: map[uint32][]connInfo{
+				100: {
+					{
+						srcIP:   net.ParseIP("192.168.0.2"),
+						srcPort: 80,
+						state:   linux.TCP_LISTEN,
+					},
+				},
+			},
+			publicIPs:  []net.IP{},
+			privateIPs: []net.IP{},
+			metrics: []telegraf.Metric{
+				testutil.MustMetric(
+					metricNameTCPConnections,
+					map[string]string{},
+					map[string]interface{}{
+						tcpListenKey: "192.168.0.2:80",
+					},
+					time.Now(),
+				),
+			},
+		},
+		{
+			name:        "process listening in a port not present in the listeners list will generate metric anyway",
+			pid:         100,
+			listenPorts: map[uint32]interface{}{},
+			tcp: map[uint32][]connInfo{
+				100: {
+					{
+						srcIP:   net.ParseIP("192.168.0.2"),
+						srcPort: 80,
+						state:   linux.TCP_LISTEN,
+					},
+				},
+			},
+			publicIPs:  []net.IP{},
+			privateIPs: []net.IP{},
+			metrics: []telegraf.Metric{
+				testutil.MustMetric(
+					metricNameTCPConnections,
+					map[string]string{},
+					map[string]interface{}{
+						tcpListenKey: "192.168.0.2:80",
+					},
+					time.Now(),
+				),
+			},
+		},
+		{
+			name:        "IPv6 listener",
+			pid:         100,
+			listenPorts: map[uint32]interface{}{80: nil},
+			tcp: map[uint32][]connInfo{
+				100: {
+					{
+						srcIP:   net.ParseIP("dead::beef"),
+						srcPort: 80,
+						state:   linux.TCP_LISTEN,
+					},
+				},
+			},
+			publicIPs:  []net.IP{},
+			privateIPs: []net.IP{},
+			metrics: []telegraf.Metric{
+				testutil.MustMetric(
+					metricNameTCPConnections,
+					map[string]string{},
+					map[string]interface{}{
+						tcpListenKey: "[dead::beef]:80",
+					},
+					time.Now(),
+				),
+			},
+		},
+		{
+			name: "private IPv4 listener do not generate metrics",
+			pid:  100,
+			listenPorts: map[uint32]interface{}{
+				80: nil,
+			},
+			tcp: map[uint32][]connInfo{
+				100: {
+					{
+						srcIP:   net.ParseIP("192.168.0.2"),
+						srcPort: 80,
+						state:   linux.TCP_LISTEN,
+					},
+				},
+			},
+			publicIPs:  []net.IP{},
+			privateIPs: []net.IP{net.ParseIP("192.168.0.2")},
+			metrics:    []telegraf.Metric{},
+		},
+		{
+			name:        "private IPv6 listener do not generate metrics",
+			pid:         100,
+			listenPorts: map[uint32]interface{}{80: nil},
+			tcp: map[uint32][]connInfo{
+				100: {
+					{
+						srcIP:   net.ParseIP("dead::beef"),
+						srcPort: 80,
+						state:   linux.TCP_LISTEN,
+					},
+				},
+			},
+			publicIPs:  []net.IP{},
+			privateIPs: []net.IP{net.ParseIP("dead::beef")},
+			metrics:    []telegraf.Metric{},
+		},
+		{
+			name:        "0.0.0.0 listener listen in all public IPv4s",
+			pid:         100,
+			listenPorts: map[uint32]interface{}{80: nil},
+			tcp: map[uint32][]connInfo{
+				100: {
+					{
+						srcIP:   net.ParseIP("0.0.0.0"),
+						srcPort: 80,
+						state:   linux.TCP_LISTEN,
+					},
+				},
+			},
+			publicIPs:  []net.IP{net.ParseIP("192.168.0.2"), net.ParseIP("10.10.0.2"), net.ParseIP("dead::beef")},
+			privateIPs: []net.IP{},
+			metrics: []telegraf.Metric{
+				testutil.MustMetric(
+					metricNameTCPConnections,
+					map[string]string{},
+					map[string]interface{}{
+						tcpListenKey: "10.10.0.2:80,192.168.0.2:80",
+					},
+					time.Now(),
+				),
+			},
+		},
+		{
+			name:        ":: listener listen in all public IPv4 and IPv6s",
+			pid:         100,
+			listenPorts: map[uint32]interface{}{80: nil},
+			tcp: map[uint32][]connInfo{
+				100: {
+					{
+						srcIP:   net.ParseIP("::"),
+						srcPort: 80,
+						state:   linux.TCP_LISTEN,
+					},
+				},
+			},
+			publicIPs:  []net.IP{net.ParseIP("192.168.0.2"), net.ParseIP("10.10.0.2"), net.ParseIP("dead::beef")},
+			privateIPs: []net.IP{},
+			metrics: []telegraf.Metric{
+				testutil.MustMetric(
+					metricNameTCPConnections,
+					map[string]string{},
+					map[string]interface{}{
+						tcpListenKey: "10.10.0.2:80,192.168.0.2:80,[dead::beef]:80",
+					},
+					time.Now(),
+				),
+			},
+		},
+		{
+			name:        "ignore listeners in loopback IPs",
+			pid:         100,
+			listenPorts: map[uint32]interface{}{80: nil},
+			tcp: map[uint32][]connInfo{
+				100: {
+					{
+						srcIP:   net.ParseIP("127.0.0.1"),
+						srcPort: 80,
+						state:   linux.TCP_LISTEN,
+					},
+				},
+			},
+			publicIPs:  []net.IP{},
+			privateIPs: []net.IP{},
+			metrics:    []telegraf.Metric{},
+		},
+		{
+			name:        "ignore connections from external hosts to local listeners",
+			pid:         100,
+			listenPorts: map[uint32]interface{}{80: nil},
+			tcp: map[uint32][]connInfo{
+				100: {
+					{
+						srcIP:   net.ParseIP("127.0.0.1"),
+						srcPort: 80,
+						dstIP:   net.ParseIP("54.89.89.54"),
+						dstPort: 30123,
+						state:   linux.TCP_ESTABLISHED,
+					},
+				},
+			},
+			publicIPs:  []net.IP{},
+			privateIPs: []net.IP{},
+			metrics:    []telegraf.Metric{},
+		},
+		{
+			name:        "ignore connections from internal procs to other internal procs using the public IPs",
+			pid:         100,
+			listenPorts: map[uint32]interface{}{80: nil},
+			tcp: map[uint32][]connInfo{
+				100: {
+					{
+						srcIP:   net.ParseIP("192.168.0.2"),
+						srcPort: 30000,
+						dstIP:   net.ParseIP("192.168.0.2"),
+						dstPort: 80,
+						state:   linux.TCP_ESTABLISHED,
+					},
+				},
+			},
+			publicIPs:  []net.IP{},
+			privateIPs: []net.IP{net.ParseIP("192.168.0.2")},
+			metrics:    []telegraf.Metric{},
+		},
+		{ // We are testing how behaves addConnectionEndpoints it if received a "pid not found" kind of error
+			name:        "proc without network info does not generates an error, nor metrics",
+			pid:         100,
+			listenPorts: map[uint32]interface{}{},
+			tcp:         map[uint32][]connInfo{},
+			publicIPs:   []net.IP{},
+			privateIPs:  []net.IP{},
+			metrics:     []telegraf.Metric{},
+		},
+		{
+			name: "process listening in two differents ports using :: with differents public IPs",
+		},
+		{ // same schema valid for: apache httpd, php-fpm
+			name: "service with a parent process and several child, only the parent should report the listeners, parent case (nginx style)",
+			pid:  101, // parent
+			listenPorts: map[uint32]interface{}{
+				80: nil,
+			},
+			tcp: map[uint32][]connInfo{
+				100: { // parent
+					{
+						srcIP:   net.ParseIP("192.168.0.2"),
+						srcPort: 80,
+						state:   linux.TCP_LISTEN,
+					},
+				},
+				101: { // child
+					{
+						srcIP:   net.ParseIP("192.168.0.2"),
+						srcPort: 80,
+						state:   linux.TCP_LISTEN,
+					},
+				},
+			},
+			publicIPs:  []net.IP{},
+			privateIPs: []net.IP{},
+			metrics: []telegraf.Metric{
+				testutil.MustMetric(
+					metricNameTCPConnections,
+					map[string]string{},
+					map[string]interface{}{
+						tcpListenKey: "192.168.0.2:80",
+					},
+					time.Now(),
+				),
+			},
+		},
+		{
+			name: "service with a parent process and several child, only the parent should report the listeners, child case (nginx style)",
+			pid:  101, // child
+			ppid: 100,
+			listenPorts: map[uint32]interface{}{
+				80: nil,
+			},
+			tcp: map[uint32][]connInfo{
+				100: { // parent
+					{
+						srcIP:   net.ParseIP("192.168.0.2"),
+						srcPort: 80,
+						state:   linux.TCP_LISTEN,
+					},
+				},
+				101: { // child
+					{
+						srcIP:   net.ParseIP("192.168.0.2"),
+						srcPort: 80,
+						state:   linux.TCP_LISTEN,
+					},
+				},
+			},
+			publicIPs:  []net.IP{},
+			privateIPs: []net.IP{},
+			metrics:    []telegraf.Metric{},
+		},
+		{
+			name: "child process listening in parent process plus other port, generate metric with the extra listener",
+			pid:  101, // child
+			ppid: 100,
+			listenPorts: map[uint32]interface{}{
+				80:  nil,
+				443: nil,
+			},
+			tcp: map[uint32][]connInfo{
+				100: { // parent
+					{
+						srcIP:   net.ParseIP("192.168.0.2"),
+						srcPort: 80,
+						state:   linux.TCP_LISTEN,
+					},
+				},
+				101: { // child
+					{
+						srcIP:   net.ParseIP("192.168.0.2"),
+						srcPort: 80,
+						state:   linux.TCP_LISTEN,
+					},
+					{
+						srcIP:   net.ParseIP("192.168.0.2"),
+						srcPort: 443,
+						state:   linux.TCP_LISTEN,
+					},
+				},
+			},
+			publicIPs:  []net.IP{},
+			privateIPs: []net.IP{},
+			metrics: []telegraf.Metric{
+				testutil.MustMetric(
+					metricNameTCPConnections,
+					map[string]string{},
+					map[string]interface{}{
+						tcpListenKey: "192.168.0.2:443",
+					},
+					time.Now(),
+				),
+			},
+		},
+		{
+			name:        "process listening in 0.0.0.0 and also in some IPv4 address, avoid duplication",
+			pid:         100,
+			listenPorts: map[uint32]interface{}{80: nil},
+			tcp: map[uint32][]connInfo{
+				100: {
+					{
+						srcIP:   net.ParseIP("0.0.0.0"),
+						srcPort: 80,
+						state:   linux.TCP_LISTEN,
+					},
+					{
+						srcIP:   net.ParseIP("192.168.0.2"),
+						srcPort: 80,
+						state:   linux.TCP_LISTEN,
+					},
+					{
+						srcIP:   net.ParseIP("172.17.0.1"),
+						srcPort: 80,
+						state:   linux.TCP_LISTEN,
+					},
+				},
+			},
+			publicIPs:  []net.IP{net.ParseIP("192.168.0.2"), net.ParseIP("10.10.0.2"), net.ParseIP("dead::beef")},
+			privateIPs: []net.IP{},
+			metrics: []telegraf.Metric{
+				testutil.MustMetric(
+					metricNameTCPConnections,
+					map[string]string{},
+					map[string]interface{}{
+						tcpListenKey: "10.10.0.2:80,172.17.0.1:80,192.168.0.2:80",
+					},
+					time.Now(),
+				),
+			},
+		},
+		{
+			name:        "avoid duplication in outboun connections",
+			pid:         100,
+			listenPorts: map[uint32]interface{}{},
+			tcp: map[uint32][]connInfo{
+				100: {
+					{
+						srcIP:   net.ParseIP("192.168.0.2"),
+						srcPort: 34567,
+						dstIP:   net.ParseIP("1.1.1.1"),
+						dstPort: 80,
+						state:   linux.TCP_ESTABLISHED,
+					},
+					{
+						srcIP:   net.ParseIP("192.168.0.2"),
+						srcPort: 34568,
+						dstIP:   net.ParseIP("1.1.1.1"),
+						dstPort: 80,
+						state:   linux.TCP_ESTABLISHED,
+					},
+				},
+			},
+			publicIPs:  []net.IP{},
+			privateIPs: []net.IP{},
+			metrics: []telegraf.Metric{
+				testutil.MustMetric(
+					metricNameTCPConnections,
+					map[string]string{},
+					map[string]interface{}{
+						tcpConnectionKey: "1.1.1.1:80",
+					},
+					time.Now(),
+				),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var acc testutil.Accumulator
+
+			proc := &testProc{
+				pid:  test.pid,
+				ppid: test.ppid,
+			}
+
+			netInfo := networkInfo{
+				tcp:         test.tcp,
+				listenPorts: test.listenPorts,
+				publicIPs:   test.publicIPs,
+				privateIPs:  test.privateIPs,
+			}
+
+			err := addConnectionEndpoints(&acc, proc, netInfo)
+			if err != nil {
+				assert.EqualError(t, err, test.err)
+			}
+
+			// Function has generated the same number of metrics defined in the test
+			assert.Len(t, acc.GetTelegrafMetrics(), len(test.metrics))
+
+			for _, m := range test.metrics {
+				for _, value := range m.FieldList() {
+					assert.Truef(
+						t,
+						acc.HasPoint(m.Name(), m.Tags(), value.Key, value.Value),
+						"Missing point: %s,%v %s=%s\nMetrics: %v",
+						m.Name(),
+						m.Tags(),
+						value.Key,
+						value.Value,
+						acc.GetTelegrafMetrics(),
+					)
+				}
+			}
+		})
+	}
+}

--- a/plugins/inputs/procstat/sample.conf
+++ b/plugins/inputs/procstat/sample.conf
@@ -43,3 +43,30 @@
   ## the native finder performs the search directly in a manor dependent on the
   ## platform.  Default is 'pgrep'
   # pid_finder = "pgrep"
+
+  ## Select which extra metrics should be added:
+  ##  - "threads": to enable collection of number of file descriptors
+  ##  - "fds": to enable collection of context switches
+  ##  - "ctx_switches": to enable collection of page faults
+  ##  - "page_faults": to enable collection of IO
+  ##  - "io": to enable collection of proc creation time
+  ##  - "create_time": to enable collection of CPU time used
+  ##  - "cpu": to enable collection of percentage of CPU used
+  ##  - "cpu_percent": to enable collection of memory used
+  ##  - "mem": to enable collection of memory percentage used
+  ##  - "mem_percent": to enable collection of procs' limits
+  ##  - "limits": to enable collection of procs' limits
+  ## Default value:
+  # metrics_include = [
+  #  "threads",
+  #  "fds",
+  #  "ctx_switches",
+  #  "page_faults",
+  #  "io",
+  #  "create_time",
+  #  "cpu",
+  #  "cpu_percent",
+  #  "mem",
+  #  "mem_percent",
+  #  "limits",
+  # ]

--- a/plugins/inputs/procstat/sample.conf
+++ b/plugins/inputs/procstat/sample.conf
@@ -56,6 +56,8 @@
   ##  - "mem": to enable collection of memory percentage used
   ##  - "mem_percent": to enable collection of procs' limits
   ##  - "limits": to enable collection of procs' limits
+  ##  - "tcp_stats": tcp_* and upd_socket metrics
+  ##  - "connections_endpoints": new metric procstat_tcp with connections and listeners endpoints
   ## Default value:
   # metrics_include = [
   #  "threads",


### PR DESCRIPTION
Add network information (tcp statuses and connection/listener endpoints) to the processes.

And a new option, `metrics_include`, to select which fields we want for each process, [as suggested](https://github.com/influxdata/telegraf/pull/5402#issuecomment-463022446).

Supersedes [#5402](https://github.com/influxdata/telegraf/pull/5402) and and [#8755](https://github.com/influxdata/telegraf/pull/8755).

# Required for all PRs

<!-- Before opening a pull request you should run the following checks locally to make sure the CI will pass.

make lint
make check
make check-deps
make test
make docs

-->

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->


<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->
