### PR TITLE
feat(agent): Support for cancellable Gather

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -552,7 +552,7 @@ func (a *Agent) gatherLoop(
 	for {
 		select {
 		case <-ticker.Elapsed():
-			err := a.gatherOnce(acc, input, ticker, interval)
+			err := a.gatherOnce(ctx, acc, input, ticker, interval)
 			if err != nil {
 				acc.AddError(err)
 			}
@@ -565,14 +565,16 @@ func (a *Agent) gatherLoop(
 // gatherOnce runs the input's Gather function once, logging a warning each
 // interval it fails to complete before.
 func (a *Agent) gatherOnce(
+	ctx context.Context,
 	acc telegraf.Accumulator,
 	input *models.RunningInput,
 	ticker Ticker,
 	interval time.Duration,
 ) error {
 	done := make(chan error)
+
 	go func() {
-		done <- input.Gather(acc)
+		done <- input.Gather(ctx, acc)
 	}()
 
 	// Only warn after interval seconds, even if the interval is started late.

--- a/input.go
+++ b/input.go
@@ -1,11 +1,21 @@
 package telegraf
 
+import "context"
+
 type Input interface {
 	PluginDescriber
 
 	// Gather takes in an accumulator and adds the metrics that the Input
 	// gathers. This is called every agent.interval
 	Gather(Accumulator) error
+}
+
+type InputCtx interface {
+	PluginDescriber
+
+	// Gather takes in an accumulator and adds the metrics that the Input
+	// gathers. This is called every agent.interval
+	GatherContext(context.Context, Accumulator) error
 }
 
 type ServiceInput interface {

--- a/plugins/inputs/exec/exec_test.go
+++ b/plugins/inputs/exec/exec_test.go
@@ -7,6 +7,7 @@ package exec
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"runtime"
 	"testing"
@@ -440,9 +441,9 @@ func TestCases(t *testing.T) {
 
 	var acc testutil.Accumulator
 	// Run gather once
-	require.NoError(t, plugin.Gather(&acc))
+	require.NoError(t, plugin.Gather(context.Background(), &acc))
 	// Run gather a second time
-	require.NoError(t, plugin.Gather(&acc))
+	require.NoError(t, plugin.Gather(context.Background(), &acc))
 	require.Eventuallyf(t, func() bool {
 		acc.Lock()
 		defer acc.Unlock()

--- a/plugins/inputs/postgresql_extensible/postgresql_extensible.go
+++ b/plugins/inputs/postgresql_extensible/postgresql_extensible.go
@@ -88,10 +88,6 @@ func ReadQueryFromFile(filePath string) (string, error) {
 	return string(query), err
 }
 
-func (p *Postgresql) Gather(acc telegraf.Accumulator) error {
-	return nil
-}
-
 func (p *Postgresql) GatherContext(ctx context.Context, acc telegraf.Accumulator) error {
 	var (
 		err        error
@@ -286,7 +282,7 @@ COLUMN:
 }
 
 func init() {
-	inputs.Add("postgresql_extensible", func() telegraf.Input {
+	inputs.AddCtx("postgresql_extensible", func() telegraf.InputCtx {
 		return &Postgresql{
 			Service: postgresql.Service{
 				MaxIdle:     1,

--- a/plugins/inputs/registry.go
+++ b/plugins/inputs/registry.go
@@ -3,9 +3,15 @@ package inputs
 import "github.com/influxdata/telegraf"
 
 type Creator func() telegraf.Input
+type CreatorCtx func() telegraf.InputCtx
 
 var Inputs = map[string]Creator{}
+var InputsCtx = map[string]CreatorCtx{}
 
 func Add(name string, creator Creator) {
 	Inputs[name] = creator
+}
+
+func AddCtx(name string, creatorCtx CreatorCtx) {
+	InputsCtx[name] = creatorCtx
 }

--- a/plugins/parsers/avro/parser_test.go
+++ b/plugins/parsers/avro/parser_test.go
@@ -1,6 +1,7 @@
 package avro
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -69,7 +70,7 @@ func TestCases(t *testing.T) {
 			for _, input := range cfg.Inputs {
 				require.NoError(t, input.Init())
 
-				if err := input.Gather(&acc); err != nil {
+				if err := input.Gather(context.Background(), &acc); err != nil {
 					actualErrors = append(actualErrors, err.Error())
 				}
 			}

--- a/plugins/parsers/binary/parser_test.go
+++ b/plugins/parsers/binary/parser_test.go
@@ -2,6 +2,7 @@ package binary
 
 import (
 	"bytes"
+	"context"
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
@@ -1453,7 +1454,7 @@ func TestCases(t *testing.T) {
 			var actualErrors []string
 			for _, input := range cfg.Inputs {
 				require.NoError(t, input.Init())
-				if err := input.Gather(&acc); err != nil {
+				if err := input.Gather(context.Background(), &acc); err != nil {
 					actualErrors = append(actualErrors, err.Error())
 				}
 			}

--- a/plugins/parsers/json_v2/parser_test.go
+++ b/plugins/parsers/json_v2/parser_test.go
@@ -1,6 +1,7 @@
 package json_v2_test
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"sort"
@@ -61,7 +62,7 @@ func TestMultipleConfigs(t *testing.T) {
 			var actualErrorMsgs []string
 			for _, input := range cfg.Inputs {
 				require.NoError(t, input.Init())
-				if err := input.Gather(&acc); err != nil {
+				if err := input.Gather(context.Background(), &acc); err != nil {
 					actualErrorMsgs = append(actualErrorMsgs, err.Error())
 				}
 			}

--- a/plugins/parsers/xpath/parser_test.go
+++ b/plugins/parsers/xpath/parser_test.go
@@ -1,6 +1,7 @@
 package xpath
 
 import (
+	"context"
 	"math"
 	"os"
 	"path/filepath"
@@ -1454,7 +1455,7 @@ func TestMultipleConfigs(t *testing.T) {
 			var errs []error
 			for _, input := range cfg.Inputs {
 				require.NoError(t, input.Init())
-				err := input.Gather(&acc)
+				err := input.Gather(context.Background(), &acc)
 				if err != nil {
 					errs = append(errs, err)
 				}


### PR DESCRIPTION
# Required for all PRs

- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

draft for  #13913 

This introduces `InputCtx` and changes agent to use it  internally. Plugins, which do not support gather with context (or not yet been converted) are handled via adapter implementing `InputCtx`.

One plugin `postgresql_extensible` is converted to implement `InputCtx`.

Tests are not updated, they use type assertion into concrete plugin struct which should be replaces with helper method as direct assertion is not possible when adapter used.
