### PR TITLE
feat(migrations): Add migration for inputs.jolokia

### DIFF
--- a/migrations/all/inputs_jolokia.go
+++ b/migrations/all/inputs_jolokia.go
@@ -1,0 +1,5 @@
+//go:build !custom || (migrations && (inputs || inputs.jolokia))
+
+package all
+
+import _ "github.com/influxdata/telegraf/migrations/inputs_jolokia" // register migration

--- a/migrations/inputs_jolokia/migration.go
+++ b/migrations/inputs_jolokia/migration.go
@@ -1,0 +1,353 @@
+package inputs_jolokia
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/influxdata/toml"
+	"github.com/influxdata/toml/ast"
+
+	"github.com/influxdata/telegraf/migrations"
+	"github.com/influxdata/telegraf/migrations/common"
+)
+
+// Define "old" data structure
+type jolokia struct {
+	Context               string   `toml:"context"`
+	Mode                  string   `toml:"mode"`
+	Servers               []server `toml:"servers"`
+	Metrics               []metric `toml:"metrics"`
+	Proxy                 server   `toml:"proxy"`
+	Delimiter             string   `toml:"delimiter"`
+	ResponseHeaderTimeout string   `toml:"response_header_timeout"`
+	ClientTimeout         string   `toml:"client_timeout"`
+	common.InputOptions
+}
+type server struct {
+	Name     string `toml:"name"`
+	Host     string `toml:"host"`
+	Username string `toml:"username"`
+	Password string `toml:"password"`
+	Port     string `toml:"port"`
+}
+
+type metric struct {
+	Name      string `toml:"name"`
+	Mbean     string `toml:"mbean"`
+	Attribute string `toml:"attribute"`
+	Path      string `toml:"path"`
+}
+
+// Define "new" data structure(s)
+type jolokiaAgent struct {
+	URLs                  []string       `toml:"urls"`
+	Username              string         `toml:"username,omitempty"`
+	Password              string         `toml:"password,omitempty"`
+	Metrics               []metricConfig `toml:"metric"`
+	DefaultFieldSeparator string         `toml:"default_field_separator"`
+	ResponseTimeout       string         `toml:"response_timeout,omitempty"`
+
+	// Common options
+	Interval         string            `toml:"interval,omitempty"`
+	Precision        string            `toml:"precision,omitempty"`
+	CollectionJitter string            `toml:"collection_jitter,omitempty"`
+	CollectionOffset string            `toml:"collection_offset,omitempty"`
+	NamePrefix       string            `toml:"name_prefix,omitempty"`
+	NameSuffix       string            `toml:"name_suffix,omitempty"`
+	NameOverride     string            `toml:"name_override,omitempty"`
+	Alias            string            `toml:"alias,omitempty"`
+	Tags             map[string]string `toml:"tags,omitempty"`
+
+	NamePass       []string            `toml:"namepass,omitempty"`
+	NameDrop       []string            `toml:"namedrop,omitempty"`
+	FieldPass      []string            `toml:"fieldpass,omitempty"`
+	FieldDrop      []string            `toml:"fielddrop,omitempty"`
+	TagPassFilters map[string][]string `toml:"tagpass,omitempty"`
+	TagDropFilters map[string][]string `toml:"tagdrop,omitempty"`
+	TagExclude     []string            `toml:"tagexclude,omitempty"`
+	TagInclude     []string            `toml:"taginclude,omitempty"`
+	MetricPass     string              `toml:"metricpass,omitempty"`
+}
+
+type jolokiaProxy struct {
+	URL                   string         `toml:"url"`
+	Username              string         `toml:"username,omitempty"`
+	Password              string         `toml:"password,omitempty"`
+	DefaultFieldSeparator string         `toml:"default_field_separator"`
+	ResponseTimeout       string         `toml:"response_timeout,omitempty"`
+	Targets               []targetConfig `toml:"target"`
+	Metrics               []metricConfig `toml:"metric"`
+
+	// Common options
+	Interval         string            `toml:"interval,omitempty"`
+	Precision        string            `toml:"precision,omitempty"`
+	CollectionJitter string            `toml:"collection_jitter,omitempty"`
+	CollectionOffset string            `toml:"collection_offset,omitempty"`
+	NamePrefix       string            `toml:"name_prefix,omitempty"`
+	NameSuffix       string            `toml:"name_suffix,omitempty"`
+	NameOverride     string            `toml:"name_override,omitempty"`
+	Alias            string            `toml:"alias,omitempty"`
+	Tags             map[string]string `toml:"tags,omitempty"`
+
+	NamePass       []string            `toml:"namepass,omitempty"`
+	NameDrop       []string            `toml:"namedrop,omitempty"`
+	FieldPass      []string            `toml:"fieldpass,omitempty"`
+	FieldDrop      []string            `toml:"fielddrop,omitempty"`
+	TagPassFilters map[string][]string `toml:"tagpass,omitempty"`
+	TagDropFilters map[string][]string `toml:"tagdrop,omitempty"`
+	TagExclude     []string            `toml:"tagexclude,omitempty"`
+	TagInclude     []string            `toml:"taginclude,omitempty"`
+	MetricPass     string              `toml:"metricpass,omitempty"`
+}
+
+type targetConfig struct {
+	URL      string `toml:"url"`
+	Username string `toml:"username,omitempty"`
+	Password string `toml:"password,omitempty"`
+}
+
+type metricConfig struct {
+	Name        string   `toml:"name"`
+	Mbean       string   `toml:"mbean"`
+	Paths       []string `toml:"paths"`
+	FieldPrefix *string  `toml:"field_prefix,omitempty"`
+	TagKeys     []string `toml:"tag_keys,omitempty"`
+}
+
+// Migration function
+func migrate(tbl *ast.Table) ([]byte, string, error) {
+	var messages []string
+
+	// Decode the old data structure
+	var old jolokia
+	if err := toml.UnmarshalTable(tbl, &old); err != nil {
+		return nil, "", err
+	}
+
+	// Create new-style metrics according to the old config
+	metrics := make([]metricConfig, 0, len(old.Metrics))
+	for _, oldm := range old.Metrics {
+		mbean := strings.SplitN(oldm.Mbean, "/", 2)
+		m := metricConfig{
+			Name:  oldm.Name,
+			Mbean: mbean[0],
+		}
+
+		// Construct the new path from the old attribute/path setting
+		contained := len(mbean) <= 1
+		if oldm.Attribute != "" {
+			attributes := strings.Split(oldm.Attribute, ",")
+			for _, a := range attributes {
+				if !contained && a == mbean[1] {
+					contained = true
+				}
+				if oldm.Path != "" {
+					m.Paths = append(m.Paths, a+"/"+oldm.Path)
+				} else {
+					m.Paths = append(m.Paths, a)
+				}
+			}
+		} else if oldm.Path != "" {
+			m.Paths = append(m.Paths, oldm.Path)
+		}
+		if !contained {
+			m.Paths = append(m.Paths, mbean[1])
+		}
+		metrics = append(metrics, m)
+	}
+
+	// Setup the timeout if any
+	var timeout string
+	if old.ClientTimeout != "" && old.ResponseHeaderTimeout != "" {
+		msg := "both 'client_timeout' and 'response_header_timeout' are specified using the former"
+		messages = append(messages, msg)
+		timeout = old.ClientTimeout
+	} else if old.ClientTimeout != "" {
+		timeout = old.ClientTimeout
+	} else if old.ResponseHeaderTimeout != "" {
+		timeout = old.ResponseHeaderTimeout
+	}
+
+	// Create the corresponding plugin configurations
+	var newcfg interface{}
+	if old.Mode == "proxy" {
+		// Create a new proxy setup
+		cfg := migrations.CreateTOMLStruct("inputs", "jolokia2_proxy")
+
+		// Create a new agent setup
+		for _, server := range old.Servers {
+			proxy := "http://" + old.Proxy.Host + ":" + old.Proxy.Port + strings.TrimRight(old.Context, "/")
+			plugin := jolokiaProxy{
+				URL:      proxy,
+				Username: old.Proxy.Username,
+				Password: old.Proxy.Password,
+				Targets: []targetConfig{{
+					URL:      fmt.Sprintf("service:jmx:rmi:///jndi/rmi://%s:%s/jmxrmi", server.Host, server.Port),
+					Username: server.Username,
+					Password: server.Password,
+				}},
+				Metrics:               metrics,
+				DefaultFieldSeparator: "_",
+				ResponseTimeout:       timeout,
+				NameOverride:          "jolokia",
+				Tags: map[string]string{
+					"jolokia_name": server.Name,
+					"jolokia_port": server.Port,
+					"jolokia_host": server.Host,
+				},
+			}
+			plugin.fillCommon(old.InputOptions)
+			cfg.Add("inputs", "jolokia2_proxy", plugin)
+		}
+		newcfg = cfg
+	} else {
+		cfg := migrations.CreateTOMLStruct("inputs", "jolokia2_agent")
+
+		// Create a new agent setup
+		for _, server := range old.Servers {
+			endpoint := "http://" + server.Host + ":" + server.Port + strings.TrimRight(old.Context, "/")
+			plugin := jolokiaAgent{
+				URLs:                  []string{endpoint},
+				Username:              server.Username,
+				Password:              server.Password,
+				Metrics:               metrics,
+				DefaultFieldSeparator: "_",
+				ResponseTimeout:       timeout,
+				NameOverride:          "jolokia",
+				Tags: map[string]string{
+					"jolokia_name": server.Name,
+					"jolokia_port": server.Port,
+					"jolokia_host": server.Host,
+				},
+			}
+			plugin.fillCommon(old.InputOptions)
+			cfg.Add("inputs", "jolokia2_agent", plugin)
+		}
+		newcfg = cfg
+	}
+
+	// Marshal the new configuration
+	buf, err := toml.Marshal(newcfg)
+	if err != nil {
+		return nil, "", err
+	}
+	buf = append(buf, []byte("\n")...)
+
+	// Create the new content to output
+	return buf, strings.Join(messages, ";"), nil
+}
+
+func (j *jolokiaAgent) fillCommon(o common.InputOptions) {
+	j.Interval = o.Interval
+	j.Precision = o.Precision
+	j.CollectionJitter = o.CollectionJitter
+	j.CollectionOffset = o.CollectionOffset
+	j.NamePrefix = o.NamePrefix
+	j.NameSuffix = o.NameSuffix
+	if o.NameOverride != "" {
+		j.NameOverride = o.NameOverride
+	}
+	j.Alias = o.Alias
+	if len(o.Tags) > 0 {
+		if j.Tags == nil {
+			j.Tags = make(map[string]string, len(o.Tags))
+		}
+		for k, v := range o.Tags {
+			j.Tags[k] = v
+		}
+	}
+
+	if len(o.NamePass) > 0 {
+		j.NamePass = append(j.NamePass, o.NamePass...)
+	}
+	if len(o.NameDrop) > 0 {
+		j.NameDrop = append(j.NameDrop, o.NameDrop...)
+	}
+	if len(o.FieldPass) > 0 || len(o.FieldDropOld) > 0 {
+		j.FieldPass = append(j.FieldPass, o.FieldPass...)
+		j.FieldPass = append(j.FieldPass, o.FieldPassOld...)
+	}
+	if len(o.FieldDrop) > 0 || len(o.FieldDropOld) > 0 {
+		j.FieldDrop = append(j.FieldDrop, o.FieldDrop...)
+		j.FieldDrop = append(j.FieldDrop, o.FieldDropOld...)
+	}
+	if len(o.TagPassFilters) > 0 {
+		j.TagPassFilters = make(map[string][]string, len(o.TagPassFilters))
+		for k, v := range o.TagPassFilters {
+			j.TagPassFilters[k] = v
+		}
+	}
+	if len(o.TagDropFilters) > 0 {
+		j.TagDropFilters = make(map[string][]string, len(o.TagDropFilters))
+		for k, v := range o.TagDropFilters {
+			j.TagDropFilters[k] = v
+		}
+	}
+	if len(o.TagExclude) > 0 {
+		j.TagExclude = append(j.TagExclude, o.TagExclude...)
+	}
+	if len(o.TagInclude) > 0 {
+		j.TagInclude = append(j.TagInclude, o.TagInclude...)
+	}
+	j.MetricPass = o.MetricPass
+}
+
+func (j *jolokiaProxy) fillCommon(o common.InputOptions) {
+	j.Interval = o.Interval
+	j.Precision = o.Precision
+	j.CollectionJitter = o.CollectionJitter
+	j.CollectionOffset = o.CollectionOffset
+	j.NamePrefix = o.NamePrefix
+	j.NameSuffix = o.NameSuffix
+	if o.NameOverride != "" {
+		j.NameOverride = o.NameOverride
+	}
+	j.Alias = o.Alias
+	if len(o.Tags) > 0 {
+		if j.Tags == nil {
+			j.Tags = make(map[string]string, len(o.Tags))
+		}
+		for k, v := range o.Tags {
+			j.Tags[k] = v
+		}
+	}
+
+	if len(o.NamePass) > 0 {
+		j.NamePass = append(j.NamePass, o.NamePass...)
+	}
+	if len(o.NameDrop) > 0 {
+		j.NameDrop = append(j.NameDrop, o.NameDrop...)
+	}
+	if len(o.FieldPass) > 0 || len(o.FieldDropOld) > 0 {
+		j.FieldPass = append(j.FieldPass, o.FieldPass...)
+		j.FieldPass = append(j.FieldPass, o.FieldPassOld...)
+	}
+	if len(o.FieldDrop) > 0 || len(o.FieldDropOld) > 0 {
+		j.FieldDrop = append(j.FieldDrop, o.FieldDrop...)
+		j.FieldDrop = append(j.FieldDrop, o.FieldDropOld...)
+	}
+	if len(o.TagPassFilters) > 0 {
+		j.TagPassFilters = make(map[string][]string, len(o.TagPassFilters))
+		for k, v := range o.TagPassFilters {
+			j.TagPassFilters[k] = v
+		}
+	}
+	if len(o.TagDropFilters) > 0 {
+		j.TagDropFilters = make(map[string][]string, len(o.TagDropFilters))
+		for k, v := range o.TagDropFilters {
+			j.TagDropFilters[k] = v
+		}
+	}
+	if len(o.TagExclude) > 0 {
+		j.TagExclude = append(j.TagExclude, o.TagExclude...)
+	}
+	if len(o.TagInclude) > 0 {
+		j.TagInclude = append(j.TagInclude, o.TagInclude...)
+	}
+	j.MetricPass = o.MetricPass
+}
+
+// Register the migration function for the plugin type
+func init() {
+	migrations.AddPluginMigration("inputs.jolokia", migrate)
+}

