### PR TITLE
chore: Update go to 1.21.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
     working_directory: '/go/src/github.com/influxdata/telegraf'
     resource_class: large
     docker:
-      - image: 'quay.io/influxdb/telegraf-ci:1.21.1'
+      - image: 'quay.io/influxdb/telegraf-ci:1.21.3'
     environment:
       GOFLAGS: -p=4
   mac:
@@ -40,7 +40,7 @@ commands:
         default: "v2"
       goversion:
         type: string
-        default: 1.21.1
+        default: 1.21.3
     steps:
       - check-changed-files-or-halt
       - restore_cache:
@@ -198,7 +198,7 @@ jobs:
     parameters:
       goversion:
         type: string
-        default: 1.21.1
+        default: 1.21.3
       cache_version:
         type: string
         default: "v2"
@@ -230,7 +230,7 @@ jobs:
     parameters:
       goversion:
         type: string
-        default: 1.21.1
+        default: 1.21.3
       cache_version:
         type: string
         default: "v2"
@@ -267,7 +267,7 @@ jobs:
     parameters:
       goversion:
         type: string
-        default: 1.21.1
+        default: 1.21.3
       cache_version:
         type: string
         default: "v2"
@@ -290,7 +290,7 @@ jobs:
     parameters:
       goversion:
         type: string
-        default: 1.21.1
+        default: 1.21.3
       cache_version:
         type: string
         default: "v2"
@@ -319,7 +319,7 @@ jobs:
     parameters:
       goversion:
         type: string
-        default: 1.21.1
+        default: 1.21.3
       cache_version:
         type: string
         default: "v2"

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -15,5 +15,5 @@ jobs:
       - name: Scan for Vulnerabilities in Code
         uses: golang/govulncheck-action@v1
         with:
-          go-version-input: 1.21.1
+          go-version-input: 1.21.3
           go-package: ./...

--- a/Makefile
+++ b/Makefile
@@ -249,8 +249,8 @@ plugins/parsers/influx/machine.go: plugins/parsers/influx/machine.go.rl
 
 .PHONY: ci
 ci:
-	docker build -t quay.io/influxdb/telegraf-ci:1.21.1 - < scripts/ci.docker
-	docker push quay.io/influxdb/telegraf-ci:1.21.1
+	docker build -t quay.io/influxdb/telegraf-ci:1.21.3 - < scripts/ci.docker
+	docker push quay.io/influxdb/telegraf-ci:1.21.3
 
 .PHONY: install
 install: $(buildbin)

--- a/scripts/ci.docker
+++ b/scripts/ci.docker
@@ -1,4 +1,4 @@
-FROM golang:1.21.1
+FROM golang:1.21.3
 
 RUN chmod -R 755 "$GOPATH"
 

--- a/scripts/installgo_linux.sh
+++ b/scripts/installgo_linux.sh
@@ -2,10 +2,10 @@
 
 set -eux
 
-GO_VERSION="1.21.1"
+GO_VERSION="1.21.3"
 GO_ARCH="linux-amd64"
 # from https://golang.org/dl
-GO_VERSION_SHA="b3075ae1ce5dab85f89bc7905d1632de23ca196bd8336afd93fa97434cfa55ae"
+GO_VERSION_SHA="1241381b2843fae5a9707eec1f8fb2ef94d827990582c7c7c32f5bdfbfd420c8"
 
 # Download Go and verify Go tarball
 setup_go () {

--- a/scripts/installgo_mac.sh
+++ b/scripts/installgo_mac.sh
@@ -3,9 +3,9 @@
 set -eux
 
 ARCH=$(uname -m)
-GO_VERSION="1.21.1"
-GO_VERSION_SHA_arm64="ffd40391a1e995855488b008ad9326ff8c2e81803a6e80894401003bae47fcf1" # from https://golang.org/dl
-GO_VERSION_SHA_amd64="809f5b0ef4f7dcdd5f51e9630a5b2e5a1006f22a047126d61560cdc365678a19" # from https://golang.org/dl
+GO_VERSION="1.21.3"
+GO_VERSION_SHA_arm64="65302a7a9f7a4834932b3a7a14cb8be51beddda757b567a2f9e0cbd0d7b5a6ab" # from https://golang.org/dl
+GO_VERSION_SHA_amd64="27014fc69e301d7588a169ca239b3cc609f0aa1abf38528bf0d20d3b259211eb" # from https://golang.org/dl
 
 if [ "$ARCH" = 'arm64' ]; then
     GO_ARCH="darwin-arm64"

--- a/scripts/installgo_windows.sh
+++ b/scripts/installgo_windows.sh
@@ -2,7 +2,7 @@
 
 set -eux
 
-GO_VERSION="1.21.1"
+GO_VERSION="1.21.3"
 
 setup_go () {
     rm -rf '/c/Program Files/Go'


### PR DESCRIPTION
Update golang to v1.21.3 to fix CVE-2023-44487.