### PR TITLE
feat(parsers.avro): Get metric name from the message field

### DIFF
--- a/plugins/parsers/avro/README.md
+++ b/plugins/parsers/avro/README.md
@@ -63,6 +63,10 @@ The message is supposed to be encoded as follows:
   #      }
   #'''
 
+  ## Measurement field name; The meauserment name will be taken from this field
+  ## If not set, determine measurement name from the following options
+  # avro_measurement_field = "field_name"
+
   ## Measurement string; if not set, determine measurement name from
   ## schema (as "<namespace>.<name>")
   # avro_measurement = "ratings"

--- a/plugins/parsers/avro/parser.go
+++ b/plugins/parsers/avro/parser.go
@@ -24,18 +24,19 @@ import (
 // an attached schema or schema fingerprint
 
 type Parser struct {
-	MetricName      string            `toml:"metric_name"`
-	SchemaRegistry  string            `toml:"avro_schema_registry"`
-	CaCertPath      string            `toml:"avro_schema_registry_cert"`
-	Schema          string            `toml:"avro_schema"`
-	Format          string            `toml:"avro_format"`
-	Measurement     string            `toml:"avro_measurement"`
-	Tags            []string          `toml:"avro_tags"`
-	Fields          []string          `toml:"avro_fields"`
-	Timestamp       string            `toml:"avro_timestamp"`
-	TimestampFormat string            `toml:"avro_timestamp_format"`
-	FieldSeparator  string            `toml:"avro_field_separator"`
-	DefaultTags     map[string]string `toml:"tags"`
+	MetricName       string            `toml:"metric_name"`
+	SchemaRegistry   string            `toml:"avro_schema_registry"`
+	CaCertPath       string            `toml:"avro_schema_registry_cert"`
+	Schema           string            `toml:"avro_schema"`
+	Format           string            `toml:"avro_format"`
+	Measurement      string            `toml:"avro_measurement"`
+	MeasurementField string   		   `toml:"avro_measurement_field"`
+	Tags             []string          `toml:"avro_tags"`
+	Fields           []string          `toml:"avro_fields"`
+	Timestamp        string            `toml:"avro_timestamp"`
+	TimestampFormat  string            `toml:"avro_timestamp_format"`
+	FieldSeparator   string            `toml:"avro_field_separator"`
+	DefaultTags      map[string]string `toml:"tags"`
 
 	Log         telegraf.Logger `toml:"-"`
 	registryObj *schemaRegistry
@@ -212,9 +213,24 @@ func (p *Parser) createMetric(data map[string]interface{}, schema string) (teleg
 		// A telegraf metric needs at least one field.
 		return nil, errors.New("number of fields is 0; unable to create metric")
 	}
+
+	// If measurement field name is specified in the configuration
+	// take value from that field and do not include it into fields or tags
+	name := ""
+	if p.MeasurementField != "" {
+		sMetric, err := internal.ToString(data[p.MeasurementField])
+		if err != nil {
+			p.Log.Warnf("Could not convert %v to string for measurement name %q: %w", data[p.MeasurementField], p.MeasurementField, err)
+		}
+		name = sMetric
+	}
 	// Now some fancy stuff to extract the measurement.
 	// If it's set in the configuration, use that.
-	name := p.Measurement
+	if name == "" {
+		// If field name is not specified or field does not exist and
+		// metric name set in the configuration, use that.
+		name = p.Measurement
+	}
 	separator := "."
 	if name == "" {
 		// Try using the namespace defined in the schema. In case there

--- a/plugins/parsers/avro/testdata/measurement_name_from_message/expected.out
+++ b/plugins/parsers/avro/testdata/measurement_name_from_message/expected.out
@@ -1,0 +1,1 @@
+cpu_load,Server=test_server Value=18.7 1694526986671

--- a/plugins/parsers/avro/testdata/measurement_name_from_message/message.avro
+++ b/plugins/parsers/avro/testdata/measurement_name_from_message/message.avro
@@ -1,0 +1,1 @@
+ŞæîšÑbtest_server33333³2@cpu_load

--- a/plugins/parsers/avro/testdata/measurement_name_from_message/telegraf.conf
+++ b/plugins/parsers/avro/testdata/measurement_name_from_message/telegraf.conf
@@ -1,0 +1,30 @@
+[[ inputs.file ]]
+  files = ["./testdata/measurement_name_from_message/message.avro"]
+  data_format = "avro"
+  avro_measurement_field = "Measurement"
+  avro_tags = [ "Server" ]
+  avro_fields = [ "Value" ]
+  avro_schema = '''
+{
+  "type": "record",
+  "name": "TestRecord",
+  "fields": [
+    {
+      "name": "ServerTs",
+      "type": "long"
+    },
+    {
+      "name": "Server",
+      "type": "string"
+    },
+    {
+      "name": "Value",
+      "type": "double"
+    },
+    {
+      "name": "Measurement",
+      "type": "string"
+    }
+  ]
+}
+'''	


### PR DESCRIPTION
# Required for all PRs

<!-- Before opening a pull request you should run the following checks locally to make sure the CI will pass.

make lint
make check
make check-deps
make test
make docs

-->

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [X] Updated associated README.md.
- [X] Wrote appropriate unit tests.
- [X] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

resolves #13823

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->

Added option `avro_measurement_field` which if specified allows to get metric name from the message field. This, for example, allows to proccess different metrics stored in the one Kafka topic.