### PR TITLE
fix(outputs.cloudwatch): Increase number of metrics per write

### DIFF
--- a/plugins/outputs/cloudwatch/cloudwatch.go
+++ b/plugins/outputs/cloudwatch/cloudwatch.go
@@ -188,7 +188,8 @@ func (c *CloudWatch) Write(metrics []telegraf.Metric) error {
 		datums = append(datums, d...)
 	}
 
-	const maxDatumsPerCall = 20 // PutMetricData only supports up to 20 data metrics per call
+	// PutMetricData only supports up to 1000 data metrics per call
+	const maxDatumsPerCall = 1000
 
 	for _, partition := range PartitionDatums(maxDatumsPerCall, datums) {
 		err := c.WriteToCloudWatch(partition)

--- a/plugins/outputs/cloudwatch/cloudwatch.go
+++ b/plugins/outputs/cloudwatch/cloudwatch.go
@@ -189,6 +189,7 @@ func (c *CloudWatch) Write(metrics []telegraf.Metric) error {
 	}
 
 	// PutMetricData only supports up to 1000 data metrics per call
+	// https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_PutMetricData.html
 	const maxDatumsPerCall = 1000
 
 	for _, partition := range PartitionDatums(maxDatumsPerCall, datums) {


### PR DESCRIPTION
Previously this was limited to only 20 per write. It appears AWS has increased this to no more than 1000.

fixes: #13929