### PR TITLE
docs(inputs.mqtt_consumer): Clarify persistent session and topic behavior

### DIFF
--- a/plugins/inputs/mqtt_consumer/README.md
+++ b/plugins/inputs/mqtt_consumer/README.md
@@ -83,7 +83,9 @@ to use them.
   ## In order for this option to work you must also set client_id to identify
   ## the client.  To receive messages that arrived while the client is offline,
   ## also set the qos option to 1 or 2 and don't forget to also set the QoS when
-  ## publishing.
+  ## publishing. Finally, using a persistent session will use the initial
+  ## connection topics and not subscribe to any new topics even after
+  ## reconnecting or restarting without a change in client ID.
   # persistent_session = false
 
   ## If unset, a random client ID will be generated.

--- a/plugins/inputs/mqtt_consumer/sample.conf
+++ b/plugins/inputs/mqtt_consumer/sample.conf
@@ -46,7 +46,9 @@
   ## In order for this option to work you must also set client_id to identify
   ## the client.  To receive messages that arrived while the client is offline,
   ## also set the qos option to 1 or 2 and don't forget to also set the QoS when
-  ## publishing.
+  ## publishing. Finally, using a persistent session will use the initial
+  ## connection topics and not subscribe to any new topics even after
+  ## reconnecting or restarting without a change in client ID.
   # persistent_session = false
 
   ## If unset, a random client ID will be generated.


### PR DESCRIPTION
## Summary

Provide the users with additional caveat that using a persistent session will not update topics, even after a restart of telegraf.

## Checklist
<!-- Mandatory
Please confirm the following by placing an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #9703
