### PR TITLE
feat(processors.regex): Allow batch transforms using named groups

### DIFF
--- a/plugins/processors/regex/README.md
+++ b/plugins/processors/regex/README.md
@@ -1,18 +1,11 @@
 # Regex Processor Plugin
 
-The `regex` plugin transforms tag and field values with regex pattern. If
-`result_key` parameter is present, it can produce new tags and fields from
-existing ones.
+This plugin allows to transforms tag and field _values_ as well as renaming
+tags, fields and metrics using regex patterns. Tag and field _values_ can be
+transformed using named-groups in a batch fashion.
 
 The regex processor **only operates on string fields**. It will not work on
 any other data types, like an integer or float.
-
-For tags transforms, if `append` is set to `true`, it will append the
-transformation to the existing tag value, instead of overwriting it.
-
-For metrics transforms, `key` denotes the element that should be
-transformed. Furthermore, `result_key` allows control over the behavior applied
-in case the resulting `tag` or `field` name already exists.
 
 ## Global configuration options <!-- @/docs/includes/plugin_config.md -->
 
@@ -30,67 +23,121 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 [[processors.regex]]
   namepass = ["nginx_requests"]
 
-  # Tag and field conversions defined in a separate sub-tables
+  ## Tag value conversion(s). Multiple instances are allowed.
   [[processors.regex.tags]]
-    ## Tag to change, "*" will change every tag
+    ## Tag(s) to process with optional glob expressions such as '*'.
     key = "resp_code"
-    ## Regular expression to match on a tag value
+    ## Regular expression to match on the tag value. If the value doesn't
+    ## match the tag is ignored.
     pattern = "^(\\d)\\d\\d$"
-    ## Matches of the pattern will be replaced with this string.  Use ${1}
-    ## notation to use the text of the first submatch.
+    ## Replacement expression defining the value of the target tag. Allows to
+    ## use regexp groups or named groups e.g. ${1} references the first group.
     replacement = "${1}xx"
+    ## Name of the target tag. If not specified the 'key' tag, in case of
+    ## wildcards it is the currently processed one, is used as target.
+    # result_key = "method"
+    ## Allows to append the replacement to the target tag instead of
+    ## overwriting it.
+    # append = false
 
+  ## Field value conversion(s). Multiple instances are allowed.
   [[processors.regex.fields]]
-    ## Field to change
+    ## Field(s) to process with optional glob expressions such as '*'.
     key = "request"
-    ## All the power of the Go regular expressions available here
-    ## For example, named subgroups
+    ## Regular expression to match on the tag value. If the value doesn't
+    ## match or the field doesn't contain a string the field is ignored.
     pattern = "^/api(?P<method>/[\\w/]+)\\S*"
+    ## Replacement expression defining the value of the target field. Allows to
+    ## use regexp groups or named groups e.g. ${method} references the group
+    ## named "method".
     replacement = "${method}"
-    ## If result_key is present, a new field will be created
-    ## instead of changing existing field
-    result_key = "method"
+    ## Name of the target field. If not specified the 'key' field, in case of
+    ## wildcards it is the currently processed one, is used as target.
+    # result_key = "method"
 
-  # Multiple conversions may be applied for one field sequentially
-  # Let's extract one more value
-  [[processors.regex.fields]]
-    key = "request"
-    pattern = ".*category=(\\w+).*"
-    replacement = "${1}"
-    result_key = "search_category"
-
-  # Rename metric fields
+  ## Rename metric fields
   [[processors.regex.field_rename]]
-    ## Regular expression to match on a field name
+    ## Regular expression to match on the field name
     pattern = "^search_(\\w+)d$"
-    ## Matches of the pattern will be replaced with this string.  Use ${1}
-    ## notation to use the text of the first submatch.
+    ## Replacement expression defining the name of the new field
     replacement = "${1}"
     ## If the new field name already exists, you can either "overwrite" the
     ## existing one with the value of the renamed field OR you can "keep"
     ## both the existing and source field.
     # result_key = "keep"
 
