### PR TITLE
chore(linters): Enable `equalFold`, `preferStringWriter` and `stringXbytes` checkers for gocritic.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -77,6 +77,7 @@ linters-settings:
     # To check which checks are enabled run `GL_DEBUG=gocritic golangci-lint run`.
     # By default, list of stable checks is used.
     enabled-checks:
+      # diagnostic
       - argOrder
       - badCall
       - badCond
@@ -115,6 +116,10 @@ linters-settings:
       - uncheckedInlineErr
       - unnecessaryDefer
       - weakCond
+      # performance
+      - equalFold
+      - preferStringWriter
+      - stringXbytes
   gosec:
     # To select a subset of rules to run.
     # Available rules: https://github.com/securego/gosec#available-rules

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -93,7 +93,6 @@ func (t *telegrafLog) Close() error {
 // newTelegrafWriter returns a logging-wrapped writer.
 func newTelegrafWriter(w io.Writer, c LogConfig) (io.Writer, error) {
 	timezoneName := c.LogWithTimezone
-
 	if strings.EqualFold(timezoneName, "local") {
 		timezoneName = "Local"
 	}

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -94,7 +94,7 @@ func (t *telegrafLog) Close() error {
 func newTelegrafWriter(w io.Writer, c LogConfig) (io.Writer, error) {
 	timezoneName := c.LogWithTimezone
 
-	if strings.ToLower(timezoneName) == "local" {
+	if strings.EqualFold(timezoneName, "local") {
 		timezoneName = "Local"
 	}
 

--- a/plugins/common/cookie/cookie.go
+++ b/plugins/common/cookie/cookie.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	clockutil "github.com/benbjohnson/clock"
+
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
 )
@@ -97,7 +98,7 @@ func (c *CookieAuthConfig) auth() error {
 	}
 
 	for k, v := range c.Headers {
-		if strings.ToLower(k) == "host" {
+		if strings.EqualFold(k, "host") {
 			req.Host = v
 		} else {
 			req.Header.Add(k, v)

--- a/plugins/inputs/amqp_consumer/amqp_consumer.go
+++ b/plugins/inputs/amqp_consumer/amqp_consumer.go
@@ -136,7 +136,7 @@ func (a *AMQPConsumer) createConfig() (*amqp.Config, error) {
 
 	var auth []amqp.Authentication
 
-	if strings.ToUpper(a.AuthMethod) == "EXTERNAL" {
+	if strings.EqualFold(a.AuthMethod, "EXTERNAL") {
 		auth = []amqp.Authentication{&externalAuth{}}
 	} else if !a.Username.Empty() || !a.Password.Empty() {
 		username, err := a.Username.Get()

--- a/plugins/inputs/http/http.go
+++ b/plugins/inputs/http/http.go
@@ -141,7 +141,7 @@ func (h *HTTP) gatherURL(acc telegraf.Accumulator, url string) error {
 	}
 
 	for k, v := range h.Headers {
-		if strings.ToLower(k) == "host" {
+		if strings.EqualFold(k, "host") {
 			request.Host = v
 		} else {
 			request.Header.Add(k, v)

--- a/plugins/inputs/http_response/http_response_test.go
+++ b/plugins/inputs/http_response/http_response_test.go
@@ -138,7 +138,7 @@ func setUpTestMux() http.Handler {
 			http.Error(w, "couldn't read request body", http.StatusBadRequest)
 			return
 		}
-		if string(body) == "" {
+		if len(body) == 0 {
 			http.Error(w, "body was empty", http.StatusBadRequest)
 			return
 		}

--- a/plugins/inputs/httpjson/httpjson.go
+++ b/plugins/inputs/httpjson/httpjson.go
@@ -204,7 +204,7 @@ func (h *HTTPJSON) sendRequest(serverURL string) (string, float64, error) {
 
 	// Add header parameters
 	for k, v := range h.Headers {
-		if strings.ToLower(k) == "host" {
+		if strings.EqualFold(k, "host") {
 			req.Host = v
 		} else {
 			req.Header.Add(k, v)

--- a/plugins/inputs/intel_dlb/intel_dlb.go
+++ b/plugins/inputs/intel_dlb/intel_dlb.go
@@ -459,7 +459,7 @@ func checkSocketPath(path string) error {
 func validateEventdevCommands(commands []string) error {
 	eventdevCommandRegex := regexp.MustCompile("^/eventdev/[a-z_]+$")
 	for _, command := range commands {
-		if !eventdevCommandRegex.Match([]byte(command)) {
+		if !eventdevCommandRegex.MatchString(command) {
 			return fmt.Errorf("provided command is not valid - %v", command)
 		}
 	}

--- a/plugins/inputs/intel_dlb/intel_dlb_test.go
+++ b/plugins/inputs/intel_dlb/intel_dlb_test.go
@@ -884,7 +884,7 @@ func Test_rasReader(t *testing.T) {
 		// Remove the temporary file after this test
 		defer os.Remove(fileobj.Name())
 
-		_, err = fileobj.Write([]byte(testFileContent))
+		_, err = fileobj.WriteString(testFileContent)
 		require.NoError(t, err)
 		err = fileobj.Close()
 		require.NoError(t, err)

--- a/plugins/inputs/logstash/logstash.go
+++ b/plugins/inputs/logstash/logstash.go
@@ -151,7 +151,7 @@ func (logstash *Logstash) gatherJSONData(address string, value interface{}) erro
 	}
 
 	for header, value := range logstash.Headers {
-		if strings.ToLower(header) == "host" {
+		if strings.EqualFold(header, "host") {
 			request.Host = value
 		} else {
 			request.Header.Add(header, value)

--- a/plugins/inputs/mysql/mysql.go
+++ b/plugins/inputs/mysql/mysql.go
@@ -656,7 +656,7 @@ func (m *Mysql) gatherSlaveStatuses(db *sql.DB, servtag string, acc telegraf.Acc
 			colValue := vals[i]
 
 			if m.GatherAllSlaveChannels &&
-				(strings.ToLower(colName) == "channel_name" || strings.ToLower(colName) == "connection_name") {
+				(strings.EqualFold(colName, "channel_name") || strings.EqualFold(colName, "connection_name")) {
 				// Since the default channel name is empty, we need this block
 				channelName := "default"
 				if len(colValue) > 0 {

--- a/plugins/inputs/procstat/procstat.go
+++ b/plugins/inputs/procstat/procstat.go
@@ -67,7 +67,7 @@ func (*Procstat) SampleConfig() string {
 
 func (p *Procstat) Init() error {
 	// Check solaris mode
-	p.solarisMode = strings.ToLower(p.Mode) == "solaris"
+	p.solarisMode = strings.EqualFold(p.Mode, "solaris")
 
 	// Keep the old settings for compatibility
 	if p.PidTag && !choice.Contains("pid", p.TagWith) {

--- a/plugins/inputs/sflow/binaryio/minreader_test.go
+++ b/plugins/inputs/sflow/binaryio/minreader_test.go
@@ -19,7 +19,7 @@ func TestMinReader(t *testing.T) {
 	if n != 5 {
 		t.Error("Expected n to be 5, but was ", n)
 	}
-	if string(toRead) != string([]byte{1, 2, 3, 4, 5}) {
+	if !bytes.Equal(toRead, []byte{1, 2, 3, 4, 5}) {
 		t.Error("expected 5 specific bytes to be read")
 	}
 	err = mr.Close()
@@ -33,7 +33,7 @@ func TestMinReader(t *testing.T) {
 	if n != 5 {
 		t.Error("Expected n to be 5, but was ", n)
 	}
-	if string(toRead) != string([]byte{11, 12, 13, 14, 15}) {
+	if !bytes.Equal(toRead, []byte{11, 12, 13, 14, 15}) {
 		t.Error("expected the last 5 bytes to be read")
 	}
 }

--- a/plugins/inputs/x509_cert/x509_cert_test.go
+++ b/plugins/inputs/x509_cert/x509_cert_test.go
@@ -44,7 +44,7 @@ func TestGatherRemoteIntegration(t *testing.T) {
 
 	defer os.Remove(tmpfile.Name())
 
-	_, err = tmpfile.Write([]byte(pki.ReadServerCert()))
+	_, err = tmpfile.WriteString(pki.ReadServerCert())
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -160,7 +160,7 @@ func TestGatherLocal(t *testing.T) {
 			f, err := os.CreateTemp("", "x509_cert")
 			require.NoError(t, err)
 
-			_, err = f.Write([]byte(test.content))
+			_, err = f.WriteString(test.content)
 			require.NoError(t, err)
 
 			if runtime.GOOS != "windows" {
@@ -193,7 +193,7 @@ func TestTags(t *testing.T) {
 	f, err := os.CreateTemp("", "x509_cert")
 	require.NoError(t, err)
 
-	_, err = f.Write([]byte(cert))
+	_, err = f.WriteString(cert)
 	require.NoError(t, err)
 
 	require.NoError(t, f.Close())
@@ -242,7 +242,7 @@ func TestGatherExcludeRootCerts(t *testing.T) {
 	f, err := os.CreateTemp("", "x509_cert")
 	require.NoError(t, err)
 
-	_, err = f.Write([]byte(cert))
+	_, err = f.WriteString(cert)
 	require.NoError(t, err)
 
 	require.NoError(t, f.Close())
@@ -279,7 +279,7 @@ func TestGatherChain(t *testing.T) {
 			f, err := os.CreateTemp("", "x509_cert")
 			require.NoError(t, err)
 
-			_, err = f.Write([]byte(test.content))
+			_, err = f.WriteString(test.content)
 			require.NoError(t, err)
 
 			require.NoError(t, f.Close())

--- a/plugins/outputs/amqp/amqp.go
+++ b/plugins/outputs/amqp/amqp.go
@@ -291,7 +291,7 @@ func (q *AMQP) makeClientConfig() (*ClientConfig, error) {
 	clientConfig.dialer = dialer
 
 	var auth []amqp.Authentication
-	if strings.ToUpper(q.AuthMethod) == "EXTERNAL" {
+	if strings.EqualFold(q.AuthMethod, "EXTERNAL") {
 		auth = []amqp.Authentication{&externalAuth{}}
 	} else if !q.Username.Empty() || !q.Password.Empty() {
 		username, err := q.Username.Get()

--- a/plugins/outputs/http/http.go
+++ b/plugins/outputs/http/http.go
@@ -205,7 +205,7 @@ func (h *HTTP) writeMetric(reqBody []byte) error {
 		req.Header.Set("Content-Encoding", "gzip")
 	}
 	for k, v := range h.Headers {
-		if strings.ToLower(k) == "host" {
+		if strings.EqualFold(k, "host") {
 			req.Host = v
 		}
 		req.Header.Set(k, v)

--- a/plugins/outputs/loki/loki.go
+++ b/plugins/outputs/loki/loki.go
@@ -173,7 +173,7 @@ func (l *Loki) writeMetrics(s Streams) error {
 	}
 
 	for k, v := range l.Headers {
-		if strings.ToLower(k) == "host" {
+		if strings.EqualFold(k, "host") {
 			req.Host = v
 		}
 		req.Header.Set(k, v)

--- a/plugins/parsers/logfmt/parser.go
+++ b/plugins/parsers/logfmt/parser.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/go-logfmt/logfmt"
+
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/filter"
 	"github.com/influxdata/telegraf/metric"
@@ -42,7 +43,7 @@ func (p *Parser) Parse(b []byte) ([]telegraf.Metric, error) {
 		fields := make(map[string]interface{})
 		tags := make(map[string]string)
 		for decoder.ScanKeyval() {
-			if string(decoder.Value()) == "" {
+			if len(decoder.Value()) == 0 {
 				continue
 			}
 

--- a/plugins/secretstores/http/http.go
+++ b/plugins/secretstores/http/http.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/blues/jsonata-go"
+
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
 	chttp "github.com/influxdata/telegraf/plugins/common/http"
@@ -158,7 +159,7 @@ func (h *HTTP) query() ([]byte, error) {
 	}
 
 	for k, v := range h.Headers {
-		if strings.ToLower(k) == "host" {
+		if strings.EqualFold(k, "host") {
 			request.Host = v
 		} else {
 			request.Header.Add(k, v)

--- a/plugins/secretstores/oauth2/oauth2.go
+++ b/plugins/secretstores/oauth2/oauth2.go
@@ -102,7 +102,7 @@ func (o *OAuth2) Init() error {
 		}
 
 		// Check service specific parameters
-		if strings.ToLower(o.Service) == "auth0" {
+		if strings.EqualFold(o.Service, "auth0") {
 			if audience := c.Params["audience"]; audience == "" {
 				return fmt.Errorf("'audience' parameter in key %q missing for service Auth0", c.Key)
 			}

--- a/tools/readme_config_includer/generator.go
+++ b/tools/readme_config_includer/generator.go
@@ -91,14 +91,14 @@ func insertInclude(buf *bytes.Buffer, include string) error {
 func insertIncludes(buf *bytes.Buffer, b *includeBlock) error {
 	// Insert newlines before and after
 	if b.Newlines {
-		buf.Write([]byte("\n"))
+		buf.WriteByte('\n')
 	}
 
 	// Insert all includes in the order they occurred
 	for i, include := range b.Includes {
 		if i > 0 {
 			// Add a separating newline between included blocks
-			buf.Write([]byte("\n"))
+			buf.WriteByte('\n')
 		}
 		if err := insertInclude(buf, include); err != nil {
 			return err
@@ -106,7 +106,7 @@ func insertIncludes(buf *bytes.Buffer, b *includeBlock) error {
 	}
 	// Make sure we add a trailing newline
 	if !bytes.HasSuffix(buf.Bytes(), []byte("\n")) || b.Newlines {
-		buf.Write([]byte("\n"))
+		buf.WriteByte('\n')
 	}
 
 	return nil


### PR DESCRIPTION
resolves https://github.com/influxdata/telegraf/issues/14403 (equalFold)
resolves https://github.com/influxdata/telegraf/issues/14408 (preferStringWriter)
resolves https://github.com/influxdata/telegraf/issues/14413 (stringXbytes)
