### PR TITLE
test(inputs.jolokia2_agent): ignore tags as order is not consistent

### DIFF
--- a/plugins/inputs/jolokia2_agent/jolokia2_agent_test.go
+++ b/plugins/inputs/jolokia2_agent/jolokia2_agent_test.go
@@ -826,7 +826,7 @@ func TestIntegrationArtemis(t *testing.T) {
 	require.NoError(t, plugin.Gather(&acc))
 
 	actual := acc.GetTelegrafMetrics()
-	testutil.RequireMetricsStructureEqual(t, expected, actual, testutil.IgnoreTime())
+	testutil.RequireMetricsStructureEqual(t, expected, actual, testutil.SortMetrics(), testutil.IgnoreTime())
 }
 
 func setupServer(resp string) *httptest.Server {


### PR DESCRIPTION
There is a race in some cases where the tag set during integration testing is switched between two metrics. 