--- a/migrations/inputs_jolokia/migration_test.go
+++ b/migrations/inputs_jolokia/migration_test.go
@@ -1,0 +1,62 @@
+package inputs_jolokia_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/influxdata/telegraf/config"
+	_ "github.com/influxdata/telegraf/migrations/inputs_jolokia"     // register migration
+	_ "github.com/influxdata/telegraf/plugins/inputs/jolokia2_agent" // register plugin
+	_ "github.com/influxdata/telegraf/plugins/inputs/jolokia2_proxy" // register plugin
+)
+
+func TestCases(t *testing.T) {
+	// Get all directories in testdata
+	folders, err := os.ReadDir("testcases")
+	require.NoError(t, err)
+
+	for _, f := range folders {
+		// Only handle folders
+		if !f.IsDir() {
+			continue
+		}
+
+		t.Run(f.Name(), func(t *testing.T) {
+			testcasePath := filepath.Join("testcases", f.Name())
+			inputFile := filepath.Join(testcasePath, "telegraf.conf")
+			expectedFile := filepath.Join(testcasePath, "expected.conf")
+
+			// Read the expected output
+			expected := config.NewConfig()
+			require.NoError(t, expected.LoadConfig(expectedFile))
+			require.NotEmpty(t, expected.Inputs)
+
+			// Read the input data
+			input, remote, err := config.LoadConfigFile(inputFile)
+			require.NoError(t, err)
+			require.False(t, remote)
+			require.NotEmpty(t, input)
+
+			// Migrate
+			output, n, err := config.ApplyMigrations(input)
+			require.NoError(t, err)
+			require.NotEmpty(t, output)
+			require.GreaterOrEqual(t, n, uint64(1))
+			actual := config.NewConfig()
+			require.NoError(t, actual.LoadConfigData(output))
+
+			// Test the output
+			require.Len(t, actual.Inputs, len(expected.Inputs))
+			actualIDs := make([]string, 0, len(expected.Inputs))
+			expectedIDs := make([]string, 0, len(expected.Inputs))
+			for i := range actual.Inputs {
+				actualIDs = append(actualIDs, actual.Inputs[i].ID())
+				expectedIDs = append(expectedIDs, expected.Inputs[i].ID())
+			}
+			require.ElementsMatchf(t, expectedIDs, actualIDs, "got\n%s", string(output))
+		})
+	}
+}

