### PR TITLE
fix(outputs.opensearch): Expose TLS setting correctly

### DIFF
--- a/plugins/outputs/opensearch/README.md
+++ b/plugins/outputs/opensearch/README.md
@@ -30,7 +30,7 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## Target index name for metrics (OpenSearch will create if it not exists).
   ## This is a Golang template (see https://pkg.go.dev/text/template)
   ## You can also specify
-  ## metric name (`{{.Name}}`), tag value (`{{.Tag "tag_name"}}`), field value (`{{.Field "feild_name"}}`) 
+  ## metric name (`{{.Name}}`), tag value (`{{.Tag "tag_name"}}`), field value (`{{.Field "feild_name"}}`)
   ## If the tag does not exist, the default tag value will be empty string "".
   ## the timestamp (`{{.Time.Format "xxxxxxxxx"}}`).
   ## For example: "telegraf-{{.Time.Format "2006-01-02"}}-{{.Tag "host"}}" would set it to telegraf-2023-07-27-HostName
@@ -63,9 +63,17 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   # auth_bearer_token = ""
 
   ## Optional TLS Config
-  # tls_ca = "/etc/telegraf/ca.pem"
-  # tls_cert = "/etc/telegraf/cert.pem"
-  # tls_key = "/etc/telegraf/key.pem"
+  ## Set to true/false to enforce TLS being enabled/disabled. If not set,
+  ## enable TLS only if any of the other options are specified.
+  # tls_enable =
+  ## Trusted root certificates for server
+  # tls_ca = "/path/to/cafile"
+  ## Used for TLS client certificate authentication
+  # tls_cert = "/path/to/certfile"
+  ## Used for TLS client certificate authentication
+  # tls_key = "/path/to/keyfile"
+  ## Send the specified TLS server name via SNI
+  # tls_server_name = "kubernetes.example.com"
   ## Use TLS but skip chain & host verification
   # insecure_skip_verify = false
 

--- a/plugins/outputs/opensearch/README.md
+++ b/plugins/outputs/opensearch/README.md
@@ -30,7 +30,7 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## Target index name for metrics (OpenSearch will create if it not exists).
   ## This is a Golang template (see https://pkg.go.dev/text/template)
   ## You can also specify
-  ## metric name (`{{.Name}}`), tag value (`{{.Tag "tag_name"}}`), field value (`{{.Field "feild_name"}}`)
+  ## metric name (`{{.Name}}`), tag value (`{{.Tag "tag_name"}}`), field value (`{{.Field "field_name"}}`)
   ## If the tag does not exist, the default tag value will be empty string "".
   ## the timestamp (`{{.Time.Format "xxxxxxxxx"}}`).
   ## For example: "telegraf-{{.Time.Format "2006-01-02"}}-{{.Tag "host"}}" would set it to telegraf-2023-07-27-HostName

--- a/plugins/outputs/opensearch/opensearch.go
+++ b/plugins/outputs/opensearch/opensearch.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha256"
-	"crypto/tls"
 	_ "embed"
 	"encoding/json"
 	"fmt"
@@ -23,7 +22,7 @@ import (
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/internal/choice"
-	httpconfig "github.com/influxdata/telegraf/plugins/common/http"
+	commontls "github.com/influxdata/telegraf/plugins/common/tls"
 	"github.com/influxdata/telegraf/plugins/outputs"
 )
 
@@ -50,14 +49,14 @@ type Opensearch struct {
 	HealthCheckTimeout  config.Duration `toml:"health_check_timeout"`
 	URLs                []string        `toml:"urls"`
 	Log                 telegraf.Logger `toml:"-"`
+	commontls.ClientConfig
 
-	pipelineName  string
-	indexTmpl     *template.Template
-	pipelineTmpl  *template.Template
-	onSucc        func(context.Context, opensearchutil.BulkIndexerItem, opensearchutil.BulkIndexerResponseItem)
-	onFail        func(context.Context, opensearchutil.BulkIndexerItem, opensearchutil.BulkIndexerResponseItem, error)
-	configOptions httpconfig.HTTPClientConfig
-	osClient      *opensearch.Client
+	pipelineName string
+	indexTmpl    *template.Template
+	pipelineTmpl *template.Template
+	onSucc       func(context.Context, opensearchutil.BulkIndexerItem, opensearchutil.BulkIndexerResponseItem)
+	onFail       func(context.Context, opensearchutil.BulkIndexerItem, opensearchutil.BulkIndexerResponseItem, error)
+	osClient     *opensearch.Client
 }
 
 //go:embed template.json
