### PR TITLE
fix(rpm): Ensure telegraf is installed after useradd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -368,10 +368,10 @@ $(include_packages):
 			--after-remove scripts/rpm/post-remove.sh \
 			--description "Plugin-driven server agent for reporting metrics into InfluxDB." \
 			--depends coreutils \
-			--depends shadow-utils \
 			--rpm-digest sha256 \
 			--rpm-posttrans scripts/rpm/post-install.sh \
 			--rpm-os ${GOOS} \
+			--rpm-tag "Requires(post): /usr/sbin/useradd" \
 			--name telegraf \
 			--version $(version) \
 			--iteration $(rpm_iteration) \

--- a/Makefile
+++ b/Makefile
@@ -371,7 +371,7 @@ $(include_packages):
 			--rpm-digest sha256 \
 			--rpm-posttrans scripts/rpm/post-install.sh \
 			--rpm-os ${GOOS} \
-			--rpm-tag "Requires(post): /usr/sbin/useradd" \
+			--rpm-tag "Requires(pre): /usr/sbin/useradd" \
 			--name telegraf \
 			--version $(version) \
 			--iteration $(rpm_iteration) \

--- a/tools/package_incus_test/container.go
+++ b/tools/package_incus_test/container.go
@@ -82,7 +82,7 @@ func (c *Container) Install(packageName ...string) error {
 	case "dnf":
 		cmd = append([]string{"dnf", "install", "-y"}, packageName...)
 	case "zypper":
-		cmd = append([]string{"zypper", "install", "-y"}, packageName...)
+		cmd = append([]string{"zypper", "--gpg-auto-import-keys", "install", "-y"}, packageName...)
 	}
 
 	err := c.client.Exec(c.Name, cmd...)
@@ -247,7 +247,8 @@ func (c *Container) configureDnf() error {
 func (c *Container) configureZypper() error {
 	err := c.client.Exec(
 		c.Name,
-		"echo", fmt.Sprintf("%q", influxDataRPMRepo), ">", "/etc/zypp/repos.d/influxdata.repo",
+		"bash", "-c", "--",
+		fmt.Sprintf("echo -e %q > /etc/zypp/repos.d/influxdata.repo", influxDataRPMRepo),
 	)
 	if err != nil {
 		return err
@@ -259,7 +260,7 @@ func (c *Container) configureZypper() error {
 		"cat /etc/zypp/repos.d/influxdata.repo",
 	)
 
-	return c.client.Exec(c.Name, "zypper", "refresh")
+	return c.client.Exec(c.Name, "zypper", "--no-gpg-checks", "refresh")
 }
 
 // Determine if the system uses yum or apt for software
@@ -282,6 +283,12 @@ func (c *Container) detectPackageManager() error {
 	err = c.client.Exec(c.Name, "yum", "version")
 	if err == nil {
 		c.packageManager = "yum"
+		return nil
+	}
+
+	err = c.client.Exec(c.Name, "which", "zypper")
+	if err == nil {
+		c.packageManager = "zypper"
 		return nil
 	}
 

--- a/tools/package_incus_test/main.go
+++ b/tools/package_incus_test/main.go
@@ -13,9 +13,7 @@ var imagesRPM = []string{
 	"fedora/39",
 	"fedora/38",
 	"centos/9-Stream",
-	//"opensuse/15.3", 			// shadow-utils dependency bug see #3833
-	//"opensuse/tumbleweed", 	// shadow-utils dependency bug see #3833
-	//"opensuse/15.5",			// shadow-utils dependency bug see #3833
+	"opensuse/tumbleweed",
 }
 
 var imagesDEB = []string{

--- a/tools/package_incus_test/main.go
+++ b/tools/package_incus_test/main.go
@@ -15,6 +15,7 @@ var imagesRPM = []string{
 	"centos/9-Stream",
 	//"opensuse/15.3", 			// shadow-utils dependency bug see #3833
 	//"opensuse/tumbleweed", 	// shadow-utils dependency bug see #3833
+	//"opensuse/15.5",			// shadow-utils dependency bug see #3833
 }
 
 var imagesDEB = []string{


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Enables SuSE support by ensuring telegraf is installed after useradd.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #3833
