### PR TITLE
chore(linters): Fix findings found by testifylint: require-error

### DIFF
--- a/agent/accumulator_test.go
+++ b/agent/accumulator_test.go
@@ -8,10 +8,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/models"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestAddFields(t *testing.T) {
@@ -61,12 +61,12 @@ func TestAccAddError(t *testing.T) {
 
 	errs := bytes.Split(errBuf.Bytes(), []byte{'\n'})
 	require.Len(t, errs, 4) // 4 because of trailing newline
-	assert.Contains(t, string(errs[0]), "TestPlugin")
-	assert.Contains(t, string(errs[0]), "foo")
-	assert.Contains(t, string(errs[1]), "TestPlugin")
-	assert.Contains(t, string(errs[1]), "bar")
-	assert.Contains(t, string(errs[2]), "TestPlugin")
-	assert.Contains(t, string(errs[2]), "baz")
+	require.Contains(t, string(errs[0]), "TestPlugin")
+	require.Contains(t, string(errs[0]), "foo")
+	require.Contains(t, string(errs[1]), "TestPlugin")
+	require.Contains(t, string(errs[1]), "bar")
+	require.Contains(t, string(errs[2]), "TestPlugin")
+	require.Contains(t, string(errs[2]), "baz")
 }
 
 func TestSetPrecision(t *testing.T) {

--- a/filter/filter_test.go
+++ b/filter/filter_test.go
@@ -3,38 +3,38 @@ package filter
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCompile(t *testing.T) {
 	f, err := Compile([]string{})
-	assert.NoError(t, err)
-	assert.Nil(t, f)
+	require.NoError(t, err)
+	require.Nil(t, f)
 
 	f, err = Compile([]string{"cpu"})
-	assert.NoError(t, err)
-	assert.True(t, f.Match("cpu"))
-	assert.False(t, f.Match("cpu0"))
-	assert.False(t, f.Match("mem"))
+	require.NoError(t, err)
+	require.True(t, f.Match("cpu"))
+	require.False(t, f.Match("cpu0"))
+	require.False(t, f.Match("mem"))
 
 	f, err = Compile([]string{"cpu*"})
-	assert.NoError(t, err)
-	assert.True(t, f.Match("cpu"))
-	assert.True(t, f.Match("cpu0"))
-	assert.False(t, f.Match("mem"))
+	require.NoError(t, err)
+	require.True(t, f.Match("cpu"))
+	require.True(t, f.Match("cpu0"))
+	require.False(t, f.Match("mem"))
 
 	f, err = Compile([]string{"cpu", "mem"})
-	assert.NoError(t, err)
-	assert.True(t, f.Match("cpu"))
-	assert.False(t, f.Match("cpu0"))
-	assert.True(t, f.Match("mem"))
+	require.NoError(t, err)
+	require.True(t, f.Match("cpu"))
+	require.False(t, f.Match("cpu0"))
+	require.True(t, f.Match("mem"))
 
 	f, err = Compile([]string{"cpu", "mem", "net*"})
-	assert.NoError(t, err)
-	assert.True(t, f.Match("cpu"))
-	assert.False(t, f.Match("cpu0"))
-	assert.True(t, f.Match("mem"))
-	assert.True(t, f.Match("network"))
+	require.NoError(t, err)
+	require.True(t, f.Match("cpu"))
+	require.False(t, f.Match("cpu0"))
+	require.True(t, f.Match("mem"))
+	require.True(t, f.Match("network"))
 }
 
 func TestIncludeExclude(t *testing.T) {
@@ -52,7 +52,7 @@ func TestIncludeExclude(t *testing.T) {
 		}
 	}
 
-	assert.Equal(t, []string{"best", "timeseries", "ever"}, tags)
+	require.Equal(t, []string{"best", "timeseries", "ever"}, tags)
 }
 
 var benchbool bool

--- a/internal/templating/engine_test.go
+++ b/internal/templating/engine_test.go
@@ -3,7 +3,6 @@ package templating
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -69,9 +68,9 @@ func TestEngineWithWildcardTemplate(t *testing.T) {
 			measurement, tags, field, err := engine.Apply(testCase.line)
 			require.NoError(t, err)
 
-			assert.Equal(t, testCase.measurement, measurement)
-			assert.Equal(t, testCase.field, field)
-			assert.Equal(t, testCase.tags, tags)
+			require.Equal(t, testCase.measurement, measurement)
+			require.Equal(t, testCase.field, field)
+			require.Equal(t, testCase.tags, tags)
 		})
 	}
 }

