### PR TITLE
chore: Force reinstall of go on Windows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,11 +61,7 @@ commands:
           condition:
             equal: [ windows, << parameters.os >> ]
           steps:
-            - run: rm -rf /c/Go
-            - run: rm -rf '/c/Program Files/Go'
-            - run: choco feature enable -n allowGlobalConfirmation
             - run: 'sh ./scripts/installgo_windows.sh'
-            - run: choco install mingw
       - run: go env
       - run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.54.2
       - when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,6 @@ commands:
           condition:
             equal: [ windows, << parameters.os >> ]
           steps:
-            - run: rm -rf '/c/Program Files/Go'
             - run: choco feature enable -n allowGlobalConfirmation
             - run: 'sh ./scripts/installgo_windows.sh'
             - run: choco install mingw

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,6 +90,7 @@ commands:
           condition:
             equal: [ windows, << parameters.os >> ]
           steps:
+            - run: rm -rf /c/Go
             - run:
                 name: golangci-lint cache status
                 command: $HOME/go/bin/golangci-lint.exe cache status

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ commands:
         default: "gotestsum"
       cache_version:
         type: string
-        default: "v3"
+        default: "v2"
       goversion:
         type: string
         default: 1.21.0
@@ -61,6 +61,7 @@ commands:
           condition:
             equal: [ windows, << parameters.os >> ]
           steps:
+            - run: rm -rf '/c/Program Files/Go'
             - run: choco feature enable -n allowGlobalConfirmation
             - run: 'sh ./scripts/installgo_windows.sh'
             - run: choco install mingw
@@ -200,7 +201,7 @@ jobs:
         default: 1.21.0
       cache_version:
         type: string
-        default: "v3"
+        default: "v2"
     steps:
       - checkout
       - restore_cache:
@@ -232,7 +233,7 @@ jobs:
         default: 1.21.0
       cache_version:
         type: string
-        default: "v3"
+        default: "v2"
     steps:
       - checkout
       - restore_cache:
@@ -269,7 +270,7 @@ jobs:
         default: 1.21.0
       cache_version:
         type: string
-        default: "v3"
+        default: "v2"
     steps:
       - checkout
       - restore_cache:
@@ -291,7 +292,7 @@ jobs:
         default: 1.21.0
       cache_version:
         type: string
-        default: "v3"
+        default: "v2"
     executor:
         name: win/default
         shell: bash.exe
@@ -320,7 +321,7 @@ jobs:
         default: 1.21.0
       cache_version:
         type: string
-        default: "v3"
+        default: "v2"
     steps:
       - checkout
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,6 +61,8 @@ commands:
           condition:
             equal: [ windows, << parameters.os >> ]
           steps:
+            - run: rm -rf /c/Go
+            - run: rm -rf /c/Program\ Files/Go'
             - run: choco feature enable -n allowGlobalConfirmation
             - run: 'sh ./scripts/installgo_windows.sh'
             - run: choco install mingw
@@ -90,7 +92,6 @@ commands:
           condition:
             equal: [ windows, << parameters.os >> ]
           steps:
-            - run: rm -rf /c/Go
             - run:
                 name: golangci-lint cache status
                 command: $HOME/go/bin/golangci-lint.exe cache status

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,10 @@ commands:
           condition:
             equal: [ windows, << parameters.os >> ]
           steps:
+            - run: rm -rf '/c/Program Files/Go'
+            - run: choco feature enable -n allowGlobalConfirmation
             - run: 'sh ./scripts/installgo_windows.sh'
+            - run: choco install mingw
       - run: go env
       - run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.54.2
       - when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ commands:
         default: "gotestsum"
       cache_version:
         type: string
-        default: "v2"
+        default: "v3"
       goversion:
         type: string
         default: 1.21.0
@@ -198,11 +198,14 @@ jobs:
       goversion:
         type: string
         default: 1.21.0
