### PR TITLE
fix(inputs.procstat): Correctly set tags on procstat_lookup

### DIFF
--- a/plugins/inputs/procstat/procstat.go
+++ b/plugins/inputs/procstat/procstat.go
@@ -146,6 +146,11 @@ func (p *Procstat) Gather(acc telegraf.Accumulator) error {
 			"pid_finder": p.PidFinder,
 			"result":     "lookup_error",
 		}
+		for _, pidTag := range results {
+			for key, value := range pidTag.Tags {
+				tags[key] = value
+			}
+		}
 		acc.AddFields("procstat_lookup", fields, tags, now)
 		return err
 	}
@@ -207,6 +212,11 @@ func (p *Procstat) Gather(acc telegraf.Accumulator) error {
 	tags := map[string]string{
 		"pid_finder": p.PidFinder,
 		"result":     "success",
+	}
+	for _, pidTag := range results {
+		for key, value := range pidTag.Tags {
+			tags[key] = value
+		}
 	}
 	if len(p.SupervisorUnits) > 0 {
 		tags["supervisor_unit"] = strings.Join(p.SupervisorUnits, ";")


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Correctly set the tags on procstat_lookup, we stopped adding the collected tags in the refactor.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

fixes: #14487
