### PR TITLE
feat(migrations): Add option migration for outputs.influxdb

### DIFF
--- a/migrations/all/outputs_influxdb.go
+++ b/migrations/all/outputs_influxdb.go
@@ -1,0 +1,5 @@
+//go:build !custom || (migrations && (outputs || outputs.influxdb))
+
+package all
+
+import _ "github.com/influxdata/telegraf/migrations/outputs_influxdb" // register migration

--- a/migrations/outputs_influxdb/migration.go
+++ b/migrations/outputs_influxdb/migration.go
@@ -1,0 +1,72 @@
+package outputs_influxdb
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/influxdata/toml"
+	"github.com/influxdata/toml/ast"
+
+	"github.com/influxdata/telegraf/internal/choice"
+	"github.com/influxdata/telegraf/migrations"
+)
+
+// Migration function
+func migrate(tbl *ast.Table) ([]byte, string, error) {
+	// Decode the old data structure
+	var plugin map[string]interface{}
+	if err := toml.UnmarshalTable(tbl, &plugin); err != nil {
+		return nil, "", err
+	}
+
+	// Check for deprecated option(s) and migrate them
+	var applied bool
+	if oldURL, found := plugin["url"]; found {
+		applied = true
+
+		var urls []string
+		// Merge the old URL and the new URLs with deduplication
+		if newURLs, found := plugin["urls"]; found {
+			list, ok := newURLs.([]interface{})
+			if !ok {
+				return nil, "", errors.New("'urls' setting is not a list")
+			}
+			for _, raw := range list {
+				nu, ok := raw.(string)
+				if !ok {
+					return nil, "", fmt.Errorf("unexpected 'urls' entry %v (%T)", raw, raw)
+				}
+				urls = append(urls, nu)
+			}
+		}
+		ou, ok := oldURL.(string)
+		if !ok {
+			return nil, "", fmt.Errorf("unexpected 'url' entry %v (%T)", ou, ou)
+		}
+
+		if !choice.Contains(ou, urls) {
+			urls = append(urls, ou)
+		}
+
+		// Update replacement and remove the deprecated setting
+		plugin["urls"] = urls
+		delete(plugin, "url")
+	}
+
+	// No options migrated so we can exit early
+	if !applied {
+		return nil, "", migrations.ErrNotApplicable
+	}
+
+	// Create the corresponding plugin configurations
+	cfg := migrations.CreateTOMLStruct("outputs", "influxdb")
+	cfg.Add("outputs", "influxdb", plugin)
+
+	output, err := toml.Marshal(cfg)
+	return output, "", err
+}
+
+// Register the migration function for the plugin type
+func init() {
+	migrations.AddPluginOptionMigration("outputs.influxdb", migrate)
+}

--- a/migrations/outputs_influxdb/migration_test.go
+++ b/migrations/outputs_influxdb/migration_test.go
@@ -1,0 +1,73 @@
+package outputs_influxdb_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/influxdata/telegraf/config"
+	_ "github.com/influxdata/telegraf/migrations/outputs_influxdb" // register migration
+	"github.com/influxdata/telegraf/plugins/outputs/influxdb"      // register plugin
+)
+
+func TestNoMigration(t *testing.T) {
+	plugin := &influxdb.InfluxDB{}
+	defaultCfg := []byte(plugin.SampleConfig())
+
+	// Migrate and check that nothing changed
+	output, n, err := config.ApplyMigrations(defaultCfg)
+	require.NoError(t, err)
+	require.NotEmpty(t, output)
+	require.Zero(t, n)
+	require.Equal(t, string(defaultCfg), string(output))
+}
+
+func TestCases(t *testing.T) {
+	// Get all directories in testdata
+	folders, err := os.ReadDir("testcases")
+	require.NoError(t, err)
+
+	for _, f := range folders {
+		// Only handle folders
+		if !f.IsDir() {
+			continue
+		}
+
+		t.Run(f.Name(), func(t *testing.T) {
+			testcasePath := filepath.Join("testcases", f.Name())
+			inputFile := filepath.Join(testcasePath, "telegraf.conf")
+			expectedFile := filepath.Join(testcasePath, "expected.conf")
+
+			// Read the expected output
+			expected := config.NewConfig()
+			require.NoError(t, expected.LoadConfig(expectedFile))
+			require.NotEmpty(t, expected.Outputs)
+
+			// Read the input data
+			input, remote, err := config.LoadConfigFile(inputFile)
+			require.NoError(t, err)
+			require.False(t, remote)
+			require.NotEmpty(t, input)
+
+			// Migrate
+			output, n, err := config.ApplyMigrations(input)
+			require.NoError(t, err)
+			require.NotEmpty(t, output)
+			require.GreaterOrEqual(t, n, uint64(1))
+			actual := config.NewConfig()
+			require.NoError(t, actual.LoadConfigData(output))
+
+			// Test the output
+			require.Len(t, actual.Outputs, len(expected.Outputs))
+			actualIDs := make([]string, 0, len(expected.Outputs))
+			expectedIDs := make([]string, 0, len(expected.Outputs))
+			for i := range actual.Inputs {
+				actualIDs = append(actualIDs, actual.Outputs[i].ID())
+				expectedIDs = append(expectedIDs, expected.Inputs[i].ID())
+			}
+			require.ElementsMatch(t, expectedIDs, actualIDs, string(output))
+		})
+	}
+}

--- a/migrations/outputs_influxdb/testcases/convert_url/expected.conf
+++ b/migrations/outputs_influxdb/testcases/convert_url/expected.conf
@@ -1,0 +1,2 @@
+[[outputs.influxdb]]
+urls = ["http://127.0.0.1:8086"]

