### PR TITLE
fix(inputs.win_perf_counters): Ignore PdhCstatusNoInstance as well

### DIFF
--- a/plugins/inputs/win_perf_counters/win_perf_counters.go
+++ b/plugins/inputs/win_perf_counters/win_perf_counters.go
@@ -576,6 +576,7 @@ func isKnownCounterDataError(err error) bool {
 		pdhErr.ErrorCode == PdhCalcNegativeDenominator ||
 		pdhErr.ErrorCode == PdhCalcNegativeValue ||
 		pdhErr.ErrorCode == PdhCstatusInvalidData ||
+		pdhErr.ErrorCode == PdhCstatusNoInstance ||
 		pdhErr.ErrorCode == PdhNoData) {
 		return true
 	}


### PR DESCRIPTION

## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Ignore the `PdhCstatusNoInstance` error so we do not stop collecting data for other counters. This PR builds on top of the change from #14526.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #14557
