### PR TITLE
fix(input.prometheus): read bearer token from file every time

### DIFF
--- a/plugins/inputs/prometheus/kubernetes.go
+++ b/plugins/inputs/prometheus/kubernetes.go
@@ -93,16 +93,20 @@ func (p *Prometheus) startK8s(ctx context.Context) error {
 				return
 			case <-time.After(time.Second):
 				if p.isNodeScrapeScope {
-					var bearerToken []byte
-					bearerToken, err = os.ReadFile(config.BearerTokenFile)
-					if err != nil {
-						p.Log.Errorf("Error reading bearer token file: %s", err.Error())
-					} else {
-						err = p.cAdvisor(ctx, string(bearerToken))
+					bearerToken := config.BearerToken
+					if config.BearerTokenFile != "" {
+						bearerTokenBytes, err := os.ReadFile(config.BearerTokenFile)
 						if err != nil {
-							p.Log.Errorf("Unable to monitor pods with node scrape scope: %s", err.Error())
+							p.Log.Errorf("Error reading bearer token file hence falling back to BearerToken: %s", err.Error())
+						} else {
+							bearerToken = string(bearerTokenBytes)
 						}
 					}
+					err = p.cAdvisor(ctx, bearerToken)
+					if err != nil {
+						p.Log.Errorf("Unable to monitor pods with node scrape scope: %s", err.Error())
+					}
+
 				} else {
 					<-ctx.Done()
 				}

--- a/plugins/inputs/prometheus/kubernetes.go
+++ b/plugins/inputs/prometheus/kubernetes.go
@@ -96,7 +96,7 @@ func (p *Prometheus) startK8s(ctx context.Context) error {
                     var bearerToken []byte
 					bearerToken, err = os.ReadFile(config.BearerTokenFile)
 					if err != nil {
-						p.Log.Errorf("Unable to monitor pods with node scrape scope: %s", err.Error())
+						p.Log.Errorf("Error reading bearer token file: %s", err.Error())
 					} else {
 						err = p.cAdvisor(ctx, string(bearerToken))
 						if err != nil {

--- a/plugins/inputs/prometheus/kubernetes.go
+++ b/plugins/inputs/prometheus/kubernetes.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"os/user"
 	"path/filepath"
 	"strconv"
@@ -92,10 +93,16 @@ func (p *Prometheus) startK8s(ctx context.Context) error {
 				return
 			case <-time.After(time.Second):
 				if p.isNodeScrapeScope {
-					err = p.cAdvisor(ctx, config.BearerToken)
+                    var bearerToken []byte
+					bearerToken, err = os.ReadFile(config.BearerTokenFile)
 					if err != nil {
 						p.Log.Errorf("Unable to monitor pods with node scrape scope: %s", err.Error())
-					}
+					} else {
+						err = p.cAdvisor(ctx, string(bearerToken))
+						if err != nil {
+							p.Log.Errorf("Unable to monitor pods with node scrape scope: %s", err.Error())
+						}
+				   }
 				} else {
 					<-ctx.Done()
 				}

--- a/plugins/inputs/prometheus/kubernetes.go
+++ b/plugins/inputs/prometheus/kubernetes.go
@@ -106,7 +106,6 @@ func (p *Prometheus) startK8s(ctx context.Context) error {
 					if err != nil {
 						p.Log.Errorf("Unable to monitor pods with node scrape scope: %s", err.Error())
 					}
-
 				} else {
 					<-ctx.Done()
 				}

--- a/plugins/inputs/prometheus/kubernetes.go
+++ b/plugins/inputs/prometheus/kubernetes.go
@@ -93,7 +93,7 @@ func (p *Prometheus) startK8s(ctx context.Context) error {
 				return
 			case <-time.After(time.Second):
 				if p.isNodeScrapeScope {
-                    var bearerToken []byte
+					var bearerToken []byte
 					bearerToken, err = os.ReadFile(config.BearerTokenFile)
 					if err != nil {
 						p.Log.Errorf("Error reading bearer token file: %s", err.Error())
@@ -102,7 +102,7 @@ func (p *Prometheus) startK8s(ctx context.Context) error {
 						if err != nil {
 							p.Log.Errorf("Unable to monitor pods with node scrape scope: %s", err.Error())
 						}
-				   }
+					}
 				} else {
 					<-ctx.Done()
 				}


### PR DESCRIPTION
The current implementation uses the config.BearerToken which is being read from the service account token file as part of the initialization. This  service account token becomes invalid, if the service account configured with time bound token after the specified expiry interval or service account signing key being rotated by either Kubernetes platform providers (such as AKS ) or the customer initiated signing key rotation in case of the Workload identity enabled clusters.

Fix is to read the bearer token from service account token file every time and instead of reading once at the initialization.

Fixes https://github.com/influxdata/telegraf/issues/14188

