### PR TITLE
fix(inputs.win_perf_counters): Check errors post-collection for skip

### DIFF
--- a/plugins/inputs/win_perf_counters/win_perf_counters.go
+++ b/plugins/inputs/win_perf_counters/win_perf_counters.go
@@ -458,7 +458,7 @@ func (m *WinPerfCounters) Gather(acc telegraf.Accumulator) error {
 			err := m.gatherComputerCounters(hostInfo, acc)
 			m.Log.Debugf("Gathering from %s finished in %v", hostInfo.computer, time.Since(start))
 			if err != nil {
-				acc.AddError(fmt.Errorf("error during collecting data on host %q: %w", hostInfo.computer, err))
+				acc.AddError(fmt.Errorf("error during collecting data on host %q: %w", hostInfo.computer, m.checkError(err)))
 			}
 			wg.Done()
 		}(hostCounterInfo)

--- a/plugins/inputs/win_perf_counters/win_perf_counters.go
+++ b/plugins/inputs/win_perf_counters/win_perf_counters.go
@@ -457,8 +457,8 @@ func (m *WinPerfCounters) Gather(acc telegraf.Accumulator) error {
 			start := time.Now()
 			err := m.gatherComputerCounters(hostInfo, acc)
 			m.Log.Debugf("Gathering from %s finished in %v", hostInfo.computer, time.Since(start))
-			if err != nil {
-				acc.AddError(fmt.Errorf("error during collecting data on host %q: %w", hostInfo.computer, m.checkError(err)))
+			if err != nil && m.checkError(err) != nil {
+				acc.AddError(fmt.Errorf("error during collecting data on host %q: %w", hostInfo.computer, err))
 			}
 			wg.Done()
 		}(hostCounterInfo)


### PR DESCRIPTION
## Summary

This adds the use of check error to an additional error call. This way users who want to opt of additional errors can in fact do so.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #14486
