### PR TITLE
fix(inputs.infiniband): Handle devices without counters

### DIFF
--- a/plugins/inputs/infiniband/infiniband_linux.go
+++ b/plugins/inputs/infiniband/infiniband_linux.go
@@ -28,7 +28,7 @@ func (i *Infiniband) Gather(acc telegraf.Accumulator) error {
 
 			stats, err := rdmamap.GetRdmaSysfsStats(dev, portInt)
 			if err != nil {
-				return err
+				continue
 			}
 
 			addStats(dev, port, stats, acc)


### PR DESCRIPTION
- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format]

resolves #8135

Not all rdma devices have counters parsable by `GetRdmaSysfsStats`.
This PR add `continue` statement to ignore such device (and continue with next device/port) instead of throwing an error and failing 