-  # Rename metric tags
-  # [[processors.regex.tag_rename]]
-  #   ## Regular expression to match on a tag name
-  #   pattern = "^search_(\\w+)d$"
-  #   ## Matches of the pattern will be replaced with this string.  Use ${1}
-  #   ## notation to use the text of the first submatch.
-  #   replacement = "${1}"
-  #   ## If the new tag name already exists, you can either "overwrite" the
-  #   ## existing one with the value of the renamed tag OR you can "keep"
-  #   ## both the existing and source tag.
-  #   # result_key = "keep"
+  ## Rename metric tags
+  [[processors.regex.tag_rename]]
+    ## Regular expression to match on a tag name
+    pattern = "^search_(\\w+)d$"
+    ## Replacement expression defining the name of the new tag
+    replacement = "${1}"
+    ## If the new tag name already exists, you can either "overwrite" the
+    ## existing one with the value of the renamed tag OR you can "keep"
+    ## both the existing and source tag.
+    # result_key = "keep"
 
-  # Rename metrics
-  # [[processors.regex.metric_rename]]
-  #   ## Regular expression to match on an metric name
-  #   pattern = "^search_(\\w+)d$"
-  #   ## Matches of the pattern will be replaced with this string.  Use ${1}
-  #   ## notation to use the text of the first submatch.
-  #   replacement = "${1}"
+  ## Rename metrics
+  [[processors.regex.metric_rename]]
+    ## Regular expression to match on an metric name
+    pattern = "^search_(\\w+)d$"
+    ## Replacement expression defining the new name of the metric
+    replacement = "${1}"
 ```
+
+### Tag and field _value_ conversions
+
+Values of tags and fields can be processing using the corresponding section.
+Multiple `[[processors.regex.tags]]` and/or `[[processors.regex.fields]]`
+sections can be specified.
+Conversions are only applied if a tag/field _name_ matches the `key` which can
+contain glob statements such as `*` (asterix) _and_ the `pattern` matches the
+tag/field _value_. For fields the field values has to be of type `string` to
+apply the conversion. If any of the given criteria does not apply the conversion
+is not applied to the metric.
+
+The `replacement` option specifies the value of the resulting tag or field. It
+can reference capturing groups by index (e.g. `${1}` being the first group) or
+by name (e.g. `${mygroup}` being the group named `mygroup`).
+
+By default, the currently processed tag or field is overwritten by the
+`replacement`. To create a new tag or field you can additionally specify the
+`result_key` option containing the new target tag or field name. In case the
+given tag or field already exists, its value is overwritten. For `tags` you
+might use the `append` flag to append the `replacement` value to an existing
+tag.
+
+### Batch processing using named groups
+
+In `tags` and `fields` sections it is possible to use named groups to create
+multiple new tags or fields respectively. To do so, _all_ capture groups have
+to be named in the `pattern`. Additional non-capturing ones or other
+expressions are allowed. Furthermore, neither `replacement` nor `result_key`
+can be set as the resulting tag/field name is the name of the group and the
+value corresponds to the group's content.
+
+### Tag and field _name_ conversions
+
+You can batch-rename tags and fields using the `tag_rename` and `field_rename`
+sections. Again, multiple sections can be specified. Contrary to the `tags` and
+`fields` sections, the rename operates on the tag or field _name_, not its
+_value_.
+
+A tag or field is renamed if the given `pattern` matches the name. The new name
+is specified via the `replacement` option. Optionally, the `result_key` can be
+set to either `overwrite` (default) or `keep` to control the behavior in case
+the target tag/field already exists. For `overwrite` the target tag/field is
+replaced by the source key. With this (default) setting, the source tag/field
+is removed in any case. When using the `keep` setting, the target tag/field as
+well as the source is left unchanged and no renaming takes place.
+
+### Metric _name_ conversions
+
+Similar to the tag and field renaming, `metric_rename` section(s) can be used
+to rename metrics matching the given `pattern`. The resulting metric name is
+given via `replacement` option. If matching `pattern` the conversion is always
+applied. The `result_key` option has no effect on metric renaming and shall
+not be specified.
 
 ## Tags
 
@@ -98,6 +145,94 @@ No tags are applied by this processor.
 
 ## Example
 
+In the following examples we are using this metric
+
 ```text
