### PR TITLE
fix(inputs.mqtt_consumer): Resolve could not mark message delivered

### DIFF
--- a/plugins/inputs/mqtt_consumer/mqtt_consumer.go
+++ b/plugins/inputs/mqtt_consumer/mqtt_consumer.go
@@ -325,8 +325,8 @@ func (m *MQTTConsumer) onMessage(_ mqtt.Client, msg mqtt.Message) {
 			}
 		}
 	}
-	id := m.acc.AddTrackingMetricGroup(metrics)
 	m.messagesMutex.Lock()
+	id := m.acc.AddTrackingMetricGroup(metrics)
 	m.messages[id] = msg
 	m.messagesMutex.Unlock()
 }


### PR DESCRIPTION
The lock for the messages map was collected after sending the metric to the accumulator. This was not the right behavior, as the accumulator could send the metric before we even got to the next step to lock and add the message to the map. As a result, in some scenarios the metric could get sent and attempt to mark it delivered before we even record the metric.

fixes: #14242