### PR TITLE
chore: Drop windows lint gogc value to 1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,7 +122,7 @@ jobs:
           command: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.55.0
       - run:
           name: "Windows"
-          command: GOGC=10 GOOS=windows /go/bin/golangci-lint run --verbose --timeout=30m
+          command: GOGC=1 GOOS=windows /go/bin/golangci-lint run --verbose --timeout=30m
           no_output_timeout: 30m
   test-go-linux:
     executor: telegraf-ci


### PR DESCRIPTION
## Summary
The windows lint job keeps getting killed due to memory pressure. This reduces the GOGC value even further to 1. We may need to look at a large size, at a cost, if this still does not reduce memory usage.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR


