### PR TITLE
fix(outputs.mqtt): Preserve leading slash in topic

### DIFF
--- a/plugins/outputs/mqtt/mqtt_test.go
+++ b/plugins/outputs/mqtt/mqtt_test.go
@@ -908,6 +908,11 @@ func TestGenerateTopicName(t *testing.T) {
 			pattern: "double//slashes//are//ignored",
 			want:    "double/slashes/are/ignored",
 		},
+		{
+			name:    "preserve leading forward slash",
+			pattern: "/this/is/a/topic",
+			want:    "/this/is/a/topic",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/plugins/outputs/mqtt/topic_name_generator.go
+++ b/plugins/outputs/mqtt/topic_name_generator.go
@@ -43,11 +43,8 @@ func (t *TopicNameGenerator) Generate(hostname string, m telegraf.Metric) (strin
 	if err != nil {
 		return "", err
 	}
-
-	s := b.String()
-
 	var ts []string
-	for _, p := range strings.Split(s, "/") {
+	for _, p := range strings.Split(b.String(), "/") {
 		if p != "" {
 			ts = append(ts, p)
 		}
@@ -57,7 +54,7 @@ func (t *TopicNameGenerator) Generate(hostname string, m telegraf.Metric) (strin
 	if topic == "" {
 		return m.Name(), nil
 	}
-	if strings.HasPrefix(s, "/") {
+	if strings.HasPrefix(b.String(), "/") {
 		topic = fmt.Sprintf("/%s", topic)
 	}
 	return topic, nil

--- a/plugins/outputs/mqtt/topic_name_generator.go
+++ b/plugins/outputs/mqtt/topic_name_generator.go
@@ -43,8 +43,11 @@ func (t *TopicNameGenerator) Generate(hostname string, m telegraf.Metric) (strin
 	if err != nil {
 		return "", err
 	}
+
+	s := b.String()
+
 	var ts []string
-	for _, p := range strings.Split(b.String(), "/") {
+	for _, p := range strings.Split(s, "/") {
 		if p != "" {
 			ts = append(ts, p)
 		}
@@ -53,6 +56,9 @@ func (t *TopicNameGenerator) Generate(hostname string, m telegraf.Metric) (strin
 	// This is to keep backward compatibility with previous behaviour where the plugin name was always present
 	if topic == "" {
 		return m.Name(), nil
+	}
+	if strings.HasPrefix(s, "/") {
+		topic = fmt.Sprintf("/%s", topic)
 	}
 	return topic, nil
 }

--- a/plugins/outputs/mqtt/topic_name_generator.go
+++ b/plugins/outputs/mqtt/topic_name_generator.go
@@ -55,7 +55,7 @@ func (t *TopicNameGenerator) Generate(hostname string, m telegraf.Metric) (strin
 		return m.Name(), nil
 	}
 	if strings.HasPrefix(b.String(), "/") {
-		topic = fmt.Sprintf("/%s", topic)
+		topic = "/" + topic
 	}
 	return topic, nil
 }


### PR DESCRIPTION
## Summary

When using the output plugin [MQTT Producer Output Plugin](https://github.com/influxdata/telegraf/tree/master/plugins/outputs/mqtt) and setting the topic with leading forward slash (e.g. `/sys/productKey/deviceId/thing/event/property/post`), the plugin sends messages to the topic with the leading forward slash trimmed (e.g. `sys/productKey/deviceId/thing/event/property/post`)

Though it's not recommended to use leading forward slash in MQTT topic in many places, some of the cloud IoT platform uses the topics with it, unfortunately (e.g. Aliyun IoT platform 😕 ). 

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #14583
