### PR TITLE
test(outputs.sql): Fix clean up of sql database file

### DIFF
--- a/plugins/outputs/sql/sqlite_test.go
+++ b/plugins/outputs/sql/sqlite_test.go
@@ -15,10 +15,8 @@ import (
 )
 
 func TestSqlite(t *testing.T) {
-	outDir := os.TempDir()
-	defer os.Remove(outDir)
-
-	dbfile := filepath.Join(outDir, "db")
+	dbfile := filepath.Join(os.TempDir(), "db")
+	defer os.Remove(dbfile)
 
 	// Use the plugin to write to the database address :=
 	// fmt.Sprintf("file:%v", dbfile)


### PR DESCRIPTION
The test file was not removed after testing. Additional runs of the test would conflict if this file still existed.