### PR TITLE
chore(linters): Fix findings found by testifylint: empty

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -43,7 +43,7 @@ func TestAgent_LoadPlugin(t *testing.T) {
 	err = c.LoadConfig("../config/testdata/telegraf-agent.toml")
 	require.NoError(t, err)
 	a = NewAgent(c)
-	require.Equal(t, 0, len(a.Config.Inputs))
+	require.Empty(t, a.Config.Inputs)
 
 	c = config.NewConfig()
 	c.InputFilters = []string{"mysql", "foo"}
@@ -94,7 +94,7 @@ func TestAgent_LoadOutput(t *testing.T) {
 	err = c.LoadConfig("../config/testdata/telegraf-agent.toml")
 	require.NoError(t, err)
 	a = NewAgent(c)
-	require.Equal(t, 0, len(a.Config.Outputs))
+	require.Empty(t, a.Config.Outputs)
 
 	c = config.NewConfig()
 	c.OutputFilters = []string{"influxdb", "foo"}

--- a/models/buffer_test.go
+++ b/models/buffer_test.go
@@ -4,10 +4,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/metric"
 	"github.com/influxdata/telegraf/testutil"
-	"github.com/stretchr/testify/require"
 )
 
 type MockMetric struct {
@@ -95,14 +96,14 @@ func TestBuffer_BatchLenZero(t *testing.T) {
 	b := setup(NewBuffer("test", "", 5))
 	batch := b.Batch(0)
 
-	require.Len(t, batch, 0)
+	require.Empty(t, batch)
 }
 
 func TestBuffer_BatchLenBufferEmpty(t *testing.T) {
 	b := setup(NewBuffer("test", "", 5))
 	batch := b.Batch(2)
 
-	require.Len(t, batch, 0)
+	require.Empty(t, batch)
 }
 
 func TestBuffer_BatchLenUnderfill(t *testing.T) {

--- a/models/filter_test.go
+++ b/models/filter_test.go
@@ -89,7 +89,7 @@ func TestFilter_ApplyDeleteAllFields(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, selected)
 	f.Modify(m)
-	require.Len(t, m.FieldList(), 0)
+	require.Empty(t, m.FieldList())
 }
 
 func TestFilter_Empty(t *testing.T) {

--- a/models/running_output_test.go
+++ b/models/running_output_test.go
@@ -94,7 +94,7 @@ func TestRunningOutput_DropFilter(t *testing.T) {
 	for _, metric := range next5 {
 		ro.AddMetric(metric)
 	}
-	require.Len(t, m.Metrics(), 0)
+	require.Empty(t, m.Metrics())
 
 	err := ro.Write()
 	require.NoError(t, err)
@@ -119,7 +119,7 @@ func TestRunningOutput_PassFilter(t *testing.T) {
 	for _, metric := range next5 {
 		ro.AddMetric(metric)
 	}
-	require.Len(t, m.Metrics(), 0)
+	require.Empty(t, m.Metrics())
 
 	err := ro.Write()
 	require.NoError(t, err)
@@ -139,7 +139,7 @@ func TestRunningOutput_TagIncludeNoMatch(t *testing.T) {
 	ro := NewRunningOutput(m, conf, 1000, 10000)
 
 	ro.AddMetric(testutil.TestMetric(101, "metric1"))
-	require.Len(t, m.Metrics(), 0)
+	require.Empty(t, m.Metrics())
 
 	err := ro.Write()
 	require.NoError(t, err)
@@ -160,12 +160,12 @@ func TestRunningOutput_TagExcludeMatch(t *testing.T) {
 	ro := NewRunningOutput(m, conf, 1000, 10000)
 
 	ro.AddMetric(testutil.TestMetric(101, "metric1"))
-	require.Len(t, m.Metrics(), 0)
+	require.Empty(t, m.Metrics())
 
 	err := ro.Write()
 	require.NoError(t, err)
 	require.Len(t, m.Metrics(), 1)
-	require.Len(t, m.Metrics()[0].Tags(), 0)
+	require.Empty(t, m.Metrics()[0].Tags())
 }
 
 // Test that tags are properly Excluded
@@ -181,7 +181,7 @@ func TestRunningOutput_TagExcludeNoMatch(t *testing.T) {
 	ro := NewRunningOutput(m, conf, 1000, 10000)
 
 	ro.AddMetric(testutil.TestMetric(101, "metric1"))
-	require.Len(t, m.Metrics(), 0)
+	require.Empty(t, m.Metrics())
 
 	err := ro.Write()
 	require.NoError(t, err)
@@ -202,7 +202,7 @@ func TestRunningOutput_TagIncludeMatch(t *testing.T) {
 	ro := NewRunningOutput(m, conf, 1000, 10000)
 
 	ro.AddMetric(testutil.TestMetric(101, "metric1"))
-	require.Len(t, m.Metrics(), 0)
+	require.Empty(t, m.Metrics())
 
 	err := ro.Write()
 	require.NoError(t, err)
@@ -220,7 +220,7 @@ func TestRunningOutput_NameOverride(t *testing.T) {
 	ro := NewRunningOutput(m, conf, 1000, 10000)
 
 	ro.AddMetric(testutil.TestMetric(101, "metric1"))
-	require.Len(t, m.Metrics(), 0)
+	require.Empty(t, m.Metrics())
 
 	err := ro.Write()
 	require.NoError(t, err)
@@ -238,7 +238,7 @@ func TestRunningOutput_NamePrefix(t *testing.T) {
 	ro := NewRunningOutput(m, conf, 1000, 10000)
 
 	ro.AddMetric(testutil.TestMetric(101, "metric1"))
-	require.Len(t, m.Metrics(), 0)
+	require.Empty(t, m.Metrics())
 
 	err := ro.Write()
 	require.NoError(t, err)
@@ -256,7 +256,7 @@ func TestRunningOutput_NameSuffix(t *testing.T) {
 	ro := NewRunningOutput(m, conf, 1000, 10000)
 
 	ro.AddMetric(testutil.TestMetric(101, "metric1"))
-	require.Len(t, m.Metrics(), 0)
+	require.Empty(t, m.Metrics())
 
 	err := ro.Write()
 	require.NoError(t, err)
@@ -279,7 +279,7 @@ func TestRunningOutputDefault(t *testing.T) {
 	for _, metric := range next5 {
 		ro.AddMetric(metric)
 	}
-	require.Len(t, m.Metrics(), 0)
+	require.Empty(t, m.Metrics())
 
 	err := ro.Write()
 	require.NoError(t, err)
@@ -303,13 +303,13 @@ func TestRunningOutputWriteFail(t *testing.T) {
 		ro.AddMetric(metric)
 	}
 	// no successful flush yet
-	require.Len(t, m.Metrics(), 0)
+	require.Empty(t, m.Metrics())
 
 	// manual write fails
 	err := ro.Write()
 	require.Error(t, err)
 	// no successful flush yet
-	require.Len(t, m.Metrics(), 0)
+	require.Empty(t, m.Metrics())
 
 	m.failWrite = false
 	err = ro.Write()
@@ -333,13 +333,13 @@ func TestRunningOutputWriteFailOrder(t *testing.T) {
 		ro.AddMetric(metric)
 	}
 	// no successful flush yet
-	require.Len(t, m.Metrics(), 0)
+	require.Empty(t, m.Metrics())
 
 	// Write fails
 	err := ro.Write()
 	require.Error(t, err)
 	// no successful flush yet
-	require.Len(t, m.Metrics(), 0)
+	require.Empty(t, m.Metrics())
 
 	m.failWrite = false
 	// add 5 more metrics
@@ -374,7 +374,7 @@ func TestRunningOutputWriteFailOrder2(t *testing.T) {
 	err := ro.Write()
 	require.Error(t, err)
 	// no successful flush yet
-	require.Len(t, m.Metrics(), 0)
+	require.Empty(t, m.Metrics())
 
 	// add 5 metrics
 	for _, metric := range next5 {
@@ -384,7 +384,7 @@ func TestRunningOutputWriteFailOrder2(t *testing.T) {
 	err = ro.Write()
 	require.Error(t, err)
 	// no successful flush yet
-	require.Len(t, m.Metrics(), 0)
+	require.Empty(t, m.Metrics())
 
 	// add 5 metrics
 	for _, metric := range first5 {
@@ -394,7 +394,7 @@ func TestRunningOutputWriteFailOrder2(t *testing.T) {
 	err = ro.Write()
 	require.Error(t, err)
 	// no successful flush yet
-	require.Len(t, m.Metrics(), 0)
+	require.Empty(t, m.Metrics())
 
 	// add 5 metrics
 	for _, metric := range next5 {
@@ -404,7 +404,7 @@ func TestRunningOutputWriteFailOrder2(t *testing.T) {
 	err = ro.Write()
 	require.Error(t, err)
 	// no successful flush yet
-	require.Len(t, m.Metrics(), 0)
+	require.Empty(t, m.Metrics())
 
 	m.failWrite = false
 	err = ro.Write()
@@ -435,13 +435,13 @@ func TestRunningOutputWriteFailOrder3(t *testing.T) {
 		ro.AddMetric(metric)
 	}
 	// no successful flush yet
-	require.Len(t, m.Metrics(), 0)
+	require.Empty(t, m.Metrics())
 
 	// Write fails
 	err := ro.Write()
 	require.Error(t, err)
 	// no successful flush yet
-	require.Len(t, m.Metrics(), 0)
+	require.Empty(t, m.Metrics())
 
 	// add and attempt to write a single metric:
 	ro.AddMetric(next5[0])

--- a/plugins/aggregators/histogram/histogram_test.go
+++ b/plugins/aggregators/histogram/histogram_test.go
@@ -128,7 +128,7 @@ func TestHistogramPushOnUpdate(t *testing.T) {
 
 	acc.ClearMetrics()
 	histogram.Push(acc)
-	require.Len(t, acc.Metrics, 0, "Incorrect number of metrics")
+	require.Empty(t, acc.Metrics, "Incorrect number of metrics")
 	histogram.Add(firstMetric2)
 	histogram.Push(acc)
 

--- a/plugins/inputs/aurora/aurora_test.go
+++ b/plugins/inputs/aurora/aurora_test.go
@@ -7,8 +7,9 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/influxdata/telegraf/testutil"
 	"github.com/stretchr/testify/require"
+
+	"github.com/influxdata/telegraf/testutil"
 )
 
 type (
@@ -77,7 +78,7 @@ func TestAurora(t *testing.T) {
 			check: func(t *testing.T, err error, acc *testutil.Accumulator) {
 				require.NoError(t, err)
 				require.NoError(t, acc.FirstError())
-				require.Equal(t, 0, len(acc.Metrics))
+				require.Empty(t, acc.Metrics)
 			},
 		},
 		{
@@ -93,7 +94,7 @@ func TestAurora(t *testing.T) {
 			check: func(t *testing.T, err error, acc *testutil.Accumulator) {
 				require.NoError(t, err)
 				require.NoError(t, acc.FirstError())
-				require.Equal(t, 0, len(acc.Metrics))
+				require.Empty(t, acc.Metrics)
 			},
 		},
 		{
@@ -112,7 +113,7 @@ func TestAurora(t *testing.T) {
 			check: func(t *testing.T, err error, acc *testutil.Accumulator) {
 				require.NoError(t, err)
 				require.NoError(t, acc.FirstError())
-				require.Equal(t, 0, len(acc.Metrics))
+				require.Empty(t, acc.Metrics)
 			},
 		},
 		{
@@ -132,7 +133,7 @@ func TestAurora(t *testing.T) {
 			check: func(t *testing.T, err error, acc *testutil.Accumulator) {
 				require.NoError(t, err)
 				require.Error(t, acc.FirstError())
-				require.Equal(t, 0, len(acc.Metrics))
+				require.Empty(t, acc.Metrics)
 			},
 		},
 		{
@@ -152,7 +153,7 @@ func TestAurora(t *testing.T) {
 			check: func(t *testing.T, err error, acc *testutil.Accumulator) {
 				require.NoError(t, err)
 				require.Error(t, acc.FirstError())
-				require.Equal(t, 0, len(acc.Metrics))
+				require.Empty(t, acc.Metrics)
 			},
 		},
 		{
@@ -169,7 +170,7 @@ func TestAurora(t *testing.T) {
 			check: func(t *testing.T, err error, acc *testutil.Accumulator) {
 				require.NoError(t, err)
 				require.Error(t, acc.FirstError())
-				require.Equal(t, 0, len(acc.Metrics))
+				require.Empty(t, acc.Metrics)
 			},
 		},
 		{
@@ -188,7 +189,7 @@ func TestAurora(t *testing.T) {
 			check: func(t *testing.T, err error, acc *testutil.Accumulator) {
 				require.NoError(t, err)
 				require.Error(t, acc.FirstError())
-				require.Equal(t, 0, len(acc.Metrics))
+				require.Empty(t, acc.Metrics)
 			},
 		},
 	}

--- a/plugins/inputs/cassandra/cassandra_test.go
+++ b/plugins/inputs/cassandra/cassandra_test.go
@@ -190,7 +190,7 @@ func TestHttp404(t *testing.T) {
 	err := acc.GatherError(jolokia.Gather)
 
 	require.Error(t, err)
-	require.Equal(t, 0, len(acc.Metrics))
+	require.Empty(t, acc.Metrics)
 	require.Contains(t, err.Error(), "has status code 404")
 }
 

--- a/plugins/inputs/clickhouse/clickhouse_test.go
+++ b/plugins/inputs/clickhouse/clickhouse_test.go
@@ -516,7 +516,7 @@ func TestWrongJSONMarshalling(t *testing.T) {
 	defer ts.Close()
 	require.NoError(t, ch.Gather(acc))
 
-	require.Equal(t, 0, len(acc.Metrics))
+	require.Empty(t, acc.Metrics)
 	allMeasurements := []string{
 		"clickhouse_events",
 		"clickhouse_metrics",
@@ -549,7 +549,7 @@ func TestOfflineServer(t *testing.T) {
 	)
 	require.NoError(t, ch.Gather(acc))
 
-	require.Equal(t, 0, len(acc.Metrics))
+	require.Empty(t, acc.Metrics)
 	allMeasurements := []string{
 		"clickhouse_events",
 		"clickhouse_metrics",

--- a/plugins/inputs/couchbase/couchbase_test.go
+++ b/plugins/inputs/couchbase/couchbase_test.go
@@ -166,7 +166,7 @@ func TestGatherNodeOnly(t *testing.T) {
 	var acc testutil.Accumulator
 	require.NoError(t, cb.gatherServer(&acc, faker.URL))
 
-	require.Equal(t, 0, len(acc.Errors))
+	require.Empty(t, acc.Errors)
 	require.Equal(t, 7, len(acc.Metrics))
 	acc.AssertDoesNotContainMeasurement(t, "couchbase_bucket")
 }
@@ -197,7 +197,7 @@ func TestGatherFailover(t *testing.T) {
 
 	var acc testutil.Accumulator
 	require.NoError(t, cb.gatherServer(&acc, faker.URL))
-	require.Equal(t, 0, len(acc.Errors))
+	require.Empty(t, acc.Errors)
 	require.Equal(t, 8, len(acc.Metrics))
 
 	var metric *testutil.Metric

--- a/plugins/inputs/dpdk/dpdk_connector_test.go
+++ b/plugins/inputs/dpdk/dpdk_connector_test.go
@@ -127,7 +127,7 @@ func Test_getCommandResponse(t *testing.T) {
 
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "failed to get connection to execute \"/\" command")
-		require.Equal(t, 0, len(buf))
+		require.Empty(t, buf)
 	})
 
 	t.Run("should return error if failed to set timeout duration", func(t *testing.T) {
@@ -139,7 +139,7 @@ func Test_getCommandResponse(t *testing.T) {
 
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "deadline error")
-		require.Equal(t, 0, len(buf))
+		require.Empty(t, buf)
 	})
 
 	t.Run("should return error if timeout occurred during Write operation", func(t *testing.T) {
@@ -153,7 +153,7 @@ func Test_getCommandResponse(t *testing.T) {
 
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "write timeout")
-		require.Equal(t, 0, len(buf))
+		require.Empty(t, buf)
 	})
 
 	t.Run("should return error if timeout occurred during Read operation", func(t *testing.T) {
@@ -165,7 +165,7 @@ func Test_getCommandResponse(t *testing.T) {
 
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "read timeout")
-		require.Equal(t, 0, len(buf))
+		require.Empty(t, buf)
 	})
 
 	t.Run("should return error if got empty response", func(t *testing.T) {
@@ -176,7 +176,7 @@ func Test_getCommandResponse(t *testing.T) {
 		buf, err := dpdk.connector.getCommandResponse(command)
 
 		require.Error(t, err)
-		require.Equal(t, 0, len(buf))
+		require.Empty(t, buf)
 		require.Contains(t, err.Error(), "got empty response during execution of")
 	})
 }

--- a/plugins/inputs/dpdk/dpdk_test.go
+++ b/plugins/inputs/dpdk/dpdk_test.go
@@ -177,7 +177,7 @@ func Test_processCommand(t *testing.T) {
 
 		dpdk.processCommand(mockAcc, "/")
 
-		require.Equal(t, 0, len(mockAcc.Errors))
+		require.Empty(t, mockAcc.Errors)
 	})
 
 	t.Run("if received a non-JSON object then should return error", func(t *testing.T) {
@@ -249,7 +249,7 @@ func Test_getCommandsAndParamsCombinations(t *testing.T) {
 		commands := dpdk.gatherCommands(mockAcc)
 
 		require.ElementsMatch(t, commands, expectedCommands)
-		require.Equal(t, 0, len(mockAcc.Errors))
+		require.Empty(t, mockAcc.Errors)
 	})
 
 	t.Run("when 1 rawdev command is enabled, then 2*numberOfIds new commands should be appended", func(t *testing.T) {
@@ -265,7 +265,7 @@ func Test_getCommandsAndParamsCombinations(t *testing.T) {
 		commands := dpdk.gatherCommands(mockAcc)
 
 		require.ElementsMatch(t, commands, expectedCommands)
-		require.Equal(t, 0, len(mockAcc.Errors))
+		require.Empty(t, mockAcc.Errors)
 	})
 
 	t.Run("when 2 ethdev commands are enabled but one command is disabled, then numberOfIds new commands should be appended", func(t *testing.T) {
@@ -282,7 +282,7 @@ func Test_getCommandsAndParamsCombinations(t *testing.T) {
 		commands := dpdk.gatherCommands(mockAcc)
 
 		require.ElementsMatch(t, commands, expectedCommands)
-		require.Equal(t, 0, len(mockAcc.Errors))
+		require.Empty(t, mockAcc.Errors)
 	})
 
 	t.Run("when ethdev commands are enabled but params fetching command returns error then error should be logged in accumulator", func(t *testing.T) {
@@ -296,7 +296,7 @@ func Test_getCommandsAndParamsCombinations(t *testing.T) {
 		dpdk.AdditionalCommands = []string{}
 		commands := dpdk.gatherCommands(mockAcc)
 
-		require.Equal(t, 0, len(commands))
+		require.Empty(t, commands)
 		require.Equal(t, 1, len(mockAcc.Errors))
 	})
 }
@@ -311,7 +311,7 @@ func Test_Gather(t *testing.T) {
 		err := dpdk.Gather(mockAcc)
 
 		require.NoError(t, err)
-		require.Equal(t, 0, len(mockAcc.Errors))
+		require.Empty(t, mockAcc.Errors)
 
 		expected := []telegraf.Metric{
 			testutil.MustMetric(
@@ -339,7 +339,7 @@ func Test_Gather(t *testing.T) {
 
 		err := dpdk.Gather(mockAcc)
 		require.NoError(t, err)
-		require.Equal(t, 0, len(mockAcc.Errors))
+		require.Empty(t, mockAcc.Errors)
 
 		expected := []telegraf.Metric{
 			testutil.MustMetric(

--- a/plugins/inputs/example/example_test.go
+++ b/plugins/inputs/example/example_test.go
@@ -218,7 +218,7 @@ func TestFixedValue(t *testing.T) {
 			// Call gather and check no error occurs. In case you use acc.AddError() somewhere
 			// in your code, it is not sufficient to only check the return value of Gather().
 			require.NoError(t, tt.plugin.Gather(&acc))
-			require.Len(t, acc.Errors, 0, "found errors accumulated by acc.AddError()")
+			require.Empty(t, acc.Errors, "found errors accumulated by acc.AddError()")
 
 			// Wait for the expected number of metrics to avoid flaky tests due to
 			// race conditions.
@@ -311,7 +311,7 @@ func TestRandomValue(t *testing.T) {
 			// Call gather and check no error occurs. In case you use acc.AddError() somewhere
 			// in your code, it is not sufficient to only check the return value of Gather().
 			require.NoError(t, tt.plugin.Gather(&acc))
-			require.Len(t, acc.Errors, 0, "found errors accumulated by acc.AddError()")
+			require.Empty(t, acc.Errors, "found errors accumulated by acc.AddError()")
 
 			// Wait for the expected number of metrics to avoid flaky tests due to
 			// race conditions.

--- a/plugins/inputs/google_cloud_storage/google_cloud_storage_test.go
+++ b/plugins/inputs/google_cloud_storage/google_cloud_storage_test.go
@@ -176,7 +176,7 @@ func TestRunGatherIterationWithPages(t *testing.T) {
 	emptyAcc := &testutil.Accumulator{}
 	require.NoError(t, gcs.Gather(emptyAcc))
 
-	require.Equal(t, 0, len(emptyAcc.Metrics))
+	require.Empty(t, emptyAcc.Metrics)
 }
 
 func createParser() telegraf.Parser {

--- a/plugins/inputs/http/http_test.go
+++ b/plugins/inputs/http/http_test.go
@@ -336,7 +336,7 @@ func TestOAuthClientCredentialsGrant(t *testing.T) {
 				Log:  testutil.Logger{},
 			},
 			handler: func(t *testing.T, w http.ResponseWriter, r *http.Request) {
-				require.Len(t, r.Header["Authorization"], 0)
+				require.Empty(t, r.Header["Authorization"])
 				w.WriteHeader(http.StatusOK)
 			},
 		},

--- a/plugins/inputs/influxdb_listener/influxdb_listener_test.go
+++ b/plugins/inputs/influxdb_listener/influxdb_listener_test.go
@@ -729,7 +729,7 @@ func TestPing(t *testing.T) {
 			resp, err := http.Post(createURL(listener, "http", "/ping", ""), "", nil)
 			require.NoError(t, err)
 			require.Equal(t, "1.0", resp.Header["X-Influxdb-Version"][0])
-			require.Len(t, resp.Header["Content-Type"], 0)
+			require.Empty(t, resp.Header["Content-Type"])
 			require.NoError(t, resp.Body.Close())
 			require.EqualValues(t, 204, resp.StatusCode)
 		})

--- a/plugins/inputs/intel_powerstat/intel_powerstat_test.go
+++ b/plugins/inputs/intel_powerstat/intel_powerstat_test.go
@@ -60,7 +60,7 @@ func TestInitPlugin(t *testing.T) {
 	// In case of an error when fetching cpu cores plugin should proceed with execution.
 	require.NoError(t, power.Init())
 	mockServices.fs.AssertCalled(t, "getStringsMatchingPatternOnPath", mock.Anything)
-	require.Equal(t, 0, len(power.msr.getCPUCoresData()))
+	require.Empty(t, power.msr.getCPUCoresData())
 }
 
 func TestParseCPUMetricsConfig(t *testing.T) {
@@ -142,14 +142,14 @@ func TestAddGlobalMetricsNegative(t *testing.T) {
 		On("retrieveAndCalculateData", mock.Anything).Return(errors.New("error while calculating data")).Times(len(raplDataMap))
 
 	power.addGlobalMetrics(&acc)
-	require.Equal(t, 0, len(acc.GetTelegrafMetrics()))
+	require.Empty(t, acc.GetTelegrafMetrics())
 	mockServices.rapl.AssertNumberOfCalls(t, "retrieveAndCalculateData", len(raplDataMap))
 
 	mockServices.rapl.On("initializeRaplData", mock.Anything).Once().
 		On("getRaplData").Return(make(map[string]*raplData)).Once()
 
 	power.addGlobalMetrics(&acc)
-	require.Equal(t, 0, len(acc.GetTelegrafMetrics()))
+	require.Empty(t, acc.GetTelegrafMetrics())
 	mockServices.rapl.AssertNotCalled(t, "retrieveAndCalculateData")
 
 	mockServices.rapl.On("initializeRaplData", mock.Anything).Once().
@@ -201,7 +201,7 @@ func TestAddMetricsForSingleCoreNegative(t *testing.T) {
 	power.addMetricsForSingleCore(core, &acc, &wg)
 	wg.Wait()
 
-	require.Equal(t, 0, len(acc.GetTelegrafMetrics()))
+	require.Empty(t, acc.GetTelegrafMetrics())
 }
 
 func TestAddCPUFrequencyMetric(t *testing.T) {
@@ -217,7 +217,7 @@ func TestAddCPUFrequencyMetric(t *testing.T) {
 		Return(float64(0), errors.New("error on reading file")).Once()
 
 	power.addCPUFrequencyMetric(cpuID, &acc)
-	require.Equal(t, 0, len(acc.GetTelegrafMetrics()))
+	require.Empty(t, acc.GetTelegrafMetrics())
 
 	mockServices.msr.On("retrieveCPUFrequencyForCore", mock.Anything).Return(frequency, nil).Once()
 
@@ -306,7 +306,7 @@ func TestAddC6StateResidencyMetric(t *testing.T) {
 	preparedData[cpuID].timeStampCounterDelta = 0
 
 	power.addCPUC6StateResidencyMetric(cpuID, &acc)
-	require.Equal(t, 0, len(acc.GetTelegrafMetrics()))
+	require.Empty(t, acc.GetTelegrafMetrics())
 }
 
 func TestAddC0StateResidencyMetric(t *testing.T) {
@@ -335,7 +335,7 @@ func TestAddC0StateResidencyMetric(t *testing.T) {
 	acc.ClearMetrics()
 	preparedData[cpuID].timeStampCounterDelta = 0
 	power.addCPUC0StateResidencyMetric(cpuID, &acc)
-	require.Equal(t, 0, len(acc.GetTelegrafMetrics()))
+	require.Empty(t, acc.GetTelegrafMetrics())
 }
 
 func TestAddProcessorBusyFrequencyMetric(t *testing.T) {
@@ -355,7 +355,7 @@ func TestAddProcessorBusyFrequencyMetric(t *testing.T) {
 	acc.ClearMetrics()
 	preparedData[cpuID].mperfDelta = 0
 	power.addCPUBusyFrequencyMetric(cpuID, &acc)
-	require.Equal(t, 0, len(acc.GetTelegrafMetrics()))
+	require.Empty(t, acc.GetTelegrafMetrics())
 }
 
 func TestAddC1StateResidencyMetric(t *testing.T) {
@@ -381,7 +381,7 @@ func TestAddC1StateResidencyMetric(t *testing.T) {
 	acc.ClearMetrics()
 	preparedData[cpuID].timeStampCounterDelta = 0
 	power.addCPUC1StateResidencyMetric(cpuID, &acc)
-	require.Equal(t, 0, len(acc.GetTelegrafMetrics()))
+	require.Empty(t, acc.GetTelegrafMetrics())
 }
 
 func TestAddThermalDesignPowerMetric(t *testing.T) {
@@ -395,7 +395,7 @@ func TestAddThermalDesignPowerMetric(t *testing.T) {
 		On("getConstraintMaxPowerWatts", mock.Anything).Return(maxPower, nil).Once()
 
 	power.addThermalDesignPowerMetric(sockets[0], &acc)
-	require.Equal(t, 0, len(acc.GetTelegrafMetrics()))
+	require.Empty(t, acc.GetTelegrafMetrics())
 
 	power.addThermalDesignPowerMetric(sockets[0], &acc)
 	require.Equal(t, 1, len(acc.GetTelegrafMetrics()))
@@ -827,7 +827,7 @@ func TestAddCPUBaseFreq(t *testing.T) {
 			p.addCPUBaseFreq(tt.socketID, &acc)
 			actual := acc.GetTelegrafMetrics()
 			if !tt.metricExpected {
-				require.Len(t, actual, 0)
+				require.Empty(t, actual)
 				return
 			}
 

--- a/plugins/inputs/intel_powerstat/rapl_test.go
+++ b/plugins/inputs/intel_powerstat/rapl_test.go
@@ -37,7 +37,7 @@ func TestPrepareData(t *testing.T) {
 		Return(nil, errors.New("missing RAPL")).Once()
 	rapl.prepareData()
 	fsMock.AssertCalled(t, "getStringsMatchingPatternOnPath", mock.Anything)
-	require.Equal(t, 0, len(rapl.getRaplData()))
+	require.Empty(t, rapl.getRaplData())
 }
 
 func TestFindDramFolders(t *testing.T) {

--- a/plugins/inputs/interrupts/interrupts_test.go
+++ b/plugins/inputs/interrupts/interrupts_test.go
@@ -39,7 +39,7 @@ func setup(t *testing.T, irqString string, cpuAsTags bool) (*testutil.Accumulato
 	f := bytes.NewBufferString(irqString)
 	irqs, err := parseInterrupts(f)
 	require.Equal(t, nil, err)
-	require.NotEqual(t, 0, len(irqs))
+	require.NotEmpty(t, irqs)
 
 	acc := new(testutil.Accumulator)
 	reportMetrics("soft_interrupts", irqs, acc, cpuAsTags)

--- a/plugins/inputs/jolokia/jolokia_test.go
+++ b/plugins/inputs/jolokia/jolokia_test.go
@@ -231,7 +231,7 @@ func TestHttp404(t *testing.T) {
 	err := acc.GatherError(jolokia.Gather)
 
 	require.Error(t, err)
-	require.Equal(t, 0, len(acc.Metrics))
+	require.Empty(t, acc.Metrics)
 	require.Contains(t, err.Error(), "has status code 404")
 }
 
@@ -244,6 +244,6 @@ func TestHttpInvalidJson(t *testing.T) {
 	err := acc.GatherError(jolokia.Gather)
 
 	require.Error(t, err)
-	require.Equal(t, 0, len(acc.Metrics))
+	require.Empty(t, acc.Metrics)
 	require.Contains(t, err.Error(), "error decoding JSON response")
 }

--- a/plugins/inputs/kafka_consumer_legacy/kafka_consumer_legacy_integration_test.go
+++ b/plugins/inputs/kafka_consumer_legacy/kafka_consumer_legacy_integration_test.go
@@ -51,7 +51,7 @@ func TestReadsMetricsFromKafkaIntegration(t *testing.T) {
 	var acc testutil.Accumulator
 
 	// Sanity check
-	require.Equal(t, 0, len(acc.Metrics), "There should not be any points")
+	require.Empty(t, acc.Metrics, "There should not be any points")
 	if err := k.Start(&acc); err != nil {
 		t.Fatal(err.Error())
 	} else {

--- a/plugins/inputs/nsq_consumer/nsq_consumer_test.go
+++ b/plugins/inputs/nsq_consumer/nsq_consumer_test.go
@@ -53,7 +53,7 @@ func TestReadsMetricsFromNSQ(t *testing.T) {
 	require.NoError(t, p.Init())
 	consumer.SetParser(p)
 	var acc testutil.Accumulator
-	require.Len(t, acc.Metrics, 0, "There should not be any points")
+	require.Empty(t, acc.Metrics, "There should not be any points")
 	require.NoError(t, consumer.Start(&acc))
 
 	waitForPoint(&acc, t)

--- a/plugins/inputs/prometheus/kubernetes_test.go
+++ b/plugins/inputs/prometheus/kubernetes_test.go
@@ -181,7 +181,7 @@ func TestDeletePods(t *testing.T) {
 
 	podID, _ := cache.MetaNamespaceKeyFunc(p)
 	unregisterPod(PodID(podID), prom)
-	require.Equal(t, 0, len(prom.kubernetesPods))
+	require.Empty(t, prom.kubernetesPods)
 }
 
 func TestKeepDefaultNamespaceLabelName(t *testing.T) {

--- a/plugins/inputs/rabbitmq/rabbitmq_test.go
+++ b/plugins/inputs/rabbitmq/rabbitmq_test.go
@@ -5,14 +5,13 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"testing"
 	"time"
 
-	"testing"
+	"github.com/stretchr/testify/require"
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/testutil"
-
-	"github.com/stretchr/testify/require"
 )
 
 func TestRabbitMQGeneratesMetricsSet1(t *testing.T) {
@@ -221,7 +220,7 @@ func TestRabbitMQGeneratesMetricsSet1(t *testing.T) {
 	require.NoError(t, plugin.Gather(acc))
 
 	acc.Wait(len(expected))
-	require.Len(t, acc.Errors, 0)
+	require.Empty(t, acc.Errors)
 
 	testutil.RequireMetricsEqual(t, expected, acc.GetTelegrafMetrics(), testutil.IgnoreTime(), testutil.SortMetrics())
 }

--- a/plugins/inputs/radius/radius_test.go
+++ b/plugins/inputs/radius/radius_test.go
@@ -179,7 +179,7 @@ func TestRadiusIntegration(t *testing.T) {
 
 			// Gather
 			require.NoError(t, plugin.Gather(&acc))
-			require.Len(t, acc.Errors, 0)
+			require.Empty(t, acc.Errors)
 
 			if !acc.HasMeasurement("radius") {
 				t.Errorf("acc.HasMeasurement: expected radius")

--- a/plugins/inputs/sql/sql_test.go
+++ b/plugins/inputs/sql/sql_test.go
@@ -116,7 +116,7 @@ func TestMariaDBIntegration(t *testing.T) {
 
 			// Gather
 			require.NoError(t, plugin.Gather(&acc))
-			require.Len(t, acc.Errors, 0)
+			require.Empty(t, acc.Errors)
 
 			// Stopping the plugin
 			plugin.Stop()
@@ -215,7 +215,7 @@ func TestPostgreSQLIntegration(t *testing.T) {
 
 			// Gather
 			require.NoError(t, plugin.Gather(&acc))
-			require.Len(t, acc.Errors, 0)
+			require.Empty(t, acc.Errors)
 
 			// Stopping the plugin
 			plugin.Stop()
@@ -310,7 +310,7 @@ func TestClickHouseIntegration(t *testing.T) {
 
 			// Gather
 			require.NoError(t, plugin.Gather(&acc))
-			require.Len(t, acc.Errors, 0)
+			require.Empty(t, acc.Errors)
 
 			// Stopping the plugin
 			plugin.Stop()

--- a/plugins/inputs/statsd/statsd_test.go
+++ b/plugins/inputs/statsd/statsd_test.go
@@ -1564,7 +1564,7 @@ func TestParse_Timings_Delete(t *testing.T) {
 
 	require.NoError(t, s.Gather(fakeacc))
 
-	require.Lenf(t, s.timings, 0, "All timings should have been deleted, found %d", len(s.timings))
+	require.Emptyf(t, s.timings, "All timings should have been deleted, found %d", len(s.timings))
 }
 
 // Tests the delete_gauges option
@@ -1840,7 +1840,7 @@ func TestUdpFillQueue(t *testing.T) {
 	defer plugin.Stop()
 
 	errs := logger.Errors()
-	require.Lenf(t, errs, 0, "got errors: %v", errs)
+	require.Emptyf(t, errs, "got errors: %v", errs)
 }
 
 func TestParse_Ints(t *testing.T) {

--- a/plugins/inputs/tacacs/tacacs_test.go
+++ b/plugins/inputs/tacacs/tacacs_test.go
@@ -220,7 +220,7 @@ func TestTacacsLocal(t *testing.T) {
 			require.NoError(t, plugin.Gather(&acc))
 
 			if tt.errContains == "" {
-				require.Len(t, acc.Errors, 0)
+				require.Empty(t, acc.Errors)
 				require.True(t, acc.HasMeasurement("tacacs"))
 				require.True(t, acc.HasTag("tacacs", "source"))
 				require.Equal(t, srvLocal, acc.TagValue("tacacs", "source"))

--- a/plugins/inputs/uwsgi/uwsgi_test.go
+++ b/plugins/inputs/uwsgi/uwsgi_test.go
@@ -6,10 +6,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/plugins/inputs/uwsgi"
 	"github.com/influxdata/telegraf/testutil"
-	"github.com/stretchr/testify/require"
 )
 
 func TestBasic(t *testing.T) {
@@ -125,7 +126,7 @@ func TestBasic(t *testing.T) {
 	}
 	var acc testutil.Accumulator
 	require.NoError(t, plugin.Gather(&acc))
-	require.Equal(t, 0, len(acc.Errors))
+	require.Empty(t, acc.Errors)
 }
 
 func TestInvalidJSON(t *testing.T) {

--- a/plugins/inputs/varnish/varnish_test.go
+++ b/plugins/inputs/varnish/varnish_test.go
@@ -536,7 +536,7 @@ func TestVersions(t *testing.T) {
 	require.NoError(t, server.Init())
 	acc := &testutil.Accumulator{}
 
-	require.Equal(t, 0, len(acc.Metrics))
+	require.Empty(t, acc.Metrics)
 
 	type testConfig struct {
 		jsonFile           string

--- a/plugins/inputs/vsphere/vsphere_test.go
+++ b/plugins/inputs/vsphere/vsphere_test.go
@@ -344,7 +344,7 @@ func TestFinder(t *testing.T) {
 	}
 	vm = []mo.VirtualMachine{}
 	require.NoError(t, rf.FindAll(ctx, &vm))
-	require.Equal(t, 0, len(vm))
+	require.Empty(t, vm)
 
 	rf = ResourceFilter{
 		finder:       &f,
@@ -354,7 +354,7 @@ func TestFinder(t *testing.T) {
 	}
 	vm = []mo.VirtualMachine{}
 	require.NoError(t, rf.FindAll(ctx, &vm))
-	require.Equal(t, 0, len(vm))
+	require.Empty(t, vm)
 
 	rf = ResourceFilter{
 		finder:       &f,
@@ -513,8 +513,8 @@ func testCollection(t *testing.T, excludeClusters bool) {
 	require.NoError(t, v.Start(&acc))
 	defer v.Stop()
 	require.NoError(t, v.Gather(&acc))
-	require.Equal(t, 0, len(acc.Errors), fmt.Sprintf("Errors found: %s", acc.Errors))
-	require.Greater(t, len(acc.Metrics), 0, "No metrics were collected")
+	require.Empty(t, acc.Errors, fmt.Sprintf("Errors found: %s", acc.Errors))
+	require.NotEmpty(t, acc.Metrics, "No metrics were collected")
 	cache := make(map[string]string)
 	client, err := v.endpoints[0].clientFactory.GetClient(context.Background())
 	require.NoError(t, err)

--- a/plugins/inputs/win_services/win_services_test.go
+++ b/plugins/inputs/win_services/win_services_test.go
@@ -201,7 +201,7 @@ func TestGatherContainsTag(t *testing.T) {
 
 	var acc1 testutil.Accumulator
 	require.NoError(t, winServices.Gather(&acc1))
-	require.Len(t, acc1.Errors, 0, "There should be no errors after gather")
+	require.Empty(t, acc1.Errors, "There should be no errors after gather")
 
 	for _, s := range testSimpleData[0].services {
 		fields := make(map[string]interface{})

--- a/plugins/inputs/x509_cert/x509_cert_test.go
+++ b/plugins/inputs/x509_cert/x509_cert_test.go
@@ -330,7 +330,7 @@ func TestGatherUDPCertIntegration(t *testing.T) {
 	var acc testutil.Accumulator
 	require.NoError(t, m.Gather(&acc))
 
-	require.Len(t, acc.Errors, 0)
+	require.Empty(t, acc.Errors)
 	require.True(t, acc.HasMeasurement("x509_cert"))
 	require.True(t, acc.HasTag("x509_cert", "ocsp_stapled"))
 }
@@ -350,7 +350,7 @@ func TestGatherTCPCert(t *testing.T) {
 	var acc testutil.Accumulator
 	require.NoError(t, m.Gather(&acc))
 
-	require.Len(t, acc.Errors, 0)
+	require.Empty(t, acc.Errors)
 	require.True(t, acc.HasMeasurement("x509_cert"))
 }
 

--- a/plugins/inputs/xtremio/xtremio_test.go
+++ b/plugins/inputs/xtremio/xtremio_test.go
@@ -143,7 +143,7 @@ func TestFixedValue(t *testing.T) {
 			tt.plugin.Log = testutil.Logger{}
 			require.NoError(t, tt.plugin.Init())
 			require.NoError(t, tt.plugin.Gather(&acc))
-			require.Len(t, acc.Errors, 0, "found errors accumulated by acc.AddError()")
+			require.Empty(t, acc.Errors, "found errors accumulated by acc.AddError()")
 			acc.Wait(len(tt.expected))
 			testutil.RequireMetricsEqual(t, tt.expected, acc.GetTelegrafMetrics(), testutil.IgnoreTime())
 		})

--- a/plugins/outputs/azure_monitor/azure_monitor_test.go
+++ b/plugins/outputs/azure_monitor/azure_monitor_test.go
@@ -47,7 +47,7 @@ func TestAggregate(t *testing.T) {
 			pushTime: time.Unix(3600, 0),
 			check: func(t *testing.T, plugin *AzureMonitor, metrics []telegraf.Metric) {
 				require.Equal(t, int64(1), plugin.MetricOutsideWindow.Get())
-				require.Len(t, metrics, 0)
+				require.Empty(t, metrics)
 			},
 		},
 		{
@@ -70,7 +70,7 @@ func TestAggregate(t *testing.T) {
 			addTime:  time.Unix(0, 0),
 			pushTime: time.Unix(0, 0),
 			check: func(t *testing.T, plugin *AzureMonitor, metrics []telegraf.Metric) {
-				require.Len(t, metrics, 0)
+				require.Empty(t, metrics)
 			},
 		},
 		{

--- a/plugins/outputs/cloudwatch/cloudwatch_test.go
+++ b/plugins/outputs/cloudwatch/cloudwatch_test.go
@@ -72,7 +72,7 @@ func TestBuildMetricDatums(t *testing.T) {
 	}
 	for _, point := range invalidMetrics {
 		datums := BuildMetricDatum(false, false, point)
-		require.Equal(t, 0, len(datums), fmt.Sprintf("Valid point should not create a Datum {value: %v}", point))
+		require.Empty(t, datums, fmt.Sprintf("Valid point should not create a Datum {value: %v}", point))
 	}
 
 	statisticMetric := metric.New(

--- a/plugins/outputs/groundwork/groundwork_test.go
+++ b/plugins/outputs/groundwork/groundwork_test.go
@@ -44,7 +44,7 @@ func TestWriteWithDefaults(t *testing.T) {
 		require.Equal(t, transit.MonitorStatus("SERVICE_OK"), obj.Resources[0].Services[0].Status)
 		require.Equal(t, "IntMetric", obj.Resources[0].Services[0].Name)
 		require.Equal(t, int64(42), *obj.Resources[0].Services[0].Metrics[0].Value.IntegerValue)
-		require.Equal(t, 0, len(obj.Groups))
+		require.Empty(t, obj.Groups)
 
 		_, err = fmt.Fprintln(w, "OK")
 		require.NoError(t, err)

--- a/plugins/outputs/http/http_test.go
+++ b/plugins/outputs/http/http_test.go
@@ -468,7 +468,7 @@ func TestOAuthClientCredentialsGrant(t *testing.T) {
 				URL: u.String(),
 			},
 			handler: func(t *testing.T, w http.ResponseWriter, r *http.Request) {
-				require.Len(t, r.Header["Authorization"], 0)
+				require.Empty(t, r.Header["Authorization"])
 				w.WriteHeader(http.StatusOK)
 			},
 		},
@@ -578,7 +578,7 @@ func TestOAuthAuthorizationCodeGrant(t *testing.T) {
 				URL: u.String(),
 			},
 			handler: func(t *testing.T, w http.ResponseWriter, r *http.Request) {
-				require.Len(t, r.Header["Authorization"], 0)
+				require.Empty(t, r.Header["Authorization"])
 				w.WriteHeader(http.StatusOK)
 			},
 		},

--- a/plugins/outputs/loki/loki_test.go
+++ b/plugins/outputs/loki/loki_test.go
@@ -356,7 +356,7 @@ func TestOAuthClientCredentialsGrant(t *testing.T) {
 				Domain: u.String(),
 			},
 			handler: func(t *testing.T, w http.ResponseWriter, r *http.Request) {
-				require.Len(t, r.Header["Authorization"], 0)
+				require.Empty(t, r.Header["Authorization"])
 				w.WriteHeader(http.StatusOK)
 			},
 		},

--- a/plugins/outputs/riemann/riemann_test.go
+++ b/plugins/outputs/riemann/riemann_test.go
@@ -4,11 +4,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/influxdata/telegraf/testutil"
-
 	"github.com/amir/raidman"
-	"github.com/influxdata/telegraf/metric"
 	"github.com/stretchr/testify/require"
+
+	"github.com/influxdata/telegraf/metric"
+	"github.com/influxdata/telegraf/testutil"
 )
 
 func TestAttributes(t *testing.T) {
@@ -146,7 +146,7 @@ func TestStateEvents(t *testing.T) {
 
 	events := r.buildRiemannEvents(m)
 	// no event should be present
-	require.Len(t, events, 0)
+	require.Empty(t, events)
 
 	// enable string metrics as event states
 	r.StringAsState = true

--- a/plugins/outputs/wavefront/wavefront_test.go
+++ b/plugins/outputs/wavefront/wavefront_test.go
@@ -439,7 +439,7 @@ func TestMakeAuthOptions(t *testing.T) {
 	noAuthOptionsWavefront := outputs.Outputs["wavefront"]().(*Wavefront)
 	options, err = noAuthOptionsWavefront.makeAuthOptions()
 	require.NoError(t, err)
-	require.Equal(t, 0, len(options))
+	require.Empty(t, options)
 }
 
 // Benchmarks to test performance of string replacement via Regex and Sanitize

--- a/plugins/parsers/csv/parser_test.go
+++ b/plugins/parsers/csv/parser_test.go
@@ -509,7 +509,7 @@ func TestParseStream(t *testing.T) {
 
 	metrics, err := p.Parse([]byte(csvHeader))
 	require.NoError(t, err)
-	require.Len(t, metrics, 0)
+	require.Empty(t, metrics)
 	m, err := p.ParseLine(csvBody)
 	require.NoError(t, err)
 	testutil.RequireMetricEqual(t,
@@ -539,7 +539,7 @@ func TestParseLineMultiMetricErrorMessage(t *testing.T) {
 
 	metrics, err := p.Parse([]byte(csvHeader))
 	require.NoError(t, err)
-	require.Len(t, metrics, 0)
+	require.Empty(t, metrics)
 	m, err := p.ParseLine(csvOneRow)
 	require.NoError(t, err)
 	testutil.RequireMetricEqual(t,
@@ -870,7 +870,7 @@ func TestParseMetadataSeparators(t *testing.T) {
 	err = p.Init()
 	require.NoError(t, err)
 	require.Len(t, p.metadataSeparatorList, 4)
-	require.Len(t, p.MetadataTrimSet, 0)
+	require.Empty(t, p.MetadataTrimSet)
 	require.Equal(t, p.metadataSeparatorList, metadataPattern{":=", ",", "=", ":"})
 	p = &Parser{
 		ColumnNames:        []string{"a", "b"},

--- a/plugins/parsers/dropwizard/parser_test.go
+++ b/plugins/parsers/dropwizard/parser_test.go
@@ -5,12 +5,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/influxdata/telegraf/testutil"
-
 	"github.com/stretchr/testify/require"
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/metric"
+	"github.com/influxdata/telegraf/testutil"
 )
 
 // validEmptyJSON is a valid dropwizard json document, but without any metrics
@@ -32,7 +31,7 @@ func TestParseValidEmptyJSON(t *testing.T) {
 	// Most basic vanilla test
 	metrics, err := parser.Parse([]byte(validEmptyJSON))
 	require.NoError(t, err)
-	require.Len(t, metrics, 0)
+	require.Empty(t, metrics)
 }
 
 // validCounterJSON is a valid dropwizard json document containing one counter

--- a/plugins/parsers/form_urlencoded/parser_test.go
+++ b/plugins/parsers/form_urlencoded/parser_test.go
@@ -133,7 +133,7 @@ func TestParseInvalidFormDataError(t *testing.T) {
 
 	metrics, err := parser.Parse([]byte(notEscapedProperlyFormData))
 	require.Error(t, err)
-	require.Len(t, metrics, 0)
+	require.Empty(t, metrics)
 }
 
 func TestParseInvalidFormDataEmptyKey(t *testing.T) {
@@ -168,5 +168,5 @@ func TestParseInvalidFormDataEmptyString(t *testing.T) {
 
 	metrics, err := parser.Parse([]byte(emptyFormData))
 	require.NoError(t, err)
-	require.Len(t, metrics, 0)
+	require.Empty(t, metrics)
 }

--- a/plugins/parsers/json/parser_test.go
+++ b/plugins/parsers/json/parser_test.go
@@ -116,12 +116,12 @@ func TestParseValidJSON(t *testing.T) {
 	// Test that whitespace only will parse as an empty list of metrics
 	metrics, err = parser.Parse([]byte("\n\t"))
 	require.NoError(t, err)
-	require.Len(t, metrics, 0)
+	require.Empty(t, metrics)
 
 	// Test that an empty string will parse as an empty list of metrics
 	metrics, err = parser.Parse([]byte(""))
 	require.NoError(t, err)
-	require.Len(t, metrics, 0)
+	require.Empty(t, metrics)
 }
 
 func TestParseLineValidJSON(t *testing.T) {
@@ -784,7 +784,7 @@ func TestTimeErrors(t *testing.T) {
 
 	metrics, err := parser.Parse([]byte(testString))
 	require.Error(t, err)
-	require.Equal(t, 0, len(metrics))
+	require.Empty(t, metrics)
 
 	testString2 := `{
 		"a": 5,
@@ -804,7 +804,7 @@ func TestTimeErrors(t *testing.T) {
 
 	metrics, err = parser.Parse([]byte(testString2))
 	require.Error(t, err)
-	require.Equal(t, 0, len(metrics))
+	require.Empty(t, metrics)
 	require.Equal(t, fmt.Errorf("JSON time key could not be found"), err)
 }
 

--- a/plugins/parsers/json_v2/parser_test.go
+++ b/plugins/parsers/json_v2/parser_test.go
@@ -8,13 +8,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/plugins/inputs"
 	"github.com/influxdata/telegraf/plugins/inputs/file"
 	"github.com/influxdata/telegraf/plugins/parsers/influx"
 	"github.com/influxdata/telegraf/testutil"
-	"github.com/stretchr/testify/require"
 )
 
 func TestMultipleConfigs(t *testing.T) {
@@ -22,7 +23,7 @@ func TestMultipleConfigs(t *testing.T) {
 	folders, err := os.ReadDir("testdata")
 	require.NoError(t, err)
 	// Make sure testdata contains data
-	require.Greater(t, len(folders), 0)
+	require.NotEmpty(t, folders)
 
 	// Setup influx parser for parsing the expected metrics
 	parser := &influx.Parser{}

--- a/plugins/parsers/xpath/parser_test.go
+++ b/plugins/parsers/xpath/parser_test.go
@@ -1320,7 +1320,7 @@ func TestTestCases(t *testing.T) {
 			require.Len(t, input, 1)
 
 			filefields := strings.Fields(input[0])
-			require.GreaterOrEqual(t, len(filefields), 1)
+			require.NotEmpty(t, filefields)
 			datafile := filepath.FromSlash(filefields[0])
 			fileformat := ""
 			if len(filefields) > 1 {

--- a/plugins/processors/aws/ec2/ec2_test.go
+++ b/plugins/processors/aws/ec2/ec2_test.go
@@ -4,9 +4,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/testutil"
-	"github.com/stretchr/testify/require"
 )
 
 func TestBasicStartup(t *testing.T) {
@@ -16,8 +17,8 @@ func TestBasicStartup(t *testing.T) {
 	acc := &testutil.Accumulator{}
 	require.NoError(t, p.Init())
 
-	require.Len(t, acc.GetTelegrafMetrics(), 0)
-	require.Len(t, acc.Errors, 0)
+	require.Empty(t, acc.GetTelegrafMetrics())
+	require.Empty(t, acc.Errors)
 }
 
 func TestBasicStartupWithEC2Tags(t *testing.T) {
@@ -28,8 +29,8 @@ func TestBasicStartupWithEC2Tags(t *testing.T) {
 	acc := &testutil.Accumulator{}
 	require.NoError(t, p.Init())
 
-	require.Len(t, acc.GetTelegrafMetrics(), 0)
-	require.Len(t, acc.Errors, 0)
+	require.Empty(t, acc.GetTelegrafMetrics())
+	require.Empty(t, acc.Errors)
 }
 
 func TestBasicStartupWithCacheTTL(t *testing.T) {
@@ -40,8 +41,8 @@ func TestBasicStartupWithCacheTTL(t *testing.T) {
 	acc := &testutil.Accumulator{}
 	require.NoError(t, p.Init())
 
-	require.Len(t, acc.GetTelegrafMetrics(), 0)
-	require.Len(t, acc.Errors, 0)
+	require.Empty(t, acc.GetTelegrafMetrics())
+	require.Empty(t, acc.Errors)
 }
 
 func TestBasicStartupWithTagCacheSize(t *testing.T) {
@@ -52,8 +53,8 @@ func TestBasicStartupWithTagCacheSize(t *testing.T) {
 	acc := &testutil.Accumulator{}
 	require.NoError(t, p.Init())
 
-	require.Len(t, acc.GetTelegrafMetrics(), 0)
-	require.Len(t, acc.Errors, 0)
+	require.Empty(t, acc.GetTelegrafMetrics())
+	require.Empty(t, acc.Errors)
 }
 
 func TestBasicInitNoTagsReturnAnError(t *testing.T) {

--- a/plugins/processors/converter/converter_test.go
+++ b/plugins/processors/converter/converter_test.go
@@ -5,9 +5,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/testutil"
-	"github.com/stretchr/testify/require"
 )
 
 func TestConverter(t *testing.T) {
@@ -702,7 +703,7 @@ func TestMultipleTimestamps(t *testing.T) {
 
 	result := c.Apply(input)
 	require.Len(t, result, 1)
-	require.Len(t, result[0].TagList(), 0)
+	require.Empty(t, result[0].TagList())
 	require.Len(t, result[0].FieldList(), 1)
 }
 

--- a/plugins/processors/dedup/dedup_test.go
+++ b/plugins/processors/dedup/dedup_test.go
@@ -34,7 +34,7 @@ func assertCacheRefresh(t *testing.T, proc *Dedup, item telegraf.Metric) {
 	id := item.HashID()
 	name := item.Name()
 	// cache is not empty
-	require.NotEqual(t, 0, len(proc.Cache))
+	require.NotEmpty(t, proc.Cache)
 	// cache has metric with proper id
 	cache, present := proc.Cache[id]
 	require.True(t, present)
@@ -53,7 +53,7 @@ func assertCacheHit(t *testing.T, proc *Dedup, item telegraf.Metric) {
 	id := item.HashID()
 	name := item.Name()
 	// cache is not empty
-	require.NotEqual(t, 0, len(proc.Cache))
+	require.NotEmpty(t, proc.Cache)
 	// cache has metric with proper id
 	cache, present := proc.Cache[id]
 	require.True(t, present)
@@ -70,7 +70,7 @@ func assertCacheHit(t *testing.T, proc *Dedup, item telegraf.Metric) {
 
 func assertMetricPassed(t *testing.T, target []telegraf.Metric, source telegraf.Metric) {
 	// target is not empty
-	require.NotEqual(t, 0, len(target))
+	require.NotEmpty(t, target)
 	// target has metric with proper name
 	require.Equal(t, metricName, target[0].Name())
 	// target metric has proper field
@@ -85,7 +85,7 @@ func assertMetricPassed(t *testing.T, target []telegraf.Metric, source telegraf.
 
 func assertMetricSuppressed(t *testing.T, target []telegraf.Metric) {
 	// target is empty
-	require.Equal(t, 0, len(target))
+	require.Empty(t, target)
 }
 
 func TestProcRetainsMetric(t *testing.T) {
@@ -156,7 +156,7 @@ func TestCacheShrink(t *testing.T) {
 	source := createMetric(1, time.Now().Add(-1*time.Hour))
 	deduplicate.Apply(source)
 
-	require.Equal(t, 0, len(deduplicate.Cache))
+	require.Empty(t, deduplicate.Cache)
 }
 
 func TestSameTimestamp(t *testing.T) {

--- a/plugins/processors/ifname/ttl_cache_test.go
+++ b/plugins/processors/ifname/ttl_cache_test.go
@@ -23,7 +23,7 @@ func TestTTLCacheExpire(t *testing.T) {
 
 	_, ok, _ := c.Get("ones")
 	require.False(t, ok)
-	require.Len(t, c.lru.m, 0)
+	require.Empty(t, c.lru.m)
 	require.Equal(t, c.lru.l.Len(), 0)
 }
 

--- a/plugins/processors/reverse_dns/rdnscache_test.go
+++ b/plugins/processors/reverse_dns/rdnscache_test.go
@@ -105,7 +105,7 @@ func TestCleanupHappens(t *testing.T) {
 
 	time.Sleep(ttl) // wait for cache entry to expire.
 	d.cleanup()
-	require.Len(t, d.expireList, 0)
+	require.Empty(t, d.expireList)
 
 	stats := d.Stats()
 

--- a/plugins/serializers/msgpack/msgpack_test.go
+++ b/plugins/serializers/msgpack/msgpack_test.go
@@ -27,7 +27,7 @@ func TestSerializeMetricInt(t *testing.T) {
 	left, err := m2.UnmarshalMsg(buf)
 	require.NoError(t, err)
 
-	require.Equal(t, len(left), 0)
+	require.Empty(t, left)
 
 	testutil.RequireMetricEqual(t, m, toTelegrafMetric(*m2))
 }
@@ -44,7 +44,7 @@ func TestSerializeMetricString(t *testing.T) {
 	left, err := m2.UnmarshalMsg(buf)
 	require.NoError(t, err)
 
-	require.Equal(t, len(left), 0)
+	require.Empty(t, left)
 
 	testutil.RequireMetricEqual(t, m, toTelegrafMetric(*m2))
 }
@@ -62,7 +62,7 @@ func TestSerializeMultiFields(t *testing.T) {
 	left, err := m2.UnmarshalMsg(buf)
 	require.NoError(t, err)
 
-	require.Equal(t, len(left), 0)
+	require.Empty(t, left)
 
 	testutil.RequireMetricEqual(t, m, toTelegrafMetric(*m2))
 }
@@ -81,7 +81,7 @@ func TestSerializeMetricWithEscapes(t *testing.T) {
 	left, err := m2.UnmarshalMsg(buf)
 	require.NoError(t, err)
 
-	require.Equal(t, len(left), 0)
+	require.Empty(t, left)
 
 	testutil.RequireMetricEqual(t, m, toTelegrafMetric(*m2))
 }


### PR DESCRIPTION
Address findings for [testifylint: empty](https://github.com/Antonboom/testifylint#empty) - checks usage of github.com/stretchr/testify.

```
❌   assert.Len(t, arr, 0)
     assert.Equal(t, 0, len(arr))
     assert.NotEqual(t, 0, len(arr))
     assert.GreaterOrEqual(t, len(arr), 1)
     // And other variations around len(arr)...

✅   assert.Empty(t, arr)
     assert.NotEmpty(t, err)
```

It is only part of the bigger job.
After all type of findings in whole project are handled, we can enable `testifylint` linter in `golangci-lint`.