### PR TITLE
chore(linters): Enable `perfsprint` linter and fix all findings.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,6 +24,7 @@ linters:
     - nakedret
     - nilerr
     - nolintlint
+    - perfsprint
     - prealloc
     - predeclared
     - revive

--- a/plugins/common/opcua/input/input_client.go
+++ b/plugins/common/opcua/input/input_client.go
@@ -420,7 +420,7 @@ func (o *OpcUAInputClient) MetricForNode(nodeIdx int) telegraf.Metric {
 	}
 
 	fields[nmm.Tag.FieldName] = o.LastReceivedData[nodeIdx].Value
-	fields["Quality"] = strings.TrimSpace(fmt.Sprint(o.LastReceivedData[nodeIdx].Quality))
+	fields["Quality"] = strings.TrimSpace(o.LastReceivedData[nodeIdx].Quality.Error())
 	if !o.StatusCodeOK(o.LastReceivedData[nodeIdx].Quality) {
 		mp := newMP(nmm)
 		o.Log.Debugf("status not OK for node %q(metric name %q, tags %q)",

--- a/plugins/inputs/eventhub_consumer/eventhub_consumer.go
+++ b/plugins/inputs/eventhub_consumer/eventhub_consumer.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
+	"strconv"
 	"sync"
 	"time"
 
@@ -295,7 +296,7 @@ func (e *EventHub) createMetrics(event *eventhubClient.Event) ([]telegraf.Metric
 		}
 
 		if event.SystemProperties.PartitionID != nil && e.PartitionIDTag != "" {
-			metrics[i].AddTag(e.PartitionIDTag, fmt.Sprintf("%d", *event.SystemProperties.PartitionID))
+			metrics[i].AddTag(e.PartitionIDTag, strconv.Itoa(int(*event.SystemProperties.PartitionID)))
 		}
 		if event.SystemProperties.PartitionKey != nil && e.PartitionKeyTag != "" {
 			metrics[i].AddTag(e.PartitionKeyTag, *event.SystemProperties.PartitionKey)

--- a/plugins/inputs/filestat/filestat.go
+++ b/plugins/inputs/filestat/filestat.go
@@ -4,7 +4,7 @@ package filestat
 import (
 	"crypto/md5" //nolint:gosec // G501: Blocklisted import crypto/md5: weak cryptographic primitive - md5 hash is what is desired in this case
 	_ "embed"
-	"fmt"
+	"encoding/hex"
 	"io"
 	"os"
 
@@ -131,7 +131,7 @@ func getMd5(file string) (string, error) {
 		// fatal error
 		return "", err
 	}
-	return fmt.Sprintf("%x", hash.Sum(nil)), nil
+	return hex.EncodeToString(hash.Sum(nil)), nil
 }
 
 func init() {

--- a/plugins/inputs/gnmi/handler.go
+++ b/plugins/inputs/gnmi/handler.go
@@ -8,14 +8,10 @@ import (
 	"io"
 	"net"
 	"path"
+	"strconv"
 	"strings"
 	"time"
 
-	"github.com/influxdata/telegraf"
-	"github.com/influxdata/telegraf/internal/choice"
-	"github.com/influxdata/telegraf/metric"
-	jnprHeader "github.com/influxdata/telegraf/plugins/inputs/gnmi/extensions/jnpr_gnmi_extention"
-	"github.com/influxdata/telegraf/selfstat"
 	gnmiLib "github.com/openconfig/gnmi/proto/gnmi"
 	gnmiExt "github.com/openconfig/gnmi/proto/gnmi_ext"
 	"google.golang.org/grpc"
@@ -23,6 +19,12 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/internal/choice"
+	"github.com/influxdata/telegraf/metric"
+	jnprHeader "github.com/influxdata/telegraf/plugins/inputs/gnmi/extensions/jnpr_gnmi_extention"
+	"github.com/influxdata/telegraf/selfstat"
 )
 
 const eidJuniperTelemetryHeader = 1
@@ -140,11 +142,11 @@ func (h *handler) handleSubscribeResponseUpdate(acc telegraf.Accumulator, respon
 					h.log.Errorf("unmarshal gnmi Juniper Header extension failed: %v", err)
 					break
 				}
-				// Add only relevant Tags from the Juniper Header extention.
-				// These are requiered for aggregation
-				prefixTags["component_id"] = fmt.Sprint(juniperHeader.GetComponentId())
-				prefixTags["component"] = fmt.Sprint(juniperHeader.GetComponent())
-				prefixTags["sub_component_id"] = fmt.Sprint(juniperHeader.GetSubComponentId())
+				// Add only relevant Tags from the Juniper Header extension.
+				// These are required for aggregation
+				prefixTags["component_id"] = strconv.FormatUint(uint64(juniperHeader.GetComponentId()), 10)
+				prefixTags["component"] = juniperHeader.GetComponent()
+				prefixTags["sub_component_id"] = strconv.FormatUint(uint64(juniperHeader.GetSubComponentId()), 10)
 			}
 
 		default:

--- a/plugins/inputs/influxdb_v2_listener/influxdb_v2_listener.go
+++ b/plugins/inputs/influxdb_v2_listener/influxdb_v2_listener.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/influxdata/telegraf"
@@ -323,7 +324,7 @@ func tooLarge(res http.ResponseWriter, maxLength int64) error {
 	b, _ := json.Marshal(map[string]string{
 		"code":      fmt.Sprint(Invalid),
 		"message":   "http: request body too large",
-		"maxLength": fmt.Sprint(maxLength)})
+		"maxLength": strconv.FormatInt(maxLength, 10)})
 	_, err := res.Write(b)
 	return err
 }

--- a/plugins/inputs/intel_baseband/intel_baseband.go
+++ b/plugins/inputs/intel_baseband/intel_baseband.go
@@ -7,6 +7,7 @@ import (
 	_ "embed"
 	"errors"
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/influxdata/telegraf"
@@ -162,7 +163,7 @@ func (b *Baseband) gatherVFMetric(acc telegraf.Accumulator, metricName string) e
 			tags := map[string]string{
 				"operation": metric.operationName,
 				"metric":    metricNameToTagName(metricName),
-				"vf":        fmt.Sprintf("%v", i),
+				"vf":        strconv.Itoa(i),
 			}
 			acc.AddGauge(pluginName, fields, tags)
 		}
@@ -189,7 +190,7 @@ func (b *Baseband) gatherEngineMetric(acc telegraf.Accumulator, metricName strin
 			tags := map[string]string{
 				"operation": metric.operationName,
 				"metric":    metricNameToTagName(metricName),
-				"engine":    fmt.Sprintf("%v", i),
+				"engine":    strconv.Itoa(i),
 			}
 			acc.AddGauge(pluginName, fields, tags)
 		}

--- a/plugins/inputs/intel_rdt/intel_rdt.go
+++ b/plugins/inputs/intel_rdt/intel_rdt.go
@@ -211,7 +211,7 @@ func (r *IntelRDT) associateProcessesWithPIDs(providedProcesses []string) (map[s
 	for _, availableProcess := range availableProcesses {
 		if choice.Contains(availableProcess.Name, providedProcesses) {
 			pid := availableProcess.PID
-			mapProcessPIDs[availableProcess.Name] = mapProcessPIDs[availableProcess.Name] + fmt.Sprintf("%d", pid) + ","
+			mapProcessPIDs[availableProcess.Name] = mapProcessPIDs[availableProcess.Name] + strconv.Itoa(pid) + ","
 		}
 	}
 	for key := range mapProcessPIDs {

--- a/plugins/inputs/ipvs/ipvs.go
+++ b/plugins/inputs/ipvs/ipvs.go
@@ -121,7 +121,7 @@ func destinationTags(d *ipvs.Destination) map[string]string {
 	}
 }
 
-// helper: convert protocol uint16 to human readable string (if possible)
+// helper: convert protocol uint16 to human-readable string (if possible)
 func protocolToString(p uint16) string {
 	switch p {
 	case syscall.IPPROTO_TCP:
@@ -131,11 +131,11 @@ func protocolToString(p uint16) string {
 	case syscall.IPPROTO_SCTP:
 		return "sctp"
 	default:
-		return fmt.Sprintf("%d", p)
+		return strconv.FormatUint(uint64(p), 10)
 	}
 }
 
-// helper: convert addressFamily to a human readable string
+// helper: convert addressFamily to a human-readable string
 func addressFamilyToString(af uint16) string {
 	switch af {
 	case syscall.AF_INET:
@@ -143,7 +143,7 @@ func addressFamilyToString(af uint16) string {
 	case syscall.AF_INET6:
 		return "inet6"
 	default:
-		return fmt.Sprintf("%d", af)
+		return strconv.FormatUint(uint64(af), 10)
 	}
 }
 

--- a/plugins/inputs/passenger/passenger.go
+++ b/plugins/inputs/passenger/passenger.go
@@ -198,7 +198,7 @@ func importMetric(stat []byte, acc telegraf.Accumulator) error {
 					"group_name":       group.Name,
 					"app_root":         group.AppRoot,
 					"supergroup_name":  sg.Name,
-					"pid":              fmt.Sprintf("%d", process.Pid),
+					"pid":              strconv.Itoa(process.Pid),
 					"code_revision":    process.CodeRevision,
 					"life_status":      process.LifeStatus,
 					"process_group_id": process.ProcessGroupID,

--- a/plugins/inputs/phpfpm/phpfpm_test.go
+++ b/plugins/inputs/phpfpm/phpfpm_test.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"net/http/fcgi"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -25,7 +26,7 @@ type statServer struct{}
 // We create a fake server to return test data
 func (s statServer) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "text/plain")
-	w.Header().Set("Content-Length", fmt.Sprint(len(outputSample)))
+	w.Header().Set("Content-Length", strconv.Itoa(len(outputSample)))
 	fmt.Fprint(w, outputSample)
 }
 
@@ -33,7 +34,7 @@ func TestPhpFpmGeneratesMetrics_From_Http(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, "ok", r.URL.Query().Get("test"))
 		w.Header().Set("Content-Type", "text/plain")
-		w.Header().Set("Content-Length", fmt.Sprint(len(outputSample)))
+		w.Header().Set("Content-Length", strconv.Itoa(len(outputSample)))
 		_, err := fmt.Fprint(w, outputSample)
 		require.NoError(t, err)
 	}))

--- a/plugins/inputs/webhooks/github/github_webhooks_models.go
+++ b/plugins/inputs/webhooks/github/github_webhooks_models.go
@@ -1,7 +1,7 @@
 package github
 
 import (
-	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/influxdata/telegraf"
@@ -95,9 +95,9 @@ func (s CommitCommentEvent) NewMetric() telegraf.Metric {
 	t := map[string]string{
 		"event":      event,
 		"repository": s.Repository.Repository,
-		"private":    fmt.Sprintf("%v", s.Repository.Private),
+		"private":    strconv.FormatBool(s.Repository.Private),
 		"user":       s.Sender.User,
-		"admin":      fmt.Sprintf("%v", s.Sender.Admin),
+		"admin":      strconv.FormatBool(s.Sender.Admin),
 	}
 	f := map[string]interface{}{
 		"stars":   s.Repository.Stars,
@@ -122,9 +122,9 @@ func (s CreateEvent) NewMetric() telegraf.Metric {
 	t := map[string]string{
 		"event":      event,
 		"repository": s.Repository.Repository,
-		"private":    fmt.Sprintf("%v", s.Repository.Private),
+		"private":    strconv.FormatBool(s.Repository.Private),
 		"user":       s.Sender.User,
-		"admin":      fmt.Sprintf("%v", s.Sender.Admin),
+		"admin":      strconv.FormatBool(s.Sender.Admin),
 	}
 	f := map[string]interface{}{
 		"stars":   s.Repository.Stars,
@@ -149,9 +149,9 @@ func (s DeleteEvent) NewMetric() telegraf.Metric {
 	t := map[string]string{
 		"event":      event,
 		"repository": s.Repository.Repository,
-		"private":    fmt.Sprintf("%v", s.Repository.Private),
+		"private":    strconv.FormatBool(s.Repository.Private),
 		"user":       s.Sender.User,
-		"admin":      fmt.Sprintf("%v", s.Sender.Admin),
+		"admin":      strconv.FormatBool(s.Sender.Admin),
 	}
 	f := map[string]interface{}{
 		"stars":   s.Repository.Stars,
@@ -175,9 +175,9 @@ func (s DeploymentEvent) NewMetric() telegraf.Metric {
 	t := map[string]string{
 		"event":      event,
 		"repository": s.Repository.Repository,
-		"private":    fmt.Sprintf("%v", s.Repository.Private),
+		"private":    strconv.FormatBool(s.Repository.Private),
 		"user":       s.Sender.User,
-		"admin":      fmt.Sprintf("%v", s.Sender.Admin),
+		"admin":      strconv.FormatBool(s.Sender.Admin),
 	}
 	f := map[string]interface{}{
 		"stars":       s.Repository.Stars,
@@ -204,9 +204,9 @@ func (s DeploymentStatusEvent) NewMetric() telegraf.Metric {
 	t := map[string]string{
 		"event":      event,
 		"repository": s.Repository.Repository,
-		"private":    fmt.Sprintf("%v", s.Repository.Private),
+		"private":    strconv.FormatBool(s.Repository.Private),
 		"user":       s.Sender.User,
-		"admin":      fmt.Sprintf("%v", s.Sender.Admin),
+		"admin":      strconv.FormatBool(s.Sender.Admin),
 	}
 	f := map[string]interface{}{
 		"stars":          s.Repository.Stars,
@@ -234,9 +234,9 @@ func (s ForkEvent) NewMetric() telegraf.Metric {
 	t := map[string]string{
 		"event":      event,
 		"repository": s.Repository.Repository,
-		"private":    fmt.Sprintf("%v", s.Repository.Private),
+		"private":    strconv.FormatBool(s.Repository.Private),
 		"user":       s.Sender.User,
-		"admin":      fmt.Sprintf("%v", s.Sender.Admin),
+		"admin":      strconv.FormatBool(s.Sender.Admin),
 	}
 	f := map[string]interface{}{
 		"stars":  s.Repository.Stars,
@@ -260,9 +260,9 @@ func (s GollumEvent) NewMetric() telegraf.Metric {
 	t := map[string]string{
 		"event":      event,
 		"repository": s.Repository.Repository,
-		"private":    fmt.Sprintf("%v", s.Repository.Private),
+		"private":    strconv.FormatBool(s.Repository.Private),
 		"user":       s.Sender.User,
-		"admin":      fmt.Sprintf("%v", s.Sender.Admin),
+		"admin":      strconv.FormatBool(s.Sender.Admin),
 	}
 	f := map[string]interface{}{
 		"stars":  s.Repository.Stars,
@@ -285,10 +285,10 @@ func (s IssueCommentEvent) NewMetric() telegraf.Metric {
 	t := map[string]string{
 		"event":      event,
 		"repository": s.Repository.Repository,
-		"private":    fmt.Sprintf("%v", s.Repository.Private),
+		"private":    strconv.FormatBool(s.Repository.Private),
 		"user":       s.Sender.User,
-		"admin":      fmt.Sprintf("%v", s.Sender.Admin),
-		"issue":      fmt.Sprintf("%v", s.Issue.Number),
+		"admin":      strconv.FormatBool(s.Sender.Admin),
+		"issue":      strconv.Itoa(s.Issue.Number),
 	}
 	f := map[string]interface{}{
 		"stars":    s.Repository.Stars,
@@ -314,10 +314,10 @@ func (s IssuesEvent) NewMetric() telegraf.Metric {
 	t := map[string]string{
 		"event":      event,
 		"repository": s.Repository.Repository,
-		"private":    fmt.Sprintf("%v", s.Repository.Private),
+		"private":    strconv.FormatBool(s.Repository.Private),
 		"user":       s.Sender.User,
-		"admin":      fmt.Sprintf("%v", s.Sender.Admin),
-		"issue":      fmt.Sprintf("%v", s.Issue.Number),
+		"admin":      strconv.FormatBool(s.Sender.Admin),
+		"issue":      strconv.Itoa(s.Issue.Number),
 		"action":     s.Action,
 	}
 	f := map[string]interface{}{
@@ -342,9 +342,9 @@ func (s MemberEvent) NewMetric() telegraf.Metric {
 	t := map[string]string{
 		"event":      event,
 		"repository": s.Repository.Repository,
-		"private":    fmt.Sprintf("%v", s.Repository.Private),
+		"private":    strconv.FormatBool(s.Repository.Private),
 		"user":       s.Sender.User,
-		"admin":      fmt.Sprintf("%v", s.Sender.Admin),
+		"admin":      strconv.FormatBool(s.Sender.Admin),
 	}
 	f := map[string]interface{}{
 		"stars":           s.Repository.Stars,
@@ -369,7 +369,7 @@ func (s MembershipEvent) NewMetric() telegraf.Metric {
 	t := map[string]string{
 		"event":  event,
 		"user":   s.Sender.User,
-		"admin":  fmt.Sprintf("%v", s.Sender.Admin),
+		"admin":  strconv.FormatBool(s.Sender.Admin),
 		"action": s.Action,
 	}
 	f := map[string]interface{}{
@@ -390,9 +390,9 @@ func (s PageBuildEvent) NewMetric() telegraf.Metric {
 	t := map[string]string{
 		"event":      event,
 		"repository": s.Repository.Repository,
-		"private":    fmt.Sprintf("%v", s.Repository.Private),
+		"private":    strconv.FormatBool(s.Repository.Private),
 		"user":       s.Sender.User,
-		"admin":      fmt.Sprintf("%v", s.Sender.Admin),
+		"admin":      strconv.FormatBool(s.Sender.Admin),
 	}
 	f := map[string]interface{}{
 		"stars":  s.Repository.Stars,
@@ -413,9 +413,9 @@ func (s PublicEvent) NewMetric() telegraf.Metric {
 	t := map[string]string{
 		"event":      event,
 		"repository": s.Repository.Repository,
-		"private":    fmt.Sprintf("%v", s.Repository.Private),
+		"private":    strconv.FormatBool(s.Repository.Private),
 		"user":       s.Sender.User,
-		"admin":      fmt.Sprintf("%v", s.Sender.Admin),
+		"admin":      strconv.FormatBool(s.Sender.Admin),
 	}
 	f := map[string]interface{}{
 		"stars":  s.Repository.Stars,
@@ -439,10 +439,10 @@ func (s PullRequestEvent) NewMetric() telegraf.Metric {
 		"event":      event,
 		"action":     s.Action,
 		"repository": s.Repository.Repository,
-		"private":    fmt.Sprintf("%v", s.Repository.Private),
+		"private":    strconv.FormatBool(s.Repository.Private),
 		"user":       s.Sender.User,
-		"admin":      fmt.Sprintf("%v", s.Sender.Admin),
-		"prNumber":   fmt.Sprintf("%v", s.PullRequest.Number),
+		"admin":      strconv.FormatBool(s.Sender.Admin),
+		"prNumber":   strconv.Itoa(s.PullRequest.Number),
 	}
 	f := map[string]interface{}{
 		"stars":        s.Repository.Stars,
@@ -472,10 +472,10 @@ func (s PullRequestReviewCommentEvent) NewMetric() telegraf.Metric {
 	t := map[string]string{
 		"event":      event,
 		"repository": s.Repository.Repository,
-		"private":    fmt.Sprintf("%v", s.Repository.Private),
+		"private":    strconv.FormatBool(s.Repository.Private),
 		"user":       s.Sender.User,
-		"admin":      fmt.Sprintf("%v", s.Sender.Admin),
-		"prNumber":   fmt.Sprintf("%v", s.PullRequest.Number),
+		"admin":      strconv.FormatBool(s.Sender.Admin),
+		"prNumber":   strconv.Itoa(s.PullRequest.Number),
 	}
 	f := map[string]interface{}{
 		"stars":        s.Repository.Stars,
@@ -508,9 +508,9 @@ func (s PushEvent) NewMetric() telegraf.Metric {
 	t := map[string]string{
 		"event":      event,
 		"repository": s.Repository.Repository,
-		"private":    fmt.Sprintf("%v", s.Repository.Private),
+		"private":    strconv.FormatBool(s.Repository.Private),
 		"user":       s.Sender.User,
-		"admin":      fmt.Sprintf("%v", s.Sender.Admin),
+		"admin":      strconv.FormatBool(s.Sender.Admin),
 	}
 	f := map[string]interface{}{
 		"stars":  s.Repository.Stars,
@@ -535,9 +535,9 @@ func (s ReleaseEvent) NewMetric() telegraf.Metric {
 	t := map[string]string{
 		"event":      event,
 		"repository": s.Repository.Repository,
-		"private":    fmt.Sprintf("%v", s.Repository.Private),
+		"private":    strconv.FormatBool(s.Repository.Private),
 		"user":       s.Sender.User,
-		"admin":      fmt.Sprintf("%v", s.Sender.Admin),
+		"admin":      strconv.FormatBool(s.Sender.Admin),
 	}
 	f := map[string]interface{}{
 		"stars":   s.Repository.Stars,
@@ -559,9 +559,9 @@ func (s RepositoryEvent) NewMetric() telegraf.Metric {
 	t := map[string]string{
 		"event":      event,
 		"repository": s.Repository.Repository,
-		"private":    fmt.Sprintf("%v", s.Repository.Private),
+		"private":    strconv.FormatBool(s.Repository.Private),
 		"user":       s.Sender.User,
-		"admin":      fmt.Sprintf("%v", s.Sender.Admin),
+		"admin":      strconv.FormatBool(s.Sender.Admin),
 	}
 	f := map[string]interface{}{
 		"stars":  s.Repository.Stars,
@@ -584,9 +584,9 @@ func (s StatusEvent) NewMetric() telegraf.Metric {
 	t := map[string]string{
 		"event":      event,
 		"repository": s.Repository.Repository,
-		"private":    fmt.Sprintf("%v", s.Repository.Private),
+		"private":    strconv.FormatBool(s.Repository.Private),
 		"user":       s.Sender.User,
-		"admin":      fmt.Sprintf("%v", s.Sender.Admin),
+		"admin":      strconv.FormatBool(s.Sender.Admin),
 	}
 	f := map[string]interface{}{
 		"stars":  s.Repository.Stars,
@@ -610,9 +610,9 @@ func (s TeamAddEvent) NewMetric() telegraf.Metric {
 	t := map[string]string{
 		"event":      event,
 		"repository": s.Repository.Repository,
-		"private":    fmt.Sprintf("%v", s.Repository.Private),
+		"private":    strconv.FormatBool(s.Repository.Private),
 		"user":       s.Sender.User,
-		"admin":      fmt.Sprintf("%v", s.Sender.Admin),
+		"admin":      strconv.FormatBool(s.Sender.Admin),
 	}
 	f := map[string]interface{}{
 		"stars":    s.Repository.Stars,
@@ -634,9 +634,9 @@ func (s WatchEvent) NewMetric() telegraf.Metric {
 	t := map[string]string{
 		"event":      event,
 		"repository": s.Repository.Repository,
-		"private":    fmt.Sprintf("%v", s.Repository.Private),
+		"private":    strconv.FormatBool(s.Repository.Private),
 		"user":       s.Sender.User,
-		"admin":      fmt.Sprintf("%v", s.Sender.Admin),
+		"admin":      strconv.FormatBool(s.Sender.Admin),
 	}
 	f := map[string]interface{}{
 		"stars":  s.Repository.Stars,

--- a/plugins/outputs/http/http.go
+++ b/plugins/outputs/http/http.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"crypto/sha256"
 	_ "embed"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"net/http"
@@ -150,7 +151,7 @@ func (h *HTTP) writeMetric(reqBody []byte) error {
 		reqBodyBuffer = buf
 
 		// sha256 is hex encoded
-		hash := fmt.Sprintf("%x", sum)
+		hash := hex.EncodeToString(sum[:])
 		payloadHash = &hash
 	}
 

--- a/plugins/outputs/loki/loki.go
+++ b/plugins/outputs/loki/loki.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/http"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -131,7 +132,7 @@ func (l *Loki) Write(metrics []telegraf.Metric) error {
 			line += fmt.Sprintf("%s=\"%v\" ", f.Key, f.Value)
 		}
 
-		s.insertLog(tags, Log{fmt.Sprintf("%d", m.Time().UnixNano()), line})
+		s.insertLog(tags, Log{strconv.FormatInt(m.Time().UnixNano(), 10), line})
 	}
 
 	return l.writeMetrics(s)

--- a/plugins/outputs/postgresql/postgresql_bench_test.go
+++ b/plugins/outputs/postgresql/postgresql_bench_test.go
@@ -65,7 +65,7 @@ func batchGenerator(args batchGeneratorArgs) <-chan []telegraf.Metric {
 	for i := 0; i < args.tagCardinality; i++ {
 		tags := MSS{}
 		for j := 0; j < args.numTags; j++ {
-			tags[fmt.Sprintf("tag_%d", j)] = fmt.Sprintf("%d", rand.Int())
+			tags[fmt.Sprintf("tag_%d", j)] = strconv.Itoa(rand.Int())
 		}
 		tagSets = append(tagSets, tags)
 	}

--- a/plugins/outputs/warp10/warp10.go
+++ b/plugins/outputs/warp10/warp10.go
@@ -110,7 +110,7 @@ func (w *Warp10) GenWarp10Payload(metrics []telegraf.Metric) string {
 			collectString = append(collectString, messageLine)
 		}
 	}
-	return fmt.Sprint(strings.Join(collectString, ""))
+	return strings.Join(collectString, "")
 }
 
 // Write metrics to Warp10

--- a/plugins/outputs/yandex_cloud_monitoring/yandex_cloud_monitoring.go
+++ b/plugins/outputs/yandex_cloud_monitoring/yandex_cloud_monitoring.go
@@ -135,7 +135,7 @@ func (a *YandexCloudMonitoring) Write(metrics []telegraf.Metric) error {
 				yandexCloudMonitoringMetric{
 					Name:   field.Key,
 					Labels: m.Tags(),
-					TS:     fmt.Sprint(m.Time().Format(time.RFC3339)),
+					TS:     m.Time().Format(time.RFC3339),
 					Value:  value,
 				},
 			)


### PR DESCRIPTION
[perfsprint](https://github.com/catenacyber/perfsprint#perfsprint) is a linter for performance, aiming at usages of `fmt.Sprintf` which have faster alternatives.

This PR enables mentioned linter and addresses (by using `perfsprint --fix ./...`) following findings:
```
plugins/common/opcua/input/input_client.go:423:40                          perfsprint  fmt.Sprint can be replaced with o.LastReceivedData[nodeIdx].Quality.Error()
plugins/inputs/eventhub_consumer/eventhub_consumer.go:298:40               perfsprint  fmt.Sprintf can be replaced with faster strconv.Itoa
plugins/inputs/filestat/filestat.go:134:9                                  perfsprint  fmt.Sprintf can be replaced with faster hex.EncodeToString
plugins/inputs/gnmi/handler.go:145:34                                      perfsprint  fmt.Sprint can be replaced with faster strconv.FormatUint
plugins/inputs/gnmi/handler.go:146:31                                      perfsprint  fmt.Sprint can be replaced with just using the string
plugins/inputs/gnmi/handler.go:147:38                                      perfsprint  fmt.Sprint can be replaced with faster strconv.FormatUint
plugins/inputs/influxdb_v2_listener/influxdb_v2_listener.go:326:16         perfsprint  fmt.Sprint can be replaced with faster strconv.FormatInt
plugins/inputs/intel_baseband/intel_baseband.go:165:18                     perfsprint  fmt.Sprintf can be replaced with faster strconv.Itoa
plugins/inputs/intel_baseband/intel_baseband.go:192:18                     perfsprint  fmt.Sprintf can be replaced with faster strconv.Itoa
plugins/inputs/intel_rdt/intel_rdt.go:214:84                               perfsprint  fmt.Sprintf can be replaced with faster strconv.Itoa
plugins/inputs/ipvs/ipvs.go:134:10                                         perfsprint  fmt.Sprintf can be replaced with faster strconv.FormatUint
plugins/inputs/ipvs/ipvs.go:146:10                                         perfsprint  fmt.Sprintf can be replaced with faster strconv.FormatUint
plugins/inputs/passenger/passenger.go:201:26                               perfsprint  fmt.Sprintf can be replaced with faster strconv.Itoa
plugins/inputs/phpfpm/phpfpm_test.go:28:35                                 perfsprint  fmt.Sprint can be replaced with faster strconv.Itoa
plugins/inputs/phpfpm/phpfpm_test.go:36:36                                 perfsprint  fmt.Sprint can be replaced with faster strconv.Itoa
plugins/inputs/webhooks/github/github_webhooks_models.go:98:17             perfsprint  fmt.Sprintf can be replaced with faster strconv.FormatBool
plugins/inputs/webhooks/github/github_webhooks_models.go:100:17            perfsprint  fmt.Sprintf can be replaced with faster strconv.FormatBool
plugins/inputs/webhooks/github/github_webhooks_models.go:125:17            perfsprint  fmt.Sprintf can be replaced with faster strconv.FormatBool
plugins/inputs/webhooks/github/github_webhooks_models.go:127:17            perfsprint  fmt.Sprintf can be replaced with faster strconv.FormatBool
plugins/inputs/webhooks/github/github_webhooks_models.go:152:17            perfsprint  fmt.Sprintf can be replaced with faster strconv.FormatBool
plugins/inputs/webhooks/github/github_webhooks_models.go:154:17            perfsprint  fmt.Sprintf can be replaced with faster strconv.FormatBool
plugins/inputs/webhooks/github/github_webhooks_models.go:178:17            perfsprint  fmt.Sprintf can be replaced with faster strconv.FormatBool
plugins/inputs/webhooks/github/github_webhooks_models.go:180:17            perfsprint  fmt.Sprintf can be replaced with faster strconv.FormatBool
plugins/inputs/webhooks/github/github_webhooks_models.go:207:17            perfsprint  fmt.Sprintf can be replaced with faster strconv.FormatBool
plugins/inputs/webhooks/github/github_webhooks_models.go:209:17            perfsprint  fmt.Sprintf can be replaced with faster strconv.FormatBool
plugins/inputs/webhooks/github/github_webhooks_models.go:237:17            perfsprint  fmt.Sprintf can be replaced with faster strconv.FormatBool
plugins/inputs/webhooks/github/github_webhooks_models.go:239:17            perfsprint  fmt.Sprintf can be replaced with faster strconv.FormatBool
plugins/inputs/webhooks/github/github_webhooks_models.go:263:17            perfsprint  fmt.Sprintf can be replaced with faster strconv.FormatBool
plugins/inputs/webhooks/github/github_webhooks_models.go:265:17            perfsprint  fmt.Sprintf can be replaced with faster strconv.FormatBool
plugins/inputs/webhooks/github/github_webhooks_models.go:288:17            perfsprint  fmt.Sprintf can be replaced with faster strconv.FormatBool
plugins/inputs/webhooks/github/github_webhooks_models.go:290:17            perfsprint  fmt.Sprintf can be replaced with faster strconv.FormatBool
plugins/inputs/webhooks/github/github_webhooks_models.go:291:17            perfsprint  fmt.Sprintf can be replaced with faster strconv.Itoa
plugins/inputs/webhooks/github/github_webhooks_models.go:317:17            perfsprint  fmt.Sprintf can be replaced with faster strconv.FormatBool
plugins/inputs/webhooks/github/github_webhooks_models.go:319:17            perfsprint  fmt.Sprintf can be replaced with faster strconv.FormatBool
plugins/inputs/webhooks/github/github_webhooks_models.go:320:17            perfsprint  fmt.Sprintf can be replaced with faster strconv.Itoa
plugins/inputs/webhooks/github/github_webhooks_models.go:345:17            perfsprint  fmt.Sprintf can be replaced with faster strconv.FormatBool
plugins/inputs/webhooks/github/github_webhooks_models.go:347:17            perfsprint  fmt.Sprintf can be replaced with faster strconv.FormatBool
plugins/inputs/webhooks/github/github_webhooks_models.go:372:13            perfsprint  fmt.Sprintf can be replaced with faster strconv.FormatBool
plugins/inputs/webhooks/github/github_webhooks_models.go:393:17            perfsprint  fmt.Sprintf can be replaced with faster strconv.FormatBool
plugins/inputs/webhooks/github/github_webhooks_models.go:395:17            perfsprint  fmt.Sprintf can be replaced with faster strconv.FormatBool
plugins/inputs/webhooks/github/github_webhooks_models.go:416:17            perfsprint  fmt.Sprintf can be replaced with faster strconv.FormatBool
plugins/inputs/webhooks/github/github_webhooks_models.go:418:17            perfsprint  fmt.Sprintf can be replaced with faster strconv.FormatBool
plugins/inputs/webhooks/github/github_webhooks_models.go:442:17            perfsprint  fmt.Sprintf can be replaced with faster strconv.FormatBool
plugins/inputs/webhooks/github/github_webhooks_models.go:444:17            perfsprint  fmt.Sprintf can be replaced with faster strconv.FormatBool
plugins/inputs/webhooks/github/github_webhooks_models.go:445:17            perfsprint  fmt.Sprintf can be replaced with faster strconv.Itoa
plugins/inputs/webhooks/github/github_webhooks_models.go:475:17            perfsprint  fmt.Sprintf can be replaced with faster strconv.FormatBool
plugins/inputs/webhooks/github/github_webhooks_models.go:477:17            perfsprint  fmt.Sprintf can be replaced with faster strconv.FormatBool
plugins/inputs/webhooks/github/github_webhooks_models.go:478:17            perfsprint  fmt.Sprintf can be replaced with faster strconv.Itoa
plugins/inputs/webhooks/github/github_webhooks_models.go:511:17            perfsprint  fmt.Sprintf can be replaced with faster strconv.FormatBool
plugins/inputs/webhooks/github/github_webhooks_models.go:513:17            perfsprint  fmt.Sprintf can be replaced with faster strconv.FormatBool
plugins/inputs/webhooks/github/github_webhooks_models.go:538:17            perfsprint  fmt.Sprintf can be replaced with faster strconv.FormatBool
plugins/inputs/webhooks/github/github_webhooks_models.go:540:17            perfsprint  fmt.Sprintf can be replaced with faster strconv.FormatBool
plugins/inputs/webhooks/github/github_webhooks_models.go:562:17            perfsprint  fmt.Sprintf can be replaced with faster strconv.FormatBool
plugins/inputs/webhooks/github/github_webhooks_models.go:564:17            perfsprint  fmt.Sprintf can be replaced with faster strconv.FormatBool
plugins/inputs/webhooks/github/github_webhooks_models.go:587:17            perfsprint  fmt.Sprintf can be replaced with faster strconv.FormatBool
plugins/inputs/webhooks/github/github_webhooks_models.go:589:17            perfsprint  fmt.Sprintf can be replaced with faster strconv.FormatBool
plugins/inputs/webhooks/github/github_webhooks_models.go:613:17            perfsprint  fmt.Sprintf can be replaced with faster strconv.FormatBool
plugins/inputs/webhooks/github/github_webhooks_models.go:615:17            perfsprint  fmt.Sprintf can be replaced with faster strconv.FormatBool
plugins/inputs/webhooks/github/github_webhooks_models.go:637:17            perfsprint  fmt.Sprintf can be replaced with faster strconv.FormatBool
plugins/inputs/webhooks/github/github_webhooks_models.go:639:17            perfsprint  fmt.Sprintf can be replaced with faster strconv.FormatBool
plugins/outputs/http/http.go:153:11                                        perfsprint  fmt.Sprintf can be replaced with faster hex.EncodeToString
plugins/outputs/loki/loki.go:134:25                                        perfsprint  fmt.Sprintf can be replaced with faster strconv.FormatInt
plugins/outputs/postgresql/postgresql_bench_test.go:68:37                  perfsprint  fmt.Sprintf can be replaced with faster strconv.Itoa
plugins/outputs/warp10/warp10.go:113:9                                     perfsprint  fmt.Sprint can be replaced with just using the string
plugins/outputs/yandex_cloud_monitoring/yandex_cloud_monitoring.go:138:14  perfsprint  fmt.Sprint can be replaced with just using the string
```