### PR TITLE
fix(processors.starlark): Resolve deepcopy double refcount

### DIFF
--- a/plugins/common/starlark/builtins.go
+++ b/plugins/common/starlark/builtins.go
@@ -54,7 +54,6 @@ func deepcopy(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwar
 	}
 
 	dup := sm.metric.Copy()
-	dup.Drop()
 	return &Metric{metric: dup}, nil
 }
 

--- a/plugins/processors/starlark/starlark.go
+++ b/plugins/processors/starlark/starlark.go
@@ -75,11 +75,10 @@ func (s *Starlark) Add(origMetric telegraf.Metric, acc telegraf.Accumulator) err
 					continue
 				}
 
-				// Previous metric was found, accept the starlark metric, add
+				// Previous metric was found, ignore the new metric, add
 				// the original metric to the accumulator
 				if v.ID == origMetric.HashID() {
 					origFound = true
-					m.Accept()
 					s.results = append(s.results, origMetric)
 					acc.AddMetric(origMetric)
 					continue
@@ -105,10 +104,9 @@ func (s *Starlark) Add(origMetric telegraf.Metric, acc telegraf.Accumulator) err
 		s.results = s.results[:0]
 	case *common.Metric:
 		m := rv.Unwrap()
-		// If we got the original metric back, use that and drop the new one.
+		// If we got the original metric back, use that and ignore the new one.
 		// Otherwise mark the original as accepted and use the new metric.
 		if origMetric.HashID() == rv.ID {
-			m.Accept()
 			acc.AddMetric(origMetric)
 		} else {
 			origMetric.Accept()

--- a/plugins/processors/starlark/starlark_test.go
+++ b/plugins/processors/starlark/starlark_test.go
@@ -3349,6 +3349,15 @@ def apply(metric):
 `,
 		},
 		{
+			name:       "return none after a deepcopy",
+			numMetrics: 0,
+			source: `
+def apply(metric):
+	deepcopy(metric)
+	return None
+`,
+		},
+		{
 			name:       "return empty list of metrics",
 			numMetrics: 0,
 			source: `

--- a/plugins/processors/starlark/starlark_test.go
+++ b/plugins/processors/starlark/starlark_test.go
@@ -3383,6 +3383,14 @@ def apply(metric):
 `,
 		},
 		{
+			name:       "return deep copy",
+			numMetrics: 1,
+			source: `
+def apply(metric):
+	return deepcopy(metric)
+`,
+		},
+		{
 			name:       "return new metric in a list",
 			numMetrics: 1,
 			source: `
@@ -3393,6 +3401,14 @@ def apply(metric):
 `,
 		},
 		{
+			name:       "return only deep copy in a list",
+			numMetrics: 1,
+			source: `
+def apply(metric):
+	return [deepcopy(metric)]
+`,
+		},
+		{
 			name:       "return original and new metric in a list",
 			numMetrics: 2,
 			source: `
@@ -3400,6 +3416,14 @@ def apply(metric):
 	newmetric = Metric("new_metric")
 	newmetric.fields["vaue"] = 42
 	return [metric, newmetric]
+`,
+		},
+		{
+			name:       "return original and deepcopy in a list",
+			numMetrics: 2,
+			source: `
+def apply(metric):
+	return [metric, deepcopy(metric)]
 `,
 		},
 	}
@@ -3428,6 +3452,7 @@ def apply(metric):
 			// Ensure we get back the correct number of metrics
 			require.Len(t, acc.GetTelegrafMetrics(), tt.numMetrics)
 			for _, m := range acc.GetTelegrafMetrics() {
+				fmt.Printf("%T\n", m)
 				m.Accept()
 			}
 


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

The call to copy currently will make a deepcopy of the metric, but immediately call drop on it as well. This makes no sense as if that metric ends up in an output, it could still get dropped or accepted. This can lead to issues where we double count the refcount.

Additionally, the current state of checking for original metrics is also resulting in a double accept. The problem here is our tests! When we go to accept the metrics to simulate an output, the metric is no longer a tracking metric, meaning the accept call is a no-op, and does nothing.

## Checklist
<!-- Mandatory
Please confirm the following by placing an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

fixes: #14360
