### PR TITLE
fix(outputs.influxdb*): Support setting Host header

### DIFF
--- a/plugins/outputs/influxdb/http.go
+++ b/plugins/outputs/influxdb/http.go
@@ -509,7 +509,11 @@ func (c *httpClient) addHeaders(req *http.Request) error {
 	}
 
 	for header, value := range c.config.Headers {
-		req.Header.Set(header, value)
+		if strings.EqualFold(header, "host") {
+			req.Host = value
+		} else {
+			req.Header.Set(header, value)
+		}
 	}
 
 	return nil

--- a/plugins/outputs/influxdb_v2/http.go
+++ b/plugins/outputs/influxdb_v2/http.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"path"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/influxdata/telegraf"
@@ -410,7 +411,11 @@ func (c *httpClient) requestBodyReader(metrics []telegraf.Metric) io.ReadCloser 
 
 func (c *httpClient) addHeaders(req *http.Request) {
 	for header, value := range c.Headers {
-		req.Header.Set(header, value)
+		if strings.EqualFold(header, "host") {
+			req.Host = value
+		} else {
+			req.Header.Set(header, value)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

The outputs.influxdb and outputs.influxdb_v2 plugins currently do not support setting the Host header in the `http_headers` config parameter. If set, it is silently dropped by Go's HTTP client.

The Go HTTP client requires the Host header to be set on the http.Request struct instead. This is already done in other plugins, e.g. inputs.http, outputs.http and secretstores.http.

https://github.com/influxdata/telegraf/blob/448260a90a47f72d4d395f1c070c5cb7143778bb/plugins/inputs/http/http.go#L143-L149

This PR updates the outputs.influxdb and outputs.influxdb_v2 plugins to bring it inline with the other plugins, i.e. allow setting the Host header using the `http_headers` config parameter.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #14482
