### PR TITLE
fix(inputs.ipset): Parse lines with timeout

### DIFF
--- a/plugins/inputs/ipset/ipset.go
+++ b/plugins/inputs/ipset/ipset.go
@@ -73,36 +73,30 @@ func (i *Ipset) Gather(acc telegraf.Accumulator) error {
 				"set":  data[1],
 				"rule": data[2],
 			}
+
 			fields := make(map[string]interface{}, 3)
-
-			packetsIndex := 4
-			bytesIndex := 6
-			if data[3] == "timeout" {
-				if len(data) < 9 {
-					acc.AddError(fmt.Errorf("error parsing line with timeout (expected at least 9 fields): %s", line))
-					continue
+			for i, field := range data {
+				switch field {
+				case "timeout":
+					val, err := strconv.ParseUint(data[i+1], 10, 64)
+					if err != nil {
+						acc.AddError(err)
+					}
+					fields["timeout"] = val
+				case "packets":
+					val, err := strconv.ParseUint(data[i+1], 10, 64)
+					if err != nil {
+						acc.AddError(err)
+					}
+					fields["packets_total"] = val
+				case "bytes":
+					val, err := strconv.ParseUint(data[i+1], 10, 64)
+					if err != nil {
+						acc.AddError(err)
+					}
+					fields["bytes_total"] = val
 				}
-				packetsIndex = 6
-				bytesIndex = 8
-
-				timeout, err := strconv.ParseUint(data[4], 10, 64)
-				if err != nil {
-					acc.AddError(err)
-				}
-				fields["timeout"] = timeout
 			}
-
-			packetsTotal, err := strconv.ParseUint(data[packetsIndex], 10, 64)
-			if err != nil {
-				acc.AddError(err)
-			}
-			fields["packets_total"] = packetsTotal
-
-			bytesTotal, err := strconv.ParseUint(data[bytesIndex], 10, 64)
-			if err != nil {
-				acc.AddError(err)
-			}
-			fields["bytes_total"] = bytesTotal
 
 			acc.AddCounter(measurement, fields, tags)
 		}

--- a/plugins/inputs/ipset/ipset_test.go
+++ b/plugins/inputs/ipset/ipset_test.go
@@ -74,6 +74,22 @@ func TestIpset(t *testing.T) {
 				{map[string]interface{}{"packets_total": uint64(3), "bytes_total": uint64(222)}},
 			},
 		},
+		{
+			name: "Sets with and without timeouts",
+			value: `create counter-test hash:ip family inet hashsize 1024 maxelem 65536 timeout 1800 counters
+				add counter-test 192.168.1.1 timeout 1792 packets 8 bytes 672
+				create counter-test2 hash:ip family inet hashsize 1024 maxelem 65536 counters
+				add counter-test2 192.168.1.1 packets 8 bytes 672
+				`,
+			tags: []map[string]string{
+				{"set": "counter-test", "rule": "192.168.1.1"},
+				{"set": "counter-test2", "rule": "192.168.1.1"},
+			},
+			fields: [][]map[string]interface{}{
+				{map[string]interface{}{"packets_total": uint64(8), "bytes_total": uint64(672), "timeout": uint64(1792)}},
+				{map[string]interface{}{"packets_total": uint64(8), "bytes_total": uint64(672)}},
+			},
+		},
 	}
 
 	for i, tt := range tests {

--- a/plugins/inputs/ipset/ipset_test.go
+++ b/plugins/inputs/ipset/ipset_test.go
@@ -79,7 +79,7 @@ func TestIpset(t *testing.T) {
 			value: `create counter-test hash:ip family inet hashsize 1024 maxelem 65536 timeout 1800 counters
 				add counter-test 192.168.1.1 timeout 1792 packets 8 bytes 672
 				create counter-test2 hash:ip family inet hashsize 1024 maxelem 65536 counters
-				add counter-test2 192.168.1.1 packets 8 bytes 672
+				add counter-test2 192.168.1.1 packets 18 bytes 673
 				`,
 			tags: []map[string]string{
 				{"set": "counter-test", "rule": "192.168.1.1"},
@@ -87,7 +87,7 @@ func TestIpset(t *testing.T) {
 			},
 			fields: [][]map[string]interface{}{
 				{map[string]interface{}{"packets_total": uint64(8), "bytes_total": uint64(672), "timeout": uint64(1792)}},
-				{map[string]interface{}{"packets_total": uint64(8), "bytes_total": uint64(672)}},
+				{map[string]interface{}{"packets_total": uint64(18), "bytes_total": uint64(673)}},
 			},
 		},
 	}


### PR DESCRIPTION
Parsing raw CLI output, and lines with a timeout shift the values over by two. This checks for timeout, and if it exists adds it as a field as well.

fixes: #14259