### PR TITLE
fix(inputs.jenkins): Filter after searching sub-folders

### DIFF
--- a/plugins/inputs/jenkins/jenkins.go
+++ b/plugins/inputs/jenkins/jenkins.go
@@ -263,11 +263,6 @@ func (j *Jenkins) getJobDetail(jr jobRequest, acc telegraf.Accumulator) error {
 		return nil
 	}
 
-	// filter out excluded or not included jobs
-	if !j.jobFilter.Match(jr.hierarchyName()) {
-		return nil
-	}
-
 	js, err := j.client.getJobs(context.Background(), &jr)
 	if err != nil {
 		return err
@@ -292,6 +287,11 @@ func (j *Jenkins) getJobDetail(jr jobRequest, acc telegraf.Accumulator) error {
 		}(ij, jr, acc)
 	}
 	wg.Wait()
+
+	// filter out excluded or not included jobs
+	if !j.jobFilter.Match(jr.hierarchyName()) {
+		return nil
+	}
 
 	// collect build info
 	number := js.LastBuild.Number

--- a/plugins/inputs/jenkins/jenkins_test.go
+++ b/plugins/inputs/jenkins/jenkins_test.go
@@ -797,6 +797,9 @@ func TestGatherJobs(t *testing.T) {
 							{Name: "ignore-1"},
 						},
 					},
+					"/job/ignore-1/api/json": &jobResponse{
+						Jobs: []innerJob{},
+					},
 					"/job/apps/api/json": &jobResponse{
 						Jobs: []innerJob{
 							{Name: "k8s-cloud"},
@@ -808,6 +811,16 @@ func TestGatherJobs(t *testing.T) {
 						Jobs: []innerJob{
 							{Name: "1"},
 							{Name: "2"},
+						},
+					},
+					"/job/apps/job/ignore-all/job/1/api/json": &jobResponse{
+						LastBuild: jobBuild{
+							Number: 1,
+						},
+					},
+					"/job/apps/job/ignore-all/job/2/api/json": &jobResponse{
+						LastBuild: jobBuild{
+							Number: 1,
 						},
 					},
 					"/job/apps/job/chronograf/api/json": &jobResponse{
@@ -822,6 +835,16 @@ func TestGatherJobs(t *testing.T) {
 							{Name: "PR-ignore2"},
 							{Name: "PR 1"},
 							{Name: "PR ignore"},
+						},
+					},
+					"/job/apps/job/k8s-cloud/job/PR%20ignore/api/json": &jobResponse{
+						LastBuild: jobBuild{
+							Number: 1,
+						},
+					},
+					"/job/apps/job/k8s-cloud/job/PR-ignore2/api/json": &jobResponse{
+						LastBuild: jobBuild{
+							Number: 1,
 						},
 					},
 					"/job/apps/job/k8s-cloud/job/PR-100/api/json": &jobResponse{


### PR DESCRIPTION
Currently, the Jenkins plugin will apply the user filter to directory
names immediately. If the directory does not match the filter it would
toss the folder. This prevents traversing into the folder itself where a
user might want a job inside the folder.

This change will move the filtering operation to occur after we kick off
directory traversal. The changes to the tests were necessary since we
never went into the folders correctly. The test results are the same,
the changes are to the response our mock jenkins server provides.

fixes: #14054