### PR TITLE
chore(processors.regex): Inform and warn user on operation modus

### DIFF
--- a/plugins/processors/regex/converter.go
+++ b/plugins/processors/regex/converter.go
@@ -81,8 +81,8 @@ func (c *converter) setup(ct converterType, log telegraf.Logger) error {
 				log.Infof("%s: Using named-group mode...", ct)
 				c.groups = groups[1:]
 			} else {
-				msg := "Neither 'result_key' nor 'replacement' given with unnamed or mixed groups.\n"
-				msg += "Using explicit, empty replacement!"
+				msg := "Neither 'result_key' nor 'replacement' given with unnamed or mixed groups;"
+				msg += "using explicit, empty replacement!"
 				log.Warnf("%s: %s", ct, msg)
 			}
 		} else {

--- a/plugins/processors/regex/converter.go
+++ b/plugins/processors/regex/converter.go
@@ -82,7 +82,7 @@ func (c *converter) setup(ct converterType, log telegraf.Logger) error {
 				c.groups = groups[1:]
 			} else {
 				msg := "Neither 'result_key' nor 'replacement' given with unnamed or mixed groups;"
-				msg += "using explicit, empty replacement!"
+				msg += " using explicit, empty replacement!"
 				log.Warnf("%s: %s", ct, msg)
 			}
 		} else {


### PR DESCRIPTION
- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #14028

This PR adds an information log-message on the used modus (explicit vs. named-groups) and warns in case no explicit options are given but unnamed or mixed (named & unnamed) groups are used.