### PR TITLE
fix(outputs.stackdriver): Drop metrics on InvalidArgument gRPC error

### DIFF
--- a/plugins/outputs/stackdriver/stackdriver_test.go
+++ b/plugins/outputs/stackdriver/stackdriver_test.go
@@ -397,18 +397,6 @@ func TestWriteIgnoredErrors(t *testing.T) {
 		expectedErr bool
 	}{
 		{
-			name: "points too old",
-			err:  errors.New(errStringPointsTooOld),
-		},
-		{
-			name: "points out of order",
-			err:  errors.New(errStringPointsOutOfOrder),
-		},
-		{
-			name: "points too frequent",
-			err:  errors.New(errStringPointsTooFrequent),
-		},
-		{
 			name:        "other errors reported",
 			err:         errors.New("test"),
 			expectedErr: true,
@@ -431,14 +419,8 @@ func TestWriteIgnoredErrors(t *testing.T) {
 				client:    c,
 			}
 
-			err = s.Connect()
-			require.NoError(t, err)
-			err = s.Write(testutil.MockMetrics())
-			if tt.expectedErr {
-				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
-			}
+			require.NoError(t, s.Connect())
+			require.Error(t, s.Write(testutil.MockMetrics()))
 		})
 	}
 }


### PR DESCRIPTION
Rather than rely on specific error messages that have in fact changed over time, let's instead drop metrics whenever we get an InvalidArgument gRPC error. These are not retry-able errors and should instead be dropped.

fixes: #13826
