### PR TITLE
feat(migrations): Add migration for fieldpass/fielddrop

### DIFF
--- a/migrations/all/general_metricfilter.go
+++ b/migrations/all/general_metricfilter.go
@@ -1,0 +1,5 @@
+//go:build !custom || migrations
+
+package all
+
+import _ "github.com/influxdata/telegraf/migrations/general_metricfilter" // register migration

--- a/migrations/general_metricfilter/migration.go
+++ b/migrations/general_metricfilter/migration.go
@@ -1,0 +1,112 @@
+package general_metricfilter
+
+import (
+	"fmt"
+
+	"github.com/influxdata/toml"
+	"github.com/influxdata/toml/ast"
+
+	"github.com/influxdata/telegraf/internal/choice"
+	"github.com/influxdata/telegraf/migrations"
+)
+
+// Migration function
+func migrate(category, name string, tbl *ast.Table) ([]byte, string, error) {
+	// Filter options can only be present in inputs, outputs, processors and
+	// aggregators. Skip everything else...
+	switch category {
+	case "inputs", "outputs", "processors", "aggregators":
+	default:
+		return nil, "", migrations.ErrNotApplicable
+	}
+
+	// Decode the old data structure
+	var plugin map[string]interface{}
+	if err := toml.UnmarshalTable(tbl, &plugin); err != nil {
+		return nil, "", err
+	}
+
+	// Check for deprecated option(s) and migrate them
+	var applied bool
+
+	// Get the new field settings to be able to merge it with the deprecated
+	// settings
+	var fieldinclude []string
+	if newFieldInclude, found := plugin["fieldinclude"]; found {
+		var err error
+		fieldinclude, err = migrations.AsStringSlice(newFieldInclude)
+		if err != nil {
+			return nil, "", fmt.Errorf("setting 'fieldinclude': %w", err)
+		}
+	}
+	for _, option := range []string{"pass", "fieldpass"} {
+		if rawOld, found := plugin[option]; found {
+			applied = true
+
+			old, err := migrations.AsStringSlice(rawOld)
+			if err != nil {
+				return nil, "", fmt.Errorf("setting '%s': %w", option, err)
+			}
+			for _, o := range old {
+				if !choice.Contains(o, fieldinclude) {
+					fieldinclude = append(fieldinclude, o)
+				}
+			}
+
+			// Remove the deprecated setting
+			delete(plugin, option)
+		}
+	}
+	// Add the new option if it has data
+	if len(fieldinclude) > 0 {
+		plugin["fieldinclude"] = fieldinclude
+	}
+
+	var fieldexclude []string
+	if newFieldExclude, found := plugin["fieldexclude"]; found {
+		var err error
+		fieldexclude, err = migrations.AsStringSlice(newFieldExclude)
+		if err != nil {
+			return nil, "", fmt.Errorf("setting 'fieldexclude': %w", err)
+		}
+	}
+	for _, option := range []string{"drop", "fielddrop"} {
+		if rawOld, found := plugin[option]; found {
+			applied = true
+
+			old, err := migrations.AsStringSlice(rawOld)
+			if err != nil {
+				return nil, "", fmt.Errorf("setting '%s': %w", option, err)
+			}
+			for _, o := range old {
+				if !choice.Contains(o, fieldexclude) {
+					fieldexclude = append(fieldexclude, o)
+				}
+			}
+
+			// Remove the deprecated setting
+			delete(plugin, option)
+		}
+	}
+	// Add the new option if it has data
+	if len(fieldexclude) > 0 {
+		plugin["fieldexclude"] = fieldexclude
+	}
+
+	// No options migrated so we can exit early
+	if !applied {
+		return nil, "", migrations.ErrNotApplicable
+	}
+
+	// Create the corresponding plugin configurations
+	cfg := migrations.CreateTOMLStruct(category, name)
+	cfg.Add(category, name, plugin)
+
+	output, err := toml.Marshal(cfg)
+	return output, "", err
+}
+
+// Register the migration function for the plugin type
+func init() {
+	migrations.AddGeneralMigration(migrate)
+}

