### PR TITLE
fix(inputs.mqtt): Reference correct password variable

### DIFF
--- a/plugins/common/mqtt/mqtt_v5.go
+++ b/plugins/common/mqtt/mqtt_v5.go
@@ -97,7 +97,7 @@ func NewMQTTv5Client(cfg *MqttConfig) (*mqttv5Client, error) {
 		options:    opts,
 		timeout:    time.Duration(cfg.Timeout),
 		username:   cfg.Username,
-		password:   config.Password,
+		password:   cfg.Password,
 		qos:        cfg.QoS,
 		retain:     cfg.Retain,
 		properties: properties,


### PR DESCRIPTION
For me, connecting to MQTT with username/password and mqttv5 stopped working.
Not sure, but shouldn't it be cfg.Password instead of the config.Password Type?