### PR TITLE
fix(inputs.win_perf_counter): Do not rely on returned buffer size

### DIFF
--- a/plugins/inputs/win_perf_counters/README.md
+++ b/plugins/inputs/win_perf_counters/README.md
@@ -345,6 +345,10 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## e.g. IgnoredErrors = ["PDH_NO_DATA"]
   # IgnoredErrors = []
 
+  ## Maximum size of the buffer for values returned by the API
+  ## Increase this value if you experience "buffer limit reached" errors.
+  # MaxBufferSize = "4MiB"
+
   ## NOTE: Due to the way TOML is parsed, tables must be at the END of the
   ## plugin definition, otherwise additional config options are read as part of
   ## the table

--- a/plugins/inputs/win_perf_counters/sample.conf
+++ b/plugins/inputs/win_perf_counters/sample.conf
@@ -41,6 +41,10 @@
   ## e.g. IgnoredErrors = ["PDH_NO_DATA"]
   # IgnoredErrors = []
 
+  ## Maximum size of the buffer for values returned by the API
+  ## Increase this value if you experience "buffer limit reached" errors.
+  # MaxBufferSize = "4MiB"
+
   ## NOTE: Due to the way TOML is parsed, tables must be at the END of the
   ## plugin definition, otherwise additional config options are read as part of
   ## the table

