### PR TITLE
feat(inputs.opcua_listener): Add monitoring params

### DIFF
--- a/plugins/common/opcua/input/input_client.go
+++ b/plugins/common/opcua/input/input_client.go
@@ -19,16 +19,16 @@ import (
 )
 
 type DataChangeFilter struct {
-	Trigger       string `toml:"trigger"`
-	DeadbandType  string `toml:"deadband_type"`
-	DeadbandValue string `toml:"deadband_value"`
+	Trigger       string   `toml:"trigger"`
+	DeadbandType  string   `toml:"deadband_type"`
+	DeadbandValue *float64 `toml:"deadband_value"`
 }
 
 type MonitoringParameters struct {
-	SamplingInterval config.Duration  `toml:"sampling_interval"`
-	QueueSize        string           `toml:"queue_size"`
-	DiscardOldest    string           `toml:"discard_oldest"`
-	DataChangeFilter DataChangeFilter `toml:"data_change_filter"`
+	SamplingInterval config.Duration   `toml:"sampling_interval"`
+	QueueSize        *uint32           `toml:"queue_size"`
+	DiscardOldest    *bool             `toml:"discard_oldest"`
+	DataChangeFilter *DataChangeFilter `toml:"data_change_filter"`
 }
 
 // NodeSettings describes how to map from a OPC UA node to a Metric

--- a/plugins/common/opcua/input/input_client.go
+++ b/plugins/common/opcua/input/input_client.go
@@ -18,10 +18,25 @@ import (
 	"github.com/influxdata/telegraf/plugins/common/opcua"
 )
 
