### PR TITLE
fix(outputs.sql): Move 'conversion_style' option to the right place

### DIFF
--- a/plugins/outputs/sql/README.md
+++ b/plugins/outputs/sql/README.md
@@ -106,13 +106,6 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## Initialization SQL
   # init_sql = ""
 
-  ## This setting controls the behavior of the unsigned value. By default the
-  ## setting will take the integer value and append the unsigned value to it. The other
-  ## option is "literal", which will use the actual value the user provides to
-  ## the unsigned option. This is useful for a database like ClickHouse where
-  ## the unsigned value should use a value like "uint64".
-  # conversion_style = "unsigned_suffix"
-
   ## Maximum amount of time a connection may be idle. "0s" means connections are
   ## never closed due to idle time.
   # connection_max_idle_time = "0s"
@@ -147,6 +140,12 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   #  defaultvalue         = "TEXT"
   #  unsigned             = "UNSIGNED"
   #  bool                 = "BOOL"
+  #  ## This setting controls the behavior of the unsigned value. By default the
+  #  ## setting will take the integer value and append the unsigned value to it. The other
+  #  ## option is "literal", which will use the actual value the user provides to
+  #  ## the unsigned option. This is useful for a database like ClickHouse where
+  #  ## the unsigned value should use a value like "uint64".
+  #  # conversion_style = "unsigned_suffix"
 ```
 
 ## Driver-specific information

--- a/plugins/outputs/sql/sample.conf
+++ b/plugins/outputs/sql/sample.conf
@@ -28,13 +28,6 @@
   ## Initialization SQL
   # init_sql = ""
 
-  ## This setting controls the behavior of the unsigned value. By default the
-  ## setting will take the integer value and append the unsigned value to it. The other
-  ## option is "literal", which will use the actual value the user provides to
-  ## the unsigned option. This is useful for a database like ClickHouse where
-  ## the unsigned value should use a value like "uint64".
-  # conversion_style = "unsigned_suffix"
-
   ## Maximum amount of time a connection may be idle. "0s" means connections are
   ## never closed due to idle time.
   # connection_max_idle_time = "0s"
@@ -69,3 +62,9 @@
   #  defaultvalue         = "TEXT"
   #  unsigned             = "UNSIGNED"
   #  bool                 = "BOOL"
+  #  ## This setting controls the behavior of the unsigned value. By default the
+  #  ## setting will take the integer value and append the unsigned value to it. The other
+  #  ## option is "literal", which will use the actual value the user provides to
+  #  ## the unsigned option. This is useful for a database like ClickHouse where
+  #  ## the unsigned value should use a value like "uint64".
+  #  # conversion_style = "unsigned_suffix"

--- a/plugins/outputs/sql/sql.go
+++ b/plugins/outputs/sql/sql.go
@@ -24,31 +24,31 @@ import (
 var sampleConfig string
 
 type ConvertStruct struct {
-	Integer         string
-	Real            string
-	Text            string
-	Timestamp       string
-	Defaultvalue    string
-	Unsigned        string
-	Bool            string
-	ConversionStyle string
+	Integer         string `toml:"integer"`
+	Real            string `toml:"real"`
+	Text            string `toml:"text"`
+	Timestamp       string `toml:"timestamp"`
+	Defaultvalue    string `toml:"defaultvalue"`
+	Unsigned        string `toml:"unsigned"`
+	Bool            string `toml:"bool"`
+	ConversionStyle string `toml:"conversion_style"`
 }
 
 type SQL struct {
-	Driver                string
-	DataSourceName        string
-	TimestampColumn       string
-	TableTemplate         string
-	TableExistsTemplate   string
-	InitSQL               string `toml:"init_sql"`
-	Convert               ConvertStruct
-	ConnectionMaxIdleTime config.Duration
-	ConnectionMaxLifetime config.Duration
-	ConnectionMaxIdle     int
-	ConnectionMaxOpen     int
+	Driver                string          `toml:"driver"`
+	DataSourceName        string          `toml:"data_source_name"`
+	TimestampColumn       string          `toml:"timestamp_column"`
+	TableTemplate         string          `toml:"table_template"`
+	TableExistsTemplate   string          `toml:"table_exists_template"`
+	InitSQL               string          `toml:"init_sql"`
+	Convert               ConvertStruct   `toml:"convert"`
+	ConnectionMaxIdleTime config.Duration `toml:"connection_max_idle_time"`
+	ConnectionMaxLifetime config.Duration `toml:"connection_max_lifetime"`
+	ConnectionMaxIdle     int             `toml:"connection_max_idle"`
+	ConnectionMaxOpen     int             `toml:"connection_max_open"`
+	Log                   telegraf.Logger `toml:"-"`
 
 	db     *gosql.DB
-	Log    telegraf.Logger `toml:"-"`
 	tables map[string]bool
 }
 


### PR DESCRIPTION
- [x] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #13869 

This PR fixes the location of the `conversion_style` option which really belongs to the `convert` table. Furthermore, we add the TOML tags for all settings.