--- a/migrations/inputs_jolokia/testcases/agent_default/expected.conf
+++ b/migrations/inputs_jolokia/testcases/agent_default/expected.conf
@@ -1,0 +1,24 @@
+[[inputs.jolokia2_agent]]
+urls = ["http://127.0.0.1:8080/jolokia"]
+default_field_separator = "_"
+name_override = "jolokia"
+
+[[inputs.jolokia2_agent.metric]]
+name = "heap_memory_usage"
+mbean = "java.lang:type=Memory"
+paths = ["HeapMemoryUsage"]
+
+[[inputs.jolokia2_agent.metric]]
+name = "thread_count"
+mbean = "java.lang:type=Threading"
+paths = ["TotalStartedThreadCount", "ThreadCount", "DaemonThreadCount", "PeakThreadCount"]
+
+[[inputs.jolokia2_agent.metric]]
+name = "class_count"
+mbean = "java.lang:type=ClassLoading"
+paths = ["LoadedClassCount", "UnloadedClassCount", "TotalLoadedClassCount"]
+
+[inputs.jolokia2_agent.tags]
+jolokia_host = "127.0.0.1"
+jolokia_name = "as-server-01"
+jolokia_port = "8080"

--- a/migrations/inputs_jolokia/testcases/agent_default/telegraf.conf
+++ b/migrations/inputs_jolokia/testcases/agent_default/telegraf.conf
@@ -1,0 +1,54 @@
+# Read JMX metrics through Jolokia
+[[inputs.jolokia]]
+  ## This is the context root used to compose the jolokia url
+  ## NOTE that Jolokia requires a trailing slash at the end of the context root
+  context = "/jolokia/"
+
+  ## This specifies the mode used
+  # mode = "proxy"
+  #
+  ## When in proxy mode this section is used to specify further
+  ## proxy address configurations.
+  ## Remember to change host address to fit your environment.
+  # [inputs.jolokia.proxy]
+  #   host = "127.0.0.1"
+  #   port = "8080"
+
+  ## Optional http timeouts
+  ##
+  ## response_header_timeout, if non-zero, specifies the amount of time to wait
+  ## for a server's response headers after fully writing the request.
+  # response_header_timeout = "3s"
+  ##
+  ## client_timeout specifies a time limit for requests made by this client.
+  ## Includes connection time, any redirects, and reading the response body.
+  # client_timeout = "4s"
+
+  ## List of servers exposing jolokia read service
+  [[inputs.jolokia.servers]]
+    name = "as-server-01"
+    host = "127.0.0.1"
+    port = "8080"
+    # username = "myuser"
+    # password = "mypassword"
+
+  ## List of metrics collected on above servers
+  ## Each metric consists in a name, a jmx path and either
+  ## a pass or drop slice attribute.
+  ## This collect all heap memory usage metrics.
+  [[inputs.jolokia.metrics]]
+    name = "heap_memory_usage"
+    mbean  = "java.lang:type=Memory"
+    attribute = "HeapMemoryUsage"
+
+  ## This collect thread counts metrics.
+  [[inputs.jolokia.metrics]]
+    name = "thread_count"
+    mbean  = "java.lang:type=Threading"
+    attribute = "TotalStartedThreadCount,ThreadCount,DaemonThreadCount,PeakThreadCount"
+
+  ## This collect number of class loaded/unloaded counts metrics.
+  [[inputs.jolokia.metrics]]
+    name = "class_count"
+    mbean  = "java.lang:type=ClassLoading"
+    attribute = "LoadedClassCount,UnloadedClassCount,TotalLoadedClassCount"

