### PR TITLE
fix(license): Correct spelling of jmhodges/clock license

### DIFF
--- a/docs/LICENSE_OF_DEPENDENCIES.md
+++ b/docs/LICENSE_OF_DEPENDENCIES.md
@@ -221,7 +221,7 @@ following works:
 - github.com/jeremywohl/flatten [MIT License](https://github.com/jeremywohl/flatten/blob/master/LICENSE)
 - github.com/jhump/protoreflect [Apache License 2.0](https://github.com/jhump/protoreflect/blob/master/LICENSE)
 - github.com/jmespath/go-jmespath [Apache License 2.0](https://github.com/jmespath/go-jmespath/blob/master/LICENSE)
-- github.com/jmhodges/clock [MIT Licence](https://github.com/jmhodges/clock/blob/main/LICENSE)
+- github.com/jmhodges/clock [MIT License](https://github.com/jmhodges/clock/blob/main/LICENSE)
 - github.com/josharian/intern [MIT License](https://github.com/josharian/intern/blob/master/LICENSE.md)
 - github.com/josharian/native [MIT License](https://github.com/josharian/native/blob/main/license)
 - github.com/jpillora/backoff [MIT License](https://github.com/jpillora/backoff/blob/master/LICENSE)

--- a/tools/license_checker/package.go
+++ b/tools/license_checker/package.go
@@ -24,6 +24,11 @@ func (pkg *packageInfo) ToSPDX() {
 }
 
 func (pkg *packageInfo) Classify() (float64, error) {
+	// Check for a valid SPDX
+	if pkg.spdx == "" {
+		return 0.0, fmt.Errorf("empty SPDX for license %q", pkg.license)
+	}
+
 	// Download the license text
 	source, err := normalizeURL(pkg.url)
 	if err != nil {


### PR DESCRIPTION
## Summary

This PR fixes the license check error on nightly by correctly spelling the license of `github.com/jmhodges/clock`. The PR also improves the error message of the checker to be able to find issues easier.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues
