### PR TITLE
chore(inputs.statsd): Do not deprecate convert_names as there is no replacement

### DIFF
--- a/plugins/inputs/statsd/README.md
+++ b/plugins/inputs/statsd/README.md
@@ -113,6 +113,10 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## white space with '_', replace '/' with '-', and remove charachters not
   ## matching 'a-zA-Z_\-0-9\.;='.
   #sanitize_name_method = ""
+
+  ## Replace dots (.) with underscore (_) and dashes (-) with
+  ## double underscore (__) in metric names.
+  # convert_names = false
 ```
 
 ## Description

--- a/plugins/inputs/statsd/sample.conf
+++ b/plugins/inputs/statsd/sample.conf
@@ -86,3 +86,7 @@
   ## white space with '_', replace '/' with '-', and remove charachters not
   ## matching 'a-zA-Z_\-0-9\.;='.
   #sanitize_name_method = ""
+
+  ## Replace dots (.) with underscore (_) and dashes (-) with
+  ## double underscore (__) in metric names.
+  # convert_names = false

--- a/plugins/inputs/statsd/statsd.go
+++ b/plugins/inputs/statsd/statsd.go
@@ -75,7 +75,7 @@ type Statsd struct {
 	DeleteCounters  bool     `toml:"delete_counters"`
 	DeleteSets      bool     `toml:"delete_sets"`
 	DeleteTimings   bool     `toml:"delete_timings"`
-	ConvertNames    bool     `toml:"convert_names" deprecated:"0.12.0;1.30.0;use 'metric_separator' instead"`
+	ConvertNames    bool     `toml:"convert_names"`
 
 	EnableAggregationTemporality bool `toml:"enable_aggregation_temporality"`
 


### PR DESCRIPTION
## Summary

The deprecation of `convert_names` states to use `metric_separator` as a replacement. However, this does not allow to reproduce the behavior of `convert_names = true` and I do not see any way to achieve this _without_ the deprecated option.

As I don't think there is any replacement, we cannot deprecate the option and thus this PR removes the deprecation and documents the option.

## Checklist

- [x] No AI generated code was used in this PR
- [x] Updated documentation

## Related issues

related to #13375 