--- a/models/running_input_test.go
+++ b/models/running_input_test.go
@@ -4,13 +4,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/influxdata/telegraf/selfstat"
+	"github.com/stretchr/testify/require"
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/metric"
+	"github.com/influxdata/telegraf/selfstat"
 	"github.com/influxdata/telegraf/testutil"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestMakeMetricFilterAfterApplyingGlobalTags(t *testing.T) {
@@ -127,7 +126,7 @@ func TestMakeMetricFilteredOut(t *testing.T) {
 		Filter: Filter{NamePass: []string{"foobar"}},
 	})
 
-	assert.NoError(t, ri.Config.Filter.Compile())
+	require.NoError(t, ri.Config.Filter.Compile())
 
 	m := metric.New("RITest",
 		map[string]string{},

--- a/plugins/inputs/cloud_pubsub/cloud_pubsub_test.go
+++ b/plugins/inputs/cloud_pubsub/cloud_pubsub_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/influxdata/telegraf/internal"
@@ -152,7 +151,7 @@ func TestRunGzipDecode(t *testing.T) {
 	}
 	sub.messages <- msg
 	acc.Wait(1)
-	assert.Equal(t, acc.NFields(), 1)
+	require.Equal(t, acc.NFields(), 1)
 	metric := acc.Metrics[0]
 	validateTestInfluxMetric(t, metric)
 }

