### PR TITLE
feat(questdb): QuestDB output plugin

### DIFF
--- a/plugins/outputs/all/questdb.go
+++ b/plugins/outputs/all/questdb.go
@@ -1,0 +1,5 @@
+//go:build !custom || outputs || outputs.questdb
+
+package all
+
+import _ "github.com/influxdata/telegraf/plugins/outputs/questdb" // register plugin

--- a/plugins/outputs/questdb/README.md
+++ b/plugins/outputs/questdb/README.md
@@ -1,0 +1,38 @@
+# QuestDB Output Plugin
+
+This plugin sends metrics to [QuestDB](https://questdb.io) and automatically create the target tables when they
+don't already exist. The plugin supports authentication and TLS.
+
+## Global configuration options <!-- @/docs/includes/plugin_config.md -->
+
+In addition to the plugin-specific configuration settings, plugins support
+additional global and plugin configuration settings. These settings are used to
+modify metrics, tags, and field or create aliases and configure ordering, etc.
+See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
+
+[CONFIGURATION.md]: ../../../docs/CONFIGURATION.md#plugins
+
+## Configuration
+
+```toml @sample.conf
+# QuestDB writer, supports authentication
+[[outputs.questdb]]
+  ## URL to connect to
+  # address = "tcp://127.0.0.1:9009"
+
+  ## Optional authentication
+  # user = "admin"
+  # token = "M34uWQbu_eKO3S5NnFOBXq3u43nXHwHfU34hykhDdEY"
+
+  ## Optional TLS Config
+  # tls_ca = "/etc/telegraf/ca.pem"
+  # tls_cert = "/etc/telegraf/cert.pem"
+  # tls_key = "/etc/telegraf/key.pem"
+  ## Use TLS but skip chain & host verification
+  # insecure_skip_verify = false
+
+  ## Period between keep alive probes.
+  ## 0 disables keep alive probes.
+  ## Defaults to the OS configuration.
+  # keep_alive_period = "5m"
+```

--- a/plugins/outputs/questdb/README.md
+++ b/plugins/outputs/questdb/README.md
@@ -1,7 +1,8 @@
 # QuestDB Output Plugin
 
-This plugin sends metrics to [QuestDB](https://questdb.io) and automatically create the target tables when they
-don't already exist. The plugin supports authentication and TLS.
+This plugin sends metrics to [QuestDB](https://questdb.io) and automatically
+create the target tables when they don't already exist. The plugin supports
+authentication and TLS.
 
 ## Global configuration options <!-- @/docs/includes/plugin_config.md -->
 

--- a/plugins/outputs/questdb/README.md
+++ b/plugins/outputs/questdb/README.md
@@ -10,7 +10,6 @@ This plugin supports secrets from secret-stores for the `token` option.
 See the [secret-store documentation][SECRETSTORE] for more details on how
 to use them.
 
-
 ## Global configuration options <!-- @/docs/includes/plugin_config.md -->
 
 In addition to the plugin-specific configuration settings, plugins support

--- a/plugins/outputs/questdb/README.md
+++ b/plugins/outputs/questdb/README.md
@@ -4,6 +4,13 @@ This plugin sends metrics to [QuestDB](https://questdb.io) and automatically
 create the target tables when they don't already exist. The plugin supports
 authentication and TLS.
 
+## Secret-store support
+
+This plugin supports secrets from secret-stores for the `token` option.
+See the [secret-store documentation][SECRETSTORE] for more details on how
+to use them.
+
+
 ## Global configuration options <!-- @/docs/includes/plugin_config.md -->
 
 In addition to the plugin-specific configuration settings, plugins support

--- a/plugins/outputs/questdb/questdb.go
+++ b/plugins/outputs/questdb/questdb.go
@@ -1,0 +1,212 @@
+//go:generate ../../../tools/readme_config_includer/generator
+package questdb
+
+import (
+	"bufio"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	_ "embed"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"github.com/influxdata/telegraf/plugins/serializers/influx"
+	"math/big"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/config"
+	"github.com/influxdata/telegraf/internal"
+	tlsint "github.com/influxdata/telegraf/plugins/common/tls"
+	"github.com/influxdata/telegraf/plugins/outputs"
+)
+
+//go:embed sample.conf
+var sampleConfig string
+
+type QuestDB struct {
+	User            string `toml:"user"`
+	Token           string `toml:"token"`
+	Address         string
+	KeepAlivePeriod *config.Duration
+	tlsint.ClientConfig
+	Log  telegraf.Logger `toml:"-"`
+	Conn net.Conn
+
+	serializer influx.Serializer
+	encoder    internal.ContentEncoder
+}
+
+func (*QuestDB) SampleConfig() string {
+	return sampleConfig
+}
+
+func (questdb *QuestDB) Connect() error {
+	spl := strings.SplitN(questdb.Address, "://", 2)
+	if len(spl) != 2 {
+		return fmt.Errorf("invalid address: %s", questdb.Address)
+	}
+	if spl[0] != "tcp" && spl[0] != "tcp4" {
+		return fmt.Errorf("unsupported protocol: %s, only tcp or tcp4 are supported", questdb.Address)
+	}
+
+	tlsCfg, err := questdb.ClientConfig.TLSConfig()
+	if err != nil {
+		return err
+	}
+
+	// Decode the key if provided
+	var key *ecdsa.PrivateKey
+	if questdb.User != "" && questdb.Token != "" {
+		keyRaw, err := base64.RawURLEncoding.DecodeString(questdb.Token)
+		if err != nil {
+			return err
+		}
+		key = new(ecdsa.PrivateKey)
+		key.PublicKey.Curve = elliptic.P256()
+		key.PublicKey.X, key.PublicKey.Y = key.PublicKey.Curve.ScalarBaseMult(keyRaw)
+		key.D = new(big.Int).SetBytes(keyRaw)
+	}
+
+	var c net.Conn
+	if tlsCfg == nil {
+		c, err = net.Dial(spl[0], spl[1])
+	} else {
+		c, err = tls.Dial(spl[0], spl[1], tlsCfg)
+	}
+	if err != nil {
+		return err
+	}
+
+	if err := questdb.setKeepAlive(c); err != nil {
+		questdb.Log.Debugf("Unable to configure keep alive (%s): %s", questdb.Address, err)
+	}
+
+	if key != nil {
+		_, err = c.Write([]byte(questdb.User + "\n"))
+		if err != nil {
+			c.Close()
+			return err
+		}
+
+		reader := bufio.NewReader(c)
+		raw, err := reader.ReadBytes('\n')
+		if len(raw) < 2 {
+			c.Close()
+			return err
+		}
+		// Remove the `\n` in the last position.
+		raw = raw[:len(raw)-1]
+		if err != nil {
+			c.Close()
+			return err
+		}
+
+		// Hash the challenge with sha256.
+		hash := crypto.SHA256.New()
+		hash.Write(raw)
+		hashed := hash.Sum(nil)
+
+		stdSig, err := ecdsa.SignASN1(rand.Reader, key, hashed)
+		if err != nil {
+			c.Close()
+			return err
+		}
+		_, err = c.Write([]byte(base64.StdEncoding.EncodeToString(stdSig) + "\n"))
+		if err != nil {
+			c.Close()
+			return err
+		}
+	}
+
+	questdb.encoder, err = internal.NewIdentityEncoder()
+	questdb.serializer = influx.Serializer{UintSupport: false}
+	if err := questdb.serializer.Init(); err != nil {
+		c.Close()
+		return err
+	}
+
+	if err != nil {
+		return err
+	}
+
+	questdb.Conn = c
+	return nil
+}
+
+func (questdb *QuestDB) setKeepAlive(c net.Conn) error {
+	if questdb.KeepAlivePeriod == nil {
+		return nil
+	}
+	tcpc, ok := c.(*net.TCPConn)
+	if !ok {
+		return fmt.Errorf("cannot set keep alive on a %s socket", strings.SplitN(questdb.Address, "://", 2)[0])
+	}
+	if *questdb.KeepAlivePeriod == 0 {
+		return tcpc.SetKeepAlive(false)
+	}
+	if err := tcpc.SetKeepAlive(true); err != nil {
+		return err
+	}
+	return tcpc.SetKeepAlivePeriod(time.Duration(*questdb.KeepAlivePeriod))
+}
+
+// Write writes the given metrics to the destination.
+// If an error is encountered, it is up to the caller to retry the same write again later.
+// Not parallel safe.
+func (questdb *QuestDB) Write(metrics []telegraf.Metric) error {
+	if questdb.Conn == nil {
+		// previous write failed with permanent error and socket was closed.
+		if err := questdb.Connect(); err != nil {
+			return err
+		}
+	}
+
+	for _, m := range metrics {
+		bs, err := questdb.serializer.Serialize(m)
+		if err != nil {
+			questdb.Log.Debugf("Could not serialize metric: %v", err)
+			continue
+		}
+
+		bs, err = questdb.encoder.Encode(bs)
+		if err != nil {
+			questdb.Log.Debugf("Could not encode metric: %v", err)
+			continue
+		}
+
+		if _, err := questdb.Conn.Write(bs); err != nil {
+			//TODO log & keep going with remaining strings
+			var netErr net.Error
+			if errors.As(err, &netErr) {
+				// permanent error. close the connection
+				questdb.Close()
+				questdb.Conn = nil
+				return fmt.Errorf("closing connection: %w", netErr)
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Close closes the connection. Noop if already closed.
+func (questdb *QuestDB) Close() error {
+	if questdb.Conn == nil {
+		return nil
+	}
+	err := questdb.Conn.Close()
+	questdb.Conn = nil
+	return err
+}
+
+func init() {
+	outputs.Add("questdb", func() telegraf.Output {
+		return &QuestDB{}
+	})
+}

--- a/plugins/outputs/questdb/questdb_test.go
+++ b/plugins/outputs/questdb/questdb_test.go
@@ -81,7 +81,7 @@ func TestQuestDBNoAuthIntegration(t *testing.T) {
 	container := testutil.Container{
 		Image:        "questdb/questdb",
 		ExposedPorts: []string{"9009", "9000"},
-		WaitingFor:   wait.NewHostPortStrategy("9009"),
+		WaitingFor:   wait.ForLog("server-main enjoy").AsRegexp(),
 	}
 	err := container.Start()
 	require.NoError(t, err, "failed to start QuestDB container")
@@ -101,7 +101,7 @@ func TestQuestDBAuthIntegration(t *testing.T) {
 	container := testutil.Container{
 		Image:        "questdb/questdb",
 		ExposedPorts: []string{"9009", "9000"},
-		WaitingFor:   wait.NewHostPortStrategy("9009"),
+		WaitingFor:   wait.ForLog("server-main enjoy").AsRegexp(),
 		Env: map[string]string{
 			"QDB_LINE_TCP_AUTH_DB_PATH": "conf/authDb.txt",
 		},

--- a/plugins/outputs/questdb/questdb_test.go
+++ b/plugins/outputs/questdb/questdb_test.go
@@ -74,6 +74,10 @@ func TestQuestDB_unixgram_unsupported(t *testing.T) {
 }
 
 func TestQuestDBNoAuthIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
 	container := testutil.Container{
 		Image:        "questdb/questdb",
 		ExposedPorts: []string{"9009", "9000"},
@@ -88,6 +92,10 @@ func TestQuestDBNoAuthIntegration(t *testing.T) {
 }
 
 func TestQuestDBAuthIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
 	auth, err := filepath.Abs("testdata/auth.txt")
 	require.NoError(t, err)
 	container := testutil.Container{

--- a/plugins/outputs/questdb/questdb_test.go
+++ b/plugins/outputs/questdb/questdb_test.go
@@ -88,7 +88,7 @@ func TestQuestDBNoAuthIntegration(t *testing.T) {
 	defer container.Terminate()
 
 	questdb := newQuestDB("tcp://" + container.Address + ":" + container.Ports["9009"])
-	testWithQuestDB(t, questdb, container)
+	testWithQuestDB(t, questdb, &container)
 }
 
 func TestQuestDBAuthIntegration(t *testing.T) {
@@ -114,10 +114,10 @@ func TestQuestDBAuthIntegration(t *testing.T) {
 	defer container.Terminate()
 
 	questdb := newQuestDBAuth("tcp://"+container.Address+":"+container.Ports["9009"], "testUser1", "UvuVb1USHGRRT08gEnwN2zGZrvM4MsLQ5brgF6SVkAw")
-	testWithQuestDB(t, questdb, container)
+	testWithQuestDB(t, questdb, &container)
 }
 
-func testWithQuestDB(t *testing.T, questdb *QuestDB, container testutil.Container) {
+func testWithQuestDB(t *testing.T, questdb *QuestDB, container *testutil.Container) {
 	err := questdb.Connect()
 	require.NoError(t, err, "error connecting to QuestDB")
 	defer questdb.Close()
@@ -153,10 +153,10 @@ func testWithQuestDB(t *testing.T, questdb *QuestDB, container testutil.Containe
 	require.True(t, reflect.DeepEqual(receivedObj, expectedObj), "Received object does not match expected object")
 }
 
-func queryTestTable(t *testing.T, container testutil.Container) *http.Response {
+func queryTestTable(t *testing.T, container *testutil.Container) *http.Response {
 	client := http.Client{}
 
-	for i := 0; i < 10; i++ {
+	for i := 0; i < 30; i++ {
 		response, err := client.Get("http://" + container.Address + ":" + container.Ports["9000"] + "/exec?query=select%20*%20from%20test")
 		if err != nil {
 			t.Logf("QuestDB HTTP API error: %s", err)

--- a/plugins/outputs/questdb/questdb_test.go
+++ b/plugins/outputs/questdb/questdb_test.go
@@ -1,0 +1,260 @@
+package questdb
+
+import (
+	"bufio"
+	"encoding/json"
+	"github.com/testcontainers/testcontainers-go/wait"
+	"io"
+	"net"
+	"net/http"
+	"path/filepath"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/plugins/serializers/influx"
+	"github.com/influxdata/telegraf/testutil"
+)
+
+func newSerializer(t *testing.T) influx.Serializer {
+	serializer := influx.Serializer{UintSupport: false}
+	err := serializer.Init()
+	require.NoError(t, err)
+	return serializer
+}
+
+func newQuestDB(addr string) *QuestDB {
+	return &QuestDB{
+		Address: addr,
+	}
+}
+
+func newQuestDBAuth(addr string, user string, token string) *QuestDB {
+	return &QuestDB{
+		Address: addr,
+		User:    user,
+		Token:   token,
+	}
+}
+
+func TestQuestDB_tcp(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	sw := newQuestDB("tcp://" + listener.Addr().String())
+	require.NoError(t, sw.Connect())
+
+	lconn, err := listener.Accept()
+	require.NoError(t, err)
+
+	testQuestDBStream(t, sw, lconn)
+}
+
+func TestQuestDB_udp_not_supported(t *testing.T) {
+	listener, err := net.ListenPacket("udp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer listener.Close()
+
+	sw := newQuestDB("udp://" + listener.LocalAddr().String())
+	require.Error(t, sw.Connect())
+}
+
+func TestQuestDB_unix_unsupported(t *testing.T) {
+	sw := newQuestDB("unix://whatever")
+	require.Error(t, sw.Connect())
+}
+
+func TestQuestDB_unixgram_unsupported(t *testing.T) {
+	sw := newQuestDB("unixgram://whatever")
+	require.Error(t, sw.Connect())
+}
+
+func TestQuestDBNoAuthIntegration(t *testing.T) {
+	container := testutil.Container{
+		Image:        "questdb/questdb",
+		ExposedPorts: []string{"9009", "9000"},
+		WaitingFor:   wait.NewHostPortStrategy("9009"),
+	}
+	err := container.Start()
+	require.NoError(t, err, "failed to start QuestDB container")
+	defer container.Terminate()
+
+	questdb := newQuestDB("tcp://" + container.Address + ":" + container.Ports["9009"])
+	testWithQuestDB(t, questdb, container)
+}
+
+func TestQuestDBAuthIntegration(t *testing.T) {
+	auth, err := filepath.Abs("testdata/auth.txt")
+	require.NoError(t, err)
+	container := testutil.Container{
+		Image:        "questdb/questdb",
+		ExposedPorts: []string{"9009", "9000"},
+		WaitingFor:   wait.NewHostPortStrategy("9009"),
+		Env: map[string]string{
+			"QDB_LINE_TCP_AUTH_DB_PATH": "conf/authDb.txt",
+		},
+		BindMounts: map[string]string{
+			"/var/lib/questdb/conf/authDb.txt": auth,
+		},
+	}
+	err = container.Start()
+	require.NoError(t, err, "failed to start QuestDB container")
+	defer container.Terminate()
+
+	questdb := newQuestDBAuth("tcp://"+container.Address+":"+container.Ports["9009"], "testUser1", "UvuVb1USHGRRT08gEnwN2zGZrvM4MsLQ5brgF6SVkAw")
+	testWithQuestDB(t, questdb, container)
+}
+
+func testWithQuestDB(t *testing.T, questdb *QuestDB, container testutil.Container) {
+	err := questdb.Connect()
+	require.NoError(t, err, "error connecting to QuestDB")
+	defer questdb.Close()
+
+	metrics := []telegraf.Metric{}
+	metrics = append(metrics, testutil.TestMetric(1, "test"))
+	metrics = append(metrics, testutil.TestMetric(2, "test"))
+
+	err = questdb.Write(metrics)
+	require.NoError(t, err, "error writing to QuestDB")
+
+	response := queryTestTable(t, container)
+	defer response.Body.Close()
+
+	b, err := io.ReadAll(response.Body)
+	require.NoError(t, err, "Error reading response body")
+
+	var receivedObj map[string]interface{}
+	err = json.Unmarshal(b, &receivedObj)
+	require.NoError(t, err, "Error unmarshaling received JSON")
+
+	expectedJSON := `{
+		"query":"select * from test",
+		"columns":[{"name":"tag1","type":"SYMBOL"},{"name":"value","type":"LONG"},{"name":"timestamp","type":"TIMESTAMP"}],
+		"timestamp":2,
+		"dataset":[["value1",1,"2009-11-10T23:00:00.000000Z"],["value1",2,"2009-11-10T23:00:00.000000Z"]],
+		"count":2
+	}`
+	var expectedObj map[string]interface{}
+	err = json.Unmarshal([]byte(expectedJSON), &expectedObj)
+	require.NoError(t, err, "Error unmarshaling expected JSON")
+
+	require.True(t, reflect.DeepEqual(receivedObj, expectedObj), "Received object does not match expected object")
+}
+
+func queryTestTable(t *testing.T, container testutil.Container) *http.Response {
+	client := http.Client{}
+
+	for i := 0; i < 10; i++ {
+		response, err := client.Get("http://" + container.Address + ":" + container.Ports["9000"] + "/exec?query=select%20*%20from%20test")
+		if err != nil {
+			t.Logf("QuestDB HTTP API error: %s", err)
+			time.Sleep(1 * time.Second)
+			continue
+		}
+		if response.StatusCode != 200 {
+			t.Logf("QuestDB HTTP API error: %s", response.Status)
+			time.Sleep(1 * time.Second)
+			continue
+		}
+		require.NotNil(t, response)
+		require.Equal(t, 200, response.StatusCode)
+		return response
+	}
+	require.Fail(t, "QuestDB HTTP API did not become available")
+	return nil
+}
+
+func testQuestDBStream(t *testing.T, sw *QuestDB, lconn net.Conn) {
+	serializer := newSerializer(t)
+
+	metrics := []telegraf.Metric{}
+	metrics = append(metrics, testutil.TestMetric(1, "test"))
+	mbs1out, _ := serializer.Serialize(metrics[0])
+	mbs1out, _ = sw.encoder.Encode(mbs1out)
+	metrics = append(metrics, testutil.TestMetric(2, "test"))
+	mbs2out, _ := serializer.Serialize(metrics[1])
+	mbs2out, _ = sw.encoder.Encode(mbs2out)
+
+	err := sw.Write(metrics)
+	require.NoError(t, err)
+
+	scnr := bufio.NewScanner(lconn)
+	require.True(t, scnr.Scan())
+	mstr1in := scnr.Text() + "\n"
+	require.True(t, scnr.Scan())
+	mstr2in := scnr.Text() + "\n"
+
+	require.Equal(t, string(mbs1out), mstr1in)
+	require.Equal(t, string(mbs2out), mstr2in)
+}
+
+func TestQuestDB_Write_err(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	sw := newQuestDB("tcp://" + listener.Addr().String())
+	require.NoError(t, sw.Connect())
+	require.NoError(t, sw.Conn.(*net.TCPConn).SetReadBuffer(256))
+
+	lconn, err := listener.Accept()
+	require.NoError(t, err)
+	err = lconn.(*net.TCPConn).SetWriteBuffer(256)
+	require.NoError(t, err)
+
+	metrics := []telegraf.Metric{testutil.TestMetric(1, "testerr")}
+
+	// close the socket to generate an error
+	err = lconn.Close()
+	require.NoError(t, err)
+
+	err = sw.Conn.Close()
+	require.NoError(t, err)
+
+	err = sw.Write(metrics)
+	require.Error(t, err)
+	require.Nil(t, sw.Conn)
+}
+
+func TestQuestDB_Write_reconnect(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	sw := newQuestDB("tcp://" + listener.Addr().String())
+	require.NoError(t, sw.Connect())
+	require.NoError(t, sw.Conn.(*net.TCPConn).SetReadBuffer(256))
+
+	lconn, err := listener.Accept()
+	require.NoError(t, err)
+	err = lconn.(*net.TCPConn).SetWriteBuffer(256)
+	require.NoError(t, err)
+
+	err = lconn.Close()
+	require.NoError(t, err)
+	sw.Conn = nil
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	var lerr error
+	go func() {
+		lconn, lerr = listener.Accept()
+		wg.Done()
+	}()
+
+	metrics := []telegraf.Metric{testutil.TestMetric(1, "testerr")}
+	err = sw.Write(metrics)
+	require.NoError(t, err)
+
+	wg.Wait()
+	require.NoError(t, lerr)
+
+	serializer := newSerializer(t)
+	mbsout, _ := serializer.Serialize(metrics[0])
+	buf := make([]byte, 256)
+	n, err := lconn.Read(buf)
+	require.NoError(t, err)
+	require.Equal(t, string(mbsout), string(buf[:n]))
+}

--- a/plugins/outputs/questdb/questdb_test.go
+++ b/plugins/outputs/questdb/questdb_test.go
@@ -3,6 +3,7 @@ package questdb
 import (
 	"bufio"
 	"encoding/json"
+	"github.com/influxdata/telegraf/config"
 	"github.com/testcontainers/testcontainers-go/wait"
 	"io"
 	"net"
@@ -37,7 +38,7 @@ func newQuestDBAuth(addr string, user string, token string) *QuestDB {
 	return &QuestDB{
 		Address: addr,
 		User:    user,
-		Token:   token,
+		Token:   config.NewSecret([]byte(token)),
 	}
 }
 

--- a/plugins/outputs/questdb/sample.conf
+++ b/plugins/outputs/questdb/sample.conf
@@ -1,0 +1,20 @@
+# QuestDB writer, supports authentication
+[[outputs.questdb]]
+  ## URL to connect to
+  # address = "tcp://127.0.0.1:9009"
+
+  ## Optional authentication
+  # user = "admin"
+  # token = "M34uWQbu_eKO3S5NnFOBXq3u43nXHwHfU34hykhDdEY"
+
+  ## Optional TLS Config
+  # tls_ca = "/etc/telegraf/ca.pem"
+  # tls_cert = "/etc/telegraf/cert.pem"
+  # tls_key = "/etc/telegraf/key.pem"
+  ## Use TLS but skip chain & host verification
+  # insecure_skip_verify = false
+
+  ## Period between keep alive probes.
+  ## 0 disables keep alive probes.
+  ## Defaults to the OS configuration.
+  # keep_alive_period = "5m"

--- a/plugins/outputs/questdb/testdata/auth.txt
+++ b/plugins/outputs/questdb/testdata/auth.txt
@@ -1,0 +1,2 @@
+testUser1	ec-p-256-sha256	AKfkxOBlqBN8uDfTxu2Oo6iNsOPBnXkEH4gt44tBJKCY	AL7WVjoH-IfeX_CXo5G1xXKp_PqHUrdo3xeRyDuWNbBX
+


### PR DESCRIPTION
- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

The plugin is based on SocketWriter and at this point, it's only adding authentication support, removing unnecessary configuration options and adding an integration test.

The code is a literal copy'n'paste from the Socker Writer output with the changes described above.