### PR TITLE
fix(common.encoding): Remove locally-defined errors and use upstream ones

### DIFF
--- a/plugins/common/encoding/decoder_reader.go
+++ b/plugins/common/encoding/decoder_reader.go
@@ -78,14 +78,6 @@ type Reader struct {
 }
 
 var (
-	// ErrShortDst means that the destination buffer was too short to
-	// receive all of the transformed bytes.
-	ErrShortDst = errors.New("transform: short destination buffer")
-
-	// ErrShortSrc means that the source buffer has insufficient data to
-	// complete the transformation.
-	ErrShortSrc = errors.New("transform: short source buffer")
-
 	// errInconsistentByteCount means that Transform returned success (nil
 	// error) but also returned nSrc inconsistent with the src argument.
 	errInconsistentByteCount = errors.New("transform: inconsistent byte count returned")
@@ -145,10 +137,10 @@ func (r *Reader) Read(p []byte) (int, error) {
 				// cannot read more bytes into src.
 				r.transformComplete = r.err != nil
 				continue
-			case errors.Is(err, ErrShortDst) && (r.dst1 != 0 || n != 0):
+			case errors.Is(err, transform.ErrShortDst) && (r.dst1 != 0 || n != 0):
 				// Make room in dst by copying out, and try again.
 				continue
-			case errors.Is(err, ErrShortSrc) && r.src1-r.src0 != len(r.src) && r.err == nil:
+			case errors.Is(err, transform.ErrShortSrc) && r.src1-r.src0 != len(r.src) && r.err == nil:
 				// Read more bytes into src via the code below, and try again.
 			default:
 				r.transformComplete = true


### PR DESCRIPTION
## Summary
We have a local defined error (ie ErrShortDst, ErrShortSrc) objects in **decoder_reader.go** which has transferred from an original transformer package. Those uses inside the Read() function to properly manage a slice allocations. It does not work
cause **errors.Is** never set to true cause local errors object it's not the same transformer defined errors objects.
I got this error on my production when _character_encoding = "utf8"_ option was used for _inputs.file_ and dst buffer size is not enough to decode obviously.
Well, we need just to use a proper error objects. This PR to solve the problem. Thx.


- [x] No AI generated code was used in this PR
