### PR TITLE
fix(inputs.clickhouse): Omit zookeeper metrics on clickhouse cloud

### DIFF
--- a/plugins/inputs/clickhouse/README.md
+++ b/plugins/inputs/clickhouse/README.md
@@ -36,6 +36,12 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## https://clickhouse.tech/docs/en/interfaces/http/
   servers = ["http://127.0.0.1:8123"]
 
+  ## Server Variant
+  ## When set to "managed", some queries are excluded from being run. This is
+  ## useful for instances hosted in ClickHouse Cloud where certain tables are
+  ## not available.
+  # variant = "self"
+
   ## If "auto_discovery"" is "true" plugin tries to connect to all servers
   ## available in the cluster with using same "user:password" described in
   ## "user" and "password" parameters and get this server hostname list from

--- a/plugins/inputs/clickhouse/README.md
+++ b/plugins/inputs/clickhouse/README.md
@@ -3,6 +3,9 @@
 This plugin gathers the statistic data from
 [ClickHouse](https://github.com/ClickHouse/ClickHouse) server.
 
+User's on Clickhouse Cloud will not see the Zookeeper metrics as they may not
+have permissions to query those tables.
+
 ## Global configuration options <!-- @/docs/includes/plugin_config.md -->
 
 In addition to the plugin-specific configuration settings, plugins support

--- a/plugins/inputs/clickhouse/README.md
+++ b/plugins/inputs/clickhouse/README.md
@@ -40,7 +40,7 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## When set to "managed", some queries are excluded from being run. This is
   ## useful for instances hosted in ClickHouse Cloud where certain tables are
   ## not available.
-  # variant = "self"
+  # variant = "self-hosted"
 
   ## If "auto_discovery"" is "true" plugin tries to connect to all servers
   ## available in the cluster with using same "user:password" described in

--- a/plugins/inputs/clickhouse/clickhouse.go
+++ b/plugins/inputs/clickhouse/clickhouse.go
@@ -67,8 +67,8 @@ func (*ClickHouse) SampleConfig() string {
 func (ch *ClickHouse) Init() error {
 	switch ch.Variant {
 	case "":
-		ch.Variant = "self"
-	case "self", "managed":
+		ch.Variant = "self-hosted"
+	case "self-hosted", "managed":
 		// valid options
 	default:
 		return fmt.Errorf("unknown variant %q", ch.Variant)

--- a/plugins/inputs/clickhouse/clickhouse.go
+++ b/plugins/inputs/clickhouse/clickhouse.go
@@ -130,7 +130,6 @@ func (ch *ClickHouse) Gather(acc telegraf.Accumulator) (err error) {
 	for i := range connects {
 		metricsFuncs := []func(acc telegraf.Accumulator, conn *connect) error{
 			ch.tables,
-			ch.zookeeper,
 			ch.replicationQueue,
 			ch.detachedParts,
 			ch.dictionaries,
@@ -138,6 +137,11 @@ func (ch *ClickHouse) Gather(acc telegraf.Accumulator) (err error) {
 			ch.disks,
 			ch.processes,
 			ch.textLog,
+		}
+
+		// Clickhouse Cloud does not give user's permissions to the zookeeper table
+		if !strings.Contains(connects[i].url.String(), "clickhouse.cloud") {
+			metricsFuncs = append(metricsFuncs, ch.zookeeper)
 		}
 
 		for _, metricFunc := range metricsFuncs {

--- a/plugins/inputs/clickhouse/clickhouse.go
+++ b/plugins/inputs/clickhouse/clickhouse.go
@@ -54,12 +54,27 @@ type ClickHouse struct {
 	ClusterInclude []string        `toml:"cluster_include"`
 	ClusterExclude []string        `toml:"cluster_exclude"`
 	Timeout        config.Duration `toml:"timeout"`
-	HTTPClient     http.Client
+	Variant        string          `toml:"variant"`
+
+	HTTPClient http.Client
 	tls.ClientConfig
 }
 
 func (*ClickHouse) SampleConfig() string {
 	return sampleConfig
+}
+
+func (ch *ClickHouse) Init() error {
+	switch ch.Variant {
+	case "":
+		ch.Variant = "self"
+	case "self", "managed":
+		// valid options
+	default:
+		return fmt.Errorf("unknown variant %q", ch.Variant)
+	}
+
+	return nil
 }
 
 // Start ClickHouse input service
@@ -139,8 +154,9 @@ func (ch *ClickHouse) Gather(acc telegraf.Accumulator) (err error) {
 			ch.textLog,
 		}
 
-		// Clickhouse Cloud does not give user's permissions to the zookeeper table
-		if !strings.Contains(connects[i].url.String(), "clickhouse.cloud") {
+		// Managed instances on Clickhouse Cloud does not give a user
+		// permissions to the zookeeper table
+		if ch.Variant != "managed" {
 			metricsFuncs = append(metricsFuncs, ch.zookeeper)
 		}
 

--- a/plugins/inputs/clickhouse/clickhouse_test.go
+++ b/plugins/inputs/clickhouse/clickhouse_test.go
@@ -492,6 +492,47 @@ func TestGatherWithSomeTablesNotExists(t *testing.T) {
 	acc.AssertDoesNotContainMeasurement(t, "clickhouse_text_log")
 }
 
+func TestGatherClickhouseCloud(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		type result struct {
+			Data interface{} `json:"data"`
+		}
+		enc := json.NewEncoder(w)
+		switch query := r.URL.Query().Get("query"); {
+		case strings.Contains(query, "zk_exists"):
+			err := enc.Encode(result{
+				Data: []struct {
+					ZkExists chUInt64 `json:"zk_exists"`
+				}{
+					{
+						ZkExists: 1,
+					},
+				},
+			})
+			require.NoError(t, err)
+		case strings.Contains(query, "zk_root_nodes"):
+			err := enc.Encode(result{
+				Data: []struct {
+					ZkRootNodes chUInt64 `json:"zk_root_nodes"`
+				}{
+					{
+						ZkRootNodes: 2,
+					},
+				},
+			})
+			require.NoError(t, err)
+		}
+	}))
+	defer ts.Close()
+
+	ch := &ClickHouse{
+		Servers: []string{ts.URL + "?clickhouse.cloud"},
+	}
+	acc := &testutil.Accumulator{}
+	require.NoError(t, ch.Gather(acc))
+	acc.AssertDoesNotContainMeasurement(t, "clickhouse_zookeeper")
+}
+
 func TestWrongJSONMarshalling(t *testing.T) {
 	var (
 		ts = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/plugins/inputs/clickhouse/clickhouse_test.go
+++ b/plugins/inputs/clickhouse/clickhouse_test.go
@@ -526,7 +526,8 @@ func TestGatherClickhouseCloud(t *testing.T) {
 	defer ts.Close()
 
 	ch := &ClickHouse{
-		Servers: []string{ts.URL + "?clickhouse.cloud"},
+		Servers: []string{ts.URL},
+		Variant: "managed",
 	}
 	acc := &testutil.Accumulator{}
 	require.NoError(t, ch.Gather(acc))

--- a/plugins/inputs/clickhouse/sample.conf
+++ b/plugins/inputs/clickhouse/sample.conf
@@ -16,6 +16,12 @@
   ## https://clickhouse.tech/docs/en/interfaces/http/
   servers = ["http://127.0.0.1:8123"]
 
+  ## Server Variant
+  ## When set to "managed", some queries are excluded from being run. This is
+  ## useful for instances hosted in ClickHouse Cloud where certain tables are
+  ## not available.
+  # variant = "self"
+
   ## If "auto_discovery"" is "true" plugin tries to connect to all servers
   ## available in the cluster with using same "user:password" described in
   ## "user" and "password" parameters and get this server hostname list from

--- a/plugins/inputs/clickhouse/sample.conf
+++ b/plugins/inputs/clickhouse/sample.conf
@@ -20,7 +20,7 @@
   ## When set to "managed", some queries are excluded from being run. This is
   ## useful for instances hosted in ClickHouse Cloud where certain tables are
   ## not available.
-  # variant = "self"
+  # variant = "self-hosted"
 
   ## If "auto_discovery"" is "true" plugin tries to connect to all servers
   ## available in the cluster with using same "user:password" described in


### PR DESCRIPTION
fixes: #14436

## Summary

Removes the zookeeper queries when connecting to a URL with clickhouse.cloud in the connection string. I used a string to more easily test this, however, it might be wise to constrain this to the hostname. Obviously if a user is using an IP address this check won't catch that.

## Checklist
<!-- Mandatory
Please confirm the following by placing an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #14436
