### PR TITLE
fix(inputs.netflow): Fix sFlow metric timestamp

### DIFF
--- a/plugins/inputs/netflow/sflow_v5.go
+++ b/plugins/inputs/netflow/sflow_v5.go
@@ -34,6 +34,7 @@ func (d *sflowv5Decoder) Init() error {
 }
 
 func (d *sflowv5Decoder) Decode(srcIP net.IP, payload []byte) ([]telegraf.Metric, error) {
+	t := time.Now()
 	src := srcIP.String()
 
 	// Decode the message
@@ -49,7 +50,6 @@ func (d *sflowv5Decoder) Decode(srcIP net.IP, payload []byte) ([]telegraf.Metric
 		return nil, fmt.Errorf("unexpected message type %T", packet)
 	}
 
-	t := time.Unix(0, int64(msg.Uptime)*int64(time.Millisecond))
 	metrics := make([]telegraf.Metric, 0, len(msg.Samples))
 	for _, s := range msg.Samples {
 		tags := map[string]string{


### PR DESCRIPTION
# Required for all PRs

<!-- Before opening a pull request you should run the following checks locally to make sure the CI will pass.

make lint
make check
make check-deps
make test
make docs

-->

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

Currently, the sysUptime field was used, but that isn't a unix timestamp:

>The time (in hundredths of a second) since the network management portion of the system was last re-initialized.

This PR rectifies this and uses the same as for the netflow decoders.

```diff
-netflow,source=127.0.0.1,version=sFlowV5 sys_uptime=12414u,agent_ip="192.168.119.184",agent_subid=100000u,seq_number=2u,in_snmp=3u,port_name="eno1",ip_version="IPv4" 12414000000
+netflow,source=127.0.0.1,version=sFlowV5 sys_uptime=12414u,agent_ip="192.168.119.184",agent_subid=100000u,seq_number=2u,in_snmp=3u,port_name="eno1",ip_version="IPv4" 16983296530
```