### PR TITLE
tests(parsers.json_v2): Fix timestamp parsing expectations

### DIFF
--- a/plugins/parsers/json_v2/testdata/timestamp/expected.out
+++ b/plugins/parsers/json_v2/testdata/timestamp/expected.out
@@ -1,4 +1,4 @@
-file,name=temperature,units=℃ value=23.4 1555745371450794118
-file,name=moisture,units=% value=5 1555745371450794118
-file,name=light,units=lux value=10118 1555745371450794118
-file,name=fertility,units=us/cm value=0 1555745371450794118
+file,name=temperature,units=℃ value=23.4 1555745371410000000
+file,name=moisture,units=% value=5 1555745371410000000
+file,name=light,units=lux value=10118 1555745371410000000
+file,name=fertility,units=us/cm value=0 1555745371410000000

--- a/plugins/parsers/json_v2/testdata/timestamp/telegraf.conf
+++ b/plugins/parsers/json_v2/testdata/timestamp/telegraf.conf
@@ -3,6 +3,7 @@
 [[inputs.file]]
     files = ["./testdata/timestamp/input.json"]
     data_format = "json_v2"
+    precision = "1ms"
     [[inputs.file.json_v2]]
         timestamp_path = "time"
         timestamp_format = "unix_ms"

--- a/plugins/parsers/json_v2/testdata/timestamp_ns/telegraf.conf
+++ b/plugins/parsers/json_v2/testdata/timestamp_ns/telegraf.conf
@@ -3,6 +3,7 @@
 [[inputs.file]]
     files = ["./testdata/timestamp_ns/input.json"]
     data_format = "json_v2"
+    precision = "1ns"
     [[inputs.file.json_v2]]
         measurement_name = "test"
         timestamp_path = "timestamp"


### PR DESCRIPTION
This PR improves and corrects the testdata for parsing of timestamps when using the JSON_V2 parser plugin.