### PR TITLE
test(inputs.redis_sentinel): Resolve timeout looking for port

### DIFF
--- a/plugins/inputs/redis_sentinel/redis_sentinel_test.go
+++ b/plugins/inputs/redis_sentinel/redis_sentinel_test.go
@@ -358,12 +358,13 @@ func TestRedisSentinelInfoAll(t *testing.T) {
 
 func createRedisContainer() testutil.Container {
 	return testutil.Container{
-		Image:    "redis:7.0-alpine",
-		Name:     "telegraf-test-redis-sentinel-redis",
-		Networks: []string{networkName},
+		Image:        "redis:7.0-alpine",
+		Name:         "telegraf-test-redis-sentinel-redis",
+		Networks:     []string{networkName},
+		ExposedPorts: []string{"6379"},
 		WaitingFor: wait.ForAll(
 			wait.ForLog("Ready to accept connections"),
-			wait.ForExposedPort(),
+			wait.ForListeningPort(nat.Port("6379")),
 		),
 	}
 }


### PR DESCRIPTION
Force the specific exposed port for the base redis container to prevent a timeout from getting hit and avoid scanning the entire port range.