### PR TITLE
fix(inputs.postgresql_extensible): Restore default db name

### DIFF
--- a/plugins/inputs/postgresql/service.go
+++ b/plugins/inputs/postgresql/service.go
@@ -177,16 +177,8 @@ func (p *Service) SanitizedAddress() (sanitizedAddress string, err error) {
 // GetConnectDatabase utility function for getting the database to which the connection was made
 // If the user set the output address use that before parsing anything else.
 func (p *Service) GetConnectDatabase(connectionString string) (string, error) {
-	if p.OutputAddress != "" {
-		return p.OutputAddress, nil
-	}
-
 	connConfig, err := pgx.ParseConfig(connectionString)
-	if err != nil {
-		return "", fmt.Errorf("connection string parsing failed: %w", err)
-	}
-
-	if len(connConfig.Database) != 0 {
+	if err == nil && len(connConfig.Database) != 0 {
 		return connConfig.Database, nil
 	}
 

--- a/plugins/inputs/postgresql_extensible/postgresql_extensible_test.go
+++ b/plugins/inputs/postgresql_extensible/postgresql_extensible_test.go
@@ -311,14 +311,14 @@ func TestAccRow(t *testing.T) {
 			fields: fakeRow{
 				fields: []interface{}{1, "gato"},
 			},
-			dbName: "server",
+			dbName: "postgres",
 			server: "server",
 		},
 		{
 			fields: fakeRow{
 				fields: []interface{}{nil, "gato"},
 			},
-			dbName: "server",
+			dbName: "postgres",
 			server: "server",
 		},
 		{


### PR DESCRIPTION
The database name should either be postgres or the value from a correctly parsed dsn.

fixes: #14007