### PR TITLE
feat(agent): persist to statefile at a regular interval

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -564,17 +564,7 @@ func (a *Agent) gatherLoop(
 			err := a.gatherOnce(acc, input, ticker, interval)
 			if err != nil {
 				acc.AddError(err)
-			} else {
-				if a.Config.Persister != nil {
-					id := input.ID()
-					log.Printf("D! [agent] Persisting plugin state for id %q", id)
-
-					if err := a.Config.Persister.StoreOnce(id); err != nil {
-						log.Printf("E! [agent] Error persisting plugin state: %v", err)
-					}
-				}
 			}
-
 		case <-ctx.Done():
 			return
 		}

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -194,7 +194,7 @@ func (a *Agent) Run(ctx context.Context) error {
 		a.runInputs(ctx, startTime, iu)
 	}()
 
-	if a.Config.Persister != nil && a.Config.Agent.EnablePersistInterval {
+	if a.Config.Persister != nil && time.Duration(a.Config.Agent.PersistInterval) > 0 {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -564,7 +564,17 @@ func (a *Agent) gatherLoop(
 			err := a.gatherOnce(acc, input, ticker, interval)
 			if err != nil {
 				acc.AddError(err)
+			} else {
+				if a.Config.Persister != nil {
+					id := input.ID()
+					log.Printf("D! [agent] Persisting plugin state for id %q", id)
+
+					if err := a.Config.Persister.StoreOnce(id); err != nil {
+						log.Printf("E! [agent] Error persisting plugin state: %v", err)
+					}
+				}
 			}
+
 		case <-ctx.Done():
 			return
 		}

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -353,7 +353,7 @@ func (a *Agent) runPersistLoop(
 
 	a.persistLoop(ctx, ticker)
 
-	log.Printf("D! [agent] Stopping the persist loop)")
+	log.Printf("D! [agent] Stopping the persist loop")
 }
 
 func (a *Agent) persistLoop(
@@ -363,6 +363,7 @@ func (a *Agent) persistLoop(
 	for {
 		select {
 		case <-ticker.Elapsed():
+			log.Printf("D! [agent] Persisting state")
 			err := a.Config.Persister.Store()
 			if err != nil {
 				log.Printf("E! [agent] Error writing state on persist loop: %v", err)

--- a/cmd/telegraf/agent.conf
+++ b/cmd/telegraf/agent.conf
@@ -94,3 +94,14 @@
   ## stateful plugins on termination of Telegraf. If the file exists on start,
   ## the state in the file will be restored for the plugins.
   # statefile = ""
+
+  ## If set to true, the agent will persist it's state at a regular interval set
+  ## by statefile_persist_interval.
+  # enable_statefile_persist_interval = false
+
+  ## The interval of time at which the state is peristed into the statefile.
+  # statefile_persist_interval = "10m"
+
+  ## Rounds persist interval to 'interval'
+  ## ie, if interval="10s" then always persist state on :00, :10, :20, etc.
+  # round_statefile_persist_interval = true

--- a/cmd/telegraf/agent.conf
+++ b/cmd/telegraf/agent.conf
@@ -95,12 +95,9 @@
   ## the state in the file will be restored for the plugins.
   # statefile = ""
 
-  ## If set to true, the agent will persist it's state at a regular interval set
-  ## by statefile_persist_interval.
-  # enable_statefile_persist_interval = false
-
   ## The interval of time at which the state is peristed into the statefile.
-  # statefile_persist_interval = "10m"
+  ## When set to 0, persist interval is disabled.
+  # statefile_persist_interval = "0h"
 
   ## Rounds persist interval to 'interval'
   ## ie, if interval="10s" then always persist state on :00, :10, :20, etc.

--- a/cmd/telegraf/agent.conf
+++ b/cmd/telegraf/agent.conf
@@ -95,10 +95,11 @@
   ## the state in the file will be restored for the plugins.
   # statefile = ""
 
-  ## The interval of time at which the state is peristed into the statefile.
-  ## When set to 0, persist interval is disabled.
-  # statefile_persist_interval = "0h"
+  ## When set to 0s, persist interval is disabled.
+  ## Example: statefile_persist_interval = "10m"
+  # statefile_persist_interval = "0s"
 
-  ## Rounds persist interval to 'interval'
-  ## ie, if interval="10s" then always persist state on :00, :10, :20, etc.
+  ## Rounds persist interval to 'statefile_persist_interval'
+  ## ie, if statefile_persist_interval = "10m" then always persist state on
+  ## :00, :10, :20, etc.
   # round_statefile_persist_interval = true

--- a/cmd/telegraf/agent.conf
+++ b/cmd/telegraf/agent.conf
@@ -98,6 +98,7 @@
   ## The interval of time at which the state is peristed into the statefile.
   ## When set to 0s, persist interval is disabled.
   ## Example: statefile_persist_interval = "10m"
+  ## Note: This state may not be consistent across all plugins.
   # statefile_persist_interval = "0s"
 
   ## Rounds persist interval to 'statefile_persist_interval'

--- a/cmd/telegraf/agent.conf
+++ b/cmd/telegraf/agent.conf
@@ -95,6 +95,7 @@
   ## the state in the file will be restored for the plugins.
   # statefile = ""
 
+  ## The interval of time at which the state is peristed into the statefile.
   ## When set to 0s, persist interval is disabled.
   ## Example: statefile_persist_interval = "10m"
   # statefile_persist_interval = "0s"

--- a/cmd/telegraf/telegraf.go
+++ b/cmd/telegraf/telegraf.go
@@ -278,6 +278,10 @@ func (t *Telegraf) runAgent(ctx context.Context, c *config.Config, reloadConfig 
 		return fmt.Errorf("agent flush_interval must be positive; found %v", c.Agent.Interval)
 	}
 
+	if int64(c.Agent.PersistInterval) <= 0 {
+		return fmt.Errorf("agent statefile_persist_interval must be positive; found %v", c.Agent.Interval)
+	}
+
 	// Setup logging as configured.
 	telegraf.Debug = c.Agent.Debug || t.debug
 	logConfig := logger.LogConfig{

--- a/cmd/telegraf/telegraf.go
+++ b/cmd/telegraf/telegraf.go
@@ -279,7 +279,7 @@ func (t *Telegraf) runAgent(ctx context.Context, c *config.Config, reloadConfig 
 	}
 
 	if int64(c.Agent.PersistInterval) < 0 {
-		return fmt.Errorf("agent statefile_persist_interval must be positive or zero; found %v", c.Agent.Interval)
+		return fmt.Errorf("agent statefile_persist_interval must be positive or zero; found %v", c.Agent.PersistInterval)
 	}
 
 	// Setup logging as configured.

--- a/cmd/telegraf/telegraf.go
+++ b/cmd/telegraf/telegraf.go
@@ -278,8 +278,8 @@ func (t *Telegraf) runAgent(ctx context.Context, c *config.Config, reloadConfig 
 		return fmt.Errorf("agent flush_interval must be positive; found %v", c.Agent.Interval)
 	}
 
-	if int64(c.Agent.PersistInterval) <= 0 {
-		return fmt.Errorf("agent statefile_persist_interval must be positive; found %v", c.Agent.Interval)
+	if int64(c.Agent.PersistInterval) < 0 {
+		return fmt.Errorf("agent statefile_persist_interval must be positive or zero; found %v", c.Agent.Interval)
 	}
 
 	// Setup logging as configured.

--- a/config/config.go
+++ b/config/config.go
@@ -261,7 +261,8 @@ type AgentConfig struct {
 	Statefile string `toml:"statefile"`
 
 	// PersistInterval The interval in which the state will be stored into the
-	// statefile. When set to 0, persist interval is disabled.
+	// statefile. When set to 0, persist interval is disabled. Note: This state may not
+	// be consistent across all plugins.
 	PersistInterval Duration `toml:"statefile_persist_interval"`
 
 	// RoundPersistInterval rounds persist interval to 'PersistInterval'.

--- a/config/config.go
+++ b/config/config.go
@@ -119,8 +119,7 @@ func NewConfig() *Config {
 			FlushInterval:              Duration(10 * time.Second),
 			LogTarget:                  "file",
 			LogfileRotationMaxArchives: 5,
-			PersistInterval:            Duration(10 * time.Minute),
-			EnablePersistInterval:      false,
+			PersistInterval:            Duration(0),
 			RoundPersistInterval:       true,
 		},
 
@@ -261,17 +260,13 @@ type AgentConfig struct {
 	// the state in the file will be restored for the plugins.
 	Statefile string `toml:"statefile"`
 
-	// EnablePersistInterval enables the statefile to be persisted to at the
-	// interval specified in PersistInterval
-	EnablePersistInterval bool `toml:"enable_statefile_persist_interval"`
+	// PersistInterval The interval in which the state will be stored into the
+	// statefile. When set to 0, persist interval is disabled.
+	PersistInterval Duration `toml:"statefile_persist_interval"`
 
 	// RoundPersistInterval rounds persist interval to 'interval'.
 	//     ie, if Interval=10s then always persist state on :00, :10, :20, etc.
 	RoundPersistInterval bool `toml:"round_statefile_persist_interval"`
-
-	// PersistInterval The interval in which the state will be stored into the
-	// statefile
-	PersistInterval Duration `toml:"statefile_persist_interval"`
 
 	// Flag to always keep tags explicitly defined in the plugin itself and
 	// ensure those tags always pass filtering.

--- a/config/config.go
+++ b/config/config.go
@@ -264,8 +264,8 @@ type AgentConfig struct {
 	// statefile. When set to 0, persist interval is disabled.
 	PersistInterval Duration `toml:"statefile_persist_interval"`
 
-	// RoundPersistInterval rounds persist interval to 'interval'.
-	//     ie, if Interval=10s then always persist state on :00, :10, :20, etc.
+	// RoundPersistInterval rounds persist interval to 'PersistInterval'.
+	//     ie, if PersistInterval=10m then always persist state on :00, :10, :20, etc.
 	RoundPersistInterval bool `toml:"round_statefile_persist_interval"`
 
 	// Flag to always keep tags explicitly defined in the plugin itself and

--- a/config/config.go
+++ b/config/config.go
@@ -119,6 +119,9 @@ func NewConfig() *Config {
 			FlushInterval:              Duration(10 * time.Second),
 			LogTarget:                  "file",
 			LogfileRotationMaxArchives: 5,
+			PersistInterval:            Duration(10 * time.Minute),
+			EnablePersistInterval:      false,
+			RoundPersistInterval:       true,
 		},
 
 		Tags:               make(map[string]string),
@@ -257,6 +260,18 @@ type AgentConfig struct {
 	// stateful plugins on termination of Telegraf. If the file exists on start,
 	// the state in the file will be restored for the plugins.
 	Statefile string `toml:"statefile"`
+
+	// EnablePersistInterval enables the statefile to be persisted to at the
+	// interval specified in PersistInterval
+	EnablePersistInterval bool `toml:"enable_statefile_persist_interval"`
+
+	// RoundPersistInterval rounds persist interval to 'interval'.
+	//     ie, if Interval=10s then always persist state on :00, :10, :20, etc.
+	RoundPersistInterval bool `toml:"round_statefile_persist_interval"`
+
+	// PersistInterval The interval in which the state will be stored into the
+	// statefile
+	PersistInterval Duration `toml:"statefile_persist_interval"`
 
 	// Flag to always keep tags explicitly defined in the plugin itself and
 	// ensure those tags always pass filtering.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -334,7 +334,7 @@ The agent table configures Telegraf and the defaults used across all plugins.
 
 - **statefile_persist_interval**:
   The interval of time at which the state is peristed into the statefile. When
-  set to 0, persist interval is disabled.
+  set to 0, persist interval is disabled. Note: This state may not be consistent across all plugins.
 
 - **round_statefile_persist_interval**:
   Rounds persist interval to 'statefile_persist_interval'

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -332,6 +332,17 @@ The agent table configures Telegraf and the defaults used across all plugins.
   stateful plugins on termination of Telegraf. If the file exists on start,
   the state in the file will be restored for the plugins.
 
+- **enable_statefile_persist_interval**:
+  If set to true, the agent will persist it's state at a regular interval set
+  by statefile_persist_interval.
+
+- **statefile_persist_interval**:
+  The interval of time at which the state is peristed into the statefile.
+
+- **round_statefile_persist_interval**:
+  Rounds persist interval to 'interval'
+  ie, if interval="10s" then always persist state on :00, :10, :20, etc.
+
 - **always_include_local_tags**:
   Ensure tags explicitly defined in a plugin will *always* pass tag-filtering
   via `taginclude` or `tagexclude`. This removes the need to specify local tags

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -337,8 +337,8 @@ The agent table configures Telegraf and the defaults used across all plugins.
   set to 0, persist interval is disabled.
 
 - **round_statefile_persist_interval**:
-  Rounds persist interval to 'interval'
-  ie, if interval="10s" then always persist state on :00, :10, :20, etc.
+  Rounds persist interval to 'statefile_persist_interval'
+  ie, if statefile_persist_interval ="10m" then always persist state on :00, :10, :20, etc.
 
 - **always_include_local_tags**:
   Ensure tags explicitly defined in a plugin will *always* pass tag-filtering

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -332,12 +332,9 @@ The agent table configures Telegraf and the defaults used across all plugins.
   stateful plugins on termination of Telegraf. If the file exists on start,
   the state in the file will be restored for the plugins.
 
-- **enable_statefile_persist_interval**:
-  If set to true, the agent will persist it's state at a regular interval set
-  by statefile_persist_interval.
-
 - **statefile_persist_interval**:
-  The interval of time at which the state is peristed into the statefile.
+  The interval of time at which the state is peristed into the statefile. When
+  set to 0, persist interval is disabled.
 
 - **round_statefile_persist_interval**:
   Rounds persist interval to 'interval'

--- a/persister/persister.go
+++ b/persister/persister.go
@@ -92,6 +92,11 @@ func (p *Persister) Store() error {
 }
 
 func (p *Persister) StoreOnce(id string) error {
+	plugin, found := p.register[id]
+	if !found {
+		return nil
+	}
+
 	p.stateMutex.Lock()
 	defer p.stateMutex.Unlock()
 
@@ -100,7 +105,6 @@ func (p *Persister) StoreOnce(id string) error {
 		return err
 	}
 
-	plugin := p.register[id]
 	state, err := json.Marshal(plugin.GetState())
 	if err != nil {
 		return fmt.Errorf("marshalling state for id %q failed: %w", id, err)

--- a/persister/persister.go
+++ b/persister/persister.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"reflect"
-	"sync"
 
 	"github.com/influxdata/telegraf"
 )
@@ -13,8 +12,7 @@ import (
 type Persister struct {
 	Filename string
 
-	register   map[string]telegraf.StatefulPlugin
-	stateMutex sync.Mutex
+	register map[string]telegraf.StatefulPlugin
 }
 
 func (p *Persister) Init() error {
@@ -33,9 +31,16 @@ func (p *Persister) Register(id string, plugin telegraf.StatefulPlugin) error {
 }
 
 func (p *Persister) Load() error {
-	states, err := p.loadFile(p.Filename)
+	// Read the states from disk
+	in, err := os.ReadFile(p.Filename)
 	if err != nil {
-		return err
+		return fmt.Errorf("reading states file failed: %w", err)
+	}
+
+	// Unmarshal the id to serialized states map
+	var states map[string][]byte
+	if err := json.Unmarshal(in, &states); err != nil {
+		return fmt.Errorf("unmarshalling states failed: %w", err)
 	}
 
 	// Get the initialized state as blueprint for unmarshalling
@@ -83,68 +88,8 @@ func (p *Persister) Store() error {
 		return fmt.Errorf("marshalling states failed: %w", err)
 	}
 
-	err = p.writeFile(p.Filename, serialized)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (p *Persister) StoreOnce(id string) error {
-	plugin, found := p.register[id]
-	if !found {
-		return nil
-	}
-
-	p.stateMutex.Lock()
-	defer p.stateMutex.Unlock()
-
-	states, err := p.loadFile(p.Filename)
-	if err != nil {
-		return err
-	}
-
-	state, err := json.Marshal(plugin.GetState())
-	if err != nil {
-		return fmt.Errorf("marshalling state for id %q failed: %w", id, err)
-	}
-
-	states[id] = state
-
-	// Serialize the states
-	serialized, err := json.Marshal(states)
-	if err != nil {
-		return fmt.Errorf("marshalling states failed: %w", err)
-	}
-
-	err = p.writeFile(p.Filename, serialized)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (p *Persister) loadFile(filename string) (map[string][]byte, error) {
-	// Read the states from disk
-	in, err := os.ReadFile(filename)
-	if err != nil {
-		return nil, fmt.Errorf("reading states file failed: %w", err)
-	}
-
-	// Unmarshal the id to serialized states map
-	var states map[string][]byte
-	if err := json.Unmarshal(in, &states); err != nil {
-		return nil, fmt.Errorf("unmarshalling states failed: %w", err)
-	}
-
-	return states, nil
-}
-
-func (p *Persister) writeFile(filename string, serialized []byte) error {
 	// Write the states to disk
-	f, err := os.Create(filename)
+	f, err := os.Create(p.Filename)
 	if err != nil {
 		return fmt.Errorf("creating states file %q failed: %w", p.Filename, err)
 	}

--- a/plugins/inputs/tail/tail.go
+++ b/plugins/inputs/tail/tail.go
@@ -108,8 +108,8 @@ func (t *Tail) Init() error {
 }
 
 func (t *Tail) GetState() interface{} {
-	for _, tailer := range t.tailers {
-		if !t.Pipe && !t.FromBeginning {
+	if !t.Pipe && !t.FromBeginning {
+		for _, tailer := range t.tailers {
 			t.storeOffsets(tailer)
 		}
 	}

--- a/plugins/inputs/tail/tail.go
+++ b/plugins/inputs/tail/tail.go
@@ -108,6 +108,12 @@ func (t *Tail) Init() error {
 }
 
 func (t *Tail) GetState() interface{} {
+	for _, tailer := range t.tailers {
+		if !t.Pipe && !t.FromBeginning {
+			t.storeOffsets(tailer)
+		}
+	}
+
 	return t.offsets
 }
 
@@ -123,11 +129,6 @@ func (t *Tail) SetState(state interface{}) error {
 }
 
 func (t *Tail) Gather(_ telegraf.Accumulator) error {
-	for _, tailer := range t.tailers {
-		if !t.Pipe && !t.FromBeginning {
-			t.storeOffsets(tailer)
-		}
-	}
 	return t.tailNewFiles(true)
 }
 

--- a/plugins/inputs/tail/tail.go
+++ b/plugins/inputs/tail/tail.go
@@ -123,6 +123,11 @@ func (t *Tail) SetState(state interface{}) error {
 }
 
 func (t *Tail) Gather(_ telegraf.Accumulator) error {
+	for _, tailer := range t.tailers {
+		if !t.Pipe && !t.FromBeginning {
+			t.storeOffsets(tailer)
+		}
+	}
 	return t.tailNewFiles(true)
 }
 
@@ -372,14 +377,7 @@ func (t *Tail) receiver(parser telegraf.Parser, tailer *tail.Tail) {
 func (t *Tail) Stop() {
 	for _, tailer := range t.tailers {
 		if !t.Pipe && !t.FromBeginning {
-			// store offset for resume
-			offset, err := tailer.Tell()
-			if err == nil {
-				t.Log.Debugf("Recording offset %d for %q", offset, tailer.Filename)
-				t.offsets[tailer.Filename] = offset
-			} else {
-				t.Log.Errorf("Recording offset for %q: %s", tailer.Filename, err.Error())
-			}
+			t.storeOffsets(tailer)
 		}
 		err := tailer.Stop()
 		if err != nil {
@@ -396,6 +394,19 @@ func (t *Tail) Stop() {
 		offsets[k] = v
 	}
 	offsetsMutex.Unlock()
+}
+
+func (t *Tail) storeOffsets(tailer *tail.Tail) {
+	if !t.Pipe && !t.FromBeginning {
+		// store offset for resume
+		offset, err := tailer.Tell()
+		if err == nil {
+			t.Log.Debugf("Recording offset %d for %q", offset, tailer.Filename)
+			t.offsets[tailer.Filename] = offset
+		} else {
+			t.Log.Errorf("Recording offset for %q: %s", tailer.Filename, err.Error())
+		}
+	}
 }
 
 func (t *Tail) SetParserFunc(fn telegraf.ParserFunc) {


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
State is now stored at each gather for each plugin individually.
<img width="1259" alt="Screenshot 2024-01-11 at 11 14 09 AM" src="https://github.com/influxdata/telegraf/assets/34921713/d061ff44-2fe7-433c-b4f1-14739e816ba8">

State is restored correctly if telegraf fails catastrophically.
![Screenshot 2024-01-11 at 11 19 46 AM](https://github.com/influxdata/telegraf/assets/34921713/710b4931-f16c-46be-a133-8498e36481d9)

Change shouldn't affect any current implementation of state usage as its simply writing to the state more frequently.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #14566 
