### PR TITLE
test: Update lxc images

### DIFF
--- a/tools/package_lxd_test/main.go
+++ b/tools/package_lxd_test/main.go
@@ -10,11 +10,11 @@ import (
 )
 
 var imagesRPM = []string{
+	"fedora/39",
 	"fedora/38",
-	"fedora/37",
 	"centos/7",
 	"centos/9-Stream",
-	"amazonlinux/current",
+	"amazonlinux/2",
 	//"opensuse/15.3", 			// shadow-utils dependency bug see #3833
 	//"opensuse/tumbleweed", 	// shadow-utils dependency bug see #3833
 }


### PR DESCRIPTION


## Summary
Updates to the latest Fedora images as well as updates to the Amazon Linux 2 image as the original image no longer exists.

## Checklist
<!-- Mandatory
Please confirm the following by placing an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
