### PR TITLE
fix(inputs.http): Use correct token variable

### DIFF
--- a/plugins/inputs/http/http.go
+++ b/plugins/inputs/http/http.go
@@ -128,7 +128,7 @@ func (h *HTTP) gatherURL(acc telegraf.Accumulator, url string) error {
 		token.Destroy()
 		request.Header.Set("Authorization", bearer)
 	} else if h.TokenFile != "" {
-		token, err := os.ReadFile(h.BearerToken)
+		token, err := os.ReadFile(h.TokenFile)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
We deprecated bearer token, and switched to using token file everywhere, except the actual reading of it ;)

fixes: #14347
