### PR TITLE
fix(parsers.avro): Only attempt to read CA Cert file if filename is not empty string

### DIFF
--- a/plugins/parsers/avro/schema_registry.go
+++ b/plugins/parsers/avro/schema_registry.go
@@ -29,14 +29,13 @@ type schemaRegistry struct {
 const schemaByID = "%s/schemas/ids/%d"
 
 func newSchemaRegistry(addr string, caCertPath string) (*schemaRegistry, error) {
-	caCert, err := os.ReadFile(caCertPath)
-	if err != nil {
-		return nil, err
-	}
-
 	var client *http.Client
 	var tlsCfg *tls.Config
 	if caCertPath != "" {
+		caCert, err := os.ReadFile(caCertPath)
+		if err != nil {
+			return nil, err
+		}
 		caCertPool := x509.NewCertPool()
 		caCertPool.AppendCertsFromPEM(caCert)
 		tlsCfg = &tls.Config{


### PR DESCRIPTION
# Required for all PRs

<!-- Before opening a pull request you should run the following checks locally to make sure the CI will pass.

make lint
make check
make check-deps
make test
make docs

-->

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [n/a] Updated associated README.md.
- [n/a] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

resolves #13938

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->

Moved the attempted opening of the CA cert file inside the check that that filename is not the empty string.