### PR TITLE
chore(tools): Bump golangci-lint from v1.54.2 to v1.55.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ commands:
             - run: 'sh ./scripts/installgo_windows.sh'
             - run: choco install mingw --version=12.2.0.03042023
       - run: go env
-      - run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.54.2
+      - run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.55.0
       - when:
           condition:
             equal: [ linux, << parameters.os >> ]

--- a/Makefile
+++ b/Makefile
@@ -174,7 +174,7 @@ vet:
 .PHONY: lint-install
 lint-install:
 	@echo "Installing golangci-lint"
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.54.2
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.55.0
 
 	@echo "Installing markdownlint"
 	npm install -g markdownlint-cli

--- a/plugins/inputs/aerospike/aerospike.go
+++ b/plugins/inputs/aerospike/aerospike.go
@@ -438,10 +438,9 @@ func parseAerospikeValue(key string, v string) interface{} {
 		return parsed
 	} else if parsed, err := strconv.ParseFloat(v, 32); err == nil {
 		return parsed
-	} else {
-		// leave as string
-		return v
 	}
+	// leave as string
+	return v
 }
 
 func createTags(hostPort string, nodeName string, namespace string, set string) map[string]string {

--- a/plugins/inputs/chrony/chrony_test.go
+++ b/plugins/inputs/chrony/chrony_test.go
@@ -96,17 +96,17 @@ Leap status     : Not synchronized
 	// /tmp/go-build970079519/…/_test/integration.test -test.run=TestHelperProcess --
 	cmd, args := args[3], args[4:]
 
-	if cmd == "chronyc" {
-		if args[0] == "tracking" {
-			fmt.Fprint(os.Stdout, lookup+mockData)
-		} else {
-			fmt.Fprint(os.Stdout, noLookup+mockData)
-		}
-	} else {
+	if cmd != "chronyc" {
 		fmt.Fprint(os.Stdout, "command not found")
 		//nolint:revive // error code is important for this "test"
 		os.Exit(1)
 	}
+	if args[0] == "tracking" {
+		fmt.Fprint(os.Stdout, lookup+mockData)
+	} else {
+		fmt.Fprint(os.Stdout, noLookup+mockData)
+	}
+
 	//nolint:revive // error code is important for this "test"
 	os.Exit(0)
 }

--- a/plugins/inputs/csgo/csgo.go
+++ b/plugins/inputs/csgo/csgo.go
@@ -177,7 +177,6 @@ func requestServer(url string, rconPw string) (string, error) {
 		return "", err
 	} else if reqID != respReqID {
 		return "", errors.New("response/request mismatch")
-	} else {
-		return resp, nil
 	}
+	return resp, nil
 }

--- a/plugins/inputs/dcos/dcos.go
+++ b/plugins/inputs/dcos/dcos.go
@@ -349,10 +349,9 @@ func (d *DCOS) createCredentials() (Credentials, error) {
 			Path: d.TokenFile,
 		}
 		return creds, nil
-	} else {
-		creds := &NullCreds{}
-		return creds, nil
 	}
+
+	return &NullCreds{}, nil
 }
 
 func (d *DCOS) createFilters() error {

--- a/plugins/inputs/disk/disk.go
+++ b/plugins/inputs/disk/disk.go
@@ -97,9 +97,8 @@ func (opts MountOptions) Mode() string {
 		return "rw"
 	} else if opts.exists("ro") {
 		return "ro"
-	} else {
-		return "unknown"
 	}
+	return "unknown"
 }
 
 func (opts MountOptions) exists(opt string) bool {

--- a/plugins/inputs/ipmi_sensor/ipmi_sensor_test.go
+++ b/plugins/inputs/ipmi_sensor/ipmi_sensor_test.go
@@ -375,13 +375,12 @@ OS RealTime Mod  | 0x00              | ok
 	cmd := args[3]
 
 	// Ignore the returned errors for the mocked interface as tests will fail anyway
-	if cmd == "ipmitool" {
-		fmt.Fprint(os.Stdout, mockData)
-	} else {
+	if cmd != "ipmitool" {
 		fmt.Fprint(os.Stdout, "command not found")
 		//nolint:revive // error code is important for this "test"
 		os.Exit(1)
 	}
+	fmt.Fprint(os.Stdout, mockData)
 	//nolint:revive // error code is important for this "test"
 	os.Exit(0)
 }
@@ -573,13 +572,12 @@ Power Supply 1   | 03h | ok  | 10.1 | 110 Watts, Presence detected
 	cmd := args[3]
 
 	// Ignore the returned errors for the mocked interface as tests will fail anyway
-	if cmd == "ipmitool" {
-		fmt.Fprint(os.Stdout, mockData)
-	} else {
+	if cmd != "ipmitool" {
 		fmt.Fprint(os.Stdout, "command not found")
 		//nolint:revive // error code is important for this "test"
 		os.Exit(1)
 	}
+	fmt.Fprint(os.Stdout, mockData)
 	//nolint:revive // error code is important for this "test"
 	os.Exit(0)
 }

--- a/plugins/inputs/ipmi_sensor/ipmi_sensor_test.go
+++ b/plugins/inputs/ipmi_sensor/ipmi_sensor_test.go
@@ -380,7 +380,6 @@ OS RealTime Mod  | 0x00              | ok
 		//nolint:revive // error code is important for this "test"
 		os.Exit(1)
 	}
