### PR TITLE
fix(rpm): Resolve nightly rpm tests

### DIFF
--- a/scripts/rpm/post-install.sh
+++ b/scripts/rpm/post-install.sh
@@ -20,7 +20,8 @@ if [[ ! -d /etc/telegraf/telegraf.d ]]; then
 fi
 
 # If 'telegraf.conf' is not present use package's sample (fresh install)
-if [[ ! -f /etc/telegraf/telegraf.conf.rpmnew ]] && [[ ! -f /etc/telegraf/telegraf.conf.rpmsave ]] &&[[ -f /etc/telegraf/telegraf.conf.sample ]]; then
+if [[ ! -f /etc/telegraf/telegraf.conf ]] && [[ ! -f /etc/telegraf/telegraf.conf.rpmnew ]] &&
+    [[ ! -f /etc/telegraf/telegraf.conf.rpmsave ]] && [[ -f /etc/telegraf/telegraf.conf.sample ]]; then
    cp /etc/telegraf/telegraf.conf.sample /etc/telegraf/telegraf.conf
    chmod 640 /etc/telegraf/telegraf.conf
    chmod 750 /etc/telegraf/telegraf.d

--- a/scripts/rpm/post-install.sh
+++ b/scripts/rpm/post-install.sh
@@ -20,7 +20,7 @@ if [[ ! -d /etc/telegraf/telegraf.d ]]; then
 fi
 
 # If 'telegraf.conf' is not present use package's sample (fresh install)
-if [[ ! -f /etc/telegraf/telegraf.conf ]] && [[ -f /etc/telegraf/telegraf.conf.sample ]]; then
+if [[ ! -f /etc/telegraf/telegraf.conf.rpmnew ]] && [[ ! -f /etc/telegraf/telegraf.conf.rpmsave ]] &&[[ -f /etc/telegraf/telegraf.conf.sample ]]; then
    cp /etc/telegraf/telegraf.conf.sample /etc/telegraf/telegraf.conf
    chmod 640 /etc/telegraf/telegraf.conf
    chmod 750 /etc/telegraf/telegraf.d

--- a/tools/package_lxd_test/container.go
+++ b/tools/package_lxd_test/container.go
@@ -107,6 +107,17 @@ func (c *Container) CheckStatus(serviceName string) error {
 		return err
 	}
 
+	err = c.client.Exec(
+		c.Name,
+		"bash",
+		"-c",
+		"--",
+		"ls -la /etc/telegraf/",
+	)
+	if err != nil {
+		return err
+	}
+
 	err = c.client.Exec(c.Name, "systemctl", "start", serviceName)
 	if err != nil {
 		_ = c.client.Exec(c.Name, "systemctl", "status", serviceName)

--- a/tools/package_lxd_test/main.go
+++ b/tools/package_lxd_test/main.go
@@ -36,6 +36,7 @@ func main() {
 				Name:        "package",
 				Usage:       ".deb or .rpm file for upgrade testing",
 				Destination: &packageFile,
+				Required:    true,
 			},
 			&cli.StringFlag{
 				Name:        "image",
@@ -44,6 +45,10 @@ func main() {
 			},
 		},
 		Action: func(c *cli.Context) error {
+			if _, err := os.Stat(packageFile); err != nil {
+				return fmt.Errorf("unknown package file: %w", err)
+			}
+
 			if image != "" && packageFile != "" {
 				fmt.Printf("test package %q on image %q\n", packageFile, image)
 				return launchTests(packageFile, []string{image})
@@ -61,7 +66,7 @@ func main() {
 				}
 			}
 
-			return fmt.Errorf("please provide at least a package to test")
+			return nil
 		},
 	}
 


### PR DESCRIPTION
Fixes the check for permissions and update the test CLI to require the package parameter and verify that the package is real.
