### PR TITLE
test(inputs.vault): Fix integration test by only testing for subset

### DIFF
--- a/plugins/inputs/vault/vault_test.go
+++ b/plugins/inputs/vault/vault_test.go
@@ -241,5 +241,5 @@ func TestIntegration(t *testing.T) {
 	require.NoError(t, plugin.Gather(&acc))
 
 	actual := acc.GetTelegrafMetrics()
-	testutil.RequireMetricsStructureEqual(t, expected, actual, options...)
+	testutil.RequireMetricsStructureSubset(t, expected, actual, options...)
 }

--- a/testutil/metric_test.go
+++ b/testutil/metric_test.go
@@ -104,3 +104,156 @@ func TestRequireMetricsEqual(t *testing.T) {
 		})
 	}
 }
+
+func TestRequireMetricsSubset(t *testing.T) {
+	tests := []struct {
+		name string
+		got  []telegraf.Metric
+		want []telegraf.Metric
+		opts []cmp.Option
+	}{
+		{
+			name: "subset of metrics",
+			got: []telegraf.Metric{
+				MustMetric(
+					"cpu",
+					map[string]string{},
+					map[string]interface{}{"value": float64(3.14)},
+					time.Unix(0, 0),
+				),
+				MustMetric(
+					"net",
+					map[string]string{},
+					map[string]interface{}{"value": int64(42)},
+					time.Unix(0, 0),
+				),
+				MustMetric(
+					"superfluous",
+					map[string]string{},
+					map[string]interface{}{"value": true},
+					time.Unix(0, 0),
+				),
+			},
+			want: []telegraf.Metric{
+				MustMetric(
+					"net",
+					map[string]string{},
+					map[string]interface{}{"value": int64(42)},
+					time.Unix(0, 0),
+				),
+				MustMetric(
+					"cpu",
+					map[string]string{},
+					map[string]interface{}{"value": float64(3.14)},
+					time.Unix(0, 0),
+				),
+			},
+			opts: []cmp.Option{SortMetrics()},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			RequireMetricsSubset(t, tt.want, tt.got, tt.opts...)
+		})
+	}
+}
+
+func TestRequireMetricsStructureEqual(t *testing.T) {
+	tests := []struct {
+		name string
+		got  []telegraf.Metric
+		want []telegraf.Metric
+		opts []cmp.Option
+	}{
+		{
+			name: "compare structure",
+			got: []telegraf.Metric{
+				MustMetric(
+					"cpu",
+					map[string]string{},
+					map[string]interface{}{"value": float64(3.14)},
+					time.Unix(0, 0),
+				),
+				MustMetric(
+					"net",
+					map[string]string{},
+					map[string]interface{}{"value": int64(42)},
+					time.Unix(0, 0),
+				),
+			},
+			want: []telegraf.Metric{
+				MustMetric(
+					"net",
+					map[string]string{},
+					map[string]interface{}{"value": int64(0)},
+					time.Unix(0, 0),
+				),
+				MustMetric(
+					"cpu",
+					map[string]string{},
+					map[string]interface{}{"value": float64(0)},
+					time.Unix(0, 0),
+				),
+			},
+			opts: []cmp.Option{SortMetrics()},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			RequireMetricsStructureEqual(t, tt.want, tt.got, tt.opts...)
+		})
+	}
+}
+
+func TestRequireMetricsStructureSubset(t *testing.T) {
+	tests := []struct {
+		name string
+		got  []telegraf.Metric
+		want []telegraf.Metric
+		opts []cmp.Option
+	}{
+		{
+			name: "subset of metric structure",
+			got: []telegraf.Metric{
+				MustMetric(
+					"cpu",
+					map[string]string{},
+					map[string]interface{}{"value": float64(3.14)},
+					time.Unix(0, 0),
+				),
+				MustMetric(
+					"net",
+					map[string]string{},
+					map[string]interface{}{"value": int64(42)},
+					time.Unix(0, 0),
+				),
+				MustMetric(
+					"superfluous",
+					map[string]string{},
+					map[string]interface{}{"value": true},
+					time.Unix(0, 0),
+				),
+			},
+			want: []telegraf.Metric{
+				MustMetric(
+					"net",
+					map[string]string{},
+					map[string]interface{}{"value": int64(0)},
+					time.Unix(0, 0),
+				),
+				MustMetric(
+					"cpu",
+					map[string]string{},
+					map[string]interface{}{"value": float64(0)},
+					time.Unix(0, 0),
+				),
+			},
+			opts: []cmp.Option{SortMetrics()},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			RequireMetricsStructureSubset(t, tt.want, tt.got, tt.opts...)
+		})
+	}
+}


### PR DESCRIPTION
Currently the integration test of `inputs.vault` fails as vault reports more metrics with time. However, the timing between starting the container and the call to `Gather` cannot be known. Therefore, the PR adds functions to check if `expected` is a **subset** of the actual metrics (also for structure comparison). Furthermore, it also provides unit tests for the testutil functions.