### PR TITLE
feat(processors.dedup): Add state persistence between runs

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -609,17 +609,17 @@ func (a *Agent) gatherOnce(
 // processors.  If an error occurs any started processors are Stopped.
 func (a *Agent) startProcessors(
 	dst chan<- telegraf.Metric,
-	processors models.RunningProcessors,
+	runningProcessors models.RunningProcessors,
 ) (chan<- telegraf.Metric, []*processorUnit, error) {
 	var src chan telegraf.Metric
-	units := make([]*processorUnit, 0, len(processors))
+	units := make([]*processorUnit, 0, len(runningProcessors))
 	// The processor chain is constructed from the output side starting from
 	// the output(s) and walking the way back to the input(s). However, the
 	// processor-list is sorted by order and/or by appearance in the config,
 	// i.e. in input-to-output direction. Therefore, reverse the processor list
 	// to reflect the order/definition order in the processing chain.
-	for i := len(processors) - 1; i >= 0; i-- {
-		processor := processors[i]
+	for i := len(runningProcessors) - 1; i >= 0; i-- {
+		processor := runningProcessors[i]
 
 		src = make(chan telegraf.Metric, 100)
 		acc := NewAccumulator(processor, dst)

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/influxdata/telegraf/plugins/processors"
 	"log"
 	"os"
 	"runtime"
@@ -265,9 +266,17 @@ func (a *Agent) initPersister() error {
 	}
 
 	for _, processor := range a.Config.Processors {
-		plugin, ok := processor.Processor.(telegraf.StatefulPlugin)
-		if !ok {
-			continue
+		var plugin telegraf.StatefulPlugin
+		if p, ok := processor.Processor.(processors.HasUnwrap); ok {
+			plugin, ok = p.Unwrap().(telegraf.StatefulPlugin)
+			if !ok {
+				continue
+			}
+		} else {
+			plugin, ok = processor.Processor.(telegraf.StatefulPlugin)
+			if !ok {
+				continue
+			}
 		}
 
 		name := processor.LogName()

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-
 	"log"
 	"os"
 	"runtime"

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/influxdata/telegraf/plugins/processors"
+
 	"log"
 	"os"
 	"runtime"
@@ -16,6 +16,7 @@ import (
 	"github.com/influxdata/telegraf/internal"
 	"github.com/influxdata/telegraf/internal/snmp"
 	"github.com/influxdata/telegraf/models"
+	"github.com/influxdata/telegraf/plugins/processors"
 	"github.com/influxdata/telegraf/plugins/serializers/influx"
 )
 

--- a/plugins/processors/dedup/README.md
+++ b/plugins/processors/dedup/README.md
@@ -1,6 +1,8 @@
 # Dedup Processor Plugin
 
 Filter metrics whose field values are exact repetitions of the previous values.
+This plugin will store its state between runs if the `statefile` option in the
+agent config section is set.
 
 ## Global configuration options <!-- @/docs/includes/plugin_config.md -->
 

--- a/plugins/processors/dedup/dedup.go
+++ b/plugins/processors/dedup/dedup.go
@@ -4,13 +4,13 @@ package dedup
 import (
 	_ "embed"
 	"fmt"
-	"github.com/influxdata/telegraf/plugins/parsers/influx"
-	influxSerializer "github.com/influxdata/telegraf/plugins/serializers/influx"
 	"time"
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
+	"github.com/influxdata/telegraf/plugins/parsers/influx"
 	"github.com/influxdata/telegraf/plugins/processors"
+	influxSerializer "github.com/influxdata/telegraf/plugins/serializers/influx"
 )
 
 //go:embed sample.conf


### PR DESCRIPTION
- [x] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

resolves #14059

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->

This adds the state persistence interface to the processors.dedup plugin. It's implemented by using the influx serializer/parser to store the metrics.

Turns out there was a bug that non-streaming processors couldn't have state persistence, also fixed that issue in here to make it work.