### PR TITLE
feat(migrations): Add migration for inputs.snmp_legacy

### DIFF
--- a/migrations/all/inputs_snmp_legacy.go
+++ b/migrations/all/inputs_snmp_legacy.go
@@ -1,0 +1,5 @@
+//go:build !custom || (migrations && (inputs || inputs.snmp_legacy))
+
+package all
+
+import _ "github.com/influxdata/telegraf/migrations/inputs_snmp_legacy" // register migration

--- a/migrations/inputs_snmp_legacy/migration.go
+++ b/migrations/inputs_snmp_legacy/migration.go
@@ -1,0 +1,21 @@
+package inputs_snmp_legacy
+
+import (
+	"github.com/influxdata/toml/ast"
+
+	"github.com/influxdata/telegraf/migrations"
+)
+
+const msg = `
+    This plugin cannot be migrated automatically and requires manual intervention!
+`
+
+// Migration function
+func migrate(tbl *ast.Table) ([]byte, string, error) {
+	return nil, msg, nil
+}
+
+// Register the migration function for the plugin type
+func init() {
+	migrations.AddPluginMigration("inputs.snmp_legacy", migrate)
+}

--- a/migrations/inputs_snmp_legacy/migration.go
+++ b/migrations/inputs_snmp_legacy/migration.go
@@ -11,7 +11,7 @@ const msg = `
 `
 
 // Migration function
-func migrate(tbl *ast.Table) ([]byte, string, error) {
+func migrate(_ *ast.Table) ([]byte, string, error) {
 	return nil, msg, nil
 }
 

--- a/migrations/inputs_snmp_legacy/migration_test.go
+++ b/migrations/inputs_snmp_legacy/migration_test.go
@@ -1,8 +1,7 @@
 package inputs_snmp_legacy_test
 
 import (
-	"os"
-	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -11,50 +10,14 @@ import (
 	_ "github.com/influxdata/telegraf/migrations/inputs_snmp_legacy" // register migration
 )
 
-func TestCases(t *testing.T) {
-	// Get all directories in testdata
-	folders, err := os.ReadDir("testcases")
+func TestNoMigration(t *testing.T) {
+	input := []byte(`
+[[inputs.snmp_legacy]]
+  address = "192.168.2.2:161"
+`)
+
+	output, n, err := config.ApplyMigrations(input)
 	require.NoError(t, err)
-
-	for _, f := range folders {
-		// Only handle folders
-		if !f.IsDir() {
-			continue
-		}
-
-		t.Run(f.Name(), func(t *testing.T) {
-			testcasePath := filepath.Join("testcases", f.Name())
-			inputFile := filepath.Join(testcasePath, "telegraf.conf")
-			expectedFile := filepath.Join(testcasePath, "expected.conf")
-
-			// Read the expected output
-			expected := config.NewConfig()
-			require.NoError(t, expected.LoadConfig(expectedFile))
-			require.NotEmpty(t, expected.Inputs)
-
-			// Read the input data
-			input, remote, err := config.LoadConfigFile(inputFile)
-			require.NoError(t, err)
-			require.False(t, remote)
-			require.NotEmpty(t, input)
-
-			// Migrate
-			output, n, err := config.ApplyMigrations(input)
-			require.NoError(t, err)
-			require.NotEmpty(t, output)
-			require.GreaterOrEqual(t, n, uint64(1))
-			actual := config.NewConfig()
-			require.NoError(t, actual.LoadConfigData(output))
-
-			// Test the output
-			require.Len(t, actual.Inputs, len(expected.Inputs))
-			actualIDs := make([]string, 0, len(expected.Inputs))
-			expectedIDs := make([]string, 0, len(expected.Inputs))
-			for i := range actual.Inputs {
-				actualIDs = append(actualIDs, actual.Inputs[i].ID())
-				expectedIDs = append(expectedIDs, expected.Inputs[i].ID())
-			}
-			require.ElementsMatch(t, expectedIDs, actualIDs)
-		})
-	}
+	require.Empty(t, strings.TrimSpace(string(output)))
+	require.Equal(t, uint64(1), n)
 }

--- a/migrations/inputs_snmp_legacy/migration_test.go
+++ b/migrations/inputs_snmp_legacy/migration_test.go
@@ -1,0 +1,60 @@
+package inputs_snmp_legacy_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/influxdata/telegraf/config"
+	_ "github.com/influxdata/telegraf/migrations/inputs_snmp_legacy" // register migration
+)
+
+func TestCases(t *testing.T) {
+	// Get all directories in testdata
+	folders, err := os.ReadDir("testcases")
+	require.NoError(t, err)
+
+	for _, f := range folders {
+		// Only handle folders
+		if !f.IsDir() {
+			continue
+		}
+
+		t.Run(f.Name(), func(t *testing.T) {
+			testcasePath := filepath.Join("testcases", f.Name())
+			inputFile := filepath.Join(testcasePath, "telegraf.conf")
+			expectedFile := filepath.Join(testcasePath, "expected.conf")
+
+			// Read the expected output
+			expected := config.NewConfig()
+			require.NoError(t, expected.LoadConfig(expectedFile))
+			require.NotEmpty(t, expected.Inputs)
+
+			// Read the input data
+			input, remote, err := config.LoadConfigFile(inputFile)
+			require.NoError(t, err)
+			require.False(t, remote)
+			require.NotEmpty(t, input)
+
+			// Migrate
+			output, n, err := config.ApplyMigrations(input)
+			require.NoError(t, err)
+			require.NotEmpty(t, output)
+			require.GreaterOrEqual(t, n, uint64(1))
+			actual := config.NewConfig()
+			require.NoError(t, actual.LoadConfigData(output))
+
+			// Test the output
+			require.Len(t, actual.Inputs, len(expected.Inputs))
+			actualIDs := make([]string, 0, len(expected.Inputs))
+			expectedIDs := make([]string, 0, len(expected.Inputs))
+			for i := range actual.Inputs {
+				actualIDs = append(actualIDs, actual.Inputs[i].ID())
+				expectedIDs = append(expectedIDs, expected.Inputs[i].ID())
+			}
+			require.ElementsMatch(t, expectedIDs, actualIDs)
+		})
+	}
+}


### PR DESCRIPTION
- [ ] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

relates to #13376

This PR adds migrations for the deprecated `inputs.snmp_legacy` plugin that requires manual intervention.