-nginx_requests,verb=GET,resp_code=2xx request="/api/search/?category=plugins&q=regex&sort=asc",method="/search/",category="plugins",referrer="-",ident="-",http_version=1.1,agent="UserAgent",client_ip="127.0.0.1",auth="-",resp_bytes=270i 1519652321000000000
+nginx_requests,verb=GET,resp_code=200 request="/api/search/?category=plugins&q=regex&sort=asc",referrer="-",ident="-",http_version=1.1,agent="UserAgent",client_ip="127.0.0.1",auth="-",resp_bytes=270i 1519652321000000000
+```
+
+### Explicit specification
+
+```toml
+[[processors.regex]]
+  namepass = ["nginx_requests"]
+
+  [[processors.regex.tags]]
+    key = "resp_code"
+    pattern = "^(\\d)\\d\\d$"
+    replacement = "${1}xx"
+
+  [[processors.regex.fields]]
+    key = "request"
+    pattern = "^/api(?P<method>/[\\w/]+)\\S*"
+    replacement = "${method}"
+    result_key = "method"
+
+  [[processors.regex.fields]]
+    key = "request"
+    pattern = ".*category=(\\w+).*"
+    replacement = "${1}"
+    result_key = "search_category"
+
+  [[processors.regex.field_rename]]
+    pattern = "^client_(\\w+)$"
+    replacement = "${1}"
+```
+
+will result in
+
+```text
+nginx_requests,verb=GET,resp_code=2xx request="/api/search/?category=plugins&q=regex&sort=asc",method="/search/",category="plugins",referrer="-",ident="-",http_version=1.1,agent="UserAgent",ip="127.0.0.1",auth="-",resp_bytes=270i 1519652321000000000
+```
+
+### Appending
+
+```toml
+[[processors.regex]]
+  namepass = ["nginx_requests"]
+
+  [[processors.regex.tags]]
+    key = "resp_code"
+    pattern = '^2\d\d$'
+    replacement = " OK"
+    result_key = "verb"
+    append = true
+```
+
+will result in
+
+```text
+nginx_requests,verb=GET\ OK,resp_code=200 request="/api/search/?category=plugins&q=regex&sort=asc",referrer="-",ident="-",http_version=1.1,agent="UserAgent",client_ip="127.0.0.1",auth="-",resp_bytes=270i 1519652321000000000
+```
+
+### Named groups
+
+```toml
+[[processors.regex]]
+  namepass = ["nginx_requests"]
+
+  [[processors.regex.fields]]
+    key = "request"
+    pattern = '^/api/(?P<method>\w+)[/?].*category=(?P<category>\w+)&(?:.*)'
+```
+
+will result in
+
+```text
+nginx_requests,verb=GET,resp_code=200 request="/api/search/?category=plugins&q=regex&sort=asc",method="search",category="plugins",referrer="-",ident="-",http_version=1.1,agent="UserAgent",client_ip="127.0.0.1",auth="-",resp_bytes=270i 1519652321000000000
+```
+
+### Metric renaming
+
+```toml
+[[processors.regex]]
+  [[processors.regex.metric_rename]]
+    pattern = '^(\w+)_.*$'
+    replacement = "${1}"
+```
+
+will result in
+
+```text
+nginx,verb=GET,resp_code=200 request="/api/search/?category=plugins&q=regex&sort=asc",referrer="-",ident="-",http_version=1.1,agent="UserAgent",client_ip="127.0.0.1",auth="-",resp_bytes=270i 1519652321000000000
 ```

--- a/plugins/processors/regex/README.md
+++ b/plugins/processors/regex/README.md
@@ -1,8 +1,8 @@
 # Regex Processor Plugin
 
-This plugin allows to transforms tag and field _values_ as well as renaming
-tags, fields and metrics using regex patterns. Tag and field _values_ can be
-transformed using named-groups in a batch fashion.
+This plugin transforms tag and field _values_ as well as renaming tags, fields
+and metrics using regex patterns. Tag and field _values_ can be transformed
+using named-groups in a batch fashion.
 
 The regex processor **only operates on string fields**. It will not work on
 any other data types, like an integer or float.
@@ -27,32 +27,34 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   [[processors.regex.tags]]
     ## Tag(s) to process with optional glob expressions such as '*'.
     key = "resp_code"
-    ## Regular expression to match on the tag value. If the value doesn't
+    ## Regular expression to match the tag value. If the value doesn't
     ## match the tag is ignored.
     pattern = "^(\\d)\\d\\d$"
-    ## Replacement expression defining the value of the target tag. Allows to
+    ## Replacement expression defining the value of the target tag. You can
     ## use regexp groups or named groups e.g. ${1} references the first group.
     replacement = "${1}xx"
-    ## Name of the target tag. If not specified the 'key' tag, in case of
-    ## wildcards it is the currently processed one, is used as target.
+    ## Name of the target tag defaulting to 'key' if not specified.
+    ## In case of wildcards being used in `key` the currently processed
+    ## tag-name is used as target.
     # result_key = "method"
-    ## Allows to append the replacement to the target tag instead of
-    ## overwriting it.
+    ## Appends the replacement to the target tag instead of overwriting it when
+    ## set to true.
     # append = false
 
   ## Field value conversion(s). Multiple instances are allowed.
   [[processors.regex.fields]]
     ## Field(s) to process with optional glob expressions such as '*'.
     key = "request"
-    ## Regular expression to match on the tag value. If the value doesn't
+    ## Regular expression to match the field value. If the value doesn't
     ## match or the field doesn't contain a string the field is ignored.
     pattern = "^/api(?P<method>/[\\w/]+)\\S*"
-    ## Replacement expression defining the value of the target field. Allows to
+    ## Replacement expression defining the value of the target field. You can
     ## use regexp groups or named groups e.g. ${method} references the group
     ## named "method".
     replacement = "${method}"
-    ## Name of the target field. If not specified the 'key' field, in case of
-    ## wildcards it is the currently processed one, is used as target.
+    ## Name of the target field defaulting to 'key' if not specified.
+    ## In case of wildcards being used in `key` the currently processed
+    ## field-name is used as target.
     # result_key = "method"
 
   ## Rename metric fields
@@ -85,11 +87,11 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
     replacement = "${1}"
 ```
 
