### PR TITLE
docs(outputs.prometheus_client): Fix metric-type parameter naming

### DIFF
--- a/plugins/outputs/prometheus_client/README.md
+++ b/plugins/outputs/prometheus_client/README.md
@@ -73,7 +73,7 @@ to use them.
 
   ## Specify the metric type explicitly.
   ## This overrides the metric-type of the Telegraf metric. Globbing is allowed.
-  # [outputs.prometheus_client.prometheus_metric_types]
+  # [outputs.prometheus_client.metric_types]
   #   counter = []
   #   gauge = []
 ```

--- a/plugins/outputs/prometheus_client/sample.conf
+++ b/plugins/outputs/prometheus_client/sample.conf
@@ -48,6 +48,6 @@
 
   ## Specify the metric type explicitly.
   ## This overrides the metric-type of the Telegraf metric. Globbing is allowed.
-  # [outputs.prometheus_client.prometheus_metric_types]
+  # [outputs.prometheus_client.metric_types]
   #   counter = []
   #   gauge = []


### PR DESCRIPTION
- [x] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [ ] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #14005 

Fix the naming of `metric_types` in the `sample.conf` to match the actual code.