### PR TITLE
fix(inputs.zfs): Gathering poolMetrics failed on zfs 2.2.0

### DIFF
--- a/plugins/inputs/zfs/README.md
+++ b/plugins/inputs/zfs/README.md
@@ -413,6 +413,6 @@ memory is too low)
 ### ZIL (Linux Only)
 
 note: `zil` measurements in `kstatMetrics` are system-wide, in `poolMetrics`
-are pool-wide
+they are pool-wide
 
 `zil_commit_count` counts when ZFS transactions are committed to a ZIL

--- a/plugins/inputs/zfs/README.md
+++ b/plugins/inputs/zfs/README.md
@@ -418,6 +418,7 @@ memory is too low)
 
 ### ZIL (Linux Only)
 
-note: `zil` measurements in `kstatMetrics` are system-wide, in `poolMetrics` are pool-wide
+note: `zil` measurements in `kstatMetrics` are system-wide, in `poolMetrics`
+are pool-wide
 
 `zil_commit_count` counts when ZFS transactions are committed to a ZIL

--- a/plugins/inputs/zfs/README.md
+++ b/plugins/inputs/zfs/README.md
@@ -223,15 +223,9 @@ For ZFS >= 2.1.x the format has changed significantly:
   - nunlinks (integer, count)
   - nunlinked (integer, count)
 
-For ZFS >= 2.2.x the format has changed significantly:
+For ZFS >= 2.2.x the following additional fields are available:
 
-- zfs_pool
-  - writes (integer, count)
-  - nwritten (integer, bytes)
-  - reads (integer, count)
-  - nread (integer, bytes)
-  - nunlinks (integer, count)
-  - nunlinked (integer, count)
+- additional fields for ZFS > 2.2.x
   - zil_commit_count (integer, count)
   - zil_commit_writer_count (integer, count)
   - zil_itx_count (integer, count)

--- a/plugins/inputs/zfs/README.md
+++ b/plugins/inputs/zfs/README.md
@@ -223,6 +223,33 @@ For ZFS >= 2.1.x the format has changed significantly:
   - nunlinks (integer, count)
   - nunlinked (integer, count)
 
+For ZFS >= 2.2.x the format has changed significantly:
+
+- zfs_pool
+  - writes (integer, count)
+  - nwritten (integer, bytes)
+  - reads (integer, count)
+  - nread (integer, bytes)
+  - nunlinks (integer, count)
+  - nunlinked (integer, count)
+  - zil_commit_count (integer, count)
+  - zil_commit_writer_count (integer, count)
+  - zil_itx_count (integer, count)
+  - zil_itx_indirect_count (integer, count)
+  - zil_itx_indirect_bytes (integer, bytes)
+  - zil_itx_copied_count (integer, count)
+  - zil_itx_copied_bytes (integer, bytes)
+  - zil_itx_needcopy_count (integer, count)
+  - zil_itx_needcopy_bytes (integer, bytes)
+  - zil_itx_metaslab_normal_count (integer, count)
+  - zil_itx_metaslab_normal_bytes (integer, bytes)
+  - zil_itx_metaslab_normal_write (integer, bytes)
+  - zil_itx_metaslab_normal_alloc (integer, bytes)
+  - zil_itx_metaslab_slog_count (integer, count)
+  - zil_itx_metaslab_slog_bytes (integer, bytes)
+  - zil_itx_metaslab_slog_write (integer, bytes)
+  - zil_itx_metaslab_slog_alloc (integer, bytes)
+
 On FreeBSD:
 
 - zfs_pool
@@ -391,6 +418,6 @@ memory is too low)
 
 ### ZIL (Linux Only)
 
-note: ZIL measurements are system-wide, neither per-pool nor per-dataset
+note: `zil` measurements in `kstatMetrics` are system-wide, in `poolMetrics` are pool-wide
 
 `zil_commit_count` counts when ZFS transactions are committed to a ZIL

--- a/plugins/inputs/zfs/zfs_linux.go
+++ b/plugins/inputs/zfs/zfs_linux.go
@@ -83,9 +83,9 @@ func getTags(pools []poolInfo) map[string]string {
 	return map[string]string{"pools": poolNames}
 }
 
