### PR TITLE
feat(parsers.avro): Allow connection to https schema registry

### DIFF
--- a/plugins/parsers/avro/README.md
+++ b/plugins/parsers/avro/README.md
@@ -64,9 +64,8 @@ The message is supposed to be encoded as follows:
   ## For example "Aladdin:open sesame" equals to "QWxhZGRpbjpvcGVuIHNlc2FtZQ==" in base64
   # avro_schema_registry_authorization_base64 = "QWxhZGRpbjpvcGVuIHNlc2FtZQ=="
 
-  ## Path to the schema registry certificate. Should be specified when it is required 
-  ## for connection to the schema registry only. 
-  ## For example "Aladdin:open sesame" equals to "QWxhZGRpbjpvcGVuIHNlc2FtZQ==" in base64
+  ## Path to the schema registry certificate. Should be specified only when it is 
+  ## required for connection to the schema registry. 
   # avro_schema_registry_cacert_path = "/etc/telegraf/ca_cert.crt"
 
   ## Measurement string; if not set, determine measurement name from

--- a/plugins/parsers/avro/README.md
+++ b/plugins/parsers/avro/README.md
@@ -31,9 +31,14 @@ The message is supposed to be encoded as follows:
   ## Supported values are "binary" (default) and "json"
   # avro_format = "binary"
 
-  ## Url of the schema registry; exactly one of schema registry and
-  ## schema must be set
+  ## URL of the schema registry which may contain username and password in the
+  ## form http[s]://[username[:password]@]<host>[:port]
+  ## NOTE: Exactly one of schema registry and schema must be set
   avro_schema_registry = "http://localhost:8081"
+
+  ## Path to the schema registry certificate. Should be specified only if
+  ## required for connection to the schema registry.
+  # avro_schema_registry_cert = "/etc/telegraf/ca_cert.crt"
 
   ## Schema string; exactly one of schema registry and schema must be set
   #avro_schema = '''
@@ -57,16 +62,6 @@ The message is supposed to be encoded as follows:
   #          ]
   #      }
   #'''
-
-  ## login and password in format "Login:Password" encoded to base64 string
-  ## that will be added as a basic auth header to the schema registry requests
-  ## Should be filled only when schema registry uses basic authentication 
-  ## For example "Aladdin:open sesame" equals to "QWxhZGRpbjpvcGVuIHNlc2FtZQ==" in base64
-  # avro_schema_registry_authorization_base64 = "QWxhZGRpbjpvcGVuIHNlc2FtZQ=="
-
-  ## Path to the schema registry certificate. Should be specified only when it is 
-  ## required for connection to the schema registry. 
-  # avro_schema_registry_cacert_path = "/etc/telegraf/ca_cert.crt"
 
   ## Measurement string; if not set, determine measurement name from
   ## schema (as "<namespace>.<name>")

--- a/plugins/parsers/avro/README.md
+++ b/plugins/parsers/avro/README.md
@@ -58,6 +58,17 @@ The message is supposed to be encoded as follows:
   #      }
   #'''
 
+  ## login and password in format "Login:Password" encoded to base64 string
+  ## that will be added as a basic auth header to the schema registry requests
+  ## Should be filled only when schema registry uses basic authentication 
+  ## For example "Aladdin:open sesame" equals to "QWxhZGRpbjpvcGVuIHNlc2FtZQ==" in base64
+  # avro_schema_registry_authorization_base64 = "QWxhZGRpbjpvcGVuIHNlc2FtZQ=="
+
+  ## Path to the schema registry certificate. Should be specified when it is required 
+  ## for connection to the schema registry only. 
+  ## For example "Aladdin:open sesame" equals to "QWxhZGRpbjpvcGVuIHNlc2FtZQ==" in base64
+  # avro_schema_registry_cacert_path = "/etc/telegraf/ca_cert.crt"
+
   ## Measurement string; if not set, determine measurement name from
   ## schema (as "<namespace>.<name>")
   # avro_measurement = "ratings"

