### PR TITLE
fix(metricpass): Use correct logic expression in benchmark

### DIFF
--- a/models/filter_test.go
+++ b/models/filter_test.go
@@ -660,8 +660,8 @@ func BenchmarkFilter(b *testing.B) {
 			name: "metric filter complex",
 			filter: Filter{
 				MetricPass: `"source" in tags` +
-					` and fields.exists(f, type(fields[f]) in [int, uint, double] and fields[f] > 20.0)` +
-					` and time >= timestamp("2023-04-25T00:00:00Z") - duration("24h")`,
+					` && fields.exists(f, type(fields[f]) in [int, uint, double] && fields[f] > 20.0)` +
+					` && time >= timestamp("2023-04-25T00:00:00Z") - duration("24h")`,
 			},
 			metric: testutil.MustMetric("cpu",
 				map[string]string{},


### PR DESCRIPTION
This replaces the python-style `and` keyword in `BenchmarkFilter` with the correct logic operator. This is an oversight of PR #13791 removing python-style logic keywords.
