### PR TITLE
feat(inputs.kube_inventory): Support filtering pods and nodes by node name

### DIFF
--- a/plugins/inputs/kube_inventory/README.md
+++ b/plugins/inputs/kube_inventory/README.md
@@ -52,7 +52,7 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## If empty in-cluster config with POD's service account token will be used.
   # url = ""
 
-  ## URL for the kubelet, if set it will be used to collect pods resource metrics
+  ## URL for the kubelet, if set it will be used to collect the pods resource metrics
   # url_kubelet = "http://127.0.0.1:10255"
 
   ## Namespace to use. Set to "" to use all namespaces.

--- a/plugins/inputs/kube_inventory/README.md
+++ b/plugins/inputs/kube_inventory/README.md
@@ -52,6 +52,9 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## If empty in-cluster config with POD's service account token will be used.
   # url = ""
 
+  ## URL for the kubelet, if set it will be used to collect pods resource metrics
+  # url_kubelet = "http://127.0.0.1:10255"
+
   ## Namespace to use. Set to "" to use all namespaces.
   # namespace = "default"
 

--- a/plugins/inputs/kube_inventory/README.md
+++ b/plugins/inputs/kube_inventory/README.md
@@ -55,8 +55,8 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## Namespace to use. Set to "" to use all namespaces.
   # namespace = "default"
 
-  ## Node name to filter to.
-  # node = "minikube"
+  ## Node name to filter to. No filtering by default.
+  # node = ""
 
   ## Use bearer token for authorization. ('bearer_token' takes priority)
   ##
@@ -186,7 +186,6 @@ tls_key = "/run/telegraf-kubernetes-key"
 ## Metrics
 
 - kubernetes_daemonset
-
   - tags:
     - daemonset_name
     - namespace
@@ -202,7 +201,6 @@ tls_key = "/run/telegraf-kubernetes-key"
     - updated_number_scheduled
 
 - kubernetes_deployment
-
   - tags:
     - deployment_name
     - namespace
@@ -213,7 +211,6 @@ tls_key = "/run/telegraf-kubernetes-key"
     - created
 
 - kubernetes_endpoints
-
   - tags:
     - endpoint_name
     - namespace
@@ -229,7 +226,6 @@ tls_key = "/run/telegraf-kubernetes-key"
     - port
 
 - kubernetes_ingress
-
   - tags:
     - ingress_name
     - namespace
@@ -245,7 +241,6 @@ tls_key = "/run/telegraf-kubernetes-key"
     - tls
 
 - kubernetes_node
-
   - tags:
     - node_name
     - status
@@ -265,7 +260,6 @@ tls_key = "/run/telegraf-kubernetes-key"
     - node_count
 
 - kubernetes_persistentvolume
-
   - tags:
     - pv_name
     - phase