--- a/migrations/general_metricfilter/migration_test.go
+++ b/migrations/general_metricfilter/migration_test.go
@@ -1,0 +1,96 @@
+package general_metricfilter_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/config"
+	_ "github.com/influxdata/telegraf/migrations/general_metricfilter" // register migration
+	"github.com/influxdata/telegraf/plugins/inputs"
+)
+
+func TestNoMigration(t *testing.T) {
+	cfg := []byte(`
+# Dummy plugin
+[[inputs.dummy]]
+  ## A dummy server
+  servers = ["tcp://127.0.0.1:1883"]
+
+  ## A commented option
+  # timeout = "10s"
+`)
+
+	// Migrate and check that nothing changed
+	output, n, err := config.ApplyMigrations(cfg)
+	require.NoError(t, err)
+	require.NotEmpty(t, output)
+	require.Zero(t, n)
+	require.Equal(t, string(cfg), string(output))
+}
+
+func TestCases(t *testing.T) {
+	// Get all directories in testdata
+	folders, err := os.ReadDir("testcases")
+	require.NoError(t, err)
+
+	inputs.Add("dummy", func() telegraf.Input { return &MockupInputPlugin{} })
+
+	for _, f := range folders {
+		// Only handle folders
+		if !f.IsDir() {
+			continue
+		}
+
+		t.Run(f.Name(), func(t *testing.T) {
+			testcasePath := filepath.Join("testcases", f.Name())
+			inputFile := filepath.Join(testcasePath, "telegraf.conf")
+			expectedFile := filepath.Join(testcasePath, "expected.conf")
+
+			// Read the expected output
+			expected := config.NewConfig()
+			require.NoError(t, expected.LoadConfig(expectedFile))
+			require.NotEmpty(t, expected.Inputs)
+
+			// Read the input data
+			input, remote, err := config.LoadConfigFile(inputFile)
+			require.NoError(t, err)
+			require.False(t, remote)
+			require.NotEmpty(t, input)
+
+			// Migrate
+			output, n, err := config.ApplyMigrations(input)
+			require.NoError(t, err)
+			require.NotEmpty(t, output)
+			require.GreaterOrEqual(t, n, uint64(1))
+			actual := config.NewConfig()
+			require.NoError(t, actual.LoadConfigData(output))
+
+			// Test the output
+			require.Len(t, actual.Inputs, len(expected.Inputs))
+			actualIDs := make([]string, 0, len(expected.Inputs))
+			expectedIDs := make([]string, 0, len(expected.Inputs))
+			for i := range actual.Inputs {
+				actualIDs = append(actualIDs, actual.Inputs[i].ID())
+				expectedIDs = append(expectedIDs, expected.Inputs[i].ID())
+			}
+			require.ElementsMatch(t, expectedIDs, actualIDs, string(output))
+		})
+	}
+}
+
+// Implement a mock input plugin for testing
+type MockupInputPlugin struct {
+	Servers []string        `toml:"servers"`
+	Timeout config.Duration `toml:"timeout"`
+}
+
+func (m *MockupInputPlugin) SampleConfig() string {
+	return "Mockup test input plugin"
+}
+func (m *MockupInputPlugin) Gather(_ telegraf.Accumulator) error {
+	return nil
+}

--- a/migrations/general_metricfilter/testcases/deprecated_drop/expected.conf
+++ b/migrations/general_metricfilter/testcases/deprecated_drop/expected.conf
@@ -1,0 +1,3 @@
+[[inputs.dummy]]
+servers = ["tcp://127.0.0.1:1883"]
+fieldexclude = ["value"]

--- a/migrations/general_metricfilter/testcases/deprecated_drop/telegraf.conf
+++ b/migrations/general_metricfilter/testcases/deprecated_drop/telegraf.conf
@@ -1,0 +1,10 @@
+# A dummy plugin
+[[inputs.dummy]]
+  ## A server
+  servers = ["tcp://127.0.0.1:1883"]
+
+  ## Default timestamp
+  # timestamp = "10s"
+
+  ## Deprecated drop
+  drop = ["value"]

--- a/migrations/general_metricfilter/testcases/deprecated_fielddrop/expected.conf
+++ b/migrations/general_metricfilter/testcases/deprecated_fielddrop/expected.conf
@@ -1,0 +1,3 @@
+[[inputs.dummy]]
+servers = ["tcp://127.0.0.1:1883"]
+fieldexclude = ["value"]

--- a/migrations/general_metricfilter/testcases/deprecated_fielddrop/telegraf.conf
+++ b/migrations/general_metricfilter/testcases/deprecated_fielddrop/telegraf.conf
@@ -1,0 +1,10 @@
+# A dummy plugin
+[[inputs.dummy]]
+  ## A server
+  servers = ["tcp://127.0.0.1:1883"]
+
+  ## Default timestamp
+  # timestamp = "10s"
+
+  ## Deprecated fielddrop
+  fielddrop = ["value"]

--- a/migrations/general_metricfilter/testcases/deprecated_fieldpass/expected.conf
+++ b/migrations/general_metricfilter/testcases/deprecated_fieldpass/expected.conf
@@ -1,0 +1,3 @@
+[[inputs.dummy]]
+servers = ["tcp://127.0.0.1:1883"]
+fieldinclude = ["value"]