--- a/plugins/inputs/intel_rdt/publisher_test.go
+++ b/plugins/inputs/intel_rdt/publisher_test.go
@@ -7,8 +7,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/influxdata/telegraf/testutil"
-	"github.com/stretchr/testify/assert"
 )
 
 var metricsValues = map[string]float64{
@@ -40,25 +41,25 @@ func TestParseCoresMeasurement(t *testing.T) {
 
 		result, err := parseCoresMeasurement(measurement)
 
-		assert.Nil(t, err)
-		assert.Equal(t, expectedCores, result.cores)
-		assert.Equal(t, expectedTimestamp, result.time)
-		assert.Equal(t, result.values[0], metricsValues["IPC"])
-		assert.Equal(t, result.values[1], metricsValues["LLC_Misses"])
-		assert.Equal(t, result.values[2], metricsValues["LLC"])
-		assert.Equal(t, result.values[3], metricsValues["MBL"])
-		assert.Equal(t, result.values[4], metricsValues["MBR"])
-		assert.Equal(t, result.values[5], metricsValues["MBT"])
+		require.Nil(t, err)
+		require.Equal(t, expectedCores, result.cores)
+		require.Equal(t, expectedTimestamp, result.time)
+		require.Equal(t, result.values[0], metricsValues["IPC"])
+		require.Equal(t, result.values[1], metricsValues["LLC_Misses"])
+		require.Equal(t, result.values[2], metricsValues["LLC"])
+		require.Equal(t, result.values[3], metricsValues["MBL"])
+		require.Equal(t, result.values[4], metricsValues["MBR"])
+		require.Equal(t, result.values[5], metricsValues["MBT"])
 	})
 	t.Run("not valid measurement string", func(t *testing.T) {
 		measurement := "not, valid, measurement"
 
 		result, err := parseCoresMeasurement(measurement)
 
-		assert.NotNil(t, err)
-		assert.Equal(t, "", result.cores)
-		assert.Nil(t, result.values)
-		assert.Equal(t, time.Time{}, result.time)
+		require.NotNil(t, err)
+		require.Equal(t, "", result.cores)
+		require.Nil(t, result.values)
+		require.Equal(t, time.Time{}, result.time)
 	})
 	t.Run("not valid values string", func(t *testing.T) {
 		measurement := fmt.Sprintf("%s,%s,%s,%s,%f,%f,%f,%f",
@@ -73,10 +74,10 @@ func TestParseCoresMeasurement(t *testing.T) {
 
 		result, err := parseCoresMeasurement(measurement)
 
-		assert.NotNil(t, err)
-		assert.Equal(t, "", result.cores)
-		assert.Nil(t, result.values)
-		assert.Equal(t, time.Time{}, result.time)
+		require.NotNil(t, err)
+		require.Equal(t, "", result.cores)
+		require.Nil(t, result.values)
+		require.Equal(t, time.Time{}, result.time)
 	})
 	t.Run("not valid timestamp format", func(t *testing.T) {
 		invalidTimestamp := "2020-08-12-21 13:34:"
@@ -92,10 +93,10 @@ func TestParseCoresMeasurement(t *testing.T) {
 
 		result, err := parseCoresMeasurement(measurement)
 
-		assert.NotNil(t, err)
-		assert.Equal(t, "", result.cores)
-		assert.Nil(t, result.values)
-		assert.Equal(t, time.Time{}, result.time)
+		require.NotNil(t, err)
+		require.Equal(t, "", result.cores)
+		require.Nil(t, result.values)
+		require.Equal(t, time.Time{}, result.time)
 	})
 }
 
@@ -126,16 +127,16 @@ func TestParseProcessesMeasurement(t *testing.T) {
 		}
 		result, err := parseProcessesMeasurement(newMeasurement)
 
-		assert.Nil(t, err)
-		assert.Equal(t, processName, result.process)
-		assert.Equal(t, expectedCores, result.cores)
-		assert.Equal(t, expectedTimestamp, result.time)
-		assert.Equal(t, result.values[0], metricsValues["IPC"])
-		assert.Equal(t, result.values[1], metricsValues["LLC_Misses"])
-		assert.Equal(t, result.values[2], metricsValues["LLC"])
-		assert.Equal(t, result.values[3], metricsValues["MBL"])
-		assert.Equal(t, result.values[4], metricsValues["MBR"])
-		assert.Equal(t, result.values[5], metricsValues["MBT"])
+		require.Nil(t, err)
+		require.Equal(t, processName, result.process)
+		require.Equal(t, expectedCores, result.cores)
+		require.Equal(t, expectedTimestamp, result.time)
+		require.Equal(t, result.values[0], metricsValues["IPC"])
+		require.Equal(t, result.values[1], metricsValues["LLC_Misses"])
+		require.Equal(t, result.values[2], metricsValues["LLC"])
+		require.Equal(t, result.values[3], metricsValues["MBL"])
+		require.Equal(t, result.values[4], metricsValues["MBR"])
+		require.Equal(t, result.values[5], metricsValues["MBT"])
 	})
 
 	invalidTimestamp := "2020-20-20-31"
@@ -185,11 +186,11 @@ func TestParseProcessesMeasurement(t *testing.T) {
 			}
 			result, err := parseProcessesMeasurement(newMeasurement)
 
-			assert.NotNil(t, err)
-			assert.Equal(t, "", result.process)
-			assert.Equal(t, "", result.cores)
-			assert.Nil(t, result.values)
-			assert.Equal(t, time.Time{}, result.time)
+			require.NotNil(t, err)
+			require.Equal(t, "", result.process)
+			require.Equal(t, "", result.cores)
+			require.Nil(t, result.values)
+			require.Equal(t, time.Time{}, result.time)
 		})
 	}
 }

