### PR TITLE
chore(CI): Enable CGO for race testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,6 +103,7 @@ commands:
             equal: [ "386", << parameters.arch >> ]
           steps:
             - run: echo 'export RACE="-race"' >> $BASH_ENV
+            - run: echo 'export CGO_ENABLED=1' >> $BASH_ENV
       - run: |
           GOARCH=<< parameters.arch >> ./<< parameters.gotestsum >> -- ${RACE} -short -cover -coverprofile=coverage.out ./...
       - when:


### PR DESCRIPTION
Race-testing requires CGO to be enabled. Enforce this to fix CircleCI tests.