### PR TITLE
docs(inputs.fireboard):  Revert typo fix as the typo is returned in the actual code too.

### DIFF
--- a/plugins/inputs/fireboard/README.md
+++ b/plugins/inputs/fireboard/README.md
@@ -53,7 +53,7 @@ values are included if they are less than a minute old.
 - fireboard
   - tags:
     - channel
-    - scale (Celsius; Fahrenheit)
+    - scale (Celcius; Fahrenheit)
     - title (name of the Fireboard)
     - uuid (UUID of the Fireboard)
   - fields:


### PR DESCRIPTION
## Summary
Reverts typo fix in fireboard plugin docs, because the typo is actually what the code in fact returns as a tag.

## Checklist
<!-- Mandatory
Please confirm the following by placing an "x" between the []:
-->

- [ x] No AI generated code was used in this PR

## Related issues
https://github.com/influxdata/telegraf/pull/14359


