### PR TITLE
chore: Update Windows zip archive creation

### DIFF
--- a/scripts/windows-signing.ps1
+++ b/scripts/windows-signing.ps1
@@ -11,16 +11,20 @@ $certBytes = [Convert]::FromBase64String($certText)
 $CertPath = $finalFileName
 $Cert = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2($CertPath, $CertPass)
 
+# Update the version of Compress-Archive to support zipping correctly.
+Install-Module Microsoft.PowerShell.Archive -MinimumVersion 1.2.3.0 -Repository PSGallery -Force
+Import-Module Microsoft.PowerShell.Archive
+
 # Go through the artifacts directory and sign the 'windows' artifacts.
 $artifactDirectory = "./build/dist"
-$extractDirectory = $artifactDirectory + "\" + "extracted"
-foreach ($file in get-ChildItem $artifactDirectory | where {$_.name -like "*windows*"} | select name) 
+$extractDirectory = $artifactDirectory + "/" + "extracted"
+foreach ($file in get-ChildItem $artifactDirectory | where {$_.name -like "*windows*"} | select name)
 {
-    $artifact = $artifactDirectory + "\" + $file.Name
+    $artifact = $artifactDirectory + "/" + $file.Name
     Expand-Archive -LiteralPath $artifact -DestinationPath $extractDirectory -Force
 
-    $subDirectoryPath = $extractDirectory + "\" + (Get-ChildItem -Path $extractDirectory | Select-Object -First 1).Name
-    $telegrafExePath = $subDirectoryPath + "\" + "telegraf.exe"
+    $subDirectoryPath = $extractDirectory + "/" + (Get-ChildItem -Path $extractDirectory | Select-Object -First 1).Name
+    $telegrafExePath = $subDirectoryPath + "/" + "telegraf.exe"
     Set-AuthenticodeSignature -Certificate $Cert -FilePath  $telegrafExePath -TimestampServer http://timestamp.digicert.com
     Compress-Archive -Path $subDirectoryPath -DestinationPath $artifact -Force
     Remove-Item $extractDirectory -Force -Recurse


### PR DESCRIPTION
This updates the version of the PowerShell archive tooling to ensure we are creating an archive with forward slashes only.

I SSH'ed into a CircleCI runner to confirm this runs and that the zip file extracts. We can double check the run on a nightly build after this is added.

fixes: #13974