@@ -158,16 +157,17 @@ func (o *Opensearch) newClient() error {
 	}
 	defer password.Destroy()
 
+	tlsConfig, err := o.ClientConfig.TLSConfig()
+	if err != nil {
+		return fmt.Errorf("creating TLS config failed: %w", err)
+	}
 	clientConfig := opensearch.Config{
 		Addresses: o.URLs,
 		Username:  username.String(),
 		Password:  password.String(),
-	}
-
-	if o.configOptions.InsecureSkipVerify {
-		clientConfig.Transport = &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-		}
+		Transport: &http.Transport{
+			TLSClientConfig: tlsConfig,
+		},
 	}
 
 	header := http.Header{}

--- a/plugins/outputs/opensearch/opensearch.go
+++ b/plugins/outputs/opensearch/opensearch.go
@@ -22,7 +22,7 @@ import (
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/internal/choice"
-	commontls "github.com/influxdata/telegraf/plugins/common/tls"
+	"github.com/influxdata/telegraf/plugins/common/tls"
 	"github.com/influxdata/telegraf/plugins/outputs"
 )
 
@@ -49,7 +49,7 @@ type Opensearch struct {
 	HealthCheckTimeout  config.Duration `toml:"health_check_timeout"`
 	URLs                []string        `toml:"urls"`
 	Log                 telegraf.Logger `toml:"-"`
-	commontls.ClientConfig
+	tls.ClientConfig
 
 	pipelineName string
 	indexTmpl    *template.Template

--- a/plugins/outputs/opensearch/sample.conf
+++ b/plugins/outputs/opensearch/sample.conf
@@ -10,7 +10,7 @@
   ## Target index name for metrics (OpenSearch will create if it not exists).
   ## This is a Golang template (see https://pkg.go.dev/text/template)
   ## You can also specify
-  ## metric name (`{{.Name}}`), tag value (`{{.Tag "tag_name"}}`), field value (`{{.Field "feild_name"}}`) 
+  ## metric name (`{{.Name}}`), tag value (`{{.Tag "tag_name"}}`), field value (`{{.Field "feild_name"}}`)
   ## If the tag does not exist, the default tag value will be empty string "".
   ## the timestamp (`{{.Time.Format "xxxxxxxxx"}}`).
   ## For example: "telegraf-{{.Time.Format "2006-01-02"}}-{{.Tag "host"}}" would set it to telegraf-2023-07-27-HostName
@@ -43,9 +43,17 @@
   # auth_bearer_token = ""
 
   ## Optional TLS Config
-  # tls_ca = "/etc/telegraf/ca.pem"
-  # tls_cert = "/etc/telegraf/cert.pem"
-  # tls_key = "/etc/telegraf/key.pem"
+  ## Set to true/false to enforce TLS being enabled/disabled. If not set,
+  ## enable TLS only if any of the other options are specified.
+  # tls_enable =
+  ## Trusted root certificates for server
+  # tls_ca = "/path/to/cafile"
+  ## Used for TLS client certificate authentication
+  # tls_cert = "/path/to/certfile"
+  ## Used for TLS client certificate authentication
+  # tls_key = "/path/to/keyfile"
+  ## Send the specified TLS server name via SNI
+  # tls_server_name = "kubernetes.example.com"
   ## Use TLS but skip chain & host verification
   # insecure_skip_verify = false
 

--- a/plugins/outputs/opensearch/sample.conf
+++ b/plugins/outputs/opensearch/sample.conf
@@ -10,7 +10,7 @@
   ## Target index name for metrics (OpenSearch will create if it not exists).
   ## This is a Golang template (see https://pkg.go.dev/text/template)
   ## You can also specify
-  ## metric name (`{{.Name}}`), tag value (`{{.Tag "tag_name"}}`), field value (`{{.Field "feild_name"}}`)
+  ## metric name (`{{.Name}}`), tag value (`{{.Tag "tag_name"}}`), field value (`{{.Field "field_name"}}`)
   ## If the tag does not exist, the default tag value will be empty string "".
   ## the timestamp (`{{.Time.Format "xxxxxxxxx"}}`).
   ## For example: "telegraf-{{.Time.Format "2006-01-02"}}-{{.Tag "host"}}" would set it to telegraf-2023-07-27-HostName


### PR DESCRIPTION
- [x] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

resolves #14334 

This PR exposes the `insecure_skip_verify` option correctly by embedding `commontls.TLSConfig` (instead of the full HTTP option set). By doing so, we also expose all other TLS options reflected by the `sample.conf` update.