### PR TITLE
feat(inputs.vsphere): Allow to set vSAN sampling interval

### DIFF
--- a/plugins/inputs/vsphere/README.md
+++ b/plugins/inputs/vsphere/README.md
@@ -184,6 +184,10 @@ to use them.
   ## Whether to skip verifying vSAN metrics against the ones from GetSupportedEntityTypes API.
   # vsan_metric_skip_verify = false ## false by default.
 
+  ## Interval for sampling vSAN performance metrics, can be reduced down to
+  ## 30 seconds for vSAN 8 U1.
+  # vsan_interval = "5m"
+
   ## Plugin Settings
   ## separator character to use for measurement and field names (default: "_")
   # separator = "_"

--- a/plugins/inputs/vsphere/endpoint.go
+++ b/plugins/inputs/vsphere/endpoint.go
@@ -245,7 +245,7 @@ func NewEndpoint(ctx context.Context, parent *VSphere, address *url.URL, log tel
 			parentTag:        "dcname",
 			enabled:          anythingEnabled(parent.VSANMetricExclude),
 			realTime:         false,
-			sampling:         300,
+			sampling:         int32(time.Duration(parent.VSANInterval).Seconds()),
 			objects:          make(objectMap),
 			filters:          newFilterOrPanic(parent.VSANMetricInclude, parent.VSANMetricExclude),
 			paths:            parent.VSANClusterInclude,

--- a/plugins/inputs/vsphere/sample.conf
+++ b/plugins/inputs/vsphere/sample.conf
@@ -142,6 +142,10 @@
   ## Whether to skip verifying vSAN metrics against the ones from GetSupportedEntityTypes API.
   # vsan_metric_skip_verify = false ## false by default.
 
+  ## Interval for sampling vSAN performance metrics, can be reduced down to
+  ## 30 seconds for vSAN 8 U1.
+  # vsan_interval = "5m"
+
   ## Plugin Settings
   ## separator character to use for measurement and field names (default: "_")
   # separator = "_"

--- a/plugins/inputs/vsphere/vsphere.go
+++ b/plugins/inputs/vsphere/vsphere.go
@@ -60,6 +60,7 @@ type VSphere struct {
 	VSANMetricExclude           []string        `toml:"vsan_metric_exclude"`
 	VSANMetricSkipVerify        bool            `toml:"vsan_metric_skip_verify"`
 	VSANClusterInclude          []string        `toml:"vsan_cluster_include"`
+	VSANInterval                config.Duration `toml:"vsan_interval"`
 	Separator                   string          `toml:"separator"`
 	CustomAttributeInclude      []string        `toml:"custom_attribute_include"`
 	CustomAttributeExclude      []string        `toml:"custom_attribute_exclude"`
@@ -180,6 +181,7 @@ func init() {
 			ObjectDiscoveryInterval:     config.Duration(time.Second * 300),
 			Timeout:                     config.Duration(time.Second * 60),
 			HistoricalInterval:          config.Duration(time.Second * 300),
+			VSANInterval:                config.Duration(time.Second * 300),
 			DisconnectedServersBehavior: "error",
 			HTTPProxy:                   proxy.HTTPProxy{UseSystemProxy: true},
 		}


### PR DESCRIPTION
- [x] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #13880

This PR allows the user to set the sampling interval for vSAN performance metrics. This is important to make full use of vSAN 8 U1 supporting intervals as low as 30 seconds compared to the hard-coded 5 minute interval.