### PR TITLE
feat(inputs.kafka_consumer): Use metric name from message header

### DIFF
--- a/plugins/inputs/kafka_consumer/README.md
+++ b/plugins/inputs/kafka_consumer/README.md
@@ -68,6 +68,11 @@ to use them.
   ## are not available
   # msg_headers_to_tags = []
 
+  ## The name of kafka message header which value should override the metric name.
+  ## In case when the same header specified in current option and in msg_headers_to_tags
+  ## option, it will be excluded from the msg_headers_to_tags list. 
+  # msg_header_as_metric_name = ""
+
   ## Optional Client id
   # client_id = "Telegraf"
 

--- a/plugins/inputs/kafka_consumer/kafka_consumer.go
+++ b/plugins/inputs/kafka_consumer/kafka_consumer.go
@@ -46,6 +46,7 @@ type KafkaConsumer struct {
 	TopicRegexps           []string        `toml:"topic_regexps"`
 	TopicTag               string          `toml:"topic_tag"`
 	MsgHeadersAsTags       []string        `toml:"msg_headers_as_tags"`
+	MsgHeaderAsMetricName  string          `toml:"msg_header_as_metric_name"`
 	ConsumerFetchDefault   config.Size     `toml:"consumer_fetch_default"`
 	ConnectionStrategy     string          `toml:"connection_strategy"`
 
@@ -330,6 +331,8 @@ func (k *KafkaConsumer) Start(acc telegraf.Accumulator) error {
 			}
 			handler.MsgHeadersToTags = msgHeadersMap
 
+			handler.MsgHeaderToMetricName = k.MsgHeaderAsMetricName
+
 			// We need to copy allWantedTopics; the Consume() is
 			// long-running and we can easily deadlock if our
 			// topic-update-checker fires.
@@ -390,9 +393,10 @@ func NewConsumerGroupHandler(acc telegraf.Accumulator, maxUndelivered int, parse
 
 // ConsumerGroupHandler is a sarama.ConsumerGroupHandler implementation.
 type ConsumerGroupHandler struct {
-	MaxMessageLen    int
-	TopicTag         string
-	MsgHeadersToTags map[string]bool
+	MaxMessageLen         int
+	TopicTag              string
+	MsgHeadersToTags      map[string]bool
+	MsgHeaderToMetricName string
 
 	acc    telegraf.TrackingAccumulator
 	sem    semaphore
@@ -482,9 +486,9 @@ func (h *ConsumerGroupHandler) Handle(session sarama.ConsumerGroupSession, msg *
 		return err
 	}
 
-	// Check if any message header should be pass as tag
 	headerKey := ""
-	if len(h.MsgHeadersToTags) > 0 {
+	// Check if any message header should override metric name or should be pass as tag
+	if len(h.MsgHeadersToTags) > 0 || h.MsgHeaderToMetricName != "" {
 		for _, header := range msg.Headers {
 			//convert to a string as the header and value are byte arrays.
 			headerKey = string(header.Key)
@@ -492,6 +496,12 @@ func (h *ConsumerGroupHandler) Handle(session sarama.ConsumerGroupSession, msg *
 				// If message header should be pass as tag then add it to the metrics
 				for _, metric := range metrics {
 					metric.AddTag(headerKey, string(header.Value))
+				}
+			} else {
+				if h.MsgHeaderToMetricName == headerKey {
+					for _, metric := range metrics {
+						metric.SetName(string(header.Value))
+					}
 				}
 			}
 		}

--- a/plugins/inputs/kafka_consumer/kafka_consumer.go
+++ b/plugins/inputs/kafka_consumer/kafka_consumer.go
@@ -322,16 +322,17 @@ func (k *KafkaConsumer) Start(acc telegraf.Accumulator) error {
 			handler := NewConsumerGroupHandler(acc, k.MaxUndeliveredMessages, k.parser, k.Log)
 			handler.MaxMessageLen = k.MaxMessageLen
 			handler.TopicTag = k.TopicTag
+			handler.MsgHeaderToMetricName = k.MsgHeaderAsMetricName
 			//if message headers list specified, put it as map to handler
 			msgHeadersMap := make(map[string]bool, len(k.MsgHeadersAsTags))
 			if len(k.MsgHeadersAsTags) > 0 {
 				for _, header := range k.MsgHeadersAsTags {
-					msgHeadersMap[header] = true
+					if k.MsgHeaderAsMetricName != header {
+						msgHeadersMap[header] = true
+					}
 				}
 			}
 			handler.MsgHeadersToTags = msgHeadersMap
-
-			handler.MsgHeaderToMetricName = k.MsgHeaderAsMetricName
 
 			// We need to copy allWantedTopics; the Consume() is
 			// long-running and we can easily deadlock if our

--- a/plugins/inputs/kafka_consumer/sample.conf
+++ b/plugins/inputs/kafka_consumer/sample.conf
@@ -27,6 +27,11 @@
   ## works only for Kafka version 0.11+, on lower versions the message headers
   ## are not available
   # msg_headers_to_tags = []
+  
+  ## The name of kafka message header which value should override the metric name.
+  ## In case when the same header specified in current option and in msg_headers_to_tags
+  ## option, it will be excluded from the msg_headers_to_tags list. 
+  # msg_header_as_metric_name = ""
 
   ## Optional Client id
   # client_id = "Telegraf"


### PR DESCRIPTION
# Required for all PRs

<!-- Before opening a pull request you should run the following checks locally to make sure the CI will pass.

make lint
make check
make check-deps
make test
make docs

-->

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [x] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

resolves #13980
Adds a mechanism to Kafka_consumer input for overriding metric name with a value from the kafka message header.