### PR TITLE
chore(linters): Fix findings found by testifylint: compares

### DIFF
--- a/agent/tick_test.go
+++ b/agent/tick_test.go
@@ -74,8 +74,8 @@ func TestAlignedTickerJitter(t *testing.T) {
 		case tm := <-ticker.Elapsed():
 			dur := tm.Sub(last)
 			// 10s interval + 5s jitter + up to 1s late firing.
-			require.True(t, dur <= 16*time.Second, "expected elapsed time to be less than 16 seconds, but was %s", dur)
-			require.True(t, dur >= 5*time.Second, "expected elapsed time to be more than 5 seconds, but was %s", dur)
+			require.LessOrEqual(t, dur, 16*time.Second, "expected elapsed time to be less than 16 seconds, but was %s", dur)
+			require.GreaterOrEqual(t, dur, 5*time.Second, "expected elapsed time to be more than 5 seconds, but was %s", dur)
 			last = last.Add(interval)
 		default:
 		}
@@ -252,7 +252,7 @@ func TestAlignedTickerDistribution(t *testing.T) {
 	defer ticker.Stop()
 	dist := simulatedDist(ticker, clk)
 	printDist(dist)
-	require.True(t, 350 < dist.Count)
+	require.Less(t, 350, dist.Count)
 	require.True(t, 9 < dist.Mean() && dist.Mean() < 11)
 }
 
@@ -278,7 +278,7 @@ func TestAlignedTickerDistributionWithOffset(t *testing.T) {
 	defer ticker.Stop()
 	dist := simulatedDist(ticker, clk)
 	printDist(dist)
-	require.True(t, 350 < dist.Count)
+	require.Less(t, 350, dist.Count)
 	require.True(t, 9 < dist.Mean() && dist.Mean() < 11)
 }
 
@@ -304,7 +304,7 @@ func TestUnalignedTickerDistribution(t *testing.T) {
 	defer ticker.Stop()
 	dist := simulatedDist(ticker, clk)
 	printDist(dist)
-	require.True(t, 350 < dist.Count)
+	require.Less(t, 350, dist.Count)
 	require.True(t, 9 < dist.Mean() && dist.Mean() < 11)
 }
 
@@ -328,7 +328,7 @@ func TestUnalignedTickerDistributionWithOffset(t *testing.T) {
 	defer ticker.Stop()
 	dist := simulatedDist(ticker, clk)
 	printDist(dist)
-	require.True(t, 350 < dist.Count)
+	require.Less(t, 350, dist.Count)
 	require.True(t, 9 < dist.Mean() && dist.Mean() < 11)
 }
 
@@ -352,7 +352,7 @@ func TestRollingTickerDistribution(t *testing.T) {
 	defer ticker.Stop()
 	dist := simulatedDist(ticker, clk)
 	printDist(dist)
-	require.True(t, 275 < dist.Count)
+	require.Less(t, 275, dist.Count)
 	require.True(t, 12 < dist.Mean() && 13 > dist.Mean())
 }
 

--- a/internal/internal_test.go
+++ b/internal/internal_test.go
@@ -63,7 +63,7 @@ func TestRunTimeout(t *testing.T) {
 
 	require.Equal(t, ErrTimeout, err)
 	// Verify that command gets killed in 20ms, with some breathing room
-	require.True(t, elapsed < time.Millisecond*75)
+	require.Less(t, elapsed, time.Millisecond*75)
 }
 
 // Verifies behavior of a command that doesn't get killed.
