### PR TITLE
docs: Improve behavior documentation of metricpass

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -661,11 +661,11 @@ for time-based filtering. An introduction to the CEL language can be found
 are provided in the [language definition][CEL lang] as well as in the
 [extension documentation][CEL ext].
 
-**Caution** - Errorhandling: Sometimes an expression can be compiled
-but failes at runtime. One example for this is to try to read a non
-existing field. If this happens, the evaluation is aborted, an error
-is logged and the expression is reported to be `true`, so the metric
-passes.
+**NOTE:** Expressions that may be valid and compile, but fail at runtime will
+result in the expression reporting as `true`. The metrics will pass through
+as a result. An example is when reading a non-existing field. If this happens,
+the evaluation is aborted, an error is logged, and the expression is reported as
+`true`, so the metric passes.
 
 > NOTE: As CEL is an *interpreted* languguage, this type of filtering is much
 > slower compared to `namepass`/`namedrop` and friends. So consider to use the

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -661,6 +661,12 @@ for time-based filtering. An introduction to the CEL language can be found
 are provided in the [language definition][CEL lang] as well as in the
 [extension documentation][CEL ext].
 
+**Caution** - Errorhandling: Sometimes an expression can be compiled
+but failed at runtime. One example for this is to try to read a non
+existing field. If this happens, the evaluation is aborted, an error
+is logged and the expression is reported to be `true`, so the metric
+passes.
+
 > NOTE: As CEL is an *interpreted* languguage, this type of filtering is much
 > slower compared to `namepass`/`namedrop` and friends. So consider to use the
 > more restricted filter options where possible in case of high-throughput

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -662,7 +662,7 @@ are provided in the [language definition][CEL lang] as well as in the
 [extension documentation][CEL ext].
 
 **Caution** - Errorhandling: Sometimes an expression can be compiled
-but failed at runtime. One example for this is to try to read a non
+but failes at runtime. One example for this is to try to read a non
 existing field. If this happens, the evaluation is aborted, an error
 is logged and the expression is reported to be `true`, so the metric
 passes.


### PR DESCRIPTION
Add note about failing `metricpass` expressions being valued as true

resolves #13815

