### PR TITLE
fix(inputs.kafka_consumer): Use per-message parser to avoid races

### DIFF
--- a/plugins/inputs/kafka_consumer/kafka_consumer_test.go
+++ b/plugins/inputs/kafka_consumer/kafka_consumer_test.go
@@ -293,12 +293,16 @@ func (c *FakeConsumerGroupClaim) Messages() <-chan *sarama.ConsumerMessage {
 
 func TestConsumerGroupHandler_Lifecycle(t *testing.T) {
 	acc := &testutil.Accumulator{}
-	parser := value.Parser{
-		MetricName: "cpu",
-		DataType:   "int",
+
+	parserFunc := func() (telegraf.Parser, error) {
+		parser := &value.Parser{
+			MetricName: "cpu",
+			DataType:   "int",
+		}
+		err := parser.Init()
+		return parser, err
 	}
-	require.NoError(t, parser.Init())
-	cg := NewConsumerGroupHandler(acc, 1, &parser, testutil.Logger{})
+	cg := NewConsumerGroupHandler(acc, 1, parserFunc, testutil.Logger{})
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -326,12 +330,15 @@ func TestConsumerGroupHandler_Lifecycle(t *testing.T) {
 
 func TestConsumerGroupHandler_ConsumeClaim(t *testing.T) {
 	acc := &testutil.Accumulator{}
-	parser := value.Parser{
-		MetricName: "cpu",
-		DataType:   "int",
+	parserFunc := func() (telegraf.Parser, error) {
+		parser := &value.Parser{
+			MetricName: "cpu",
+			DataType:   "int",
+		}
+		err := parser.Init()
+		return parser, err
 	}
-	require.NoError(t, parser.Init())
-	cg := NewConsumerGroupHandler(acc, 1, &parser, testutil.Logger{})
+	cg := NewConsumerGroupHandler(acc, 1, parserFunc, testutil.Logger{})
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -444,12 +451,15 @@ func TestConsumerGroupHandler_Handle(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			acc := &testutil.Accumulator{}
-			parser := value.Parser{
-				MetricName: "cpu",
-				DataType:   "int",
+			parserFunc := func() (telegraf.Parser, error) {
+				parser := &value.Parser{
+					MetricName: "cpu",
+					DataType:   "int",
+				}
+				err := parser.Init()
+				return parser, err
 			}
-			require.NoError(t, parser.Init())
-			cg := NewConsumerGroupHandler(acc, 1, &parser, testutil.Logger{})
+			cg := NewConsumerGroupHandler(acc, 1, parserFunc, testutil.Logger{})
 			cg.MaxMessageLen = tt.maxMessageLen
 			cg.TopicTag = tt.topicTag
 
@@ -563,9 +573,12 @@ func TestKafkaRoundTripIntegration(t *testing.T) {
 				MaxUndeliveredMessages: 1,
 				ConnectionStrategy:     tt.connectionStrategy,
 			}
-			parser := &influx.Parser{}
-			require.NoError(t, parser.Init())
-			input.SetParser(parser)
+			parserFunc := func() (telegraf.Parser, error) {
+				parser := &influx.Parser{}
+				err := parser.Init()
+				return parser, err
+			}
+			input.SetParserFunc(parserFunc)
 			require.NoError(t, input.Init())
 
 			acc := testutil.Accumulator{}
@@ -621,9 +634,12 @@ func TestExponentialBackoff(t *testing.T) {
 			},
 		},
 	}
-	parser := &influx.Parser{}
-	require.NoError(t, parser.Init())
-	input.SetParser(parser)
+	parserFunc := func() (telegraf.Parser, error) {
+		parser := &influx.Parser{}
+		err := parser.Init()
+		return parser, err
+	}
+	input.SetParserFunc(parserFunc)
 
 	//time how long initialization (connection) takes
 	start := time.Now()
@@ -666,9 +682,12 @@ func TestExponentialBackoffDefault(t *testing.T) {
 			},
 		},
 	}
-	parser := &influx.Parser{}
-	require.NoError(t, parser.Init())
-	input.SetParser(parser)
+	parserFunc := func() (telegraf.Parser, error) {
+		parser := &influx.Parser{}
+		err := parser.Init()
+		return parser, err
+	}
+	input.SetParserFunc(parserFunc)
 
 	require.NoError(t, input.Init())
 


### PR DESCRIPTION
Using parsers like json_v2 will result in undesired parser results. This switches to the ParserFunc pattern to create a dedicated parser in each thread.

# Required for all PRs

<!-- Before opening a pull request you should run the following checks locally to make sure the CI will pass.

make lint
make check
make check-deps
make test
make docs

-->

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

fixes #13888