### PR TITLE
fix(inputs.smart): Remove parsing error message

### DIFF
--- a/plugins/inputs/smart/smart.go
+++ b/plugins/inputs/smart/smart.go
@@ -865,7 +865,6 @@ func (m *Smart) gatherDisk(acc telegraf.Accumulator, device string, wg *sync.Wai
 					}
 
 					if err := parse(fields, deviceFields, matches[2]); err != nil {
-						acc.AddError(fmt.Errorf("error parsing %s: %q: %w", attr.Name, matches[2], err))
 						continue
 					}
 					// if the field is classified as an attribute, only add it


### PR DESCRIPTION
Rather than error out on a parsing error, ignore the error and continue on parsing other fields. This avoids tossing all the data and not returning any metrics. This is the behavior for other parsing functions and fields throughout the plugin.

fixes: #13926