### PR TITLE
chore: Update all cache strings with go version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ commands:
         default: "gotestsum"
       cache_version:
         type: string
-        default: "v1"
+        default: "v2"
       goversion:
         type: string
         default: 1.21.0
@@ -202,7 +202,7 @@ jobs:
       - checkout
       - restore_cache:
           name: "Restore Go caches"
-          key: linux-amd64-go<< parameters.goversion >>-cache-v1-{{ checksum "go.sum" }}
+          key: linux-amd64-go<< parameters.goversion >>-cache-v2-{{ checksum "go.sum" }}
       - check-changed-files-or-halt
       - run: ./scripts/make_docs.sh
       - run: 'make deps'
@@ -212,7 +212,7 @@ jobs:
       - test-go
       - save_cache:
           name: "Save Go caches"
-          key: linux-amd64-go<< parameters.goversion >>-v1-{{ checksum "go.sum" }}
+          key: linux-amd64-go<< parameters.goversion >>-v2-{{ checksum "go.sum" }}
           paths:
             - '/go/pkg/mod'
             - '~/.cache/golangci-lint'
@@ -231,7 +231,7 @@ jobs:
       - checkout
       - restore_cache:
           name: "Restore Go caches"
-          key: linux-386-go<< parameters.goversion >>-cache-v1-{{ checksum "go.sum" }}
+          key: linux-386-go<< parameters.goversion >>-cache-v2-{{ checksum "go.sum" }}
       - check-changed-files-or-halt
       - run: 'GOARCH=386 make deps'
       - run: 'GOARCH=386 make tidy'
@@ -240,7 +240,7 @@ jobs:
           arch: "386"
       - save_cache:
           name: "Save Go caches"
-          key: linux-386-go<< parameters.goversion >>-cache-v1-{{ checksum "go.sum" }}
+          key: linux-386-go<< parameters.goversion >>-cache-v2-{{ checksum "go.sum" }}
           paths:
             - '/go/pkg/mod'
             - '~/.cache/golangci-lint'
@@ -265,12 +265,12 @@ jobs:
       - checkout
       - restore_cache:
           name: "Restore Go caches"
-          key: darwin-amd64-go<< parameters.goversion >>-cache-v1-{{ checksum "go.sum" }}
+          key: darwin-amd64-go<< parameters.goversion >>-cache-v2-{{ checksum "go.sum" }}
       - test-go:
           os: darwin
       - save_cache:
           name: "Save Go caches"
-          key: darwin-amd64-go<< parameters.goversion >>-cache-v1-{{ checksum "go.sum" }}
+          key: darwin-amd64-go<< parameters.goversion >>-cache-v2-{{ checksum "go.sum" }}
           paths:
             - '~/go/pkg/mod'
             - '~/Library/Caches/golangci-lint'
@@ -288,13 +288,13 @@ jobs:
       - checkout
       - restore_cache:
           name: "Restore Go caches"
-          key: windows-amd64-go<< parameters.goversion >>-cache-v1-{{ checksum "go.sum" }}
+          key: windows-amd64-go<< parameters.goversion >>-cache-v2-{{ checksum "go.sum" }}
       - test-go:
           os: windows
           gotestsum: "gotestsum.exe"
       - save_cache:
           name: "Save Go caches"
-          key: windows-amd64-go<< parameters.goversion >>-cache-v1-{{ checksum "go.sum" }}
+          key: windows-amd64-go<< parameters.goversion >>-cache-v2-{{ checksum "go.sum" }}
           paths:
             - '~\go\pkg\mod'
             - '~\AppData\Local\golangci-lint'
@@ -310,13 +310,13 @@ jobs:
       - checkout
       - restore_cache:
           name: "Restore Go caches"
-          key: linux-amd64-go<< parameters.goversion >>-cache-v1-{{ checksum "go.sum" }}
+          key: linux-amd64-go<< parameters.goversion >>-cache-v2-{{ checksum "go.sum" }}
       - check-changed-files-or-halt
       - run: 'make build_tools'
       - run: './tools/license_checker/license_checker -whitelist ./tools/license_checker/data/whitelist'
       - save_cache:
           name: "Save Go caches"
-          key: linux-amd64-go<< parameters.goversion >>-cache-v1-{{ checksum "go.sum" }}
+          key: linux-amd64-go<< parameters.goversion >>-cache-v2-{{ checksum "go.sum" }}
           paths:
             - '/go/pkg/mod'
             - '~/.cache/golangci-lint'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -194,6 +194,10 @@ commands:
 jobs:
   test-go-linux:
     executor: telegraf-ci
+    parameters:
+      goversion:
+        type: string
+        default: 1.21.0
     steps:
       - checkout
       - restore_cache:
@@ -219,6 +223,10 @@ jobs:
             - '*'
   test-go-linux-386:
     executor: telegraf-ci
+    parameters:
+      goversion:
+        type: string
+        default: 1.21.0
     steps:
       - checkout
       - restore_cache:
@@ -249,6 +257,10 @@ jobs:
       - run: 'make test-integration'
   test-go-mac:
     executor: mac
