### PR TITLE
fix(inputs.phpfpm): Use logger without causing panic

### DIFF
--- a/plugins/inputs/phpfpm/phpfpm.go
+++ b/plugins/inputs/phpfpm/phpfpm.go
@@ -83,7 +83,7 @@ type phpfpm struct {
 
 	tls.ClientConfig
 	client *http.Client
-	log    telegraf.Logger
+	Log    telegraf.Logger
 }
 
 func (*phpfpm) SampleConfig() string {
@@ -300,7 +300,7 @@ func parseLines(r io.Reader, acc telegraf.Accumulator, addr string) {
 func (p *phpfpm) parseJSON(r io.Reader, acc telegraf.Accumulator, addr string) {
 	var metrics JSONMetrics
 	if err := json.NewDecoder(r).Decode(&metrics); err != nil {
-		p.log.Errorf("Unable to decode JSON response: %s", err)
+		p.Log.Errorf("Unable to decode JSON response: %s", err)
 		return
 	}
 	timestamp := time.Now()

--- a/plugins/inputs/phpfpm/phpfpm_test.go
+++ b/plugins/inputs/phpfpm/phpfpm_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/influxdata/telegraf/plugins/common/shim"
 	"github.com/influxdata/telegraf/plugins/parsers/influx"
 	"github.com/influxdata/telegraf/testutil"
 )
@@ -94,7 +95,7 @@ func TestPhpFpmGeneratesJSONMetrics_From_Http(t *testing.T) {
 	input := &phpfpm{
 		Urls:   []string{server.URL + "?full&json"},
 		Format: "json",
-		log:    testutil.Logger{},
+		Log:    testutil.Logger{},
 	}
 	require.NoError(t, input.Init())
 
@@ -358,3 +359,14 @@ max active processes: 1
 max children reached: 2
 slow requests:        1
 `
+
+func TestPhpFpmLogWithoutPanic(t *testing.T) {
+	p := &phpfpm{}
+	// AddInput sets the Logger
+	if err := shim.New().AddInput(p); err != nil {
+		t.Error(err)
+		return
+	}
+
+	p.Log.Debug("test")
+}

--- a/plugins/inputs/phpfpm/phpfpm_test.go
+++ b/plugins/inputs/phpfpm/phpfpm_test.go
@@ -382,7 +382,7 @@ func TestPhpFpmParseJSON_Log_Error_Without_Panic_When_When_JSON_Is_Invalid(t *te
 	// parse valid JSON without panic and without log output
 	validJSON := outputSampleJSON
 	require.NotPanics(t, func() { p.parseJSON(bytes.NewReader(validJSON), &testutil.NopAccumulator{}, "") })
-	require.Equal(t, logOutput.String(), "")
+	require.Equal(t, "", logOutput.String())
 
 	// parse invalid JSON without panic but with log output
 	invalidJSON := []byte("X")


### PR DESCRIPTION
## Summary

Use logger without causing panic.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

Resolves #14485