+Please note, you can use multiple `tags`, `fields`, `tag_rename`, `field_rename`
+and `metric_rename` sections in one processor. All of those are applied.
+
 ### Tag and field _value_ conversions
 
-Values of tags and fields can be processing using the corresponding section.
-Multiple `[[processors.regex.tags]]` and/or `[[processors.regex.fields]]`
-sections can be specified.
 Conversions are only applied if a tag/field _name_ matches the `key` which can
 contain glob statements such as `*` (asterix) _and_ the `pattern` matches the
 tag/field _value_. For fields the field values has to be of type `string` to
@@ -119,9 +121,8 @@ value corresponds to the group's content.
 ### Tag and field _name_ conversions
 
 You can batch-rename tags and fields using the `tag_rename` and `field_rename`
-sections. Again, multiple sections can be specified. Contrary to the `tags` and
-`fields` sections, the rename operates on the tag or field _name_, not its
-_value_.
+sections. Contrary to the `tags` and `fields` sections, the rename operates on
+the tag or field _name_, not its _value_.
 
 A tag or field is renamed if the given `pattern` matches the name. The new name
 is specified via the `replacement` option. Optionally, the `result_key` can be
@@ -181,8 +182,9 @@ nginx_requests,verb=GET,resp_code=200 request="/api/search/?category=plugins&q=r
 
 will result in
 
-```text
-nginx_requests,verb=GET,resp_code=2xx request="/api/search/?category=plugins&q=regex&sort=asc",method="/search/",category="plugins",referrer="-",ident="-",http_version=1.1,agent="UserAgent",ip="127.0.0.1",auth="-",resp_bytes=270i 1519652321000000000
+```diff
+-nginx_requests,verb=GET,resp_code=200 request="/api/search/?category=plugins&q=regex&sort=asc",referrer="-",ident="-",http_version=1.1,agent="UserAgent",client_ip="127.0.0.1",auth="-",resp_bytes=270i 1519652321000000000
++nginx_requests,verb=GET,resp_code=2xx request="/api/search/?category=plugins&q=regex&sort=asc",method="/search/",category="plugins",referrer="-",ident="-",http_version=1.1,agent="UserAgent",ip="127.0.0.1",auth="-",resp_bytes=270i 1519652321000000000
 ```
 
 ### Appending
@@ -201,8 +203,9 @@ nginx_requests,verb=GET,resp_code=2xx request="/api/search/?category=plugins&q=r
 
 will result in
 
-```text
-nginx_requests,verb=GET\ OK,resp_code=200 request="/api/search/?category=plugins&q=regex&sort=asc",referrer="-",ident="-",http_version=1.1,agent="UserAgent",client_ip="127.0.0.1",auth="-",resp_bytes=270i 1519652321000000000
+```diff
+-nginx_requests,verb=GET,resp_code=200 request="/api/search/?category=plugins&q=regex&sort=asc",referrer="-",ident="-",http_version=1.1,agent="UserAgent",client_ip="127.0.0.1",auth="-",resp_bytes=270i 1519652321000000000
++nginx_requests,verb=GET\ OK,resp_code=200 request="/api/search/?category=plugins&q=regex&sort=asc",referrer="-",ident="-",http_version=1.1,agent="UserAgent",client_ip="127.0.0.1",auth="-",resp_bytes=270i 1519652321000000000
 ```
 
 ### Named groups
