### PR TITLE
fix(inputs.nfsclient): Avoid panics, better error messages

### DIFF
--- a/plugins/inputs/nfsclient/README.md
+++ b/plugins/inputs/nfsclient/README.md
@@ -64,6 +64,16 @@ _N.B._ the `include_mounts` and `exclude_mounts` arguments are both applied to
 the local mount location (e.g. /mnt/NFS), not the server export
 (e.g. nfsserver:/vol/NFS).  Go regexp patterns can be used in either.
 
+## Location of mountstats
+
+If you have mounted the /proc file system in a container, to tell this plugin
+where to find the new location, set the `MOUNT_PROC` environment variable. For
+example, in a Docker compose file, if /proc is mounted to /host/proc, then use:
+
+```yaml
+MOUNT_PROC: /host/proc/self/mountstats
+```
+
 ### References
 
 1. [nfsiostat](http://git.linux-nfs.org/?p=steved/nfs-utils.git;a=summary)

--- a/plugins/inputs/nfsclient/nfsclient.go
+++ b/plugins/inputs/nfsclient/nfsclient.go
@@ -296,6 +296,16 @@ func (*NFSClient) SampleConfig() string {
 }
 
 func (n *NFSClient) Gather(acc telegraf.Accumulator) error {
+	if _, err := os.Stat(n.mountstatsPath); os.IsNotExist(err) {
+		return err
+	}
+
+	// Attempt to read the file to see if we have permissions before opening
+	// which can lead to a panic
+	if _, err := os.ReadFile(n.mountstatsPath); err != nil {
+		return err
+	}
+
 	file, err := os.Open(n.mountstatsPath)
 	if err != nil {
 		n.Log.Errorf("Failed opening the %q file: %v ", file.Name(), err)

--- a/plugins/inputs/nfsclient/nfsclient_test.go
+++ b/plugins/inputs/nfsclient/nfsclient_test.go
@@ -205,3 +205,10 @@ func TestNFSClientProcessFull(t *testing.T) {
 	acc.AssertContainsFields(t, "nfs_bytes", fieldsBytes)
 	acc.AssertContainsFields(t, "nfs_xprt_tcp", fieldsXprtTCP)
 }
+
+func TestNFSClientFileDoesNotExist(t *testing.T) {
+	var acc testutil.Accumulator
+	nfsclient := NFSClient{Fullstat: true}
+	nfsclient.mountstatsPath = "/does_not_exist"
+	require.Error(t, nfsclient.Gather(&acc))
+}


### PR DESCRIPTION
Provide error messages on permission denied or file does not exist, rather than panics. Does not change how the plugin operates or reads the file, only does some additional checks.

Document the environment variable for changing the location of the file to read.

fixes: #13979
