### PR TITLE
fix(inputs.intel_rdt): Do not fail on missing PIDs

### DIFF
--- a/plugins/inputs/intel_rdt/intel_rdt.go
+++ b/plugins/inputs/intel_rdt/intel_rdt.go
@@ -309,7 +309,7 @@ func (r *IntelRDT) processOutput(cmdReader io.ReadCloser, processesPIDsAssociati
 
 			pids, err := findPIDsInMeasurement(out)
 			if err != nil {
-				r.Log.Warnf("Skipping measurement: %w", err)
+				r.Log.Warnf("Skipping measurement: %v", err)
 				continue
 			}
 			for processName, PIDsProcess := range processesPIDsAssociation {

--- a/plugins/inputs/intel_rdt/intel_rdt.go
+++ b/plugins/inputs/intel_rdt/intel_rdt.go
@@ -309,7 +309,7 @@ func (r *IntelRDT) processOutput(cmdReader io.ReadCloser, processesPIDsAssociati
 
 			pids, err := findPIDsInMeasurement(out)
 			if err != nil {
-				r.Log.Warn("skipping text: %w", err)
+				r.Log.Warnf("Skipping measurement: %w", err)
 				continue
 			}
 			for processName, PIDsProcess := range processesPIDsAssociation {

--- a/plugins/inputs/intel_rdt/intel_rdt.go
+++ b/plugins/inputs/intel_rdt/intel_rdt.go
@@ -309,8 +309,8 @@ func (r *IntelRDT) processOutput(cmdReader io.ReadCloser, processesPIDsAssociati
 
 			pids, err := findPIDsInMeasurement(out)
 			if err != nil {
-				r.errorChan <- err
-				break
+				r.Log.Warn("skipping text: %w", err)
+				continue
 			}
 			for processName, PIDsProcess := range processesPIDsAssociation {
 				if pids == PIDsProcess {


### PR DESCRIPTION
Instead, continue the loop as some PIDs can be so short-lived that they do not exist by the time we look for them.

fixes: #14272