### PR TITLE
docs(README): Update minimum system requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,12 @@ incorporate as many pull requests as possible. Consider looking at the
 
 Telegraf shares the same [minimum requirements][] as Go:
 
-- Linux kernel version 2.6.23 or later
-- Windows 7 or later
-- FreeBSD 11.2 or later
-- MacOS 10.11 El Capitan or later
+- Linux kernel version 2.6.32 or later
+- Windows 10 or later
+- FreeBSD 12 or later
+- macOS 10.15 Catalina or later
 
-[minimum requirements]: https://github.com/golang/go/wiki/MinimumRequirements#minimum-requirements
+[minimum requirements]: https://go.dev/wiki/MinimumRequirements
 
 ## Obtaining Telegraf
 


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

Go 1.21 has raised OS requirements once again, and the previous README was no longer accurate.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [X] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

Resolves #14535
