### PR TITLE
docs(outputs.mqtt): Correct typo in protocol config parameter

### DIFF
--- a/plugins/outputs/mqtt/README.md
+++ b/plugins/outputs/mqtt/README.md
@@ -44,7 +44,7 @@ to use them.
   servers = ["localhost:1883", ] # or ["mqtts://tls.example.com:1883"]
 
   ## Protocol can be `3.1.1` or `5`. Default is `3.1.1`
-  # procotol = "3.1.1"
+  # protocol = "3.1.1"
 
   ## MQTT Topic for Producer Messages
   ## MQTT outputs send metrics to this topic format:

--- a/plugins/outputs/mqtt/sample.conf
+++ b/plugins/outputs/mqtt/sample.conf
@@ -9,7 +9,7 @@
   servers = ["localhost:1883", ] # or ["mqtts://tls.example.com:1883"]
 
   ## Protocol can be `3.1.1` or `5`. Default is `3.1.1`
-  # procotol = "3.1.1"
+  # protocol = "3.1.1"
 
   ## MQTT Topic for Producer Messages
   ## MQTT outputs send metrics to this topic format:


### PR DESCRIPTION
# Required for all PRs

- [x] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [ ] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #14072

Renamed `protocol` to match [common/mqtt](https://github.com/influxdata/telegraf/blob/master/plugins/common/mqtt/mqtt.go) configuration definition 
