### PR TITLE
fix(outputs.prometheus_client): Always default to TCP

### DIFF
--- a/plugins/outputs/prometheus_client/prometheus_client.go
+++ b/plugins/outputs/prometheus_client/prometheus_client.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"crypto/tls"
 	_ "embed"
-	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -221,8 +220,9 @@ func (p *PrometheusClient) listen() (net.Listener, error) {
 		return p.listenTCP(u.Host)
 	case "vsock":
 		return p.listenVsock(u.Host)
+	default:
+		return p.listenTCP(u.Host)
 	}
-	return nil, errors.New("Unknown scheme")
 }
 
 func (p *PrometheusClient) Connect() error {

--- a/plugins/outputs/prometheus_client/prometheus_client.go
+++ b/plugins/outputs/prometheus_client/prometheus_client.go
@@ -217,7 +217,7 @@ func (p *PrometheusClient) listen() (net.Listener, error) {
 		return p.listenTCP(p.Listen)
 	}
 	switch strings.ToLower(u.Scheme) {
-	case "tcp", "http":
+	case "", "tcp", "http":
 		return p.listenTCP(u.Host)
 	case "vsock":
 		return p.listenVsock(u.Host)


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

https://github.com/influxdata/telegraf/pull/14108 introduced the ability to listen on vsock. In that PR, telegraf parses the URL and determines which function to call based on the scheme of the URL. This function was missing what to do when there is no scheme, breaking backwards compatibility. Additionally, if using a URL like `mgt:3839`, scheme will report as `mgt`. To maintain backwards compatibility we should always try TCP.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #14468
