### PR TITLE
fix(outputs.timestream): Clip uint64 values

### DIFF
--- a/plugins/outputs/timestream/README.md
+++ b/plugins/outputs/timestream/README.md
@@ -123,6 +123,12 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ##
 ```
 
+### Unsigned Integers
+
+Timestream does **DOES NOT** support unsigned int64 values. Values using uint64,
+which are less than the maximum signed int64 are returned as expected. Any
+larger value is caped at the maximum int64 value.
+
 ### Batching
 
 Timestream WriteInputRequest.CommonAttributes are used to efficiently write data

--- a/plugins/outputs/timestream/timestream.go
+++ b/plugins/outputs/timestream/timestream.go
@@ -6,6 +6,7 @@ import (
 	_ "embed"
 	"errors"
 	"fmt"
+	"math"
 	"reflect"
 	"strconv"
 	"sync"
@@ -609,7 +610,11 @@ func convertValue(v interface{}) (value string, valueType types.MeasureValueType
 		value = strconv.FormatUint(uint64(t), 10)
 	case uint64:
 		valueType = types.MeasureValueTypeBigint
-		value = strconv.FormatUint(t, 10)
+		if t <= uint64(math.MaxInt64) {
+			value = strconv.FormatUint(t, 10)
+		} else {
+			value = strconv.FormatUint(math.MaxInt64, 10)
+		}
 	case float32:
 		valueType = types.MeasureValueTypeDouble
 		value = strconv.FormatFloat(float64(t), 'f', -1, 32)


### PR DESCRIPTION
Timestream does not support uint64 values. Instead of returning an error, this will return values less than the max uint64 and cap values larger.

fixes: #14212