### PR TITLE
fix(inputs.s7comm): Truncate string to actual length

### DIFF
--- a/plugins/inputs/s7comm/type_conversions.go
+++ b/plugins/inputs/s7comm/type_conversions.go
@@ -29,7 +29,7 @@ func determineConversion(dtype string, extra int) converterFunc {
 				return ""
 			}
 			// Get the length of the encoded string
-			length := int(buf[0])
+			length := int(buf[1])
 			// Clip the string if we do not fill the whole buffer
 			if length < len(buf)-2 {
 				return string(buf[2 : 2+length])


### PR DESCRIPTION
- [x] Updated associated README.md. - Not necessary
- [x] Wrote appropriate unit tests.- Not necessary
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #

Change string parsing to truncate string at actual length instead of the max string length. 
Byte 0 reflects the max string length, 
Byte 1 reflects the actual length

Behavior before this PR: 
`got [30 17 76 95 50 52 48 95 84 75 49 52 95 51 48 46 112 114 100 112 114 100 97 111 46 112 114 100 76 79 0 0] for field "ProgrammName" @ 24 --> L_240_TK14_30.prdprdao.prdLO (string)`
now:
`got [30 17 76 95 50 52 48 95 84 75 49 52 95 51 48 46 112 114 100 112 114 100 97 111 46 112 114 100 76 79 0 0] for field "ProgrammName" @ 24 --> L_240_TK14_30.prd (string)`