### PR TITLE
feat(outputs.prometheus_client): Add secretstore support for basic_password

### DIFF
--- a/plugins/outputs/prometheus_client/README.md
+++ b/plugins/outputs/prometheus_client/README.md
@@ -12,6 +12,14 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 [CONFIGURATION.md]: ../../../docs/CONFIGURATION.md#plugins
 
+## Secret-store support
+
+This plugin supports secrets from secret-stores for the `basic_password` option.
+See the [secret-store documentation][SECRETSTORE] for more details on how
+to use them.
+
+[SECRETSTORE]: ../../../docs/CONFIGURATION.md#secret-store-secrets
+
 ## Configuration
 
 ```toml @sample.conf

--- a/plugins/outputs/prometheus_client/prometheus_client.go
+++ b/plugins/outputs/prometheus_client/prometheus_client.go
@@ -127,10 +127,10 @@ func (p *PrometheusClient) Init() error {
 	if err != nil {
 		return err
 	}
-	password_str := string(password)
+	passwordStr := string(password)
 	defer config.ReleaseSecret(password)
 
-	authHandler := internal.BasicAuthHandler(p.BasicUsername, password_str, "prometheus", onAuthError)
+	authHandler := internal.BasicAuthHandler(p.BasicUsername, passwordStr, "prometheus", onAuthError)
 	rangeHandler := internal.IPRangeHandler(ipRange, onError)
 	promHandler := promhttp.HandlerFor(registry, promhttp.HandlerOpts{ErrorHandling: promhttp.ContinueOnError})
 	landingPageHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/plugins/outputs/prometheus_client/prometheus_client.go
+++ b/plugins/outputs/prometheus_client/prometheus_client.go
@@ -127,9 +127,10 @@ func (p *PrometheusClient) Init() error {
 	if err != nil {
 		return err
 	}
+	password_str := string(password)
 	defer config.ReleaseSecret(password)
 
-	authHandler := internal.BasicAuthHandler(p.BasicUsername, string(password), "prometheus", onAuthError)
+	authHandler := internal.BasicAuthHandler(p.BasicUsername, password_str, "prometheus", onAuthError)
 	rangeHandler := internal.IPRangeHandler(ipRange, onError)
 	promHandler := promhttp.HandlerFor(registry, promhttp.HandlerOpts{ErrorHandling: promhttp.ContinueOnError})
 	landingPageHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/plugins/outputs/prometheus_client/prometheus_client.go
+++ b/plugins/outputs/prometheus_client/prometheus_client.go
@@ -57,10 +57,9 @@ type PrometheusClient struct {
 	StringAsLabel      bool                   `toml:"string_as_label"`
 	ExportTimestamp    bool                   `toml:"export_timestamp"`
 	TypeMappings       serializer.MetricTypes `toml:"metric_types"`
-  
-	tlsint.ServerConfig
+	Log                telegraf.Logger        `toml:"-"`
 
-	Log telegraf.Logger `toml:"-"`
+	tlsint.ServerConfig
 
 	server    *http.Server
 	url       *url.URL

--- a/plugins/outputs/prometheus_client/prometheus_client.go
+++ b/plugins/outputs/prometheus_client/prometheus_client.go
@@ -48,7 +48,7 @@ type PrometheusClient struct {
 	WriteTimeout       config.Duration `toml:"write_timeout"`
 	MetricVersion      int             `toml:"metric_version"`
 	BasicUsername      string          `toml:"basic_username"`
-	BasicPassword      string          `toml:"basic_password"`
+	BasicPassword      config.Secret   `toml:"basic_password"`
 	IPRange            []string        `toml:"ip_range"`
 	ExpirationInterval config.Duration `toml:"expiration_interval"`
 	Path               string          `toml:"path"`
@@ -123,7 +123,13 @@ func (p *PrometheusClient) Init() error {
 		ipRange = append(ipRange, ipNet)
 	}
 
-	authHandler := internal.BasicAuthHandler(p.BasicUsername, p.BasicPassword, "prometheus", onAuthError)
+	password, err := p.BasicPassword.Get()
+	if err != nil {
+		return nil
+	}
+	defer config.ReleaseSecret(password)
+
+	authHandler := internal.BasicAuthHandler(p.BasicUsername, string(password), "prometheus", onAuthError)
 	rangeHandler := internal.IPRangeHandler(ipRange, onError)
 	promHandler := promhttp.HandlerFor(registry, promhttp.HandlerOpts{ErrorHandling: promhttp.ContinueOnError})
 	landingPageHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/plugins/outputs/prometheus_client/prometheus_client.go
+++ b/plugins/outputs/prometheus_client/prometheus_client.go
@@ -125,7 +125,7 @@ func (p *PrometheusClient) Init() error {
 
 	password, err := p.BasicPassword.Get()
 	if err != nil {
-		return nil
+		return err
 	}
 	defer config.ReleaseSecret(password)
 


### PR DESCRIPTION
- [x] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format]

resolves #13898

Changes the Prometheus Client output basic_password option to support using the secretstore.