### PR TITLE
fix(processors.filter): processors.Filter -> processors.filter

### DIFF
--- a/plugins/processors/filter/filter.go
+++ b/plugins/processors/filter/filter.go
@@ -69,7 +69,7 @@ func (f *Filter) applyRules(m telegraf.Metric) bool {
 }
 
 func init() {
-	processors.Add("Filter", func() telegraf.Processor {
+	processors.Add("filter", func() telegraf.Processor {
 		return &Filter{}
 	})
 }


### PR DESCRIPTION
## Summary
processors.filter was named Filter, I guess incorrectly. The sample file didn't work.

## Checklist
- [X] No AI generated code was used in this PR

## Related issues
https://github.com/influxdata/telegraf/issues/14459

resolves #14459 