+    parameters:
+      goversion:
+        type: string
+        default: 1.21.0
     steps:
       - checkout
       - restore_cache:
@@ -264,6 +276,10 @@ jobs:
             - '~/Library/Caches/golangci-lint'
             - '~/Library/Caches/go-build'
   test-go-windows:
+    parameters:
+      goversion:
+        type: string
+        default: 1.21.0
     executor:
         name: win/default
         shell: bash.exe
@@ -286,6 +302,10 @@ jobs:
 
   test-licenses:
     executor: telegraf-ci
+    parameters:
+      goversion:
+        type: string
+        default: 1.21.0
     steps:
       - checkout
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -198,7 +198,7 @@ jobs:
       - checkout
       - restore_cache:
           name: "Restore Go caches"
-          key: linux-amd64-go-cache-v1-{{ checksum "go.sum" }}
+          key: linux-amd64-go<< parameters.goversion >>-cache-v1-{{ checksum "go.sum" }}
       - check-changed-files-or-halt
       - run: ./scripts/make_docs.sh
       - run: 'make deps'
@@ -208,7 +208,7 @@ jobs:
       - test-go
       - save_cache:
           name: "Save Go caches"
-          key: linux-amd64-go-cache-v1-{{ checksum "go.sum" }}
+          key: linux-amd64-go<< parameters.goversion >>-v1-{{ checksum "go.sum" }}
           paths:
             - '/go/pkg/mod'
             - '~/.cache/golangci-lint'
@@ -223,7 +223,7 @@ jobs:
       - checkout
       - restore_cache:
           name: "Restore Go caches"
-          key: linux-386-go-cache-v1-{{ checksum "go.sum" }}
+          key: linux-386-go<< parameters.goversion >>-cache-v1-{{ checksum "go.sum" }}
       - check-changed-files-or-halt
       - run: 'GOARCH=386 make deps'
       - run: 'GOARCH=386 make tidy'
@@ -232,7 +232,7 @@ jobs:
           arch: "386"
       - save_cache:
           name: "Save Go caches"
-          key: linux-386-go-cache-v1-{{ checksum "go.sum" }}
+          key: linux-386-go<< parameters.goversion >>-cache-v1-{{ checksum "go.sum" }}
           paths:
             - '/go/pkg/mod'
             - '~/.cache/golangci-lint'
@@ -253,12 +253,12 @@ jobs:
       - checkout
       - restore_cache:
           name: "Restore Go caches"
-          key: darwin-amd64-go-cache-v1-{{ checksum "go.sum" }}
+          key: darwin-amd64-go<< parameters.goversion >>-cache-v1-{{ checksum "go.sum" }}
       - test-go:
           os: darwin
       - save_cache:
           name: "Save Go caches"
-          key: darwin-amd64-go-cache-v1-{{ checksum "go.sum" }}
+          key: darwin-amd64-go<< parameters.goversion >>-cache-v1-{{ checksum "go.sum" }}
           paths:
             - '~/go/pkg/mod'
             - '~/Library/Caches/golangci-lint'
@@ -272,13 +272,13 @@ jobs:
       - checkout
       - restore_cache:
           name: "Restore Go caches"
-          key: windows-amd64-go-cache-v1-{{ checksum "go.sum" }}
+          key: windows-amd64-go<< parameters.goversion >>-cache-v1-{{ checksum "go.sum" }}
       - test-go:
           os: windows
           gotestsum: "gotestsum.exe"
       - save_cache:
           name: "Save Go caches"
-          key: windows-amd64-go-cache-v1-{{ checksum "go.sum" }}
+          key: windows-amd64-go<< parameters.goversion >>-cache-v1-{{ checksum "go.sum" }}
           paths:
             - '~\go\pkg\mod'
             - '~\AppData\Local\golangci-lint'
@@ -290,13 +290,13 @@ jobs:
       - checkout
       - restore_cache:
           name: "Restore Go caches"
-          key: linux-amd64-go-cache-v1-{{ checksum "go.sum" }}
+          key: linux-amd64-go<< parameters.goversion >>-cache-v1-{{ checksum "go.sum" }}
       - check-changed-files-or-halt
       - run: 'make build_tools'
       - run: './tools/license_checker/license_checker -whitelist ./tools/license_checker/data/whitelist'
       - save_cache:
           name: "Save Go caches"
-          key: linux-amd64-go-cache-v1-{{ checksum "go.sum" }}
+          key: linux-amd64-go<< parameters.goversion >>-cache-v1-{{ checksum "go.sum" }}
           paths:
             - '/go/pkg/mod'
             - '~/.cache/golangci-lint'

--- a/tools/update_goversion/main.go
+++ b/tools/update_goversion/main.go
@@ -151,7 +151,7 @@ func main() {
 		},
 		{
 			FileName: ".circleci/config.yml",
-			Regex:    `(default): "(\d.\d*.\d)"`,
+			Regex:    `(default): (\d.\d*.\d)`,
 			Replace:  fmt.Sprintf("$1: %s", version),
 		},
 		{


### PR DESCRIPTION
Ensures that all cache restore and save include the specific go version that we are on. Additionally, because some were updated, but not all, this updates the version to v2.