### PR TITLE
chore: Disable -race on Windows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,7 +100,9 @@ commands:
       - run: ./scripts/install_gotestsum.sh << parameters.os >> << parameters.gotestsum >>
       - unless:
           condition:
-            equal: [ "386", << parameters.arch >> ]
+            or:
+              - equal: [ "386", << parameters.arch >> ]
+              - equal: [ "windows", << parameters.os >> ]
           steps:
             - run: echo 'export RACE="-race"' >> $BASH_ENV
       - run: |


### PR DESCRIPTION
Recently we started getting a message that race requires CGO on Windows. We do not install a compiler on that system so for no let's disable the race detector on Windows like we do for i386.