--- a/migrations/outputs_influxdb/testcases/convert_url/telegraf.conf
+++ b/migrations/outputs_influxdb/testcases/convert_url/telegraf.conf
@@ -1,0 +1,78 @@
+# Configuration for sending metrics to InfluxDB
+[[outputs.influxdb]]
+  url = "http://127.0.0.1:8086"
+  ## The full HTTP or UDP URL for your InfluxDB instance.
+  ##
+  ## Multiple URLs can be specified for a single cluster, only ONE of the
+  ## urls will be written to each interval.
+  # urls = ["unix:///var/run/influxdb.sock"]
+  # urls = ["udp://127.0.0.1:8089"]
+  # urls = ["http://127.0.0.1:8086"]
+
+  ## The target database for metrics; will be created as needed.
+  ## For UDP url endpoint database needs to be configured on server side.
+  # database = "telegraf"
+
+  ## The value of this tag will be used to determine the database.  If this
+  ## tag is not set the 'database' option is used as the default.
+  # database_tag = ""
+
+  ## If true, the 'database_tag' will not be included in the written metric.
+  # exclude_database_tag = false
+
+  ## If true, no CREATE DATABASE queries will be sent.  Set to true when using
+  ## Telegraf with a user without permissions to create databases or when the
+  ## database already exists.
+  # skip_database_creation = false
+
+  ## Name of existing retention policy to write to.  Empty string writes to
+  ## the default retention policy.  Only takes effect when using HTTP.
+  # retention_policy = ""
+
+  ## The value of this tag will be used to determine the retention policy.  If this
+  ## tag is not set the 'retention_policy' option is used as the default.
+  # retention_policy_tag = ""
+
+  ## If true, the 'retention_policy_tag' will not be included in the written metric.
+  # exclude_retention_policy_tag = false
+
+  ## Write consistency (clusters only), can be: "any", "one", "quorum", "all".
+  ## Only takes effect when using HTTP.
+  # write_consistency = "any"
+
+  ## Timeout for HTTP messages.
+  # timeout = "5s"
+
+  ## HTTP Basic Auth
+  # username = "telegraf"
+  # password = "metricsmetricsmetricsmetrics"
+
+  ## HTTP User-Agent
+  # user_agent = "telegraf"
+
+  ## UDP payload size is the maximum packet size to send.
+  # udp_payload = "512B"
+
+  ## Optional TLS Config for use on HTTP connections.
+  # tls_ca = "/etc/telegraf/ca.pem"
+  # tls_cert = "/etc/telegraf/cert.pem"
+  # tls_key = "/etc/telegraf/key.pem"
+  ## Use TLS but skip chain & host verification
+  # insecure_skip_verify = false
+
+  ## HTTP Proxy override, if unset values the standard proxy environment
+  ## variables are consulted to determine which proxy, if any, should be used.
+  # http_proxy = "http://corporate.proxy:3128"
+
+  ## Additional HTTP headers
+  # http_headers = {"X-Special-Header" = "Special-Value"}
+
+  ## HTTP Content-Encoding for write request body, can be set to "gzip" to
+  ## compress body or "identity" to apply no encoding.
+  # content_encoding = "gzip"
+
+  ## When true, Telegraf will output unsigned integers as unsigned values,
+  ## i.e.: "42u".  You will need a version of InfluxDB supporting unsigned
+  ## integer values.  Enabling this option will result in field type errors if
+  ## existing data has been written.
+  # influx_uint_support = false

--- a/migrations/outputs_influxdb/testcases/merge_url/expected.conf
+++ b/migrations/outputs_influxdb/testcases/merge_url/expected.conf
@@ -1,0 +1,5 @@
+[[outputs.influxdb]]
+namepass = ["metrics"]
+urls = ["udp://127.0.0.1:8089", "http://127.0.0.1:8086"]
+database_tag = "table"
+skip_database_creation = true

--- a/migrations/outputs_influxdb/testcases/merge_url/telegraf.conf
+++ b/migrations/outputs_influxdb/testcases/merge_url/telegraf.conf
@@ -1,0 +1,7 @@
+# Configuration for sending metrics to InfluxDB
+[[outputs.influxdb]]
+  namepass = ["metrics"]
+  url = "http://127.0.0.1:8086"
+  urls = ["udp://127.0.0.1:8089"]
+  database_tag = "table"
+  skip_database_creation = true

--- a/migrations/outputs_influxdb/testcases/merge_url_overlap/expected.conf
+++ b/migrations/outputs_influxdb/testcases/merge_url_overlap/expected.conf
@@ -1,0 +1,5 @@
+[[outputs.influxdb]]
+namepass = ["metrics"]
+urls = ["http://127.0.0.1:8086", "udp://127.0.0.1:8089"]
+database_tag = "table"
+skip_database_creation = true

--- a/migrations/outputs_influxdb/testcases/merge_url_overlap/telegraf.conf
+++ b/migrations/outputs_influxdb/testcases/merge_url_overlap/telegraf.conf
@@ -1,0 +1,7 @@
+# Configuration for sending metrics to InfluxDB
+[[outputs.influxdb]]
+  namepass = ["metrics"]
+  url = "http://127.0.0.1:8086"
+  urls = ["http://127.0.0.1:8086", "udp://127.0.0.1:8089"]
+  database_tag = "table"
+  skip_database_creation = true


### PR DESCRIPTION
- [ ] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [x] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

relates to #13375

This PR adds migration for the deprecated `url` option replaced by `urls` in `outputs.influxdb`.