### PR TITLE
fix(serializers.json): Append newline for batch-serialization

### DIFF
--- a/plugins/serializers/json/json.go
+++ b/plugins/serializers/json/json.go
@@ -103,6 +103,8 @@ func (s *Serializer) SerializeBatch(metrics []telegraf.Metric) ([]byte, error) {
 	if err != nil {
 		return []byte{}, err
 	}
+	serialized = append(serialized, '\n')
+
 	return serialized, nil
 }
 

--- a/plugins/serializers/json/json_test.go
+++ b/plugins/serializers/json/json_test.go
@@ -197,7 +197,7 @@ func TestSerializeBatch(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(
 		t,
-		[]byte(`{"metrics":[{"fields":{"value":42},"name":"cpu","tags":{},"timestamp":0},{"fields":{"value":42},"name":"cpu","tags":{},"timestamp":0}]}`),
+		[]byte(`{"metrics":[{"fields":{"value":42},"name":"cpu","tags":{},"timestamp":0},{"fields":{"value":42},"name":"cpu","tags":{},"timestamp":0}]}`+"\n"),
 		buf,
 	)
 }
@@ -219,7 +219,7 @@ func TestSerializeBatchSkipInf(t *testing.T) {
 	require.NoError(t, s.Init())
 	buf, err := s.SerializeBatch(metrics)
 	require.NoError(t, err)
-	require.Equal(t, []byte(`{"metrics":[{"fields":{"time_idle":42},"name":"cpu","tags":{},"timestamp":0}]}`), buf)
+	require.Equal(t, []byte(`{"metrics":[{"fields":{"time_idle":42},"name":"cpu","tags":{},"timestamp":0}]}`+"\n"), buf)
 }
 
 func TestSerializeBatchSkipInfAllFields(t *testing.T) {
@@ -238,7 +238,7 @@ func TestSerializeBatchSkipInfAllFields(t *testing.T) {
 	require.NoError(t, s.Init())
 	buf, err := s.SerializeBatch(metrics)
 	require.NoError(t, err)
-	require.Equal(t, []byte(`{"metrics":[{"fields":{},"name":"cpu","tags":{},"timestamp":0}]}`), buf)
+	require.Equal(t, []byte(`{"metrics":[{"fields":{},"name":"cpu","tags":{},"timestamp":0}]}`+"\n"), buf)
 }
 
 func TestSerializeTransformationNonBatch(t *testing.T) {


### PR DESCRIPTION
- [ ] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #14142 

Add a trailing newline to the batch-serialization output to match the non-batch behavior.