### PR TITLE
fix(inputs.procstat): Revert unintended renaming of 'systemd_unit' option

### DIFF
--- a/plugins/inputs/procstat/procstat_test.go
+++ b/plugins/inputs/procstat/procstat_test.go
@@ -460,10 +460,10 @@ func TestGather_PercentSecondPass(t *testing.T) {
 
 func TestGather_systemdUnitPIDs(t *testing.T) {
 	p := Procstat{
-		SystemdUnits: "TestGather_systemdUnitPIDs",
-		PidFinder:    "test",
-		Log:          testutil.Logger{},
-		finder:       newTestFinder([]PID{pid}),
+		SystemdUnit: "TestGather_systemdUnitPIDs",
+		PidFinder:   "test",
+		Log:         testutil.Logger{},
+		finder:      newTestFinder([]PID{pid}),
 	}
 	require.NoError(t, p.Init())
 


### PR DESCRIPTION
## Summary

PR #13417 renamed the `systemd_unit` option to `systemd_units`, while this was  unintended. This PR reverts the renaming to `systemd_unit`.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #14438 