--- a/migrations/inputs_jolokia/testcases/agent_more_complex/expected.conf
+++ b/migrations/inputs_jolokia/testcases/agent_more_complex/expected.conf
@@ -1,0 +1,27 @@
+[[inputs.jolokia2_agent]]
+urls = ["http://127.0.0.1:8080/jolokia"]
+username = "myuser"
+password = "mypassword"
+response_timeout = "4s"
+default_field_separator = "_"
+name_override = "jolokia"
+
+[[inputs.jolokia2_agent.metric]]
+name = "heap_memory_usage"
+mbean = "java.lang:type=Memory"
+paths = ["HeapMemoryUsage"]
+
+[[inputs.jolokia2_agent.metric]]
+name = "thread_count"
+mbean = "java.lang:type=Threading"
+paths = ["TotalStartedThreadCount", "ThreadCount", "DaemonThreadCount", "PeakThreadCount"]
+
+[[inputs.jolokia2_agent.metric]]
+name = "class_count"
+mbean = "java.lang:type=ClassLoading"
+paths = ["LoadedClassCount", "UnloadedClassCount", "TotalLoadedClassCount"]
+
+[inputs.jolokia2_agent.tags]
+jolokia_host = "127.0.0.1"
+jolokia_name = "as-server-01"
+jolokia_port = "8080"

