### PR TITLE
fix(inputs.cisco_telemetry_mdt): Print string message on decode failure

### DIFF
--- a/plugins/inputs/cisco_telemetry_mdt/cisco_telemetry_mdt.go
+++ b/plugins/inputs/cisco_telemetry_mdt/cisco_telemetry_mdt.go
@@ -361,7 +361,7 @@ func (c *CiscoTelemetryMDT) handleTelemetry(data []byte) {
 	msg := &telemetry.Telemetry{}
 	err := proto.Unmarshal(data, msg)
 	if err != nil {
-		c.acc.AddError(fmt.Errorf("failed to decode: %w", err))
+		c.acc.AddError(fmt.Errorf("failed to decode: %w: %s", err, msg.String()))
 		return
 	}
 


### PR DESCRIPTION
If a user gets a message that we failed to decode the message it would be super helpful to know what message failed to decode in the first place.

fixes: #13928
