### PR TITLE
chore(linters): Enable `indexAlloc`, `preferWriteByte`, `rangeExprCopy` and `sliceClear` checkers for gocritic

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -77,6 +77,7 @@ linters-settings:
     # To check which checks are enabled run `GL_DEBUG=gocritic golangci-lint run`.
     # By default, list of stable checks is used.
     enabled-checks:
+      # diagnostic
       - argOrder
       - badCall
       - badCond
@@ -115,6 +116,11 @@ linters-settings:
       - uncheckedInlineErr
       - unnecessaryDefer
       - weakCond
+      # performance
+      - indexAlloc
+      - preferWriteByte
+      - rangeExprCopy
+      - sliceClear
   gosec:
     # To select a subset of rules to run.
     # Available rules: https://github.com/securego/gosec#available-rules


### PR DESCRIPTION
resolves https://github.com/influxdata/telegraf/issues/14405 (indexAlloc)
resolves https://github.com/influxdata/telegraf/issues/14409 (preferWriteByte)
resolves https://github.com/influxdata/telegraf/issues/14410 (rangeExprCopy)
resolves https://github.com/influxdata/telegraf/issues/14412 (sliceClear)