### PR TITLE
chore(inputs.temp): Convert warning on missing sensors to debug message

### DIFF
--- a/plugins/inputs/temp/temp_linux.go
+++ b/plugins/inputs/temp/temp_linux.go
@@ -166,7 +166,7 @@ func (t *Temperature) gatherHwmon(syspath string) ([]TemperatureStat, error) {
 		fn := filepath.Join(path, prefix+"_input")
 		buf, err := os.ReadFile(fn)
 		if err != nil {
-			t.Log.Warnf("Couldn't read temperature from %q: %v", fn, err)
+			t.Log.Debugf("Couldn't read temperature from %q: %v", fn, err)
 			continue
 		}
 		if v, err := strconv.ParseFloat(strings.TrimSpace(string(buf)), 64); err == nil {


### PR DESCRIPTION
## Summary

See discussion in #14645. tl;dr a warning is overkill and a nuisance.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #14645
