### PR TITLE
fix(inputs.jti_openconfig_telemetry): Do not block GRPC dial

### DIFF
--- a/plugins/inputs/jti_openconfig_telemetry/jti_openconfig_telemetry.go
+++ b/plugins/inputs/jti_openconfig_telemetry/jti_openconfig_telemetry.go
@@ -386,7 +386,6 @@ func (m *OpenConfigTelemetry) Start(acc telegraf.Accumulator) error {
 	// Setup the basic connection options
 	options := []grpc.DialOption{
 		grpc.WithTransportCredentials(creds),
-		grpc.WithBlock(),
 	}
 
 	// Add keep-alive settings


### PR DESCRIPTION
- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #13917 

This does not block the GRPC dial and restores the old behavior (hopefully).