@@ -218,8 +221,9 @@ nginx_requests,verb=GET\ OK,resp_code=200 request="/api/search/?category=plugins
 
 will result in
 
-```text
-nginx_requests,verb=GET,resp_code=200 request="/api/search/?category=plugins&q=regex&sort=asc",method="search",category="plugins",referrer="-",ident="-",http_version=1.1,agent="UserAgent",client_ip="127.0.0.1",auth="-",resp_bytes=270i 1519652321000000000
+```diff
+-nginx_requests,verb=GET,resp_code=200 request="/api/search/?category=plugins&q=regex&sort=asc",referrer="-",ident="-",http_version=1.1,agent="UserAgent",client_ip="127.0.0.1",auth="-",resp_bytes=270i 1519652321000000000
++nginx_requests,verb=GET,resp_code=200 request="/api/search/?category=plugins&q=regex&sort=asc",method="search",category="plugins",referrer="-",ident="-",http_version=1.1,agent="UserAgent",client_ip="127.0.0.1",auth="-",resp_bytes=270i 1519652321000000000
 ```
 
 ### Metric renaming
@@ -233,6 +237,7 @@ nginx_requests,verb=GET,resp_code=200 request="/api/search/?category=plugins&q=r
 
 will result in
 
-```text
-nginx,verb=GET,resp_code=200 request="/api/search/?category=plugins&q=regex&sort=asc",referrer="-",ident="-",http_version=1.1,agent="UserAgent",client_ip="127.0.0.1",auth="-",resp_bytes=270i 1519652321000000000
+```diff
+-nginx_requests,verb=GET,resp_code=200 request="/api/search/?category=plugins&q=regex&sort=asc",referrer="-",ident="-",http_version=1.1,agent="UserAgent",client_ip="127.0.0.1",auth="-",resp_bytes=270i 1519652321000000000
++nginx,verb=GET,resp_code=200 request="/api/search/?category=plugins&q=regex&sort=asc",referrer="-",ident="-",http_version=1.1,agent="UserAgent",client_ip="127.0.0.1",auth="-",resp_bytes=270i 1519652321000000000
 ```

--- a/plugins/processors/regex/README.md
+++ b/plugins/processors/regex/README.md
@@ -125,11 +125,11 @@ _value_.
 
 A tag or field is renamed if the given `pattern` matches the name. The new name
 is specified via the `replacement` option. Optionally, the `result_key` can be
-set to either `overwrite` (default) or `keep` to control the behavior in case
+set to either `overwrite` or `keep` (default) to control the behavior in case
 the target tag/field already exists. For `overwrite` the target tag/field is
-replaced by the source key. With this (default) setting, the source tag/field
-is removed in any case. When using the `keep` setting, the target tag/field as
-well as the source is left unchanged and no renaming takes place.
+replaced by the source key. With this setting, the source tag/field
+is removed in any case. When using the `keep` setting (default), the target
+tag/field as well as the source is left unchanged and no renaming takes place.
 
 ### Metric _name_ conversions
 

--- a/plugins/processors/regex/converter.go
+++ b/plugins/processors/regex/converter.go
@@ -139,6 +139,7 @@ func (c *converter) applyFields(m telegraf.Metric) {
 			continue
 		}
 