--- a/migrations/inputs_jolokia/testcases/agent_more_complex/telegraf.conf
+++ b/migrations/inputs_jolokia/testcases/agent_more_complex/telegraf.conf
@@ -1,0 +1,54 @@
+# Read JMX metrics through Jolokia
+[[inputs.jolokia]]
+  ## This is the context root used to compose the jolokia url
+  ## NOTE that Jolokia requires a trailing slash at the end of the context root
+  context = "/jolokia/"
+
+  ## This specifies the mode used
+  # mode = "proxy"
+  #
+  ## When in proxy mode this section is used to specify further
+  ## proxy address configurations.
+  ## Remember to change host address to fit your environment.
+  # [inputs.jolokia.proxy]
+  #   host = "127.0.0.1"
+  #   port = "8080"
+
+  ## Optional http timeouts
+  ##
+  ## response_header_timeout, if non-zero, specifies the amount of time to wait
+  ## for a server's response headers after fully writing the request.
+  # response_header_timeout = "3s"
+  ##
+  ## client_timeout specifies a time limit for requests made by this client.
+  ## Includes connection time, any redirects, and reading the response body.
+  client_timeout = "4s"
+
+  ## List of servers exposing jolokia read service
+  [[inputs.jolokia.servers]]
+    name = "as-server-01"
+    host = "127.0.0.1"
+    port = "8080"
+    username = "myuser"
+    password = "mypassword"
+
+  ## List of metrics collected on above servers
+  ## Each metric consists in a name, a jmx path and either
+  ## a pass or drop slice attribute.
+  ## This collect all heap memory usage metrics.
+  [[inputs.jolokia.metrics]]
+    name = "heap_memory_usage"
+    mbean  = "java.lang:type=Memory"
+    attribute = "HeapMemoryUsage"
+
+  ## This collect thread counts metrics.
+  [[inputs.jolokia.metrics]]
+    name = "thread_count"
+    mbean  = "java.lang:type=Threading"
+    attribute = "TotalStartedThreadCount,ThreadCount,DaemonThreadCount,PeakThreadCount"
+
+  ## This collect number of class loaded/unloaded counts metrics.
+  [[inputs.jolokia.metrics]]
+    name = "class_count"
+    mbean  = "java.lang:type=ClassLoading"
+    attribute = "LoadedClassCount,UnloadedClassCount,TotalLoadedClassCount"

