### PR TITLE
feat(inputs.intel_powerstat): Add core selection

### DIFF
--- a/plugins/inputs/intel_powerstat/README.md
+++ b/plugins/inputs/intel_powerstat/README.md
@@ -48,6 +48,13 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ##   "cpu_busy_frequency"
   ## ATTENTION: cpu_busy_cycles is DEPRECATED - use cpu_c0_state_residency
   # cpu_metrics = []
+
+  ## The user can select from which cores he wants to collect metrics.
+  ## The user can set the cores as the example below.
+  ## cores = ["0,3", "10", "20-30"]
+  ## The cores can be passed singular or from a range.
+  ## The default is empty, which reports every core in the system.
+  # cores = []
 ```
 
 ## Example: Configuration with no per-CPU telemetry

--- a/plugins/inputs/intel_powerstat/intel_powerstat_test.go
+++ b/plugins/inputs/intel_powerstat/intel_powerstat_test.go
@@ -120,6 +120,7 @@ func TestGather(t *testing.T) {
 		On("retrieveAndCalculateData", mock.Anything).Return(nil).Times(len(raplDataMap)).
 		On("getConstraintMaxPowerWatts", mock.Anything).Return(546783852.3, nil)
 	mockServices.msr.On("getCPUCoresData").Return(preparedCPUData).
+		On("getReadableCPUCores").Return(coreIDs).
 		On("isMsrLoaded", mock.Anything).Return(true).
 		On("openAndReadMsr", mock.Anything).Return(nil).
 		On("retrieveCPUFrequencyForCore", mock.Anything).Return(1200000.2, nil)
@@ -640,6 +641,7 @@ func getPowerWithMockedServices() (*PowerStat, *MockServices) {
 	p.packageCurrentPowerConsumption = true
 	p.packageCurrentDramPowerConsumption = true
 	p.packageThermalDesignPower = true
+	p.Cores = []string{"0-3"}
 
 	return p, &mockServices
 }
@@ -730,7 +732,7 @@ func TestGetBusClock(t *testing.T) {
 			p.cpuInfo = map[string]*cpuInfo{
 				tt.socketID: {cpuID: tt.socketID, physicalID: tt.socketID, model: strconv.FormatUint(tt.modelCPU, 10)},
 			}
-			if contains(busClockCalculate, tt.modelCPU) {
+			if Contains(busClockCalculate, tt.modelCPU) {
 				mockServices.msr.On("readSingleMsr", mock.Anything, msrFSBFreqString).Return(tt.msrFSBFreqValue, tt.readSingleMsrErrFSB)
 			}
 			defer mockServices.msr.AssertExpectations(t)

--- a/plugins/inputs/intel_powerstat/msr_mock_test.go
+++ b/plugins/inputs/intel_powerstat/msr_mock_test.go
@@ -41,6 +41,21 @@ func (_m *mockMsrService) getCPUCoresData() map[string]*msrData {
 	return r0
 }
 
+func (_m *mockMsrService) getReadableCPUCores() []string {
+	ret := _m.Called()
+
+	var r0 []string
+	if rf, ok := ret.Get(0).(func() []string); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
+	}
+
+	return r0
+}
+
 // openAndReadMsr provides a mock function with given fields: core
 func (_m *mockMsrService) openAndReadMsr(core string) error {
 	ret := _m.Called(core)

--- a/plugins/inputs/intel_powerstat/msr_test.go
+++ b/plugins/inputs/intel_powerstat/msr_test.go
@@ -178,11 +178,12 @@ func verifyCPUCoresData(cores []string, t *testing.T, msr *msrServiceImpl, expec
 
 func getMsrServiceWithMockedFs() (*msrServiceImpl, *mockFileService) {
 	cores := []string{"cpu0", "cpu1", "cpu2", "cpu3"}
+	mockedCores := []string{"0-3"}
 	logger := testutil.Logger{Name: "PowerPluginTest"}
 	fsMock := &mockFileService{}
 	fsMock.On("getStringsMatchingPatternOnPath", mock.Anything).
 		Return(cores, nil).Once()
-	msr := newMsrServiceWithFs(logger, fsMock)
+	msr := newMsrServiceWithFs(logger, fsMock, mockedCores)
 
 	return msr, fsMock
 }

--- a/plugins/inputs/intel_powerstat/sample.conf
+++ b/plugins/inputs/intel_powerstat/sample.conf
@@ -25,3 +25,10 @@
   ##   "cpu_busy_frequency"
   ## ATTENTION: cpu_busy_cycles is DEPRECATED - use cpu_c0_state_residency
   # cpu_metrics = []
+
+  ## The user can select from which cores he wants to collect metrics.
+  ## The user can set the cores as the example below.
+  ## cores = ["0,3", "10", "20-30"]
+  ## The cores can be passed singular or from a range.
+  ## The default is empty, which reports every core in the system.
+  # cores = []


### PR DESCRIPTION
With this commit it's possible to select from which cores telegraf can gather cpu metrics.
This is achieved by overriding the config.intel_powerstat.cores field in telegraf with the desired cores, i.e., cores: ["0-10"], to gather metrics from cores 0 to 10.

- [X] Updated associated README.md.
- [X] Wrote appropriate unit tests.
- [X] Pull request title or commits are in [conventional commit format]

<!-- Before opening a pull request you should run the following checks locally to make sure the CI will pass.
# Required for all PRs

make lint
make check
make check-deps
make test
make docs

- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [ ] Pull request title or commits are in [conventional commit format]
-->

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->


<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->


<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->
