### PR TITLE
chore(linters): Fix findings found by testifylint: error-is-as

### DIFF
--- a/plugins/inputs/beat/beat_test.go
+++ b/plugins/inputs/beat/beat_test.go
@@ -44,7 +44,7 @@ func Test_BeatStats(t *testing.T) {
 	fakeServer.Start()
 	defer fakeServer.Close()
 
-	require.NoError(t, err, beatTest.Gather(&beat6StatsAccumulator))
+	require.NoError(t, beatTest.Gather(&beat6StatsAccumulator))
 
 	beat6StatsAccumulator.AssertContainsTaggedFields(
 		t,


### PR DESCRIPTION
Address findings for [testifylint: error-is-as](https://github.com/Antonboom/testifylint#error-is-as) - checks usage of github.com/stretchr/testify.

```
❌   assert.Error(t, err, errSentinel) // Typo, errSentinel hits `msgAndArgs`.
     assert.NoError(t, err, errSentinel)
     assert.True(t, errors.Is(err, errSentinel))
     assert.False(t, errors.Is(err, errSentinel))
     assert.True(t, errors.As(err, &target))

✅   assert.ErrorIs(t, err, errSentinel)
     assert.NotErrorIs(t, err, errSentinel)
     assert.ErrorAs(t, err, &target)
```

In the first two cases, a common mistake that leads to hiding the incorrect wrapping of sentinel errors.

For single finding in Telegraf code it seems that `require.NoError` was used correctly but `err` should not be passed at all.

It is only part of the bigger job.
After all type of findings in whole project are handled, we can enable `testifylint` linter in `golangci-lint`.