### PR TITLE
feat: Use HTTPClientConfig struct in elastic stack plugins

### DIFF
--- a/plugins/inputs/elasticsearch/README.md
+++ b/plugins/inputs/elasticsearch/README.md
@@ -94,6 +94,13 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   # tls_key = "/etc/telegraf/key.pem"
   ## Use TLS but skip chain & host verification
   # insecure_skip_verify = false
+ 
+  ## If 'use_system_proxy' is set to true, Telegraf will check env vars such as
+  ## HTTP_PROXY, HTTPS_PROXY, and NO_PROXY (or their lowercase counterparts).
+  ## If 'use_system_proxy' is set to false (default) and 'http_proxy_url' is
+  ## provided, Telegraf will use the specified URL as HTTP proxy.
+  # use_system_proxy = false
+  # http_proxy_url = "http://localhost:8888"
 
   ## Sets the number of most recent indices to return for indices that are
   ## configured with a date-stamped suffix. Each 'indices_include' entry

--- a/plugins/inputs/elasticsearch/README.md
+++ b/plugins/inputs/elasticsearch/README.md
@@ -47,6 +47,7 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   servers = ["http://localhost:9200"]
 
   ## Timeout for HTTP requests to the elastic search server(s)
+  ## deprecated in 1.29.0; use 'timeout' instead
   http_timeout = "5s"
 
   ## When local is true (the default), the node will read only its own stats.

--- a/plugins/inputs/elasticsearch/elasticsearch.go
+++ b/plugins/inputs/elasticsearch/elasticsearch.go
@@ -135,6 +135,7 @@ func NewElasticsearch() *Elasticsearch {
 		ClusterHealthLevel:         "indices",
 		HTTPClientConfig: httpconfig.HTTPClientConfig{
 			ResponseHeaderTimeout: config.Duration(5 * time.Second),
+			Timeout:               config.Duration(5 * time.Second),
 		},
 	}
 }

--- a/plugins/inputs/elasticsearch/elasticsearch.go
+++ b/plugins/inputs/elasticsearch/elasticsearch.go
@@ -289,8 +289,6 @@ func (e *Elasticsearch) createHTTPClient() (*http.Client, error) {
 		e.HTTPClientConfig.ResponseHeaderTimeout = e.HTTPTimeout
 	}
 	return e.HTTPClientConfig.CreateClient(ctx, e.Log)
-
-	return client, nil
 }
 
 func (e *Elasticsearch) nodeStatsURL(baseURL string) string {

--- a/plugins/inputs/elasticsearch/elasticsearch.go
+++ b/plugins/inputs/elasticsearch/elasticsearch.go
@@ -288,10 +288,7 @@ func (e *Elasticsearch) createHTTPClient() (*http.Client, error) {
 		e.HTTPClientConfig.Timeout = e.HTTPTimeout
 		e.HTTPClientConfig.ResponseHeaderTimeout = e.HTTPTimeout
 	}
-	client, err := e.HTTPClientConfig.CreateClient(ctx, e.Log)
-	if err != nil {
-		return nil, err
-	}
+	return e.HTTPClientConfig.CreateClient(ctx, e.Log)
 
 	return client, nil
 }

--- a/plugins/inputs/elasticsearch/elasticsearch.go
+++ b/plugins/inputs/elasticsearch/elasticsearch.go
@@ -282,6 +282,7 @@ func (e *Elasticsearch) createHTTPClient() (*http.Client, error) {
 		return nil, err
 	}
 	tr := &http.Transport{
+		Proxy:                 http.ProxyFromEnvironment,
 		ResponseHeaderTimeout: time.Duration(e.HTTPTimeout),
 		TLSClientConfig:       tlsCfg,
 	}