@@ -274,7 +268,6 @@ tls_key = "/run/telegraf-kubernetes-key"
     - phase_type (int, [see below](#pv-phase_type))
 
 - kubernetes_persistentvolumeclaim
-
   - tags:
     - pvc_name
     - namespace
@@ -285,7 +278,6 @@ tls_key = "/run/telegraf-kubernetes-key"
     - phase_type (int, [see below](#pvc-phase_type))
 
 - kubernetes_pod_container
-
   - tags:
     - container_name
     - namespace
@@ -309,7 +301,6 @@ tls_key = "/run/telegraf-kubernetes-key"
     - status_condition
 
 - kubernetes_service
-
   - tags:
     - service_name
     - namespace
@@ -325,7 +316,6 @@ tls_key = "/run/telegraf-kubernetes-key"
     - target_port
 
 - kubernetes_statefulset
-
   - tags:
     - statefulset_name
     - namespace
@@ -341,7 +331,6 @@ tls_key = "/run/telegraf-kubernetes-key"
     - observed_generation
 
 - kubernetes_resourcequota
-
   - tags:
     - resource
     - namespace

--- a/plugins/inputs/kube_inventory/README.md
+++ b/plugins/inputs/kube_inventory/README.md
@@ -56,7 +56,7 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   # namespace = "default"
 
   ## Node name to filter to. No filtering by default.
-  # node = ""
+  # node_name = ""
 
   ## Use bearer token for authorization. ('bearer_token' takes priority)
   ##

--- a/plugins/inputs/kube_inventory/README.md
+++ b/plugins/inputs/kube_inventory/README.md
@@ -55,6 +55,9 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## Namespace to use. Set to "" to use all namespaces.
   # namespace = "default"
 
+  ## Node name to filter to.
+  # node = "minikube"
+
   ## Use bearer token for authorization. ('bearer_token' takes priority)
   ##
   ## Ignored if url is empty and in-cluster config is used.
@@ -112,7 +115,6 @@ list "persistentvolumes" and "nodes". You will then need to make an [aggregated
 ClusterRole][agg] that will eventually be bound to a user or group.
 
 [rbac]: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
-
 [agg]: https://kubernetes.io/docs/reference/access-authn-authz/rbac/#aggregated-clusterroles
 
 ```yaml
@@ -184,6 +186,7 @@ tls_key = "/run/telegraf-kubernetes-key"
 ## Metrics
 
 - kubernetes_daemonset
+
   - tags:
     - daemonset_name
     - namespace
@@ -199,6 +202,7 @@ tls_key = "/run/telegraf-kubernetes-key"
     - updated_number_scheduled
 
 - kubernetes_deployment
+
   - tags:
     - deployment_name
     - namespace
@@ -209,6 +213,7 @@ tls_key = "/run/telegraf-kubernetes-key"
     - created
 
 - kubernetes_endpoints
+
   - tags:
     - endpoint_name
     - namespace
@@ -224,6 +229,7 @@ tls_key = "/run/telegraf-kubernetes-key"
     - port
 
 - kubernetes_ingress
+
   - tags:
     - ingress_name
     - namespace
@@ -239,6 +245,7 @@ tls_key = "/run/telegraf-kubernetes-key"
     - tls
 
 - kubernetes_node
+
   - tags:
     - node_name
     - status
@@ -258,6 +265,7 @@ tls_key = "/run/telegraf-kubernetes-key"
     - node_count
 
 - kubernetes_persistentvolume
+
   - tags:
     - pv_name
     - phase
@@ -266,6 +274,7 @@ tls_key = "/run/telegraf-kubernetes-key"
     - phase_type (int, [see below](#pv-phase_type))
 
 - kubernetes_persistentvolumeclaim
+
   - tags:
     - pvc_name
     - namespace
@@ -276,6 +285,7 @@ tls_key = "/run/telegraf-kubernetes-key"
     - phase_type (int, [see below](#pvc-phase_type))
 
 - kubernetes_pod_container
+
   - tags:
     - container_name
     - namespace
@@ -299,6 +309,7 @@ tls_key = "/run/telegraf-kubernetes-key"
     - status_condition
 
 - kubernetes_service
+
   - tags:
     - service_name
     - namespace
@@ -314,6 +325,7 @@ tls_key = "/run/telegraf-kubernetes-key"
     - target_port
 
 - kubernetes_statefulset
+
   - tags:
     - statefulset_name
     - namespace
@@ -329,6 +341,7 @@ tls_key = "/run/telegraf-kubernetes-key"
     - observed_generation
 
 - kubernetes_resourcequota
+
   - tags:
     - resource
     - namespace
@@ -365,11 +378,11 @@ tls_key = "/run/telegraf-kubernetes-key"
 
 The node status ready can mean 3 different values.
 
-| Tag value | Corresponding field value |  Meaning |
-| --------- | ------------------------- |  -------
-| ready     | 0                         |  NotReady|
-| ready     | 1                         |  Ready   |
-| ready     | 2                         |  Unknown |
+| Tag value | Corresponding field value | Meaning  |
+| --------- | ------------------------- | -------- |
+| ready     | 0                         | NotReady |
+| ready     | 1                         | Ready    |
+| ready     | 2                         | Unknown  |
 
 ### pv `phase_type`
 

--- a/plugins/inputs/kube_inventory/client.go
+++ b/plugins/inputs/kube_inventory/client.go
@@ -113,7 +113,7 @@ func (c *client) getPods(ctx context.Context, nodeName string) (*corev1.PodList,
 	defer cancel()
 	var fieldSelector string
 	if nodeName != "" {
-		fieldSelector = "spec.nodeName=%s=" + nodeName
+		fieldSelector = "spec.nodeName=" + nodeName
 	}
 	return c.CoreV1().Pods(c.namespace).List(ctx, metav1.ListOptions{FieldSelector: fieldSelector})
 }

--- a/plugins/inputs/kube_inventory/client.go
+++ b/plugins/inputs/kube_inventory/client.go
@@ -2,7 +2,6 @@ package kube_inventory
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -90,10 +89,10 @@ func (c *client) getIngress(ctx context.Context) (*netv1.IngressList, error) {
 func (c *client) getNodes(ctx context.Context, name string) (*corev1.NodeList, error) {
 	ctx, cancel := context.WithTimeout(ctx, c.timeout)
 	defer cancel()
-	if name == "" {
-		return c.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	var fieldSelector string
+	if name != "" {
+		fieldSelector = "metadata.name=" + name
 	}
-	fieldSelector := fmt.Sprintf("metadata.name=%s", name)
 	return c.CoreV1().Nodes().List(ctx, metav1.ListOptions{FieldSelector: fieldSelector})
 }
 
@@ -112,10 +111,10 @@ func (c *client) getPersistentVolumeClaims(ctx context.Context) (*corev1.Persist
 func (c *client) getPods(ctx context.Context, nodeName string) (*corev1.PodList, error) {
 	ctx, cancel := context.WithTimeout(ctx, c.timeout)
 	defer cancel()
-	if nodeName == "" {
-		return c.CoreV1().Pods(c.namespace).List(ctx, metav1.ListOptions{})
+	var fieldSelector string
+	if nodeName != "" {
+		fieldSelector = "spec.nodeName=%s=" + nodeName
 	}
-	fieldSelector := fmt.Sprintf("spec.nodeName=%s", nodeName)
 	return c.CoreV1().Pods(c.namespace).List(ctx, metav1.ListOptions{FieldSelector: fieldSelector})
 }
 

--- a/plugins/inputs/kube_inventory/client.go
+++ b/plugins/inputs/kube_inventory/client.go
@@ -2,6 +2,7 @@ package kube_inventory
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -86,10 +87,14 @@ func (c *client) getIngress(ctx context.Context) (*netv1.IngressList, error) {
 	return c.NetworkingV1().Ingresses(c.namespace).List(ctx, metav1.ListOptions{})
 }
 
-func (c *client) getNodes(ctx context.Context) (*corev1.NodeList, error) {
+func (c *client) getNodes(ctx context.Context, name string) (*corev1.NodeList, error) {
 	ctx, cancel := context.WithTimeout(ctx, c.timeout)
 	defer cancel()
-	return c.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	if name == "" {
+		return c.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	}
+	fieldSelector := fmt.Sprintf("metadata.name=%s", name)
+	return c.CoreV1().Nodes().List(ctx, metav1.ListOptions{FieldSelector: fieldSelector})
 }
 
 func (c *client) getPersistentVolumes(ctx context.Context) (*corev1.PersistentVolumeList, error) {
@@ -104,10 +109,14 @@ func (c *client) getPersistentVolumeClaims(ctx context.Context) (*corev1.Persist
 	return c.CoreV1().PersistentVolumeClaims(c.namespace).List(ctx, metav1.ListOptions{})
 }
 
-func (c *client) getPods(ctx context.Context) (*corev1.PodList, error) {
+func (c *client) getPods(ctx context.Context, nodeName string) (*corev1.PodList, error) {
 	ctx, cancel := context.WithTimeout(ctx, c.timeout)
 	defer cancel()
-	return c.CoreV1().Pods(c.namespace).List(ctx, metav1.ListOptions{})
+	if nodeName == "" {
+		return c.CoreV1().Pods(c.namespace).List(ctx, metav1.ListOptions{})
+	}
+	fieldSelector := fmt.Sprintf("spec.nodeName=%s", nodeName)
+	return c.CoreV1().Pods(c.namespace).List(ctx, metav1.ListOptions{FieldSelector: fieldSelector})
 }
 
 func (c *client) getServices(ctx context.Context) (*corev1.ServiceList, error) {

--- a/plugins/inputs/kube_inventory/kube_inventory.go
+++ b/plugins/inputs/kube_inventory/kube_inventory.go
@@ -36,10 +36,10 @@ type KubernetesInventory struct {
 	ResourceInclude   []string        `toml:"resource_include"`
 	MaxConfigMapAge   config.Duration `toml:"max_config_map_age"`
 
-	SelectorInclude []string `toml:"selector_include"`
-	SelectorExclude []string `toml:"selector_exclude"`
-
-	Log telegraf.Logger `toml:"-"`
+	SelectorInclude []string        `toml:"selector_include"`
+	SelectorExclude []string        `toml:"selector_exclude"`
+	NodeName        string          `toml:"node_name"`
+	Log             telegraf.Logger `toml:"-"`
 
 	tls.ClientConfig
 	client *client

--- a/plugins/inputs/kube_inventory/kube_inventory.go
+++ b/plugins/inputs/kube_inventory/kube_inventory.go
@@ -47,8 +47,8 @@ type KubernetesInventory struct {
 	Log             telegraf.Logger `toml:"-"`
 
 	tls.ClientConfig
-	client     *client
-	httpClient *http.Client
+	client      *client
+	shttpClient *http.Client
 
 	selectorFilter filter.Filter
 }

--- a/plugins/inputs/kube_inventory/kube_inventory.go
+++ b/plugins/inputs/kube_inventory/kube_inventory.go
@@ -47,8 +47,8 @@ type KubernetesInventory struct {
 	Log             telegraf.Logger `toml:"-"`
 
 	tls.ClientConfig
-	client      *client
-	shttpClient *http.Client
+	client     *client
+	httpClient *http.Client
 
 	selectorFilter filter.Filter
 }

--- a/plugins/inputs/kube_inventory/node.go
+++ b/plugins/inputs/kube_inventory/node.go
@@ -9,7 +9,7 @@ import (
 )
 
 func collectNodes(ctx context.Context, acc telegraf.Accumulator, ki *KubernetesInventory) {
-	list, err := ki.client.getNodes(ctx)
+	list, err := ki.client.getNodes(ctx, ki.NodeName)
 	if err != nil {
 		acc.AddError(err)
 		return

--- a/plugins/inputs/kube_inventory/pod.go
+++ b/plugins/inputs/kube_inventory/pod.go
@@ -6,13 +6,12 @@ import (
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 
 	"github.com/influxdata/telegraf"
 )
 
 func collectPods(ctx context.Context, acc telegraf.Accumulator, ki *KubernetesInventory) {
-	var list *v1.PodList
+	var list *corev1.PodList
 	var err error
 
 	if ki.URL_KUBELET != "" {

--- a/plugins/inputs/kube_inventory/pod.go
+++ b/plugins/inputs/kube_inventory/pod.go
@@ -2,15 +2,24 @@ package kube_inventory
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 
 	"github.com/influxdata/telegraf"
 )
 
 func collectPods(ctx context.Context, acc telegraf.Accumulator, ki *KubernetesInventory) {
-	list, err := ki.client.getPods(ctx, ki.NodeName)
+	var list *v1.PodList
+	var err error
+
+	if ki.URL_KUBELET != "" {
+		err = ki.LoadJSON(fmt.Sprintf("%s/pods", ki.URL_KUBELET), list)
+	} else {
+		list, err = ki.client.getPods(ctx, ki.NodeName)
+	}
 	if err != nil {
 		acc.AddError(err)
 		return

--- a/plugins/inputs/kube_inventory/pod.go
+++ b/plugins/inputs/kube_inventory/pod.go
@@ -10,7 +10,7 @@ import (
 )
 
 func collectPods(ctx context.Context, acc telegraf.Accumulator, ki *KubernetesInventory) {
-	list, err := ki.client.getPods(ctx)
+	list, err := ki.client.getPods(ctx, ki.NodeName)
 	if err != nil {
 		acc.AddError(err)
 		return

--- a/plugins/inputs/kube_inventory/pod.go
+++ b/plugins/inputs/kube_inventory/pod.go
@@ -11,19 +11,20 @@ import (
 )
 
 func collectPods(ctx context.Context, acc telegraf.Accumulator, ki *KubernetesInventory) {
-	var list *corev1.PodList
+	var list corev1.PodList
+	listRef := &list
 	var err error
 
 	if ki.KubeletURL != "" {
-		err = ki.LoadJSON(fmt.Sprintf("%s/pods", ki.KubeletURL), list)
+		err = ki.LoadJSON(fmt.Sprintf("%s/pods", ki.KubeletURL), listRef)
 	} else {
-		list, err = ki.client.getPods(ctx, ki.NodeName)
+		listRef, err = ki.client.getPods(ctx, ki.NodeName)
 	}
 	if err != nil {
 		acc.AddError(err)
 		return
 	}
-	for _, p := range list.Items {
+	for _, p := range listRef.Items {
 		ki.gatherPod(p, acc)
 	}
 }

--- a/plugins/inputs/kube_inventory/pod.go
+++ b/plugins/inputs/kube_inventory/pod.go
@@ -14,8 +14,8 @@ func collectPods(ctx context.Context, acc telegraf.Accumulator, ki *KubernetesIn
 	var list *corev1.PodList
 	var err error
 
-	if ki.URL_KUBELET != "" {
-		err = ki.LoadJSON(fmt.Sprintf("%s/pods", ki.URL_KUBELET), list)
+	if ki.KubeletURL != "" {
+		err = ki.LoadJSON(fmt.Sprintf("%s/pods", ki.KubeletURL), list)
 	} else {
 		list, err = ki.client.getPods(ctx, ki.NodeName)
 	}

--- a/plugins/inputs/kube_inventory/sample.conf
+++ b/plugins/inputs/kube_inventory/sample.conf
@@ -7,6 +7,9 @@
   ## Namespace to use. Set to "" to use all namespaces.
   # namespace = "default"
 
+  ## Node name to filter to.
+  # node = "minikube"
+
   ## Use bearer token for authorization. ('bearer_token' takes priority)
   ##
   ## Ignored if url is empty and in-cluster config is used.

--- a/plugins/inputs/kube_inventory/sample.conf
+++ b/plugins/inputs/kube_inventory/sample.conf
@@ -8,7 +8,7 @@
   # namespace = "default"
 
   ## Node name to filter to. No filtering by default.
-  # node = ""
+  # node_name = ""
 
   ## Use bearer token for authorization. ('bearer_token' takes priority)
   ##

--- a/plugins/inputs/kube_inventory/sample.conf
+++ b/plugins/inputs/kube_inventory/sample.conf
@@ -4,6 +4,9 @@
   ## If empty in-cluster config with POD's service account token will be used.
   # url = ""
 
+  ## URL for the kubelet, if set it will be used to collect the pods resource metrics
+  # url_kubelet = "http://127.0.0.1:10255"
+
   ## Namespace to use. Set to "" to use all namespaces.
   # namespace = "default"
 

--- a/plugins/inputs/kube_inventory/sample.conf
+++ b/plugins/inputs/kube_inventory/sample.conf
@@ -7,8 +7,8 @@
   ## Namespace to use. Set to "" to use all namespaces.
   # namespace = "default"
 
-  ## Node name to filter to.
-  # node = "minikube"
+  ## Node name to filter to. No filtering by default.
+  # node = ""
 
   ## Use bearer token for authorization. ('bearer_token' takes priority)
   ##


### PR DESCRIPTION
- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

[resolves #13878](https://github.com/influxdata/telegraf/issues/13878)

Add the option to filter nodes and pods by node name in the kuberetes_inventory input plugin
Add an option to get pods info using Kubelet to avoid loading on the API server 