+      cache_version:
+        type: string
+        default: "v3"
     steps:
       - checkout
       - restore_cache:
           name: "Restore Go caches"
-          key: linux-amd64-go<< parameters.goversion >>-cache-v2-{{ checksum "go.sum" }}
+          key: linux-amd64-go<< parameters.goversion >>-cache-<< parameters.cache_version >>-{{ checksum "go.sum" }}
       - check-changed-files-or-halt
       - run: ./scripts/make_docs.sh
       - run: 'make deps'
@@ -212,7 +215,7 @@ jobs:
       - test-go
       - save_cache:
           name: "Save Go caches"
-          key: linux-amd64-go<< parameters.goversion >>-v2-{{ checksum "go.sum" }}
+          key: linux-amd64-go<< parameters.goversion >>-<< parameters.cache_version >>-{{ checksum "go.sum" }}
           paths:
             - '/go/pkg/mod'
             - '~/.cache/golangci-lint'
@@ -227,11 +230,14 @@ jobs:
       goversion:
         type: string
         default: 1.21.0
+      cache_version:
+        type: string
+        default: "v3"
     steps:
       - checkout
       - restore_cache:
           name: "Restore Go caches"
-          key: linux-386-go<< parameters.goversion >>-cache-v2-{{ checksum "go.sum" }}
+          key: linux-386-go<< parameters.goversion >>-cache-<< parameters.cache_version >>-{{ checksum "go.sum" }}
       - check-changed-files-or-halt
       - run: 'GOARCH=386 make deps'
       - run: 'GOARCH=386 make tidy'
@@ -240,7 +246,7 @@ jobs:
           arch: "386"
       - save_cache:
           name: "Save Go caches"
-          key: linux-386-go<< parameters.goversion >>-cache-v2-{{ checksum "go.sum" }}
+          key: linux-386-go<< parameters.goversion >>-cache-<< parameters.cache_version >>-{{ checksum "go.sum" }}
           paths:
             - '/go/pkg/mod'
             - '~/.cache/golangci-lint'
@@ -261,16 +267,19 @@ jobs:
       goversion:
         type: string
         default: 1.21.0
+      cache_version:
+        type: string
+        default: "v3"
     steps:
       - checkout
       - restore_cache:
           name: "Restore Go caches"
-          key: darwin-amd64-go<< parameters.goversion >>-cache-v2-{{ checksum "go.sum" }}
+          key: darwin-amd64-go<< parameters.goversion >>-cache-<< parameters.cache_version >>-{{ checksum "go.sum" }}
       - test-go:
           os: darwin
       - save_cache:
           name: "Save Go caches"
-          key: darwin-amd64-go<< parameters.goversion >>-cache-v2-{{ checksum "go.sum" }}
+          key: darwin-amd64-go<< parameters.goversion >>-cache-<< parameters.cache_version >>-{{ checksum "go.sum" }}
           paths:
             - '~/go/pkg/mod'
             - '~/Library/Caches/golangci-lint'
@@ -280,6 +289,9 @@ jobs:
       goversion:
         type: string
         default: 1.21.0
+      cache_version:
+        type: string
+        default: "v3"
     executor:
         name: win/default
         shell: bash.exe
@@ -288,13 +300,13 @@ jobs:
       - checkout
       - restore_cache:
           name: "Restore Go caches"
-          key: windows-amd64-go<< parameters.goversion >>-cache-v2-{{ checksum "go.sum" }}
+          key: windows-amd64-go<< parameters.goversion >>-cache-<< parameters.cache_version >>-{{ checksum "go.sum" }}
       - test-go:
           os: windows
           gotestsum: "gotestsum.exe"
       - save_cache:
           name: "Save Go caches"
-          key: windows-amd64-go<< parameters.goversion >>-cache-v2-{{ checksum "go.sum" }}
+          key: windows-amd64-go<< parameters.goversion >>-cache-<< parameters.cache_version >>-{{ checksum "go.sum" }}
           paths:
             - '~\go\pkg\mod'
             - '~\AppData\Local\golangci-lint'
