### PR TITLE
feat(inputs.nats_consumer): Add nkey-seed-file authentication

### DIFF
--- a/plugins/inputs/nats_consumer/README.md
+++ b/plugins/inputs/nats_consumer/README.md
@@ -56,7 +56,12 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   # password = ""
 
   ## Optional NATS 2.0 and NATS NGS compatible user credentials
+  ## Expects a credentials file with a JWT and nkey seed
   # credentials = "/etc/telegraf/nats.creds"
+
+  ## Optional NATS 2.0 Nkey seed file
+  ## Expects a file with the nkey seed
+  # credentials = "/etc/telegraf/seed.txt"
 
   ## Use Transport Layer Security
   # secure = false

--- a/plugins/inputs/nats_consumer/README.md
+++ b/plugins/inputs/nats_consumer/README.md
@@ -6,6 +6,10 @@ creates metrics using one of the supported [input data formats][].
 A [Queue Group][queue group] is used when subscribing to subjects so multiple
 instances of telegraf can read from a NATS cluster in parallel.
 
+There are three methods of (optionally) authenticating with NATS:
+[username/password][userpass], [a NATS creds file][creds] (NATS 2.0), or
+an [nkey seed file][nkey] (NATS 2.0).
+
 ## Service Input <!-- @/docs/includes/service_input.md -->
 
 This plugin is a service input. Normal plugins gather metrics determined by the
@@ -51,17 +55,15 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## name a queue group
   queue_group = "telegraf_consumers"
 
-  ## Optional credentials
+  ## Optional authentication with username and password credentials
   # username = ""
   # password = ""
 
-  ## Optional NATS 2.0 and NATS NGS compatible user credentials
-  ## Expects a credentials file with a JWT and nkey seed
+  ## Optional authentication with NATS credentials file (NATS 2.0)
   # credentials = "/etc/telegraf/nats.creds"
 
-  ## Optional NATS 2.0 Nkey seed file
-  ## Expects a file with the nkey seed
-  # credentials = "/etc/telegraf/seed.txt"
+  ## Optional authentication with nkey seed file (NATS 2.0)
+  # nkey_seed = "/etc/telegraf/seed.txt"
 
   ## Use Transport Layer Security
   # secure = false
@@ -100,6 +102,9 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 [nats]: https://www.nats.io/about/
 [input data formats]: /docs/DATA_FORMATS_INPUT.md
 [queue group]: https://www.nats.io/documentation/concepts/nats-queueing/
+[userpass]: https://docs.nats.io/using-nats/developer/connecting/userpass
+[creds]: https://docs.nats.io/using-nats/developer/connecting/creds
+[nkey]: https://docs.nats.io/using-nats/developer/connecting/nkey
 
 ## Metrics
 

--- a/plugins/inputs/nats_consumer/nats_consumer.go
+++ b/plugins/inputs/nats_consumer/nats_consumer.go
@@ -44,6 +44,7 @@ type natsConsumer struct {
 	Username    string   `toml:"username"`
 	Password    string   `toml:"password"`
 	Credentials string   `toml:"credentials"`
+	NkeySeed    string   `toml:"nkey_seed"`
 	JsSubjects  []string `toml:"jetstream_subjects"`
 
 	tls.ClientConfig
@@ -104,6 +105,14 @@ func (n *natsConsumer) Start(acc telegraf.Accumulator) error {
 
 	if n.Credentials != "" {
 		options = append(options, nats.UserCredentials(n.Credentials))
+	}
+
+	if n.NkeySeed != "" {
+		opt, err := nats.NkeyOptionFromSeed(n.NkeySeed)
+		if err != nil {
+			return err
+		}
+		options = append(options, opt)
 	}
 
 	if n.Secure {

--- a/plugins/inputs/nats_consumer/sample.conf
+++ b/plugins/inputs/nats_consumer/sample.conf
@@ -25,7 +25,12 @@
   # password = ""
 
   ## Optional NATS 2.0 and NATS NGS compatible user credentials
+  ## Expects a credentials file with a JWT and nkey seed
   # credentials = "/etc/telegraf/nats.creds"
+
+  ## Optional NATS 2.0 Nkey seed file
+  ## Expects a file with the nkey seed
+  # credentials = "/etc/telegraf/seed.txt"
 
   ## Use Transport Layer Security
   # secure = false

--- a/plugins/inputs/nats_consumer/sample.conf
+++ b/plugins/inputs/nats_consumer/sample.conf
@@ -20,17 +20,15 @@
   ## name a queue group
   queue_group = "telegraf_consumers"
 
-  ## Optional credentials
+  ## Optional authentication with username and password credentials
   # username = ""
   # password = ""
 
-  ## Optional NATS 2.0 and NATS NGS compatible user credentials
-  ## Expects a credentials file with a JWT and nkey seed
+  ## Optional authentication with NATS credentials file (NATS 2.0)
   # credentials = "/etc/telegraf/nats.creds"
 
-  ## Optional NATS 2.0 Nkey seed file
-  ## Expects a file with the nkey seed
-  # credentials = "/etc/telegraf/seed.txt"
+  ## Optional authentication with nkey seed file (NATS 2.0)
+  # nkey_seed = "/etc/telegraf/seed.txt"
 
   ## Use Transport Layer Security
   # secure = false


### PR DESCRIPTION
## Summary
This PR makes it possible for the nats_consumer input plugin to authenticate with NATS via an [nkey](https://docs.nats.io/using-nats/developer/connecting/nkey) seed file.

## Checklist

- [X] Updated associated README.md
- [X] Pull request title or commits are in [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/#summary)

- [X] No AI generated code was used in this PR

## Related issues

resolves #14374
