### PR TITLE
fix(outputs.bigquery): Ignore individual fields containing NaN or infinity

### DIFF
--- a/plugins/outputs/bigquery/bigquery.go
+++ b/plugins/outputs/bigquery/bigquery.go
@@ -193,6 +193,7 @@ func (s *BigQuery) newCompactValuesSaver(m telegraf.Metric) (*bigquery.ValuesSav
 		if fv, ok := field.Value.(float64); ok {
 			// JSON does not support these special values
 			if math.IsNaN(fv) || math.IsInf(fv, 0) {
+				s.Log.Debugf("Ignoring unsupported field %s with value %q for metric %s", field.Key, field.Value, m.Name())
 				continue
 			}
 		}


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

When one of the fields contain a NaN, +Inf or -Inf, the following message is emitted and the whole metric gets discarded:
> W! [outputs.bigquery] could not prepare metric as compact value: serializing fields: json: unsupported value: NaN

The JSON serialiser is ignoring those fields, so we do that here as wel.

## Checklist
<!-- Mandatory
Please confirm the following by placing an "x" between the []:
-->

- [x] No AI generated code was used in this PR