+		// Handle explicit replacements
 		newKey := field.Key
 		if c.ResultKey != "" {
 			newKey = c.ResultKey

--- a/plugins/processors/regex/converter.go
+++ b/plugins/processors/regex/converter.go
@@ -1,0 +1,172 @@
+package regex
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/influxdata/telegraf"
+)
+
+func (c *converter) setup(ct converterType) error {
+	switch ct {
+	case convertTagRename, convertFieldRename:
+		switch c.ResultKey {
+		case "":
+			c.ResultKey = "keep"
+		case "overwrite", "keep":
+			// Do nothing as those are valid choices
+		default:
+			return fmt.Errorf("invalid metrics result_key %q", c.ResultKey)
+		}
+	}
+
+	// Compile the pattern
+	re, err := regexp.Compile(c.Pattern)
+	if err != nil {
+		return err
+	}
+	c.re = re
+
+	// Select the application function
+	switch ct {
+	case convertTags:
+		c.apply = c.applyTags
+	case convertFields:
+		c.apply = c.applyFields
+	case convertTagRename:
+		c.apply = c.applyTagRename
+	case convertFieldRename:
+		c.apply = c.applyFieldRename
+	case convertMetricRename:
+		c.apply = c.applyMetricRename
+	}
+
+	return nil
+}
+
+func (c *converter) applyTags(m telegraf.Metric) {
+	if c.Key == "*" {
+		for _, tag := range m.TagList() {
+			if c.re.MatchString(tag.Value) {
+				newValue := c.re.ReplaceAllString(tag.Value, c.Replacement)
+				if c.Append {
+					if v, ok := m.GetTag(tag.Key); ok {
+						newValue = v + newValue
+					}
+				}
+				m.AddTag(tag.Key, newValue)
+			}
+		}
+		return
+	}
+
+	newKey := c.Key
+	if c.ResultKey != "" {
+		newKey = c.ResultKey
+	}
+
+	value, ok := m.GetTag(c.Key)
+	if !ok || !c.re.MatchString(value) {
+		return
+	}
+	newValue := c.re.ReplaceAllString(value, c.Replacement)
+
+	if c.Append {
+		if v, ok := m.GetTag(newKey); ok {
+			newValue = v + newValue
+		}
+	}
+	m.AddTag(newKey, newValue)
+}
+
+func (c *converter) applyFields(m telegraf.Metric) {
+	value, ok := m.GetField(c.Key)
+	if !ok {
+		return
+	}
+
+	v, ok := value.(string)
+	if !ok || !c.re.MatchString(v) {
+		return
+	}
+
+	newKey := c.Key
+	if c.ResultKey != "" {
+		newKey = c.ResultKey
+	}
+
+	newValue := c.re.ReplaceAllString(v, c.Replacement)
+	m.AddField(newKey, newValue)
+}
+
+func (c *converter) applyTagRename(m telegraf.Metric) {
+	replacements := make(map[string]string)
+	for _, tag := range m.TagList() {
+		name := tag.Key
+		if c.re.MatchString(name) {
+			newName := c.re.ReplaceAllString(name, c.Replacement)
+
+			if !m.HasTag(newName) {
+				// There is no colliding tag, we can just change the name.
+				tag.Key = newName
+				continue
+			}
+
+			if c.ResultKey == "overwrite" {
+				// We got a colliding tag, remember the replacement and do it later
+				replacements[name] = newName
+			}
+		}
+	}
+	// We needed to postpone the replacement as we cannot modify the tag-list
+	// while iterating it as this will result in invalid memory dereference panic.
+	for oldName, newName := range replacements {
+		value, ok := m.GetTag(oldName)
+		if !ok {
+			// Just in case the tag got removed in the meantime
+			continue
+		}
+		m.AddTag(newName, value)
+		m.RemoveTag(oldName)
+	}
+}
+
+func (c *converter) applyFieldRename(m telegraf.Metric) {
+	replacements := make(map[string]string)
+	for _, field := range m.FieldList() {
+		name := field.Key
+		if c.re.MatchString(name) {
+			newName := c.re.ReplaceAllString(name, c.Replacement)
+
+			if !m.HasField(newName) {
+				// There is no colliding field, we can just change the name.
+				field.Key = newName
+				continue
+			}
+
+			if c.ResultKey == "overwrite" {
+				// We got a colliding field, remember the replacement and do it later
+				replacements[name] = newName
+			}
+		}
+	}
+	// We needed to postpone the replacement as we cannot modify the field-list
+	// while iterating it as this will result in invalid memory dereference panic.
+	for oldName, newName := range replacements {
+		value, ok := m.GetField(oldName)
+		if !ok {
+			// Just in case the field got removed in the meantime
+			continue
+		}
+		m.AddField(newName, value)
+		m.RemoveField(oldName)
+	}
+}
+
+func (c *converter) applyMetricRename(m telegraf.Metric) {
+	value := m.Name()
+	if c.re.MatchString(value) {
+		newValue := c.re.ReplaceAllString(value, c.Replacement)
+		m.SetName(newValue)
+	}
+}

