### PR TITLE
feat(agent): change Gather to accept Context to support cancellation

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -2,6 +2,7 @@ package config_test
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -1202,7 +1203,7 @@ type MockupInputPluginParserNew struct {
 func (m *MockupInputPluginParserNew) SampleConfig() string {
 	return "Mockup old parser test plugin"
 }
-func (m *MockupInputPluginParserNew) Gather(_ telegraf.Accumulator) error {
+func (m *MockupInputPluginParserNew) Gather(_ context.Context, _ telegraf.Accumulator) error {
 	return nil
 }
 func (m *MockupInputPluginParserNew) SetParser(parser telegraf.Parser) {
@@ -1234,7 +1235,7 @@ type MockupInputPlugin struct {
 func (m *MockupInputPlugin) SampleConfig() string {
 	return "Mockup test input plugin"
 }
-func (m *MockupInputPlugin) Gather(_ telegraf.Accumulator) error {
+func (m *MockupInputPlugin) Gather(_ context.Context, _ telegraf.Accumulator) error {
 	return nil
 }
 func (m *MockupInputPlugin) SetParser(parser telegraf.Parser) {
@@ -1249,7 +1250,7 @@ type MockupInputPluginParserFunc struct {
 func (m *MockupInputPluginParserFunc) SampleConfig() string {
 	return "Mockup test input plugin"
 }
-func (m *MockupInputPluginParserFunc) Gather(_ telegraf.Accumulator) error {
+func (m *MockupInputPluginParserFunc) Gather(_ context.Context, _ telegraf.Accumulator) error {
 	return nil
 }
 func (m *MockupInputPluginParserFunc) SetParserFunc(pf telegraf.ParserFunc) {
@@ -1264,7 +1265,7 @@ type MockupInputPluginParserOnly struct {
 func (m *MockupInputPluginParserOnly) SampleConfig() string {
 	return "Mockup test input plugin"
 }
-func (m *MockupInputPluginParserOnly) Gather(_ telegraf.Accumulator) error {
+func (m *MockupInputPluginParserOnly) Gather(_ context.Context, _ telegraf.Accumulator) error {
 	return nil
 }
 func (m *MockupInputPluginParserOnly) SetParser(p telegraf.Parser) {
@@ -1497,7 +1498,7 @@ func (m *MockupStatePlugin) SampleConfig() string {
 	return "Mockup test plugin"
 }
 
-func (m *MockupStatePlugin) Gather(_ telegraf.Accumulator) error {
+func (m *MockupStatePlugin) Gather(_ context.Context, _ telegraf.Accumulator) error {
 	return nil
 }
 

--- a/config/secret_test.go
+++ b/config/secret_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"testing"
@@ -701,8 +702,8 @@ type MockupSecretPlugin struct {
 	Expected string `toml:"expected"`
 }
 
-func (*MockupSecretPlugin) SampleConfig() string                { return "Mockup test secret plugin" }
-func (*MockupSecretPlugin) Gather(_ telegraf.Accumulator) error { return nil }
+func (*MockupSecretPlugin) SampleConfig() string                                   { return "Mockup test secret plugin" }
+func (*MockupSecretPlugin) Gather(_ context.Context, _ telegraf.Accumulator) error { return nil }
 
 type MockupSecretStore struct {
 	Secrets map[string][]byte

--- a/config/types_test.go
+++ b/config/types_test.go
@@ -1,6 +1,7 @@
 package config_test
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -267,8 +268,8 @@ type MockupTypesPlugin struct {
 	Sizes     []config.Size     `toml:"sizes"`
 }
 
-func (*MockupTypesPlugin) SampleConfig() string                { return "Mockup test types plugin" }
-func (*MockupTypesPlugin) Gather(_ telegraf.Accumulator) error { return nil }
+func (*MockupTypesPlugin) SampleConfig() string                                   { return "Mockup test types plugin" }
+func (*MockupTypesPlugin) Gather(_ context.Context, _ telegraf.Accumulator) error { return nil }
 
 // Register the mockup plugin on loading
 func init() {

--- a/input.go
+++ b/input.go
@@ -1,11 +1,13 @@
 package telegraf
 
+import "context"
+
 type Input interface {
 	PluginDescriber
 
 	// Gather takes in an accumulator and adds the metrics that the Input
 	// gathers. This is called every agent.interval
-	Gather(Accumulator) error
+	Gather(context.Context, Accumulator) error
 }
 
 type ServiceInput interface {

--- a/migrations/inputs_httpjson/migration_test.go
+++ b/migrations/inputs_httpjson/migration_test.go
@@ -1,6 +1,7 @@
 package inputs_httpjson_test
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -124,7 +125,7 @@ func TestParsing(t *testing.T) {
 			plugin.URLs = []string{addr}
 			require.NoError(t, plugin.Init())
 			var acc testutil.Accumulator
-			require.NoError(t, plugin.Gather(&acc))
+			require.NoError(t, plugin.Gather(context.Background(), &acc))
 
 			// Prepare metrics for comparison
 			for i := range expected {

--- a/models/running_input.go
+++ b/models/running_input.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"context"
 	"time"
 
 	"github.com/influxdata/telegraf"
@@ -144,9 +145,9 @@ func (r *RunningInput) MakeMetric(metric telegraf.Metric) telegraf.Metric {
 	return metric
 }
 
-func (r *RunningInput) Gather(acc telegraf.Accumulator) error {
+func (r *RunningInput) Gather(ctx context.Context, acc telegraf.Accumulator) error {
 	start := time.Now()
-	err := r.Input.Gather(acc)
+	err := r.Input.Gather(ctx, acc)
 	elapsed := time.Since(start)
 	r.GatherTime.Incr(elapsed.Nanoseconds())
 	return err

--- a/models/running_input_test.go
+++ b/models/running_input_test.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -431,6 +432,6 @@ func TestMakeMetricWithAlwaysKeepingPluginTagsEnabled(t *testing.T) {
 
 type testInput struct{}
 
-func (t *testInput) Description() string                 { return "" }
-func (t *testInput) SampleConfig() string                { return "" }
-func (t *testInput) Gather(_ telegraf.Accumulator) error { return nil }
+func (t *testInput) Description() string                                    { return "" }
+func (t *testInput) SampleConfig() string                                   { return "" }
+func (t *testInput) Gather(_ context.Context, _ telegraf.Accumulator) error { return nil }

--- a/plugins/common/shim/config_test.go
+++ b/plugins/common/shim/config_test.go
@@ -1,6 +1,7 @@
 package shim
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -73,7 +74,7 @@ func (i *testDurationInput) SampleConfig() string {
 func (i *testDurationInput) Description() string {
 	return ""
 }
-func (i *testDurationInput) Gather(_ telegraf.Accumulator) error {
+func (i *testDurationInput) Gather(_ context.Context, _ telegraf.Accumulator) error {
 	return nil
 }
 

--- a/plugins/common/shim/goshim_test.go
+++ b/plugins/common/shim/goshim_test.go
@@ -2,6 +2,7 @@ package shim
 
 import (
 	"bufio"
+	"context"
 	"errors"
 	"io"
 	"log"
@@ -64,7 +65,7 @@ func (i *erroringInput) SampleConfig() string {
 	return ""
 }
 
-func (i *erroringInput) Gather(acc telegraf.Accumulator) error {
+func (i *erroringInput) Gather(_ context.Context, acc telegraf.Accumulator) error {
 	acc.AddError(errors.New("intentional"))
 	return nil
 }

--- a/plugins/common/shim/input.go
+++ b/plugins/common/shim/input.go
@@ -91,11 +91,11 @@ func (s *Shim) startGathering(ctx context.Context, input telegraf.Input, acc tel
 		case <-ctx.Done():
 			return
 		case <-s.gatherPromptCh:
-			if err := input.Gather(acc); err != nil {
+			if err := input.Gather(ctx, acc); err != nil {
 				fmt.Fprintf(s.stderr, "failed to gather metrics: %s\n", err)
 			}
 		case <-t.C:
-			if err := input.Gather(acc); err != nil {
+			if err := input.Gather(ctx, acc); err != nil {
 				fmt.Fprintf(s.stderr, "failed to gather metrics: %s\n", err)
 			}
 		}

--- a/plugins/common/shim/input_test.go
+++ b/plugins/common/shim/input_test.go
@@ -2,6 +2,7 @@ package shim
 
 import (
 	"bufio"
+	"context"
 	"io"
 	"strings"
 	"testing"
@@ -92,7 +93,7 @@ func (i *testInput) Description() string {
 	return "test"
 }
 
-func (i *testInput) Gather(acc telegraf.Accumulator) error {
+func (i *testInput) Gather(_ context.Context, acc telegraf.Accumulator) error {
 	acc.AddFields("measurement",
 		map[string]interface{}{
 			"field": 1,
@@ -125,7 +126,7 @@ func (i *serviceInput) Description() string {
 	return ""
 }
 
-func (i *serviceInput) Gather(acc telegraf.Accumulator) error {
+func (i *serviceInput) Gather(_ context.Context, acc telegraf.Accumulator) error {
 	acc.AddFields("measurement",
 		map[string]interface{}{
 			"field": 1,

--- a/plugins/inputs/activemq/activemq.go
+++ b/plugins/inputs/activemq/activemq.go
@@ -2,6 +2,7 @@
 package activemq
 
 import (
+	"context"
 	_ "embed"
 	"encoding/xml"
 	"fmt"
@@ -221,7 +222,7 @@ func (a *ActiveMQ) GatherSubscribersMetrics(acc telegraf.Accumulator, subscriber
 	}
 }
 
-func (a *ActiveMQ) Gather(acc telegraf.Accumulator) error {
+func (a *ActiveMQ) Gather(_ context.Context, acc telegraf.Accumulator) error {
 	dataQueues, err := a.GetMetrics(a.QueuesURL())
 	if err != nil {
 		return err

--- a/plugins/inputs/activemq/activemq_test.go
+++ b/plugins/inputs/activemq/activemq_test.go
@@ -1,6 +1,7 @@
 package activemq
 
 import (
+	"context"
 	"encoding/xml"
 	"net/http"
 	"net/http/httptest"
@@ -173,7 +174,7 @@ func TestURLs(t *testing.T) {
 	require.NoError(t, err)
 
 	var acc testutil.Accumulator
-	err = plugin.Gather(&acc)
+	err = plugin.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	require.Len(t, acc.GetTelegrafMetrics(), 0)

--- a/plugins/inputs/aerospike/aerospike.go
+++ b/plugins/inputs/aerospike/aerospike.go
@@ -2,6 +2,7 @@
 package aerospike
 
 import (
+	"context"
 	"crypto/tls"
 	_ "embed"
 	"fmt"
@@ -59,7 +60,7 @@ func (*Aerospike) SampleConfig() string {
 	return sampleConfig
 }
 
-func (a *Aerospike) Gather(acc telegraf.Accumulator) error {
+func (a *Aerospike) Gather(_ context.Context, acc telegraf.Accumulator) error {
 	if !a.initialized {
 		tlsConfig, err := a.ClientConfig.TLSConfig()
 		if err != nil {

--- a/plugins/inputs/aliyuncms/aliyuncms.go
+++ b/plugins/inputs/aliyuncms/aliyuncms.go
@@ -2,6 +2,7 @@
 package aliyuncms
 
 import (
+	"context"
 	_ "embed"
 	"encoding/json"
 	"errors"
@@ -217,7 +218,7 @@ func (s *AliyunCMS) Start(telegraf.Accumulator) error {
 }
 
 // Gather implements telegraf.Inputs interface
-func (s *AliyunCMS) Gather(acc telegraf.Accumulator) error {
+func (s *AliyunCMS) Gather(_ context.Context, acc telegraf.Accumulator) error {
 	s.updateWindow(time.Now())
 
 	// limit concurrency or we can easily exhaust user connection limit

--- a/plugins/inputs/amd_rocm_smi/amd_rocm_smi.go
+++ b/plugins/inputs/amd_rocm_smi/amd_rocm_smi.go
@@ -2,6 +2,7 @@
 package amd_rocm_smi
 
 import (
+	"context"
 	_ "embed"
 	"encoding/json"
 	"fmt"
@@ -32,7 +33,7 @@ func (*ROCmSMI) SampleConfig() string {
 }
 
 // Gather implements the telegraf interface
-func (rsmi *ROCmSMI) Gather(acc telegraf.Accumulator) error {
+func (rsmi *ROCmSMI) Gather(_ context.Context, acc telegraf.Accumulator) error {
 	if _, err := os.Stat(rsmi.BinPath); os.IsNotExist(err) {
 		return fmt.Errorf("rocm-smi binary not found in path %s, cannot query GPUs statistics", rsmi.BinPath)
 	}

--- a/plugins/inputs/amqp_consumer/amqp_consumer.go
+++ b/plugins/inputs/amqp_consumer/amqp_consumer.go
@@ -123,7 +123,7 @@ func (a *AMQPConsumer) SetParser(parser telegraf.Parser) {
 }
 
 // All gathering is done in the Start function
-func (a *AMQPConsumer) Gather(_ telegraf.Accumulator) error {
+func (a *AMQPConsumer) Gather(_ context.Context, _ telegraf.Accumulator) error {
 	return nil
 }
 

--- a/plugins/inputs/apcupsd/apcupsd.go
+++ b/plugins/inputs/apcupsd/apcupsd.go
@@ -32,9 +32,7 @@ func (*ApcUpsd) SampleConfig() string {
 	return sampleConfig
 }
 
-func (h *ApcUpsd) Gather(acc telegraf.Accumulator) error {
-	ctx := context.Background()
-
+func (h *ApcUpsd) Gather(ctx context.Context, acc telegraf.Accumulator) error {
 	for _, server := range h.Servers {
 		err := func(address string) error {
 			addrBits, err := url.Parse(address)

--- a/plugins/inputs/apcupsd/apcupsd_test.go
+++ b/plugins/inputs/apcupsd/apcupsd_test.go
@@ -96,7 +96,7 @@ func TestConfig(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			apc.Servers = tt.servers
 
-			err := apc.Gather(&acc)
+			err := apc.Gather(context.Background(), &acc)
 			if tt.err {
 				require.Error(t, err)
 			} else {
@@ -169,7 +169,7 @@ func TestApcupsdGather(t *testing.T) {
 
 			apc.Servers = []string{"tcp://" + lAddr}
 
-			err = apc.Gather(&acc)
+			err = apc.Gather(context.Background(), &acc)
 			if tt.err {
 				require.Error(t, err)
 			} else {

--- a/plugins/inputs/aurora/aurora.go
+++ b/plugins/inputs/aurora/aurora.go
@@ -63,7 +63,7 @@ func (*Aurora) SampleConfig() string {
 	return sampleConfig
 }
 
-func (a *Aurora) Gather(acc telegraf.Accumulator) error {
+func (a *Aurora) Gather(ctx context.Context, acc telegraf.Accumulator) error {
 	if a.client == nil {
 		err := a.initialize()
 		if err != nil {
@@ -71,7 +71,7 @@ func (a *Aurora) Gather(acc telegraf.Accumulator) error {
 		}
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(a.Timeout))
+	ctx, cancel := context.WithTimeout(ctx, time.Duration(a.Timeout))
 	defer cancel()
 
 	var wg sync.WaitGroup

--- a/plugins/inputs/aurora/aurora_test.go
+++ b/plugins/inputs/aurora/aurora_test.go
@@ -1,6 +1,7 @@
 package aurora
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -209,7 +210,7 @@ func TestAurora(t *testing.T) {
 			plugin := &Aurora{}
 			plugin.Schedulers = []string{u.String()}
 			plugin.Roles = tt.roles
-			err := plugin.Gather(&acc)
+			err := plugin.Gather(context.Background(), &acc)
 			tt.check(t, err, &acc)
 		})
 	}
@@ -260,7 +261,7 @@ func TestBasicAuth(t *testing.T) {
 			plugin.Schedulers = []string{u.String()}
 			plugin.Username = tt.username
 			plugin.Password = tt.password
-			err := plugin.Gather(&acc)
+			err := plugin.Gather(context.Background(), &acc)
 			require.NoError(t, err)
 		})
 	}

--- a/plugins/inputs/azure_monitor/azure_monitor.go
+++ b/plugins/inputs/azure_monitor/azure_monitor.go
@@ -2,6 +2,7 @@
 package azure_monitor
 
 import (
+	"context"
 	_ "embed"
 	"fmt"
 	"sync"
@@ -96,7 +97,7 @@ func (am *AzureMonitor) Init() error {
 	return nil
 }
 
-func (am *AzureMonitor) Gather(acc telegraf.Accumulator) error {
+func (am *AzureMonitor) Gather(_ context.Context, acc telegraf.Accumulator) error {
 	var waitGroup sync.WaitGroup
 
 	for _, target := range am.receiver.Targets.ResourceTargets {

--- a/plugins/inputs/azure_storage_queue/azure_storage_queue.go
+++ b/plugins/inputs/azure_storage_queue/azure_storage_queue.go
@@ -79,13 +79,11 @@ func (a *AzureStorageQueue) GatherQueueMetrics(
 	acc.AddFields("azure_storage_queues", fields, tags)
 }
 
-func (a *AzureStorageQueue) Gather(acc telegraf.Accumulator) error {
+func (a *AzureStorageQueue) Gather(ctx context.Context, acc telegraf.Accumulator) error {
 	serviceURL, err := a.GetServiceURL()
 	if err != nil {
 		return err
 	}
-
-	ctx := context.TODO()
 
 	for marker := (azqueue.Marker{}); marker.NotDone(); {
 		a.Log.Debugf("Listing queues of storage account %q", a.StorageAccountName)

--- a/plugins/inputs/bcache/bcache.go
+++ b/plugins/inputs/bcache/bcache.go
@@ -100,7 +100,7 @@ func (*Bcache) SampleConfig() string {
 	return sampleConfig
 }
 
-func (b *Bcache) Gather(acc telegraf.Accumulator) error {
+func (b *Bcache) Gather(_ context.Context(), acc telegraf.Accumulator) error {
 	bcacheDevsChecked := make(map[string]bool)
 	var restrictDevs bool
 	if len(b.BcacheDevs) != 0 {

--- a/plugins/inputs/bcache/bcache_notlinux.go
+++ b/plugins/inputs/bcache/bcache_notlinux.go
@@ -4,6 +4,7 @@
 package bcache
 
 import (
+	"context"
 	_ "embed"
 
 	"github.com/influxdata/telegraf"
@@ -21,8 +22,8 @@ func (b *Bcache) Init() error {
 	b.Log.Warn("current platform is not supported")
 	return nil
 }
-func (*Bcache) SampleConfig() string                { return sampleConfig }
-func (*Bcache) Gather(_ telegraf.Accumulator) error { return nil }
+func (*Bcache) SampleConfig() string                                   { return sampleConfig }
+func (*Bcache) Gather(_ context.Context, _ telegraf.Accumulator) error { return nil }
 
 func init() {
 	inputs.Add("bcache", func() telegraf.Input {

--- a/plugins/inputs/beanstalkd/beanstalkd.go
+++ b/plugins/inputs/beanstalkd/beanstalkd.go
@@ -2,6 +2,7 @@
 package beanstalkd
 
 import (
+	"context"
 	_ "embed"
 	"fmt"
 	"io"
@@ -26,7 +27,7 @@ func (*Beanstalkd) SampleConfig() string {
 	return sampleConfig
 }
 
-func (b *Beanstalkd) Gather(acc telegraf.Accumulator) error {
+func (b *Beanstalkd) Gather(_ context.Context, acc telegraf.Accumulator) error {
 	connection, err := textproto.Dial("tcp", b.Server)
 	if err != nil {
 		return err

--- a/plugins/inputs/beat/beat.go
+++ b/plugins/inputs/beat/beat.go
@@ -2,6 +2,7 @@
 package beat
 
 import (
+	"context"
 	_ "embed"
 	"encoding/json"
 	"fmt"
@@ -104,8 +105,8 @@ func (beat *Beat) createHTTPClient() (*http.Client, error) {
 }
 
 // gatherJSONData query the data source and parse the response JSON
-func (beat *Beat) gatherJSONData(address string, value interface{}) error {
-	request, err := http.NewRequest(beat.Method, address, nil)
+func (beat *Beat) gatherJSONData(ctx context.Context, address string, value interface{}) error {
+	request, err := http.NewRequestWithContext(ctx, beat.Method, address, nil)
 	if err != nil {
 		return err
 	}
@@ -130,7 +131,7 @@ func (beat *Beat) gatherJSONData(address string, value interface{}) error {
 	return json.NewDecoder(response.Body).Decode(value)
 }
 
-func (beat *Beat) Gather(accumulator telegraf.Accumulator) error {
+func (beat *Beat) Gather(ctx context.Context, accumulator telegraf.Accumulator) error {
 	beatStats := &Stats{}
 	beatInfo := &Info{}
 
@@ -143,7 +144,7 @@ func (beat *Beat) Gather(accumulator telegraf.Accumulator) error {
 		return err
 	}
 
-	err = beat.gatherJSONData(infoURL.String(), beatInfo)
+	err = beat.gatherJSONData(ctx, infoURL.String(), beatInfo)
 	if err != nil {
 		return err
 	}
@@ -155,7 +156,7 @@ func (beat *Beat) Gather(accumulator telegraf.Accumulator) error {
 		"beat_version": beatInfo.Version,
 	}
 
-	err = beat.gatherJSONData(statsURL.String(), beatStats)
+	err = beat.gatherJSONData(ctx, statsURL.String(), beatStats)
 	if err != nil {
 		return err
 	}

--- a/plugins/inputs/beat/beat_test.go
+++ b/plugins/inputs/beat/beat_test.go
@@ -1,6 +1,7 @@
 package beat
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"net/http"
@@ -44,7 +45,7 @@ func Test_BeatStats(t *testing.T) {
 	fakeServer.Start()
 	defer fakeServer.Close()
 
-	require.NoError(t, err, beatTest.Gather(&beat6StatsAccumulator))
+	require.NoError(t, err, beatTest.Gather(context.Background(), &beat6StatsAccumulator))
 
 	beat6StatsAccumulator.AssertContainsTaggedFields(
 		t,
@@ -199,5 +200,5 @@ func Test_BeatRequest(t *testing.T) {
 	beatTest.Username = "admin"
 	beatTest.Password = "PWD"
 
-	require.NoError(t, beatTest.Gather(&beat6StatsAccumulator))
+	require.NoError(t, beatTest.Gather(context.Background(), &beat6StatsAccumulator))
 }

--- a/plugins/inputs/bind/bind.go
+++ b/plugins/inputs/bind/bind.go
@@ -2,6 +2,7 @@
 package bind
 
 import (
+	"context"
 	_ "embed"
 	"fmt"
 	"net/http"
@@ -38,7 +39,7 @@ func (b *Bind) Init() error {
 	return nil
 }
 
-func (b *Bind) Gather(acc telegraf.Accumulator) error {
+func (b *Bind) Gather(_ context.Context, acc telegraf.Accumulator) error {
 	var wg sync.WaitGroup
 
 	if len(b.Urls) == 0 {
@@ -55,7 +56,7 @@ func (b *Bind) Gather(acc telegraf.Accumulator) error {
 		wg.Add(1)
 		go func(addr *url.URL) {
 			defer wg.Done()
-			acc.AddError(b.gatherURL(addr, acc))
+			acc.AddError(b.gatherURL(context.TODO(), addr, acc))
 		}(addr)
 	}
 
@@ -63,7 +64,7 @@ func (b *Bind) Gather(acc telegraf.Accumulator) error {
 	return nil
 }
 
-func (b *Bind) gatherURL(addr *url.URL, acc telegraf.Accumulator) error {
+func (b *Bind) gatherURL(_ context.Context, addr *url.URL, acc telegraf.Accumulator) error {
 	switch addr.Path {
 	case "":
 		// BIND 9.6 - 9.8

--- a/plugins/inputs/bond/bond.go
+++ b/plugins/inputs/bond/bond.go
@@ -3,6 +3,7 @@ package bond
 
 import (
 	"bufio"
+	"context"
 	_ "embed"
 	"fmt"
 	"os"
@@ -43,7 +44,7 @@ func (*Bond) SampleConfig() string {
 	return sampleConfig
 }
 
-func (bond *Bond) Gather(acc telegraf.Accumulator) error {
+func (bond *Bond) Gather(_ context.Context, acc telegraf.Accumulator) error {
 	// load proc path, get default value if config value and env variable are empty
 	bond.loadPaths()
 	// list bond interfaces from bonding directory or gather all interfaces.

--- a/plugins/inputs/burrow/burrow_test.go
+++ b/plugins/inputs/burrow/burrow_test.go
@@ -1,6 +1,7 @@
 package burrow
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -72,7 +73,7 @@ func TestBurrowTopic(t *testing.T) {
 
 	plugin := &burrow{Servers: []string{s.URL}}
 	acc := &testutil.Accumulator{}
-	require.NoError(t, plugin.Gather(acc))
+	require.NoError(t, plugin.Gather(context.Background(), acc))
 
 	fields := []map[string]interface{}{
 		// topicA
@@ -103,7 +104,7 @@ func TestBurrowPartition(t *testing.T) {
 		Servers: []string{s.URL},
 	}
 	acc := &testutil.Accumulator{}
-	require.NoError(t, plugin.Gather(acc))
+	require.NoError(t, plugin.Gather(context.Background(), acc))
 
 	fields := []map[string]interface{}{
 		{
@@ -151,7 +152,7 @@ func TestBurrowGroup(t *testing.T) {
 		Servers: []string{s.URL},
 	}
 	acc := &testutil.Accumulator{}
-	require.NoError(t, plugin.Gather(acc))
+	require.NoError(t, plugin.Gather(context.Background(), acc))
 
 	fields := []map[string]interface{}{
 		{
@@ -189,7 +190,7 @@ func TestMultipleServers(t *testing.T) {
 		Servers: []string{s1.URL, s2.URL},
 	}
 	acc := &testutil.Accumulator{}
-	require.NoError(t, plugin.Gather(acc))
+	require.NoError(t, plugin.Gather(context.Background(), acc))
 
 	require.Exactly(t, 14, len(acc.Metrics))
 	require.Empty(t, acc.Errors)
@@ -205,7 +206,7 @@ func TestMultipleRuns(t *testing.T) {
 	}
 	for i := 0; i < 4; i++ {
 		acc := &testutil.Accumulator{}
-		require.NoError(t, plugin.Gather(acc))
+		require.NoError(t, plugin.Gather(context.Background(), acc))
 
 		require.Exactly(t, 7, len(acc.Metrics))
 		require.Empty(t, acc.Errors)
@@ -224,7 +225,7 @@ func TestBasicAuthConfig(t *testing.T) {
 	}
 
 	acc := &testutil.Accumulator{}
-	require.NoError(t, plugin.Gather(acc))
+	require.NoError(t, plugin.Gather(context.Background(), acc))
 
 	require.Exactly(t, 7, len(acc.Metrics))
 	require.Empty(t, acc.Errors)
@@ -241,7 +242,7 @@ func TestFilterClusters(t *testing.T) {
 	}
 
 	acc := &testutil.Accumulator{}
-	require.NoError(t, plugin.Gather(acc))
+	require.NoError(t, plugin.Gather(context.Background(), acc))
 
 	// no match by cluster
 	require.Exactly(t, 0, len(acc.Metrics))
@@ -260,7 +261,7 @@ func TestFilterGroups(t *testing.T) {
 	}
 
 	acc := &testutil.Accumulator{}
-	require.NoError(t, plugin.Gather(acc))
+	require.NoError(t, plugin.Gather(context.Background(), acc))
 
 	require.Exactly(t, 1, len(acc.Metrics))
 	require.Empty(t, acc.Errors)
@@ -278,7 +279,7 @@ func TestFilterTopics(t *testing.T) {
 	}
 
 	acc := &testutil.Accumulator{}
-	require.NoError(t, plugin.Gather(acc))
+	require.NoError(t, plugin.Gather(context.Background(), acc))
 
 	require.Exactly(t, 3, len(acc.Metrics))
 	require.Empty(t, acc.Errors)

--- a/plugins/inputs/cassandra/cassandra.go
+++ b/plugins/inputs/cassandra/cassandra.go
@@ -2,6 +2,7 @@
 package cassandra
 
 import (
+	"context"
 	_ "embed"
 	"encoding/json"
 	"errors"
@@ -170,9 +171,9 @@ func (c cassandraMetric) addTagsFields(out map[string]interface{}) {
 	}
 }
 
-func (c *Cassandra) getAttr(requestURL *url.URL) (map[string]interface{}, error) {
+func (c *Cassandra) getAttr(ctx context.Context, requestURL *url.URL) (map[string]interface{}, error) {
 	// Create + send request
-	req, err := http.NewRequest("GET", requestURL.String(), nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", requestURL.String(), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -247,7 +248,7 @@ func (c *Cassandra) Start(_ telegraf.Accumulator) error {
 func (c *Cassandra) Stop() {
 }
 
-func (c *Cassandra) Gather(acc telegraf.Accumulator) error {
+func (c *Cassandra) Gather(ctx context.Context, acc telegraf.Accumulator) error {
 	context := c.Context
 	servers := c.Servers
 	metrics := c.Metrics
@@ -280,7 +281,7 @@ func (c *Cassandra) Gather(acc telegraf.Accumulator) error {
 					serverTokens["passwd"])
 			}
 
-			out, err := c.getAttr(requestURL)
+			out, err := c.getAttr(ctx, requestURL)
 			if err != nil {
 				acc.AddError(err)
 				continue

--- a/plugins/inputs/ceph/ceph.go
+++ b/plugins/inputs/ceph/ceph.go
@@ -3,6 +3,7 @@ package ceph
 
 import (
 	"bytes"
+	"context"
 	_ "embed"
 	"encoding/json"
 	"fmt"
@@ -51,7 +52,7 @@ func (*Ceph) SampleConfig() string {
 	return sampleConfig
 }
 
-func (c *Ceph) Gather(acc telegraf.Accumulator) error {
+func (c *Ceph) Gather(_ context.Context, acc telegraf.Accumulator) error {
 	if c.GatherAdminSocketStats {
 		if err := c.gatherAdminSocketStats(acc); err != nil {
 			return err

--- a/plugins/inputs/cgroup/cgroup_linux.go
+++ b/plugins/inputs/cgroup/cgroup_linux.go
@@ -3,6 +3,7 @@
 package cgroup
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path"
@@ -16,7 +17,7 @@ import (
 
 const metricName = "cgroup"
 
-func (g *CGroup) Gather(acc telegraf.Accumulator) error {
+func (g *CGroup) Gather(_ context.Context, acc telegraf.Accumulator) error {
 	list := make(chan pathInfo)
 	go g.generateDirs(list)
 

--- a/plugins/inputs/cgroup/cgroup_notlinux.go
+++ b/plugins/inputs/cgroup/cgroup_notlinux.go
@@ -3,9 +3,11 @@
 package cgroup
 
 import (
+	"context"
+
 	"github.com/influxdata/telegraf"
 )
 
-func (*CGroup) Gather(_ telegraf.Accumulator) error {
+func (*CGroup) Gather(_ context.Context, _ telegraf.Accumulator) error {
 	return nil
 }

--- a/plugins/inputs/chrony/chrony.go
+++ b/plugins/inputs/chrony/chrony.go
@@ -2,6 +2,7 @@
 package chrony
 
 import (
+	"context"
 	_ "embed"
 	"errors"
 	"fmt"
@@ -40,7 +41,7 @@ func (c *Chrony) Init() error {
 	return nil
 }
 
-func (c *Chrony) Gather(acc telegraf.Accumulator) error {
+func (c *Chrony) Gather(_ context.Context, acc telegraf.Accumulator) error {
 	flags := []string{}
 	if !c.DNSLookup {
 		flags = append(flags, "-n")

--- a/plugins/inputs/chrony/chrony_test.go
+++ b/plugins/inputs/chrony/chrony_test.go
@@ -1,6 +1,7 @@
 package chrony
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -18,7 +19,7 @@ func TestGather(t *testing.T) {
 	defer func() { execCommand = exec.Command }()
 	var acc testutil.Accumulator
 
-	err := c.Gather(&acc)
+	err := c.Gather(context.Background(), &acc)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -48,7 +49,7 @@ func TestGather(t *testing.T) {
 
 	// test with dns lookup
 	c.DNSLookup = true
-	err = c.Gather(&acc)
+	err = c.Gather(context.Background(), &acc)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/inputs/cisco_telemetry_mdt/cisco_telemetry_mdt.go
+++ b/plugins/inputs/cisco_telemetry_mdt/cisco_telemetry_mdt.go
@@ -3,6 +3,7 @@ package cisco_telemetry_mdt
 
 import (
 	"bytes"
+	"context"
 	_ "embed"
 	"encoding/binary"
 	"encoding/json"
@@ -789,7 +790,7 @@ func (c *CiscoTelemetryMDT) Stop() {
 }
 
 // Gather plugin measurements (unused)
-func (c *CiscoTelemetryMDT) Gather(_ telegraf.Accumulator) error {
+func (c *CiscoTelemetryMDT) Gather(_ context.Context, _ telegraf.Accumulator) error {
 	return nil
 }
 

--- a/plugins/inputs/clickhouse/clickhouse_test.go
+++ b/plugins/inputs/clickhouse/clickhouse_test.go
@@ -1,6 +1,7 @@
 package clickhouse
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -309,7 +310,7 @@ func TestGather(t *testing.T) {
 		acc = &testutil.Accumulator{}
 	)
 	defer ts.Close()
-	require.NoError(t, ch.Gather(acc))
+	require.NoError(t, ch.Gather(context.Background(), acc))
 
 	acc.AssertContainsTaggedFields(t, "clickhouse_tables",
 		map[string]interface{}{
@@ -485,7 +486,7 @@ func TestGatherWithSomeTablesNotExists(t *testing.T) {
 		acc = &testutil.Accumulator{}
 	)
 	defer ts.Close()
-	require.NoError(t, ch.Gather(acc))
+	require.NoError(t, ch.Gather(context.Background(), acc))
 
 	acc.AssertDoesNotContainMeasurement(t, "clickhouse_zookeeper")
 	acc.AssertDoesNotContainMeasurement(t, "clickhouse_replication_queue")
@@ -514,7 +515,7 @@ func TestWrongJSONMarshalling(t *testing.T) {
 		acc = &testutil.Accumulator{}
 	)
 	defer ts.Close()
-	require.NoError(t, ch.Gather(acc))
+	require.NoError(t, ch.Gather(context.Background(), acc))
 
 	require.Equal(t, 0, len(acc.Metrics))
 	allMeasurements := []string{
@@ -547,7 +548,7 @@ func TestOfflineServer(t *testing.T) {
 			},
 		}
 	)
-	require.NoError(t, ch.Gather(acc))
+	require.NoError(t, ch.Gather(context.Background(), acc))
 
 	require.Equal(t, 0, len(acc.Metrics))
 	allMeasurements := []string{
@@ -602,5 +603,5 @@ func TestAutoDiscovery(t *testing.T) {
 		acc = &testutil.Accumulator{}
 	)
 	defer ts.Close()
-	require.NoError(t, ch.Gather(acc))
+	require.NoError(t, ch.Gather(context.Background(), acc))
 }

--- a/plugins/inputs/cloud_pubsub/cloud_pubsub.go
+++ b/plugins/inputs/cloud_pubsub/cloud_pubsub.go
@@ -72,7 +72,7 @@ func (*PubSub) SampleConfig() string {
 }
 
 // Gather does nothing for this service input.
-func (ps *PubSub) Gather(_ telegraf.Accumulator) error {
+func (ps *PubSub) Gather(_ context.Context, _ telegraf.Accumulator) error {
 	return nil
 }
 

--- a/plugins/inputs/cloud_pubsub_push/cloud_pubsub_push.go
+++ b/plugins/inputs/cloud_pubsub_push/cloud_pubsub_push.go
@@ -69,7 +69,7 @@ func (*PubSubPush) SampleConfig() string {
 	return sampleConfig
 }
 
-func (p *PubSubPush) Gather(_ telegraf.Accumulator) error {
+func (p *PubSubPush) Gather(_ context.Context, _ telegraf.Accumulator) error {
 	return nil
 }
 

--- a/plugins/inputs/cloudwatch/cloudwatch_test.go
+++ b/plugins/inputs/cloudwatch/cloudwatch_test.go
@@ -355,7 +355,7 @@ func TestSelectMetrics(t *testing.T) {
 	}
 	require.NoError(t, c.Init())
 	c.client = &mockSelectMetricsCloudWatchClient{}
-	filtered, err := getFilteredMetrics(c)
+	filtered, err := getFilteredMetrics(context.Background(), c)
 	// We've asked for 2 (out of 4) metrics, over all 3 load balancers in all 2
 	// AZs. We should get 12 metrics.
 	require.Equal(t, 12, len(filtered[0].metrics))

--- a/plugins/inputs/cloudwatch_metric_streams/cloudwatch_metric_streams.go
+++ b/plugins/inputs/cloudwatch_metric_streams/cloudwatch_metric_streams.go
@@ -3,6 +3,7 @@ package cloudwatch_metric_streams
 
 import (
 	"compress/gzip"
+	"context"
 	"crypto/tls"
 	_ "embed"
 	"encoding/base64"
@@ -111,7 +112,7 @@ func (cms *CloudWatchMetricStreams) Description() string {
 	return "HTTP listener & parser for AWS Metric Streams"
 }
 
-func (cms *CloudWatchMetricStreams) Gather(_ telegraf.Accumulator) error {
+func (cms *CloudWatchMetricStreams) Gather(_ context.Context, _ telegraf.Accumulator) error {
 	return nil
 }
 

--- a/plugins/inputs/conntrack/conntrack.go
+++ b/plugins/inputs/conntrack/conntrack.go
@@ -4,6 +4,7 @@
 package conntrack
 
 import (
+	"context"
 	_ "embed"
 	"fmt"
 	"os"
@@ -68,7 +69,7 @@ func (c *Conntrack) Init() error {
 	return nil
 }
 
-func (c *Conntrack) Gather(acc telegraf.Accumulator) error {
+func (c *Conntrack) Gather(_ context.Context, acc telegraf.Accumulator) error {
 	var metricKey string
 	fields := make(map[string]interface{})
 

--- a/plugins/inputs/conntrack/conntrack_notlinux.go
+++ b/plugins/inputs/conntrack/conntrack_notlinux.go
@@ -4,6 +4,7 @@
 package conntrack
 
 import (
+	"context"
 	_ "embed"
 
 	"github.com/influxdata/telegraf"
@@ -21,8 +22,8 @@ func (c *Conntrack) Init() error {
 	c.Log.Warn("current platform is not supported")
 	return nil
 }
-func (*Conntrack) SampleConfig() string                { return sampleConfig }
-func (*Conntrack) Gather(_ telegraf.Accumulator) error { return nil }
+func (*Conntrack) SampleConfig() string                                   { return sampleConfig }
+func (*Conntrack) Gather(_ context.Context, _ telegraf.Accumulator) error { return nil }
 
 func init() {
 	inputs.Add("conntrack", func() telegraf.Input {

--- a/plugins/inputs/consul/consul.go
+++ b/plugins/inputs/consul/consul.go
@@ -2,6 +2,7 @@
 package consul
 
 import (
+	"context"
 	_ "embed"
 	"net/http"
 	"strings"
@@ -128,7 +129,7 @@ func (c *Consul) GatherHealthCheck(acc telegraf.Accumulator, checks []*api.Healt
 	}
 }
 
-func (c *Consul) Gather(acc telegraf.Accumulator) error {
+func (c *Consul) Gather(ctx context.Context, acc telegraf.Accumulator) error {
 	if c.client == nil {
 		newClient, err := c.createAPIClient()
 
@@ -139,7 +140,7 @@ func (c *Consul) Gather(acc telegraf.Accumulator) error {
 		c.client = newClient
 	}
 
-	checks, _, err := c.client.Health().State("any", nil)
+	checks, _, err := c.client.Health().State("any", (&api.QueryOptions{}).WithContext(ctx))
 
 	if err != nil {
 		return err

--- a/plugins/inputs/consul_agent/consul_agent.go
+++ b/plugins/inputs/consul_agent/consul_agent.go
@@ -2,6 +2,7 @@
 package consul_agent
 
 import (
+	"context"
 	_ "embed"
 	"encoding/json"
 	"errors"
@@ -81,8 +82,8 @@ func (n *ConsulAgent) Init() error {
 }
 
 // Gather, collects metrics from Consul endpoint
-func (n *ConsulAgent) Gather(acc telegraf.Accumulator) error {
-	summaryMetrics, err := n.loadJSON(n.URL + "/v1/agent/metrics")
+func (n *ConsulAgent) Gather(ctx context.Context, acc telegraf.Accumulator) error {
+	summaryMetrics, err := n.loadJSON(ctx, n.URL+"/v1/agent/metrics")
 	if err != nil {
 		return err
 	}
@@ -90,8 +91,8 @@ func (n *ConsulAgent) Gather(acc telegraf.Accumulator) error {
 	return buildConsulAgent(acc, summaryMetrics)
 }
 
-func (n *ConsulAgent) loadJSON(url string) (*AgentInfo, error) {
-	req, err := http.NewRequest("GET", url, nil)
+func (n *ConsulAgent) loadJSON(ctx context.Context, url string) (*AgentInfo, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/inputs/consul_agent/consul_agent_test.go
+++ b/plugins/inputs/consul_agent/consul_agent_test.go
@@ -1,6 +1,7 @@
 package consul_agent
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -88,7 +89,7 @@ func TestConsulStats(t *testing.T) {
 			require.NoError(t, err)
 
 			acc := testutil.Accumulator{}
-			err = plugin.Gather(&acc)
+			err = plugin.Gather(context.Background(), &acc)
 			require.NoError(t, err)
 
 			testutil.RequireMetricsEqual(t, tt.expected, acc.GetTelegrafMetrics())

--- a/plugins/inputs/couchbase/couchbase.go
+++ b/plugins/inputs/couchbase/couchbase.go
@@ -2,6 +2,7 @@
 package couchbase
 
 import (
+	"context"
 	_ "embed"
 	"encoding/json"
 	"fmt"
@@ -50,7 +51,7 @@ func (*Couchbase) SampleConfig() string {
 
 // Reads stats from all configured clusters. Accumulates stats.
 // Returns one of the errors encountered while gathering stats (if any).
-func (cb *Couchbase) Gather(acc telegraf.Accumulator) error {
+func (cb *Couchbase) Gather(_ context.Context, acc telegraf.Accumulator) error {
 	if len(cb.Servers) == 0 {
 		return cb.gatherServer(acc, "http://localhost:8091/")
 	}

--- a/plugins/inputs/cpu/cpu.go
+++ b/plugins/inputs/cpu/cpu.go
@@ -2,6 +2,7 @@
 package cpu
 
 import (
+	"context"
 	_ "embed"
 	"fmt"
 	"time"
@@ -44,7 +45,7 @@ func (*CPUStats) SampleConfig() string {
 	return sampleConfig
 }
 
-func (c *CPUStats) Gather(acc telegraf.Accumulator) error {
+func (c *CPUStats) Gather(_ context.Context, acc telegraf.Accumulator) error {
 	times, err := c.ps.CPUTimes(c.PerCPU, c.TotalCPU)
 	if err != nil {
 		return fmt.Errorf("error getting CPU info: %w", err)

--- a/plugins/inputs/cpu/cpu_test.go
+++ b/plugins/inputs/cpu/cpu_test.go
@@ -1,6 +1,7 @@
 package cpu
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -48,7 +49,7 @@ func TestCPUStats(t *testing.T) {
 
 	cs := NewCPUStats(&mps)
 
-	err := cs.Gather(&acc)
+	err := cs.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	// Computed values are checked with delta > 0 because of floating point arithmetic
@@ -70,7 +71,7 @@ func TestCPUStats(t *testing.T) {
 	cs.ps = &mps2
 
 	// Should have added cpu percentages too
-	err = cs.Gather(&acc)
+	err = cs.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	assertContainsTaggedFloat(t, &acc, "time_user", 24.9, 0)
@@ -161,7 +162,7 @@ func TestCPUCountIncrease(t *testing.T) {
 			},
 		}, nil)
 
-	err = cs.Gather(&acc)
+	err = cs.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	mps2.On("CPUTimes").Return(
@@ -175,7 +176,7 @@ func TestCPUCountIncrease(t *testing.T) {
 		}, nil)
 	cs.ps = &mps2
 
-	err = cs.Gather(&acc)
+	err = cs.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 }
 
@@ -211,7 +212,7 @@ func TestCPUTimesDecrease(t *testing.T) {
 
 	cs := NewCPUStats(&mps)
 
-	err := cs.Gather(&acc)
+	err := cs.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	// Computed values are checked with delta > 0 because of floating point arithmetic
@@ -225,14 +226,14 @@ func TestCPUTimesDecrease(t *testing.T) {
 	cs.ps = &mps2
 
 	// CPU times decreased. An error should be raised
-	err = cs.Gather(&acc)
+	err = cs.Gather(context.Background(), &acc)
 	require.Error(t, err)
 
 	mps3 := system.MockPS{}
 	mps3.On("CPUTimes").Return([]cpuUtil.TimesStat{cts3}, nil)
 	cs.ps = &mps3
 
-	err = cs.Gather(&acc)
+	err = cs.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	assertContainsTaggedFloat(t, &acc, "time_user", 56, 0)

--- a/plugins/inputs/csgo/csgo.go
+++ b/plugins/inputs/csgo/csgo.go
@@ -2,6 +2,7 @@
 package csgo
 
 import (
+	"context"
 	_ "embed"
 	"encoding/json"
 	"errors"
@@ -40,7 +41,7 @@ func (*CSGO) SampleConfig() string {
 	return sampleConfig
 }
 
-func (s *CSGO) Gather(acc telegraf.Accumulator) error {
+func (s *CSGO) Gather(_ context.Context, acc telegraf.Accumulator) error {
 	var wg sync.WaitGroup
 
 	// Loop through each server and collect metrics

--- a/plugins/inputs/ctrlx_datalayer/ctrlx_datalayer.go
+++ b/plugins/inputs/ctrlx_datalayer/ctrlx_datalayer.go
@@ -355,7 +355,7 @@ func (c *CtrlXDataLayer) Stop() {
 }
 
 // Gather is called by telegraf to collect the metrics.
-func (c *CtrlXDataLayer) Gather(_ telegraf.Accumulator) error {
+func (c *CtrlXDataLayer) Gather(_ context.Context, _ telegraf.Accumulator) error {
 	// Metrics are sent to the accumulator asynchronously in worker thread. So nothing to do here.
 	return nil
 }

--- a/plugins/inputs/ctrlx_datalayer/ctrlx_datalayer_test.go
+++ b/plugins/inputs/ctrlx_datalayer/ctrlx_datalayer_test.go
@@ -1,6 +1,7 @@
 package ctrlx_datalayer
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -8,6 +9,7 @@ import (
 	"time"
 
 	"github.com/boschrexroth/ctrlx-datalayer-golang/pkg/token"
+	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
 	httpconfig "github.com/influxdata/telegraf/plugins/common/http"
 	"github.com/influxdata/telegraf/plugins/common/tls"
@@ -202,7 +204,9 @@ func TestCtrlXMetricsField(t *testing.T) {
 	defer cleanup(server)
 
 	var acc testutil.Accumulator
-	require.NoError(t, acc.GatherError(s.Start))
+	require.NoError(t, acc.GatherError(func(_ context.Context, acc telegraf.Accumulator) error {
+		return s.Start(acc)
+	}))
 	require.Eventually(t, func() bool {
 		if v, found := acc.FloatField(measurement, fieldName); found {
 			require.Equal(t, 43.0, v)
@@ -222,7 +226,9 @@ func TestCtrlXMetricsMulti(t *testing.T) {
 
 	var acc testutil.Accumulator
 
-	require.NoError(t, acc.GatherError(s.Start))
+	require.NoError(t, acc.GatherError(func(_ context.Context, acc telegraf.Accumulator) error {
+		return s.Start(acc)
+	}))
 	require.Eventually(t, func() bool {
 		if v, found := acc.FloatField(measurement, fieldName); found {
 			require.Equal(t, 44.0, v)

--- a/plugins/inputs/dcos/dcos.go
+++ b/plugins/inputs/dcos/dcos.go
@@ -79,13 +79,11 @@ func (*DCOS) SampleConfig() string {
 	return sampleConfig
 }
 
-func (d *DCOS) Gather(acc telegraf.Accumulator) error {
+func (d *DCOS) Gather(ctx context.Context, acc telegraf.Accumulator) error {
 	err := d.init()
 	if err != nil {
 		return err
 	}
-
-	ctx := context.Background()
 
 	token, err := d.creds.Token(ctx, d.client)
 	if err != nil {

--- a/plugins/inputs/dcos/dcos_test.go
+++ b/plugins/inputs/dcos/dcos_test.go
@@ -431,7 +431,7 @@ func TestGatherFilterNode(t *testing.T) {
 				NodeExclude: tt.nodeExclude,
 				client:      tt.client,
 			}
-			err := dcos.Gather(&acc)
+			err := dcos.Gather(context.Background(), &acc)
 			require.NoError(t, err)
 			for i, ok := range tt.check(&acc) {
 				require.True(t, ok, fmt.Sprintf("Index was not true: %d", i))

--- a/plugins/inputs/directory_monitor/directory_monitor.go
+++ b/plugins/inputs/directory_monitor/directory_monitor.go
@@ -75,7 +75,7 @@ func (*DirectoryMonitor) SampleConfig() string {
 	return sampleConfig
 }
 
-func (monitor *DirectoryMonitor) Gather(_ telegraf.Accumulator) error {
+func (monitor *DirectoryMonitor) Gather(_ context.Context, _ telegraf.Accumulator) error {
 	processFile := func(path string) error {
 		// We've been cancelled via Stop().
 		if monitor.context.Err() != nil {

--- a/plugins/inputs/directory_monitor/directory_monitor_test.go
+++ b/plugins/inputs/directory_monitor/directory_monitor_test.go
@@ -3,6 +3,7 @@ package directory_monitor
 import (
 	"bytes"
 	"compress/gzip"
+	"context"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -83,7 +84,7 @@ func TestCSVGZImport(t *testing.T) {
 	// Start plugin before adding file.
 	err = r.Start(&acc)
 	require.NoError(t, err)
-	err = r.Gather(&acc)
+	err = r.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 	acc.Wait(6)
 	r.Stop()
@@ -154,7 +155,7 @@ func TestCSVGZImportWithHeader(t *testing.T) {
 	// Start plugin before adding file.
 	err = r.Start(&acc)
 	require.NoError(t, err)
-	err = r.Gather(&acc)
+	err = r.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 	acc.Wait(6)
 	r.Stop()
@@ -211,7 +212,7 @@ func TestMultipleJSONFileImports(t *testing.T) {
 	err = r.Start(&acc)
 	r.Log = testutil.Logger{}
 	require.NoError(t, err)
-	err = r.Gather(&acc)
+	err = r.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 	acc.Wait(5)
 	r.Stop()
@@ -258,7 +259,7 @@ func TestFileTag(t *testing.T) {
 	err = r.Start(&acc)
 	r.Log = testutil.Logger{}
 	require.NoError(t, err)
-	err = r.Gather(&acc)
+	err = r.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 	acc.Wait(1)
 	r.Stop()
@@ -322,7 +323,7 @@ hello,80,test_name2`
 	// Start plugin before adding file.
 	err = r.Start(&acc)
 	require.NoError(t, err)
-	err = r.Gather(&acc)
+	err = r.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 	acc.Wait(1)
 	r.Stop()
@@ -393,7 +394,7 @@ hello,80,test_name2`
 	// Start plugin before adding file.
 	err = r.Start(&acc)
 	require.NoError(t, err)
-	err = r.Gather(&acc)
+	err = r.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 	acc.Wait(1)
 	r.Stop()
@@ -462,7 +463,7 @@ hello,80,test_name2`
 	// Start plugin before adding file.
 	err = r.Start(&acc)
 	require.NoError(t, err)
-	err = r.Gather(&acc)
+	err = r.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 	acc.Wait(1)
 	r.Stop()
@@ -523,7 +524,7 @@ func TestParseCompleteFile(t *testing.T) {
 
 	err = r.Start(&acc)
 	require.NoError(t, err)
-	err = r.Gather(&acc)
+	err = r.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 	acc.Wait(1)
 	r.Stop()
@@ -589,7 +590,7 @@ func TestParseSubdirectories(t *testing.T) {
 
 	err = r.Start(&acc)
 	require.NoError(t, err)
-	err = r.Gather(&acc)
+	err = r.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 	acc.Wait(2)
 	r.Stop()
@@ -667,7 +668,7 @@ func TestParseSubdirectoriesFilesIgnore(t *testing.T) {
 
 	err = r.Start(&acc)
 	require.NoError(t, err)
-	err = r.Gather(&acc)
+	err = r.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 	acc.Wait(1)
 	r.Stop()

--- a/plugins/inputs/disk/disk.go
+++ b/plugins/inputs/disk/disk.go
@@ -2,6 +2,7 @@
 package disk
 
 import (
+	"context"
 	_ "embed"
 	"fmt"
 	"strings"
@@ -44,7 +45,7 @@ func (ds *DiskStats) Init() error {
 	return nil
 }
 
-func (ds *DiskStats) Gather(acc telegraf.Accumulator) error {
+func (ds *DiskStats) Gather(_ context.Context, acc telegraf.Accumulator) error {
 	disks, partitions, err := ds.ps.DiskUsage(ds.MountPoints, ds.IgnoreMountOpts, ds.IgnoreFS)
 	if err != nil {
 		return fmt.Errorf("error getting disk usage info: %w", err)

--- a/plugins/inputs/disk/disk_test.go
+++ b/plugins/inputs/disk/disk_test.go
@@ -1,6 +1,7 @@
 package disk
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -89,7 +90,7 @@ func TestDiskUsage(t *testing.T) {
 	mps.On("PSDiskUsage", "/home").Return(&duAll[1], nil)
 	mps.On("PSDiskUsage", "/var/rootbind").Return(&duAll[2], nil)
 
-	err = (&DiskStats{ps: mps}).Gather(&acc)
+	err = (&DiskStats{ps: mps}).Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	numDiskMetrics := acc.NFields()
@@ -148,18 +149,18 @@ func TestDiskUsage(t *testing.T) {
 
 	// We expect 7 more DiskMetrics to show up with an explicit match on "/"
 	// and /home not matching the /dev in MountPoints
-	err = (&DiskStats{ps: &mps, MountPoints: []string{"/", "/dev"}}).Gather(&acc)
+	err = (&DiskStats{ps: &mps, MountPoints: []string{"/", "/dev"}}).Gather(context.Background(), &acc)
 	require.NoError(t, err)
 	require.Equal(t, expectedAllDiskMetrics+7, acc.NFields())
 
 	// We should see all the diskpoints as MountPoints includes both
 	// /, /home, and /var/rootbind
-	err = (&DiskStats{ps: &mps, MountPoints: []string{"/", "/home", "/var/rootbind"}}).Gather(&acc)
+	err = (&DiskStats{ps: &mps, MountPoints: []string{"/", "/home", "/var/rootbind"}}).Gather(context.Background(), &acc)
 	require.NoError(t, err)
 	require.Equal(t, expectedAllDiskMetrics+7*4, acc.NFields())
 
 	// We should see all the mounts as MountPoints except the bind mound
-	err = (&DiskStats{ps: &mps, IgnoreMountOpts: []string{"bind"}}).Gather(&acc)
+	err = (&DiskStats{ps: &mps, IgnoreMountOpts: []string{"bind"}}).Gather(context.Background(), &acc)
 	require.NoError(t, err)
 	require.Equal(t, expectedAllDiskMetrics+7*6, acc.NFields())
 }
@@ -290,7 +291,7 @@ func TestDiskUsageHostMountPrefix(t *testing.T) {
 
 			mps.On("OSGetenv", "HOST_MOUNT_PREFIX").Return(tt.hostMountPrefix)
 
-			err = (&DiskStats{ps: mps}).Gather(&acc)
+			err = (&DiskStats{ps: mps}).Gather(context.Background(), &acc)
 			require.NoError(t, err)
 
 			acc.AssertContainsTaggedFields(t, "disk", tt.expectedFields, tt.expectedTags)
@@ -420,7 +421,7 @@ func TestDiskStats(t *testing.T) {
 	mps.On("DiskUsage", []string{"/", "/home", "/var/rootbind"}, []string(nil), []string(nil)).Return(duAll, psAll, nil)
 	mps.On("DiskUsage", []string(nil), []string{"bind"}, []string(nil)).Return(duOptFiltered, psOptFiltered, nil)
 
-	err = (&DiskStats{ps: &mps}).Gather(&acc)
+	err = (&DiskStats{ps: &mps}).Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	numDiskMetrics := acc.NFields()
@@ -463,18 +464,18 @@ func TestDiskStats(t *testing.T) {
 
 	// We expect 7 more DiskMetrics to show up with an explicit match on "/"
 	// and /home and /var/rootbind not matching the /dev in MountPoints
-	err = (&DiskStats{ps: &mps, MountPoints: []string{"/", "/dev"}}).Gather(&acc)
+	err = (&DiskStats{ps: &mps, MountPoints: []string{"/", "/dev"}}).Gather(context.Background(), &acc)
 	require.NoError(t, err)
 	require.Equal(t, expectedAllDiskMetrics+7, acc.NFields())
 
 	// We should see all the diskpoints as MountPoints includes both
 	// /, /home, and /var/rootbind
-	err = (&DiskStats{ps: &mps, MountPoints: []string{"/", "/home", "/var/rootbind"}}).Gather(&acc)
+	err = (&DiskStats{ps: &mps, MountPoints: []string{"/", "/home", "/var/rootbind"}}).Gather(context.Background(), &acc)
 	require.NoError(t, err)
 	require.Equal(t, expectedAllDiskMetrics+7*4, acc.NFields())
 
 	// We should see all the mounts as MountPoints except the bind mound
-	err = (&DiskStats{ps: &mps, IgnoreMountOpts: []string{"bind"}}).Gather(&acc)
+	err = (&DiskStats{ps: &mps, IgnoreMountOpts: []string{"bind"}}).Gather(context.Background(), &acc)
 	require.NoError(t, err)
 	require.Equal(t, expectedAllDiskMetrics+7*6, acc.NFields())
 }
@@ -635,7 +636,7 @@ func TestDiskUsageIssues(t *testing.T) {
 			// Setup the plugin and run the test
 			var acc testutil.Accumulator
 			plugin := &DiskStats{ps: &mps}
-			require.NoError(t, plugin.Gather(&acc))
+			require.NoError(t, plugin.Gather(context.Background(), &acc))
 
 			actual := acc.GetTelegrafMetrics()
 			testutil.RequireMetricsEqual(t, tt.expected, actual, testutil.IgnoreTime(), testutil.SortMetrics())

--- a/plugins/inputs/diskio/diskio.go
+++ b/plugins/inputs/diskio/diskio.go
@@ -2,6 +2,7 @@
 package diskio
 
 import (
+	"context"
 	_ "embed"
 	"fmt"
 	"regexp"
@@ -42,7 +43,7 @@ func (d *DiskIO) Init() error {
 	return nil
 }
 
-func (d *DiskIO) Gather(acc telegraf.Accumulator) error {
+func (d *DiskIO) Gather(_ context.Context, acc telegraf.Accumulator) error {
 	var devices []string
 	if d.deviceFilter == nil {
 		for _, dev := range d.Devices {

--- a/plugins/inputs/diskio/diskio_test.go
+++ b/plugins/inputs/diskio/diskio_test.go
@@ -1,6 +1,7 @@
 package diskio
 
 import (
+	"context"
 	"testing"
 
 	"github.com/influxdata/telegraf/plugins/inputs/system"
@@ -112,7 +113,7 @@ func TestDiskIO(t *testing.T) {
 				Devices: tt.devices,
 			}
 			require.NoError(t, diskio.Init())
-			err := diskio.Gather(&acc)
+			err := diskio.Gather(context.Background(), &acc)
 			require.Equal(t, tt.err, err)
 
 			for _, metric := range tt.metrics {

--- a/plugins/inputs/disque/disque.go
+++ b/plugins/inputs/disque/disque.go
@@ -3,6 +3,7 @@ package disque
 
 import (
 	"bufio"
+	"context"
 	_ "embed"
 	"errors"
 	"fmt"
@@ -56,7 +57,7 @@ func (*Disque) SampleConfig() string {
 
 // Reads stats from all configured servers accumulates stats.
 // Returns one of the errors encountered while gather stats (if any).
-func (d *Disque) Gather(acc telegraf.Accumulator) error {
+func (d *Disque) Gather(_ context.Context, acc telegraf.Accumulator) error {
 	if len(d.Servers) == 0 {
 		address := &url.URL{
 			Host: ":7711",

--- a/plugins/inputs/dmcache/dmcache_linux.go
+++ b/plugins/inputs/dmcache/dmcache_linux.go
@@ -3,6 +3,7 @@
 package dmcache
 
 import (
+	"context"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -33,7 +34,7 @@ type cacheStatus struct {
 	dirty             int64
 }
 
-func (c *DMCache) Gather(acc telegraf.Accumulator) error {
+func (c *DMCache) Gather(_ context.Context, acc telegraf.Accumulator) error {
 	outputLines, err := c.getCurrentStatus()
 	if err != nil {
 		return err

--- a/plugins/inputs/dmcache/dmcache_notlinux.go
+++ b/plugins/inputs/dmcache/dmcache_notlinux.go
@@ -3,10 +3,12 @@
 package dmcache
 
 import (
+	"context"
+
 	"github.com/influxdata/telegraf"
 )
 
-func (*DMCache) Gather(_ telegraf.Accumulator) error {
+func (*DMCache) Gather(_ context.Context, _ telegraf.Accumulator) error {
 	return nil
 }
 

--- a/plugins/inputs/docker/docker_test.go
+++ b/plugins/inputs/docker/docker_test.go
@@ -451,7 +451,7 @@ func TestDocker_WindowsMemoryContainerStats(t *testing.T) {
 			}, nil
 		},
 	}
-	err := d.Gather(&acc)
+	err := d.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 }
 
@@ -571,7 +571,7 @@ func TestContainerLabels(t *testing.T) {
 				TotalInclude: []string{"cpu"},
 			}
 
-			err := d.Gather(&acc)
+			err := d.Gather(context.Background(), &acc)
 			require.NoError(t, err)
 
 			// Grab tags from a container metric
@@ -693,7 +693,7 @@ func TestContainerNames(t *testing.T) {
 				ContainerExclude: tt.exclude,
 			}
 
-			err := d.Gather(&acc)
+			err := d.Gather(context.Background(), &acc)
 			require.NoError(t, err)
 
 			// Set of expected names
@@ -910,7 +910,7 @@ func TestContainerStatus(t *testing.T) {
 				now = time.Now
 			}()
 
-			err := d.Gather(&acc)
+			err := d.Gather(context.Background(), &acc)
 			require.NoError(t, err)
 
 			actual := FilterMetrics(acc.GetTelegrafMetrics(), func(m telegraf.Metric) bool {
@@ -1084,7 +1084,7 @@ func TestDockerGatherSwarmInfo(t *testing.T) {
 	err := acc.GatherError(d.Gather)
 	require.NoError(t, err)
 
-	require.NoError(t, d.gatherSwarmInfo(&acc))
+	require.NoError(t, d.gatherSwarmInfo(context.Background(), &acc))
 
 	// test docker_container_net measurement
 	acc.AssertContainsTaggedFields(t,
@@ -1191,7 +1191,7 @@ func TestContainerStateFilter(t *testing.T) {
 				ContainerStateExclude: tt.exclude,
 			}
 
-			err := d.Gather(&acc)
+			err := d.Gather(context.Background(), &acc)
 			require.NoError(t, err)
 		})
 	}
@@ -1251,7 +1251,7 @@ func TestContainerName(t *testing.T) {
 				newClient: tt.clientFunc,
 			}
 			var acc testutil.Accumulator
-			err := d.Gather(&acc)
+			err := d.Gather(context.Background(), &acc)
 			require.NoError(t, err)
 
 			for _, metric := range acc.Metrics {

--- a/plugins/inputs/http/http.go
+++ b/plugins/inputs/http/http.go
@@ -81,13 +81,13 @@ func (h *HTTP) Init() error {
 
 // Gather takes in an accumulator and adds the metrics that the Input
 // gathers. This is called every "interval"
-func (h *HTTP) Gather(acc telegraf.Accumulator) error {
+func (h *HTTP) Gather(ctx context.Context, acc telegraf.Accumulator) error {
 	var wg sync.WaitGroup
 	for _, u := range h.URLs {
 		wg.Add(1)
 		go func(url string) {
 			defer wg.Done()
-			if err := h.gatherURL(acc, url); err != nil {
+			if err := h.gatherURL(ctx, acc, url); err != nil {
 				acc.AddError(fmt.Errorf("[url=%s]: %w", url, err))
 			}
 		}(u)
@@ -113,11 +113,12 @@ func (h *HTTP) SetParserFunc(fn telegraf.ParserFunc) {
 //
 //	error: Any error that may have occurred
 func (h *HTTP) gatherURL(
+	ctx context.Context,
 	acc telegraf.Accumulator,
 	url string,
 ) error {
 	body := makeRequestBodyReader(h.ContentEncoding, h.Body)
-	request, err := http.NewRequest(h.Method, url, body)
+	request, err := http.NewRequestWithContext(ctx, h.Method, url, body)
 	if err != nil {
 		return err
 	}

--- a/plugins/inputs/system/system.go
+++ b/plugins/inputs/system/system.go
@@ -4,6 +4,7 @@ package system
 import (
 	"bufio"
 	"bytes"
+	"context"
 	_ "embed"
 	"fmt"
 	"os"
@@ -29,7 +30,7 @@ func (*SystemStats) SampleConfig() string {
 	return sampleConfig
 }
 
-func (s *SystemStats) Gather(acc telegraf.Accumulator) error {
+func (s *SystemStats) Gather(_ context.Context, acc telegraf.Accumulator) error {
 	loadavg, err := load.Avg()
 	if err != nil && !strings.Contains(err.Error(), "not implemented") {
 		return err

--- a/plugins/inputs/systemd_units/systemd_units.go
+++ b/plugins/inputs/systemd_units/systemd_units.go
@@ -4,6 +4,7 @@ package systemd_units
 import (
 	"bufio"
 	"bytes"
+	"context"
 	_ "embed"
 	"fmt"
 	"os/exec"
@@ -129,7 +130,7 @@ func (*SystemdUnits) SampleConfig() string {
 }
 
 // Gather parses systemctl outputs and adds counters to the Accumulator
-func (s *SystemdUnits) Gather(acc telegraf.Accumulator) error {
+func (s *SystemdUnits) Gather(_ context.Context, acc telegraf.Accumulator) error {
 	out, err := s.systemctl(s.Timeout, s.UnitType, s.Pattern)
 	if err != nil {
 		return err

--- a/plugins/inputs/tacacs/tacacs_test.go
+++ b/plugins/inputs/tacacs/tacacs_test.go
@@ -217,7 +217,7 @@ func TestTacacsLocal(t *testing.T) {
 			var acc testutil.Accumulator
 
 			require.NoError(t, plugin.Init())
-			require.NoError(t, plugin.Gather(&acc))
+			require.NoError(t, plugin.Gather(context.Background(), &acc))
 
 			if tt.errContains == "" {
 				require.Len(t, acc.Errors, 0)
@@ -299,7 +299,7 @@ func TestTacacsIntegration(t *testing.T) {
 
 			// Startup the plugin & Gather
 			require.NoError(t, plugin.Init())
-			require.NoError(t, plugin.Gather(&acc))
+			require.NoError(t, plugin.Gather(context.Background(), &acc))
 
 			require.NoError(t, acc.FirstError())
 

--- a/plugins/inputs/tail/tail.go
+++ b/plugins/inputs/tail/tail.go
@@ -122,7 +122,7 @@ func (t *Tail) SetState(state interface{}) error {
 	return nil
 }
 
-func (t *Tail) Gather(_ telegraf.Accumulator) error {
+func (t *Tail) Gather(_ context.Context, _ telegraf.Accumulator) error {
 	return t.tailNewFiles(true)
 }
 

--- a/plugins/inputs/tail/tail_test.go
+++ b/plugins/inputs/tail/tail_test.go
@@ -2,6 +2,7 @@ package tail
 
 import (
 	"bytes"
+	"context"
 	"log"
 	"os"
 	"path/filepath"
@@ -363,7 +364,7 @@ cpu,42
 	err = plugin.Start(&acc)
 	require.NoError(t, err)
 	defer plugin.Stop()
-	err = plugin.Gather(&acc)
+	err = plugin.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 	acc.Wait(2)
 	plugin.Stop()
@@ -426,7 +427,7 @@ skip2,mem,100
 	err = plugin.Start(&acc)
 	require.NoError(t, err)
 	defer plugin.Stop()
-	err = plugin.Gather(&acc)
+	err = plugin.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 	acc.Wait(2)
 	plugin.Stop()
@@ -482,7 +483,7 @@ func TestMultipleMetricsOnFirstLine(t *testing.T) {
 	err = plugin.Start(&acc)
 	require.NoError(t, err)
 	defer plugin.Stop()
-	err = plugin.Gather(&acc)
+	err = plugin.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 	acc.Wait(2)
 	plugin.Stop()
@@ -751,13 +752,13 @@ func TestCSVBehavior(t *testing.T) {
 	_, err = input.WriteString("1,2\n")
 	require.NoError(t, err)
 	require.NoError(t, input.Sync())
-	require.NoError(t, plugin.Gather(&acc))
+	require.NoError(t, plugin.Gather(context.Background(), &acc))
 
 	// Write another line of data
 	_, err = input.WriteString("3,4\n")
 	require.NoError(t, err)
 	require.NoError(t, input.Sync())
-	require.NoError(t, plugin.Gather(&acc))
+	require.NoError(t, plugin.Gather(context.Background(), &acc))
 	require.Eventuallyf(t, func() bool {
 		acc.Lock()
 		defer acc.Unlock()

--- a/plugins/inputs/tcp_listener/tcp_listener.go
+++ b/plugins/inputs/tcp_listener/tcp_listener.go
@@ -3,6 +3,7 @@ package tcp_listener
 
 import (
 	"bufio"
+	"context"
 	_ "embed"
 	"fmt"
 	"net"
@@ -68,7 +69,7 @@ func (*TCPListener) SampleConfig() string {
 
 // All the work is done in the Start() function, so this is just a dummy
 // function.
-func (t *TCPListener) Gather(_ telegraf.Accumulator) error {
+func (t *TCPListener) Gather(_ context.Context, _ telegraf.Accumulator) error {
 	return nil
 }
 

--- a/plugins/inputs/tcp_listener/tcp_listener_test.go
+++ b/plugins/inputs/tcp_listener/tcp_listener_test.go
@@ -1,6 +1,7 @@
 package tcp_listener
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net"
@@ -258,7 +259,7 @@ func TestRunParser(t *testing.T) {
 	go listener.tcpParser()
 
 	in <- testmsg
-	require.NoError(t, listener.Gather(&acc))
+	require.NoError(t, listener.Gather(context.Background(), &acc))
 
 	acc.Wait(1)
 	acc.AssertContainsTaggedFields(t, "cpu_load_short",
@@ -303,7 +304,7 @@ func TestRunParserGraphiteMsg(t *testing.T) {
 	go listener.tcpParser()
 
 	in <- testmsg
-	require.NoError(t, listener.Gather(&acc))
+	require.NoError(t, listener.Gather(context.Background(), &acc))
 
 	acc.Wait(1)
 	acc.AssertContainsFields(t, "cpu_load_graphite",
@@ -326,7 +327,7 @@ func TestRunParserJSONMsg(t *testing.T) {
 	go listener.tcpParser()
 
 	in <- testmsg
-	require.NoError(t, listener.Gather(&acc))
+	require.NoError(t, listener.Gather(context.Background(), &acc))
 
 	acc.Wait(1)
 	acc.AssertContainsFields(t, "udp_json_test",

--- a/plugins/inputs/teamspeak/teamspeak.go
+++ b/plugins/inputs/teamspeak/teamspeak.go
@@ -2,6 +2,7 @@
 package teamspeak
 
 import (
+	"context"
 	_ "embed"
 	"strconv"
 
@@ -58,7 +59,7 @@ func (*Teamspeak) SampleConfig() string {
 	return sampleConfig
 }
 
-func (ts *Teamspeak) Gather(acc telegraf.Accumulator) error {
+func (ts *Teamspeak) Gather(_ context.Context, acc telegraf.Accumulator) error {
 	var err error
 
 	if !ts.connected {

--- a/plugins/inputs/temp/temp.go
+++ b/plugins/inputs/temp/temp.go
@@ -2,6 +2,7 @@
 package temp
 
 import (
+	"context"
 	_ "embed"
 	"fmt"
 	"strings"
@@ -22,7 +23,7 @@ func (*Temperature) SampleConfig() string {
 	return sampleConfig
 }
 
-func (t *Temperature) Gather(acc telegraf.Accumulator) error {
+func (t *Temperature) Gather(_ context.Context, acc telegraf.Accumulator) error {
 	temps, err := t.ps.Temperature()
 	if err != nil {
 		if strings.Contains(err.Error(), "not implemented yet") {

--- a/plugins/inputs/tengine/tengine.go
+++ b/plugins/inputs/tengine/tengine.go
@@ -3,6 +3,7 @@ package tengine
 
 import (
 	"bufio"
+	"context"
 	_ "embed"
 	"errors"
 	"fmt"
@@ -36,7 +37,7 @@ func (*Tengine) SampleConfig() string {
 	return sampleConfig
 }
 
-func (n *Tengine) Gather(acc telegraf.Accumulator) error {
+func (n *Tengine) Gather(_ context.Context, acc telegraf.Accumulator) error {
 	var wg sync.WaitGroup
 
 	// Create an HTTP client that is re-used for each
@@ -59,7 +60,7 @@ func (n *Tengine) Gather(acc telegraf.Accumulator) error {
 		wg.Add(1)
 		go func(addr *url.URL) {
 			defer wg.Done()
-			acc.AddError(n.gatherURL(addr, acc))
+			acc.AddError(n.gatherURL(context.TODO(), addr, acc))
 		}(addr)
 	}
 
@@ -120,7 +121,7 @@ type TengineStatus struct {
 	httpUps5xx            uint64
 }
 
-func (n *Tengine) gatherURL(addr *url.URL, acc telegraf.Accumulator) error {
+func (n *Tengine) gatherURL(_ context.Context, addr *url.URL, acc telegraf.Accumulator) error {
 	var tengineStatus TengineStatus
 	resp, err := n.client.Get(addr.String())
 	if err != nil {

--- a/plugins/inputs/tomcat/tomcat.go
+++ b/plugins/inputs/tomcat/tomcat.go
@@ -2,6 +2,7 @@
 package tomcat
 
 import (
+	"context"
 	_ "embed"
 	"encoding/xml"
 	"fmt"
@@ -79,7 +80,7 @@ func (*Tomcat) SampleConfig() string {
 	return sampleConfig
 }
 
-func (s *Tomcat) Gather(acc telegraf.Accumulator) error {
+func (s *Tomcat) Gather(ctx context.Context, acc telegraf.Accumulator) error {
 	if s.client == nil {
 		client, err := s.createHTTPClient()
 		if err != nil {
@@ -93,7 +94,7 @@ func (s *Tomcat) Gather(acc telegraf.Accumulator) error {
 		if err != nil {
 			return err
 		}
-		request, err := http.NewRequest("GET", s.URL, nil)
+		request, err := http.NewRequestWithContext(ctx, "GET", s.URL, nil)
 		if err != nil {
 			return err
 		}

--- a/plugins/inputs/tomcat/tomcat_test.go
+++ b/plugins/inputs/tomcat/tomcat_test.go
@@ -1,6 +1,7 @@
 package tomcat
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -53,7 +54,7 @@ func TestHTTPTomcat8(t *testing.T) {
 	}
 
 	var acc testutil.Accumulator
-	require.NoError(t, tc.Gather(&acc))
+	require.NoError(t, tc.Gather(context.Background(), &acc))
 
 	// tomcat_jvm_memory
 	jvmMemoryFields := map[string]interface{}{
@@ -138,7 +139,7 @@ func TestHTTPTomcat6(t *testing.T) {
 	}
 
 	var acc testutil.Accumulator
-	require.NoError(t, tc.Gather(&acc))
+	require.NoError(t, tc.Gather(context.Background(), &acc))
 
 	// tomcat_jvm_memory
 	jvmMemoryFields := map[string]interface{}{

--- a/plugins/inputs/trig/trig.go
+++ b/plugins/inputs/trig/trig.go
@@ -2,6 +2,7 @@
 package trig
 
 import (
+	"context"
 	_ "embed"
 	"math"
 
@@ -21,7 +22,7 @@ func (*Trig) SampleConfig() string {
 	return sampleConfig
 }
 
-func (s *Trig) Gather(acc telegraf.Accumulator) error {
+func (s *Trig) Gather(_ context.Context, acc telegraf.Accumulator) error {
 	sinner := math.Sin((s.x*math.Pi)/5.0) * s.Amplitude
 	cosinner := math.Cos((s.x*math.Pi)/5.0) * s.Amplitude
 

--- a/plugins/inputs/trig/trig_test.go
+++ b/plugins/inputs/trig/trig_test.go
@@ -1,6 +1,7 @@
 package trig
 
 import (
+	"context"
 	"math"
 	"testing"
 
@@ -19,7 +20,7 @@ func TestTrig(t *testing.T) {
 		sine := math.Sin((i*math.Pi)/5.0) * s.Amplitude
 		cosine := math.Cos((i*math.Pi)/5.0) * s.Amplitude
 
-		require.NoError(t, s.Gather(&acc))
+		require.NoError(t, s.Gather(context.Background(), &acc))
 
 		fields := make(map[string]interface{})
 		fields["sine"] = sine

--- a/plugins/inputs/twemproxy/twemproxy.go
+++ b/plugins/inputs/twemproxy/twemproxy.go
@@ -2,6 +2,7 @@
 package twemproxy
 
 import (
+	"context"
 	_ "embed"
 	"encoding/json"
 	"errors"
@@ -26,11 +27,16 @@ func (*Twemproxy) SampleConfig() string {
 }
 
 // Gather data from all Twemproxy instances
-func (t *Twemproxy) Gather(acc telegraf.Accumulator) error {
-	conn, err := net.DialTimeout("tcp", t.Addr, 1*time.Second)
+func (t *Twemproxy) Gather(ctx context.Context, acc telegraf.Accumulator) error {
+	ctx, cancelFunc := context.WithTimeout(ctx, 1*time.Second)
+	defer cancelFunc()
+	var d net.Dialer
+	conn, err := d.DialContext(ctx, "tcp", t.Addr)
 	if err != nil {
 		return err
 	}
+	cancelFunc()
+
 	body, err := io.ReadAll(conn)
 	if err != nil {
 		return err

--- a/plugins/inputs/twemproxy/twemproxy_test.go
+++ b/plugins/inputs/twemproxy/twemproxy_test.go
@@ -1,6 +1,7 @@
 package twemproxy
 
 import (
+	"context"
 	"encoding/json"
 	"net"
 	"testing"
@@ -92,7 +93,7 @@ func TestGather(t *testing.T) {
 
 	var acc testutil.Accumulator
 	acc.SetDebug(true)
-	err = twemproxy.Gather(&acc)
+	err = twemproxy.Gather(context.Background(), &acc)
 	require.NoError(t, err)
 
 	var sourceData map[string]interface{}

--- a/plugins/inputs/udp_listener/udp_listener.go
+++ b/plugins/inputs/udp_listener/udp_listener.go
@@ -2,6 +2,7 @@
 package udp_listener
 
 import (
+	"context"
 	_ "embed"
 	"errors"
 	"fmt"
@@ -78,7 +79,7 @@ func (*UDPListener) SampleConfig() string {
 
 // All the work is done in the Start() function, so this is just a dummy
 // function.
-func (u *UDPListener) Gather(_ telegraf.Accumulator) error {
+func (u *UDPListener) Gather(_ context.Context, _ telegraf.Accumulator) error {
 	return nil
 }
 

--- a/plugins/inputs/unbound/unbound_test.go
+++ b/plugins/inputs/unbound/unbound_test.go
@@ -2,6 +2,7 @@ package unbound
 
 import (
 	"bytes"
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -9,8 +10,8 @@ import (
 	"github.com/influxdata/telegraf/testutil"
 )
 
-func UnboundControl(output string) func(unbound Unbound) (*bytes.Buffer, error) {
-	return func(unbound Unbound) (*bytes.Buffer, error) {
+func UnboundControl(output string) func(_ context.Context, unbound Unbound) (*bytes.Buffer, error) {
+	return func(_ context.Context, unbound Unbound) (*bytes.Buffer, error) {
 		return bytes.NewBuffer([]byte(output)), nil
 	}
 }
@@ -20,7 +21,7 @@ func TestParseFullOutput(t *testing.T) {
 	v := &Unbound{
 		run: UnboundControl(fullOutput),
 	}
-	err := v.Gather(acc)
+	err := v.Gather(context.Background(), acc)
 
 	require.NoError(t, err)
 
@@ -38,7 +39,7 @@ func TestParseFullOutputThreadAsTag(t *testing.T) {
 		run:         UnboundControl(fullOutput),
 		ThreadAsTag: true,
 	}
-	err := v.Gather(acc)
+	err := v.Gather(context.Background(), acc)
 
 	require.NoError(t, err)
 

--- a/plugins/inputs/upsd/upsd.go
+++ b/plugins/inputs/upsd/upsd.go
@@ -2,6 +2,7 @@
 package upsd
 
 import (
+	"context"
 	_ "embed"
 	"fmt"
 	"strings"
@@ -36,7 +37,7 @@ func (*Upsd) SampleConfig() string {
 	return sampleConfig
 }
 
-func (u *Upsd) Gather(acc telegraf.Accumulator) error {
+func (u *Upsd) Gather(_ context.Context, acc telegraf.Accumulator) error {
 	upsList, err := u.fetchVariables(u.Server, u.Port)
 	if err != nil {
 		return err

--- a/plugins/inputs/upsd/upsd_test.go
+++ b/plugins/inputs/upsd/upsd_test.go
@@ -96,7 +96,7 @@ func TestUpsdGather(t *testing.T) {
 			nut.Port = (lAddr.(*net.TCPAddr)).Port
 			nut.ForceFloat = tt.forceFloat
 
-			err = nut.Gather(&acc)
+			err = nut.Gather(context.Background(), &acc)
 			if tt.err {
 				require.Error(t, err)
 			} else {
@@ -140,7 +140,7 @@ func TestUpsdGatherFail(t *testing.T) {
 			nut.Server = (lAddr.(*net.TCPAddr)).IP.String()
 			nut.Port = (lAddr.(*net.TCPAddr)).Port
 
-			err = nut.Gather(&acc)
+			err = nut.Gather(context.Background(), &acc)
 			if tt.err {
 				require.Error(t, err)
 			} else {

--- a/plugins/inputs/uwsgi/uwsgi.go
+++ b/plugins/inputs/uwsgi/uwsgi.go
@@ -5,6 +5,7 @@
 package uwsgi
 
 import (
+	"context"
 	_ "embed"
 	"encoding/json"
 	"fmt"
@@ -38,7 +39,7 @@ func (*Uwsgi) SampleConfig() string {
 }
 
 // Gather collect data from uWSGI Server
-func (u *Uwsgi) Gather(acc telegraf.Accumulator) error {
+func (u *Uwsgi) Gather(_ context.Context, acc telegraf.Accumulator) error {
 	if u.client == nil {
 		u.client = &http.Client{
 			Timeout: time.Duration(u.Timeout),
@@ -56,7 +57,7 @@ func (u *Uwsgi) Gather(acc telegraf.Accumulator) error {
 				return
 			}
 
-			if err := u.gatherServer(acc, n); err != nil {
+			if err := u.gatherServer(context.TODO(), acc, n); err != nil {
 				acc.AddError(err)
 				return
 			}
@@ -68,7 +69,7 @@ func (u *Uwsgi) Gather(acc telegraf.Accumulator) error {
 	return nil
 }
 
-func (u *Uwsgi) gatherServer(acc telegraf.Accumulator, address *url.URL) error {
+func (u *Uwsgi) gatherServer(_ context.Context, acc telegraf.Accumulator, address *url.URL) error {
 	var err error
 	var r io.ReadCloser
 	var s StatsServer

--- a/plugins/inputs/uwsgi/uwsgi_test.go
+++ b/plugins/inputs/uwsgi/uwsgi_test.go
@@ -1,6 +1,7 @@
 package uwsgi_test
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -124,7 +125,7 @@ func TestBasic(t *testing.T) {
 		Servers: []string{fakeServer.URL + "/"},
 	}
 	var acc testutil.Accumulator
-	require.NoError(t, plugin.Gather(&acc))
+	require.NoError(t, plugin.Gather(context.Background(), &acc))
 	require.Equal(t, 0, len(acc.Errors))
 }
 
@@ -155,7 +156,7 @@ func TestInvalidJSON(t *testing.T) {
 		Servers: []string{fakeServer.URL + "/"},
 	}
 	var acc testutil.Accumulator
-	require.NoError(t, plugin.Gather(&acc))
+	require.NoError(t, plugin.Gather(context.Background(), &acc))
 	require.Equal(t, 1, len(acc.Errors))
 }
 
@@ -165,7 +166,7 @@ func TestHttpError(t *testing.T) {
 		Timeout: config.Duration(10 * time.Millisecond),
 	}
 	var acc testutil.Accumulator
-	require.NoError(t, plugin.Gather(&acc))
+	require.NoError(t, plugin.Gather(context.Background(), &acc))
 	require.Equal(t, 1, len(acc.Errors))
 }
 
@@ -174,7 +175,7 @@ func TestTcpError(t *testing.T) {
 		Servers: []string{"tcp://novalidtcpadress/"},
 	}
 	var acc testutil.Accumulator
-	require.NoError(t, plugin.Gather(&acc))
+	require.NoError(t, plugin.Gather(context.Background(), &acc))
 	require.Equal(t, 1, len(acc.Errors))
 }
 
@@ -183,6 +184,6 @@ func TestUnixSocketError(t *testing.T) {
 		Servers: []string{"unix:///novalidunixsocket"},
 	}
 	var acc testutil.Accumulator
-	require.NoError(t, plugin.Gather(&acc))
+	require.NoError(t, plugin.Gather(context.Background(), &acc))
 	require.Equal(t, 1, len(acc.Errors))
 }

--- a/plugins/inputs/x509_cert/x509_cert.go
+++ b/plugins/inputs/x509_cert/x509_cert.go
@@ -5,6 +5,7 @@ package x509_cert
 
 import (
 	"bytes"
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	_ "embed"
@@ -92,7 +93,7 @@ func (c *X509Cert) Init() error {
 }
 
 // Gather adds metrics into the accumulator.
-func (c *X509Cert) Gather(acc telegraf.Accumulator) error {
+func (c *X509Cert) Gather(_ context.Context, acc telegraf.Accumulator) error {
 	now := time.Now()
 
 	collectedUrls := append(c.locations, c.collectCertURLs()...)

--- a/plugins/inputs/x509_cert/x509_cert_test.go
+++ b/plugins/inputs/x509_cert/x509_cert_test.go
@@ -1,6 +1,7 @@
 package x509_cert
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/tls"
@@ -118,7 +119,7 @@ func TestGatherRemoteIntegration(t *testing.T) {
 			testErr := false
 
 			acc := testutil.Accumulator{}
-			err = sc.Gather(&acc)
+			err = sc.Gather(context.Background(), &acc)
 			if len(acc.Errors) > 0 {
 				testErr = true
 			}
@@ -178,7 +179,7 @@ func TestGatherLocal(t *testing.T) {
 			require.NoError(t, sc.Init())
 
 			acc := testutil.Accumulator{}
-			err = sc.Gather(&acc)
+			err = sc.Gather(context.Background(), &acc)
 
 			if (len(acc.Errors) > 0) != test.error {
 				t.Errorf("%s", err)
@@ -207,7 +208,7 @@ func TestTags(t *testing.T) {
 	require.NoError(t, sc.Init())
 
 	acc := testutil.Accumulator{}
-	require.NoError(t, sc.Gather(&acc))
+	require.NoError(t, sc.Gather(context.Background(), &acc))
 
 	require.True(t, acc.HasMeasurement("x509_cert"))
 
@@ -257,7 +258,7 @@ func TestGatherExcludeRootCerts(t *testing.T) {
 	require.NoError(t, sc.Init())
 
 	acc := testutil.Accumulator{}
-	require.NoError(t, sc.Gather(&acc))
+	require.NoError(t, sc.Gather(context.Background(), &acc))
 
 	require.True(t, acc.HasMeasurement("x509_cert"))
 	require.Equal(t, acc.NMetrics(), uint64(1))
@@ -293,7 +294,7 @@ func TestGatherChain(t *testing.T) {
 			require.NoError(t, sc.Init())
 
 			acc := testutil.Accumulator{}
-			err = sc.Gather(&acc)
+			err = sc.Gather(context.Background(), &acc)
 			if (err != nil) != test.error {
 				t.Errorf("%s", err)
 			}
@@ -328,7 +329,7 @@ func TestGatherUDPCertIntegration(t *testing.T) {
 	require.NoError(t, m.Init())
 
 	var acc testutil.Accumulator
-	require.NoError(t, m.Gather(&acc))
+	require.NoError(t, m.Gather(context.Background(), &acc))
 
 	require.Len(t, acc.Errors, 0)
 	require.True(t, acc.HasMeasurement("x509_cert"))
@@ -348,7 +349,7 @@ func TestGatherTCPCert(t *testing.T) {
 	require.NoError(t, m.Init())
 
 	var acc testutil.Accumulator
-	require.NoError(t, m.Gather(&acc))
+	require.NoError(t, m.Gather(context.Background(), &acc))
 
 	require.Len(t, acc.Errors, 0)
 	require.True(t, acc.HasMeasurement("x509_cert"))
@@ -366,7 +367,7 @@ func TestGatherCertIntegration(t *testing.T) {
 	require.NoError(t, m.Init())
 
 	var acc testutil.Accumulator
-	require.NoError(t, m.Gather(&acc))
+	require.NoError(t, m.Gather(context.Background(), &acc))
 
 	require.True(t, acc.HasMeasurement("x509_cert"))
 	require.True(t, acc.HasTag("x509_cert", "ocsp_stapled"))
@@ -385,7 +386,7 @@ func TestGatherCertMustNotTimeoutIntegration(t *testing.T) {
 	require.NoError(t, m.Init())
 
 	var acc testutil.Accumulator
-	require.NoError(t, m.Gather(&acc))
+	require.NoError(t, m.Gather(context.Background(), &acc))
 	require.Empty(t, acc.Errors)
 	require.True(t, acc.HasMeasurement("x509_cert"))
 	require.True(t, acc.HasTag("x509_cert", "ocsp_stapled"))
@@ -577,7 +578,7 @@ func TestClassification(t *testing.T) {
 	require.NoError(t, plugin.Init())
 
 	var acc testutil.Accumulator
-	require.NoError(t, plugin.Gather(&acc))
+	require.NoError(t, plugin.Gather(context.Background(), &acc))
 	require.Empty(t, acc.Errors)
 
 	expected := []telegraf.Metric{

--- a/plugins/inputs/xtremio/xtremio.go
+++ b/plugins/inputs/xtremio/xtremio.go
@@ -2,6 +2,7 @@
 package xtremio
 
 import (
+	"context"
 	_ "embed"
 	"encoding/json"
 	"errors"
@@ -72,7 +73,7 @@ func (xio *XtremIO) Init() error {
 	return nil
 }
 
-func (xio *XtremIO) Gather(acc telegraf.Accumulator) error {
+func (xio *XtremIO) Gather(_ context.Context, acc telegraf.Accumulator) error {
 	if err := xio.authenticate(); err != nil {
 		return err
 	}

--- a/plugins/inputs/xtremio/xtremio_test.go
+++ b/plugins/inputs/xtremio/xtremio_test.go
@@ -1,6 +1,7 @@
 package xtremio
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -142,7 +143,7 @@ func TestFixedValue(t *testing.T) {
 			var acc testutil.Accumulator
 			tt.plugin.Log = testutil.Logger{}
 			require.NoError(t, tt.plugin.Init())
-			require.NoError(t, tt.plugin.Gather(&acc))
+			require.NoError(t, tt.plugin.Gather(context.Background(), &acc))
 			require.Len(t, acc.Errors, 0, "found errors accumulated by acc.AddError()")
 			acc.Wait(len(tt.expected))
 			testutil.RequireMetricsEqual(t, tt.expected, acc.GetTelegrafMetrics(), testutil.IgnoreTime())
@@ -184,7 +185,7 @@ func TestAuthenticationFailed(t *testing.T) {
 			tt.plugin.Log = testutil.Logger{}
 			require.NoError(t, tt.plugin.Init())
 
-			err := tt.plugin.Gather(&acc)
+			err := tt.plugin.Gather(context.Background(), &acc)
 			require.Error(t, err)
 			require.EqualError(t, err, tt.expected)
 		})

--- a/plugins/inputs/zfs/zfs_linux.go
+++ b/plugins/inputs/zfs/zfs_linux.go
@@ -3,6 +3,7 @@
 package zfs
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"path/filepath"
@@ -179,7 +180,7 @@ func gatherPoolStats(pool poolInfo, acc telegraf.Accumulator) error {
 	return nil
 }
 
-func (z *Zfs) Gather(acc telegraf.Accumulator) error {
+func (z *Zfs) Gather(_ context.Context, acc telegraf.Accumulator) error {
 	kstatMetrics := z.KstatMetrics
 	if len(kstatMetrics) == 0 {
 		// vdev_cache_stats is deprecated

--- a/plugins/inputs/zfs/zfs_other.go
+++ b/plugins/inputs/zfs/zfs_other.go
@@ -3,11 +3,13 @@
 package zfs
 
 import (
+	"context"
+
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/plugins/inputs"
 )
 
-func (*Zfs) Gather(_ telegraf.Accumulator) error {
+func (*Zfs) Gather(_ context.Context, _ telegraf.Accumulator) error {
 	return nil
 }
 

--- a/plugins/inputs/zipkin/zipkin.go
+++ b/plugins/inputs/zipkin/zipkin.go
@@ -77,7 +77,7 @@ func (*Zipkin) SampleConfig() string {
 
 // Gather is empty for the zipkin plugin; all gathering is done through
 // the separate goroutine launched in (*Zipkin).Start()
-func (z *Zipkin) Gather(_ telegraf.Accumulator) error { return nil }
+func (z *Zipkin) Gather(_ context.Context, _ telegraf.Accumulator) error { return nil }
 
 // Start launches a separate goroutine for collecting zipkin client http requests,
 // passing in a telegraf.Accumulator such that data can be collected.

--- a/plugins/inputs/zookeeper/zookeeper.go
+++ b/plugins/inputs/zookeeper/zookeeper.go
@@ -57,9 +57,7 @@ func (*Zookeeper) SampleConfig() string {
 }
 
 // Gather reads stats from all configured servers accumulates stats
-func (z *Zookeeper) Gather(acc telegraf.Accumulator) error {
-	ctx := context.Background()
-
+func (z *Zookeeper) Gather(ctx context.Context, acc telegraf.Accumulator) error {
 	if !z.initialized {
 		tlsConfig, err := z.ClientConfig.TLSConfig()
 		if err != nil {

--- a/plugins/inputs/zookeeper/zookeeper_test.go
+++ b/plugins/inputs/zookeeper/zookeeper_test.go
@@ -1,6 +1,7 @@
 package zookeeper
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -8,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go/wait"
 
+	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/testutil"
 )
 
@@ -57,7 +59,10 @@ func TestZookeeperGeneratesMetricsIntegration(t *testing.T) {
 	for _, tt := range testset {
 		t.Run(tt.name, func(t *testing.T) {
 			var acc testutil.Accumulator
-			require.NoError(t, acc.GatherError(tt.zookeeper.Gather))
+			require.NoError(t, acc.GatherError(
+				func(acc telegraf.Accumulator) error {
+					return tt.zookeeper.Gather(context.Background(), acc)
+				}))
 
 			intMetrics := []string{
 				"max_latency",

--- a/testutil/accumulator.go
+++ b/testutil/accumulator.go
@@ -1,6 +1,7 @@
 package testutil
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -297,8 +298,8 @@ func (a *Accumulator) TagValue(measurement string, key string) string {
 }
 
 // GatherError calls the given Gather function and returns the first error found.
-func (a *Accumulator) GatherError(gf func(telegraf.Accumulator) error) error {
-	if err := gf(a); err != nil {
+func (a *Accumulator) GatherError(gf func(context.Context, telegraf.Accumulator) error) error {
+	if err := gf(context.Background(), a); err != nil {
 		return err
 	}
 	if len(a.Errors) > 0 {


### PR DESCRIPTION
# Required for all PRs


- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

Draft pathfinder for  #13913 to collect initial feedback


This change introduces `context.Context` argument to `Gather` function and changes some of the plugins to show it's use. It is mainly mechanical change which changes plugins in one of 3 ways:

- if doesn't make it obvious that context is used somewhere, then just pass it as unused argument `_ context.Context`
- for any obvious use like explicit context initialization in Gather or use of http.NewRequest then just plumb `ctx context.Context` 
- any non trivial use or potential use of context is not done, but marked as `context.TODO()` to revisit later

I didn't convert all plugins, but enough of them to demonstrate approach.

I considered adding context to Accumulator, then it will make change smaller in number of lines, but it feels like a hack for no purpose, so I decided against it.

