### PR TITLE
chore(internal.snmp): Rephrase error message is about translating OID

### DIFF
--- a/internal/snmp/translate.go
+++ b/internal/snmp/translate.go
@@ -224,7 +224,7 @@ func SnmpTranslateCall(oid string) (mibName string, oidNum string, oidText strin
 		}
 
 		if oidNum = out.RenderNumeric(); oidNum == "" {
-			return oid, oid, oid, oid, out, fmt.Errorf("cannot make %v numeric, please ensure all imported mibs are in the path", oid)
+			return oid, oid, oid, oid, out, fmt.Errorf("cannot translate %v into a numeric OID, please ensure all imported MIBs are in the path", oid)
 		}
 
 		oidNum = "." + oidNum + end


### PR DESCRIPTION
## Summary
This addresses #14598 and #10444 
The previous error message was unclear, especially to newcommers to SNMP, SMI and MIBs. With this slight rephrasing, users may have a better clue as to what the issue might be and can start looking for issues approprietly.

## Checklist
- [X] No AI generated code was used in this PR

## Related issues

resolves #14598 and #10444 - at least partially.
