### PR TITLE
chore(linters): Fix findings found by testifylint: error-nil

### DIFF
--- a/internal/globpath/globpath_test.go
+++ b/internal/globpath/globpath_test.go
@@ -51,7 +51,7 @@ func TestCompileAndMatch(t *testing.T) {
 
 	for _, tc := range tests {
 		g, err := Compile(tc.path)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		matches := g.Match()
 		require.Len(t, matches, tc.matches)
 	}

--- a/plugins/inputs/aliyuncms/aliyuncms_test.go
+++ b/plugins/inputs/aliyuncms/aliyuncms_test.go
@@ -191,7 +191,7 @@ func TestPluginInitialize(t *testing.T) {
 			if tt.expectedErrorString != "" {
 				require.EqualError(t, plugin.Init(), tt.expectedErrorString)
 			} else {
-				require.Equal(t, nil, plugin.Init())
+				require.NoError(t, plugin.Init())
 			}
 			if len(tt.regions) == 0 { //Check if set to default
 				require.Equal(t, plugin.Regions, aliyunRegionList)
@@ -295,7 +295,7 @@ func TestPluginMetricsInitialize(t *testing.T) {
 			if tt.expectedErrorString != "" {
 				require.EqualError(t, plugin.Init(), tt.expectedErrorString)
 			} else {
-				require.Equal(t, nil, plugin.Init())
+				require.NoError(t, plugin.Init())
 			}
 		})
 	}

--- a/plugins/inputs/gnmi/gnmi_test.go
+++ b/plugins/inputs/gnmi/gnmi_test.go
@@ -44,7 +44,7 @@ func TestParsePath(t *testing.T) {
 
 	parsed, err = parsePath("", "/foo[[", "")
 	require.Nil(t, parsed)
-	require.NotNil(t, err)
+	require.Error(t, err)
 }
 
 type MockServer struct {

--- a/plugins/inputs/intel_powerstat/msr_test.go
+++ b/plugins/inputs/intel_powerstat/msr_test.go
@@ -88,49 +88,49 @@ func TestReadValueFromFileAtOffset(t *testing.T) {
 
 	fsMock.On("readFileAtOffsetToUint64", mock.Anything, mock.Anything).
 		Return(zero, nil).Once()
-	require.Equal(t, nil, msr.readValueFromFileAtOffset(ctx, testChannel, nil, 0))
+	require.NoError(t, msr.readValueFromFileAtOffset(ctx, testChannel, nil, 0))
 	require.Equal(t, zero, <-testChannel)
 }
 
 func TestCreateUncoreFreqPath(t *testing.T) {
 	path, err := createUncoreFreqPath("0", "initial", "min", "0")
 	expectedPath := "/sys/devices/system/cpu/intel_uncore_frequency/package_00_die_00/initial_min_freq_khz"
-	require.Equal(t, nil, err)
+	require.NoError(t, err)
 	require.Equal(t, expectedPath, path)
 
 	path, err = createUncoreFreqPath("0", "initial", "max", "0")
 	expectedPath = "/sys/devices/system/cpu/intel_uncore_frequency/package_00_die_00/initial_max_freq_khz"
-	require.Equal(t, nil, err)
+	require.NoError(t, err)
 	require.Equal(t, expectedPath, path)
 
 	path, err = createUncoreFreqPath("0", "current", "min", "0")
 	expectedPath = "/sys/devices/system/cpu/intel_uncore_frequency/package_00_die_00/min_freq_khz"
-	require.Equal(t, nil, err)
+	require.NoError(t, err)
 	require.Equal(t, expectedPath, path)
 
 	path, err = createUncoreFreqPath("0", "current", "max", "0")
 	expectedPath = "/sys/devices/system/cpu/intel_uncore_frequency/package_00_die_00/max_freq_khz"
-	require.Equal(t, nil, err)
+	require.NoError(t, err)
 	require.Equal(t, expectedPath, path)
 
 	path, err = createUncoreFreqPath("9", "current", "max", "0")
 	expectedPath = "/sys/devices/system/cpu/intel_uncore_frequency/package_09_die_00/max_freq_khz"
-	require.Equal(t, nil, err)
+	require.NoError(t, err)
 	require.Equal(t, expectedPath, path)
 
 	path, err = createUncoreFreqPath("99", "current", "max", "0")
 	expectedPath = "/sys/devices/system/cpu/intel_uncore_frequency/package_99_die_00/max_freq_khz"
-	require.Equal(t, nil, err)
+	require.NoError(t, err)
 	require.Equal(t, expectedPath, path)
 
 	path, err = createUncoreFreqPath("0", "current", "max", "9")
 	expectedPath = "/sys/devices/system/cpu/intel_uncore_frequency/package_00_die_09/max_freq_khz"
-	require.Equal(t, nil, err)
+	require.NoError(t, err)
 	require.Equal(t, expectedPath, path)
 
 	path, err = createUncoreFreqPath("0", "current", "max", "99")
 	expectedPath = "/sys/devices/system/cpu/intel_uncore_frequency/package_00_die_99/max_freq_khz"
-	require.Equal(t, nil, err)
+	require.NoError(t, err)
 	require.Equal(t, expectedPath, path)
 
 	path, err = createUncoreFreqPath("0", "foo", "max", "0")

--- a/plugins/inputs/intel_rdt/intel_rdt_test.go
+++ b/plugins/inputs/intel_rdt/intel_rdt_test.go
@@ -31,18 +31,18 @@ func TestAssociateProcessesWithPIDs(t *testing.T) {
 	processes := []string{"process"}
 	expectedPID := "1000"
 	result, err := rdt.associateProcessesWithPIDs(processes)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, expectedPID, result[processes[0]])
 
 	processes = []string{"process2"}
 	expectedPID = "1002,1003"
 	result, err = rdt.associateProcessesWithPIDs(processes)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, expectedPID, result[processes[0]])
 
 	processes = []string{"process1"}
 	result, err = rdt.associateProcessesWithPIDs(processes)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Empty(t, result)
 }
 
@@ -53,14 +53,14 @@ func TestSplitCSVLineIntoValues(t *testing.T) {
 	expectedCoreOrPidsValue := []string{"\"45417", "29170\"", "37", "44"}
 
 	splitCSV, err := splitCSVLineIntoValues(line)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, expectedTimeValue, splitCSV.timeValue)
 	require.Equal(t, expectedMetricsValue, splitCSV.metricsValues)
 	require.Equal(t, expectedCoreOrPidsValue, splitCSV.coreOrPIDsValues)
 
 	wrongLine := "2020-08-12 13:34:36,37,44,0.00,0,0.0"
 	splitCSV, err = splitCSVLineIntoValues(wrongLine)
-	require.NotNil(t, err)
+	require.Error(t, err)
 	require.Equal(t, "", splitCSV.timeValue)
 	require.Nil(t, nil, splitCSV.metricsValues)
 	require.Nil(t, nil, splitCSV.coreOrPIDsValues)
@@ -70,12 +70,12 @@ func TestFindPIDsInMeasurement(t *testing.T) {
 	line := "2020-08-12 13:34:36,\"45417,29170\""
 	expected := "45417,29170"
 	result, err := findPIDsInMeasurement(line)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, expected, result)
 
 	line = "pids not included"
 	result, err = findPIDsInMeasurement(line)
-	require.NotNil(t, err)
+	require.Error(t, err)
 	require.Equal(t, "", result)
 }
 
