### PR TITLE
fix(input.intel_pmt): Handle telem devices without numa_node attribute

### DIFF
--- a/plugins/inputs/intel_pmt/intel_pmt.go
+++ b/plugins/inputs/intel_pmt/intel_pmt.go
@@ -177,19 +177,21 @@ func (p *IntelPMT) explorePmtInSysfs() error {
 			continue
 		}
 
-		numaNodePath := filepath.Join(telemDirPath, "device", "numa_node")
-		numaNodeSymlink, err := filepath.EvalSymlinks(numaNodePath)
+		telemDevicePath := filepath.Join(telemDirPath, "device")
+		telemDeviceSymlink, err := filepath.EvalSymlinks(telemDevicePath)
 		if err != nil {
-			return fmt.Errorf("error while evaluating symlink %q: %w", numaNodePath, err)
+			return fmt.Errorf("error while evaluating symlink %q: %w", telemDeviceSymlink, err)
 		}
 
-		numaNode, err := os.ReadFile(numaNodeSymlink)
+		numaNodePath := filepath.Join(telemDeviceSymlink, "..", "numa_node")
+
+		numaNode, err := os.ReadFile(numaNodePath)
 		if err != nil {
-			return fmt.Errorf("error while reading symlink %q: %w", numaNodeSymlink, err)
+			return fmt.Errorf("error while reading numa_node file %q: %w", numaNodePath, err)
 		}
 		numaNodeString := strings.TrimSpace(string(numaNode))
 		if numaNodeString == "" {
-			return fmt.Errorf("numa_node file %q is empty", numaNodeSymlink)
+			return fmt.Errorf("numa_node file %q is empty", numaNodePath)
 		}
 
 		fi := fileInfo{


### PR DESCRIPTION
When the intel_pmt input plugin is enabled currently, it will cause telegraf to fail on startup like so:

```
telegraf[47878]: 2023-09-21T22:27:09Z E! [telegraf] Error running agent: could not initialize input inputs.intel_pmt: error while exploring pmt sysfs: error while evaluating symlink "/sys/class/intel_pmt/telem0/numa_node": lstat /sys/devices/pci0000:00/0000:00:0a.0/intel_vsec.telemetry.0/intel_pmt/telem0/numa_node: no such file or directory
```

While intel_pmt telem devices do not have a numa_node attribute, their parent intel_vsec devices do. For example the current behavior:

```
$ ls -l /sys/class/intel_pmt/telem0/device/numa_node
ls: cannot access '/sys/class/intel_pmt/telem0/device/numa_node': No such file or directory
```

Versus traversing up to intel_vsec device:

```
$ ls -l /sys/class/intel_pmt/telem0/device/../numa_node
-rw-r--r--. 1 root root 4096 Sep 18 14:13 /sys/class/intel_pmt/telem0/device/../numa_node
```

Thus update explorePmtInSysfs() to traverse up to the intel_vsec device to find numa_node.

Note, filepath.Join() will interpret the `..` ahead of the filepath.EvalSymlinks, thus we evalSymlinks `/sys/class/intel_pmt/telem0/device` and then use filepath.Join() to traverse up.

Tested on Fedora 38's 6.4.14-200.fc38.x86_64 kernel and OpenSUSE's 15.4's 5.14.21-150400.24.55-default.

- [N/A] Updated associated README.md.
- [N/A] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #13976