### PR TITLE
fix(parsers.json_v2): Reset parser before parsing (#13805)

### DIFF
--- a/plugins/parsers/json_v2/parser.go
+++ b/plugins/parsers/json_v2/parser.go
@@ -100,6 +100,7 @@ type MetricNode struct {
 }
 
 func (p *Parser) Reset() {
+	// Reset parser to a consistent state
 	p.subPathResults = nil
 }
 
@@ -137,6 +138,8 @@ func (p *Parser) parseCriticalPath(input []byte) ([]telegraf.Metric, error) {
 	p.parseMutex.Lock()
 	defer p.parseMutex.Unlock()
 
+	// Reset Parser instance in case it has been left in an inconsistent state,
+	// otherwise reusing the instance may yield parsing errors.
 	p.Reset()
 
 	reader := strings.NewReader(string(input))

--- a/plugins/parsers/json_v2/parser.go
+++ b/plugins/parsers/json_v2/parser.go
@@ -99,6 +99,10 @@ type MetricNode struct {
 	gjson.Result
 }
 
+func (p *Parser) Reset() {
+	p.subPathResults = nil
+}
+
 func (p *Parser) Init() error {
 	// Propagate the default metric name to the configs in case it is not set there
 	for i, cfg := range p.Configs {
@@ -113,6 +117,8 @@ func (p *Parser) Init() error {
 			p.Configs[i].Location = loc
 		}
 	}
+	p.Reset()
+
 	return nil
 }
 
@@ -130,6 +136,9 @@ func (p *Parser) Parse(input []byte) ([]telegraf.Metric, error) {
 func (p *Parser) parseCriticalPath(input []byte) ([]telegraf.Metric, error) {
 	p.parseMutex.Lock()
 	defer p.parseMutex.Unlock()
+
+	p.Reset()
+
 	reader := strings.NewReader(string(input))
 	body, _ := utfbom.Skip(reader)
 	input, err := io.ReadAll(body)

--- a/plugins/parsers/json_v2/parser.go
+++ b/plugins/parsers/json_v2/parser.go
@@ -99,11 +99,6 @@ type MetricNode struct {
 	gjson.Result
 }
 
-func (p *Parser) Reset() {
-	// Reset parser to a consistent state
-	p.subPathResults = nil
-}
-
 func (p *Parser) Init() error {
 	// Propagate the default metric name to the configs in case it is not set there
 	for i, cfg := range p.Configs {
@@ -118,8 +113,6 @@ func (p *Parser) Init() error {
 			p.Configs[i].Location = loc
 		}
 	}
-	p.Reset()
-
 	return nil
 }
 
@@ -138,9 +131,8 @@ func (p *Parser) parseCriticalPath(input []byte) ([]telegraf.Metric, error) {
 	p.parseMutex.Lock()
 	defer p.parseMutex.Unlock()
 
-	// Reset Parser instance in case it has been left in an inconsistent state,
-	// otherwise reusing the instance may yield parsing errors.
-	p.Reset()
+	// Clear intermediate results if left by previous call
+	p.subPathResults = nil
 
 	reader := strings.NewReader(string(input))
 	body, _ := utfbom.Skip(reader)


### PR DESCRIPTION
# Required for all PRs

<!-- Before opening a pull request you should run the following checks locally to make sure the CI will pass.

make lint
make check
make check-deps
make test
make docs

-->

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.
- [ ] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

resolves #13805

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->

Running json_v2 parser leaves `p.subPathResults` dirty, affecting subsequent runs. This is a problem for input plugins reusing json_v2 parser instance instead of creating a new one.

Following the pattern of `csv` parser, added a `Reset()` method, which clears `subPathResults`. It is called in `Init()` and when starting `Parse()`. 
