### PR TITLE
docs(inputs.opcua_listener): Fix nodes example

### DIFF
--- a/plugins/inputs/opcua_listener/README.md
+++ b/plugins/inputs/opcua_listener/README.md
@@ -252,7 +252,7 @@ An OPC UA node ID may resemble: "ns=3;s=Temperature". In this example:
 To gather data from this node enter the following line into the 'nodes' property above:
 
 ```text
-{field_name="temp", namespace="3", identifier_type="s", identifier="Temperature"},
+{name="temp", namespace="3", identifier_type="s", identifier="Temperature"},
 ```
 
 This node configuration produces a metric like this:


### PR DESCRIPTION
## Summary

In opcua-listener nodes' settings `NodeSettings`, `FieldName` in Go is mapped to `name` in toml configuration.  However it's `field_name` in the README.

`NodeSettings`'s definition is as below:

```go
type NodeSettings struct {
	FieldName        string               `toml:"name"`
	Namespace        string               `toml:"namespace"`
	IdentifierType   string               `toml:"identifier_type"`
	Identifier       string               `toml:"identifier"`
	DataType         string               `toml:"data_type" deprecated:"1.17.0;option is ignored"`
	Description      string               `toml:"description" deprecated:"1.17.0;option is ignored"`
	TagsSlice        [][]string           `toml:"tags" deprecated:"1.25.0;use 'default_tags' instead"`
	DefaultTags      map[string]string    `toml:"default_tags"`
	MonitoringParams MonitoringParameters `toml:"monitoring_params"`
}
```

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

N/A