--- a/migrations/inputs_jolokia/testcases/agent_response_timeout/expected.conf
+++ b/migrations/inputs_jolokia/testcases/agent_response_timeout/expected.conf
@@ -1,0 +1,25 @@
+[[inputs.jolokia2_agent]]
+urls = ["http://127.0.0.1:8080/jolokia"]
+response_timeout = "10s"
+default_field_separator = "_"
+name_override = "jolokia"
+
+[[inputs.jolokia2_agent.metric]]
+name = "heap_memory_usage"
+mbean = "java.lang:type=Memory"
+paths = ["HeapMemoryUsage"]
+
+[[inputs.jolokia2_agent.metric]]
+name = "thread_count"
+mbean = "java.lang:type=Threading"
+paths = ["TotalStartedThreadCount", "ThreadCount", "DaemonThreadCount", "PeakThreadCount"]
+
+[[inputs.jolokia2_agent.metric]]
+name = "class_count"
+mbean = "java.lang:type=ClassLoading"
+paths = ["LoadedClassCount", "UnloadedClassCount", "TotalLoadedClassCount"]
+
+[inputs.jolokia2_agent.tags]
+jolokia_host = "127.0.0.1"
+jolokia_name = "as-server-01"
+jolokia_port = "8080"

--- a/migrations/inputs_jolokia/testcases/agent_response_timeout/telegraf.conf
+++ b/migrations/inputs_jolokia/testcases/agent_response_timeout/telegraf.conf
@@ -1,0 +1,54 @@
+# Read JMX metrics through Jolokia
+[[inputs.jolokia]]
+  ## This is the context root used to compose the jolokia url
+  ## NOTE that Jolokia requires a trailing slash at the end of the context root
+  context = "/jolokia/"
+
+  ## This specifies the mode used
+  # mode = "proxy"
+  #
+  ## When in proxy mode this section is used to specify further
+  ## proxy address configurations.
+  ## Remember to change host address to fit your environment.
+  # [inputs.jolokia.proxy]
+  #   host = "127.0.0.1"
+  #   port = "8080"
+
+  ## Optional http timeouts
+  ##
+  ## response_header_timeout, if non-zero, specifies the amount of time to wait
+  ## for a server's response headers after fully writing the request.
+  response_header_timeout = "10s"
+  ##
+  ## client_timeout specifies a time limit for requests made by this client.
+  ## Includes connection time, any redirects, and reading the response body.
+  # client_timeout = "4s"
+
+  ## List of servers exposing jolokia read service
+  [[inputs.jolokia.servers]]
+    name = "as-server-01"
+    host = "127.0.0.1"
+    port = "8080"
+    # username = "myuser"
+    # password = "mypassword"
+
+  ## List of metrics collected on above servers
+  ## Each metric consists in a name, a jmx path and either
+  ## a pass or drop slice attribute.
+  ## This collect all heap memory usage metrics.
+  [[inputs.jolokia.metrics]]
+    name = "heap_memory_usage"
+    mbean  = "java.lang:type=Memory"
+    attribute = "HeapMemoryUsage"
+
+  ## This collect thread counts metrics.
+  [[inputs.jolokia.metrics]]
+    name = "thread_count"
+    mbean  = "java.lang:type=Threading"
+    attribute = "TotalStartedThreadCount,ThreadCount,DaemonThreadCount,PeakThreadCount"
+
+  ## This collect number of class loaded/unloaded counts metrics.
+  [[inputs.jolokia.metrics]]
+    name = "class_count"
+    mbean  = "java.lang:type=ClassLoading"
+    attribute = "LoadedClassCount,UnloadedClassCount,TotalLoadedClassCount"