--- a/plugins/inputs/win_perf_counters/win_perf_counters.go
+++ b/plugins/inputs/win_perf_counters/win_perf_counters.go
@@ -21,7 +21,7 @@ import (
 //go:embed sample.conf
 var sampleConfig string
 
-var defaultMaxBufferSize = config.Size(100 * 1024 * 1024)
+var defaultMaxBufferSize = config.Size(4 * 1024 * 1024)
 
 type WinPerfCounters struct {
 	PrintValid                 bool `toml:"PrintValid"`

--- a/plugins/inputs/win_perf_counters/win_perf_counters.go
+++ b/plugins/inputs/win_perf_counters/win_perf_counters.go
@@ -21,7 +21,7 @@ import (
 //go:embed sample.conf
 var sampleConfig string
 
-var defaultMaxBufferSize = config.Size(4 * 1024 * 1024)
+var defaultMaxBufferSize = config.Size(100 * 1024 * 1024)
 
 type WinPerfCounters struct {
 	PrintValid                 bool `toml:"PrintValid"`
@@ -588,7 +588,7 @@ func (m *WinPerfCounters) Init() error {
 		return fmt.Errorf("maximum buffer size should at least be %d", 2*initialBufferSize)
 	}
 	if m.MaxBufferSize > math.MaxUint32 {
-		return fmt.Errorf("maximum buffer size should be smaller than %d", math.MaxUint32)
+		return fmt.Errorf("maximum buffer size should be smaller than %d", uint32(math.MaxUint32))
 	}
 
 	if m.UseWildcardsExpansion && !m.LocalizeWildcardsExpansion {

--- a/plugins/inputs/win_perf_counters/win_perf_counters.go
+++ b/plugins/inputs/win_perf_counters/win_perf_counters.go
@@ -7,6 +7,7 @@ import (
 	_ "embed"
 	"errors"
 	"fmt"
+	"math"
 	"os"
 	"strings"
 	"sync"
@@ -20,6 +21,8 @@ import (
 //go:embed sample.conf
 var sampleConfig string
 
+var defaultMaxBufferSize = config.Size(100 * 1024 * 1024)
+
 type WinPerfCounters struct {
 	PrintValid                 bool `toml:"PrintValid"`
 	PreVistaSupport            bool `toml:"PreVistaSupport" deprecated:"1.7.0;determined dynamically"`
@@ -29,6 +32,7 @@ type WinPerfCounters struct {
 	UseWildcardsExpansion      bool
 	LocalizeWildcardsExpansion bool
 	IgnoredErrors              []string `toml:"IgnoredErrors"`
+	MaxBufferSize              config.Size
 	Sources                    []string
 
 	Log telegraf.Logger
@@ -207,7 +211,7 @@ func (m *WinPerfCounters) AddItem(counterPath, computer, objectName, instance, c
 	if !ok {
 		hostCounter = &hostCountersInfo{computer: computer, tag: sourceTag}
 		m.hostCounters[computer] = hostCounter
-		hostCounter.query = m.queryCreator.NewPerformanceQuery(computer)
+		hostCounter.query = m.queryCreator.NewPerformanceQuery(computer, uint32(m.MaxBufferSize))
 		if err := hostCounter.query.Open(); err != nil {
 			return err
 		}
@@ -579,9 +583,16 @@ func isKnownCounterDataError(err error) bool {
 }
 
 func (m *WinPerfCounters) Init() error {
+	// Check the buffer size
+	if m.MaxBufferSize < config.Size(initialBufferSize) {
+		return fmt.Errorf("maximum buffer size should at least be %d", 2*initialBufferSize)
+	}
+	if m.MaxBufferSize > math.MaxUint32 {
+		return fmt.Errorf("maximum buffer size should be smaller than %d", math.MaxUint32)
+	}
+
 	if m.UseWildcardsExpansion && !m.LocalizeWildcardsExpansion {
 		// Counters must not have wildcards with this option
-
 		found := false
 		wildcards := []string{"*", "?"}
 
@@ -614,6 +625,7 @@ func init() {
 		return &WinPerfCounters{
 			CountersRefreshInterval:    config.Duration(time.Second * 60),
 			LocalizeWildcardsExpansion: true,
+			MaxBufferSize:              defaultMaxBufferSize,
 			queryCreator:               &PerformanceQueryCreatorImpl{},
 		}
 	})

--- a/plugins/inputs/win_perf_counters/win_perf_counters_integration_test.go
+++ b/plugins/inputs/win_perf_counters/win_perf_counters_integration_test.go
@@ -18,7 +18,7 @@ func TestWinPerformanceQueryImplIntegration(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
-	query := &PerformanceQueryImpl{}
+	query := &PerformanceQueryImpl{maxBufferSize: uint32(defaultMaxBufferSize)}
 
 	err := query.Close()
 	require.Error(t, err, "uninitialized query must return errors")
@@ -62,11 +62,11 @@ func TestWinPerformanceQueryImplIntegration(t *testing.T) {
 
 	fcounter, err := query.GetFormattedCounterValueDouble(hCounter)
 	require.NoError(t, err)
-	require.Greater(t, fcounter, 0)
+	require.Greater(t, fcounter, float64(0))
 
 	rcounter, err := query.GetRawCounterValue(hCounter)
 	require.NoError(t, err)
-	require.Greater(t, rcounter, 10000000)
+	require.Greater(t, rcounter, int64(10000000))
 
 	now := time.Now()
 	mtime, err := query.CollectDataWithTime()
@@ -131,10 +131,11 @@ func TestWinPerfCountersConfigGet1Integration(t *testing.T) {
 	}}
 
 	m := WinPerfCounters{
-		PrintValid:   false,
-		Object:       perfObjects,
-		queryCreator: &PerformanceQueryCreatorImpl{},
-		Log:          testutil.Logger{},
+		PrintValid:    false,
+		Object:        perfObjects,
+		MaxBufferSize: defaultMaxBufferSize,
+		Log:           testutil.Logger{},
+		queryCreator:  &PerformanceQueryCreatorImpl{},
 	}
 
 	require.NoError(t, m.ParseConfig())
@@ -158,10 +159,11 @@ func TestWinPerfCountersConfigGet2Integration(t *testing.T) {
 	}}
 
 	m := WinPerfCounters{
-		PrintValid:   false,
-		Object:       perfObjects,
-		queryCreator: &PerformanceQueryCreatorImpl{},
-		Log:          testutil.Logger{},
+		PrintValid:    false,
+		Object:        perfObjects,
+		MaxBufferSize: defaultMaxBufferSize,
+		Log:           testutil.Logger{},
+		queryCreator:  &PerformanceQueryCreatorImpl{},
 	}
 
 	require.NoError(t, m.ParseConfig())
@@ -200,10 +202,11 @@ func TestWinPerfCountersConfigGet3Integration(t *testing.T) {
 	}}
 
 	m := WinPerfCounters{
-		PrintValid:   false,
-		Object:       perfObjects,
-		queryCreator: &PerformanceQueryCreatorImpl{},
-		Log:          testutil.Logger{},
+		PrintValid:    false,
+		Object:        perfObjects,
+		MaxBufferSize: defaultMaxBufferSize,
+		Log:           testutil.Logger{},
+		queryCreator:  &PerformanceQueryCreatorImpl{},
 	}
 
 	require.NoError(t, m.ParseConfig())
@@ -240,10 +243,11 @@ func TestWinPerfCountersConfigGet4Integration(t *testing.T) {
 	}}
 
 	m := WinPerfCounters{
-		PrintValid:   false,
-		Object:       perfObjects,
-		queryCreator: &PerformanceQueryCreatorImpl{},
-		Log:          testutil.Logger{},
+		PrintValid:    false,
+		Object:        perfObjects,
+		MaxBufferSize: defaultMaxBufferSize,
+		Log:           testutil.Logger{},
+		queryCreator:  &PerformanceQueryCreatorImpl{},
 	}
 
 	require.NoError(t, m.ParseConfig())
@@ -280,10 +284,11 @@ func TestWinPerfCountersConfigGet5Integration(t *testing.T) {
 	}}
 
 	m := WinPerfCounters{
-		PrintValid:   false,
-		Object:       perfObjects,
-		queryCreator: &PerformanceQueryCreatorImpl{},
-		Log:          testutil.Logger{},
+		PrintValid:    false,
+		Object:        perfObjects,
+		MaxBufferSize: defaultMaxBufferSize,
+		Log:           testutil.Logger{},
+		queryCreator:  &PerformanceQueryCreatorImpl{},
 	}
 
 	require.NoError(t, m.ParseConfig())
@@ -320,10 +325,11 @@ func TestWinPerfCountersConfigGet6Integration(t *testing.T) {
 	}}
 
 	m := WinPerfCounters{
-		PrintValid:   false,
-		Object:       perfObjects,
-		queryCreator: &PerformanceQueryCreatorImpl{},
-		Log:          testutil.Logger{},
+		PrintValid:    false,
+		Object:        perfObjects,
+		MaxBufferSize: defaultMaxBufferSize,
+		Log:           testutil.Logger{},
+		queryCreator:  &PerformanceQueryCreatorImpl{},
 	}
 
 	require.NoError(t, m.ParseConfig())
@@ -347,10 +353,11 @@ func TestWinPerfCountersConfigGet7Integration(t *testing.T) {
 	}}
 
 	m := WinPerfCounters{
-		PrintValid:   false,
-		Object:       perfObjects,
-		queryCreator: &PerformanceQueryCreatorImpl{},
-		Log:          testutil.Logger{},
+		PrintValid:    false,
+		Object:        perfObjects,
+		MaxBufferSize: defaultMaxBufferSize,
+		Log:           testutil.Logger{},
+		queryCreator:  &PerformanceQueryCreatorImpl{},
 	}
 
 	require.NoError(t, m.ParseConfig())
@@ -387,10 +394,11 @@ func TestWinPerfCountersConfigError1Integration(t *testing.T) {
 	}}
 
 	m := WinPerfCounters{
-		PrintValid:   false,
-		Object:       perfObjects,
-		queryCreator: &PerformanceQueryCreatorImpl{},
-		Log:          testutil.Logger{},
+		PrintValid:    false,
+		Object:        perfObjects,
+		MaxBufferSize: defaultMaxBufferSize,
+		Log:           testutil.Logger{},
+		queryCreator:  &PerformanceQueryCreatorImpl{},
 	}
 
 	require.Error(t, m.ParseConfig())
@@ -414,10 +422,11 @@ func TestWinPerfCountersConfigError2Integration(t *testing.T) {
 	}}
 
 	m := WinPerfCounters{
-		PrintValid:   false,
-		Object:       perfObjects,
-		queryCreator: &PerformanceQueryCreatorImpl{},
-		Log:          testutil.Logger{},
+		PrintValid:    false,
+		Object:        perfObjects,
+		MaxBufferSize: defaultMaxBufferSize,
+		Log:           testutil.Logger{},
+		queryCreator:  &PerformanceQueryCreatorImpl{},
 	}
 
 	require.NoError(t, m.ParseConfig())
@@ -443,10 +452,11 @@ func TestWinPerfCountersConfigError3Integration(t *testing.T) {
 	}}
 
 	m := WinPerfCounters{
-		PrintValid:   false,
-		Object:       perfObjects,
-		queryCreator: &PerformanceQueryCreatorImpl{},
-		Log:          testutil.Logger{},
+		PrintValid:    false,
+		Object:        perfObjects,
+		MaxBufferSize: defaultMaxBufferSize,
+		Log:           testutil.Logger{},
+		queryCreator:  &PerformanceQueryCreatorImpl{},
 	}
 
 	require.Error(t, m.ParseConfig())
@@ -470,10 +480,11 @@ func TestWinPerfCountersCollect1Integration(t *testing.T) {
 	}}
 
 	m := WinPerfCounters{
-		PrintValid:   false,
-		Object:       perfObjects,
-		queryCreator: &PerformanceQueryCreatorImpl{},
-		Log:          testutil.Logger{},
+		PrintValid:    false,
+		Object:        perfObjects,
+		MaxBufferSize: defaultMaxBufferSize,
+		Log:           testutil.Logger{},
+		queryCreator:  &PerformanceQueryCreatorImpl{},
 	}
 
 	var acc testutil.Accumulator
@@ -510,9 +521,10 @@ func TestWinPerfCountersCollect2Integration(t *testing.T) {
 		PrintValid:            false,
 		UsePerfCounterTime:    true,
 		Object:                perfObjects,
-		queryCreator:          &PerformanceQueryCreatorImpl{},
 		UseWildcardsExpansion: true,
+		MaxBufferSize:         defaultMaxBufferSize,
 		Log:                   testutil.Logger{},
+		queryCreator:          &PerformanceQueryCreatorImpl{},
 	}
 
 	var acc testutil.Accumulator
@@ -550,9 +562,10 @@ func TestWinPerfCountersCollectRawIntegration(t *testing.T) {
 	m := WinPerfCounters{
 		PrintValid:            false,
 		Object:                perfObjects,
-		queryCreator:          &PerformanceQueryCreatorImpl{},
 		UseWildcardsExpansion: true,
+		MaxBufferSize:         defaultMaxBufferSize,
 		Log:                   testutil.Logger{},
+		queryCreator:          &PerformanceQueryCreatorImpl{},
 	}
 	var acc testutil.Accumulator
 	require.NoError(t, m.Gather(&acc))
@@ -566,17 +579,18 @@ func TestWinPerfCountersCollectRawIntegration(t *testing.T) {
 		val, ok := metric.Fields[expectedCounter]
 		require.True(t, ok, "Expected presence of %s field", expectedCounter)
 		valInt64, ok := val.(int64)
-		require.True(t, ok, fmt.Sprintf("Expected int64, got %T", val))
-		require.Greater(t, valInt64, 0, fmt.Sprintf("Expected > 0, got %d, for %#v", valInt64, metric))
+		require.Truef(t, ok, "Expected int64, got %T", val)
+		require.Greaterf(t, valInt64, int64(0), "Expected > 0, got %d, for %#v", valInt64, metric)
 	}
 
 	// Test *Array way
 	m = WinPerfCounters{
 		PrintValid:            false,
 		Object:                perfObjects,
-		queryCreator:          &PerformanceQueryCreatorImpl{},
 		UseWildcardsExpansion: false,
+		MaxBufferSize:         defaultMaxBufferSize,
 		Log:                   testutil.Logger{},
+		queryCreator:          &PerformanceQueryCreatorImpl{},
 	}
 	var acc2 testutil.Accumulator
 	require.NoError(t, m.Gather(&acc))
@@ -589,7 +603,7 @@ func TestWinPerfCountersCollectRawIntegration(t *testing.T) {
 		val, ok := metric.Fields[expectedCounter]
 		require.True(t, ok, "Expected presence of %s field", expectedCounter)
 		valInt64, ok := val.(int64)
-		require.True(t, ok, fmt.Sprintf("Expected int64, got %T", val))
-		require.Greater(t, valInt64, 0, fmt.Sprintf("Expected > 0, got %d, for %#v", valInt64, metric))
+		require.Truef(t, ok, "Expected int64, got %T", val)
+		require.Greaterf(t, valInt64, int64(0), "Expected > 0, got %d, for %#v", valInt64, metric)
 	}
 }

--- a/plugins/inputs/win_perf_counters/win_perf_counters_test.go
+++ b/plugins/inputs/win_perf_counters/win_perf_counters_test.go
@@ -214,7 +214,7 @@ type FakePerformanceQueryCreator struct {
 	fakeQueries map[string]*FakePerformanceQuery
 }
 
-func (m FakePerformanceQueryCreator) NewPerformanceQuery(computer string) PerformanceQuery {
+func (m FakePerformanceQueryCreator) NewPerformanceQuery(computer string, _ uint32) PerformanceQuery {
 	var ret PerformanceQuery
 	var ok bool
 	if ret, ok = m.fakeQueries[computer]; !ok {
@@ -2043,6 +2043,7 @@ func TestLocalizeWildcardsExpansion(t *testing.T) {
 			[]string{"_Total"}, []string{counter}, true, false, false),
 		LocalizeWildcardsExpansion: false,
 		UseWildcardsExpansion:      true,
+		MaxBufferSize:              defaultMaxBufferSize,
 		Log:                        testutil.Logger{},
 	}
 


### PR DESCRIPTION
- [x] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #14097
might resolve #9809 

In the current implementation we rely on the buffer-size returned by the Microsoft API in e.g. `GetCounterPath()`. However, as stated in the [API documentation](https://learn.microsoft.com/en-us/windows/win32/api/pdh/nf-pdh-pdhexpandwildcardpatha#return-value) we should not rely on this returned value to allocate the buffer as the data might for example grow while querying.

This PR fixes the instances that currently relies on the returned size by preallocate a buffer with a start size (currently 1KiB) and grow exponentially until the data fits or the maximum size is reached. The "maximum size" can be specified by a new `MaxBufferSize` config option (default 4MiB). As an optimization we short-cut some iterations by jumping to the size returned by the API in case it is bigger that the current buffer length...