@@ -120,35 +120,35 @@ func TestParseCoresConfig(t *testing.T) {
 	t.Run("empty slice", func(t *testing.T) {
 		var configCores []string
 		result, err := parseCoresConfig(configCores)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Empty(t, result)
 	})
 
 	t.Run("empty string in slice", func(t *testing.T) {
 		configCores := []string{""}
 		result, err := parseCoresConfig(configCores)
-		require.NotNil(t, err)
+		require.Error(t, err)
 		require.Empty(t, result)
 	})
 
 	t.Run("not correct string", func(t *testing.T) {
 		configCores := []string{"wrong string"}
 		result, err := parseCoresConfig(configCores)
-		require.NotNil(t, err)
+		require.Error(t, err)
 		require.Empty(t, result)
 	})
 
 	t.Run("not correct string", func(t *testing.T) {
 		configCores := []string{"1,2", "wasd:#$!;"}
 		result, err := parseCoresConfig(configCores)
-		require.NotNil(t, err)
+		require.Error(t, err)
 		require.Empty(t, result)
 	})
 
 	t.Run("not correct string", func(t *testing.T) {
 		configCores := []string{"1,2,2"}
 		result, err := parseCoresConfig(configCores)
-		require.NotNil(t, err)
+		require.Error(t, err)
 		require.Empty(t, result)
 	})
 
@@ -156,19 +156,19 @@ func TestParseCoresConfig(t *testing.T) {
 		configCores := []string{"0,1,2,3,4,5"}
 		expected := []string{"0,1,2,3,4,5"}
 		result, err := parseCoresConfig(configCores)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.EqualValues(t, expected, result)
 
 		configCores = []string{"0,1,2", "3,4,5"}
 		expected = []string{"0,1,2", "3,4,5"}
 		result, err = parseCoresConfig(configCores)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.EqualValues(t, expected, result)
 
 		configCores = []string{"0,4,1", "2,3,5", "9"}
 		expected = []string{"0,4,1", "2,3,5", "9"}
 		result, err = parseCoresConfig(configCores)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.EqualValues(t, expected, result)
 	})
 
