### PR TITLE
feat(inputs.procstat)!: Remove useless zero cpu_times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 <!-- markdownlint-disable MD024 -->
 # Changelog
 
+## Unreleased
+
+### Important Changes
+
+- Remove useless, all-zero fields in `inputs.procstat`. Up to now, Telegraf
+  reports the fields `cpu_time_guest`, `cpu_time_guest_nice`, `cpu_time_idle`,
+  `cpu_time_irq`, `cpu_time_nice`, `cpu_time_soft_irq` and `cpu_time_steal`
+  which are never set by the underlying library. As a consequence those fields
+  were always zero. [#14224](https://github.com/influxdata/telegraf/pull/14224)
+  removes those useless fields. In case you reference them, please adapt your
+  queries!
+
 ## v1.28.3 [2023-10-23]
 
 ### Bugfixes

--- a/plugins/inputs/procstat/README.md
+++ b/plugins/inputs/procstat/README.md
@@ -115,14 +115,7 @@ Below are an example set of tags and fields:
     - child_minor_faults (int)
     - created_at (int) [epoch in nanoseconds]
     - cpu_time (int)
-    - cpu_time_guest (float)
-    - cpu_time_guest_nice (float)
-    - cpu_time_idle (float)
-    - cpu_time_iowait (float)
-    - cpu_time_irq (float)
-    - cpu_time_nice (float)
-    - cpu_time_soft_irq (float)
-    - cpu_time_steal (float)
+    - cpu_time_iowait (float) (zero for all OSes except Linux)
     - cpu_time_system (float)
     - cpu_time_user (float)
     - cpu_usage (float)
@@ -199,5 +192,5 @@ Below are an example set of tags and fields:
 
 ```text
 procstat_lookup,host=prash-laptop,pattern=influxd,pid_finder=pgrep,result=success pid_count=1i,running=1i,result_code=0i 1582089700000000000
-procstat,host=prash-laptop,pattern=influxd,process_name=influxd,user=root involuntary_context_switches=151496i,child_minor_faults=1061i,child_major_faults=8i,cpu_time_user=2564.81,cpu_time_idle=0,cpu_time_irq=0,cpu_time_guest=0,pid=32025i,major_faults=8609i,created_at=1580107536000000000i,voluntary_context_switches=1058996i,cpu_time_system=616.98,cpu_time_steal=0,cpu_time_guest_nice=0,memory_swap=0i,memory_locked=0i,memory_usage=1.7797634601593018,num_threads=18i,cpu_time_nice=0,cpu_time_iowait=0,cpu_time_soft_irq=0,memory_rss=148643840i,memory_vms=1435688960i,memory_data=0i,memory_stack=0i,minor_faults=1856550i 1582089700000000000
+procstat,host=prash-laptop,pattern=influxd,process_name=influxd,user=root involuntary_context_switches=151496i,child_minor_faults=1061i,child_major_faults=8i,cpu_time_user=2564.81,pid=32025i,major_faults=8609i,created_at=1580107536000000000i,voluntary_context_switches=1058996i,cpu_time_system=616.98,memory_swap=0i,memory_locked=0i,memory_usage=1.7797634601593018,num_threads=18i,cpu_time_iowait=0,memory_rss=148643840i,memory_vms=1435688960i,memory_data=0i,memory_stack=0i,minor_faults=1856550i 1582089700000000000
 ```

--- a/plugins/inputs/procstat/native_finder.go
+++ b/plugins/inputs/procstat/native_finder.go
@@ -45,7 +45,7 @@ func (pg *NativeFinder) PidFile(path string) ([]PID, error) {
 	var pids []PID
 	pidString, err := os.ReadFile(path)
 	if err != nil {
-		return pids, fmt.Errorf("Failed to read pidfile %q: %w", path, err)
+		return pids, fmt.Errorf("failed to read pidfile %q: %w", path, err)
 	}
 	pid, err := strconv.ParseInt(strings.TrimSpace(string(pidString)), 10, 32)
 	if err != nil {

--- a/plugins/inputs/procstat/procstat.go
+++ b/plugins/inputs/procstat/procstat.go
@@ -197,23 +197,16 @@ func (p *Procstat) addMetric(proc Process, acc telegraf.Accumulator, t time.Time
 		fields[prefix+"write_bytes"] = io.WriteBytes
 	}
 
-	createdAt, err := proc.CreateTime() //Returns epoch in ms
+	createdAt, err := proc.CreateTime() // returns epoch in ms
 	if err == nil {
-		fields[prefix+"created_at"] = createdAt * 1000000 //Convert ms to ns
+		fields[prefix+"created_at"] = createdAt * 1000000 // ms to ns
 	}
 
 	cpuTime, err := proc.Times()
 	if err == nil {
 		fields[prefix+"cpu_time_user"] = cpuTime.User
 		fields[prefix+"cpu_time_system"] = cpuTime.System
-		fields[prefix+"cpu_time_idle"] = cpuTime.Idle
-		fields[prefix+"cpu_time_nice"] = cpuTime.Nice
-		fields[prefix+"cpu_time_iowait"] = cpuTime.Iowait
-		fields[prefix+"cpu_time_irq"] = cpuTime.Irq
-		fields[prefix+"cpu_time_soft_irq"] = cpuTime.Softirq
-		fields[prefix+"cpu_time_steal"] = cpuTime.Steal
-		fields[prefix+"cpu_time_guest"] = cpuTime.Guest
-		fields[prefix+"cpu_time_guest_nice"] = cpuTime.GuestNice
+		fields[prefix+"cpu_time_iowait"] = cpuTime.Iowait // only reported on Linux
 	}
 
 	cpuPerc, err := proc.Percent(time.Duration(0))


### PR DESCRIPTION
- [x] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #2627 

This PR removes the useless fields

- `cpu_time_guest`
- `cpu_time_guest_nice`
- `cpu_time_idle`
- `cpu_time_irq`
- `cpu_time_nice`
- `cpu_time_soft_irq`
- `cpu_time_steal`

as those are never set by the underlying gopsutil library. Thus those fields are always zero. The PR keeps `cpu_time_iowait` which is zero for all platforms except Linux and adds a notice to the README about that fact.