### PR TITLE
docs(Changelog): Fix reference to python-syntax removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,7 +155,7 @@
 
 ### Important Changes
 
-- [#13791](https://github.com/influxdata/telegraf/pull/11493) `metricpass`
+- [#13791](https://github.com/influxdata/telegraf/pull/13791) `metricpass`
 Removed the Python compatibility support for "not", "and", and "or" keywords.
 This support was incorrectly removing these keywords from actual data. Users
 should instead use the standard "!", "&&", and "||" operators.


### PR DESCRIPTION
## Summary

Fix Changelog reference to python-syntax removal in `metricpass`.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #14426