-func gather(lines []string, fileLines int) ([]string, []string, error) {
-	if len(lines) != fileLines {
-		return nil, nil, errors.New("expected lines in kstat does not match")
+func gather(lines []string, minimalFileLines int) ([]string, []string, error) {
+	if len(lines) < minimalFileLines {
+		return nil, nil, errors.New("lines in kstat is not enough")
 	}
 
 	keys := strings.Fields(lines[1])
@@ -130,8 +130,8 @@ func gatherV1(lines []string) (map[string]interface{}, error) {
 //
 // For explanation of the first line's values see https://github.com/openzfs/zfs/blob/master/module/os/linux/spl/spl-kstat.c#L61
 func gatherV2(lines []string, tags map[string]string) (map[string]interface{}, error) {
-	fileLines := 9
-	_, _, err := gather(lines, fileLines)
+	minimalFileLines := 9
+	_, _, err := gather(lines, minimalFileLines)
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/inputs/zfs/zfs_linux.go
+++ b/plugins/inputs/zfs/zfs_linux.go
@@ -172,7 +172,7 @@ func gatherPoolStats(pool poolInfo, acc telegraf.Accumulator) error {
 	}
 
 	if gatherErr != nil {
-		return err
+		return gatherErr
 	}
 
 	acc.AddFields("zfs_pool", fields, tags)

--- a/plugins/inputs/zfs/zfs_linux.go
+++ b/plugins/inputs/zfs/zfs_linux.go
@@ -83,9 +83,9 @@ func getTags(pools []poolInfo) map[string]string {
 	return map[string]string{"pools": poolNames}
 }
 
-func gather(lines []string, minimalFileLines int) ([]string, []string, error) {
-	if len(lines) < minimalFileLines {
-		return nil, nil, errors.New("lines in kstat is not enough")
+func gather(lines []string, fileLines int) ([]string, []string, error) {
+	if len(lines) < fileLines {
+		return nil, nil, errors.New("expected lines in kstat does not match")
 	}
 
 	keys := strings.Fields(lines[1])
@@ -130,8 +130,8 @@ func gatherV1(lines []string) (map[string]interface{}, error) {
 //
 // For explanation of the first line's values see https://github.com/openzfs/zfs/blob/master/module/os/linux/spl/spl-kstat.c#L61
 func gatherV2(lines []string, tags map[string]string) (map[string]interface{}, error) {
-	minimalFileLines := 9
-	_, _, err := gather(lines, minimalFileLines)
+	fileLines := 9
+	_, _, err := gather(lines, fileLines)
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/inputs/zfs/zfs_linux_test.go
+++ b/plugins/inputs/zfs/zfs_linux_test.go
@@ -253,7 +253,7 @@ func TestZfsPoolMetrics(t *testing.T) {
 	err = z.Gather(&acc)
 	require.NoError(t, err)
 
-	// one pool, all metrics
+	//one pool, all metrics
 	tags := map[string]string{
 		"pool": "HOME",
 	}
@@ -319,7 +319,7 @@ func TestZfsGeneratesMetrics(t *testing.T) {
 
 	var acc testutil.Accumulator
 
-	// one pool, all metrics
+	//one pool, all metrics
 	tags := map[string]string{
 		"pools": "HOME",
 	}
@@ -331,7 +331,7 @@ func TestZfsGeneratesMetrics(t *testing.T) {
 	acc.AssertContainsTaggedFields(t, "zfs", intMetrics, tags)
 	acc.Metrics = nil
 
-	// two pools, all metrics
+	//two pools, all metrics
 	err = os.MkdirAll(testKstatPath+"/STORAGE", 0750)
 	require.NoError(t, err)
 
@@ -352,7 +352,7 @@ func TestZfsGeneratesMetrics(t *testing.T) {
 
 	intMetrics = getKstatMetricsArcOnly()
 
-	// two pools, one metric
+	//two pools, one metric
 	z = &Zfs{KstatPath: testKstatPath, KstatMetrics: []string{"arcstats"}}
 	acc3 := testutil.Accumulator{}
 	err = z.Gather(&acc3)

--- a/plugins/inputs/zfs/zfs_linux_test.go
+++ b/plugins/inputs/zfs/zfs_linux_test.go
@@ -130,6 +130,33 @@ nread                           4    1884160
 nunlinks                        4    14148
 nunlinked                       4    14147
 `
+const objsetV22Contents = `36 1 0x01 7 2160 5214787391 74985931356512
+name                            type data
+dataset_name                    7    HOMEV22
+writes                          4    978
+nwritten                        4    6450688
+reads                           4    22
+nread                           4    1884160
+nunlinks                        4    14148
+nunlinked                       4    14147
+zil_commit_count                4    1
+zil_commit_writer_count         4    2
+zil_itx_count                   4    3
+zil_itx_indirect_count          4    4
+zil_itx_indirect_bytes          4    5
+zil_itx_copied_count            4    6
+zil_itx_copied_bytes            4    7
+zil_itx_needcopy_count          4    8
+zil_itx_needcopy_bytes          4    9
+zil_itx_metaslab_normal_count   4    10
+zil_itx_metaslab_normal_bytes   4    11
+zil_itx_metaslab_normal_write   4    12
+zil_itx_metaslab_normal_alloc   4    13
+zil_itx_metaslab_slog_count     4    14
+zil_itx_metaslab_slog_bytes     4    15
+zil_itx_metaslab_slog_write     4    16
+zil_itx_metaslab_slog_alloc     4    17
+`
 const zilContents = `7 1 0x01 14 672 34118481334 437444452158445
 name                            type data
 zil_commit_count                4    77
@@ -226,7 +253,7 @@ func TestZfsPoolMetrics(t *testing.T) {
 	err = z.Gather(&acc)
 	require.NoError(t, err)
 
-	//one pool, all metrics
+	// one pool, all metrics
 	tags := map[string]string{
 		"pool": "HOME",
 	}
@@ -235,6 +262,8 @@ func TestZfsPoolMetrics(t *testing.T) {
 
 	err = os.WriteFile(testKstatPath+"/HOME/objset-0x20a", []byte(objsetContents), 0640)
 	require.NoError(t, err)
+	err = os.WriteFile(testKstatPath+"/HOME/objset-0x20b", []byte(objsetV22Contents), 0640)
+	require.NoError(t, err)
 
 	acc.Metrics = nil
 
@@ -242,8 +271,11 @@ func TestZfsPoolMetrics(t *testing.T) {
 	require.NoError(t, err)
 
 	tags["dataset"] = "HOME"
-
 	poolMetrics = getPoolMetricsNewFormat()
+	acc.AssertContainsTaggedFields(t, "zfs_pool", poolMetrics, tags)
+
+	tags["dataset"] = "HOMEV22"
+	poolMetrics = getPoolMetricsNewFormatV22()
 	acc.AssertContainsTaggedFields(t, "zfs_pool", poolMetrics, tags)
 }
 
@@ -287,7 +319,7 @@ func TestZfsGeneratesMetrics(t *testing.T) {
 
 	var acc testutil.Accumulator
 
-	//one pool, all metrics
+	// one pool, all metrics
 	tags := map[string]string{
 		"pools": "HOME",
 	}
@@ -299,7 +331,7 @@ func TestZfsGeneratesMetrics(t *testing.T) {
 	acc.AssertContainsTaggedFields(t, "zfs", intMetrics, tags)
 	acc.Metrics = nil
 
-	//two pools, all metrics
+	// two pools, all metrics
 	err = os.MkdirAll(testKstatPath+"/STORAGE", 0750)
 	require.NoError(t, err)
 
@@ -320,7 +352,7 @@ func TestZfsGeneratesMetrics(t *testing.T) {
 
 	intMetrics = getKstatMetricsArcOnly()
 
-	//two pools, one metric
+	// two pools, one metric
 	z = &Zfs{KstatPath: testKstatPath, KstatMetrics: []string{"arcstats"}}
 	acc3 := testutil.Accumulator{}
 	err = z.Gather(&acc3)
@@ -552,5 +584,33 @@ func getPoolMetricsNewFormat() map[string]interface{} {
 		"nwritten":  int64(6450688),
 		"reads":     int64(22),
 		"writes":    int64(978),
+	}
+}
+
+func getPoolMetricsNewFormatV22() map[string]interface{} {
+	return map[string]interface{}{
+		"nread":                         int64(1884160),
+		"nunlinked":                     int64(14147),
+		"nunlinks":                      int64(14148),
+		"nwritten":                      int64(6450688),
+		"reads":                         int64(22),
+		"writes":                        int64(978),
+		"zil_commit_count":              int64(1),
+		"zil_commit_writer_count":       int64(2),
+		"zil_itx_count":                 int64(3),
+		"zil_itx_indirect_count":        int64(4),
+		"zil_itx_indirect_bytes":        int64(5),
+		"zil_itx_copied_count":          int64(6),
+		"zil_itx_copied_bytes":          int64(7),
+		"zil_itx_needcopy_count":        int64(8),
+		"zil_itx_needcopy_bytes":        int64(9),
+		"zil_itx_metaslab_normal_count": int64(10),
+		"zil_itx_metaslab_normal_bytes": int64(11),
+		"zil_itx_metaslab_normal_write": int64(12),
+		"zil_itx_metaslab_normal_alloc": int64(13),
+		"zil_itx_metaslab_slog_count":   int64(14),
+		"zil_itx_metaslab_slog_bytes":   int64(15),
+		"zil_itx_metaslab_slog_write":   int64(16),
+		"zil_itx_metaslab_slog_alloc":   int64(17),
 	}
 }


### PR DESCRIPTION
- [x] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)


resolves #14279 