### PR TITLE
test(opensearch): Disable perf analyzer in test images

### DIFF
--- a/plugins/inputs/opensearch_query/opensearch_query_test.go
+++ b/plugins/inputs/opensearch_query/opensearch_query_test.go
@@ -551,7 +551,8 @@ func setupIntegrationTest(t *testing.T, image string) (*testutil.Container, *Ope
 		Image:        image,
 		ExposedPorts: []string{servicePort},
 		Env: map[string]string{
-			"discovery.type": "single-node",
+			"discovery.type":                         "single-node",
+			"DISABLE_PERFORMANCE_ANALYZER_AGENT_CLI": "true",
 		},
 		WaitingFor: wait.ForAll(
 			wait.ForLog(".opendistro_security is used as internal security index."),

--- a/plugins/outputs/opensearch/opensearch_test.go
+++ b/plugins/outputs/opensearch/opensearch_test.go
@@ -23,9 +23,10 @@ func launchTestContainer(t *testing.T, imageVersion string) *testutil.Container 
 		Image:        "opensearchproject/opensearch:" + imageVersion,
 		ExposedPorts: []string{servicePort},
 		Env: map[string]string{
-			"discovery.type":              "single-node",
-			"DISABLE_INSTALL_DEMO_CONFIG": "true",
-			"DISABLE_SECURITY_PLUGIN":     "true",
+			"discovery.type":                         "single-node",
+			"DISABLE_INSTALL_DEMO_CONFIG":            "true",
+			"DISABLE_SECURITY_PLUGIN":                "true",
+			"DISABLE_PERFORMANCE_ANALYZER_AGENT_CLI": "true",
 		},
 		WaitingFor: wait.ForAll(
 			wait.ForListeningPort(nat.Port(servicePort)),


### PR DESCRIPTION
The performance analyzer agent is known to be heavy-weight, and not something we need for our testing. As such let's disable it to prevent issues with starting up a container.