### PR TITLE
chore(packaging): Remove unnecessary service file removal

### DIFF
--- a/scripts/deb/post-install.sh
+++ b/scripts/deb/post-install.sh
@@ -26,10 +26,6 @@ function install_chkconfig {
 if [[ -L /etc/init.d/telegraf ]]; then
     rm -f /etc/init.d/telegraf
 fi
-# Remove legacy symlink, if it exists
-if [[ -L /etc/systemd/system/telegraf.service ]]; then
-    rm -f /etc/systemd/system/telegraf.service
-fi
 
 # Add defaults file, if it doesn't exist
 if [[ ! -f /etc/default/telegraf ]]; then

--- a/scripts/rpm/post-install.sh
+++ b/scripts/rpm/post-install.sh
@@ -4,10 +4,6 @@
 if [[ -L /etc/init.d/telegraf ]]; then
     rm -f /etc/init.d/telegraf
 fi
-# Remove legacy symlink, if it exists
-if [[ -L /etc/systemd/system/telegraf.service ]]; then
-    rm -f /etc/systemd/system/telegraf.service
-fi
 
 # Add defaults file, if it doesn't exist
 if [[ ! -f /etc/default/telegraf ]]; then


### PR DESCRIPTION
This removal was added before 1.x was officially out. It was due to an alias setting in systemd causing a naming loop. This check currently prevents a user from masking the service and running their own custom service file.

fixes: #14052