### PR TITLE
fix(outputs.iotdb): Handle paths that contain illegal characters

### DIFF
--- a/plugins/outputs/iotdb/README.md
+++ b/plugins/outputs/iotdb/README.md
@@ -141,4 +141,19 @@ to use them.
   ##   - "fields"     --  root.sg.device, s1=100, s2="hello", tag1="private", tag2="working"
   ##   - "device_id"  --  root.sg.device.private.working, s1=100, s2="hello"
   # convert_tags_to = "device_id"
+
+  ## Handling of Unsupported Characters
+  ## Some characters in different versions of IoTDB are not supported in path name
+  ## A guide with suggetions on valid paths can be found here:
+  ## for iotdb 0.13.x           -> https://iotdb.apache.org/UserGuide/V0.13.x/Reference/Syntax-Conventions.html#timestamp-literals
+  ## for iotdb 1.x.x and above  -> https://iotdb.apache.org/UserGuide/V1.3.x/User-Manual/Syntax-Rule.html#identifier
+  ##
+  ## Available values are:
+  ##   - "1.0", "1.1", "1.2", "1.3"  -- enclose in `` the world having forbidden character 
+  ##                                    such as @ $ # : [ ] { } ( ) space
+  ##   - "0.13"                      -- enclose in `` the world having forbidden character 
+  ##                                    such as space
+  ##
+  ## Keep this section commented if you don't want to sanitize the path
+  # sanitize_tag = "1.3"
 ```

--- a/plugins/outputs/iotdb/README.md
+++ b/plugins/outputs/iotdb/README.md
@@ -145,7 +145,7 @@ to use them.
   ## Handling of Unsupported Characters
   ## Some characters in different versions of IoTDB are not supported in path name
   ## A guide with suggetions on valid paths can be found here:
-  ## for iotdb 0.13.x           -> https://iotdb.apache.org/UserGuide/V0.13.x/Reference/Syntax-Conventions.html#timestamp-literals
+  ## for iotdb 0.13.x           -> https://iotdb.apache.org/UserGuide/V0.13.x/Reference/Syntax-Conventions.html#identifiers
   ## for iotdb 1.x.x and above  -> https://iotdb.apache.org/UserGuide/V1.3.x/User-Manual/Syntax-Rule.html#identifier
   ##
   ## Available values are:

--- a/plugins/outputs/iotdb/README.md
+++ b/plugins/outputs/iotdb/README.md
@@ -142,7 +142,7 @@ to use them.
   ##   - "device_id"  --  root.sg.device.private.working, s1=100, s2="hello"
   # convert_tags_to = "device_id"
 
-  ## Handling of Unsupported Characters
+  ## Handling of unsupported characters
   ## Some characters in different versions of IoTDB are not supported in path name
   ## A guide with suggetions on valid paths can be found here:
   ## for iotdb 0.13.x           -> https://iotdb.apache.org/UserGuide/V0.13.x/Reference/Syntax-Conventions.html#identifiers

--- a/plugins/outputs/iotdb/iotdb.go
+++ b/plugins/outputs/iotdb/iotdb.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"regexp"
 
 	"github.com/apache/iotdb-client-go/client"
 
@@ -251,7 +252,17 @@ func (s *IoTDB) modifyRecordsWithTags(rwt *recordsWithTags) error {
 		for index, tags := range rwt.TagsList { // for each record
 			topic := []string{rwt.DeviceIDList[index]}
 			for _, tag := range tags { // for each tag, append it's Value
-				topic = append(topic, tag.Value)
+				tag_value := tag.Value
+				// checking if the tag contains a forbidden character
+				is_not_iotdb_valid, _ := regexp.MatchString("[^0-9a-zA-Z_:@#${}]", tag_value)
+				// even if the documentation states that it should work
+				// if the tag is made only of digits an error is trown
+				is_numeric, _ := regexp.MatchString("^\\d+$", tag_value)
+				if (is_not_iotdb_valid || is_numeric) {
+					// wrapping the tag in `` to make it a valid path
+					tag_value = "`" + tag.Value + "`"
+				}
+				topic = append(topic, tag_value)
 			}
 			rwt.DeviceIDList[index] = strings.Join(topic, ".")
 		}

--- a/plugins/outputs/iotdb/iotdb.go
+++ b/plugins/outputs/iotdb/iotdb.go
@@ -255,7 +255,7 @@ func (s *IoTDB) validateTag(tag string) (string, error) {
 
 	// IoTDB uses "root" as a keyword and can be called only at the start of the path
 	if tag == "root" {
-		return "", errors.New("cannot use \"root\" as tag")
+		return "", errors.New("cannot use 'root' as tag")
 	} else if forbiddenBacktick.MatchString(tag) { // returns an error if the backsticks are used in an inappropriate way
 		return "", errors.New("cannot use ` in tag names")
 	} else if allowedBacktick.MatchString(tag) { // if the tag in already enclosed in tags returns the tag

--- a/plugins/outputs/iotdb/iotdb.go
+++ b/plugins/outputs/iotdb/iotdb.go
@@ -232,7 +232,9 @@ func (s *IoTDB) convertMetricsToRecordsWithTags(metrics []telegraf.Metric) (*rec
 
 // checks is the tag contains any IoTDB invalid characters
 func validateTag(tag string) string {
-	matchForbiddenCharacter, _ := regexp.Compile("[^0-9a-zA-Z_:@#${}]")
+	// watch https://iotdb.apache.org/UserGuide/V0.13.x/Reference/Syntax-Conventions.html#identifiers for reference
+	// :@#${} have been excluded after some tests as they seem to not be supported
+	matchForbiddenCharacter, _ := regexp.Compile("[^0-9a-zA-Z_]")
 	// tags made only of int's should be supported
 	// but are still not deemed as valid
 	machNumericString, _ := regexp.Compile("^\\d+$")

--- a/plugins/outputs/iotdb/iotdb.go
+++ b/plugins/outputs/iotdb/iotdb.go
@@ -255,9 +255,9 @@ func (s *IoTDB) validateTag(tag string) (string, error) {
 
 	// IoTDB uses "root" as a keyword and can be called only at the start of the path
 	if tag == "root" {
-		return "", fmt.Errorf("can't append keyword \"root\" to IoTDB base path")
+		return "", errors.New("cannot use \"root\" as tag")
 	} else if forbiddenBacktick.MatchString(tag) { // returns an error if the backsticks are used in an inappropriate way
-		return "", fmt.Errorf("can't use ` in IoTDB base path")
+		return "", errors.New("cannot use ` in tag names")
 	} else if allowedBacktick.MatchString(tag) { // if the tag in already enclosed in tags returns the tag
 		return tag, nil
 	}
@@ -308,11 +308,9 @@ func (s *IoTDB) modifyRecordsWithTags(rwt *recordsWithTags) error {
 			topic := []string{rwt.DeviceIDList[index]}
 			for _, tag := range tags { // for each tag, append it's Value
 				tagValue, err := s.validateTag(tag.Value) // validates tag
-
 				if err != nil {
 					return err
 				}
-
 				topic = append(topic, tagValue)
 			}
 			rwt.DeviceIDList[index] = strings.Join(topic, ".")

--- a/plugins/outputs/iotdb/iotdb.go
+++ b/plugins/outputs/iotdb/iotdb.go
@@ -40,7 +40,7 @@ type IoTDB struct {
 	SanitizeTags    string          `toml:"sanitize_tag"`
 	Log             telegraf.Logger `toml:"-"`
 
-	SanityRegex []*regexp.Regexp
+	sanityRegex []*regexp.Regexp
 	session     *client.Session
 }
 
@@ -85,18 +85,18 @@ func (s *IoTDB) Init() error {
 
 	switch s.SanitizeTags {
 	case "0.13":
-		matchUnsopportedCharacter := regexp.MustCompile("[^0-9a-zA-Z_:@#${}\x60]")
+		matchUnsupportedCharacter := regexp.MustCompile("[^0-9a-zA-Z_:@#${}\x60]")
 
-		regex := []*regexp.Regexp{matchUnsopportedCharacter}
-		s.SanityRegex = append(s.SanityRegex, regex...)
+		regex := []*regexp.Regexp{matchUnsupportedCharacter}
+		s.sanityRegex = append(s.sanityRegex, regex...)
 
 	// from version 1.x.x IoTDB changed the allowed keys in nodes
 	case "1.0", "1.1", "1.2", "1.3":
-		matchUnsopportedCharacter := regexp.MustCompile("[^0-9a-zA-Z_\x60]")
+		matchUnsupportedCharacter := regexp.MustCompile("[^0-9a-zA-Z_\x60]")
 		matchNumericString := regexp.MustCompile(`^\d+$`)
 
-		regex := []*regexp.Regexp{matchUnsopportedCharacter, matchNumericString}
-		s.SanityRegex = append(s.SanityRegex, regex...)
+		regex := []*regexp.Regexp{matchUnsupportedCharacter, matchNumericString}
+		s.sanityRegex = append(s.sanityRegex, regex...)
 	}
 
 	s.Log.Info("Initialization completed.")
@@ -267,7 +267,7 @@ func (s *IoTDB) validateTag(tag string) (string, error) {
 
 	// loops through all the regex patterns and if one
 	// pattern matches returns the tag between `
-	for _, regex := range s.SanityRegex {
+	for _, regex := range s.sanityRegex {
 		if regex.MatchString(tag) {
 			return "`" + tag + "`", nil
 		}

--- a/plugins/outputs/iotdb/iotdb.go
+++ b/plugins/outputs/iotdb/iotdb.go
@@ -250,8 +250,8 @@ func (s *IoTDB) validateTag(tag string) (string, error) {
 	// matches any word that has a non valid backtick
 	// `word`  							 <- dosen't match
 	// ``word , `wo`rd` , `word , word`  <- match
-	forbiddenBacktick, _ := regexp.Compile("^[^\x60].*?[\x60]+.*?[^\x60]$|^[\x60].*[\x60]+.*[\x60]$|^[\x60]+.*[^\x60]$|^[^\x60].*[\x60]+$")
-	allowedBacktick, _ := regexp.Compile("^[\x60].*[\x60]$")
+	forbiddenBacktick := regexp.MustCompile("^[^\x60].*?[\x60]+.*?[^\x60]$|^[\x60].*[\x60]+.*[\x60]$|^[\x60]+.*[^\x60]$|^[^\x60].*[\x60]+$")
+	allowedBacktick := regexp.MustCompile("^[\x60].*[\x60]$")
 
 	// IoTDB uses "root" as a keyword and can be called only at the start of the path
 	if tag == "root" {
@@ -266,15 +266,15 @@ func (s *IoTDB) validateTag(tag string) (string, error) {
 
 	switch s.SanitizeTags {
 	case "0.13":
-		matchUnsopportedCharacter, _ := regexp.Compile("[^0-9a-zA-Z_:@#${}\x60]")
+		matchUnsopportedCharacter := regexp.MustCompile("[^0-9a-zA-Z_:@#${}\x60]")
 
 		regex := []*regexp.Regexp{matchUnsopportedCharacter}
 		regexArray = append(regexArray, regex...)
 
 	// from version 1.x.x IoTDB changed the allowed keys in nodes
 	case "1.0", "1.1", "1.2", "1.3":
-		matchUnsopportedCharacter, _ := regexp.Compile("[^0-9a-zA-Z_\x60]")
-		matchNumericString, _ := regexp.Compile(`^\d+$`)
+		matchUnsopportedCharacter := regexp.MustCompile("[^0-9a-zA-Z_\x60]")
+		matchNumericString := regexp.MustCompile(`^\d+$`)
 
 		regex := []*regexp.Regexp{matchUnsopportedCharacter, matchNumericString}
 		regexArray = append(regexArray, regex...)

--- a/plugins/outputs/iotdb/iotdb.go
+++ b/plugins/outputs/iotdb/iotdb.go
@@ -274,7 +274,7 @@ func (s *IoTDB) validateTag(tag string) (string, error) {
 	// from version 1.x.x IoTDB changed the allowed keys in nodes
 	case "1.0", "1.1", "1.2", "1.3":
 		matchUnsopportedCharacter, _ := regexp.Compile("[^0-9a-zA-Z_\x60]")
-		matchNumericString, _ := regexp.Compile("^\\d+$")
+		matchNumericString, _ := regexp.Compile(`^\d+$`)
 
 		regex := []*regexp.Regexp{matchUnsopportedCharacter, matchNumericString}
 		regexArray = append(regexArray, regex...)
@@ -307,13 +307,13 @@ func (s *IoTDB) modifyRecordsWithTags(rwt *recordsWithTags) error {
 		for index, tags := range rwt.TagsList { // for each record
 			topic := []string{rwt.DeviceIDList[index]}
 			for _, tag := range tags { // for each tag, append it's Value
-				tag_value, err := s.validateTag(tag.Value) // validates tag
+				tagValue, err := s.validateTag(tag.Value) // validates tag
 
 				if err != nil {
 					return err
 				}
 
-				topic = append(topic, tag_value)
+				topic = append(topic, tagValue)
 			}
 			rwt.DeviceIDList[index] = strings.Join(topic, ".")
 		}

--- a/plugins/outputs/iotdb/iotdb_test.go
+++ b/plugins/outputs/iotdb/iotdb_test.go
@@ -271,6 +271,68 @@ func TestMetricConversionToRecordsWithTags(t *testing.T) {
 	}
 }
 
+// Test tag sanitize
+func TestTagSanitization(t *testing.T) {
+	tests := []struct {
+		name     string
+		plugin   *IoTDB
+		expected []string
+		input    []string
+	}{
+		{ //don't sanitize tags containing UnsopportedCharacter on IoTDB V1.3
+			name:     "Don't Sanitize Tags",
+			plugin:   func() *IoTDB { s := newIoTDB(); s.SanitizeTags = "1.3"; return s }(),
+			expected: []string{"word", "`word`", "word_"},
+			input:    []string{"word", "`word`", "word_"},
+		},
+		{ //sanitize tags containing UnsopportedCharacter on IoTDB V1.3 enclosing them in backticks
+			name:     "Sanitize Tags",
+			plugin:   func() *IoTDB { s := newIoTDB(); s.SanitizeTags = "1.3"; return s }(),
+			expected: []string{"`wo rd`", "`@`", "`$`", "`#`", "`:`", "`{`", "`}`", "`1`", "`1234`"},
+			input:    []string{"wo rd", "@", "$", "#", ":", "{", "}", "1", "1234"},
+		},
+		{ //test on forbidden word and forbidden syntax
+			name:     "Errors",
+			plugin:   func() *IoTDB { s := newIoTDB(); s.SanitizeTags = "1.3"; return s }(),
+			expected: []string{"", ""},
+			input:    []string{"root", "wo`rd"},
+		},
+
+		{
+			name:     "Don't Sanitize Tags",
+			plugin:   func() *IoTDB { s := newIoTDB(); s.SanitizeTags = "0.13"; return s }(),
+			expected: []string{"word", "`word`", "word_", "@", "$", "#", ":", "{", "}"},
+			input:    []string{"word", "`word`", "word_", "@", "$", "#", ":", "{", "}"},
+		},
+		{ //sanitize tags containing UnsopportedCharacter on IoTDB V0.13 enclosing them in backticks
+			name:     "Sanitize Tags",
+			plugin:   func() *IoTDB { s := newIoTDB(); s.SanitizeTags = "0.13"; return s }(),
+			expected: []string{"`wo rd`", "`\\`"},
+			input:    []string{"wo rd", "\\"},
+		},
+		{ //test on forbidden word and forbidden syntax on IoTDB V0.13
+			name:     "Errors",
+			plugin:   func() *IoTDB { s := newIoTDB(); s.SanitizeTags = "0.13"; return s }(),
+			expected: []string{"", ""},
+			input:    []string{"root", "wo`rd"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.plugin.Log = &testutil.Logger{}
+			actuals := []string{}
+
+			for _, input := range tt.input {
+				actual, _ := tt.plugin.validateTag(input)
+				actuals = append(actuals, actual)
+			}
+
+			require.EqualValues(t, tt.expected, actuals)
+		})
+	}
+}
+
 // Test tags handling, which means testing function `modifyRecordsWithTags`
 func TestTagsHandling(t *testing.T) {
 	var testTimestamp = time.Date(2022, time.July, 20, 12, 25, 33, 44, time.UTC)

--- a/plugins/outputs/iotdb/iotdb_test.go
+++ b/plugins/outputs/iotdb/iotdb_test.go
@@ -377,7 +377,7 @@ func TestTagsHandling(t *testing.T) {
 			name:   "treat tags as device IDs",
 			plugin: func() *IoTDB { s := newIoTDB(); s.TreatTagsAs = "device_id"; return s }(),
 			expected: recordsWithTags{
-				DeviceIDList:     []string{"root.computer.deviceID.cpu.expensive.`Adattatore Ethernet vmxnet3`"},
+				DeviceIDList:     []string{"root.computer.deviceID.cpu.expensive"},
 				MeasurementsList: [][]string{{"temperature", "counter"}},
 				ValuesList: [][]interface{}{
 					{float64(42.55), int64(987654321)},
@@ -400,7 +400,6 @@ func TestTagsHandling(t *testing.T) {
 				TagsList: [][]*telegraf.Tag{{
 					{Key: "owner", Value: "cpu"},
 					{Key: "price", Value: "expensive"},
-					{Key: "netnic", Value: "Adattatore Ethernet vmxnet3"},
 				}},
 			},
 		},

--- a/plugins/outputs/iotdb/iotdb_test.go
+++ b/plugins/outputs/iotdb/iotdb_test.go
@@ -297,7 +297,6 @@ func TestTagSanitization(t *testing.T) {
 			expected: []string{"", ""},
 			input:    []string{"root", "wo`rd"},
 		},
-
 		{
 			name:     "Don't Sanitize Tags",
 			plugin:   func() *IoTDB { s := newIoTDB(); s.SanitizeTags = "0.13"; return s }(),

--- a/plugins/outputs/iotdb/iotdb_test.go
+++ b/plugins/outputs/iotdb/iotdb_test.go
@@ -315,7 +315,7 @@ func TestTagsHandling(t *testing.T) {
 			name:   "treat tags as device IDs",
 			plugin: func() *IoTDB { s := newIoTDB(); s.TreatTagsAs = "device_id"; return s }(),
 			expected: recordsWithTags{
-				DeviceIDList:     []string{"root.computer.deviceID.cpu.expensive"},
+				DeviceIDList:     []string{"root.computer.deviceID.cpu.expensive.`Adattatore Ethernet vmxnet3`"},
 				MeasurementsList: [][]string{{"temperature", "counter"}},
 				ValuesList: [][]interface{}{
 					{float64(42.55), int64(987654321)},
@@ -338,6 +338,7 @@ func TestTagsHandling(t *testing.T) {
 				TagsList: [][]*telegraf.Tag{{
 					{Key: "owner", Value: "cpu"},
 					{Key: "price", Value: "expensive"},
+					{Key: "netnic", Value: "Adattatore Ethernet vmxnet3"},
 				}},
 			},
 		},

--- a/plugins/outputs/iotdb/iotdb_test.go
+++ b/plugins/outputs/iotdb/iotdb_test.go
@@ -322,6 +322,8 @@ func TestTagSanitization(t *testing.T) {
 			tt.plugin.Log = &testutil.Logger{}
 			actuals := []string{}
 
+			require.NoError(t, tt.plugin.Init())
+
 			for _, input := range tt.input {
 				actual, _ := tt.plugin.validateTag(input)
 				actuals = append(actuals, actual)

--- a/plugins/outputs/iotdb/sample.conf
+++ b/plugins/outputs/iotdb/sample.conf
@@ -43,3 +43,18 @@
   ##   - "fields"     --  root.sg.device, s1=100, s2="hello", tag1="private", tag2="working"
   ##   - "device_id"  --  root.sg.device.private.working, s1=100, s2="hello"
   # convert_tags_to = "device_id"
+
+  ## Handling of Unsupported Characters
+  ## Some characters in different versions of IoTDB are not supported in path name
+  ## A guide with suggetions on valid paths can be found here:
+  ## for iotdb 0.13.x           -> https://iotdb.apache.org/UserGuide/V0.13.x/Reference/Syntax-Conventions.html#timestamp-literals
+  ## for iotdb 1.x.x and above  -> https://iotdb.apache.org/UserGuide/V1.3.x/User-Manual/Syntax-Rule.html#identifier
+  ##
+  ## Available values are:
+  ##   - "1.0", "1.1", "1.2", "1.3"  -- enclose in `` the world having forbidden character 
+  ##                                    such as @ $ # : [ ] { } ( ) space
+  ##   - "0.13"                      -- enclose in `` the world having forbidden character 
+  ##                                    such as space
+  ##
+  ## Keep this section commented if you don't want to sanitize the path
+  # sanitize_tag = "1.3"

--- a/plugins/outputs/iotdb/sample.conf
+++ b/plugins/outputs/iotdb/sample.conf
@@ -47,7 +47,7 @@
   ## Handling of Unsupported Characters
   ## Some characters in different versions of IoTDB are not supported in path name
   ## A guide with suggetions on valid paths can be found here:
-  ## for iotdb 0.13.x           -> https://iotdb.apache.org/UserGuide/V0.13.x/Reference/Syntax-Conventions.html#timestamp-literals
+  ## for iotdb 0.13.x           -> https://iotdb.apache.org/UserGuide/V0.13.x/Reference/Syntax-Conventions.html#identifiers
   ## for iotdb 1.x.x and above  -> https://iotdb.apache.org/UserGuide/V1.3.x/User-Manual/Syntax-Rule.html#identifier
   ##
   ## Available values are:

--- a/plugins/outputs/iotdb/sample.conf
+++ b/plugins/outputs/iotdb/sample.conf
@@ -44,7 +44,7 @@
   ##   - "device_id"  --  root.sg.device.private.working, s1=100, s2="hello"
   # convert_tags_to = "device_id"
 
-  ## Handling of Unsupported Characters
+  ## Handling of unsupported characters
   ## Some characters in different versions of IoTDB are not supported in path name
   ## A guide with suggetions on valid paths can be found here:
   ## for iotdb 0.13.x           -> https://iotdb.apache.org/UserGuide/V0.13.x/Reference/Syntax-Conventions.html#identifiers


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Support for IoTDB ILLEGAL_PATH error when tags contains an illegal character, explained more in detail in issue.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->
resolves #14518 