@@ -176,17 +176,17 @@ func TestParseCoresConfig(t *testing.T) {
 		// cannot monitor same cores in different groups
 		configCores := []string{"0,1,2", "2"}
 		result, err := parseCoresConfig(configCores)
-		require.NotNil(t, err)
+		require.Error(t, err)
 		require.Nil(t, result)
 
 		configCores = []string{"0,1,2", "2,3,4"}
 		result, err = parseCoresConfig(configCores)
-		require.NotNil(t, err)
+		require.Error(t, err)
 		require.Nil(t, result)
 
 		configCores = []string{"0,-1,2", "2,3,4"}
 		result, err = parseCoresConfig(configCores)
-		require.NotNil(t, err)
+		require.Error(t, err)
 		require.Nil(t, result)
 	})
 
@@ -194,19 +194,19 @@ func TestParseCoresConfig(t *testing.T) {
 		configCores := []string{"0-5"}
 		expected := []string{"0,1,2,3,4,5"}
 		result, err := parseCoresConfig(configCores)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.EqualValues(t, expected, result)
 
 		configCores = []string{"0-5", "7-10"}
 		expected = []string{"0,1,2,3,4,5", "7,8,9,10"}
 		result, err = parseCoresConfig(configCores)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.EqualValues(t, expected, result)
 
 		configCores = []string{"5-5"}
 		expected = []string{"5"}
 		result, err = parseCoresConfig(configCores)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.EqualValues(t, expected, result)
 	})
 
@@ -214,24 +214,24 @@ func TestParseCoresConfig(t *testing.T) {
 		// cannot monitor same cores in different groups
 		configCores := []string{"0-5", "2-7"}
 		result, err := parseCoresConfig(configCores)
-		require.NotNil(t, err)
+		require.Error(t, err)
 		require.Nil(t, result)
 
 		// more than two values in range
 		configCores = []string{"0-5-10"}
 		result, err = parseCoresConfig(configCores)
-		require.NotNil(t, err)
+		require.Error(t, err)
 		require.Nil(t, result)
 
 		// first value cannot be higher than second
 		configCores = []string{"12-5"}
 		result, err = parseCoresConfig(configCores)
-		require.NotNil(t, err)
+		require.Error(t, err)
 		require.Nil(t, result)
 
 		configCores = []string{"0-"}
 		result, err = parseCoresConfig(configCores)
-		require.NotNil(t, err)
+		require.Error(t, err)
 		require.Nil(t, result)
 	})
 
@@ -239,19 +239,19 @@ func TestParseCoresConfig(t *testing.T) {
 		configCores := []string{"0-5,6,7"}
 		expected := []string{"0,1,2,3,4,5,6,7"}
 		result, err := parseCoresConfig(configCores)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.EqualValues(t, expected, result)
 
 		configCores = []string{"0-5,6,7", "8,9,10"}
 		expected = []string{"0,1,2,3,4,5,6,7", "8,9,10"}
 		result, err = parseCoresConfig(configCores)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.EqualValues(t, expected, result)
 
 		configCores = []string{"0-7", "8-10"}
 		expected = []string{"0,1,2,3,4,5,6,7", "8,9,10"}
 		result, err = parseCoresConfig(configCores)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.EqualValues(t, expected, result)
 	})
 
@@ -259,19 +259,19 @@ func TestParseCoresConfig(t *testing.T) {
 		// cannot monitor same cores in different groups
 		configCores := []string{"0-5,", "2-7"}
 		result, err := parseCoresConfig(configCores)
-		require.NotNil(t, err)
+		require.Error(t, err)
 		require.Nil(t, result)
 
 		// cores cannot be duplicated
 		configCores = []string{"0-5,5"}
 		result, err = parseCoresConfig(configCores)
-		require.NotNil(t, err)
+		require.Error(t, err)
 		require.Nil(t, result)
 
 		// more than two values in range
 		configCores = []string{"0-5-6,9"}
 		result, err = parseCoresConfig(configCores)
-		require.NotNil(t, err)
+		require.Error(t, err)
 		require.Nil(t, result)
 	})
 }

