### PR TITLE
fix(service): Allow notify access from all

### DIFF
--- a/scripts/telegraf.service
+++ b/scripts/telegraf.service
@@ -6,6 +6,7 @@ Wants=network-online.target
 
 [Service]
 Type=notify
+NotifyAccess=all
 EnvironmentFile=-/etc/default/telegraf
 User=telegraf
 ImportCredential=telegraf.*


### PR DESCRIPTION
## Summary

Adds the `NotifyAccess=all` option to the systemd service file we use. Without this, `NotifyAccess` is set to `main`, due to `Type=notify`. This means only the main pid can communicate. Users using exec/execd like plugins need to be able to communicate with other PIDs.

See: https://www.freedesktop.org/software/systemd/man/latest/systemd.service.html#NotifyAccess=

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #14500
