### PR TITLE
feat(prometheus): Allow to specify metric type

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/influxdata/telegraf/plugins/processors"
 	"github.com/influxdata/telegraf/plugins/serializers"
 	_ "github.com/influxdata/telegraf/plugins/serializers/all" // Blank import to have all serializers for testing
+	promserializer "github.com/influxdata/telegraf/plugins/serializers/prometheus"
 	"github.com/influxdata/telegraf/testutil"
 )
 
@@ -612,6 +613,7 @@ func TestConfig_SerializerInterfaceNewFormat(t *testing.T) {
 		// Ignore all unexported fields and fields not relevant for functionality
 		options := []cmp.Option{
 			cmpopts.IgnoreUnexported(stype),
+			cmpopts.IgnoreUnexported(reflect.Indirect(reflect.ValueOf(promserializer.MetricTypes{})).Interface()),
 			cmpopts.IgnoreTypes(sync.Mutex{}, regexp.Regexp{}),
 			cmpopts.IgnoreInterfaces(struct{ telegraf.Logger }{}),
 		}
@@ -703,6 +705,7 @@ func TestConfig_SerializerInterfaceOldFormat(t *testing.T) {
 		// Ignore all unexported fields and fields not relevant for functionality
 		options := []cmp.Option{
 			cmpopts.IgnoreUnexported(stype),
+			cmpopts.IgnoreUnexported(reflect.Indirect(reflect.ValueOf(promserializer.MetricTypes{})).Interface()),
 			cmpopts.IgnoreTypes(sync.Mutex{}, regexp.Regexp{}),
 			cmpopts.IgnoreInterfaces(struct{ telegraf.Logger }{}),
 		}

--- a/plugins/outputs/prometheus_client/README.md
+++ b/plugins/outputs/prometheus_client/README.md
@@ -62,6 +62,12 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
   ## Export metric collection time.
   # export_timestamp = false
+
+  ## Specify the metric type explicitly.
+  ## This overrides the metric-type of the Telegraf metric. Globbing is allowed.
+  # [outputs.file.prometheus_metric_types]
+  #   counter = []
+  #   gauge = []
 ```
 
 ## Metrics

--- a/plugins/outputs/prometheus_client/README.md
+++ b/plugins/outputs/prometheus_client/README.md
@@ -65,7 +65,7 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
   ## Specify the metric type explicitly.
   ## This overrides the metric-type of the Telegraf metric. Globbing is allowed.
-  # [outputs.file.prometheus_metric_types]
+  # [outputs.prometheus_client.prometheus_metric_types]
   #   counter = []
   #   gauge = []
 ```

--- a/plugins/outputs/prometheus_client/prometheus_client.go
+++ b/plugins/outputs/prometheus_client/prometheus_client.go
@@ -23,6 +23,7 @@ import (
 	"github.com/influxdata/telegraf/plugins/outputs"
 	v1 "github.com/influxdata/telegraf/plugins/outputs/prometheus_client/v1"
 	v2 "github.com/influxdata/telegraf/plugins/outputs/prometheus_client/v2"
+	serializer "github.com/influxdata/telegraf/plugins/serializers/prometheus"
 )
 
 //go:embed sample.conf
@@ -43,18 +44,19 @@ type Collector interface {
 }
 
 type PrometheusClient struct {
-	Listen             string          `toml:"listen"`
-	ReadTimeout        config.Duration `toml:"read_timeout"`
-	WriteTimeout       config.Duration `toml:"write_timeout"`
-	MetricVersion      int             `toml:"metric_version"`
-	BasicUsername      string          `toml:"basic_username"`
-	BasicPassword      string          `toml:"basic_password"`
-	IPRange            []string        `toml:"ip_range"`
-	ExpirationInterval config.Duration `toml:"expiration_interval"`
-	Path               string          `toml:"path"`
-	CollectorsExclude  []string        `toml:"collectors_exclude"`
-	StringAsLabel      bool            `toml:"string_as_label"`
-	ExportTimestamp    bool            `toml:"export_timestamp"`
+	Listen             string                 `toml:"listen"`
+	ReadTimeout        config.Duration        `toml:"read_timeout"`
+	WriteTimeout       config.Duration        `toml:"write_timeout"`
+	MetricVersion      int                    `toml:"metric_version"`
+	BasicUsername      string                 `toml:"basic_username"`
+	BasicPassword      string                 `toml:"basic_password"`
+	IPRange            []string               `toml:"ip_range"`
+	ExpirationInterval config.Duration        `toml:"expiration_interval"`
+	Path               string                 `toml:"path"`
+	CollectorsExclude  []string               `toml:"collectors_exclude"`
+	StringAsLabel      bool                   `toml:"string_as_label"`
+	ExportTimestamp    bool                   `toml:"export_timestamp"`
+	TypeMappings       serializer.MetricTypes `toml:"metric_types"`
 	tlsint.ServerConfig
 
 	Log telegraf.Logger `toml:"-"`
@@ -96,17 +98,32 @@ func (p *PrometheusClient) Init() error {
 		}
 	}
 
+	if err := p.TypeMappings.Init(); err != nil {
+		return err
+	}
+
 	switch p.MetricVersion {
 	default:
 		fallthrough
 	case 1:
-		p.collector = v1.NewCollector(time.Duration(p.ExpirationInterval), p.StringAsLabel, p.ExportTimestamp, p.Log)
+		p.collector = v1.NewCollector(
+			time.Duration(p.ExpirationInterval),
+			p.StringAsLabel,
+			p.ExportTimestamp,
+			p.TypeMappings,
+			p.Log,
+		)
 		err := registry.Register(p.collector)
 		if err != nil {
 			return err
 		}
 	case 2:
-		p.collector = v2.NewCollector(time.Duration(p.ExpirationInterval), p.StringAsLabel, p.ExportTimestamp)
+		p.collector = v2.NewCollector(
+			time.Duration(p.ExpirationInterval),
+			p.StringAsLabel,
+			p.ExportTimestamp,
+			p.TypeMappings,
+		)
 		err := registry.Register(p.collector)
 		if err != nil {
 			return err

--- a/plugins/outputs/prometheus_client/prometheus_client_v2_test.go
+++ b/plugins/outputs/prometheus_client/prometheus_client_v2_test.go
@@ -331,7 +331,7 @@ cpu_time_idle{host="example.org"} 42
 `),
 		},
 		{
-			name: "untyped forced to counter",
+			name: "untyped forced to gauge",
 			output: &PrometheusClient{
 				Listen:            ":0",
 				MetricVersion:     2,

--- a/plugins/outputs/prometheus_client/sample.conf
+++ b/plugins/outputs/prometheus_client/sample.conf
@@ -48,6 +48,6 @@
 
   ## Specify the metric type explicitly.
   ## This overrides the metric-type of the Telegraf metric. Globbing is allowed.
-  # [outputs.file.prometheus_metric_types]
+  # [outputs.prometheus_client.prometheus_metric_types]
   #   counter = []
   #   gauge = []

--- a/plugins/outputs/prometheus_client/sample.conf
+++ b/plugins/outputs/prometheus_client/sample.conf
@@ -45,3 +45,9 @@
 
   ## Export metric collection time.
   # export_timestamp = false
+
+  ## Specify the metric type explicitly.
+  ## This overrides the metric-type of the Telegraf metric. Globbing is allowed.
+  # [outputs.file.prometheus_metric_types]
+  #   counter = []
+  #   gauge = []

--- a/plugins/outputs/prometheus_client/v2/collector.go
+++ b/plugins/outputs/prometheus_client/v2/collector.go
@@ -43,10 +43,16 @@ type Collector struct {
 	coll           *serializer.Collection
 }
 
-func NewCollector(expire time.Duration, stringsAsLabel bool, exportTimestamp bool) *Collector {
+func NewCollector(
+	expire time.Duration,
+	stringsAsLabel bool,
+	exportTimestamp bool,
+	typeMapping serializer.MetricTypes,
+) *Collector {
 	cfg := serializer.FormatConfig{
 		StringAsLabel:   stringsAsLabel,
 		ExportTimestamp: exportTimestamp,
+		TypeMappings:    typeMapping,
 	}
 
 	return &Collector{

--- a/plugins/serializers/prometheus/README.md
+++ b/plugins/serializers/prometheus/README.md
@@ -40,6 +40,12 @@ reporting others every bucket/quantile will continue to exist.
   ## more about them here:
   ##   https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_INPUT.md
   data_format = "prometheus"
+
+  ## Specify the metric type explicitly.
+  ## This overrides the metric-type of the Telegraf metric. Globbing is allowed.
+  [outputs.file.prometheus_metric_types]
+    counter = []
+    gauge = []
 ```
 
 ### Metrics

--- a/plugins/serializers/prometheus/collection.go
+++ b/plugins/serializers/prometheus/collection.go
@@ -188,10 +188,11 @@ func (c *Collection) Add(metric telegraf.Metric, now time.Time) {
 		if !ok {
 			continue
 		}
+		metricType := c.config.TypeMappings.DetermineType(metricName, metric)
 
 		family := MetricFamily{
 			Name: metricName,
-			Type: metric.Type(),
+			Type: metricType,
 		}
 
 		entry, ok := c.Entries[family]

--- a/plugins/serializers/prometheus/prometheus.go
+++ b/plugins/serializers/prometheus/prometheus.go
@@ -2,13 +2,48 @@ package prometheus
 
 import (
 	"bytes"
+	"fmt"
 	"time"
 
 	"github.com/prometheus/common/expfmt"
 
 	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/filter"
 	"github.com/influxdata/telegraf/plugins/serializers"
 )
+
+type MetricTypes struct {
+	Counter []string `toml:"counter"`
+	Gauge   []string `toml:"gauge"`
+
+	filterCounter filter.Filter
+	filterGauge   filter.Filter
+}
+
+func (mt *MetricTypes) Init() error {
+	// Setup the explicit type mappings
+	var err error
+	mt.filterCounter, err = filter.Compile(mt.Counter)
+	if err != nil {
+		return fmt.Errorf("creating counter filter failed: %w", err)
+	}
+	mt.filterGauge, err = filter.Compile(mt.Gauge)
+	if err != nil {
+		return fmt.Errorf("creating gauge filter failed: %w", err)
+	}
+	return nil
+}
+
+func (mt *MetricTypes) DetermineType(name string, m telegraf.Metric) telegraf.ValueType {
+	metricType := m.Type()
+	if mt.filterCounter != nil && mt.filterCounter.Match(name) {
+		metricType = telegraf.Counter
+	}
+	if mt.filterGauge != nil && mt.filterGauge.Match(name) {
+		metricType = telegraf.Gauge
+	}
+	return metricType
+}
 
 type FormatConfig struct {
 	ExportTimestamp bool `toml:"prometheus_export_timestamp"`
@@ -17,11 +52,16 @@ type FormatConfig struct {
 	// CompactEncoding defines whether to include
 	// HELP metadata in Prometheus payload. Setting to true
 	// helps to reduce payload size.
-	CompactEncoding bool `toml:"prometheus_compact_encoding"`
+	CompactEncoding bool        `toml:"prometheus_compact_encoding"`
+	TypeMappings    MetricTypes `toml:"prometheus_metric_types"`
 }
 
 type Serializer struct {
 	FormatConfig
+}
+
+func (s *Serializer) Init() error {
+	return s.FormatConfig.TypeMappings.Init()
 }
 
 func (s *Serializer) Serialize(metric telegraf.Metric) ([]byte, error) {


### PR DESCRIPTION
- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #13844 
resolves #13079

This PR allows to explicitly set the metric type for the prometheus serializer and the `prometheus_client` output plugin. This is required as a large number of plugins will not or cannot type Telegraf metrics but prometheus uses those types.