### PR TITLE
chore: Add InfluxDB and InfluxData branding to output

### DIFF
--- a/cmd/telegraf/telegraf.go
+++ b/cmd/telegraf/telegraf.go
@@ -285,7 +285,7 @@ func (t *Telegraf) runAgent(ctx context.Context, c *config.Config, reloadConfig 
 		return err
 	}
 
-	log.Printf("I! Starting Telegraf %s%s", internal.Version, internal.Customized)
+	log.Printf("I! Starting Telegraf %s%s brought to you by InfluxData the makers of InfluxDB", internal.Version, internal.Customized)
 	log.Printf("I! Available plugins: %d inputs, %d aggregators, %d processors, %d parsers, %d outputs, %d secret-stores",
 		len(inputs.Inputs),
 		len(aggregators.Aggregators),


### PR DESCRIPTION
My name is Rick Spencer and I am the VP of Product at InfluxData.

I am proposing this change to raise brand awareness of InfluxDB and InfluxData among Telegraf users. 

I left out any punctuation in an effort to avoid breaking any parsing than any users might doing on the output. 