### PR TITLE
docs(inputs.redis): Add more examples for TLS

### DIFF
--- a/plugins/inputs/redis/README.md
+++ b/plugins/inputs/redis/README.md
@@ -44,6 +44,8 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   # password = ""
 
   ## Optional TLS Config
+  ## Check tls/config.go ClientConfig for more options
+  # tls_enable = true
   # tls_ca = "/etc/telegraf/ca.pem"
   # tls_cert = "/etc/telegraf/cert.pem"
   # tls_key = "/etc/telegraf/key.pem"

--- a/plugins/inputs/redis/sample.conf
+++ b/plugins/inputs/redis/sample.conf
@@ -28,6 +28,8 @@
   # password = ""
 
   ## Optional TLS Config
+  ## Check tls/config.go ClientConfig for more options
+  # tls_enable = true
   # tls_ca = "/etc/telegraf/ca.pem"
   # tls_cert = "/etc/telegraf/cert.pem"
   # tls_key = "/etc/telegraf/key.pem"


### PR DESCRIPTION
## Summary
Extend Readme for using TLS on Redis because it was not clear how to use without cerfiticate.

## Checklist

- [x] No AI generated code was used in this PR
