### PR TITLE
fix(inputs.cgroup): Escape backslashes

### DIFF
--- a/plugins/inputs/cgroup/cgroup_linux.go
+++ b/plugins/inputs/cgroup/cgroup_linux.go
@@ -109,6 +109,8 @@ func (g *CGroup) generateDirs(list chan<- pathInfo) {
 }
 
 func (g *CGroup) generateFiles(dir string, list chan<- pathInfo) {
+	dir = strings.Replace(dir, "\\", "\\\\", -1)
+
 	defer close(list)
 	for _, file := range g.Files {
 		// getting all file paths that match the pattern 'dir + file'

--- a/plugins/inputs/cgroup/testdata/backslash/machine-qemu-1-ubuntu/cpu.stat
+++ b/plugins/inputs/cgroup/testdata/backslash/machine-qemu-1-ubuntu/cpu.stat
@@ -1,0 +1,4 @@
+usage_usec 614953149468
+user_usec 511415566817
+system_usec 103537582650
+core_sched.force_idle_usec 0


### PR DESCRIPTION
Ensure we escape backslashes before the glob to avoid missing directories.

fixes: #8340
