### PR TITLE
fix(inputs.intel_powerstat): Unit tests should work on every CPU/platform

### DIFF
--- a/plugins/inputs/intel_powerstat/intel_powerstat_test.go
+++ b/plugins/inputs/intel_powerstat/intel_powerstat_test.go
@@ -729,7 +729,7 @@ func TestInit(t *testing.T) {
 }
 
 func TestStart(t *testing.T) {
-	t.Run("FailedToStart", func(t *testing.T) {
+	t.Run("FailedToStartCPUDoesNotExist", func(t *testing.T) {
 		t.Setenv("HOST_PROC", "./testdata")
 
 		acc := &testutil.Accumulator{}
@@ -747,7 +747,23 @@ func TestStart(t *testing.T) {
 		require.Empty(t, logger.Warnings())
 	})
 
+	t.Run("FailedToStartNotSupportedCPUVendor", func(t *testing.T) {
+		t.Setenv("HOST_PROC", "./testdata/vendor_not_supported")
+
+		acc := &testutil.Accumulator{}
+		logger := &testutil.CaptureLogger{}
+
+		p := &PowerStat{
+			Log:    logger,
+			option: &optGenerator{},
+		}
+
+		require.ErrorContains(t, p.Start(acc), "host processor is not supported")
+	})
+
 	t.Run("WithWarning", func(t *testing.T) {
+		t.Setenv("HOST_PROC", "./testdata")
+
 		acc := &testutil.Accumulator{}
 		logger := &testutil.CaptureLogger{}
 

--- a/plugins/inputs/intel_powerstat/intel_powerstat_test.go
+++ b/plugins/inputs/intel_powerstat/intel_powerstat_test.go
@@ -702,6 +702,8 @@ func TestInit(t *testing.T) {
 	})
 
 	t.Run("FailedToParseConfigWithDuplicates", func(t *testing.T) {
+		t.Setenv("HOST_PROC", "./testdata")
+
 		logger := &testutil.CaptureLogger{}
 
 		p := &PowerStat{
@@ -715,6 +717,8 @@ func TestInit(t *testing.T) {
 	})
 
 	t.Run("FailedToParseConfigWithNegativeTimeout", func(t *testing.T) {
+		t.Setenv("HOST_PROC", "./testdata")
+
 		logger := &testutil.CaptureLogger{}
 
 		p := &PowerStat{

--- a/plugins/inputs/intel_powerstat/testdata/vendor_not_supported/cpuinfo
+++ b/plugins/inputs/intel_powerstat/testdata/vendor_not_supported/cpuinfo
@@ -1,0 +1,25 @@
+processor	: 0
+vendor_id	: AuthenticAMD
+cpu family	: 16
+model		: 2
+model name	: AMD Phenom(tm) 9550 Quad-Core Processor
+stepping	: 3
+cpu MHz		: 1100.000
+cache size	: 512 KB
+physical id	: 0
+siblings	: 4
+core id		: 0
+cpu cores	: 4
+apicid		: 0
+initial apicid	: 0
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 5
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ht syscall nx mmxext fxsr_opt pdpe1gb rdtscp lm 3dnowext 3dnow constant_tsc rep_good nonstop_tsc extd_apicid pni monitor cx16 popcnt lahf_lm cmp_legacy svm extapic cr8_legacy abm sse4a misalignsse 3dnowprefetch osvw ibs
+bogomips	: 4409.53
+TLB size	: 1024 4K pages
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 48 bits physical, 48 bits virtual
+power management: ts ttp tm stc 100mhzsteps hwpstate


### PR DESCRIPTION
This PR addresses following issues:
- proper CPU hasn't been set for 3 unit tests (using `testdata`)
- missing test for the behavior of launching the plugin on an unsupported CPU