### PR TITLE
chore: Force previous version of mingw

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ commands:
             - run: rm -rf '/c/Program Files/Go'
             - run: choco feature enable -n allowGlobalConfirmation
             - run: 'sh ./scripts/installgo_windows.sh'
-            - run: choco install mingw --version=12.2.0.3042023
+            - run: choco install mingw --version=12.2.0.03042023
       - run: go env
       - run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.54.2
       - when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ commands:
             - run: rm -rf '/c/Program Files/Go'
             - run: choco feature enable -n allowGlobalConfirmation
             - run: 'sh ./scripts/installgo_windows.sh'
-            - run: choco install mingw
+            - run: choco install mingw --version=12.2.0.3042023
       - run: go env
       - run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.54.2
       - when:


### PR DESCRIPTION
The latest version of mingw causes issues with the -race test flag and messages about cgo needing gcc. Binds us to the last known working version.