### PR TITLE
test: Have vault wait for minimum number of metrics

### DIFF
--- a/plugins/inputs/vault/vault_test.go
+++ b/plugins/inputs/vault/vault_test.go
@@ -238,7 +238,10 @@ func TestIntegration(t *testing.T) {
 
 	// Collect the metrics and compare
 	var acc testutil.Accumulator
-	require.NoError(t, plugin.Gather(&acc))
+	require.Eventually(t, func() bool {
+		require.NoError(t, plugin.Gather(&acc))
+		return len(acc.GetTelegrafMetrics()) > 50
+	}, 5*time.Second, 100*time.Millisecond)
 
 	actual := acc.GetTelegrafMetrics()
 	testutil.RequireMetricsStructureSubset(t, expected, actual, options...)


### PR DESCRIPTION
Additional support for vault test to ensure we wait for the minimum 50 metrics we are expecting due to the way that vault takes time to start up. 

If we continue to have issues with vault not having all the right metrics I will suggest we just ensure we get something back.