--- a/migrations/general_metricfilter/testcases/deprecated_fieldpass/telegraf.conf
+++ b/migrations/general_metricfilter/testcases/deprecated_fieldpass/telegraf.conf
@@ -1,0 +1,10 @@
+# A dummy plugin
+[[inputs.dummy]]
+  ## A server
+  servers = ["tcp://127.0.0.1:1883"]
+
+  ## Default timestamp
+  # timestamp = "10s"
+
+  ## Deprecated fieldpass
+  fieldpass = ["value"]

--- a/migrations/general_metricfilter/testcases/deprecated_pass/expected.conf
+++ b/migrations/general_metricfilter/testcases/deprecated_pass/expected.conf
@@ -1,0 +1,3 @@
+[[inputs.dummy]]
+servers = ["tcp://127.0.0.1:1883"]
+fieldinclude = ["value"]

--- a/migrations/general_metricfilter/testcases/deprecated_pass/telegraf.conf
+++ b/migrations/general_metricfilter/testcases/deprecated_pass/telegraf.conf
@@ -1,0 +1,10 @@
+# A dummy plugin
+[[inputs.dummy]]
+  ## A server
+  servers = ["tcp://127.0.0.1:1883"]
+
+  ## Default timestamp
+  # timestamp = "10s"
+
+  ## Deprecated pass
+  pass = ["value"]

--- a/migrations/general_metricfilter/testcases/merge_all_overlap/expected.conf
+++ b/migrations/general_metricfilter/testcases/merge_all_overlap/expected.conf
@@ -1,0 +1,4 @@
+[[inputs.dummy]]
+servers = ["tcp://127.0.0.1:1883"]
+fieldexclude = ["bugA", "bugX", "bugB", "bugY", "bugC"]
+fieldinclude = ["valueA", "valueX", "valueB", "valueY", "valueC"]

--- a/migrations/general_metricfilter/testcases/merge_all_overlap/telegraf.conf
+++ b/migrations/general_metricfilter/testcases/merge_all_overlap/telegraf.conf
@@ -1,0 +1,15 @@
+# A dummy plugin
+[[inputs.dummy]]
+  ## A server
+  servers = ["tcp://127.0.0.1:1883"]
+
+  ## Default timestamp
+  # timestamp = "10s"
+
+  ## Deprecated field options
+  fieldinclude = ["valueA", "valueX"]
+  fieldexclude = ["bugA", "bugX"]
+  drop = ["bugB", "bugX", "bugY"]
+  pass = ["valueB", "valueX", "valueY"]
+  fieldpass = ["valueY", "valueC", "valueX"]
+  fielddrop = ["bugY", "bugC", "bugX"]

--- a/migrations/general_metricfilter/testcases/merge_fieldexclude/expected.conf
+++ b/migrations/general_metricfilter/testcases/merge_fieldexclude/expected.conf
@@ -1,0 +1,3 @@
+[[inputs.dummy]]
+servers = ["tcp://127.0.0.1:1883"]
+fieldexclude = ["valueA", "valueB", "valueC"]

--- a/migrations/general_metricfilter/testcases/merge_fieldexclude/telegraf.conf
+++ b/migrations/general_metricfilter/testcases/merge_fieldexclude/telegraf.conf
@@ -1,0 +1,12 @@
+# A dummy plugin
+[[inputs.dummy]]
+  ## A server
+  servers = ["tcp://127.0.0.1:1883"]
+
+  ## Default timestamp
+  # timestamp = "10s"
+
+  ## Deprecated field-exclude options
+  fieldexclude = ["valueA"]
+  drop = ["valueB"]
+  fielddrop = ["valueC"]

--- a/migrations/general_metricfilter/testcases/merge_fieldexclude_overlap/expected.conf
+++ b/migrations/general_metricfilter/testcases/merge_fieldexclude_overlap/expected.conf
@@ -1,0 +1,3 @@
+[[inputs.dummy]]
+servers = ["tcp://127.0.0.1:1883"]
+fieldexclude = ["valueA", "valueX", "valueB", "valueY", "valueC"]

--- a/migrations/general_metricfilter/testcases/merge_fieldexclude_overlap/telegraf.conf
+++ b/migrations/general_metricfilter/testcases/merge_fieldexclude_overlap/telegraf.conf
@@ -1,0 +1,12 @@
+# A dummy plugin
+[[inputs.dummy]]
+  ## A server
+  servers = ["tcp://127.0.0.1:1883"]
+
+  ## Default timestamp
+  # timestamp = "10s"
+
+  ## Deprecated field-exclude options
+  fieldexclude = ["valueA", "valueX"]
+  drop = ["valueB", "valueX", "valueY"]
+  fielddrop = ["valueY", "valueC", "valueX"]