--- a/migrations/inputs_jolokia/testcases/proxy_default/expected.conf
+++ b/migrations/inputs_jolokia/testcases/proxy_default/expected.conf
@@ -1,0 +1,27 @@
+[[inputs.jolokia2_proxy]]
+url = "http://127.0.0.1:8080/jolokia"
+default_field_separator = "_"
+name_override = "jolokia"
+
+[[inputs.jolokia2_proxy.target]]
+url = "service:jmx:rmi:///jndi/rmi://192.168.0.1:8080/jmxrmi"
+
+[[inputs.jolokia2_proxy.metric]]
+name = "heap_memory_usage"
+mbean = "java.lang:type=Memory"
+paths = ["HeapMemoryUsage"]
+
+[[inputs.jolokia2_proxy.metric]]
+name = "thread_count"
+mbean = "java.lang:type=Threading"
+paths = ["TotalStartedThreadCount", "ThreadCount", "DaemonThreadCount", "PeakThreadCount"]
+
+[[inputs.jolokia2_proxy.metric]]
+name = "class_count"
+mbean = "java.lang:type=ClassLoading"
+paths = ["LoadedClassCount", "UnloadedClassCount", "TotalLoadedClassCount"]
+
+[inputs.jolokia2_proxy.tags]
+jolokia_host = "192.168.0.1"
+jolokia_name = "as-server-01"
+jolokia_port = "8080"

