### PR TITLE
docs(inputs.cpu): Clarify 'time_active' contains 'iowait'

### DIFF
--- a/plugins/inputs/cpu/README.md
+++ b/plugins/inputs/cpu/README.md
@@ -36,6 +36,7 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## If true, collect raw CPU time metrics
   collect_cpu_time = false
   ## If true, compute and report the sum of all non-idle CPU states
+  ## NOTE: The resulting 'time_active' field INCLUDES 'iowait'!
   report_active = false
   ## If true and the info is available then add core_id and physical_id tags
   core_tags = false

--- a/plugins/inputs/cpu/cpu.go
+++ b/plugins/inputs/cpu/cpu.go
@@ -32,14 +32,6 @@ type CPUStats struct {
 	Log telegraf.Logger `toml:"-"`
 }
 
-func NewCPUStats(ps system.PS) *CPUStats {
-	return &CPUStats{
-		ps:             ps,
-		CollectCPUTime: true,
-		ReportActive:   true,
-	}
-}
-
 func (*CPUStats) SampleConfig() string {
 	return sampleConfig
 }

--- a/plugins/inputs/cpu/cpu_test.go
+++ b/plugins/inputs/cpu/cpu_test.go
@@ -11,6 +11,14 @@ import (
 	"github.com/influxdata/telegraf/testutil"
 )
 
+func NewCPUStats(ps system.PS) *CPUStats {
+	return &CPUStats{
+		ps:             ps,
+		CollectCPUTime: true,
+		ReportActive:   true,
+	}
+}
+
 func TestCPUStats(t *testing.T) {
 	var mps system.MockPS
 	defer mps.AssertExpectations(t)

--- a/plugins/inputs/cpu/sample.conf
+++ b/plugins/inputs/cpu/sample.conf
@@ -7,6 +7,7 @@
   ## If true, collect raw CPU time metrics
   collect_cpu_time = false
   ## If true, compute and report the sum of all non-idle CPU states
+  ## NOTE: The resulting 'time_active' field INCLUDES 'iowait'!
   report_active = false
   ## If true and the info is available then add core_id and physical_id tags
   core_tags = false


### PR DESCRIPTION
- [x] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #6306

This PR adds a comment stating the fact that `time_active` contains/includes `iowait` which might be counter-intuitive. Additionally, the PR moves the test-only `NewCPUStats` function to the test file.