--- a/plugins/inputs/elasticsearch/elasticsearch.go
+++ b/plugins/inputs/elasticsearch/elasticsearch.go
@@ -2,6 +2,7 @@
 package elasticsearch
 
 import (
+	"context"
 	_ "embed"
 	"encoding/json"
 	"errors"
@@ -17,7 +18,7 @@ import (
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/filter"
-	"github.com/influxdata/telegraf/plugins/common/tls"
+	httpconfig "github.com/influxdata/telegraf/plugins/common/http"
 	"github.com/influxdata/telegraf/plugins/inputs"
 	jsonparser "github.com/influxdata/telegraf/plugins/parsers/json"
 )
@@ -97,7 +98,7 @@ type indexStat struct {
 type Elasticsearch struct {
 	Local                      bool            `toml:"local"`
 	Servers                    []string        `toml:"servers"`
-	HTTPTimeout                config.Duration `toml:"http_timeout"`
+	HTTPTimeout                config.Duration `toml:"http_timeout" deprecated:"1.29.0;use 'timeout' instead"`
 	ClusterHealth              bool            `toml:"cluster_health"`
 	ClusterHealthLevel         string          `toml:"cluster_health_level"`
 	ClusterStats               bool            `toml:"cluster_stats"`
@@ -109,9 +110,11 @@ type Elasticsearch struct {
 	Password                   string          `toml:"password"`
 	NumMostRecentIndices       int             `toml:"num_most_recent_indices"`
 
-	tls.ClientConfig
+	Log telegraf.Logger `toml:"-"`
 
-	client          *http.Client
+	client *http.Client
+	httpconfig.HTTPClientConfig
+
 	serverInfo      map[string]serverInfo
 	serverInfoMutex sync.Mutex
 	indexMatchers   map[string]filter.Filter
@@ -128,9 +131,11 @@ func (i serverInfo) isMaster() bool {
 // NewElasticsearch return a new instance of Elasticsearch
 func NewElasticsearch() *Elasticsearch {
 	return &Elasticsearch{
-		HTTPTimeout:                config.Duration(time.Second * 5),
 		ClusterStatsOnlyFromMaster: true,
 		ClusterHealthLevel:         "indices",
+		HTTPClientConfig: httpconfig.HTTPClientConfig{
+			ResponseHeaderTimeout: config.Duration(5 * time.Second),
+		},
 	}
 }
 
@@ -277,18 +282,14 @@ func (e *Elasticsearch) Gather(acc telegraf.Accumulator) error {
 }
 
 func (e *Elasticsearch) createHTTPClient() (*http.Client, error) {
-	tlsCfg, err := e.ClientConfig.TLSConfig()
+	ctx := context.Background()
+	if e.HTTPTimeout != 0 {
+		e.HTTPClientConfig.Timeout = e.HTTPTimeout
+		e.HTTPClientConfig.ResponseHeaderTimeout = e.HTTPTimeout
+	}
+	client, err := e.HTTPClientConfig.CreateClient(ctx, e.Log)
 	if err != nil {
 		return nil, err
-	}
-	tr := &http.Transport{
-		Proxy:                 http.ProxyFromEnvironment,
-		ResponseHeaderTimeout: time.Duration(e.HTTPTimeout),
-		TLSClientConfig:       tlsCfg,
-	}
-	client := &http.Client{
-		Transport: tr,
-		Timeout:   time.Duration(e.HTTPTimeout),
 	}
 
 	return client, nil

--- a/plugins/inputs/elasticsearch/sample.conf
+++ b/plugins/inputs/elasticsearch/sample.conf
@@ -53,6 +53,13 @@
   # tls_key = "/etc/telegraf/key.pem"
   ## Use TLS but skip chain & host verification
   # insecure_skip_verify = false
+ 
+  ## If 'use_system_proxy' is set to true, Telegraf will check env vars such as
+  ## HTTP_PROXY, HTTPS_PROXY, and NO_PROXY (or their lowercase counterparts).
+  ## If 'use_system_proxy' is set to false (default) and 'http_proxy_url' is
+  ## provided, Telegraf will use the specified URL as HTTP proxy.
+  # use_system_proxy = false
+  # http_proxy_url = "http://localhost:8888"
 
   ## Sets the number of most recent indices to return for indices that are
   ## configured with a date-stamped suffix. Each 'indices_include' entry

--- a/plugins/inputs/elasticsearch/sample.conf
+++ b/plugins/inputs/elasticsearch/sample.conf
@@ -6,6 +6,7 @@
   servers = ["http://localhost:9200"]
 
   ## Timeout for HTTP requests to the elastic search server(s)
+  ## deprecated in 1.29.0; use 'timeout' instead
   http_timeout = "5s"
 
   ## When local is true (the default), the node will read only its own stats.

--- a/plugins/inputs/elasticsearch_query/README.md
+++ b/plugins/inputs/elasticsearch_query/README.md
@@ -55,6 +55,13 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   # tls_key = "/etc/telegraf/key.pem"
   ## Use TLS but skip chain & host verification
   # insecure_skip_verify = false
+ 
+  ## If 'use_system_proxy' is set to true, Telegraf will check env vars such as
+  ## HTTP_PROXY, HTTPS_PROXY, and NO_PROXY (or their lowercase counterparts).
+  ## If 'use_system_proxy' is set to false (default) and 'http_proxy_url' is
+  ## provided, Telegraf will use the specified URL as HTTP proxy.
+  # use_system_proxy = false
+  # http_proxy_url = "http://localhost:8888"
 
   [[inputs.elasticsearch_query.aggregation]]
     ## measurement name for the results of the aggregation query

--- a/plugins/inputs/elasticsearch_query/elasticsearch_query.go
+++ b/plugins/inputs/elasticsearch_query/elasticsearch_query.go
@@ -199,8 +199,6 @@ func (e *ElasticsearchQuery) Gather(acc telegraf.Accumulator) error {
 func (e *ElasticsearchQuery) createHTTPClient() (*http.Client, error) {
 	ctx := context.Background()
 	return e.HTTPClientConfig.CreateClient(ctx, e.Log)
-
-	return httpclient, nil
 }
 
 func (e *ElasticsearchQuery) esAggregationQuery(acc telegraf.Accumulator, aggregation esAggregation, i int) error {

--- a/plugins/inputs/elasticsearch_query/elasticsearch_query.go
+++ b/plugins/inputs/elasticsearch_query/elasticsearch_query.go
@@ -198,10 +198,7 @@ func (e *ElasticsearchQuery) Gather(acc telegraf.Accumulator) error {
 
 func (e *ElasticsearchQuery) createHTTPClient() (*http.Client, error) {
 	ctx := context.Background()
-	httpclient, err := e.HTTPClientConfig.CreateClient(ctx, e.Log)
-	if err != nil {
-		return nil, err
-	}
+	return e.HTTPClientConfig.CreateClient(ctx, e.Log)
 
 	return httpclient, nil
 }

--- a/plugins/inputs/elasticsearch_query/elasticsearch_query.go
+++ b/plugins/inputs/elasticsearch_query/elasticsearch_query.go
@@ -238,6 +238,7 @@ func init() {
 			HealthCheckInterval: config.Duration(time.Second * 10),
 			HTTPClientConfig: httpconfig.HTTPClientConfig{
 				ResponseHeaderTimeout: config.Duration(5 * time.Second),
+				Timeout:               config.Duration(5 * time.Second),
 			},
 		}
 	})

--- a/plugins/inputs/elasticsearch_query/elasticsearch_query.go
+++ b/plugins/inputs/elasticsearch_query/elasticsearch_query.go
@@ -202,6 +202,7 @@ func (e *ElasticsearchQuery) createHTTPClient() (*http.Client, error) {
 		return nil, err
 	}
 	tr := &http.Transport{
+		Proxy:                 http.ProxyFromEnvironment,
 		ResponseHeaderTimeout: time.Duration(e.Timeout),
 		TLSClientConfig:       tlsCfg,
 	}

--- a/plugins/inputs/elasticsearch_query/elasticsearch_query.go
+++ b/plugins/inputs/elasticsearch_query/elasticsearch_query.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
-	"github.com/influxdata/telegraf/plugins/common/tls"
+	httpconfig "github.com/influxdata/telegraf/plugins/common/http"
 	"github.com/influxdata/telegraf/plugins/inputs"
 )
 
@@ -28,15 +28,15 @@ type ElasticsearchQuery struct {
 	Username            string          `toml:"username"`
 	Password            string          `toml:"password"`
 	EnableSniffer       bool            `toml:"enable_sniffer"`
-	Timeout             config.Duration `toml:"timeout"`
 	HealthCheckInterval config.Duration `toml:"health_check_interval"`
 	Aggregations        []esAggregation `toml:"aggregation"`
 
 	Log telegraf.Logger `toml:"-"`
 
-	tls.ClientConfig
 	httpclient *http.Client
-	esClient   *elastic5.Client
+	httpconfig.HTTPClientConfig
+
+	esClient *elastic5.Client
 }
 
 // esAggregation struct
@@ -197,18 +197,10 @@ func (e *ElasticsearchQuery) Gather(acc telegraf.Accumulator) error {
 }
 
 func (e *ElasticsearchQuery) createHTTPClient() (*http.Client, error) {
-	tlsCfg, err := e.ClientConfig.TLSConfig()
+	ctx := context.Background()
+	httpclient, err := e.HTTPClientConfig.CreateClient(ctx, e.Log)
 	if err != nil {
 		return nil, err
-	}
-	tr := &http.Transport{
-		Proxy:                 http.ProxyFromEnvironment,
-		ResponseHeaderTimeout: time.Duration(e.Timeout),
-		TLSClientConfig:       tlsCfg,
-	}
-	httpclient := &http.Client{
-		Transport: tr,
-		Timeout:   time.Duration(e.Timeout),
 	}
 
 	return httpclient, nil
@@ -243,8 +235,10 @@ func (e *ElasticsearchQuery) esAggregationQuery(acc telegraf.Accumulator, aggreg
 func init() {
 	inputs.Add("elasticsearch_query", func() telegraf.Input {
 		return &ElasticsearchQuery{
-			Timeout:             config.Duration(time.Second * 5),
 			HealthCheckInterval: config.Duration(time.Second * 10),
+			HTTPClientConfig: httpconfig.HTTPClientConfig{
+				ResponseHeaderTimeout: config.Duration(5 * time.Second),
+			},
 		}
 	})
 }

--- a/plugins/inputs/elasticsearch_query/elasticsearch_query_test.go
+++ b/plugins/inputs/elasticsearch_query/elasticsearch_query_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
+	httpconfig "github.com/influxdata/telegraf/plugins/common/http"
 	"github.com/influxdata/telegraf/testutil"
 )
 
@@ -536,9 +537,12 @@ func setupIntegrationTest(t *testing.T) (*testutil.Container, error) {
 		"http://%s:%s", container.Address, container.Ports[servicePort],
 	)
 	e := &ElasticsearchQuery{
-		URLs:    []string{url},
-		Timeout: config.Duration(time.Second * 30),
-		Log:     testutil.Logger{},
+		URLs: []string{url},
+		HTTPClientConfig: httpconfig.HTTPClientConfig{
+			ResponseHeaderTimeout: config.Duration(30 * time.Second),
+			Timeout:               config.Duration(30 * time.Second),
+		},
+		Log: testutil.Logger{},
 	}
 
 	err = e.connectToES()
@@ -612,8 +616,11 @@ func TestElasticsearchQueryIntegration(t *testing.T) {
 		URLs: []string{
 			fmt.Sprintf("http://%s:%s", container.Address, container.Ports[servicePort]),
 		},
-		Timeout: config.Duration(time.Second * 30),
-		Log:     testutil.Logger{},
+		HTTPClientConfig: httpconfig.HTTPClientConfig{
+			ResponseHeaderTimeout: config.Duration(30 * time.Second),
+			Timeout:               config.Duration(30 * time.Second),
+		},
+		Log: testutil.Logger{},
 	}
 
 	err = e.connectToES()
@@ -675,8 +682,11 @@ func TestElasticsearchQueryIntegration_getMetricFields(t *testing.T) {
 		URLs: []string{
 			fmt.Sprintf("http://%s:%s", container.Address, container.Ports[servicePort]),
 		},
-		Timeout: config.Duration(time.Second * 30),
-		Log:     testutil.Logger{},
+		HTTPClientConfig: httpconfig.HTTPClientConfig{
+			ResponseHeaderTimeout: config.Duration(30 * time.Second),
+			Timeout:               config.Duration(30 * time.Second),
+		},
+		Log: testutil.Logger{},
 	}
 
 	err = e.connectToES()

--- a/plugins/inputs/elasticsearch_query/sample.conf
+++ b/plugins/inputs/elasticsearch_query/sample.conf
@@ -26,6 +26,13 @@
   # tls_key = "/etc/telegraf/key.pem"
   ## Use TLS but skip chain & host verification
   # insecure_skip_verify = false
+ 
+  ## If 'use_system_proxy' is set to true, Telegraf will check env vars such as
+  ## HTTP_PROXY, HTTPS_PROXY, and NO_PROXY (or their lowercase counterparts).
+  ## If 'use_system_proxy' is set to false (default) and 'http_proxy_url' is
+  ## provided, Telegraf will use the specified URL as HTTP proxy.
+  # use_system_proxy = false
+  # http_proxy_url = "http://localhost:8888"
 
   [[inputs.elasticsearch_query.aggregation]]
     ## measurement name for the results of the aggregation query

--- a/plugins/inputs/kibana/README.md
+++ b/plugins/inputs/kibana/README.md
@@ -37,6 +37,13 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   # tls_key = "/etc/telegraf/key.pem"
   ## Use TLS but skip chain & host verification
   # insecure_skip_verify = false
+ 
+  ## If 'use_system_proxy' is set to true, Telegraf will check env vars such as
+  ## HTTP_PROXY, HTTPS_PROXY, and NO_PROXY (or their lowercase counterparts).
+  ## If 'use_system_proxy' is set to false (default) and 'http_proxy_url' is
+  ## provided, Telegraf will use the specified URL as HTTP proxy.
+  # use_system_proxy = false
+  # http_proxy_url = "http://localhost:8888"
 ```
 
 ## Metrics

--- a/plugins/inputs/kibana/kibana.go
+++ b/plugins/inputs/kibana/kibana.go
@@ -152,10 +152,7 @@ func (k *Kibana) Gather(acc telegraf.Accumulator) error {
 
 func (k *Kibana) createHTTPClient() (*http.Client, error) {
 	ctx := context.Background()
-	client, err := k.HTTPClientConfig.CreateClient(ctx, k.Log)
-	if err != nil {
-		return nil, err
-	}
+	return k.HTTPClientConfig.CreateClient(ctx, k.Log)
 
 	return client, nil
 }

--- a/plugins/inputs/kibana/kibana.go
+++ b/plugins/inputs/kibana/kibana.go
@@ -154,6 +154,7 @@ func (k *Kibana) createHTTPClient() (*http.Client, error) {
 
 	client := &http.Client{
 		Transport: &http.Transport{
+			Proxy:           http.ProxyFromEnvironment,
 			TLSClientConfig: tlsCfg,
 		},
 		Timeout: time.Duration(k.Timeout),

--- a/plugins/inputs/kibana/kibana.go
+++ b/plugins/inputs/kibana/kibana.go
@@ -153,8 +153,6 @@ func (k *Kibana) Gather(acc telegraf.Accumulator) error {
 func (k *Kibana) createHTTPClient() (*http.Client, error) {
 	ctx := context.Background()
 	return k.HTTPClientConfig.CreateClient(ctx, k.Log)
-
-	return client, nil
 }
 
 func (k *Kibana) gatherKibanaStatus(baseURL string, acc telegraf.Accumulator) error {

--- a/plugins/inputs/kibana/kibana.go
+++ b/plugins/inputs/kibana/kibana.go
@@ -11,8 +11,10 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/config"
 	httpconfig "github.com/influxdata/telegraf/plugins/common/http"
 	"github.com/influxdata/telegraf/plugins/inputs"
 )
@@ -97,7 +99,11 @@ type Kibana struct {
 }
 
 func NewKibana() *Kibana {
-	return &Kibana{}
+	return &Kibana{
+		HTTPClientConfig: httpconfig.HTTPClientConfig{
+			Timeout: config.Duration(5 * time.Second),
+		},
+	}
 }
 
 // perform status mapping

--- a/plugins/inputs/kibana/sample.conf
+++ b/plugins/inputs/kibana/sample.conf
@@ -16,3 +16,10 @@
   # tls_key = "/etc/telegraf/key.pem"
   ## Use TLS but skip chain & host verification
   # insecure_skip_verify = false
+ 
+  ## If 'use_system_proxy' is set to true, Telegraf will check env vars such as
+  ## HTTP_PROXY, HTTPS_PROXY, and NO_PROXY (or their lowercase counterparts).
+  ## If 'use_system_proxy' is set to false (default) and 'http_proxy_url' is
+  ## provided, Telegraf will use the specified URL as HTTP proxy.
+  # use_system_proxy = false
+  # http_proxy_url = "http://localhost:8888"

--- a/plugins/inputs/logstash/README.md
+++ b/plugins/inputs/logstash/README.md
@@ -44,6 +44,13 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
   ## Use TLS but skip chain & host verification.
   # insecure_skip_verify = false
+ 
+  ## If 'use_system_proxy' is set to true, Telegraf will check env vars such as
+  ## HTTP_PROXY, HTTPS_PROXY, and NO_PROXY (or their lowercase counterparts).
+  ## If 'use_system_proxy' is set to false (default) and 'http_proxy_url' is
+  ## provided, Telegraf will use the specified URL as HTTP proxy.
+  # use_system_proxy = false
+  # http_proxy_url = "http://localhost:8888"
 
   ## Optional HTTP headers.
   # [inputs.logstash.headers]

--- a/plugins/inputs/logstash/logstash.go
+++ b/plugins/inputs/logstash/logstash.go
@@ -137,7 +137,6 @@ func (logstash *Logstash) Init() error {
 func (logstash *Logstash) createHTTPClient() (*http.Client, error) {
 	ctx := context.Background()
 	return logstash.HTTPClientConfig.CreateClient(ctx, logstash.Log)
-	return client, nil
 }
 
 // gatherJSONData query the data source and parse the response JSON

--- a/plugins/inputs/logstash/logstash.go
+++ b/plugins/inputs/logstash/logstash.go
@@ -10,8 +10,10 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/internal/choice"
 	httpconfig "github.com/influxdata/telegraf/plugins/common/http"
 	"github.com/influxdata/telegraf/plugins/inputs"
@@ -44,6 +46,9 @@ func NewLogstash() *Logstash {
 		SinglePipeline: false,
 		Collect:        []string{"pipelines", "process", "jvm"},
 		Headers:        make(map[string]string),
+		HTTPClientConfig: httpconfig.HTTPClientConfig{
+			Timeout: config.Duration(5 * time.Second),
+		},
 	}
 }
 

--- a/plugins/inputs/logstash/logstash.go
+++ b/plugins/inputs/logstash/logstash.go
@@ -138,6 +138,7 @@ func (logstash *Logstash) createHTTPClient() (*http.Client, error) {
 
 	client := &http.Client{
 		Transport: &http.Transport{
+			Proxy:           http.ProxyFromEnvironment,
 			TLSClientConfig: tlsConfig,
 		},
 		Timeout: time.Duration(logstash.Timeout),

--- a/plugins/inputs/logstash/logstash.go
+++ b/plugins/inputs/logstash/logstash.go
@@ -136,11 +136,7 @@ func (logstash *Logstash) Init() error {
 // createHTTPClient create a clients to access API
 func (logstash *Logstash) createHTTPClient() (*http.Client, error) {
 	ctx := context.Background()
-	client, err := logstash.HTTPClientConfig.CreateClient(ctx, logstash.Log)
-	if err != nil {
-		return nil, err
-	}
-
+	return logstash.HTTPClientConfig.CreateClient(ctx, logstash.Log)
 	return client, nil
 }
 

--- a/plugins/inputs/logstash/logstash.go
+++ b/plugins/inputs/logstash/logstash.go
@@ -2,6 +2,7 @@
 package logstash
 
 import (
+	"context"
 	_ "embed"
 	"encoding/json"
 	"fmt"
@@ -9,12 +10,10 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
-	"time"
 
 	"github.com/influxdata/telegraf"
-	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/internal/choice"
-	"github.com/influxdata/telegraf/plugins/common/tls"
+	httpconfig "github.com/influxdata/telegraf/plugins/common/http"
 	"github.com/influxdata/telegraf/plugins/inputs"
 	jsonParser "github.com/influxdata/telegraf/plugins/parsers/json"
 )
@@ -31,10 +30,11 @@ type Logstash struct {
 	Username string            `toml:"username"`
 	Password string            `toml:"password"`
 	Headers  map[string]string `toml:"headers"`
-	Timeout  config.Duration   `toml:"timeout"`
-	tls.ClientConfig
+
+	Log telegraf.Logger `toml:"-"`
 
 	client *http.Client
+	httpconfig.HTTPClientConfig
 }
 
 // NewLogstash create an instance of the plugin with default settings
@@ -44,7 +44,6 @@ func NewLogstash() *Logstash {
 		SinglePipeline: false,
 		Collect:        []string{"pipelines", "process", "jvm"},
 		Headers:        make(map[string]string),
-		Timeout:        config.Duration(time.Second * 5),
 	}
 }
 
@@ -131,17 +130,10 @@ func (logstash *Logstash) Init() error {
 
 // createHTTPClient create a clients to access API
 func (logstash *Logstash) createHTTPClient() (*http.Client, error) {
-	tlsConfig, err := logstash.ClientConfig.TLSConfig()
+	ctx := context.Background()
+	client, err := logstash.HTTPClientConfig.CreateClient(ctx, logstash.Log)
 	if err != nil {
 		return nil, err
-	}
-
-	client := &http.Client{
-		Transport: &http.Transport{
-			Proxy:           http.ProxyFromEnvironment,
-			TLSClientConfig: tlsConfig,
-		},
-		Timeout: time.Duration(logstash.Timeout),
 	}
 
 	return client, nil

--- a/plugins/inputs/logstash/sample.conf
+++ b/plugins/inputs/logstash/sample.conf
@@ -25,6 +25,13 @@
 
   ## Use TLS but skip chain & host verification.
   # insecure_skip_verify = false
+ 
+  ## If 'use_system_proxy' is set to true, Telegraf will check env vars such as
+  ## HTTP_PROXY, HTTPS_PROXY, and NO_PROXY (or their lowercase counterparts).
+  ## If 'use_system_proxy' is set to false (default) and 'http_proxy_url' is
+  ## provided, Telegraf will use the specified URL as HTTP proxy.
+  # use_system_proxy = false
+  # http_proxy_url = "http://localhost:8888"
 
   ## Optional HTTP headers.
   # [inputs.logstash.headers]


### PR DESCRIPTION
Enable elasticsearch, elasticsearch_query, kibana, and logstash plugins to use environment variables HTTP_PROXY, HTTPS_PROXY and NO_PROXY (or the lowercase versions) in order to connect through a proxy

- [x] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #14206

Adds Proxy to Transport struct, as in many other plugins.