--- a/plugins/inputs/intel_rdt/publisher_test.go
+++ b/plugins/inputs/intel_rdt/publisher_test.go
@@ -41,7 +41,7 @@ func TestParseCoresMeasurement(t *testing.T) {
 
 		result, err := parseCoresMeasurement(measurement)
 
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Equal(t, expectedCores, result.cores)
 		require.Equal(t, expectedTimestamp, result.time)
 		require.Equal(t, result.values[0], metricsValues["IPC"])
@@ -56,7 +56,7 @@ func TestParseCoresMeasurement(t *testing.T) {
 
 		result, err := parseCoresMeasurement(measurement)
 
-		require.NotNil(t, err)
+		require.Error(t, err)
 		require.Equal(t, "", result.cores)
 		require.Nil(t, result.values)
 		require.Equal(t, time.Time{}, result.time)
@@ -74,7 +74,7 @@ func TestParseCoresMeasurement(t *testing.T) {
 
 		result, err := parseCoresMeasurement(measurement)
 
-		require.NotNil(t, err)
+		require.Error(t, err)
 		require.Equal(t, "", result.cores)
 		require.Nil(t, result.values)
 		require.Equal(t, time.Time{}, result.time)
@@ -93,7 +93,7 @@ func TestParseCoresMeasurement(t *testing.T) {
 
 		result, err := parseCoresMeasurement(measurement)
 
-		require.NotNil(t, err)
+		require.Error(t, err)
 		require.Equal(t, "", result.cores)
 		require.Nil(t, result.values)
 		require.Equal(t, time.Time{}, result.time)
@@ -127,7 +127,7 @@ func TestParseProcessesMeasurement(t *testing.T) {
 		}
 		result, err := parseProcessesMeasurement(newMeasurement)
 
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Equal(t, processName, result.process)
 		require.Equal(t, expectedCores, result.cores)
 		require.Equal(t, expectedTimestamp, result.time)
@@ -186,7 +186,7 @@ func TestParseProcessesMeasurement(t *testing.T) {
 			}
 			result, err := parseProcessesMeasurement(newMeasurement)
 
-			require.NotNil(t, err)
+			require.Error(t, err)
 			require.Equal(t, "", result.process)
 			require.Equal(t, "", result.cores)
 			require.Nil(t, result.values)

--- a/plugins/inputs/interrupts/interrupts_test.go
+++ b/plugins/inputs/interrupts/interrupts_test.go
@@ -38,7 +38,7 @@ func expectCPUAsFields(m *testutil.Accumulator, t *testing.T, measurement string
 func setup(t *testing.T, irqString string, cpuAsTags bool) (*testutil.Accumulator, []IRQ) {
 	f := bytes.NewBufferString(irqString)
 	irqs, err := parseInterrupts(f)
-	require.Equal(t, nil, err)
+	require.NoError(t, err)
 	require.NotEmpty(t, irqs)
 
 	acc := new(testutil.Accumulator)

--- a/plugins/inputs/kinesis_consumer/kinesis_consumer_test.go
+++ b/plugins/inputs/kinesis_consumer/kinesis_consumer_test.go
@@ -201,7 +201,7 @@ func TestKinesisConsumer_onMessage(t *testing.T) {
 		ContentEncoding: "notsupported",
 	}
 	err := k.Init()
-	require.NotNil(t, err)
+	require.Error(t, err)
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -211,7 +211,7 @@ func TestKinesisConsumer_onMessage(t *testing.T) {
 				records:         tt.fields.records,
 			}
 			err := k.Init()
-			require.Nil(t, err)
+			require.NoError(t, err)
 
 			acc := testutil.Accumulator{}
 			if err := k.onMessage(acc.WithTracking(tt.expected.numberOfMetrics), tt.args.r); (err != nil) != tt.wantErr {

--- a/plugins/inputs/mcrouter/mcrouter_test.go
+++ b/plugins/inputs/mcrouter/mcrouter_test.go
@@ -34,7 +34,7 @@ func TestAddressParsing(t *testing.T) {
 	for _, args := range acceptTests {
 		address, protocol, err := m.ParseAddress(args[0])
 
-		require.Nil(t, err, args[0])
+		require.NoError(t, err, args[0])
 		require.Equal(t, args[1], address, args[0])
 		require.Equal(t, args[2], protocol, args[0])
 	}
@@ -42,7 +42,7 @@ func TestAddressParsing(t *testing.T) {
 	for _, addr := range rejectTests {
 		address, protocol, err := m.ParseAddress(addr)
 
-		require.NotNil(t, err, addr)
+		require.Error(t, err, addr)
 		require.Empty(t, address, addr)
 		require.Empty(t, protocol, addr)
 	}

--- a/plugins/inputs/prometheus/kubernetes_test.go
+++ b/plugins/inputs/prometheus/kubernetes_test.go
@@ -238,7 +238,7 @@ func TestPodHasMatchingLabelSelector(t *testing.T) {
 	pod.Labels["label5"] = "label5"
 
 	labelSelector, err := labels.Parse(prom.KubernetesLabelSelector)
-	require.Equal(t, err, nil)
+	require.NoError(t, err)
 	require.True(t, podHasMatchingLabelSelector(pod, labelSelector))
 }
 
@@ -250,7 +250,7 @@ func TestPodHasMatchingFieldSelector(t *testing.T) {
 	pod.Spec.NodeName = "node1000"
 
 	fieldSelector, err := fields.ParseSelector(prom.KubernetesFieldSelector)
-	require.Equal(t, err, nil)
+	require.NoError(t, err)
 	require.True(t, podHasMatchingFieldSelector(pod, fieldSelector))
 }
 
@@ -262,7 +262,7 @@ func TestInvalidFieldSelector(t *testing.T) {
 	pod.Spec.NodeName = "node1000"
 
 	_, err := fields.ParseSelector(prom.KubernetesFieldSelector)
-	require.NotEqual(t, err, nil)
+	require.Error(t, err)
 }
 
 func TestAnnotationFilters(t *testing.T) {

--- a/plugins/inputs/smart/smart_test.go
+++ b/plugins/inputs/smart/smart_test.go
@@ -397,7 +397,7 @@ func TestGatherIntelNVMeDeprecatedFormatMetrics(t *testing.T) {
 func Test_findVIDFromNVMeOutput(t *testing.T) {
 	device, err := findNVMeDeviceInfo(nvmeIdentifyController)
 
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, "0x8086", device.vendorID)
 	require.Equal(t, "CVFT5123456789ABCD", device.serialNumber)
 	require.Equal(t, "INTEL SSDPEDABCDEFG", device.model)

--- a/plugins/inputs/syslog/rfc5426_test.go
+++ b/plugins/inputs/syslog/rfc5426_test.go
@@ -355,7 +355,7 @@ func TestTimeIncrement_udp(t *testing.T) {
 
 	// Write
 	_, e := conn.Write([]byte("<1>1 - - - - - -"))
-	require.Nil(t, e)
+	require.NoError(t, e)
 
 	// Wait
 	acc.Wait(1)
@@ -386,7 +386,7 @@ func TestTimeIncrement_udp(t *testing.T) {
 
 	// Write
 	_, e = conn.Write([]byte("<1>1 - - - - - -"))
-	require.Nil(t, e)
+	require.NoError(t, e)
 
 	// Wait
 	acc.Wait(1)
@@ -416,7 +416,7 @@ func TestTimeIncrement_udp(t *testing.T) {
 
 	// Write
 	_, e = conn.Write([]byte("<1>1 - - - - - -"))
-	require.Nil(t, e)
+	require.NoError(t, e)
 
 	// Wait
 	acc.Wait(1)

--- a/plugins/outputs/cloudwatch_logs/cloudwatch_logs_test.go
+++ b/plugins/outputs/cloudwatch_logs/cloudwatch_logs_test.go
@@ -250,7 +250,7 @@ func TestInit(t *testing.T) {
 			if tt.expectedErrorString != "" {
 				require.EqualError(t, tt.plugin.Init(), tt.expectedErrorString)
 			} else {
-				require.Nil(t, tt.plugin.Init())
+				require.NoError(t, tt.plugin.Init())
 			}
 		})
 	}
@@ -292,8 +292,8 @@ func TestConnect(t *testing.T) {
 		},
 	}
 
-	require.Nil(t, plugin.Init())
-	require.Nil(t, plugin.Connect())
+	require.NoError(t, plugin.Init())
+	require.NoError(t, plugin.Connect())
 }
 
 func TestWrite(t *testing.T) {
@@ -331,8 +331,8 @@ func TestWrite(t *testing.T) {
 			Name: "outputs.cloudwatch_logs",
 		},
 	}
-	require.Nil(t, plugin.Init())
-	require.Nil(t, plugin.Connect())
+	require.NoError(t, plugin.Init())
+	require.NoError(t, plugin.Connect())
 
 	tests := []struct {
 		name                 string
@@ -572,7 +572,7 @@ func TestWrite(t *testing.T) {
 			mockCwl := &mockCloudWatchLogs{}
 			mockCwl.Init(tt.logStreamName)
 			plugin.svc = mockCwl
-			require.Nil(t, plugin.Write(tt.metrics))
+			require.NoError(t, plugin.Write(tt.metrics))
 			require.Equal(t, tt.expectedMetricsCount, len(mockCwl.pushedLogEvents))
 
 			for index, elem := range mockCwl.pushedLogEvents {

--- a/plugins/outputs/signalfx/signalfx_test.go
+++ b/plugins/outputs/signalfx/signalfx_test.go
@@ -420,7 +420,7 @@ func TestSignalFx_SignalFx(t *testing.T) {
 			s.SignalFxRealm = "test"
 			s.Log = testutil.Logger{}
 
-			require.Nil(t, s.Connect())
+			require.NoError(t, s.Connect())
 
 			s.client = &sink{
 				dps: []*datapoint.Datapoint{},
@@ -586,7 +586,7 @@ func TestSignalFx_Errors(t *testing.T) {
 			s.SignalFxRealm = "test"
 			s.Log = testutil.Logger{}
 
-			require.Nil(t, s.Connect())
+			require.NoError(t, s.Connect())
 
 			s.client = &errorsink{
 				dps: []*datapoint.Datapoint{},

--- a/plugins/outputs/timestream/timestream_test.go
+++ b/plugins/outputs/timestream/timestream_test.go
@@ -95,7 +95,7 @@ func TestConnectValidatesConfigParameters(t *testing.T) {
 		MeasureNameForMultiMeasureRecords: "multi-measure-name",
 		Log:                               testutil.Logger{},
 	}
-	require.Nil(t, validConfigMultiMeasureMultiTableMode.Connect())
+	require.NoError(t, validConfigMultiMeasureMultiTableMode.Connect())
 
 	invalidConfigMultiMeasureMultiTableMode := Timestream{
 		DatabaseName:           tsDbName,
@@ -115,7 +115,7 @@ func TestConnectValidatesConfigParameters(t *testing.T) {
 		// measurement name (from telegraf metric) is used as multi-measure name in TS
 		Log: testutil.Logger{},
 	}
-	require.Nil(t, validConfigMultiMeasureSingleTableMode.Connect())
+	require.NoError(t, validConfigMultiMeasureSingleTableMode.Connect())
 
 	invalidConfigMultiMeasureSingleTableMode := Timestream{
 		DatabaseName:                      tsDbName,
@@ -136,7 +136,7 @@ func TestConnectValidatesConfigParameters(t *testing.T) {
 		MappingMode:  MappingModeMultiTable,
 		Log:          testutil.Logger{},
 	}
-	require.Nil(t, validMappingModeMultiTable.Connect())
+	require.NoError(t, validMappingModeMultiTable.Connect())
 
 	singleTableNameWithMultiTable := Timestream{
 		DatabaseName:    tsDbName,
@@ -179,7 +179,7 @@ func TestConnectValidatesConfigParameters(t *testing.T) {
 		SingleTableDimensionNameForTelegrafMeasurementName: testSingleTableDim,
 		Log: testutil.Logger{},
 	}
-	require.Nil(t, validConfigurationMappingModeSingleTable.Connect())
+	require.NoError(t, validConfigurationMappingModeSingleTable.Connect())
 
 	// create table arguments
 	createTableNoMagneticRetention := Timestream{
@@ -209,7 +209,7 @@ func TestConnectValidatesConfigParameters(t *testing.T) {
 		CreateTableMemoryStoreRetentionPeriodInHours:  3,
 		Log: testutil.Logger{},
 	}
-	require.Nil(t, createTableValid.Connect())
+	require.NoError(t, createTableValid.Connect())
 
 	// describe table on start arguments
 	describeTableInvoked := Timestream{
@@ -274,7 +274,7 @@ func TestWriteMultiMeasuresSingleTableMode(t *testing.T) {
 	require.Equal(t, recordCount+1, len(transformedRecords), "Expected 101 records after transforming")
 	// validate write to TS
 	err := plugin.Write(inputs)
-	require.Nil(t, err, "Write to Timestream failed")
+	require.NoError(t, err, "Write to Timestream failed")
 	require.Equal(t, mockClient.WriteRecordsRequestCount, 2, "Expected 2 WriteRecords calls")
 }
 
@@ -315,7 +315,7 @@ func TestWriteMultiMeasuresMultiTableMode(t *testing.T) {
 
 	// validate config correctness
 	err := plugin.Connect()
-	require.Nil(t, err, "Invalid configuration")
+	require.NoError(t, err, "Invalid configuration")
 
 	// validate multi-record generation
 	result := plugin.TransformMetrics(inputs)
@@ -340,7 +340,7 @@ func TestWriteMultiMeasuresMultiTableMode(t *testing.T) {
 
 	// validate successful write to TS
 	err = plugin.Write(inputs)
-	require.Nil(t, err, "Write to Timestream failed")
+	require.NoError(t, err, "Write to Timestream failed")
 	require.Equal(t, mockClient.WriteRecordsRequestCount, 1, "Expected 1 WriteRecords call")
 }
 
@@ -393,7 +393,7 @@ func TestBuildMultiMeasuresInSingleAndMultiTableMode(t *testing.T) {
 
 	// validate config correctness
 	err := plugin.Connect()
-	require.Nil(t, err, "Invalid configuration")
+	require.NoError(t, err, "Invalid configuration")
 
 	// validate multi-record generation with MappingModeMultiTable
 	result := plugin.TransformMetrics([]telegraf.Metric{input1, input2, input3, input4})
@@ -416,7 +416,7 @@ func TestBuildMultiMeasuresInSingleAndMultiTableMode(t *testing.T) {
 
 	// validate config correctness
 	err = plugin.Connect()
-	require.Nil(t, err, "Invalid configuration")
+	require.NoError(t, err, "Invalid configuration")
 
 	expectedResultSingleTable := buildExpectedMultiRecords(metricName1, "singleTableName")
 
@@ -532,7 +532,7 @@ func TestThrottlingErrorIsReturnedToTelegraf(t *testing.T) {
 
 	err := plugin.Write([]telegraf.Metric{input})
 
-	require.NotNil(t, err, "Expected an error to be returned to Telegraf, "+
+	require.Error(t, err, "Expected an error to be returned to Telegraf, "+
 		"so that the write will be retried by Telegraf later.")
 }
 
@@ -558,7 +558,7 @@ func TestRejectedRecordsErrorResultsInMetricsBeingSkipped(t *testing.T) {
 
 	err := plugin.Write([]telegraf.Metric{input})
 
-	require.Nil(t, err, "Expected to silently swallow the RejectedRecordsException, "+
+	require.NoError(t, err, "Expected to silently swallow the RejectedRecordsException, "+
 		"as retrying this error doesn't make sense.")
 }
 func TestWriteWhenRequestsGreaterThanMaxWriteGoRoutinesCount(t *testing.T) {
@@ -596,7 +596,7 @@ func TestWriteWhenRequestsGreaterThanMaxWriteGoRoutinesCount(t *testing.T) {
 	}
 
 	err := plugin.Write(inputs)
-	require.Nil(t, err, "Expected to write without any errors ")
+	require.NoError(t, err, "Expected to write without any errors ")
 	require.Equal(t, mockClient.WriteRecordsRequestCount, maxWriteRecordsCalls, "Expected 5 calls to WriteRecords")
 }
 
@@ -635,7 +635,7 @@ func TestWriteWhenRequestsLesserThanMaxWriteGoRoutinesCount(t *testing.T) {
 	}
 
 	err := plugin.Write(inputs)
-	require.Nil(t, err, "Expected to write without any errors ")
+	require.NoError(t, err, "Expected to write without any errors ")
 	require.Equal(t, mockClient.WriteRecordsRequestCount, maxWriteRecordsCalls, "Expected 5 calls to WriteRecords")
 }
 
@@ -1180,7 +1180,7 @@ func TestCustomEndpoint(t *testing.T) {
 
 	// validate config correctness
 	err := plugin.Connect()
-	require.Nil(t, err, "Invalid configuration")
+	require.NoError(t, err, "Invalid configuration")
 	// Check customURL is used
 	require.Equal(t, plugin.EndpointURL, customEndpoint)
 }

--- a/plugins/parsers/csv/parser_test.go
+++ b/plugins/parsers/csv/parser_test.go
@@ -1015,7 +1015,7 @@ timestamp,type,name,status
 		require.Nil(t, m)
 	}
 	m, err := p.ParseLine(testCSVRows[rowIndex])
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Nil(t, m)
 	rowIndex++
 	m, err = p.ParseLine(testCSVRows[rowIndex])

--- a/plugins/processors/enum/enum_test.go
+++ b/plugins/processors/enum/enum_test.go
@@ -54,7 +54,7 @@ func assertTagValue(t *testing.T, expected interface{}, tag string, tags map[str
 func TestRetainsMetric(t *testing.T) {
 	mapper := EnumMapper{}
 	err := mapper.Init()
-	require.Nil(t, err)
+	require.NoError(t, err)
 	source := createTestMetric()
 
 	target := mapper.Apply(source)[0]
@@ -73,7 +73,7 @@ func TestRetainsMetric(t *testing.T) {
 func TestMapsSingleStringValueTag(t *testing.T) {
 	mapper := EnumMapper{Mappings: []Mapping{{Tag: "tag", ValueMappings: map[string]interface{}{"tag_value": "valuable"}}}}
 	err := mapper.Init()
-	require.Nil(t, err)
+	require.NoError(t, err)
 	tags := calculateProcessedTags(mapper, createTestMetric())
 
 	assertTagValue(t, "valuable", "tag", tags)
@@ -122,7 +122,7 @@ func TestMappings(t *testing.T) {
 				},
 			}
 			err := mapper.Init()
-			require.Nil(t, err)
+			require.NoError(t, err)
 			fields := calculateProcessedValues(mapper, createTestMetric())
 			assertFieldValue(t, mapping["expected_value"][index], fieldName, fields)
 		}
@@ -132,7 +132,7 @@ func TestMappings(t *testing.T) {
 func TestMapsToDefaultValueOnUnknownSourceValue(t *testing.T) {
 	mapper := EnumMapper{Mappings: []Mapping{{Field: "string_value", Default: int64(42), ValueMappings: map[string]interface{}{"other": int64(1)}}}}
 	err := mapper.Init()
-	require.Nil(t, err)
+	require.NoError(t, err)
 	fields := calculateProcessedValues(mapper, createTestMetric())
 
 	assertFieldValue(t, 42, "string_value", fields)
@@ -141,7 +141,7 @@ func TestMapsToDefaultValueOnUnknownSourceValue(t *testing.T) {
 func TestDoNotMapToDefaultValueKnownSourceValue(t *testing.T) {
 	mapper := EnumMapper{Mappings: []Mapping{{Field: "string_value", Default: int64(42), ValueMappings: map[string]interface{}{"test": int64(1)}}}}
 	err := mapper.Init()
-	require.Nil(t, err)
+	require.NoError(t, err)
 	fields := calculateProcessedValues(mapper, createTestMetric())
 
 	assertFieldValue(t, 1, "string_value", fields)
@@ -150,7 +150,7 @@ func TestDoNotMapToDefaultValueKnownSourceValue(t *testing.T) {
 func TestNoMappingWithoutDefaultOrDefinedMappingValue(t *testing.T) {
 	mapper := EnumMapper{Mappings: []Mapping{{Field: "string_value", ValueMappings: map[string]interface{}{"other": int64(1)}}}}
 	err := mapper.Init()
-	require.Nil(t, err)
+	require.NoError(t, err)
 	fields := calculateProcessedValues(mapper, createTestMetric())
 
 	assertFieldValue(t, "test", "string_value", fields)
@@ -159,7 +159,7 @@ func TestNoMappingWithoutDefaultOrDefinedMappingValue(t *testing.T) {
 func TestWritesToDestination(t *testing.T) {
 	mapper := EnumMapper{Mappings: []Mapping{{Field: "string_value", Dest: "string_code", ValueMappings: map[string]interface{}{"test": int64(1)}}}}
 	err := mapper.Init()
-	require.Nil(t, err)
+	require.NoError(t, err)
 	fields := calculateProcessedValues(mapper, createTestMetric())
 
 	assertFieldValue(t, "test", "string_value", fields)
@@ -170,7 +170,7 @@ func TestDoNotWriteToDestinationWithoutDefaultOrDefinedMapping(t *testing.T) {
 	field := "string_code"
 	mapper := EnumMapper{Mappings: []Mapping{{Field: "string_value", Dest: field, ValueMappings: map[string]interface{}{"other": int64(1)}}}}
 	err := mapper.Init()
-	require.Nil(t, err)
+	require.NoError(t, err)
 	fields := calculateProcessedValues(mapper, createTestMetric())
 
 	assertFieldValue(t, "test", "string_value", fields)
@@ -181,7 +181,7 @@ func TestDoNotWriteToDestinationWithoutDefaultOrDefinedMapping(t *testing.T) {
 func TestFieldGlobMatching(t *testing.T) {
 	mapper := EnumMapper{Mappings: []Mapping{{Field: "*", ValueMappings: map[string]interface{}{"test": "glob"}}}}
 	err := mapper.Init()
-	require.Nil(t, err)
+	require.NoError(t, err)
 	fields := calculateProcessedValues(mapper, createTestMetric())
 
 	assertFieldValue(t, "glob", "string_value", fields)
@@ -191,7 +191,7 @@ func TestFieldGlobMatching(t *testing.T) {
 func TestTagGlobMatching(t *testing.T) {
 	mapper := EnumMapper{Mappings: []Mapping{{Tag: "*", ValueMappings: map[string]interface{}{"tag_value": "glob"}}}}
 	err := mapper.Init()
-	require.Nil(t, err)
+	require.NoError(t, err)
 	tags := calculateProcessedTags(mapper, createTestMetric())
 
 	assertTagValue(t, "glob", "tag", tags)


### PR DESCRIPTION
Address findings for [testifylint: error-nil](https://github.com/Antonboom/testifylint#error-nil) - checks usage of github.com/stretchr/testify.

```
❌   assert.Nil(t, err)
     assert.NotNil(t, err)
     assert.Equal(t, err, nil)
     assert.NotEqual(t, err, nil)

✅   assert.NoError(t, err)
     assert.Error(t, err)
```

It is only part of the bigger job.
After all type of findings in whole project are handled, we can enable `testifylint` linter in `golangci-lint`.