--- a/migrations/general_metricfilter/testcases/merge_fieldinclude/expected.conf
+++ b/migrations/general_metricfilter/testcases/merge_fieldinclude/expected.conf
@@ -1,0 +1,3 @@
+[[inputs.dummy]]
+servers = ["tcp://127.0.0.1:1883"]
+fieldinclude = ["valueA", "valueB", "valueC"]

--- a/migrations/general_metricfilter/testcases/merge_fieldinclude/telegraf.conf
+++ b/migrations/general_metricfilter/testcases/merge_fieldinclude/telegraf.conf
@@ -1,0 +1,12 @@
+# A dummy plugin
+[[inputs.dummy]]
+  ## A server
+  servers = ["tcp://127.0.0.1:1883"]
+
+  ## Default timestamp
+  # timestamp = "10s"
+
+  ## Deprecated field-include options
+  fieldinclude = ["valueA"]
+  pass = ["valueB"]
+  fieldpass = ["valueC"]

--- a/migrations/general_metricfilter/testcases/merge_fieldinclude_overlap/expected.conf
+++ b/migrations/general_metricfilter/testcases/merge_fieldinclude_overlap/expected.conf
@@ -1,0 +1,3 @@
+[[inputs.dummy]]
+servers = ["tcp://127.0.0.1:1883"]
+fieldinclude = ["valueA", "valueX", "valueB", "valueY", "valueC"]

--- a/migrations/general_metricfilter/testcases/merge_fieldinclude_overlap/telegraf.conf
+++ b/migrations/general_metricfilter/testcases/merge_fieldinclude_overlap/telegraf.conf
@@ -1,0 +1,12 @@
+# A dummy plugin
+[[inputs.dummy]]
+  ## A server
+  servers = ["tcp://127.0.0.1:1883"]
+
+  ## Default timestamp
+  # timestamp = "10s"
+
+  ## Deprecated field-include options
+  fieldinclude = ["valueA", "valueX"]
+  pass = ["valueB", "valueX", "valueY"]
+  fieldpass = ["valueY", "valueC", "valueX"]

--- a/migrations/outputs_influxdb/migration.go
+++ b/migrations/outputs_influxdb/migration.go
@@ -1,7 +1,6 @@
 package outputs_influxdb
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/influxdata/toml"
@@ -27,16 +26,10 @@ func migrate(tbl *ast.Table) ([]byte, string, error) {
 		var urls []string
 		// Merge the old URL and the new URLs with deduplication
 		if newURLs, found := plugin["urls"]; found {
-			list, ok := newURLs.([]interface{})
-			if !ok {
-				return nil, "", errors.New("'urls' setting is not a list")
-			}
-			for _, raw := range list {
-				nu, ok := raw.(string)
-				if !ok {
-					return nil, "", fmt.Errorf("unexpected 'urls' entry %v (%T)", raw, raw)
-				}
-				urls = append(urls, nu)
+			var err error
+			urls, err = migrations.AsStringSlice(newURLs)
+			if err != nil {
+				return nil, "", fmt.Errorf("'urls' setting: %w", err)
 			}
 		}
 		ou, ok := oldURL.(string)

--- a/migrations/registry.go
+++ b/migrations/registry.go
@@ -31,6 +31,14 @@ func AddPluginOptionMigration(name string, f PluginOptionMigrationFunc) {
 	PluginOptionMigrations[name] = f
 }
 
+type GeneralMigrationFunc func(string, string, *ast.Table) ([]byte, string, error)
+
+var GeneralMigrations []GeneralMigrationFunc
+
+func AddGeneralMigration(f GeneralMigrationFunc) {
+	GeneralMigrations = append(GeneralMigrations, f)
+}
+
 type pluginTOMLStruct map[string]map[string][]interface{}
 
 func CreateTOMLStruct(category, name string) pluginTOMLStruct {

--- a/migrations/utils.go
+++ b/migrations/utils.go
@@ -1,0 +1,22 @@
+package migrations
+
+import (
+	"fmt"
+)
+
+func AsStringSlice(raw interface{}) ([]string, error) {
+	rawList, ok := raw.([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("unexpected type : %T", raw)
+	}
+
+	converted := make([]string, 0, len(rawList))
+	for _, rawElement := range rawList {
+		el, ok := rawElement.(string)
+		if !ok {
+			return nil, fmt.Errorf("unexpected type for list element: %T", rawElement)
+		}
+		converted = append(converted, el)
+	}
+	return converted, nil
+}


### PR DESCRIPTION
## Summary

PR #14012 deprecated `fieldpass` and `fielddrop` and replaced those options with the better-named `fieldinclude` and `fieldexclude` respectively. Additionally, the deprecated `pass` and `drop` options exist.

This PR adds a migration to consolidate all those settings into the new `fieldpass` and `fielddrop`.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues
