### PR TITLE
chore: Update macOS CircleCI runner

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ executors:
       GOFLAGS: -p=4
   mac:
     working_directory: '~/go/src/github.com/influxdata/telegraf'
-    resource_class: macos.x86.medium.gen2
+    resource_class: macos.m1.medium.gen1
     macos:
       xcode: 14.2.0
     environment:


### PR DESCRIPTION
Per macOS Intel deprecation notification on CircleCI, the existing Intel-based resource classes are deprecated and will be removed in shortly after the new year in 2024.

https://discuss.circleci.com/t/macos-intel-support-deprecation-in-january-2024/48718