### PR TITLE
fix(outputs.bigquery): Correct use of auto-detected project ID

### DIFF
--- a/plugins/outputs/bigquery/bigquery.go
+++ b/plugins/outputs/bigquery/bigquery.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
+	"github.com/influxdata/telegraf/internal"
 	"github.com/influxdata/telegraf/plugins/outputs"
 )
 
@@ -102,7 +103,10 @@ func (s *BigQuery) setUpDefaultClient() error {
 		credentialsOption = option.WithCredentials(creds)
 	}
 
-	client, err := bigquery.NewClient(ctx, s.Project, credentialsOption)
+	client, err := bigquery.NewClient(ctx, s.Project,
+		credentialsOption,
+		option.WithUserAgent(internal.ProductToken()),
+	)
 	s.client = client
 	return err
 }

--- a/plugins/outputs/bigquery/bigquery.go
+++ b/plugins/outputs/bigquery/bigquery.go
@@ -75,7 +75,7 @@ func (s *BigQuery) Connect() error {
 		defer cancel()
 
 		// Check if the compact table exists
-		_, err := s.client.DatasetInProject(s.Project, s.Dataset).Table(s.CompactTable).Metadata(ctx)
+		_, err := s.client.Dataset(s.Dataset).Table(s.CompactTable).Metadata(ctx)
 		if err != nil {
 			return fmt.Errorf("compact table: %w", err)
 		}
@@ -136,7 +136,7 @@ func (s *BigQuery) writeCompact(metrics []telegraf.Metric) error {
 	defer cancel()
 
 	// Always returns an instance, even if table doesn't exist (anymore).
-	inserter := s.client.DatasetInProject(s.Project, s.Dataset).Table(s.CompactTable).Inserter()
+	inserter := s.client.Dataset(s.Dataset).Table(s.CompactTable).Inserter()
 
 	var compactValues []*bigquery.ValuesSaver
 	for _, m := range metrics {
@@ -269,7 +269,7 @@ func (s *BigQuery) insertToTable(metricName string, metrics []bigquery.ValueSave
 	defer cancel()
 
 	tableName := s.metricToTable(metricName)
-	table := s.client.DatasetInProject(s.Project, s.Dataset).Table(tableName)
+	table := s.client.Dataset(s.Dataset).Table(tableName)
 	inserter := table.Inserter()
 
 	if err := inserter.Put(ctx, metrics); err != nil {

--- a/plugins/outputs/bigquery/bigquery_test.go
+++ b/plugins/outputs/bigquery/bigquery_test.go
@@ -221,10 +221,10 @@ func TestAutoDetect(t *testing.T) {
 		CompactTable: "test-metrics",
 	}
 
-	credentialsJson := []byte(`{ "type": "service_account", "project_id": "test-project"}`)
+	credentialsJSON := []byte(`{"type": "service_account", "project_id": "test-project"}`)
 
 	require.NoError(t, b.Init())
-	require.NoError(t, b.setUpTestClientWithJSON(srv.URL, credentialsJson))
+	require.NoError(t, b.setUpTestClientWithJSON(srv.URL, credentialsJSON))
 	require.NoError(t, b.Connect())
 	require.NoError(t, b.Close())
 }
@@ -246,10 +246,10 @@ func (b *BigQuery) setUpTestClient(endpointURL string) error {
 	return nil
 }
 
-func (b *BigQuery) setUpTestClientWithJSON(endpointURL string, credentialsJson []byte) error {
+func (b *BigQuery) setUpTestClientWithJSON(endpointURL string, credentialsJSON []byte) error {
 	noAuth := option.WithoutAuthentication()
 	endpoint := option.WithEndpoint(endpointURL)
-	credentials := option.WithCredentialsJSON(credentialsJson)
+	credentials := option.WithCredentialsJSON(credentialsJSON)
 
 	ctx := context.Background()
 


### PR DESCRIPTION
## Summary

The `project` config isn't a required field anymore since #14086, but telegraf did not use the auto-detected project ID, this PR fixes that.

The client now also identifies telegraf as the user agent.

## Checklist
<!-- Mandatory
Please confirm the following by placing an "x" between the []:
-->

- [x] No AI generated code was used in this PR
