### PR TITLE
fix(inputs.vsphere): Resolve occasional serverFault

### DIFF
--- a/plugins/inputs/vsphere/endpoint.go
+++ b/plugins/inputs/vsphere/endpoint.go
@@ -1015,7 +1015,11 @@ func (e *Endpoint) chunkify(ctx context.Context, res *resourceKind, now time.Tim
 			}
 
 			if !start.Truncate(time.Second).Before(now.Truncate(time.Second)) {
-				e.log.Debugf("Start >= end (rounded to seconds): %s > %s", start, now)
+				// this happens when the hiwater mark was estimated using a larger estInterval than is currently used
+				// the estInterval is reset to 1m in case of some errors
+				// there are no new metrics to be expected here and querying this gets us an error, so: skip!
+				e.log.Debugf("Start >= end (rounded to seconds): %s > %s. Skipping!", start, now)
+				continue
 			}
 
 			// Create bucket if we don't already have it


### PR DESCRIPTION
the serverFaultCode "A specified parameter was not correct: querySpec.startTime, querySpec.endTime" results from requests for metrics from the future.

Those requests get planned (check: hiwater mark, hwMark) for a plugin-run (-> plugin "interval") in the future in relation to the estimated time the vcenter will have collected the next metrics.

This estimated time/interval gets mangled up on a connection error (e.g. connection reset), because the est. interval gets reset to 1.

Solution: If we realize (ourselves) that the metric we are about to request is from the future, then... don't request it. Skip it.

- [X] No AI generated code was used in this PR

resolves #12500