--- a/plugins/inputs/nginx_plus/nginx_plus_test.go
+++ b/plugins/inputs/nginx_plus/nginx_plus_test.go
@@ -8,9 +8,9 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/influxdata/telegraf/testutil"
-	//"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/influxdata/telegraf/testutil"
 )
 
 const sampleStatusResponse = `

--- a/plugins/inputs/p4runtime/p4runtime_test.go
+++ b/plugins/inputs/p4runtime/p4runtime_test.go
@@ -10,7 +10,6 @@ import (
 
 	p4ConfigV1 "github.com/p4lang/p4runtime/go/p4/config/v1"
 	p4v1 "github.com/p4lang/p4runtime/go/p4/v1"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -568,7 +567,7 @@ func TestFailReadCounterEntryFromEntry(t *testing.T) {
 
 	var acc testutil.Accumulator
 	require.NoError(t, plugin.Gather(&acc))
-	assert.Equal(
+	require.Equal(
 		t,
 		acc.Errors[0],
 		errors.New("reading counter entry from entry table_entry:<>  failed"),
@@ -615,7 +614,7 @@ func TestFailReadAllEntries(t *testing.T) {
 
 	var acc testutil.Accumulator
 	require.NoError(t, plugin.Gather(&acc))
-	assert.Equal(
+	require.Equal(
 		t,
 		acc.Errors[0],
 		fmt.Errorf("reading counter entries with ID=1111 failed with error: %w",
@@ -640,7 +639,7 @@ func TestFilterCounterNamesInclude(t *testing.T) {
 	counterNamesInclude := []string{"bar"}
 
 	filteredCounters := filterCounters(counters, counterNamesInclude)
-	assert.Equal(
+	require.Equal(
 		t,
 		filteredCounters,
 		[]*p4ConfigV1.Counter{

--- a/plugins/outputs/postgresql/table_manager_test.go
+++ b/plugins/outputs/postgresql/table_manager_test.go
@@ -4,7 +4,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/influxdata/telegraf"
@@ -35,11 +34,11 @@ func TestTableManagerIntegration_EnsureStructure(t *testing.T) {
 		nil,
 	)
 	require.NoError(t, err)
-	assert.Empty(t, missingCols)
+	require.Empty(t, missingCols)
 
 	tblCols := p.tableManager.table(t.Name()).columns
-	assert.EqualValues(t, cols[0], tblCols["foo"])
-	assert.EqualValues(t, cols[1], tblCols["baz"])
+	require.EqualValues(t, cols[0], tblCols["foo"])
+	require.EqualValues(t, cols[1], tblCols["baz"])
 }
 
 func TestTableManagerIntegration_EnsureStructure_alter(t *testing.T) {
@@ -78,12 +77,12 @@ func TestTableManagerIntegration_EnsureStructure_alter(t *testing.T) {
 		nil,
 	)
 	require.NoError(t, err)
-	assert.Empty(t, missingCols)
+	require.Empty(t, missingCols)
 
 	tblCols := p.tableManager.table(t.Name()).columns
-	assert.EqualValues(t, cols[0], tblCols["foo"])
-	assert.EqualValues(t, cols[1], tblCols["bar"])
-	assert.EqualValues(t, cols[2], tblCols["baz"])
+	require.EqualValues(t, cols[0], tblCols["foo"])
+	require.EqualValues(t, cols[1], tblCols["bar"])
+	require.EqualValues(t, cols[2], tblCols["baz"])
 }
 
 func TestTableManagerIntegration_EnsureStructure_overflowTableName(t *testing.T) {
@@ -109,8 +108,8 @@ func TestTableManagerIntegration_EnsureStructure_overflowTableName(t *testing.T)
 		nil,
 	)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "table name too long")
-	assert.False(t, isTempError(err))
+	require.Contains(t, err.Error(), "table name too long")
+	require.False(t, isTempError(err))
 }
 
 func TestTableManagerIntegration_EnsureStructure_overflowTagName(t *testing.T) {
@@ -137,7 +136,7 @@ func TestTableManagerIntegration_EnsureStructure_overflowTagName(t *testing.T) {
 		nil,
 	)
 	require.Error(t, err)
-	assert.False(t, isTempError(err))
+	require.False(t, isTempError(err))
 }
 
 func TestTableManagerIntegration_EnsureStructure_overflowFieldName(t *testing.T) {
@@ -164,8 +163,8 @@ func TestTableManagerIntegration_EnsureStructure_overflowFieldName(t *testing.T)
 		nil,
 	)
 	require.NoError(t, err)
-	assert.Len(t, missingCols, 1)
-	assert.Equal(t, cols[1], missingCols[0])
+	require.Len(t, missingCols, 1)
+	require.Equal(t, cols[1], missingCols[0])
 }
 
 func TestTableManagerIntegration_getColumns(t *testing.T) {
@@ -198,8 +197,8 @@ func TestTableManagerIntegration_getColumns(t *testing.T) {
 	curCols, err := p.tableManager.getColumns(ctx, p.db, t.Name())
 	require.NoError(t, err)
 
-	assert.EqualValues(t, cols[0], curCols["foo"])
-	assert.EqualValues(t, cols[1], curCols["baz"])
+	require.EqualValues(t, cols[0], curCols["foo"])
+	require.EqualValues(t, cols[1], curCols["baz"])
 }
 
 func TestTableManagerIntegration_MatchSource(t *testing.T) {
@@ -217,8 +216,8 @@ func TestTableManagerIntegration_MatchSource(t *testing.T) {
 	tsrc := NewTableSources(p.Postgresql, metrics)[t.Name()]
 
 	require.NoError(t, p.tableManager.MatchSource(ctx, p.db, tsrc))
-	assert.Contains(t, p.tableManager.table(t.Name()+p.TagTableSuffix).columns, "tag")
-	assert.Contains(t, p.tableManager.table(t.Name()).columns, "a")
+	require.Contains(t, p.tableManager.table(t.Name()+p.TagTableSuffix).columns, "tag")
+	require.Contains(t, p.tableManager.table(t.Name()).columns, "a")
 }
 
 func TestTableManagerIntegration_MatchSource_UnsignedIntegers(t *testing.T) {
@@ -243,7 +242,7 @@ func TestTableManagerIntegration_MatchSource_UnsignedIntegers(t *testing.T) {
 	tsrc := NewTableSources(p.Postgresql, metrics)[t.Name()]
 
 	require.NoError(t, p.tableManager.MatchSource(ctx, p.db, tsrc))
-	assert.Equal(t, PgUint8, p.tableManager.table(t.Name()).columns["a"].Type)
+	require.Equal(t, PgUint8, p.tableManager.table(t.Name()).columns["a"].Type)
 }
 
 func TestTableManagerIntegration_noCreateTable(t *testing.T) {
@@ -321,7 +320,7 @@ func TestTableManagerIntegration_noAlterMissingTag(t *testing.T) {
 	}
 	tsrc = NewTableSources(p.Postgresql, metrics)[t.Name()]
 	require.NoError(t, p.tableManager.MatchSource(ctx, p.db, tsrc))
-	assert.NotContains(t, tsrc.ColumnNames(), "bar")
+	require.NotContains(t, tsrc.ColumnNames(), "bar")
 }
 
 // Verify that when using foreign tags and alter statements are disabled and a metric comes in with a new tag key, that
@@ -349,7 +348,7 @@ func TestTableManagerIntegration_noAlterMissingTagTableTag(t *testing.T) {
 	tsrc = NewTableSources(p.Postgresql, metrics)[t.Name()]
 	ttsrc := NewTagTableSource(tsrc)
 	require.NoError(t, p.tableManager.MatchSource(ctx, p.db, tsrc))
-	assert.NotContains(t, ttsrc.ColumnNames(), "bar")
+	require.NotContains(t, ttsrc.ColumnNames(), "bar")
 }
 
 // Verify that when using foreign tags and alter statements generate a permanent error and a metric comes in with a new
@@ -379,7 +378,7 @@ func TestTableManagerIntegration_badAlterTagTable(t *testing.T) {
 	tsrc = NewTableSources(p.Postgresql, metrics)[t.Name()]
 	ttsrc := NewTagTableSource(tsrc)
 	require.NoError(t, p.tableManager.MatchSource(ctx, p.db, tsrc))
-	assert.NotContains(t, ttsrc.ColumnNames(), "bar")
+	require.NotContains(t, ttsrc.ColumnNames(), "bar")
 }
 
 // verify that when alter statements are disabled and a metric comes in with a new field key, that the field is omitted.
@@ -404,7 +403,7 @@ func TestTableManagerIntegration_noAlterMissingField(t *testing.T) {
 	}
 	tsrc = NewTableSources(p.Postgresql, metrics)[t.Name()]
 	require.NoError(t, p.tableManager.MatchSource(ctx, p.db, tsrc))
-	assert.NotContains(t, tsrc.ColumnNames(), "b")
+	require.NotContains(t, tsrc.ColumnNames(), "b")
 }
 
 // verify that when alter statements generate a permanent error and a metric comes in with a new field key, that the field is omitted.
@@ -431,7 +430,7 @@ func TestTableManagerIntegration_badAlterField(t *testing.T) {
 	}
 	tsrc = NewTableSources(p.Postgresql, metrics)[t.Name()]
 	require.NoError(t, p.tableManager.MatchSource(ctx, p.db, tsrc))
-	assert.NotContains(t, tsrc.ColumnNames(), "b")
+	require.NotContains(t, tsrc.ColumnNames(), "b")
 }
 
 func TestTableManager_addColumnTemplates(t *testing.T) {
@@ -468,7 +467,7 @@ func TestTableManager_addColumnTemplates(t *testing.T) {
 		}
 	}
 
-	assert.Equal(t, 1, stmtCount)
+	require.Equal(t, 1, stmtCount)
 }
 
 func TestTableManager_TimeWithTimezone(t *testing.T) {

--- a/selfstat/selfstat_test.go
+++ b/selfstat/selfstat_test.go
@@ -4,9 +4,9 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/influxdata/telegraf/testutil"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/influxdata/telegraf/testutil"
 )
 
 var (
@@ -51,29 +51,29 @@ func TestRegisterAndIncrAndSet(t *testing.T) {
 	defer testCleanup()
 	s1 := Register("test", "test_field1", map[string]string{"test": "foo"})
 	s2 := Register("test", "test_field2", map[string]string{"test": "foo"})
-	assert.Equal(t, int64(0), s1.Get())
+	require.Equal(t, int64(0), s1.Get())
 
 	s1.Incr(10)
 	s1.Incr(5)
-	assert.Equal(t, int64(15), s1.Get())
+	require.Equal(t, int64(15), s1.Get())
 
 	s1.Set(12)
-	assert.Equal(t, int64(12), s1.Get())
+	require.Equal(t, int64(12), s1.Get())
 
 	s1.Incr(-2)
-	assert.Equal(t, int64(10), s1.Get())
+	require.Equal(t, int64(10), s1.Get())
 
 	s2.Set(101)
-	assert.Equal(t, int64(101), s2.Get())
+	require.Equal(t, int64(101), s2.Get())
 
 	// make sure that the same field returns the same metric
 	// this one should be the same as s2.
 	foo := Register("test", "test_field2", map[string]string{"test": "foo"})
-	assert.Equal(t, int64(101), foo.Get())
+	require.Equal(t, int64(101), foo.Get())
 
 	// check that tags are consistent
-	assert.Equal(t, map[string]string{"test": "foo"}, foo.Tags())
-	assert.Equal(t, "internal_test", foo.Name())
+	require.Equal(t, map[string]string{"test": "foo"}, foo.Tags())
+	require.Equal(t, "internal_test", foo.Name())
 }
 
 func TestRegisterTimingAndIncrAndSet(t *testing.T) {
@@ -81,31 +81,31 @@ func TestRegisterTimingAndIncrAndSet(t *testing.T) {
 	defer testCleanup()
 	s1 := RegisterTiming("test", "test_field1_ns", map[string]string{"test": "foo"})
 	s2 := RegisterTiming("test", "test_field2_ns", map[string]string{"test": "foo"})
-	assert.Equal(t, int64(0), s1.Get())
+	require.Equal(t, int64(0), s1.Get())
 
 	s1.Incr(10)
 	s1.Incr(5)
-	assert.Equal(t, int64(7), s1.Get())
+	require.Equal(t, int64(7), s1.Get())
 	// previous value is used on subsequent calls to Get()
-	assert.Equal(t, int64(7), s1.Get())
+	require.Equal(t, int64(7), s1.Get())
 
 	s1.Set(12)
-	assert.Equal(t, int64(12), s1.Get())
+	require.Equal(t, int64(12), s1.Get())
 
 	s1.Incr(-2)
-	assert.Equal(t, int64(-2), s1.Get())
+	require.Equal(t, int64(-2), s1.Get())
 
 	s2.Set(101)
-	assert.Equal(t, int64(101), s2.Get())
+	require.Equal(t, int64(101), s2.Get())
 
 	// make sure that the same field returns the same metric
 	// this one should be the same as s2.
 	foo := RegisterTiming("test", "test_field2_ns", map[string]string{"test": "foo"})
-	assert.Equal(t, int64(101), foo.Get())
+	require.Equal(t, int64(101), foo.Get())
 
 	// check that tags are consistent
-	assert.Equal(t, map[string]string{"test": "foo"}, foo.Tags())
-	assert.Equal(t, "internal_test", foo.Name())
+	require.Equal(t, map[string]string{"test": "foo"}, foo.Tags())
+	require.Equal(t, "internal_test", foo.Name())
 }
 
 func TestStatKeyConsistency(t *testing.T) {
@@ -131,14 +131,14 @@ func TestRegisterMetricsAndVerify(t *testing.T) {
 	s2 := RegisterTiming("test_timing", "test_field2_ns", map[string]string{"test": "foo"})
 	s1.Incr(10)
 	s2.Incr(15)
-	assert.Len(t, Metrics(), 1)
+	require.Len(t, Metrics(), 1)
 
 	// register two more metrics with different keys
 	s3 := RegisterTiming("test_timing", "test_field1_ns", map[string]string{"test": "bar"})
 	s4 := RegisterTiming("test_timing", "test_field2_ns", map[string]string{"test": "baz"})
 	s3.Incr(10)
 	s4.Incr(15)
-	assert.Len(t, Metrics(), 3)
+	require.Len(t, Metrics(), 3)
 
 	// register some non-timing metrics
 	s5 := Register("test", "test_field1", map[string]string{"test": "bar"})
@@ -147,7 +147,7 @@ func TestRegisterMetricsAndVerify(t *testing.T) {
 	s5.Incr(10)
 	s5.Incr(18)
 	s6.Incr(15)
-	assert.Len(t, Metrics(), 5)
+	require.Len(t, Metrics(), 5)
 
 	acc := testutil.Accumulator{}
 	acc.AddMetrics(Metrics())

--- a/testutil/accumulator.go
+++ b/testutil/accumulator.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/influxdata/telegraf"
 )
@@ -369,7 +369,7 @@ func (a *Accumulator) AssertContainsTaggedFields(
 		}
 	}
 	msg := fmt.Sprintf("unknown measurement %q with tags %v", measurement, tags)
-	assert.Fail(t, msg)
+	require.Fail(t, msg)
 }
 
 func (a *Accumulator) AssertDoesNotContainsTaggedFields(
@@ -389,7 +389,7 @@ func (a *Accumulator) AssertDoesNotContainsTaggedFields(
 			msg := fmt.Sprintf(
 				"found measurement %s with tagged fields (tags %v) which should not be there",
 				measurement, tags)
-			assert.Fail(t, msg)
+			require.Fail(t, msg)
 		}
 	}
 }
@@ -402,12 +402,12 @@ func (a *Accumulator) AssertContainsFields(
 	defer a.Unlock()
 	for _, p := range a.Metrics {
 		if p.Measurement == measurement {
-			assert.Equal(t, fields, p.Fields)
+			require.Equal(t, fields, p.Fields)
 			return
 		}
 	}
 	msg := fmt.Sprintf("unknown measurement %q", measurement)
-	assert.Fail(t, msg)
+	require.Fail(t, msg)
 }
 
 func (a *Accumulator) HasPoint(
@@ -441,7 +441,7 @@ func (a *Accumulator) AssertDoesNotContainMeasurement(t *testing.T, measurement 
 	for _, p := range a.Metrics {
 		if p.Measurement == measurement {
 			msg := fmt.Sprintf("found unexpected measurement %s", measurement)
-			assert.Fail(t, msg)
+			require.Fail(t, msg)
 		}
 	}
 }


### PR DESCRIPTION
Address findings for [testifylint: require-error](https://github.com/Antonboom/testifylint#require-error) - checks usage of github.com/stretchr/testify.

```
❌   assert.NoError(t, err)
     s.ErrorIs(err, io.EOF)
     s.Assert().Error(err)
     // And other error assertions...

✅   require.NoError(t, err)
     s.Require().ErrorIs(err, io.EOF)
     s.Require().Error(err)
```

Such "ignoring" of errors leads to further panics, making the test harder to debug.

It is only part of the bigger job.
After all type of findings in whole project are handled, we can enable `testifylint` linter in `golangci-lint`.