### PR TITLE
feat(outputs.bigquery): Add option to add metrics in one compact table

### DIFF
--- a/plugins/outputs/bigquery/README.md
+++ b/plugins/outputs/bigquery/README.md
@@ -36,6 +36,10 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
   ## Character to replace hyphens on Metric name
   # replace_hyphen_to = "_"
+
+  ## Write all metrics in a single compact table
+  # compact_table = false
+  # compact_table_name = ""
 ```
 
 Leaving `project` empty indicates the plugin will try to retrieve the project

--- a/plugins/outputs/bigquery/sample.conf
+++ b/plugins/outputs/bigquery/sample.conf
@@ -14,3 +14,7 @@
 
   ## Character to replace hyphens on Metric name
   # replace_hyphen_to = "_"
+
+  ## Write all metrics in a single compact table
+  # compact_table = false
+  # compact_table_name = ""


### PR DESCRIPTION
# Required for all PRs

<!-- Before opening a pull request you should run the following checks locally to make sure the CI will pass.

make lint
make check
make check-deps
make test
make docs

-->

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [ ] Updated associated README.md.
- [x] Wrote appropriate unit tests.
- [ ] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->
