### PR TITLE
feat(inputs.amqp_consumer): AMQP input add check queue for the presen…

### DIFF
--- a/plugins/inputs/amqp_consumer/amqp_consumer_test.go
+++ b/plugins/inputs/amqp_consumer/amqp_consumer_test.go
@@ -1,15 +1,19 @@
 package amqp_consumer
 
 import (
-	"testing"
-
+	"fmt"
 	"github.com/rabbitmq/amqp091-go"
 	"github.com/stretchr/testify/require"
+	"net/http"
+	"testing"
+	"time"
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/internal"
 	"github.com/influxdata/telegraf/plugins/parsers/influx"
 	"github.com/influxdata/telegraf/testutil"
+
+	_ "net/http/pprof"
 )
 
 func TestAutoEncoding(t *testing.T) {
@@ -49,4 +53,161 @@ func TestAutoEncoding(t *testing.T) {
 	err = a.onMessage(acc, d)
 	require.NoError(t, err)
 	acc.AssertContainsFields(t, "measurementName2", map[string]interface{}{"fieldKey": "identity"})
+}
+
+func TestQueueConsume(t *testing.T) {
+	// pprof
+	go http.ListenAndServe(":80", nil)
+
+	rmq := AMQPConsumer{
+		Brokers: []string{
+			"amqp://username:password@127.0.0.1:5672",
+		},
+		Exchange:     "test_exchange",
+		ExchangeType: "direct",
+		Queue:        "test_queue",
+		//QueuePassive:              true,
+		QueueConsumeCheck:         true,
+		QueueConsumeCheckInterval: time.Second * 10,
+		BindingKey:                "#",
+		Log:                       log{},
+	}
+
+	if err := rmq.Start(new(ac)); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Log("waiting...")
+
+	select {}
+	// delete the "test_queue" queue to test checkQueueConsume.
+	// test result:
+	// 		Errorf Error inspecting queue: Exception (404) Reason: "NOT_FOUND - no queue 'test_queue' in vhost '/'"
+	// 		Errorf Error inspect queue test_queue: no consumers
+	// 		panic: QueueConsumeCheckFailCallback test_queue
+}
+
+type ac struct {
+}
+
+func (a ac) AddFields(measurement string, fields map[string]interface{}, tags map[string]string, t ...time.Time) {
+
+}
+
+func (a ac) AddGauge(measurement string, fields map[string]interface{}, tags map[string]string, t ...time.Time) {
+
+}
+
+func (a ac) AddCounter(measurement string, fields map[string]interface{}, tags map[string]string, t ...time.Time) {
+
+}
+
+func (a ac) AddSummary(measurement string, fields map[string]interface{}, tags map[string]string, t ...time.Time) {
+
+}
+
+func (a ac) AddHistogram(measurement string, fields map[string]interface{}, tags map[string]string, t ...time.Time) {
+
+}
+
+func (a ac) AddMetric(metric telegraf.Metric) {
+
+}
+
+func (a ac) SetPrecision(precision time.Duration) {
+
+}
+
+func (a ac) AddError(err error) {
+
+}
+
+func (a ac) WithTracking(maxTracked int) telegraf.TrackingAccumulator {
+	return tkAc{}
+}
+
+type tkAc struct {
+}
+
+func (t2 tkAc) AddFields(measurement string, fields map[string]interface{}, tags map[string]string, t ...time.Time) {
+
+}
+
+func (t2 tkAc) AddGauge(measurement string, fields map[string]interface{}, tags map[string]string, t ...time.Time) {
+
+}
+
+func (t2 tkAc) AddCounter(measurement string, fields map[string]interface{}, tags map[string]string, t ...time.Time) {
+
+}
+
+func (t2 tkAc) AddSummary(measurement string, fields map[string]interface{}, tags map[string]string, t ...time.Time) {
+
+}
+
+func (t2 tkAc) AddHistogram(measurement string, fields map[string]interface{}, tags map[string]string, t ...time.Time) {
+
+}
+
+func (t2 tkAc) AddMetric(metric telegraf.Metric) {
+
+}
+
+func (t2 tkAc) SetPrecision(precision time.Duration) {
+
+}
+
+func (t2 tkAc) AddError(err error) {
+
+}
+
+func (t2 tkAc) WithTracking(maxTracked int) telegraf.TrackingAccumulator {
+	return nil
+}
+
+func (t2 tkAc) AddTrackingMetric(m telegraf.Metric) telegraf.TrackingID {
+	return 0
+}
+
+func (t2 tkAc) AddTrackingMetricGroup(group []telegraf.Metric) telegraf.TrackingID {
+	return 0
+}
+
+func (t2 tkAc) Delivered() <-chan telegraf.DeliveryInfo {
+	return nil
+}
+
+type log struct {
+}
+
+func (l log) Errorf(format string, args ...interface{}) {
+	fmt.Println("Errorf", fmt.Sprintf(format, args...))
+}
+
+func (l log) Error(args ...interface{}) {
+	fmt.Println("Error", args)
+}
+
+func (l log) Debugf(format string, args ...interface{}) {
+	fmt.Println("Debugf", fmt.Sprintf(format, args...))
+}
+
+func (l log) Debug(args ...interface{}) {
+	fmt.Println("Debug", args)
+}
+
+func (l log) Warnf(format string, args ...interface{}) {
+	fmt.Println("Warnf", fmt.Sprintf(format, args...))
+}
+
+func (l log) Warn(args ...interface{}) {
+	fmt.Println("Warn", args)
+}
+
+func (l log) Infof(format string, args ...interface{}) {
+	fmt.Println("Infof", fmt.Sprintf(format, args...))
+}
+
+func (l log) Info(args ...interface{}) {
+	fmt.Println("Info", args)
 }


### PR DESCRIPTION
…ce of consumers

# Required for all PRs

<!-- Before opening a pull request you should run the following checks locally to make sure the CI will pass.

make lint
make check
make check-deps
make test
make docs

-->

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

resolves #

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->

In some cases consumer will loss, it has been confirmed that it is not a code logic problem, perhaps related to Rabbitmq's mirror queue mode, and amqp client sends heartbeat packets using the same function "send" as other packet, the heartbeat message loses its effect.  so add a consumer check loop to enable the program to restart and recover