### PR TITLE
fix(service): Change systemd's `KillMode` to "mixed"

### DIFF
--- a/scripts/telegraf.service
+++ b/scripts/telegraf.service
@@ -12,7 +12,8 @@ ExecStart=/usr/bin/telegraf -config /etc/telegraf/telegraf.conf -config-director
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=on-failure
 RestartForceExitStatus=SIGPIPE
-KillMode=control-group
+KillMode=mixed
+TimeoutStopSec=5
 LimitMEMLOCK=8M:8M
 
 [Install]


### PR DESCRIPTION
Currently all processes created by Telegraf are killed as-soon-as a the service is stopped. This triggers some errors in Telegraf as its child processes died unexpectedly. By changing the `KillMode`  to `mixed` Telegraf is given a chance to shut-down its child-processes cleanly while keeping the property of a clean exit if it fails.

fixes #13842