--- a/plugins/processors/regex/regex.go
+++ b/plugins/processors/regex/regex.go
@@ -42,6 +42,7 @@ type converter struct {
 
 	filter filter.Filter
 	re     *regexp.Regexp
+	groups []string
 	apply  func(m telegraf.Metric)
 }
 

--- a/plugins/processors/regex/regex.go
+++ b/plugins/processors/regex/regex.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 
 	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/filter"
 	"github.com/influxdata/telegraf/plugins/processors"
 )
 
@@ -39,8 +40,9 @@ type converter struct {
 	ResultKey   string `toml:"result_key"`
 	Append      bool   `toml:"append"`
 
-	re    *regexp.Regexp
-	apply func(m telegraf.Metric)
+	filter filter.Filter
+	re     *regexp.Regexp
+	apply  func(m telegraf.Metric)
 }
 
 func (*Regex) SampleConfig() string {

--- a/plugins/processors/regex/regex_test.go
+++ b/plugins/processors/regex/regex_test.go
@@ -776,7 +776,7 @@ func TestNamedGroups(t *testing.T) {
 		Fields: []converter{
 			{
 				Key:     "request",
-				Pattern: `^/api/(?P<method>[\w/]+)/.*category=(?P<search_category>\w+).*`,
+				Pattern: `^/api/(?P<method>\w+)[/?].*category=(?P<search_category>\w+)&(?:.*)`,
 			},
 		},
 		Log: testutil.Logger{},

--- a/plugins/processors/regex/sample.conf
+++ b/plugins/processors/regex/sample.conf
@@ -2,63 +2,63 @@
 [[processors.regex]]
   namepass = ["nginx_requests"]
 
-  # Tag and field conversions defined in a separate sub-tables
+  ## Tag value conversion(s). Multiple instances are allowed.
   [[processors.regex.tags]]
-    ## Tag to change, "*" will change every tag
+    ## Tag(s) to process with optional glob expressions such as '*'.
     key = "resp_code"
-    ## Regular expression to match on a tag value
+    ## Regular expression to match on the tag value. If the value doesn't
+    ## match the tag is ignored.
     pattern = "^(\\d)\\d\\d$"
-    ## Matches of the pattern will be replaced with this string.  Use ${1}
-    ## notation to use the text of the first submatch.
+    ## Replacement expression defining the value of the target tag. Allows to
+    ## use regexp groups or named groups e.g. ${1} references the first group.
     replacement = "${1}xx"
+    ## Name of the target tag. If not specified the 'key' tag, in case of
+    ## wildcards it is the currently processed one, is used as target.
+    # result_key = "method"
+    ## Allows to append the replacement to the target tag instead of
+    ## overwriting it.
+    # append = false
 
+  ## Field value conversion(s). Multiple instances are allowed.
   [[processors.regex.fields]]
-    ## Field to change
+    ## Field(s) to process with optional glob expressions such as '*'.
     key = "request"
-    ## All the power of the Go regular expressions available here
-    ## For example, named subgroups
+    ## Regular expression to match on the tag value. If the value doesn't
+    ## match or the field doesn't contain a string the field is ignored.
     pattern = "^/api(?P<method>/[\\w/]+)\\S*"
+    ## Replacement expression defining the value of the target field. Allows to
+    ## use regexp groups or named groups e.g. ${method} references the group
+    ## named "method".
     replacement = "${method}"
-    ## If result_key is present, a new field will be created
-    ## instead of changing existing field
-    result_key = "method"
+    ## Name of the target field. If not specified the 'key' field, in case of
+    ## wildcards it is the currently processed one, is used as target.
+    # result_key = "method"
 
-  # Multiple conversions may be applied for one field sequentially
-  # Let's extract one more value
-  [[processors.regex.fields]]
-    key = "request"
-    pattern = ".*category=(\\w+).*"
-    replacement = "${1}"
-    result_key = "search_category"
-
-  # Rename metric fields
+  ## Rename metric fields
   [[processors.regex.field_rename]]
-    ## Regular expression to match on a field name
+    ## Regular expression to match on the field name
     pattern = "^search_(\\w+)d$"
-    ## Matches of the pattern will be replaced with this string.  Use ${1}
-    ## notation to use the text of the first submatch.
+    ## Replacement expression defining the name of the new field
     replacement = "${1}"
     ## If the new field name already exists, you can either "overwrite" the
     ## existing one with the value of the renamed field OR you can "keep"
     ## both the existing and source field.
     # result_key = "keep"
 
-  # Rename metric tags
-  # [[processors.regex.tag_rename]]
-  #   ## Regular expression to match on a tag name
-  #   pattern = "^search_(\\w+)d$"
-  #   ## Matches of the pattern will be replaced with this string.  Use ${1}
-  #   ## notation to use the text of the first submatch.
-  #   replacement = "${1}"
-  #   ## If the new tag name already exists, you can either "overwrite" the
-  #   ## existing one with the value of the renamed tag OR you can "keep"
-  #   ## both the existing and source tag.
-  #   # result_key = "keep"
+  ## Rename metric tags
+  [[processors.regex.tag_rename]]
+    ## Regular expression to match on a tag name
+    pattern = "^search_(\\w+)d$"
+    ## Replacement expression defining the name of the new tag
+    replacement = "${1}"
+    ## If the new tag name already exists, you can either "overwrite" the
+    ## existing one with the value of the renamed tag OR you can "keep"
+    ## both the existing and source tag.
+    # result_key = "keep"
 
-  # Rename metrics
-  # [[processors.regex.metric_rename]]
-  #   ## Regular expression to match on an metric name
-  #   pattern = "^search_(\\w+)d$"
-  #   ## Matches of the pattern will be replaced with this string.  Use ${1}
-  #   ## notation to use the text of the first submatch.
-  #   replacement = "${1}"
+  ## Rename metrics
+  [[processors.regex.metric_rename]]
+    ## Regular expression to match on an metric name
+    pattern = "^search_(\\w+)d$"
+    ## Replacement expression defining the new name of the metric
+    replacement = "${1}"

--- a/plugins/processors/regex/sample.conf
+++ b/plugins/processors/regex/sample.conf
@@ -6,32 +6,34 @@
   [[processors.regex.tags]]
     ## Tag(s) to process with optional glob expressions such as '*'.
     key = "resp_code"
-    ## Regular expression to match on the tag value. If the value doesn't
+    ## Regular expression to match the tag value. If the value doesn't
     ## match the tag is ignored.
     pattern = "^(\\d)\\d\\d$"
-    ## Replacement expression defining the value of the target tag. Allows to
+    ## Replacement expression defining the value of the target tag. You can
     ## use regexp groups or named groups e.g. ${1} references the first group.
     replacement = "${1}xx"
-    ## Name of the target tag. If not specified the 'key' tag, in case of
-    ## wildcards it is the currently processed one, is used as target.
+    ## Name of the target tag defaulting to 'key' if not specified.
+    ## In case of wildcards being used in `key` the currently processed
+    ## tag-name is used as target.
     # result_key = "method"
-    ## Allows to append the replacement to the target tag instead of
-    ## overwriting it.
+    ## Appends the replacement to the target tag instead of overwriting it when
+    ## set to true.
     # append = false
 
   ## Field value conversion(s). Multiple instances are allowed.
   [[processors.regex.fields]]
     ## Field(s) to process with optional glob expressions such as '*'.
     key = "request"
-    ## Regular expression to match on the tag value. If the value doesn't
+    ## Regular expression to match the field value. If the value doesn't
     ## match or the field doesn't contain a string the field is ignored.
     pattern = "^/api(?P<method>/[\\w/]+)\\S*"
-    ## Replacement expression defining the value of the target field. Allows to
+    ## Replacement expression defining the value of the target field. You can
     ## use regexp groups or named groups e.g. ${method} references the group
     ## named "method".
     replacement = "${method}"
-    ## Name of the target field. If not specified the 'key' field, in case of
-    ## wildcards it is the currently processed one, is used as target.
+    ## Name of the target field defaulting to 'key' if not specified.
+    ## In case of wildcards being used in `key` the currently processed
+    ## field-name is used as target.
     # result_key = "method"
 
   ## Rename metric fields


### PR DESCRIPTION
- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #5505

This PR restructures and simplifies the regexp-processor and then implements the possibility to transform multiple tags/fields using named capture-groups. In the course, it unifies the ability to specify wildcards on tags and fields (previously only possible on tags) by using standard `filter` expressions.
Finally, it improves the README explaining behavior of the possible operations and modi in more detail.