### PR TITLE
fix(processors.starlark): Maintain tracking information post-apply

### DIFF
--- a/plugins/common/starlark/metric.go
+++ b/plugins/common/starlark/metric.go
@@ -12,6 +12,8 @@ import (
 )
 
 type Metric struct {
+	ID uint64
+
 	metric         telegraf.Metric
 	tagIterCount   int
 	fieldIterCount int
@@ -20,6 +22,7 @@ type Metric struct {
 
 // Wrap updates the starlark.Metric to wrap a new telegraf.Metric.
 func (m *Metric) Wrap(metric telegraf.Metric) {
+	m.ID = metric.HashID()
 	m.metric = metric
 	m.tagIterCount = 0
 	m.fieldIterCount = 0

--- a/plugins/processors/starlark/starlark.go
+++ b/plugins/processors/starlark/starlark.go
@@ -95,7 +95,7 @@ func (s *Starlark) Add(origMetric telegraf.Metric, acc telegraf.Accumulator) err
 		// If the script didn't return the original metrics, mark it as
 		// successfully handled.
 		if !origFound {
-			origMetric.Accept()
+			origMetric.Drop()
 		}
 
 		// clear results

--- a/plugins/processors/starlark/starlark.go
+++ b/plugins/processors/starlark/starlark.go
@@ -47,12 +47,12 @@ func (s *Starlark) Start(_ telegraf.Accumulator) error {
 	return nil
 }
 
-func (s *Starlark) Add(metric telegraf.Metric, acc telegraf.Accumulator) error {
+func (s *Starlark) Add(origMetric telegraf.Metric, acc telegraf.Accumulator) error {
 	parameters, found := s.GetParameters("apply")
 	if !found {
 		return fmt.Errorf("the parameters of the apply function could not be found")
 	}
-	parameters[0].(*common.Metric).Wrap(metric)
+	parameters[0].(*common.Metric).Wrap(origMetric)
 
 	rv, err := s.Call("apply")
 	if err != nil {
@@ -65,6 +65,7 @@ func (s *Starlark) Add(metric telegraf.Metric, acc telegraf.Accumulator) error {
 		iter := rv.Iterate()
 		defer iter.Done()
 		var v starlark.Value
+		var origFound bool
 		for iter.Next(&v) {
 			switch v := v.(type) {
 			case *common.Metric:
@@ -73,6 +74,17 @@ func (s *Starlark) Add(metric telegraf.Metric, acc telegraf.Accumulator) error {
 					s.Log.Errorf("Duplicate metric reference detected")
 					continue
 				}
+
+				// Previous metric was found, accept the starlark metric, add
+				// the original metric to the accumulator
+				if v.ID == origMetric.HashID() {
+					origFound = true
+					m.Accept()
+					s.results = append(s.results, origMetric)
+					acc.AddMetric(origMetric)
+					continue
+				}
+
 				s.results = append(s.results, m)
 				acc.AddMetric(m)
 			default:
@@ -82,8 +94,8 @@ func (s *Starlark) Add(metric telegraf.Metric, acc telegraf.Accumulator) error {
 
 		// If the script didn't return the original metrics, mark it as
 		// successfully handled.
-		if !containsMetric(s.results, metric) {
-			metric.Accept()
+		if !origFound {
+			origMetric.Accept()
 		}
 
 		// clear results
@@ -93,15 +105,17 @@ func (s *Starlark) Add(metric telegraf.Metric, acc telegraf.Accumulator) error {
 		s.results = s.results[:0]
 	case *common.Metric:
 		m := rv.Unwrap()
-
-		// If the script returned a different metric, mark this metric as
-		// successfully handled.
-		if m != metric {
-			metric.Accept()
+		// If we got the original metric back, use that and drop the new one.
+		// Otherwise mark the original as accepted and use the new metric.
+		if origMetric.HashID() == rv.ID {
+			m.Accept()
+			acc.AddMetric(origMetric)
+		} else {
+			origMetric.Accept()
+			acc.AddMetric(m)
 		}
-		acc.AddMetric(m)
 	case starlark.NoneType:
-		metric.Drop()
+		origMetric.Drop()
 	default:
 		return fmt.Errorf("invalid type returned: %T", rv)
 	}
@@ -111,9 +125,9 @@ func (s *Starlark) Add(metric telegraf.Metric, acc telegraf.Accumulator) error {
 func (s *Starlark) Stop() {
 }
 
-func containsMetric(metrics []telegraf.Metric, metric telegraf.Metric) bool {
+func containsMetric(metrics []telegraf.Metric, target telegraf.Metric) bool {
 	for _, m := range metrics {
-		if m == metric {
+		if m == target {
 			return true
 		}
 	}


### PR DESCRIPTION
The starlark process is used to make modifications to metrics, create
new metrics, or even remove metrics. When the starlark script returns it
does not return a metric with tracking information, only a generic
metric.

Currently we test to see if the metric returned is the same, but even if
they are idential, the tracking informiation is lost and the metric is
never marked accepted or dropped, hence we lose the tracking
information.

Instead of accepting everything, track the hash ID of each metric.
If the metric is the same, then continue on with the original metric.
For tracking metrics, we accept the new metric, since we can count on the
original metric to get ack'ed or nack'ed by the output.