### PR TITLE
feat(inputs.opcua_listener): Add retry options for connection failures

### DIFF
--- a/docs/developers/SAMPLE_CONFIG.md
+++ b/docs/developers/SAMPLE_CONFIG.md
@@ -28,7 +28,7 @@ Documentation is double commented, full sentences, and ends with a period.
   # exchange_type = "topic"
 ```
 
-Try to give every parameter a default value whenever possible.  If an
+Try to give every parameter a default value whenever possible.  If a
 parameter does not have a default or must frequently be changed then have it
 uncommented.
 

--- a/plugins/inputs/opcua_listener/README.md
+++ b/plugins/inputs/opcua_listener/README.md
@@ -48,6 +48,12 @@ to use them.
   ## Maximum time allowed to establish a connect to the endpoint.
   # connect_timeout = "10s"
   #
+  ## Behavior when we fail to connect to the endpoint on initialization. Valid options are:
+  ##     "error": throw an error and exits Telegraf
+  ##     "ignore": ignore this plugin if errors are encountered
+  #      "retry": retry connecting at each interval
+  # connect_fail_behavior = "error"
+  #
   ## Maximum time allowed for a request over the established connection.
   # request_timeout = "5s"
   #

--- a/plugins/inputs/opcua_listener/sample.conf
+++ b/plugins/inputs/opcua_listener/sample.conf
@@ -9,6 +9,12 @@
   ## Maximum time allowed to establish a connect to the endpoint.
   # connect_timeout = "10s"
   #
+  ## Behavior when we fail to connect to the endpoint on initialization. Valid options are:
+  ##     "error": throw an error and exits Telegraf
+  ##     "ignore": ignore this plugin if errors are encountered
+  #      "retry": retry connecting at each interval
+  # connect_fail_behavior = "error"
+  #
   ## Maximum time allowed for a request over the established connection.
   # request_timeout = "5s"
   #


### PR DESCRIPTION

## Summary

We have several sites with multiple OPC UA servers that may or may not be on at a given time. We would like the ability to for Telegraf to still collect information from other successfully initiated inputs even if it can't talk to the OPC UA server. Now, we have three options when Telegraf fails to start subscriptions:

- error: Exit out of Telegraf (current behavior, new default)
- ignore: Ignore this plugin failure, and continue running all others
- retry: Continue running other plugins, and try to re-establish the connection every collection interval


## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues

resolves #14533 
