### PR TITLE
feat(inputs.prometheus): Add option to limit body length

### DIFF
--- a/plugins/inputs/prometheus/README.md
+++ b/plugins/inputs/prometheus/README.md
@@ -106,6 +106,11 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   # Default is 60 minutes.
   # cache_refresh_interval = 60
 
+  ## Content lenght limit
+  ## When set, telegraf will drop responses with length larger than the
+  ## configured value in bytes.
+  # content_length_limit = 0
+
   ## Scrape Services available in Consul Catalog
   # [inputs.prometheus.consul]
   #   enabled = true

--- a/plugins/inputs/prometheus/sample.conf
+++ b/plugins/inputs/prometheus/sample.conf
@@ -89,6 +89,11 @@
   # Default is 60 minutes.
   # cache_refresh_interval = 60
 
+  ## Content lenght limit
+  ## When set, telegraf will drop responses with length larger than the
+  ## configured value in bytes.
+  # content_length_limit = 0
+
   ## Scrape Services available in Consul Catalog
   # [inputs.prometheus.consul]
   #   enabled = true


### PR DESCRIPTION


## Summary

Introduce new config option to check the content length when receiving data back. Before reading the data, verify the length is less than the limit. Can prevent running out of buffer space and dropping metrics when very large data is received.

## Checklist
<!-- Mandatory
Please confirm the following by placing an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves: #14437
