### PR TITLE
docs(inputs.memcached): Correct typo in README.md

### DIFF
--- a/plugins/inputs/memcached/README.md
+++ b/plugins/inputs/memcached/README.md
@@ -60,7 +60,7 @@ Fields:
 * decr_hits - Number of successful decr reqs
 * decr_misses - Number of decr reqs against missing keys
 * delete_hits - Number of deletion reqs resulting in an item being removed
-* delete_misses - umber of deletions reqs for missing keys
+* delete_misses - Number of deletions reqs for missing keys
 * evicted_active - Items evicted from LRU that had been hit recently but did
   not jump to top of LRU
 * evicted_unfetched - Items evicted from LRU that were never touched by


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
--> There's a typo in the documentation that I've reading for days

## Checklist
<!-- Mandatory
Please confirm the following by placing an "x" between the []:
-->

- [X] No AI generated code was used in this PR

## Related issues