@@ -83,7 +83,7 @@ func TestRunTimeoutFastExit(t *testing.T) {
 
 	require.NoError(t, err)
 	// Verify that command gets killed in 20ms, with some breathing room
-	require.True(t, elapsed < time.Millisecond*75)
+	require.Less(t, elapsed, time.Millisecond*75)
 
 	// Verify "process already finished" log doesn't occur.
 	time.Sleep(time.Millisecond * 75)
@@ -103,7 +103,7 @@ func TestCombinedOutputTimeout(t *testing.T) {
 
 	require.Equal(t, ErrTimeout, err)
 	// Verify that command gets killed in 20ms, with some breathing room
-	require.True(t, elapsed < time.Millisecond*75)
+	require.Less(t, elapsed, time.Millisecond*75)
 }
 
 func TestCombinedOutput(t *testing.T) {
@@ -151,13 +151,13 @@ func TestRandomSleep(t *testing.T) {
 	s := time.Now()
 	RandomSleep(time.Duration(0), make(chan struct{}))
 	elapsed := time.Since(s)
-	require.True(t, elapsed < time.Millisecond)
+	require.Less(t, elapsed, time.Millisecond)
 
 	// test that max sleep is respected
 	s = time.Now()
 	RandomSleep(time.Millisecond*50, make(chan struct{}))
 	elapsed = time.Since(s)
-	require.True(t, elapsed < time.Millisecond*100)
+	require.Less(t, elapsed, time.Millisecond*100)
 
 	// test that shutdown is respected
 	s = time.Now()
@@ -168,7 +168,7 @@ func TestRandomSleep(t *testing.T) {
 	}()
 	RandomSleep(time.Second, shutdown)
 	elapsed = time.Since(s)
-	require.True(t, elapsed < time.Millisecond*150)
+	require.Less(t, elapsed, time.Millisecond*150)
 }
 
 func TestCompressWithGzip(t *testing.T) {

--- a/plugins/inputs/pgbouncer/pgbouncer_test.go
+++ b/plugins/inputs/pgbouncer/pgbouncer_test.go
@@ -98,7 +98,7 @@ func TestPgBouncerGeneratesMetricsIntegration(t *testing.T) {
 		metricsCounted++
 	}
 
-	require.True(t, metricsCounted > 0)
+	require.Greater(t, metricsCounted, 0)
 	require.Equal(t, len(intMetricsPgBouncer)+len(intMetricsPgBouncerPools), metricsCounted)
 }
 
@@ -208,6 +208,6 @@ func TestPgBouncerGeneratesMetricsIntegrationShowCommands(t *testing.T) {
 		metricsCounted++
 	}
 
-	require.True(t, metricsCounted > 0)
+	require.Greater(t, metricsCounted, 0)
 	require.Equal(t, len(intMetricsPgBouncerPools)+len(intMetricsPgBouncerLists)+len(intMetricsPgBouncerDatabases), metricsCounted)
 }

--- a/plugins/inputs/ping/ping_test.go
+++ b/plugins/inputs/ping/ping_test.go
@@ -405,7 +405,7 @@ func TestPingBinary(t *testing.T) {
 		Urls:   []string{"www.google.com"},
 		Binary: "ping6",
 		pingHost: func(binary string, timeout float64, args ...string) (string, error) {
-			require.True(t, binary == "ping6")
+			require.Equal(t, binary, "ping6")
 			return "", nil
 		},
 	}

--- a/plugins/inputs/postgresql/postgresql_test.go
+++ b/plugins/inputs/postgresql/postgresql_test.go
@@ -122,7 +122,7 @@ func TestPostgresqlGeneratesMetricsIntegration(t *testing.T) {
 		metricsCounted++
 	}
 
-	require.True(t, metricsCounted > 0)
+	require.Greater(t, metricsCounted, 0)
 	require.Equal(t, len(floatMetrics)+len(intMetrics)+len(int32Metrics)+len(stringMetrics), metricsCounted)
 }
 

--- a/plugins/inputs/postgresql_extensible/postgresql_extensible_test.go
+++ b/plugins/inputs/postgresql_extensible/postgresql_extensible_test.go
@@ -119,7 +119,7 @@ func TestPostgresqlGeneratesMetricsIntegration(t *testing.T) {
 		metricsCounted++
 	}
 
-	require.True(t, metricsCounted > 0)
+	require.Greater(t, metricsCounted, 0)
 	require.Equal(t, len(floatMetrics)+len(intMetrics)+len(int32Metrics)+len(stringMetrics), metricsCounted)
 }
 