+type Trigger string
+
+const (
+	Status               Trigger = "Status"
+	StatusValue          Trigger = "StatusValue"
+	StatusValueTimestamp Trigger = "StatusValueTimestamp"
+)
+
+type DeadbandType string
+
+const (
+	Absolute DeadbandType = "Absolute"
+	Percent  DeadbandType = "Percent"
+)
+
 type DataChangeFilter struct {
-	Trigger       string   `toml:"trigger"`
-	DeadbandType  string   `toml:"deadband_type"`
-	DeadbandValue *float64 `toml:"deadband_value"`
+	Trigger       Trigger      `toml:"trigger"`
+	DeadbandType  DeadbandType `toml:"deadband_type"`
+	DeadbandValue *float64     `toml:"deadband_value"`
 }
 
 type MonitoringParameters struct {

--- a/plugins/common/opcua/input/input_client.go
+++ b/plugins/common/opcua/input/input_client.go
@@ -12,21 +12,36 @@ import (
 	"github.com/gopcua/opcua/ua"
 
 	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/internal/choice"
 	"github.com/influxdata/telegraf/metric"
 	"github.com/influxdata/telegraf/plugins/common/opcua"
 )
 
+type DataChangeFilter struct {
+	Trigger       string `toml:"trigger"`
+	DeadbandType  string `toml:"deadband_type"`
+	DeadbandValue string `toml:"deadband_value"`
+}
+
+type MonitoringParameters struct {
+	SamplingInterval config.Duration  `toml:"sampling_interval"`
+	QueueSize        string           `toml:"queue_size"`
+	DiscardOldest    string           `toml:"discard_oldest"`
+	DataChangeFilter DataChangeFilter `toml:"data_change_filter"`
+}
+
 // NodeSettings describes how to map from a OPC UA node to a Metric
 type NodeSettings struct {
-	FieldName      string            `toml:"name"`
-	Namespace      string            `toml:"namespace"`
-	IdentifierType string            `toml:"identifier_type"`
-	Identifier     string            `toml:"identifier"`
-	DataType       string            `toml:"data_type" deprecated:"1.17.0;option is ignored"`
-	Description    string            `toml:"description" deprecated:"1.17.0;option is ignored"`
-	TagsSlice      [][]string        `toml:"tags" deprecated:"1.25.0;use 'default_tags' instead"`
-	DefaultTags    map[string]string `toml:"default_tags"`
+	FieldName        string               `toml:"name"`
+	Namespace        string               `toml:"namespace"`
+	IdentifierType   string               `toml:"identifier_type"`
+	Identifier       string               `toml:"identifier"`
+	DataType         string               `toml:"data_type" deprecated:"1.17.0;option is ignored"`
+	Description      string               `toml:"description" deprecated:"1.17.0;option is ignored"`
+	TagsSlice        [][]string           `toml:"tags" deprecated:"1.25.0;use 'default_tags' instead"`
+	DefaultTags      map[string]string    `toml:"default_tags"`
+	MonitoringParams MonitoringParameters `toml:"monitoring_params"`
 }
 
 // NodeID returns the OPC UA node id
@@ -36,12 +51,13 @@ func (tag *NodeSettings) NodeID() string {
 
 // NodeGroupSettings describes a mapping of group of nodes to Metrics
 type NodeGroupSettings struct {
-	MetricName     string            `toml:"name"`            // Overrides plugin's setting
-	Namespace      string            `toml:"namespace"`       // Can be overridden by node setting
-	IdentifierType string            `toml:"identifier_type"` // Can be overridden by node setting
-	Nodes          []NodeSettings    `toml:"nodes"`
-	TagsSlice      [][]string        `toml:"tags" deprecated:"1.26.0;use default_tags"`
-	DefaultTags    map[string]string `toml:"default_tags"`
+	MetricName       string            `toml:"name"`            // Overrides plugin's setting
+	Namespace        string            `toml:"namespace"`       // Can be overridden by node setting
+	IdentifierType   string            `toml:"identifier_type"` // Can be overridden by node setting
+	Nodes            []NodeSettings    `toml:"nodes"`
+	TagsSlice        [][]string        `toml:"tags" deprecated:"1.26.0;use default_tags"`
+	DefaultTags      map[string]string `toml:"default_tags"`
+	SamplingInterval config.Duration   `toml:"sampling_interval"` // Can be overridden by monitoring parameters
 }
 
 type TimestampSource string
@@ -317,6 +333,9 @@ func (o *OpcUAInputClient) InitNodeMetricMapping() error {
 			}
 			if node.IdentifierType == "" {
 				node.IdentifierType = group.IdentifierType
+			}
+			if node.MonitoringParams.SamplingInterval == 0 {
+				node.MonitoringParams.SamplingInterval = group.SamplingInterval
 			}
 
 			nmm, err := NewNodeMetricMapping(group.MetricName, node, groupTags)

--- a/plugins/inputs/opcua_listener/README.md
+++ b/plugins/inputs/opcua_listener/README.md
@@ -101,14 +101,13 @@ to use them.
   ##
   ## Monitoring parameters
   ## sampling_interval  - interval at which the server should check for data
-  ##                      changes (default: 0)
+  ##                      changes (default: 0s)
   ## queue_size         - size of the notification queue (default: 10)
   ## discard_oldest     - how notifications should be handled in case of full
   ##                      notification queues, possible values:
-  ##                      "true": oldest entry in queue gets deleted and new value
-  ##                              is inserted (default)
-  ##                      "false": last value added to queue gets replaced with
-  ##                               new value        
+  ##                      true: oldest value added to queue gets replaced with new
+  ##                            (default)
+  ##                      false: last value added to queue gets replaced with new
   ## data_change_filter - defines the condition under which a notification should
   ##                      be reported
   ##
@@ -116,24 +115,28 @@ to use them.
   ## trigger        - specify the conditions under which a data change notification
   ##                  should be reported, possible values:
   ##                  "Status": only report notifications if the status changes
+  ##                            (default if parameter is omitted)
   ##                  "StatusValue": report notifications if either status or value
   ##                                 changes
   ##                  "StatusValueTimestamp": report notifications if either status,
   ##                                          value or timestamp changes
-  ## deadband_type  - range for value changes where no notification should be reported
+  ## deadband_type  - range for value changes where no notification should be
+  ##                  reported, possible values:
+  ##                  "None": no filter will be applied (default if parameter is omitted)
   ##                  "Absolute": absolute change in a data value to report a notification
   ##                  "Percent": works only with nodes that have an EURange property set
   ##                             and is defined as: send notification if
   ##                             (last value - current value) >
   ##                             (deadband_value/100.0) * ((high–low) of EURange)
-  ## deadband_value - value to deadband_type
+  ## deadband_value - value to deadband_type, must be a float value, no filter is set
+  ##                  for negative values
   ##
   ## Use either the inline notation or the bracketed notation, not both.
   #
   ## Inline notation (default_tags not supported yet)
   # nodes = [
-  #   {name="", namespace="", identifier_type="", identifier="", monitoring_params={sampling_interval="0s", queue_size="10", discard_oldest="true", data_change_filter={trigger="Status", deadband_type="Absolute", deadband_value="0"}}},
-  #   {name="", namespace="", identifier_type="", identifier="", monitoring_params={sampling_interval="0s", queue_size="10", discard_oldest="true", data_change_filter={trigger="Status", deadband_type="Absolute", deadband_value="0"}}},
+  #   {name="node1", namespace="", identifier_type="", identifier="",
+  #   {name="node2", namespace="", identifier_type="", identifier="", monitoring_params={sampling_interval="0s", queue_size=10, discard_oldest=true, data_change_filter={trigger="Status", deadband_type="None", deadband_value=0.0}}},
   # ]
   #
   ## Bracketed notation
@@ -152,13 +155,13 @@ to use them.
   #
   #   [inputs.opcua_listener.nodes.monitoring_params]
   #     sampling_interval = "0s"
-  #     queue_size = "10"
-  #     discard_oldest = "true"
+  #     queue_size = 10
+  #     discard_oldest = true
   #
   #     [inputs.opcua_listener.nodes.monitoring_params.data_change_filter]
   #       trigger = "Status"
-  #       deadband_type = "Absolute"
-  #       deadband_value = "0"
+  #       deadband_type = "None"
+  #       deadband_value = 0.0
   #
   ## Node Group
   ## Sets defaults so they aren't required in every node.
@@ -190,15 +193,15 @@ to use them.
   #
   ## Group default sampling interval. If a node in the group doesn't set its
   ## sampling interval, this is used.
-  # sampling_interval = 
+  # sampling_interval = "0s"
   #
   ## Node ID Configuration.  Array of nodes with the same settings as above.
   ## Use either the inline notation or the bracketed notation, not both.
   #
   ## Inline notation (default_tags not supported yet)
   # nodes = [
-  #  {name="node1", namespace="", identifier_type="", identifier="", monitoring_params={sampling_interval="0s", queue_size="10", discard_oldest="true", data_change_filter={trigger="Status", deadband_type="Absolute", deadband_value="10"}}},
-  #  {name="node2", namespace="", identifier_type="", identifier="", monitoring_params={sampling_interval="0s", queue_size="10", discard_oldest="true", data_change_filter={trigger="Status", deadband_type="Absolute", deadband_value="10"}}},
+  #  {name="node1", namespace="", identifier_type="", identifier="",
+  #  {name="node2", namespace="", identifier_type="", identifier="", monitoring_params={sampling_interval="0s", queue_size=10, discard_oldest=true, data_change_filter={trigger="Status", deadband_type="None", deadband_value=0.0}}},
   #]
   #
   ## Bracketed notation
@@ -217,13 +220,13 @@ to use them.
   #
   #   [inputs.opcua_listener.group.nodes.monitoring_params]
   #     sampling_interval = "0s"
-  #     queue_size = "10"
-  #     discard_oldest = "true"
+  #     queue_size = 10
+  #     discard_oldest = true
   #
   #     [inputs.opcua_listener.group.nodes.monitoring_params.data_change_filter]
   #       trigger = "Status"
-  #       deadband_type = "Absolute"
-  #       deadband_value = "10"
+  #       deadband_type = "None"
+  #       deadband_value = 0.0
   #
   ## Enable workarounds required by some devices to work correctly
   # [inputs.opcua_listener.workarounds]

--- a/plugins/inputs/opcua_listener/README.md
+++ b/plugins/inputs/opcua_listener/README.md
@@ -257,8 +257,8 @@ opcua,id=ns\=3;s\=Temperature temp=79.0,quality="OK (0x0)" 1597820490000000000
 ## Group Configuration
 
 Groups can set default values for the namespace, identifier type, tags
-settings and sampling interval.  The default values apply to all the 
-nodes in the group.  If a default is set, a node may omit the setting 
+settings and sampling interval.  The default values apply to all the
+nodes in the group.  If a default is set, a node may omit the setting
 altogether. This simplifies node configuration, especially when many
 nodes share the same namespace or identifier type.
 

--- a/plugins/inputs/opcua_listener/README.md
+++ b/plugins/inputs/opcua_listener/README.md
@@ -97,13 +97,43 @@ to use them.
   ## identifier_type   - OPC UA ID type (s=string, i=numeric, g=guid, b=opaque)
   ## identifier        - OPC UA ID (tag as shown in opcua browser)
   ## default_tags      - extra tags to be added to the output metric (optional)
+  ## monitoring_params - additional settings for the monitored node (optional)
+  ##
+  ## Monitoring parameters
+  ## sampling_interval  - interval at which the server should check for data
+  ##                      changes (default: 0)
+  ## queue_size         - size of the notification queue (default: 10)
+  ## discard_oldest     - how notifications should be handled in case of full
+  ##                      notification queues, possible values:
+  ##                      "true": oldest entry in queue gets deleted and new value
+  ##                              is inserted (default)
+  ##                      "false": last value added to queue gets replaced with
+  ##                               new value        
+  ## data_change_filter - defines the condition under which a notification should
+  ##                      be reported
+  ##
+  ## Data change filter
+  ## trigger        - specify the conditions under which a data change notification
+  ##                  should be reported, possible values:
+  ##                  "Status": only report notifications if the status changes
+  ##                  "StatusValue": report notifications if either status or value
+  ##                                 changes
+  ##                  "StatusValueTimestamp": report notifications if either status,
+  ##                                          value or timestamp changes
+  ## deadband_type  - range for value changes where no notification should be reported
+  ##                  "Absolute": absolute change in a data value to report a notification
+  ##                  "Percent": works only with nodes that have an EURange property set
+  ##                             and is defined as: send notification if
+  ##                             (last value - current value) >
+  ##                             (deadband_value/100.0) * ((high–low) of EURange)
+  ## deadband_value - value to deadband_type
   ##
   ## Use either the inline notation or the bracketed notation, not both.
   #
   ## Inline notation (default_tags not supported yet)
   # nodes = [
-  #   {name="", namespace="", identifier_type="", identifier=""},
-  #   {name="", namespace="", identifier_type="", identifier=""},
+  #   {name="", namespace="", identifier_type="", identifier="", monitoring_params={sampling_interval="0s", queue_size="10", discard_oldest="true", data_change_filter={trigger="Status", deadband_type="Absolute", deadband_value="0"}}},
+  #   {name="", namespace="", identifier_type="", identifier="", monitoring_params={sampling_interval="0s", queue_size="10", discard_oldest="true", data_change_filter={trigger="Status", deadband_type="Absolute", deadband_value="0"}}},
   # ]
   #
   ## Bracketed notation
@@ -120,6 +150,16 @@ to use them.
   #   identifier_type = ""
   #   identifier = ""
   #
+  #   [inputs.opcua_listener.nodes.monitoring_params]
+  #     sampling_interval = "0s"
+  #     queue_size = "10"
+  #     discard_oldest = "true"
+  #
+  #     [inputs.opcua_listener.nodes.monitoring_params.data_change_filter]
+  #       trigger = "Status"
+  #       deadband_type = "Absolute"
+  #       deadband_value = "0"
+  #
   ## Node Group
   ## Sets defaults so they aren't required in every node.
   ## Default values can be set for:
@@ -127,6 +167,7 @@ to use them.
   ## * OPC UA namespace
   ## * Identifier
   ## * Default tags
+  ## * Sampling interval
   ##
   ## Multiple node groups are allowed
   #[[inputs.opcua_listener.group]]
@@ -147,13 +188,17 @@ to use them.
   ##   example: default_tags = { tag1 = "value1" }
   # default_tags = {}
   #
+  ## Group default sampling interval. If a node in the group doesn't set its
+  ## sampling interval, this is used.
+  # sampling_interval = 
+  #
   ## Node ID Configuration.  Array of nodes with the same settings as above.
   ## Use either the inline notation or the bracketed notation, not both.
   #
   ## Inline notation (default_tags not supported yet)
   # nodes = [
-  #  {name="node1", namespace="", identifier_type="", identifier=""},
-  #  {name="node2", namespace="", identifier_type="", identifier=""},
+  #  {name="node1", namespace="", identifier_type="", identifier="", monitoring_params={sampling_interval="0s", queue_size="10", discard_oldest="true", data_change_filter={trigger="Status", deadband_type="Absolute", deadband_value="10"}}},
+  #  {name="node2", namespace="", identifier_type="", identifier="", monitoring_params={sampling_interval="0s", queue_size="10", discard_oldest="true", data_change_filter={trigger="Status", deadband_type="Absolute", deadband_value="10"}}},
   #]
   #
   ## Bracketed notation
@@ -169,7 +214,17 @@ to use them.
   #   namespace = ""
   #   identifier_type = ""
   #   identifier = ""
-
+  #
+  #   [inputs.opcua_listener.group.nodes.monitoring_params]
+  #     sampling_interval = "0s"
+  #     queue_size = "10"
+  #     discard_oldest = "true"
+  #
+  #     [inputs.opcua_listener.group.nodes.monitoring_params.data_change_filter]
+  #       trigger = "Status"
+  #       deadband_type = "Absolute"
+  #       deadband_value = "10"
+  #
   ## Enable workarounds required by some devices to work correctly
   # [inputs.opcua_listener.workarounds]
     ## Set additional valid status codes, StatusOK (0x0) is always considered valid
@@ -201,11 +256,11 @@ opcua,id=ns\=3;s\=Temperature temp=79.0,quality="OK (0x0)" 1597820490000000000
 
 ## Group Configuration
 
-Groups can set default values for the namespace, identifier type, and
-tags settings.  The default values apply to all the nodes in the
-group.  If a default is set, a node may omit the setting altogether.
-This simplifies node configuration, especially when many nodes share
-the same namespace or identifier type.
+Groups can set default values for the namespace, identifier type, tags
+settings and sampling interval.  The default values apply to all the 
+nodes in the group.  If a default is set, a node may omit the setting 
+altogether. This simplifies node configuration, especially when many
+nodes share the same namespace or identifier type.
 
 The output metric will include tags set in the group and the node.  If
 a tag with the same name is set in both places, the tag value from the

--- a/plugins/inputs/opcua_listener/README.md
+++ b/plugins/inputs/opcua_listener/README.md
@@ -120,9 +120,7 @@ to use them.
   ##                                 changes
   ##                  "StatusValueTimestamp": report notifications if either status,
   ##                                          value or timestamp changes
-  ## deadband_type  - range for value changes where no notification should be
-  ##                  reported, possible values:
-  ##                  "None": no filter will be applied (default if parameter is omitted)
+  ## deadband_type  - type of the deadband filter to be applied, possible values:
   ##                  "Absolute": absolute change in a data value to report a notification
   ##                  "Percent": works only with nodes that have an EURange property set
   ##                             and is defined as: send notification if
@@ -135,8 +133,8 @@ to use them.
   #
   ## Inline notation (default_tags not supported yet)
   # nodes = [
-  #   {name="node1", namespace="", identifier_type="", identifier="",
-  #   {name="node2", namespace="", identifier_type="", identifier="", monitoring_params={sampling_interval="0s", queue_size=10, discard_oldest=true, data_change_filter={trigger="Status", deadband_type="None", deadband_value=0.0}}},
+  #   {name="node1", namespace="", identifier_type="", identifier="",}
+  #   {name="node2", namespace="", identifier_type="", identifier="", monitoring_params={sampling_interval="0s", queue_size=10, discard_oldest=true, data_change_filter={trigger="Status", deadband_type="Absolute", deadband_value=0.0}}},
   # ]
   #
   ## Bracketed notation
@@ -160,7 +158,7 @@ to use them.
   #
   #     [inputs.opcua_listener.nodes.monitoring_params.data_change_filter]
   #       trigger = "Status"
-  #       deadband_type = "None"
+  #       deadband_type = "Absolute"
   #       deadband_value = 0.0
   #
   ## Node Group
@@ -200,8 +198,8 @@ to use them.
   #
   ## Inline notation (default_tags not supported yet)
   # nodes = [
-  #  {name="node1", namespace="", identifier_type="", identifier="",
-  #  {name="node2", namespace="", identifier_type="", identifier="", monitoring_params={sampling_interval="0s", queue_size=10, discard_oldest=true, data_change_filter={trigger="Status", deadband_type="None", deadband_value=0.0}}},
+  #  {name="node1", namespace="", identifier_type="", identifier="",}
+  #  {name="node2", namespace="", identifier_type="", identifier="", monitoring_params={sampling_interval="0s", queue_size=10, discard_oldest=true, data_change_filter={trigger="Status", deadband_type="Absolute", deadband_value=0.0}}},
   #]
   #
   ## Bracketed notation
@@ -225,7 +223,7 @@ to use them.
   #
   #     [inputs.opcua_listener.group.nodes.monitoring_params.data_change_filter]
   #       trigger = "Status"
-  #       deadband_type = "None"
+  #       deadband_type = "Absolute"
   #       deadband_value = 0.0
   #
   ## Enable workarounds required by some devices to work correctly

--- a/plugins/inputs/opcua_listener/opcua_listener_test.go
+++ b/plugins/inputs/opcua_listener/opcua_listener_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/docker/go-connections/nat"
+	"github.com/gopcua/opcua/ua"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go/wait"
 
@@ -308,4 +309,268 @@ deadband_value = 100.0
 			}},
 		},
 	}, o.SubscribeClientConfig.Groups)
