### PR TITLE
add loongarch64 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -257,6 +257,16 @@ jobs:
       - package-build:
           type: riscv64
           nightly: << parameters.nightly >>
+  loong64-package:
+    parameters:
+      nightly:
+        type: boolean
+        default: false
+    executor: telegraf-ci
+    steps:
+      - package-build:
+          type: loong64
+          nightly: << parameters.nightly >>
   s390x-package:
     parameters:
       nightly:
@@ -602,6 +612,15 @@ workflows:
                 - master
             tags:
               only: /.*/
+      - 'loong64-package':
+          requires:
+            - 'test-go-linux'
+          filters:
+            branches:
+              ignore:
+                - master
+            tags:
+              only: /.*/
       - 's390x-package':
           requires:
             - 'test-go-linux'
@@ -672,6 +691,7 @@ workflows:
             - 'amd64-package'
             - 'mipsel-package'
             - 'mips-package'
+            - 'loong64-package'
             - 'darwin-amd64-package'
             - 'darwin-arm64-package'
             - 'windows-package'
@@ -711,6 +731,7 @@ workflows:
             - 'amd64-package'
             - 'mipsel-package'
             - 'mips-package'
+            - 'loong64-package'
             - 'arm64-package'
             - 'armhf-package'
             - 'package-sign-mac'
@@ -732,6 +753,7 @@ workflows:
             - 'arm64-package'
             - 'armhf-package'
             - 'riscv64-package'
+            - 'loong64-package'
             - 'package-sign-mac'
             - 'package-sign-windows'
             - 'package-sign'
@@ -790,6 +812,11 @@ workflows:
           nightly: true
           requires:
             - 'test-go-linux'
+      - 'loong64-package':
+          name: 'loong64-package-nightly'
+          nightly: true
+          requires:
+            - 'test-go-linux'
       - 's390x-package':
           name: 's390x-package-nightly'
           nightly: true
@@ -843,6 +870,7 @@ workflows:
             - 'i386-package-nightly'
             - 'mips-package-nightly'
             - 'mipsel-package-nightly'
+            - 'loong64-package-nightly'
             - 'ppc64le-package-nightly'
             - 'riscv64-package-nightly'
             - 's390x-package-nightly'

--- a/Makefile
+++ b/Makefile
@@ -286,6 +286,10 @@ mipsel += mipsel.deb linux_mipsel.tar.gz
 .PHONY: mipsel
 mipsel:
 	@ echo $(mipsel)
+loongarch64 += linux_loongarch64.tar.gz loongarch64.deb loongarch64.rpm
+.PHONY: loongarch64
+loongarch64:
+	@ echo $(loongarch64)
 arm64 += linux_arm64.tar.gz arm64.deb aarch64.rpm
 .PHONY: arm64
 arm64:
@@ -332,7 +336,7 @@ darwin-arm64 += darwin_arm64.tar.gz
 darwin-arm64:
 	@ echo $(darwin-arm64)
 
-include_packages := $(mips) $(mipsel) $(arm64) $(amd64) $(armel) $(armhf) $(riscv64) $(s390x) $(ppc64le) $(i386) $(windows) $(darwin-amd64) $(darwin-arm64)
+include_packages := $(mips) $(mipsel) $(arm64) $(amd64) $(armel) $(armhf) $(riscv64) $(loongarch64) $(s390x) $(ppc64le) $(i386) $(windows) $(darwin-amd64) $(darwin-arm64)
 
 .PHONY: package
 package: docs config $(include_packages)
@@ -427,6 +431,9 @@ mipsel.deb linux_mipsel.tar.gz: export GOARCH := mipsle
 
 riscv64.deb riscv64.rpm linux_riscv64.tar.gz: export GOOS := linux
 riscv64.deb riscv64.rpm linux_riscv64.tar.gz: export GOARCH := riscv64
+
+riscv64.deb riscv64.rpm linux_loongarch64.tar.gz: export GOOS := linux
+riscv64.deb riscv64.rpm linux_loongarch64.tar.gz: export GOARCH := loong64
 
 s390x.deb s390x.rpm linux_s390x.tar.gz: export GOOS := linux
 s390x.deb s390x.rpm linux_s390x.tar.gz: export GOARCH := s390x


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Provide loongarch support
The LoongArch architecture (LoongArch) is an Instruction Set Architecture (ISA) that has a RISC style.
## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->
- [x] Wrote appropriate unit tests.
- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->
resolves　#13798
