### PR TITLE
chore(inputs.modbus): improve deprecation documentation

### DIFF
--- a/plugins/inputs/modbus/README.md
+++ b/plugins/inputs/modbus/README.md
@@ -104,7 +104,8 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## data_type   - INT8L, INT8H, UINT8L, UINT8H (low and high byte variants)
   ##               INT16, UINT16, INT32, UINT32, INT64, UINT64,
   ##               FLOAT16-IEEE, FLOAT32-IEEE, FLOAT64-IEEE (IEEE 754 binary representation)
-  ##               FLOAT32, FIXED, UFIXED (fixed-point representation on input)
+  ##               FIXED, UFIXED (fixed-point representation on input)
+  ##               FLOAT32 is a deprecated alias for UFIXED for historic reasons, should be avoided
   ## scale       - the final numeric variable representation
   ## address     - variable address
 
@@ -383,6 +384,9 @@ Directly jump to the styles:
 This is the original style used by this plugin. It allows a per-register
 configuration for a single slave-device.
 
+> [!NOTE]
+> _For legacy reasons this configuration style is not completely consistent with the other styles. Especially `FLOAT32` which suggests a floating point representation is actually a_ ___Fixed Point___ _data type and should be considered_ ___deprecated___
+
 #### Usage of `data_type`
 
 The field `data_type` defines the representation of the data value on input from
@@ -414,7 +418,7 @@ modbus data source. For _coil_ and _discrete_ registers only `UINT16` is valid.
 Use these types if your modbus registers contain a value that is encoded in this
 format. These types always include the sign, therefore no variant exists.
 
-##### Fixed Point: `FIXED`, `UFIXED` (`FLOAT32`)
+##### Fixed Point: `FIXED`, `UFIXED`, (`FLOAT32` - _deprecated_)
 
 These types are handled as an integer type on input, but are converted to
 floating point representation for further processing (e.g. scaling). Use one of
@@ -430,7 +434,7 @@ Select the type `FIXED` when the input type is declared to hold signed integer
 values. Your documentation of the modbus device should indicate this with a term
 like 'int32 containing fixed-point representation with N decimal places'.
 
-(FLOAT32 is deprecated and should not be used. UFIXED provides the same
+(`FLOAT32` is deprecated and should not be used. `UFIXED` provides the same
 conversion from unsigned values).
 
 ---

--- a/plugins/inputs/modbus/configuration_register.go
+++ b/plugins/inputs/modbus/configuration_register.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/models"
 )
 
 //go:embed sample_register.conf
@@ -176,12 +177,12 @@ func (c *ConfigurationOriginal) newFieldFromDefinition(def fieldDefinition, type
 func (c *ConfigurationOriginal) validateFieldDefinitions(fieldDefs []fieldDefinition, registerType string) error {
 	nameEncountered := map[string]bool{}
 	for _, item := range fieldDefs {
-		//check empty name
+		// check empty name
 		if item.Name == "" {
 			return fmt.Errorf("empty name in %q", registerType)
 		}
 
-		//search name duplicate
+		// search name duplicate
 		canonicalName := item.Measurement + "." + item.Name
 		if nameEncountered[canonicalName] {
 			return fmt.Errorf("name %q is duplicated in measurement %q %q - %q", item.Name, item.Measurement, registerType, item.Name)
@@ -258,6 +259,14 @@ func (c *ConfigurationOriginal) validateFieldDefinitions(fieldDefs []fieldDefini
 }
 
 func (c *ConfigurationOriginal) normalizeInputDatatype(dataType string, words int) (string, error) {
+	if dataType == "FLOAT32" {
+		models.PrintOptionValueDeprecationNotice(telegraf.Warn, "input.modbus", "data_type", "FLOAT32", telegraf.DeprecationInfo{
+			Since:     "v1.16.0",
+			RemovalIn: "v2.0.0",
+			Notice:    "Use 'UFIXED' instead",
+		})
+	}
+
 	// Handle our special types
 	switch dataType {
 	case "FIXED":

--- a/plugins/inputs/modbus/sample_register.conf
+++ b/plugins/inputs/modbus/sample_register.conf
@@ -32,7 +32,8 @@
   ## data_type   - INT8L, INT8H, UINT8L, UINT8H (low and high byte variants)
   ##               INT16, UINT16, INT32, UINT32, INT64, UINT64,
   ##               FLOAT16-IEEE, FLOAT32-IEEE, FLOAT64-IEEE (IEEE 754 binary representation)
-  ##               FLOAT32, FIXED, UFIXED (fixed-point representation on input)
+  ##               FIXED, UFIXED (fixed-point representation on input)
+  ##               FLOAT32 is a deprecated alias for UFIXED for historic reasons, should be avoided
   ## scale       - the final numeric variable representation
   ## address     - variable address
 


### PR DESCRIPTION
# Required for all PRs

<!-- Before opening a pull request you should run the following checks locally to make sure the CI will pass.

make lint
make check
make check-deps
make test
make docs

-->

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

resolves #13827

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->

Improve documentation on FLOAT32 in register configuration style.
Add deprecation warning on use of FLOAT32
