### PR TITLE
fix(inputs.s7comm): Reconnect if query fails

### DIFF
--- a/plugins/inputs/s7comm/s7comm_test.go
+++ b/plugins/inputs/s7comm/s7comm_test.go
@@ -2,6 +2,10 @@ package s7comm
 
 import (
 	_ "embed"
+	"encoding/binary"
+	"io"
+	"net"
+	"sync/atomic"
 	"testing"
 
 	"github.com/influxdata/telegraf/testutil"
@@ -698,4 +702,85 @@ func TestMetricCollisions(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestConnectionLoss(t *testing.T) {
+	// Create fake S7 comm server that can accept connects
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer listener.Close()
+
+	var connectionAttempts uint32
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+
+			// Count the number of connection attempts
+			atomic.AddUint32(&connectionAttempts, 1)
+
+			buf := make([]byte, 4096)
+
+			// Wait for ISO connection telegram
+			if _, err := io.ReadAtLeast(conn, buf, 22); err != nil {
+				conn.Close()
+				return
+			}
+
+			// Send fake response
+			response := make([]byte, 22)
+			response[5] = 0xD0
+			binary.BigEndian.PutUint16(response[2:4], uint16(len(response)))
+			if _, err := conn.Write(response); err != nil {
+				conn.Close()
+				return
+			}
+
+			// Wait for PDU negotiation telegram
+			if _, err := io.ReadAtLeast(conn, buf, 25); err != nil {
+				conn.Close()
+				return
+			}
+
+			// Send fake response
+			response = make([]byte, 27)
+			binary.BigEndian.PutUint16(response[2:4], uint16(len(response)))
+			binary.BigEndian.PutUint16(response[25:27], uint16(480))
+			if _, err := conn.Write(response); err != nil {
+				return
+			}
+
+			// Always close after connection is established
+			conn.Close()
+		}
+	}()
+	plugin := &S7comm{
+		Server:          listener.Addr().String(),
+		Rack:            0,
+		Slot:            2,
+		DebugConnection: true,
+		Configs: []metricDefinition{
+			{
+				Fields: []metricFieldDefinition{
+					{
+						Name:    "foo",
+						Address: "DB1.W2",
+					},
+				},
+			},
+		},
+		Log: &testutil.Logger{},
+	}
+	require.NoError(t, plugin.Init())
+
+	var acc testutil.Accumulator
+	require.NoError(t, plugin.Start(&acc))
+	plugin.Gather(&acc)
+	plugin.Gather(&acc)
+	plugin.Stop()
+	listener.Close()
+
+	require.Equal(t, 3, int(atomic.LoadUint32(&connectionAttempts)))
 }


### PR DESCRIPTION
## Summary

Currently, the plugin goes defunct if the connection is lost after `Start`, e.g.  in case the remote machine is rebooted or the network has issues. 
This PR tries to reconnect if reading the defined area(s) fails in `Gather` and skips the gather cycle. The skipping is necessary as otherwise we try to reconnect on each and every batch scheduled for gathering.

## Checklist

- [x] No AI generated code was used in this PR
- [x] Unit test

## Related issues

resolves #14392 
