### PR TITLE
test(processors.reverse_dns): Switch DNS server to avoid misbehaving test

### DIFF
--- a/plugins/processors/reverse_dns/reverse_dns_test.go
+++ b/plugins/processors/reverse_dns/reverse_dns_test.go
@@ -1,7 +1,6 @@
 package reverse_dns
 
 import (
-	"runtime"
 	"testing"
 	"time"
 
@@ -18,7 +17,7 @@ func TestSimpleReverseLookupIntegration(t *testing.T) {
 
 	now := time.Now()
 	m := metric.New("name", map[string]string{
-		"dest_ip": "8.8.8.8",
+		"dest_ip": "1.1.1.1",
 	}, map[string]interface{}{
 		"source_ip": "127.0.0.1",
 	}, now)
@@ -45,14 +44,9 @@ func TestSimpleReverseLookupIntegration(t *testing.T) {
 
 	require.Len(t, acc.GetTelegrafMetrics(), 1)
 	processedMetric := acc.GetTelegrafMetrics()[0]
-	f, ok := processedMetric.GetField("source_name")
+	_, ok := processedMetric.GetField("source_name")
 	require.True(t, ok)
-	if runtime.GOOS != "windows" {
-		// lookupAddr on Windows works differently than on Linux so `source_name` won't be "localhost" on every environment
-		require.EqualValues(t, "localhost", f)
-	}
-
 	tag, ok := processedMetric.GetTag("dest_name")
 	require.True(t, ok)
-	require.EqualValues(t, "dns.google.", tag)
+	require.EqualValues(t, "one.one.one.one.", tag)
 }


### PR DESCRIPTION
## Summary

The reverse DNS processor integration test is failing constantly. It seems the usage of Google's 8.8.8.8 server is returning with a server misbehaving error. This switches the servers and updates the test to not compare the `source_name` as well. The `source_name` already has a comment about not being localhost on windows, and I now see that on my local system, so simplify the check to ensure it exists.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