+}
+
+func TestSubscribeClientConfigInvalidTrigger(t *testing.T) {
+	subscribeConfig := SubscribeClientConfig{
+		InputClientConfig: input.InputClientConfig{
+			OpcUAClientConfig: opcua.OpcUAClientConfig{
+				Endpoint:       "opc.tcp://localhost:4840",
+				SecurityPolicy: "None",
+				SecurityMode:   "None",
+				AuthMethod:     "Anonymous",
+				ConnectTimeout: config.Duration(10 * time.Second),
+				RequestTimeout: config.Duration(1 * time.Second),
+				Workarounds:    opcua.OpcUAWorkarounds{},
+			},
+			MetricName: "testing",
+			RootNodes:  make([]input.NodeSettings, 0),
+			Groups:     make([]input.NodeGroupSettings, 0),
+		},
+		SubscriptionInterval: 0,
+	}
+	subscribeConfig.RootNodes = append(subscribeConfig.RootNodes, input.NodeSettings{
+		FieldName:      "foo",
+		Namespace:      "3",
+		Identifier:     "1",
+		IdentifierType: "i",
+		MonitoringParams: input.MonitoringParameters{
+			DataChangeFilter: &input.DataChangeFilter{
+				Trigger: "not_valid",
+			},
+		},
+	})
+
+	_, err := subscribeConfig.CreateSubscribeClient(testutil.Logger{})
+	require.ErrorContains(t, err, "trigger 'not_valid' not supported, node 'ns=3;i=1'")
+}
+
+func TestSubscribeClientConfigMissingTrigger(t *testing.T) {
+	subscribeConfig := SubscribeClientConfig{
+		InputClientConfig: input.InputClientConfig{
+			OpcUAClientConfig: opcua.OpcUAClientConfig{
+				Endpoint:       "opc.tcp://localhost:4840",
+				SecurityPolicy: "None",
+				SecurityMode:   "None",
+				AuthMethod:     "Anonymous",
+				ConnectTimeout: config.Duration(10 * time.Second),
+				RequestTimeout: config.Duration(1 * time.Second),
+				Workarounds:    opcua.OpcUAWorkarounds{},
+			},
+			MetricName: "testing",
+			RootNodes:  make([]input.NodeSettings, 0),
+			Groups:     make([]input.NodeGroupSettings, 0),
+		},
+		SubscriptionInterval: 0,
+	}
+	subscribeConfig.RootNodes = append(subscribeConfig.RootNodes, input.NodeSettings{
+		FieldName:      "foo",
+		Namespace:      "3",
+		Identifier:     "1",
+		IdentifierType: "i",
+		MonitoringParams: input.MonitoringParameters{
+			DataChangeFilter: &input.DataChangeFilter{
+				DeadbandType: "Absolute",
+			},
+		},
+	})
+
+	_, err := subscribeConfig.CreateSubscribeClient(testutil.Logger{})
+	require.ErrorContains(t, err, "trigger '' not supported, node 'ns=3;i=1'")
+}
+
+func TestSubscribeClientConfigInvalidDeadbandType(t *testing.T) {
+	subscribeConfig := SubscribeClientConfig{
+		InputClientConfig: input.InputClientConfig{
+			OpcUAClientConfig: opcua.OpcUAClientConfig{
+				Endpoint:       "opc.tcp://localhost:4840",
+				SecurityPolicy: "None",
+				SecurityMode:   "None",
+				AuthMethod:     "Anonymous",
+				ConnectTimeout: config.Duration(10 * time.Second),
+				RequestTimeout: config.Duration(1 * time.Second),
+				Workarounds:    opcua.OpcUAWorkarounds{},
+			},
+			MetricName: "testing",
+			RootNodes:  make([]input.NodeSettings, 0),
+			Groups:     make([]input.NodeGroupSettings, 0),
+		},
+		SubscriptionInterval: 0,
+	}
+	subscribeConfig.RootNodes = append(subscribeConfig.RootNodes, input.NodeSettings{
+		FieldName:      "foo",
+		Namespace:      "3",
+		Identifier:     "1",
+		IdentifierType: "i",
+		MonitoringParams: input.MonitoringParameters{
+			DataChangeFilter: &input.DataChangeFilter{
+				Trigger:      "Status",
+				DeadbandType: "not_valid",
+			},
+		},
+	})
+
+	_, err := subscribeConfig.CreateSubscribeClient(testutil.Logger{})
+	require.ErrorContains(t, err, "deadband_type 'not_valid' not supported, node 'ns=3;i=1'")
+}
+
+func TestSubscribeClientConfigMissingDeadbandType(t *testing.T) {
+	subscribeConfig := SubscribeClientConfig{
+		InputClientConfig: input.InputClientConfig{
+			OpcUAClientConfig: opcua.OpcUAClientConfig{
+				Endpoint:       "opc.tcp://localhost:4840",
+				SecurityPolicy: "None",
+				SecurityMode:   "None",
+				AuthMethod:     "Anonymous",
+				ConnectTimeout: config.Duration(10 * time.Second),
+				RequestTimeout: config.Duration(1 * time.Second),
+				Workarounds:    opcua.OpcUAWorkarounds{},
+			},
+			MetricName: "testing",
+			RootNodes:  make([]input.NodeSettings, 0),
+			Groups:     make([]input.NodeGroupSettings, 0),
+		},
+		SubscriptionInterval: 0,
+	}
+	subscribeConfig.RootNodes = append(subscribeConfig.RootNodes, input.NodeSettings{
+		FieldName:      "foo",
+		Namespace:      "3",
+		Identifier:     "1",
+		IdentifierType: "i",
+		MonitoringParams: input.MonitoringParameters{
+			DataChangeFilter: &input.DataChangeFilter{
+				Trigger: "Status",
+			},
+		},
+	})
+
+	_, err := subscribeConfig.CreateSubscribeClient(testutil.Logger{})
+	require.ErrorContains(t, err, "deadband_type '' not supported, node 'ns=3;i=1'")
+}
+
+func TestSubscribeClientConfigInvalidDeadbandValue(t *testing.T) {
+	subscribeConfig := SubscribeClientConfig{
+		InputClientConfig: input.InputClientConfig{
+			OpcUAClientConfig: opcua.OpcUAClientConfig{
+				Endpoint:       "opc.tcp://localhost:4840",
+				SecurityPolicy: "None",
+				SecurityMode:   "None",
+				AuthMethod:     "Anonymous",
+				ConnectTimeout: config.Duration(10 * time.Second),
+				RequestTimeout: config.Duration(1 * time.Second),
+				Workarounds:    opcua.OpcUAWorkarounds{},
+			},
+			MetricName: "testing",
+			RootNodes:  make([]input.NodeSettings, 0),
+			Groups:     make([]input.NodeGroupSettings, 0),
+		},
+		SubscriptionInterval: 0,
+	}
+	deadbandValue := -1.0
+	subscribeConfig.RootNodes = append(subscribeConfig.RootNodes, input.NodeSettings{
+		FieldName:      "foo",
+		Namespace:      "3",
+		Identifier:     "1",
+		IdentifierType: "i",
+		MonitoringParams: input.MonitoringParameters{
+			DataChangeFilter: &input.DataChangeFilter{
+				Trigger:       "Status",
+				DeadbandType:  "Absolute",
+				DeadbandValue: &deadbandValue,
+			},
+		},
+	})
+
+	_, err := subscribeConfig.CreateSubscribeClient(testutil.Logger{})
+	require.ErrorContains(t, err, "negative deadband_value not supported, node 'ns=3;i=1'")
+}
+
+func TestSubscribeClientConfigMissingDeadbandValue(t *testing.T) {
+	subscribeConfig := SubscribeClientConfig{
+		InputClientConfig: input.InputClientConfig{
+			OpcUAClientConfig: opcua.OpcUAClientConfig{
+				Endpoint:       "opc.tcp://localhost:4840",
+				SecurityPolicy: "None",
+				SecurityMode:   "None",
+				AuthMethod:     "Anonymous",
+				ConnectTimeout: config.Duration(10 * time.Second),
+				RequestTimeout: config.Duration(1 * time.Second),
+				Workarounds:    opcua.OpcUAWorkarounds{},
+			},
+			MetricName: "testing",
+			RootNodes:  make([]input.NodeSettings, 0),
+			Groups:     make([]input.NodeGroupSettings, 0),
+		},
+		SubscriptionInterval: 0,
+	}
+	subscribeConfig.RootNodes = append(subscribeConfig.RootNodes, input.NodeSettings{
+		FieldName:      "foo",
+		Namespace:      "3",
+		Identifier:     "1",
+		IdentifierType: "i",
+		MonitoringParams: input.MonitoringParameters{
+			DataChangeFilter: &input.DataChangeFilter{
+				Trigger:      "Status",
+				DeadbandType: "Absolute",
+			},
+		},
+	})
+
+	_, err := subscribeConfig.CreateSubscribeClient(testutil.Logger{})
+	require.ErrorContains(t, err, "deadband_value was not set, node 'ns=3;i=1'")
+}
+
+func TestSubscribeClientConfigValidMonitoringParams(t *testing.T) {
+	subscribeConfig := SubscribeClientConfig{
+		InputClientConfig: input.InputClientConfig{
+			OpcUAClientConfig: opcua.OpcUAClientConfig{
+				Endpoint:       "opc.tcp://localhost:4840",
+				SecurityPolicy: "None",
+				SecurityMode:   "None",
+				AuthMethod:     "Anonymous",
+				ConnectTimeout: config.Duration(10 * time.Second),
+				RequestTimeout: config.Duration(1 * time.Second),
+				Workarounds:    opcua.OpcUAWorkarounds{},
+			},
+			MetricName: "testing",
+			RootNodes:  make([]input.NodeSettings, 0),
+			Groups:     make([]input.NodeGroupSettings, 0),
+		},
+		SubscriptionInterval: 0,
+	}
+
+	var queueSize uint32 = 10
+	discardOldest := true
+	deadbandValue := 10.0
+	subscribeConfig.RootNodes = append(subscribeConfig.RootNodes, input.NodeSettings{
+		FieldName:      "foo",
+		Namespace:      "3",
+		Identifier:     "1",
+		IdentifierType: "i",
+		MonitoringParams: input.MonitoringParameters{
+			SamplingInterval: 50000000,
+			QueueSize:        &queueSize,
+			DiscardOldest:    &discardOldest,
+			DataChangeFilter: &input.DataChangeFilter{
+				Trigger:       "Status",
+				DeadbandType:  "Absolute",
+				DeadbandValue: &deadbandValue,
+			},
+		},
+	})
+
+	subClient, err := subscribeConfig.CreateSubscribeClient(testutil.Logger{})
+	require.NoError(t, err)
+	require.Equal(t, &ua.MonitoringParameters{
+		SamplingInterval: 50,
+		QueueSize:        queueSize,
+		DiscardOldest:    discardOldest,
+		Filter: ua.NewExtensionObject(
+			&ua.DataChangeFilter{
+				Trigger:       ua.DataChangeTriggerStatus,
+				DeadbandType:  uint32(ua.DeadbandTypeAbsolute),
+				DeadbandValue: deadbandValue,
+			},
+		),
+	}, subClient.monitoredItemsReqs[0].RequestedParameters)
 }