-
 	fmt.Fprint(os.Stdout, mockData)
 	//nolint:revive // error code is important for this "test"
 	os.Exit(0)

--- a/plugins/inputs/ipmi_sensor/ipmi_sensor_test.go
+++ b/plugins/inputs/ipmi_sensor/ipmi_sensor_test.go
@@ -380,6 +380,7 @@ OS RealTime Mod  | 0x00              | ok
 		//nolint:revive // error code is important for this "test"
 		os.Exit(1)
 	}
+
 	fmt.Fprint(os.Stdout, mockData)
 	//nolint:revive // error code is important for this "test"
 	os.Exit(0)

--- a/plugins/inputs/kube_inventory/kube_inventory.go
+++ b/plugins/inputs/kube_inventory/kube_inventory.go
@@ -195,10 +195,10 @@ const (
 	nodeMeasurement                  = "kubernetes_node"
 	persistentVolumeMeasurement      = "kubernetes_persistentvolume"
 	persistentVolumeClaimMeasurement = "kubernetes_persistentvolumeclaim"
-	podContainerMeasurement          = "kubernetes_pod_container" //nolint:gosec // G101: Potential hardcoded credentials - false positive
+	podContainerMeasurement          = "kubernetes_pod_container"
 	serviceMeasurement               = "kubernetes_service"
 	statefulSetMeasurement           = "kubernetes_statefulset"
-	resourcequotaMeasurement         = "kubernetes_resourcequota" //nolint:gosec // G101: Potential hardcoded credentials - false positive
+	resourcequotaMeasurement         = "kubernetes_resourcequota"
 	certificateMeasurement           = "kubernetes_certificate"
 )
 

--- a/plugins/inputs/monit/monit.go
+++ b/plugins/inputs/monit/monit.go
@@ -338,9 +338,8 @@ func linkMode(s Service) string {
 		return "duplex"
 	} else if s.Link.Duplex == 0 {
 		return "simplex"
-	} else {
-		return "unknown"
 	}
+	return "unknown"
 }
 
 func serviceStatus(s Service) string {

--- a/plugins/inputs/procstat/procstat.go
+++ b/plugins/inputs/procstat/procstat.go
@@ -351,15 +351,15 @@ func (p *Procstat) findPids() []PidsTags {
 	} else if p.CGroup != "" {
 		groups := p.cgroupPIDs()
 		return groups
-	} else {
-		f, err := p.getPIDFinder()
-		if err != nil {
-			pidTags = append(pidTags, PidsTags{nil, nil, err})
-			return pidTags
-		}
-		pids, tags, err := p.SimpleFindPids(f)
-		pidTags = append(pidTags, PidsTags{pids, tags, err})
 	}
+
+	f, err := p.getPIDFinder()
+	if err != nil {
+		pidTags = append(pidTags, PidsTags{nil, nil, err})
+		return pidTags
+	}
+	pids, tags, err := p.SimpleFindPids(f)
+	pidTags = append(pidTags, PidsTags{pids, tags, err})
 
 	return pidTags
 }

--- a/plugins/inputs/sensors/sensors_test.go
+++ b/plugins/inputs/sensors/sensors_test.go
@@ -370,13 +370,13 @@ Vcore Voltage:
 	// /tmp/go-build970079519/…/_test/integration.test -test.run=TestHelperProcess --
 	cmd, _ := args[3], args[4:]
 
-	if cmd == "sensors" {
-		fmt.Fprint(os.Stdout, mockData)
-	} else {
+	if cmd != "sensors" {
 		fmt.Fprint(os.Stdout, "command not found")
 		//nolint:revive // error code is important for this "test"
 		os.Exit(1)
 	}
+
+	fmt.Fprint(os.Stdout, mockData)
 	//nolint:revive // error code is important for this "test"
 	os.Exit(0)
 }

--- a/plugins/inputs/snmp/snmp.go
+++ b/plugins/inputs/snmp/snmp.go
@@ -425,9 +425,8 @@ func (t Table) Build(gs snmpConnection, walk bool, tr Translator) (*RTable, erro
 					return nil, fmt.Errorf("wrong digest (auth_protocol, auth_password)")
 				} else if errors.Is(err, gosnmp.ErrDecryption) {
 					return nil, fmt.Errorf("decryption error (priv_protocol, priv_password)")
-				} else {
-					return nil, fmt.Errorf("performing get on field %s: %w", f.Name, err)
 				}
