### PR TITLE
fix(inputs.snmp_trap): correctly handle hex strings in octetStrings

### DIFF
--- a/plugins/inputs/snmp_trap/snmp_trap.go
+++ b/plugins/inputs/snmp_trap/snmp_trap.go
@@ -3,11 +3,13 @@ package snmp_trap
 
 import (
 	_ "embed"
+	"encoding/hex"
 	"fmt"
 	"net"
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/gosnmp/gosnmp"
 
@@ -342,6 +344,13 @@ func makeTrapHandler(s *SnmpTrap) gosnmp.TrapHandlerFunc {
 				if v.Name == ".1.3.6.1.6.3.1.1.4.1.0" {
 					setTrapOid(tags, val, e)
 					continue
+				}
+			case gosnmp.OctetString:
+				// OctetStrings may contain hex data that needs its own conversion
+				if !utf8.ValidString(string(v.Value.([]byte)[:])) {
+					value = hex.EncodeToString(v.Value.([]byte))
+				} else {
+					value = v.Value
 				}
 			default:
 				value = v.Value

--- a/plugins/inputs/snmp_trap/snmp_trap_test.go
+++ b/plugins/inputs/snmp_trap/snmp_trap_test.go
@@ -319,6 +319,11 @@ func TestReceiveTrap(t *testing.T) {
 						Type:  gosnmp.OctetString,
 						Value: "payload",
 					},
+					{
+						Name:  ".1.2.3.4.6",
+						Type:  gosnmp.OctetString,
+						Value: []byte{0x7, 0xe8, 0x1, 0x4, 0xe, 0x2, 0x19, 0x0, 0x0, 0xe, 0x2},
+					},
 				},
 				Enterprise:   ".1.2.3",
 				AgentAddress: "10.20.30.40",
@@ -332,6 +337,13 @@ func TestReceiveTrap(t *testing.T) {
 					snmp.MibEntry{
 						MibName: "valueMIB",
 						OidText: "valueOID",
+					},
+				},
+				{
+					".1.2.3.4.6",
+					snmp.MibEntry{
+						MibName: "valueMIB",
+						OidText: "valueHexOID",
 					},
 				},
 				{
@@ -357,6 +369,7 @@ func TestReceiveTrap(t *testing.T) {
 					map[string]interface{}{ // fields
 						"sysUpTimeInstance": uint(now),
 						"valueOID":          "payload",
+						"valueHexOID":       "07e801040e021900000e02",
 					},
 					fakeTime,
 				),


### PR DESCRIPTION
## Summary
As discussed in #9113, any octetString data that goes beyond valid UTF-8 values will first be converted to a Golang string as the data is instantiated as a Metric. This step changes the presentation of the data but doesn't yet destroy anything, but the following json.Marshal that happens in use cases where the desired output format is JSON, the non-UTF characters get replaced with Unicode replacement characters, overwriting data octets in the process

This fix adds a check for SNMP data of type OctetString, that validates whether the data can be converted into valid UTF-8 or not. If yes, the data is passed unchanged. If not, the data is considered hex and processed with hex.EncodeToString. The end result with our test material is that the hex format timestamp is then passed correctly through processing, preserving both the data and its original presentation unchanged

## Checklist

- [X] No AI generated code was used in this PR

## Related issues

resolves #9113
