### PR TITLE
chore: Enable bad regex gocritic linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -81,6 +81,7 @@ linters-settings:
       - badCall
       - badCond
       - badLock
+      - badRegexp
       - badSorting
       - builtinShadowDecl
       - caseOrder

--- a/plugins/inputs/gnmi/path.go
+++ b/plugins/inputs/gnmi/path.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Regular expression to see if a path element contains an origin
-var originPattern = regexp.MustCompile(`^([\w-_]+):`)
+var originPattern = regexp.MustCompile(`^([\w-]+):`)
 
 type keySegment struct {
 	name string

--- a/plugins/serializers/graphite/graphite.go
+++ b/plugins/serializers/graphite/graphite.go
@@ -17,8 +17,8 @@ import (
 const DefaultTemplate = "host.tags.measurement.field"
 
 var (
-	compatibleAllowedCharsName  = regexp.MustCompile(`[^ "-:\<>-\]_a-~\p{L}]`)
-	compatibleAllowedCharsValue = regexp.MustCompile(`[^ -:<-~\p{L}]`)
+	compatibleAllowedCharsName  = regexp.MustCompile(`[^ "-:\<>-\]_a-~\p{L}]`) //nolint: gocritic  // valid range for use-case
+	compatibleAllowedCharsValue = regexp.MustCompile(`[^ -:<-~\p{L}]`)         //nolint: gocritic  // valid range for use-case
 	compatibleLeadingTildeDrop  = regexp.MustCompile(`^[~]*(.*)`)
 	hyphenChars                 = strings.NewReplacer(
 		"/", "-",


### PR DESCRIPTION
Resolves one issue with gnmi where there was overlap in the values. The other issues were with graphite serializer. There are two regex that specify all the valid characters, which include ranges. The linter was marking this as suspect given the use of - in the middle of a regex, meaning a range. It is indeed the case of what we want.

fixes: #13176