+				return nil, fmt.Errorf("performing get on field %s: %w", f.Name, err)
 			} else if pkt != nil && len(pkt.Variables) > 0 && pkt.Variables[0].Type != gosnmp.NoSuchObject && pkt.Variables[0].Type != gosnmp.NoSuchInstance {
 				ent := pkt.Variables[0]
 				fv, err := fieldConvert(tr, f.Conversion, ent)

--- a/plugins/inputs/statsd/running_stats.go
+++ b/plugins/inputs/statsd/running_stats.go
@@ -107,9 +107,8 @@ func (rs *RunningStats) Median() float64 {
 		return 0
 	} else if count%2 == 0 {
 		return (values[count/2-1] + values[count/2]) / 2
-	} else {
-		return values[count/2]
 	}
+	return values[count/2]
 }
 
 func (rs *RunningStats) Variance() float64 {

--- a/plugins/inputs/win_eventlog/util.go
+++ b/plugins/inputs/win_eventlog/util.go
@@ -49,7 +49,7 @@ func GetFromSnapProcess(pid uint32) (string, error) {
 	}
 	defer windows.CloseHandle(snap)
 	var pe32 windows.ProcessEntry32
-	pe32.Size = uint32(unsafe.Sizeof(pe32)) //nolint:gosec // G103: Valid use of unsafe call to determine the size of the struct
+	pe32.Size = uint32(unsafe.Sizeof(pe32))
 	if err := windows.Process32First(snap, &pe32); err != nil {
 		return "", err
 	}

--- a/plugins/outputs/opentsdb/opentsdb.go
+++ b/plugins/outputs/opentsdb/opentsdb.go
@@ -97,9 +97,8 @@ func (o *OpenTSDB) Write(metrics []telegraf.Metric) error {
 		return o.WriteTelnet(metrics, u)
 	} else if u.Scheme == "http" || u.Scheme == "https" {
 		return o.WriteHTTP(metrics, u)
-	} else {
-		return fmt.Errorf("unknown scheme in host parameter")
 	}
+	return fmt.Errorf("unknown scheme in host parameter")
 }
 
 func (o *OpenTSDB) WriteHTTP(metrics []telegraf.Metric, u *url.URL) error {

--- a/plugins/parsers/influx/escape.go
+++ b/plugins/parsers/influx/escape.go
@@ -77,8 +77,7 @@ func parseBoolBytes(b []byte) (bool, error) {
 }
 
 // unsafeBytesToString converts a []byte to a string without a heap allocation.
-//
-// It is unsafe, and is intended to prepare input to short-lived functions that require strings.
 func unsafeBytesToString(in []byte) string {
+	//nolint:gosec // G103: It is unsafe, and is intended to prepare input to short-lived functions that require strings.
 	return unsafe.String(&in[0], len(in))
 }


### PR DESCRIPTION
This PR bumps `golangci-lint` from `v1.54.2` to `v1.55.0` and fixes the newly found issues:
```
plugins/inputs/aerospike/aerospike.go:441:9             revive      indent-error-flow: if block ends with a return statement, so drop this else and outdent its block (move short variable declaration to its own line if necessary)
plugins/inputs/chrony/chrony_test.go:99:2               revive      early-return: if c { ... } else { ... os.Exit() } can be simplified to if !c { ... os.Exit() } ...
plugins/inputs/csgo/csgo.go:180:9                       revive      indent-error-flow: if block ends with a return statement, so drop this else and outdent its block
plugins/inputs/dcos/dcos.go:352:9                       revive      indent-error-flow: if block ends with a return statement, so drop this else and outdent its block
plugins/inputs/disk/disk.go:100:9                       revive      indent-error-flow: if block ends with a return statement, so drop this else and outdent its block
plugins/inputs/ipmi_sensor/ipmi_sensor_test.go:378:2    revive      early-return: if c { ... } else { ... os.Exit() } can be simplified to if !c { ... os.Exit() } ...
plugins/inputs/ipmi_sensor/ipmi_sensor_test.go:576:2    revive      early-return: if c { ... } else { ... os.Exit() } can be simplified to if !c { ... os.Exit() } ...
plugins/inputs/kube_inventory/kube_inventory.go:198:64  nolintlint  directive `//nolint:gosec // G101: Potential hardcoded credentials - false positive` is unused for linter "gosec"
plugins/inputs/kube_inventory/kube_inventory.go:201:64  nolintlint  directive `//nolint:gosec // G101: Potential hardcoded credentials - false positive` is unused for linter "gosec"
plugins/inputs/monit/monit.go:341:9                     revive      indent-error-flow: if block ends with a return statement, so drop this else and outdent its block
plugins/inputs/procstat/procstat.go:354:9               revive      indent-error-flow: if block ends with a return statement, so drop this else and outdent its block
plugins/inputs/sensors/sensors_test.go:373:2            revive      early-return: if c { ... } else { ... os.Exit() } can be simplified to if !c { ... os.Exit() } ...
plugins/inputs/snmp/snmp.go:428:12                      revive      indent-error-flow: if block ends with a return statement, so drop this else and outdent its block
plugins/inputs/statsd/running_stats.go:110:9            revive      indent-error-flow: if block ends with a return statement, so drop this else and outdent its block
plugins/outputs/opentsdb/opentsdb.go:100:9              revive      indent-error-flow: if block ends with a return statement, so drop this else and outdent its block
plugins/parsers/influx/escape.go:83:9                   gosec       G103: Use of unsafe calls should be audited
```