--- a/plugins/parsers/avro/parser.go
+++ b/plugins/parsers/avro/parser.go
@@ -26,6 +26,8 @@ import (
 type Parser struct {
 	MetricName      string            `toml:"metric_name"`
 	SchemaRegistry  string            `toml:"avro_schema_registry"`
+	Authorization   string            `toml:"avro_schema_registry_authorization_base64"`
+	CaCertPath      string            `toml:"avro_schema_registry_cacert_path"`
 	Schema          string            `toml:"avro_schema"`
 	Format          string            `toml:"avro_format"`
 	Measurement     string            `toml:"avro_measurement"`
@@ -62,7 +64,12 @@ func (p *Parser) Init() error {
 		}
 	}
 	if p.SchemaRegistry != "" {
-		p.registryObj = newSchemaRegistry(p.SchemaRegistry)
+		registryObj, err := newSchemaRegistry(p.SchemaRegistry, p.Authorization, p.CaCertPath)
+		if err != nil {
+			return fmt.Errorf("error connecting to the schema registry '%v'. '%v'", p.SchemaRegistry, err)
+		}
+
+		p.registryObj = registryObj
 	}
 
 	return nil

--- a/plugins/parsers/avro/parser.go
+++ b/plugins/parsers/avro/parser.go
@@ -66,7 +66,7 @@ func (p *Parser) Init() error {
 	if p.SchemaRegistry != "" {
 		registryObj, err := newSchemaRegistry(p.SchemaRegistry, p.Authorization, p.CaCertPath)
 		if err != nil {
-			return fmt.Errorf("error connecting to the schema registry '%v'. '%v'", p.SchemaRegistry, err)
+			return fmt.Errorf("error connecting to the schema registry '%v'. '%w'", p.SchemaRegistry, err)
 		}
 
 		p.registryObj = registryObj

--- a/plugins/parsers/avro/parser.go
+++ b/plugins/parsers/avro/parser.go
@@ -26,8 +26,7 @@ import (
 type Parser struct {
 	MetricName      string            `toml:"metric_name"`
 	SchemaRegistry  string            `toml:"avro_schema_registry"`
-	Authorization   string            `toml:"avro_schema_registry_authorization_base64"`
-	CaCertPath      string            `toml:"avro_schema_registry_cacert_path"`
+	CaCertPath      string            `toml:"avro_schema_registry_cert"`
 	Schema          string            `toml:"avro_schema"`
 	Format          string            `toml:"avro_format"`
 	Measurement     string            `toml:"avro_measurement"`
@@ -64,12 +63,11 @@ func (p *Parser) Init() error {
 		}
 	}
 	if p.SchemaRegistry != "" {
-		registryObj, err := newSchemaRegistry(p.SchemaRegistry, p.Authorization, p.CaCertPath)
+		registry, err := newSchemaRegistry(p.SchemaRegistry, p.CaCertPath)
 		if err != nil {
-			return fmt.Errorf("error connecting to the schema registry '%v'. '%w'", p.SchemaRegistry, err)
+			return fmt.Errorf("error connecting to the schema registry %q: %w", p.SchemaRegistry, err)
 		}
-
-		p.registryObj = registryObj
+		p.registryObj = registry
 	}
 
 	return nil

--- a/plugins/parsers/avro/schema_registry.go
+++ b/plugins/parsers/avro/schema_registry.go
@@ -34,25 +34,20 @@ func newSchemaRegistry(url string, authBase64 string, caCertPath string) (*schem
 		return nil, err
 	}
 
+	var tlsCfg *tls.Config
 	if caCertPath != "" {
 		caCertPool := x509.NewCertPool()
 		caCertPool.AppendCertsFromPEM(caCert)
-		client = &http.Client{
-			Transport: &http.Transport{
-				TLSClientConfig: &tls.Config{
-					RootCAs: caCertPool,
-				},
-				MaxIdleConns:    10,
-				IdleConnTimeout: 90 * time.Second,
-			},
+		tlsCfg = &tls.Config{
+			RootCAs: caCertPool,
 		}
-	} else {
-		client = &http.Client{
-			Transport: &http.Transport{
-				MaxIdleConns:    10,
-				IdleConnTimeout: 90 * time.Second,
-			},
-		}
+	}
+	client = &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: tlsCfg,
+			MaxIdleConns:    10,
+			IdleConnTimeout: 90 * time.Second,
+		},
 	}
 
 	return &schemaRegistry{url: url, authBase64: authBase64, cache: make(map[int]*schemaAndCodec), client: *client}, nil

--- a/plugins/parsers/avro/schema_registry.go
+++ b/plugins/parsers/avro/schema_registry.go
@@ -5,8 +5,8 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/linkedin/goavro/v2"
@@ -18,23 +18,23 @@ type schemaAndCodec struct {
 }
 
 type schemaRegistry struct {
-	url         string
-	auth_base64 string
-	cache       map[int]*schemaAndCodec
-	client      http.Client
+	url        string
+	authBase64 string
+	cache      map[int]*schemaAndCodec
+	client     http.Client
 }
 
 const schemaByID = "%s/schemas/ids/%d"
 
-func newSchemaRegistry(url string, auth_base64 string, ca_cert_path string) (*schemaRegistry, error) {
+func newSchemaRegistry(url string, authBase64 string, caCertPath string) (*schemaRegistry, error) {
 	var client *http.Client
 
-	caCert, err := ioutil.ReadFile(ca_cert_path)
+	caCert, err := os.ReadFile(caCertPath)
 	if err != nil {
 		return nil, err
 	}
 
-	if ca_cert_path != "" {
+	if caCertPath != "" {
 		caCertPool := x509.NewCertPool()
 		caCertPool.AppendCertsFromPEM(caCert)
 		client = &http.Client{
@@ -55,7 +55,7 @@ func newSchemaRegistry(url string, auth_base64 string, ca_cert_path string) (*sc
 		}
 	}
 
-	return &schemaRegistry{url: url, auth_base64: auth_base64, cache: make(map[int]*schemaAndCodec), client: *client}, nil
+	return &schemaRegistry{url: url, authBase64: authBase64, cache: make(map[int]*schemaAndCodec), client: *client}, nil
 }
 
 func (sr *schemaRegistry) getSchemaAndCodec(id int) (*schemaAndCodec, error) {
@@ -68,8 +68,8 @@ func (sr *schemaRegistry) getSchemaAndCodec(id int) (*schemaAndCodec, error) {
 		return nil, err
 	}
 
-	if sr.auth_base64 != "" {
-		req.Header.Set("Authorization", fmt.Sprintf("Basic %s", sr.auth_base64))
+	if sr.authBase64 != "" {
+		req.Header.Set("Authorization", fmt.Sprintf("Basic %s", sr.authBase64))
 	}
 
 	resp, err := sr.client.Do(req)


### PR DESCRIPTION
- [x] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #13334
superseeds #13820 

Allow to connect to HTTPS schema registry including custom certificates and basic authentification.