### PR TITLE
fix(outputs.loki): Closed body before reading it

### DIFF
--- a/plugins/outputs/loki/loki.go
+++ b/plugins/outputs/loki/loki.go
@@ -189,7 +189,7 @@ func (l *Loki) writeMetrics(s Streams) error {
 	if err != nil {
 		return err
 	}
-	_ = resp.Body.Close()
+	defer resp.Body.Close()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		body, _ := io.ReadAll(resp.Body)


### PR DESCRIPTION
## Summary
We use the response body in the error message, but were closing the response body before we had the chance to read it.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
