### PR TITLE
chore(inputs.modbus): Deprecate aggressive optimization

### DIFF
--- a/plugins/inputs/modbus/README.md
+++ b/plugins/inputs/modbus/README.md
@@ -157,10 +157,6 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
     ##  |---rearrange  -- Rearrange request boundaries within consecutive address ranges
     ##  |                 to reduce the number of requested registers by keeping
     ##  |                 the number of requests.
-    ##  |---aggressive -- Rearrange request boundaries similar to "rearrange" but
-    ##  |                 allow to request registers not specified by the user to
-    ##  |                 fill gaps. This usually reduces the number of requests at the
-    ##  |                 cost of more requested registers.
     ##  |---max_insert -- Rearrange request keeping the number of extra fields below the value
     ##                    provided in "optimization_max_register_fill". It is not necessary to define 'omitted'
     ##                    fields as the optimisation will add such field only where needed.

--- a/plugins/inputs/modbus/configuration_request.go
+++ b/plugins/inputs/modbus/configuration_request.go
@@ -7,6 +7,7 @@ import (
 	"hash/maphash"
 
 	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/models"
 )
 
 //go:embed sample_request.conf
@@ -67,7 +68,19 @@ func (c *ConfigurationPerRequest) Check() error {
 		}
 		// Check for valid optimization
 		switch def.Optimization {
-		case "", "none", "shrink", "rearrange", "aggressive":
+		case "", "none", "shrink", "rearrange":
+		case "aggressive":
+			models.PrintOptionValueDeprecationNotice(
+				telegraf.Warn,
+				"inputs.modbus",
+				"optimization",
+				"aggressive",
+				telegraf.DeprecationInfo{
+					Since:     "1.28.2",
+					RemovalIn: "1.30.0",
+					Notice:    `use "max_insert" instead`,
+				},
+			)
 		case "max_insert":
 			switch def.RegisterType {
 			case "coil":

--- a/plugins/inputs/modbus/sample_request.conf
+++ b/plugins/inputs/modbus/sample_request.conf
@@ -32,10 +32,6 @@
     ##  |---rearrange  -- Rearrange request boundaries within consecutive address ranges
     ##  |                 to reduce the number of requested registers by keeping
     ##  |                 the number of requests.
-    ##  |---aggressive -- Rearrange request boundaries similar to "rearrange" but
-    ##  |                 allow to request registers not specified by the user to
-    ##  |                 fill gaps. This usually reduces the number of requests at the
-    ##  |                 cost of more requested registers.
     ##  |---max_insert -- Rearrange request keeping the number of extra fields below the value
     ##                    provided in "optimization_max_register_fill". It is not necessary to define 'omitted'
     ##                    fields as the optimisation will add such field only where needed.


### PR DESCRIPTION
- [x] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

The `aggressive` optimization has a worst-case runtime of `O(N!)` with Telegraf appearing to hang on startup with big configurations. To avoid this veritable foot-gun let's deprecate the option in favor of the `max_insert` strategy leading to good results in most cases and being much faster `O(N)`.