### PR TITLE
chore: Fix nolintlint findings

### DIFF
--- a/plugins/common/logrus/hook.go
+++ b/plugins/common/logrus/hook.go
@@ -2,7 +2,7 @@ package logrus
 
 import (
 	"io"
-	"log" //nolint:depguard // Allow exceptional but valid use of log here.
+	"log"
 	"strings"
 	"sync"
 

--- a/plugins/common/shim/config.go
+++ b/plugins/common/shim/config.go
@@ -3,7 +3,7 @@ package shim
 import (
 	"errors"
 	"fmt"
-	"log" //nolint:depguard // Allow exceptional but valid use of log here.
+	"log"
 	"os"
 
 	"github.com/BurntSushi/toml"

--- a/plugins/common/shim/logger.go
+++ b/plugins/common/shim/logger.go
@@ -2,7 +2,7 @@ package shim
 
 import (
 	"fmt"
-	"log" //nolint:depguard // Allow exceptional but valid use of log here.
+	"log"
 	"os"
 	"reflect"
 

--- a/plugins/inputs/kube_inventory/kube_inventory.go
+++ b/plugins/inputs/kube_inventory/kube_inventory.go
@@ -195,10 +195,10 @@ const (
 	nodeMeasurement                  = "kubernetes_node"
 	persistentVolumeMeasurement      = "kubernetes_persistentvolume"
 	persistentVolumeClaimMeasurement = "kubernetes_persistentvolumeclaim"
-	podContainerMeasurement          = "kubernetes_pod_container" //nolint:gosec // G101: Potential hardcoded credentials - false positive
+	podContainerMeasurement          = "kubernetes_pod_container"
 	serviceMeasurement               = "kubernetes_service"
 	statefulSetMeasurement           = "kubernetes_statefulset"
-	resourcequotaMeasurement         = "kubernetes_resourcequota" //nolint:gosec // G101: Potential hardcoded credentials - false positive
+	resourcequotaMeasurement         = "kubernetes_resourcequota"
 	certificateMeasurement           = "kubernetes_certificate"
 )
 

--- a/plugins/inputs/s7comm/s7comm.go
+++ b/plugins/inputs/s7comm/s7comm.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"hash/maphash"
-	"log" //nolint:depguard // Required for tracing connection issues
+	"log"
 	"net"
 	"os"
 	"regexp"

--- a/plugins/inputs/snmp/netsnmp.go
+++ b/plugins/inputs/snmp/netsnmp.go
@@ -5,7 +5,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"log" //nolint:depguard // Allow exceptional but valid use of log here.
+	"log"
 	"os/exec"
 	"strings"
 	"sync"


### PR DESCRIPTION
# Required for all PRs

<!-- Before opening a pull request you should run the following checks locally to make sure the CI will pass.

make lint
make check
make check-deps
make test
make docs

-->

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)


<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->

Fixes the following findings:
```
plugins/common/logrus/hook.go:5:8                       nolintlint  directive `//nolint:depguard // Allow exceptional but valid use of log here.` is unused for linter "depguard"
plugins/common/shim/config.go:6:8                       nolintlint  directive `//nolint:depguard // Allow exceptional but valid use of log here.` is unused for linter "depguard"
plugins/common/shim/logger.go:5:8                       nolintlint  directive `//nolint:depguard // Allow exceptional but valid use of log here.` is unused for linter "depguard"
plugins/inputs/kube_inventory/kube_inventory.go:198:64  nolintlint  directive `//nolint:gosec // G101: Potential hardcoded credentials - false positive` is unused for linter "gosec"
plugins/inputs/kube_inventory/kube_inventory.go:201:64  nolintlint  directive `//nolint:gosec // G101: Potential hardcoded credentials - false positive` is unused for linter "gosec"
plugins/inputs/s7comm/s7comm.go:9:8                     nolintlint  directive `//nolint:depguard // Required for tracing connection issues` is unused for linter "depguard"
plugins/inputs/snmp/netsnmp.go:8:8                      nolintlint  directive `//nolint:depguard // Allow exceptional but valid use of log here.` is unused for linter "depguard"
```