### PR TITLE
fix(processors.parser): Drop original tracking metrics

### DIFF
--- a/plugins/processors/parser/parser.go
+++ b/plugins/processors/parser/parser.go
@@ -48,6 +48,8 @@ func (p *Parser) Apply(metrics ...telegraf.Metric) []telegraf.Metric {
 		newMetrics := []telegraf.Metric{}
 		if !p.DropOriginal {
 			newMetrics = append(newMetrics, metric)
+		} else {
+			metric.Drop()
 		}
 
 		// parse fields


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
When tracking metrics are used, the parser processor is not currently marking the tracking metrics as dropped if they are not continued on. This means that the messages are not acknowledged at the input.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

fixes: #14648