--- a/plugins/inputs/opcua_listener/opcua_listener_test.go
+++ b/plugins/inputs/opcua_listener/opcua_listener_test.go
@@ -182,6 +182,16 @@ identifier_type = "i"
 tags = [["tag1", "val1"], ["tag2", "val2"]]
 nodes = [{name="name4", identifier="4000", tags=[["tag1", "override"]]}]
 
+[inputs.opcua_listener.group.nodes.monitoring_params]
+sampling_interval = "50ms"
+queue_size = "10"
+discard_oldest = "true"
+
+[inputs.opcua_listener.group.nodes.monitoring_params.data_change_filter]
+trigger = "StatusValue"
+deadband_type = "Absolute"
+deadband_value = "100"
+
 [inputs.opcua_listener.workarounds]
 additional_valid_status_codes = ["0xC0"]
 `
@@ -242,6 +252,16 @@ additional_valid_status_codes = ["0xC0"]
 				FieldName:  "name4",
 				Identifier: "4000",
 				TagsSlice:  [][]string{{"tag1", "override"}},
+				MonitoringParams: input.MonitoringParameters{
+					SamplingInterval: 50000000,
+					QueueSize:        "10",
+					DiscardOldest:    "true",
+					DataChangeFilter: input.DataChangeFilter{
+						Trigger:       "StatusValue",
+						DeadbandType:  "Absolute",
+						DeadbandValue: "100",
+					},
+				},
 			}},
 		},
 	}, o.SubscribeClientConfig.Groups)

--- a/plugins/inputs/opcua_listener/sample.conf
+++ b/plugins/inputs/opcua_listener/sample.conf
@@ -58,13 +58,43 @@
   ## identifier_type   - OPC UA ID type (s=string, i=numeric, g=guid, b=opaque)
   ## identifier        - OPC UA ID (tag as shown in opcua browser)
   ## default_tags      - extra tags to be added to the output metric (optional)
+  ## monitoring_params - additional settings for the monitored node (optional)
+  ##
+  ## Monitoring parameters
+  ## sampling_interval  - interval at which the server should check for data
+  ##                      changes (default: 0)
+  ## queue_size         - size of the notification queue (default: 10)
+  ## discard_oldest     - how notifications should be handled in case of full
+  ##                      notification queues, possible values:
+  ##                      "true": oldest entry in queue gets deleted and new value
+  ##                              is inserted (default)
+  ##                      "false": last value added to queue gets replaced with
+  ##                               new value        
+  ## data_change_filter - defines the condition under which a notification should
+  ##                      be reported
+  ##
+  ## Data change filter
+  ## trigger        - specify the conditions under which a data change notification
+  ##                  should be reported, possible values:
+  ##                  "Status": only report notifications if the status changes
+  ##                  "StatusValue": report notifications if either status or value
+  ##                                 changes
+  ##                  "StatusValueTimestamp": report notifications if either status,
+  ##                                          value or timestamp changes
+  ## deadband_type  - range for value changes where no notification should be reported
+  ##                  "Absolute": absolute change in a data value to report a notification
+  ##                  "Percent": works only with nodes that have an EURange property set
+  ##                             and is defined as: send notification if
+  ##                             (last value - current value) >
+  ##                             (deadband_value/100.0) * ((high–low) of EURange)
+  ## deadband_value - value to deadband_type
   ##
   ## Use either the inline notation or the bracketed notation, not both.
   #
   ## Inline notation (default_tags not supported yet)
   # nodes = [
-  #   {name="", namespace="", identifier_type="", identifier=""},
-  #   {name="", namespace="", identifier_type="", identifier=""},
+  #   {name="", namespace="", identifier_type="", identifier="", monitoring_params={sampling_interval="0s", queue_size="10", discard_oldest="true", data_change_filter={trigger="Status", deadband_type="Absolute", deadband_value="0"}}},
+  #   {name="", namespace="", identifier_type="", identifier="", monitoring_params={sampling_interval="0s", queue_size="10", discard_oldest="true", data_change_filter={trigger="Status", deadband_type="Absolute", deadband_value="0"}}},
   # ]
   #
   ## Bracketed notation
@@ -81,6 +111,16 @@
   #   identifier_type = ""
   #   identifier = ""
   #
+  #   [inputs.opcua_listener.nodes.monitoring_params]
+  #     sampling_interval = "0s"
+  #     queue_size = "10"
+  #     discard_oldest = "true"
+  #
+  #     [inputs.opcua_listener.nodes.monitoring_params.data_change_filter]
+  #       trigger = "Status"
+  #       deadband_type = "Absolute"
+  #       deadband_value = "0"
+  #
   ## Node Group
   ## Sets defaults so they aren't required in every node.
   ## Default values can be set for:
@@ -88,6 +128,7 @@
   ## * OPC UA namespace
   ## * Identifier
   ## * Default tags
+  ## * Sampling interval
   ##
   ## Multiple node groups are allowed
   #[[inputs.opcua_listener.group]]
@@ -108,13 +149,17 @@
   ##   example: default_tags = { tag1 = "value1" }
   # default_tags = {}
   #
+  ## Group default sampling interval. If a node in the group doesn't set its
+  ## sampling interval, this is used.
+  # sampling_interval = 
+  #
   ## Node ID Configuration.  Array of nodes with the same settings as above.
   ## Use either the inline notation or the bracketed notation, not both.
   #
   ## Inline notation (default_tags not supported yet)
   # nodes = [
-  #  {name="node1", namespace="", identifier_type="", identifier=""},
-  #  {name="node2", namespace="", identifier_type="", identifier=""},
+  #  {name="node1", namespace="", identifier_type="", identifier="", monitoring_params={sampling_interval="0s", queue_size="10", discard_oldest="true", data_change_filter={trigger="Status", deadband_type="Absolute", deadband_value="10"}}},
+  #  {name="node2", namespace="", identifier_type="", identifier="", monitoring_params={sampling_interval="0s", queue_size="10", discard_oldest="true", data_change_filter={trigger="Status", deadband_type="Absolute", deadband_value="10"}}},
   #]
   #
   ## Bracketed notation
@@ -130,7 +175,17 @@
   #   namespace = ""
   #   identifier_type = ""
   #   identifier = ""
-
+  #
+  #   [inputs.opcua_listener.group.nodes.monitoring_params]
+  #     sampling_interval = "0s"
+  #     queue_size = "10"
+  #     discard_oldest = "true"
+  #
+  #     [inputs.opcua_listener.group.nodes.monitoring_params.data_change_filter]
+  #       trigger = "Status"
+  #       deadband_type = "Absolute"
+  #       deadband_value = "10"
+  #
   ## Enable workarounds required by some devices to work correctly
   # [inputs.opcua_listener.workarounds]
     ## Set additional valid status codes, StatusOK (0x0) is always considered valid

--- a/plugins/inputs/opcua_listener/sample.conf
+++ b/plugins/inputs/opcua_listener/sample.conf
@@ -81,9 +81,7 @@
   ##                                 changes
   ##                  "StatusValueTimestamp": report notifications if either status,
   ##                                          value or timestamp changes
-  ## deadband_type  - range for value changes where no notification should be
-  ##                  reported, possible values:
-  ##                  "None": no filter will be applied (default if parameter is omitted)
+  ## deadband_type  - type of the deadband filter to be applied, possible values:
   ##                  "Absolute": absolute change in a data value to report a notification
   ##                  "Percent": works only with nodes that have an EURange property set
   ##                             and is defined as: send notification if
@@ -96,8 +94,8 @@
   #
   ## Inline notation (default_tags not supported yet)
   # nodes = [
-  #   {name="node1", namespace="", identifier_type="", identifier="",
-  #   {name="node2", namespace="", identifier_type="", identifier="", monitoring_params={sampling_interval="0s", queue_size=10, discard_oldest=true, data_change_filter={trigger="Status", deadband_type="None", deadband_value=0.0}}},
+  #   {name="node1", namespace="", identifier_type="", identifier="",}
+  #   {name="node2", namespace="", identifier_type="", identifier="", monitoring_params={sampling_interval="0s", queue_size=10, discard_oldest=true, data_change_filter={trigger="Status", deadband_type="Absolute", deadband_value=0.0}}},
   # ]
   #
   ## Bracketed notation
@@ -121,7 +119,7 @@
   #
   #     [inputs.opcua_listener.nodes.monitoring_params.data_change_filter]
   #       trigger = "Status"
-  #       deadband_type = "None"
+  #       deadband_type = "Absolute"
   #       deadband_value = 0.0
   #
   ## Node Group
@@ -161,8 +159,8 @@
   #
   ## Inline notation (default_tags not supported yet)
   # nodes = [
-  #  {name="node1", namespace="", identifier_type="", identifier="",
-  #  {name="node2", namespace="", identifier_type="", identifier="", monitoring_params={sampling_interval="0s", queue_size=10, discard_oldest=true, data_change_filter={trigger="Status", deadband_type="None", deadband_value=0.0}}},
+  #  {name="node1", namespace="", identifier_type="", identifier="",}
+  #  {name="node2", namespace="", identifier_type="", identifier="", monitoring_params={sampling_interval="0s", queue_size=10, discard_oldest=true, data_change_filter={trigger="Status", deadband_type="Absolute", deadband_value=0.0}}},
   #]
   #
   ## Bracketed notation
@@ -186,7 +184,7 @@
   #
   #     [inputs.opcua_listener.group.nodes.monitoring_params.data_change_filter]
   #       trigger = "Status"
-  #       deadband_type = "None"
+  #       deadband_type = "Absolute"
   #       deadband_value = 0.0
   #
   ## Enable workarounds required by some devices to work correctly

--- a/plugins/inputs/opcua_listener/sample.conf
+++ b/plugins/inputs/opcua_listener/sample.conf
@@ -62,14 +62,13 @@
   ##
   ## Monitoring parameters
   ## sampling_interval  - interval at which the server should check for data
-  ##                      changes (default: 0)
+  ##                      changes (default: 0s)
   ## queue_size         - size of the notification queue (default: 10)
   ## discard_oldest     - how notifications should be handled in case of full
   ##                      notification queues, possible values:
-  ##                      "true": oldest entry in queue gets deleted and new value
-  ##                              is inserted (default)
-  ##                      "false": last value added to queue gets replaced with
-  ##                               new value        
+  ##                      true: oldest value added to queue gets replaced with new
+  ##                            (default)
+  ##                      false: last value added to queue gets replaced with new
   ## data_change_filter - defines the condition under which a notification should
   ##                      be reported
   ##
@@ -77,24 +76,28 @@
   ## trigger        - specify the conditions under which a data change notification
   ##                  should be reported, possible values:
   ##                  "Status": only report notifications if the status changes
+  ##                            (default if parameter is omitted)
   ##                  "StatusValue": report notifications if either status or value
   ##                                 changes
   ##                  "StatusValueTimestamp": report notifications if either status,
   ##                                          value or timestamp changes
-  ## deadband_type  - range for value changes where no notification should be reported
+  ## deadband_type  - range for value changes where no notification should be
+  ##                  reported, possible values:
+  ##                  "None": no filter will be applied (default if parameter is omitted)
   ##                  "Absolute": absolute change in a data value to report a notification
   ##                  "Percent": works only with nodes that have an EURange property set
   ##                             and is defined as: send notification if
   ##                             (last value - current value) >
   ##                             (deadband_value/100.0) * ((high–low) of EURange)
-  ## deadband_value - value to deadband_type
+  ## deadband_value - value to deadband_type, must be a float value, no filter is set
+  ##                  for negative values
   ##
   ## Use either the inline notation or the bracketed notation, not both.
   #
   ## Inline notation (default_tags not supported yet)
   # nodes = [
-  #   {name="", namespace="", identifier_type="", identifier="", monitoring_params={sampling_interval="0s", queue_size="10", discard_oldest="true", data_change_filter={trigger="Status", deadband_type="Absolute", deadband_value="0"}}},
-  #   {name="", namespace="", identifier_type="", identifier="", monitoring_params={sampling_interval="0s", queue_size="10", discard_oldest="true", data_change_filter={trigger="Status", deadband_type="Absolute", deadband_value="0"}}},
+  #   {name="node1", namespace="", identifier_type="", identifier="",
+  #   {name="node2", namespace="", identifier_type="", identifier="", monitoring_params={sampling_interval="0s", queue_size=10, discard_oldest=true, data_change_filter={trigger="Status", deadband_type="None", deadband_value=0.0}}},
   # ]
   #
   ## Bracketed notation
@@ -113,13 +116,13 @@
   #
   #   [inputs.opcua_listener.nodes.monitoring_params]
   #     sampling_interval = "0s"
-  #     queue_size = "10"
-  #     discard_oldest = "true"
+  #     queue_size = 10
+  #     discard_oldest = true
   #
   #     [inputs.opcua_listener.nodes.monitoring_params.data_change_filter]
   #       trigger = "Status"
-  #       deadband_type = "Absolute"
-  #       deadband_value = "0"
+  #       deadband_type = "None"
+  #       deadband_value = 0.0
   #
   ## Node Group
   ## Sets defaults so they aren't required in every node.
@@ -151,15 +154,15 @@
   #
   ## Group default sampling interval. If a node in the group doesn't set its
   ## sampling interval, this is used.
-  # sampling_interval = 
+  # sampling_interval = "0s"
   #
   ## Node ID Configuration.  Array of nodes with the same settings as above.
   ## Use either the inline notation or the bracketed notation, not both.
   #
   ## Inline notation (default_tags not supported yet)
   # nodes = [
-  #  {name="node1", namespace="", identifier_type="", identifier="", monitoring_params={sampling_interval="0s", queue_size="10", discard_oldest="true", data_change_filter={trigger="Status", deadband_type="Absolute", deadband_value="10"}}},
-  #  {name="node2", namespace="", identifier_type="", identifier="", monitoring_params={sampling_interval="0s", queue_size="10", discard_oldest="true", data_change_filter={trigger="Status", deadband_type="Absolute", deadband_value="10"}}},
+  #  {name="node1", namespace="", identifier_type="", identifier="",
+  #  {name="node2", namespace="", identifier_type="", identifier="", monitoring_params={sampling_interval="0s", queue_size=10, discard_oldest=true, data_change_filter={trigger="Status", deadband_type="None", deadband_value=0.0}}},
   #]
   #
   ## Bracketed notation
@@ -178,13 +181,13 @@
   #
   #   [inputs.opcua_listener.group.nodes.monitoring_params]
   #     sampling_interval = "0s"
-  #     queue_size = "10"
-  #     discard_oldest = "true"
+  #     queue_size = 10
+  #     discard_oldest = true
   #
   #     [inputs.opcua_listener.group.nodes.monitoring_params.data_change_filter]
   #       trigger = "Status"
-  #       deadband_type = "Absolute"
-  #       deadband_value = "10"
+  #       deadband_type = "None"
+  #       deadband_value = 0.0
   #
   ## Enable workarounds required by some devices to work correctly
   # [inputs.opcua_listener.workarounds]

--- a/plugins/inputs/opcua_listener/subscribe_client.go
+++ b/plugins/inputs/opcua_listener/subscribe_client.go
@@ -62,7 +62,7 @@ func assignConfigValuesToRequest(req *ua.MonitoredItemCreateRequest, monParams *
 	}
 
 	if monParams.DataChangeFilter != nil {
-		if err := CheckDataChangeFilterParameters(monParams.DataChangeFilter); err != nil {
+		if err := checkDataChangeFilterParameters(monParams.DataChangeFilter); err != nil {
 			return fmt.Errorf(err.Error()+", node '%s'", req.ItemToMonitor.NodeID)
 		}
 

--- a/plugins/inputs/opcua_listener/subscribe_client.go
+++ b/plugins/inputs/opcua_listener/subscribe_client.go
@@ -103,7 +103,7 @@ func (sc *SubscribeClientConfig) CreateSubscribeClient(log telegraf.Logger) (*Su
 	for i, nodeID := range client.NodeIDs {
 		// The node id index (i) is used as the handle for the monitored item
 		req := opcua.NewMonitoredItemCreateRequestWithDefaults(nodeID, ua.AttributeIDValue, uint32(i))
-		if err := AssignConfigValuesToRequest(req, &client.NodeMetricMapping[i].Tag.MonitoringParams); err != nil {
+		if err := assignConfigValuesToRequest(req, &client.NodeMetricMapping[i].Tag.MonitoringParams); err != nil {
 			return nil, err
 		}
 		subClient.monitoredItemsReqs[i] = req

--- a/plugins/inputs/opcua_listener/subscribe_client.go
+++ b/plugins/inputs/opcua_listener/subscribe_client.go
@@ -32,7 +32,7 @@ type SubscribeClient struct {
 	processingCancel context.CancelFunc
 }
 
-func CheckDataChangeFilterParameters(params *input.DataChangeFilter) error {
+func checkDataChangeFilterParameters(params *input.DataChangeFilter) error {
 	switch {
 	case params.Trigger != input.Status &&
 		params.Trigger != input.StatusValue &&

--- a/plugins/inputs/opcua_listener/subscribe_client.go
+++ b/plugins/inputs/opcua_listener/subscribe_client.go
@@ -50,7 +50,7 @@ func checkDataChangeFilterParameters(params *input.DataChangeFilter) error {
 	}
 }
 
-func AssignConfigValuesToRequest(req *ua.MonitoredItemCreateRequest, monParams *input.MonitoringParameters) error {
+func assignConfigValuesToRequest(req *ua.MonitoredItemCreateRequest, monParams *input.MonitoringParameters) error {
 	req.RequestedParameters.SamplingInterval = float64(time.Duration(monParams.SamplingInterval) / time.Millisecond)
 
 	if monParams.QueueSize != nil {


### PR DESCRIPTION
# Required for all PRs

<!-- Before opening a pull request you should run the following checks locally to make sure the CI will pass.

make lint
make check
make check-deps
make test
make docs

-->

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

resolves #13891

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->
new structs have been added to input client representing monitoring and data change filter parameters

new function has been added to subscribe client in order to override default values for parameters that have been specified in the config

monitoring parameters have been added to existing tests for subscribe client