--- a/migrations/inputs_jolokia/testcases/proxy_default/telegraf.conf
+++ b/migrations/inputs_jolokia/testcases/proxy_default/telegraf.conf
@@ -1,0 +1,54 @@
+# Read JMX metrics through Jolokia
+[[inputs.jolokia]]
+  ## This is the context root used to compose the jolokia url
+  ## NOTE that Jolokia requires a trailing slash at the end of the context root
+  context = "/jolokia/"
+
+  ## This specifies the mode used
+  mode = "proxy"
+
+  ## When in proxy mode this section is used to specify further
+  ## proxy address configurations.
+  ## Remember to change host address to fit your environment.
+  [inputs.jolokia.proxy]
+    host = "127.0.0.1"
+    port = "8080"
+
+  ## Optional http timeouts
+  ##
+  ## response_header_timeout, if non-zero, specifies the amount of time to wait
+  ## for a server's response headers after fully writing the request.
+  # response_header_timeout = "3s"
+  ##
+  ## client_timeout specifies a time limit for requests made by this client.
+  ## Includes connection time, any redirects, and reading the response body.
+  # client_timeout = "4s"
+
+  ## List of servers exposing jolokia read service
+  [[inputs.jolokia.servers]]
+    name = "as-server-01"
+    host = "192.168.0.1"
+    port = "8080"
+    # username = "myuser"
+    # password = "mypassword"
+
+  ## List of metrics collected on above servers
+  ## Each metric consists in a name, a jmx path and either
+  ## a pass or drop slice attribute.
+  ## This collect all heap memory usage metrics.
+  [[inputs.jolokia.metrics]]
+    name = "heap_memory_usage"
+    mbean  = "java.lang:type=Memory"
+    attribute = "HeapMemoryUsage"
+
+  ## This collect thread counts metrics.
+  [[inputs.jolokia.metrics]]
+    name = "thread_count"
+    mbean  = "java.lang:type=Threading"
+    attribute = "TotalStartedThreadCount,ThreadCount,DaemonThreadCount,PeakThreadCount"
+
+  ## This collect number of class loaded/unloaded counts metrics.
+  [[inputs.jolokia.metrics]]
+    name = "class_count"
+    mbean  = "java.lang:type=ClassLoading"
+    attribute = "LoadedClassCount,UnloadedClassCount,TotalLoadedClassCount"


### PR DESCRIPTION
- [ ] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

relates to #13376

This PR adds migrations for the deprecated `inputs.jolokia` plugin replaced by `inputs.jolokia2_agent` and `inputs.jolokia2_proxy`.