### PR TITLE
fix(common.oauth): Initialize 'EndpointParams' to avoid panic with 'audience' settings

### DIFF
--- a/plugins/common/oauth/config.go
+++ b/plugins/common/oauth/config.go
@@ -3,6 +3,7 @@ package oauth
 import (
 	"context"
 	"net/http"
+	"net/url"
 
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/clientcredentials"
@@ -23,10 +24,11 @@ func (o *OAuth2Config) CreateOauth2Client(ctx context.Context, client *http.Clie
 	}
 
 	oauthConfig := clientcredentials.Config{
-		ClientID:     o.ClientID,
-		ClientSecret: o.ClientSecret,
-		TokenURL:     o.TokenURL,
-		Scopes:       o.Scopes,
+		ClientID:       o.ClientID,
+		ClientSecret:   o.ClientSecret,
+		TokenURL:       o.TokenURL,
+		Scopes:         o.Scopes,
+		EndpointParams: make(url.Values),
 	}
 
 	if o.Audience != "" {

--- a/plugins/outputs/http/http_test.go
+++ b/plugins/outputs/http/http_test.go
@@ -499,6 +499,34 @@ func TestOAuthClientCredentialsGrant(t *testing.T) {
 				w.WriteHeader(http.StatusOK)
 			},
 		},
+		{
+			name: "audience",
+			plugin: &HTTP{
+				URL: u.String() + "/write",
+				HTTPClientConfig: httpconfig.HTTPClientConfig{
+					OAuth2Config: oauth.OAuth2Config{
+						ClientID:     "howdy",
+						ClientSecret: "secret",
+						TokenURL:     u.String() + "/token",
+						Scopes:       []string{"urn:opc:idm:__myscopes__"},
+						Audience:     "audience",
+					},
+				},
+			},
+			tokenHandler: func(t *testing.T, w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				values := url.Values{}
+				values.Add("access_token", token)
+				values.Add("token_type", "bearer")
+				values.Add("expires_in", "3600")
+				_, err = w.Write([]byte(values.Encode()))
+				require.NoError(t, err)
+			},
+			handler: func(t *testing.T, w http.ResponseWriter, r *http.Request) {
+				require.Equal(t, []string{"Bearer " + token}, r.Header["Authorization"])
+				w.WriteHeader(http.StatusOK)
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
- [ ] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

Initialize `EndpointParams` map to prevent the panics when setting an endpoint-parameter.