### PR TITLE
fix(common.kafka): Correctly set gssapi username/password

### DIFF
--- a/plugins/common/kafka/sasl.go
+++ b/plugins/common/kafka/sasl.go
@@ -33,7 +33,6 @@ func (k *SASLAuth) SetSASLConfig(cfg *sarama.Config) error {
 	if err != nil {
 		return fmt.Errorf("getting username failed: %w", err)
 	}
-	fmt.Println(username.String())
 	cfg.Net.SASL.User = username.String()
 	defer username.Destroy()
 	password, err := k.SASLPassword.Get()

--- a/plugins/common/kafka/sasl.go
+++ b/plugins/common/kafka/sasl.go
@@ -33,16 +33,15 @@ func (k *SASLAuth) SetSASLConfig(cfg *sarama.Config) error {
 	if err != nil {
 		return fmt.Errorf("getting username failed: %w", err)
 	}
+	fmt.Println(username.String())
 	cfg.Net.SASL.User = username.String()
-	cfg.Net.SASL.GSSAPI.Username = username.String()
-	username.Destroy()
+	defer username.Destroy()
 	password, err := k.SASLPassword.Get()
 	if err != nil {
 		return fmt.Errorf("getting password failed: %w", err)
 	}
 	cfg.Net.SASL.Password = password.String()
-	cfg.Net.SASL.GSSAPI.Password = password.String()
-	password.Destroy()
+	defer password.Destroy()
 
 	if k.SASLMechanism != "" {
 		cfg.Net.SASL.Mechanism = sarama.SASLMechanism(k.SASLMechanism)
@@ -60,6 +59,8 @@ func (k *SASLAuth) SetSASLConfig(cfg *sarama.Config) error {
 		case sarama.SASLTypeGSSAPI:
 			cfg.Net.SASL.GSSAPI.ServiceName = k.SASLGSSAPIServiceName
 			cfg.Net.SASL.GSSAPI.AuthType = gssapiAuthType(k.SASLGSSAPIAuthType)
+			cfg.Net.SASL.GSSAPI.Username = username.String()
+			cfg.Net.SASL.GSSAPI.Password = password.String()
 			cfg.Net.SASL.GSSAPI.DisablePAFXFAST = k.SASLGSSAPIDisablePAFXFAST
 			cfg.Net.SASL.GSSAPI.KerberosConfigPath = k.SASLGSSAPIKerberosConfigPath
 			cfg.Net.SASL.GSSAPI.KeyTabPath = k.SASLGSSAPIKeyTabPath

--- a/plugins/common/kafka/sasl.go
+++ b/plugins/common/kafka/sasl.go
@@ -34,12 +34,14 @@ func (k *SASLAuth) SetSASLConfig(cfg *sarama.Config) error {
 		return fmt.Errorf("getting username failed: %w", err)
 	}
 	cfg.Net.SASL.User = username.String()
+	cfg.Net.SASL.GSSAPI.Username = username.String()
 	username.Destroy()
 	password, err := k.SASLPassword.Get()
 	if err != nil {
 		return fmt.Errorf("getting password failed: %w", err)
 	}
 	cfg.Net.SASL.Password = password.String()
+	cfg.Net.SASL.GSSAPI.Password = password.String()
 	password.Destroy()
 
 	if k.SASLMechanism != "" {
@@ -58,8 +60,6 @@ func (k *SASLAuth) SetSASLConfig(cfg *sarama.Config) error {
 		case sarama.SASLTypeGSSAPI:
 			cfg.Net.SASL.GSSAPI.ServiceName = k.SASLGSSAPIServiceName
 			cfg.Net.SASL.GSSAPI.AuthType = gssapiAuthType(k.SASLGSSAPIAuthType)
-			cfg.Net.SASL.GSSAPI.Username = username.String()
-			cfg.Net.SASL.GSSAPI.Password = password.String()
 			cfg.Net.SASL.GSSAPI.DisablePAFXFAST = k.SASLGSSAPIDisablePAFXFAST
 			cfg.Net.SASL.GSSAPI.KerberosConfigPath = k.SASLGSSAPIKerberosConfigPath
 			cfg.Net.SASL.GSSAPI.KeyTabPath = k.SASLGSSAPIKeyTabPath


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
The username password settings were destroyed before the gssapi config could set them.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

fixes: #14514