--- a/plugins/inputs/processes/processes_test.go
+++ b/plugins/inputs/processes/processes_test.go
@@ -34,7 +34,7 @@ func TestProcesses(t *testing.T) {
 	require.True(t, acc.HasInt64Field("processes", "total"))
 	total, ok := acc.Get("processes")
 	require.True(t, ok)
-	require.Greater(t, total.Fields["total"].(int64), 0)
+	require.Greater(t, total.Fields["total"].(int64), int64(0))
 }
 
 func TestFromPS(t *testing.T) {

--- a/plugins/inputs/processes/processes_test.go
+++ b/plugins/inputs/processes/processes_test.go
@@ -34,7 +34,7 @@ func TestProcesses(t *testing.T) {
 	require.True(t, acc.HasInt64Field("processes", "total"))
 	total, ok := acc.Get("processes")
 	require.True(t, ok)
-	require.True(t, total.Fields["total"].(int64) > 0)
+	require.Greater(t, total.Fields["total"].(int64), 0)
 }
 
 func TestFromPS(t *testing.T) {

--- a/plugins/inputs/prometheus/prometheus_test.go
+++ b/plugins/inputs/prometheus/prometheus_test.go
@@ -75,7 +75,7 @@ func TestPrometheusGeneratesMetrics(t *testing.T) {
 	require.True(t, acc.HasFloatField("test_metric", "value"))
 	require.True(t, acc.HasTimestamp("test_metric", time.Unix(1490802350, 0)))
 	require.False(t, acc.HasTag("test_metric", "address"))
-	require.True(t, acc.TagValue("test_metric", "url") == ts.URL+"/metrics")
+	require.Equal(t, acc.TagValue("test_metric", "url"), ts.URL+"/metrics")
 }
 
 func TestPrometheusCustomHeader(t *testing.T) {
@@ -164,8 +164,8 @@ func TestPrometheusGeneratesMetricsWithHostNameTag(t *testing.T) {
 	require.True(t, acc.HasFloatField("go_goroutines", "gauge"))
 	require.True(t, acc.HasFloatField("test_metric", "value"))
 	require.True(t, acc.HasTimestamp("test_metric", time.Unix(1490802350, 0)))
-	require.True(t, acc.TagValue("test_metric", "address") == tsAddress)
-	require.True(t, acc.TagValue("test_metric", "url") == ts.URL)
+	require.Equal(t, acc.TagValue("test_metric", "address"), tsAddress)
+	require.Equal(t, acc.TagValue("test_metric", "url"), ts.URL)
 }
 
 func TestPrometheusWithTimestamp(t *testing.T) {
@@ -260,7 +260,7 @@ func TestPrometheusGeneratesMetricsSlowEndpoint(t *testing.T) {
 	require.True(t, acc.HasFloatField("test_metric", "value"))
 	require.True(t, acc.HasTimestamp("test_metric", time.Unix(1490802350, 0)))
 	require.False(t, acc.HasTag("test_metric", "address"))
-	require.True(t, acc.TagValue("test_metric", "url") == ts.URL+"/metrics")
+	require.Equal(t, acc.TagValue("test_metric", "url"), ts.URL+"/metrics")
 }
 
 func TestPrometheusGeneratesMetricsSlowEndpointHitTheTimeout(t *testing.T) {
@@ -317,7 +317,7 @@ func TestPrometheusGeneratesMetricsSlowEndpointNewConfigParameter(t *testing.T) 
 	require.True(t, acc.HasFloatField("test_metric", "value"))
 	require.True(t, acc.HasTimestamp("test_metric", time.Unix(1490802350, 0)))
 	require.False(t, acc.HasTag("test_metric", "address"))
-	require.True(t, acc.TagValue("test_metric", "url") == ts.URL+"/metrics")
+	require.Equal(t, acc.TagValue("test_metric", "url"), ts.URL+"/metrics")
 }
 
 func TestPrometheusGeneratesMetricsSlowEndpointHitTheTimeoutNewConfigParameter(t *testing.T) {
@@ -364,10 +364,10 @@ func TestPrometheusGeneratesSummaryMetricsV2(t *testing.T) {
 	err = acc.GatherError(p.Gather)
 	require.NoError(t, err)
 
-	require.True(t, acc.TagSetValue("prometheus", "quantile") == "0")
+	require.Equal(t, acc.TagSetValue("prometheus", "quantile"), "0")
 	require.True(t, acc.HasFloatField("prometheus", "go_gc_duration_seconds_sum"))
 	require.True(t, acc.HasFloatField("prometheus", "go_gc_duration_seconds_count"))
-	require.True(t, acc.TagValue("prometheus", "url") == ts.URL+"/metrics")
+	require.Equal(t, acc.TagValue("prometheus", "url"), ts.URL+"/metrics")
 }
 
 func TestSummaryMayContainNaN(t *testing.T) {
@@ -459,7 +459,7 @@ func TestPrometheusGeneratesGaugeMetricsV2(t *testing.T) {
 	require.NoError(t, err)
 
 	require.True(t, acc.HasFloatField("prometheus", "go_goroutines"))
-	require.True(t, acc.TagValue("prometheus", "url") == ts.URL+"/metrics")
+	require.Equal(t, acc.TagValue("prometheus", "url"), ts.URL+"/metrics")
 	require.True(t, acc.HasTimestamp("prometheus", time.Unix(1490802350, 0)))
 }
 

--- a/plugins/inputs/vsphere/vsphere_test.go
+++ b/plugins/inputs/vsphere/vsphere_test.go
@@ -514,7 +514,7 @@ func testCollection(t *testing.T, excludeClusters bool) {
 	defer v.Stop()
 	require.NoError(t, v.Gather(&acc))
 	require.Equal(t, 0, len(acc.Errors), fmt.Sprintf("Errors found: %s", acc.Errors))
-	require.True(t, len(acc.Metrics) > 0, "No metrics were collected")
+	require.Greater(t, len(acc.Metrics), 0, "No metrics were collected")
 	cache := make(map[string]string)
 	client, err := v.endpoints[0].clientFactory.GetClient(context.Background())
 	require.NoError(t, err)

--- a/plugins/parsers/json/parser_test.go
+++ b/plugins/parsers/json/parser_test.go
@@ -672,7 +672,7 @@ func TestTimeParser(t *testing.T) {
 	metrics, err := parser.Parse([]byte(testString))
 	require.NoError(t, err)
 	require.Equal(t, 2, len(metrics))
-	require.False(t, metrics[0].Time() == metrics[1].Time())
+	require.NotEqual(t, metrics[0].Time(), metrics[1].Time())
 }
 
 func TestTimeParserWithTimezone(t *testing.T) {
@@ -726,7 +726,7 @@ func TestUnixTimeParser(t *testing.T) {
 	metrics, err := parser.Parse([]byte(testString))
 	require.NoError(t, err)
 	require.Equal(t, 2, len(metrics))
-	require.False(t, metrics[0].Time() == metrics[1].Time())
+	require.NotEqual(t, metrics[0].Time(), metrics[1].Time())
 }
 
 func TestUnixMsTimeParser(t *testing.T) {
@@ -761,7 +761,7 @@ func TestUnixMsTimeParser(t *testing.T) {
 	metrics, err := parser.Parse([]byte(testString))
 	require.NoError(t, err)
 	require.Equal(t, 2, len(metrics))
-	require.False(t, metrics[0].Time() == metrics[1].Time())
+	require.NotEqual(t, metrics[0].Time(), metrics[1].Time())
 }
 
 func TestTimeErrors(t *testing.T) {
@@ -815,7 +815,7 @@ func TestShareTimestamp(t *testing.T) {
 	metrics, err := parser.Parse([]byte(validJSONArrayMultiple))
 	require.NoError(t, err)
 	require.Equal(t, 2, len(metrics))
-	require.True(t, metrics[0].Time() == metrics[1].Time())
+	require.Equal(t, metrics[0].Time(), metrics[1].Time())
 }
 
 func TestNameKey(t *testing.T) {

--- a/plugins/processors/starlark/starlark_test.go
+++ b/plugins/processors/starlark/starlark_test.go
@@ -3375,7 +3375,7 @@ func parseErrorMessage(t *testing.T, lines []string, header string) string {
 	if startIdx == -1 {
 		return ""
 	}
-	require.True(t, startIdx < len(lines), fmt.Sprintf("Expected to find the error message after %q, but found none", header))
+	require.Less(t, startIdx, len(lines), fmt.Sprintf("Expected to find the error message after %q, but found none", header))
 	return strings.TrimLeft(lines[startIdx], "# ")
 }
 


### PR DESCRIPTION
Address findings for [testifylint: compares](https://github.com/Antonboom/testifylint#compares) - checks usage of github.com/stretchr/testify.

```
❌   assert.True(t, a == b)
     assert.True(t, a != b)
     assert.True(t, a > b)
     assert.True(t, a >= b)
     assert.True(t, a < b)
     assert.True(t, a <= b)
     // And other variations (with assert.False too)...

✅   assert.Equal(t, a, b)
     assert.NotEqual(t, a, b)
     assert.Greater(t, a, b)
     assert.GreaterOrEqual(t, a, b)
     assert.Less(t, a, b)
     assert.LessOrEqual(t, a, b)
```

It is only part of the bigger job.
After all type of findings in whole project are handled, we can enable `testifylint` linter in `golangci-lint`.