### PR TITLE
fix(parsers.prometheus): Do not touch input data for protocol-buffers

### DIFF
--- a/plugins/parsers/prometheus/parser.go
+++ b/plugins/parsers/prometheus/parser.go
@@ -26,19 +26,20 @@ func (p *Parser) SetDefaultTags(tags map[string]string) {
 }
 
 func (p *Parser) Parse(data []byte) ([]telegraf.Metric, error) {
-	// Make sure we have a finishing newline but no trailing one
-	data = bytes.TrimPrefix(data, []byte("\n"))
-	if !bytes.HasSuffix(data, []byte("\n")) {
-		data = append(data, []byte("\n")...)
-	}
-	buf := bytes.NewBuffer(data)
-
 	// Determine the metric transport-type derived from the response header and
 	// create a matching decoder.
 	format := expfmt.ResponseFormat(p.Header)
-	if format == expfmt.FmtUnknown {
+	switch format {
+	case expfmt.FmtProtoText:
+		// Make sure we have a finishing newline but no trailing one
+		data = bytes.TrimPrefix(data, []byte("\n"))
+		if !bytes.HasSuffix(data, []byte("\n")) {
+			data = append(data, []byte("\n")...)
+		}
+	case expfmt.FmtUnknown:
 		p.Log.Warnf("Unknown format %q... Trying to continue...", p.Header.Get("Content-Type"))
 	}
+	buf := bytes.NewBuffer(data)
 	decoder := expfmt.NewDecoder(buf, format)
 
 	// Decode the input data into prometheus metrics


### PR DESCRIPTION
## Summary

In the current state we are unconditionally removing leading newlines from the input data and adding a trailing newline. However, this procedure is harmful for protocol-buffer inputs as they usually do start with a `VARINT` (aka `0a ...` aka newline) and binary data should not be tampered with anyway.

Therefore, this PR _only_ applies the newline magic to the text-based prometheus format.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues
