### PR TITLE
fix(inputs.kafka_consumer): Mark messages that failed parsing

### DIFF
--- a/plugins/inputs/kafka_consumer/kafka_consumer.go
+++ b/plugins/inputs/kafka_consumer/kafka_consumer.go
@@ -483,6 +483,7 @@ func (h *ConsumerGroupHandler) Handle(session sarama.ConsumerGroupSession, msg *
 
 	metrics, err := h.parser.Parse(msg.Value)
 	if err != nil {
+		session.MarkMessage(msg, "")
 		h.release()
 		return err
 	}


### PR DESCRIPTION
## Summary
Mark kafka messages if they failed parsing so that consumer group's partition offsets are committed properly for messages that do not parse properly.

## Checklist

- [X] No AI generated code was used in this PR

## Related issues
resolves #14579

