### PR TITLE
fix(tools.license_checker): Determine version correctly and whitelist gorilla/websocket

### DIFF
--- a/tools/license_checker/data/whitelist
+++ b/tools/license_checker/data/whitelist
@@ -1,2 +1,3 @@
 <github.com/ClickHouse/clickhouse-go@v2.0.0 MIT
 <github.com/couchbase/goutils@v0.1.2 Apache-2.0
+<=github.com/gorilla/websocket@v1.5.0 BSD-2-Clause

--- a/tools/license_checker/main.go
+++ b/tools/license_checker/main.go
@@ -147,9 +147,10 @@ func main() {
 					debugf("ignoring unknown element %T (%v)", v, v)
 				}
 			}
+			name = strings.TrimSpace(name)
 
 			info := packageInfo{
-				name:    strings.TrimSpace(name),
+				name:    name,
 				version: dependencies[name],
 				url:     strings.TrimSpace(link),
 				license: strings.TrimSpace(license),
@@ -204,10 +205,10 @@ func main() {
 		// Check if we got a whitelist entry for the package
 		if ok, found := override.Check(info.name, info.version, info.spdx); found {
 			if ok {
-				log.Printf("OK: %q (%s) (whitelist)", info.name, info.license)
+				log.Printf("OK: \"%s@%s\" (%s) (whitelist)", info.name, info.version, info.license)
 				succeeded++
 			} else {
-				log.Printf("ERR: %q (%s) %s does not match whitelist", info.name, info.license, info.spdx)
+				log.Printf("ERR: \"%s@%s\" (%s) %s does not match whitelist", info.name, info.version, info.license, info.spdx)
 				failed++
 			}
 			continue

--- a/tools/license_checker/whitelist.go
+++ b/tools/license_checker/whitelist.go
@@ -83,12 +83,12 @@ func (w *whitelist) Parse(filename string) error {
 }
 
 func (w *whitelist) Check(pkg, version, spdx string) (ok, found bool) {
-	var pkgver semver.Version
 	v := strings.TrimSpace(version)
 	v = strings.TrimPrefix(v, "v")
-	if v != "" {
-		pkgver = *semver.New(v)
+	if v == "" {
+		return false, false
 	}
+	pkgver := *semver.New(v)
 
 	for _, entry := range *w {
 		if entry.Name != pkg {


### PR DESCRIPTION
This PR fixes the handling of versions for whitelisting as before, the name was not trimmed correctly and thus the version was always empty. Furthermore, we whitelist `github.com/gorilla/websocket` due to a license change in current master of that project.

relates to #13835