@@ -306,17 +318,20 @@ jobs:
       goversion:
         type: string
         default: 1.21.0
+      cache_version:
+        type: string
+        default: "v3"
     steps:
       - checkout
       - restore_cache:
           name: "Restore Go caches"
-          key: linux-amd64-go<< parameters.goversion >>-cache-v2-{{ checksum "go.sum" }}
+          key: linux-amd64-go<< parameters.goversion >>-cache-<< parameters.cache_version >>-{{ checksum "go.sum" }}
       - check-changed-files-or-halt
       - run: 'make build_tools'
       - run: './tools/license_checker/license_checker -whitelist ./tools/license_checker/data/whitelist'
       - save_cache:
           name: "Save Go caches"
-          key: linux-amd64-go<< parameters.goversion >>-cache-v2-{{ checksum "go.sum" }}
+          key: linux-amd64-go<< parameters.goversion >>-cache-<< parameters.cache_version >>-{{ checksum "go.sum" }}
           paths:
             - '/go/pkg/mod'
             - '~/.cache/golangci-lint'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ commands:
             equal: [ windows, << parameters.os >> ]
           steps:
             - run: rm -rf /c/Go
-            - run: rm -rf /c/Program\ Files/Go'
+            - run: rm -rf '/c/Program Files/Go'
             - run: choco feature enable -n allowGlobalConfirmation
             - run: 'sh ./scripts/installgo_windows.sh'
             - run: choco install mingw

--- a/scripts/installgo_windows.sh
+++ b/scripts/installgo_windows.sh
@@ -5,14 +5,17 @@ set -eux
 GO_VERSION="1.21.0"
 
 setup_go () {
+    rm -rf '/c/Program Files/Go'
+    choco feature enable -n allowGlobalConfirmation
     choco upgrade golang --allow-downgrade --version=${GO_VERSION}
-    choco install make
+    choco install make mingw
     git config --system core.longpaths true
 }
 
 if command -v go >/dev/null 2>&1; then
     echo "Go is already installed"
     v=$(go version | { read -r _ _ v _; echo "${v#go}"; })
+    which go
     echo "$v is installed, required version is ${GO_VERSION}"
     if [ "$v" != ${GO_VERSION} ]; then
         setup_go

--- a/scripts/installgo_windows.sh
+++ b/scripts/installgo_windows.sh
@@ -14,8 +14,6 @@ setup_go () {
 if command -v go >/dev/null 2>&1; then
     echo "Go is already installed"
     v=$(go version | { read -r _ _ v _; echo "${v#go}"; })
-    which go
-    go env
     echo "$v is installed, required version is ${GO_VERSION}"
     if [ "$v" != ${GO_VERSION} ]; then
         setup_go

--- a/scripts/installgo_windows.sh
+++ b/scripts/installgo_windows.sh
@@ -6,9 +6,8 @@ GO_VERSION="1.21.0"
 
 setup_go () {
     rm -rf '/c/Program Files/Go'
-    choco feature enable -n allowGlobalConfirmation
     choco upgrade golang --allow-downgrade --version=${GO_VERSION}
-    choco install make mingw
+    choco install make
     git config --system core.longpaths true
 }
 
@@ -16,6 +15,7 @@ if command -v go >/dev/null 2>&1; then
     echo "Go is already installed"
     v=$(go version | { read -r _ _ v _; echo "${v#go}"; })
     which go
+    go env
     echo "$v is installed, required version is ${GO_VERSION}"
     if [ "$v" != ${GO_VERSION} ]; then
         setup_go


### PR DESCRIPTION
This PR forcefully deletes the cached go versions and thus forces a reinstall. This is the only way currently to avoid errors in combination with go 1.21 and golint-ci.