### PR TITLE
fix(inputs.systemd_units): Add missing upstream states

### DIFF
--- a/plugins/inputs/systemd_units/README.md
+++ b/plugins/inputs/systemd_units/README.md
@@ -109,8 +109,17 @@ were removed, tables are hex aligned to keep some space for future values
 | 0x000b | final-sigterm         | unit is ~                           |
 | 0x000c | failed                | unit is ~                           |
 | 0x000d | auto-restart          | unit is ~                           |
+| 0x000e | condition             | unit is ~                           |
+| 0x000f | cleaning              | unit is ~                           |
 |        |                       | service_state_table start at 0x0010 |
 | 0x0010 | waiting               | unit is ~                           |
+| 0x0011 | reload-signal         | unit is ~                           |
+| 0x0012 | reload-notify         | unit is ~                           |
+| 0x0013 | final-watchdog        | unit is ~                           |
+| 0x0014 | dead-before-auto-restart    | unit is ~                     |
+| 0x0015 | failed-before-auto-restart  | unit is ~                     |
+| 0x0016 | dead-resources-pinned | unit is ~                           |
+| 0x0017 | auto-restart-queued   | unit is ~                           |
 |        |                       | service_state_table start at 0x0020 |
 | 0x0020 | tentative             | unit is ~                           |
 | 0x0021 | plugged               | unit is ~                           |

--- a/plugins/inputs/systemd_units/systemd_units.go
+++ b/plugins/inputs/systemd_units/systemd_units.go
@@ -69,9 +69,19 @@ var subMap = map[string]int{
 	"final-sigterm": 0x000b,
 	"failed":        0x000c,
 	"auto-restart":  0x000d,
+	"condition":     0x000e,
+	"cleaning":      0x000f,
 
 	// automount_state_table, offset 0x0010
-	"waiting": 0x0010,
+	// continuation of service_state_table
+	"waiting":                    0x0010,
+	"reload-signal":              0x0011,
+	"reload-notify":              0x0012,
+	"final-watchdog":             0x0013,
+	"dead-before-auto-restart":   0x0014,
+	"failed-before-auto-restart": 0x0015,
+	"dead-resources-pinned":      0x0016,
+	"auto-restart-queued":        0x0017,
 
 	// device_state_table, offset 0x0020
 	"tentative": 0x0020,


### PR DESCRIPTION
fixes: #13900
