### PR TITLE
fix(inputs.redfish): Resolve iLO4 fan data

### DIFF
--- a/plugins/inputs/redfish/README.md
+++ b/plugins/inputs/redfish/README.md
@@ -42,6 +42,11 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## Available sets are: "chassis.location" and "chassis"
   # include_tag_sets = ["chassis.location"]
 
+  ## Workarounds
+  ## Defines workarounds for certain hardware vendors. Choose from:
+  ## * ilo4-thermal - Do not pass 0Data-Version header to Thermal endpoint
+  # workarounds = []
+
   ## Amount of time allowed to complete the HTTP request
   # timeout = "5s"
 

--- a/plugins/inputs/redfish/redfish.go
+++ b/plugins/inputs/redfish/redfish.go
@@ -226,7 +226,7 @@ func (r *Redfish) getData(address string, payload interface{}) error {
 	req.Header.Set("OData-Version", "4.0")
 
 	// workaround for iLO4 thermal data
-	if slices.Contains(r.Workarounds, "ilo4-thermal") && strings.Contains(address, "redfish/v1/Chassis/1/Thermal") {
+	if slices.Contains(r.Workarounds, "ilo4-thermal") && strings.Contains(address, "/Thermal") {
 		req.Header.Del("OData-Version")
 	}
 
@@ -289,7 +289,6 @@ func (r *Redfish) getPower(ref string) (*Power, error) {
 func (r *Redfish) getThermal(ref string) (*Thermal, error) {
 	loc := r.baseURL.ResolveReference(&url.URL{Path: ref})
 	thermal := &Thermal{}
-	fmt.Println(loc.String())
 	err := r.getData(loc.String(), thermal)
 	if err != nil {
 		return nil, err
@@ -377,9 +376,7 @@ func (r *Redfish) gatherThermal(acc telegraf.Accumulator, address string, system
 		acc.AddFields("redfish_thermal_temperatures", fields, tags)
 	}
 
-	fmt.Printf("found %d fans\n", len(thermal.Fans))
 	for _, j := range thermal.Fans {
-		fmt.Println(j)
 		tags := map[string]string{}
 		fields := make(map[string]interface{})
 		tags["member_id"] = j.MemberID

--- a/plugins/inputs/redfish/redfish.go
+++ b/plugins/inputs/redfish/redfish.go
@@ -111,6 +111,8 @@ type Thermal struct {
 	Fans []struct {
 		Name                   string
 		MemberID               string
+		FanName                string
+		CurrentReading         *int64
 		Reading                *int64
 		ReadingUnits           *string
 		UpperThresholdCritical *int64
@@ -364,6 +366,9 @@ func (r *Redfish) gatherThermal(acc telegraf.Accumulator, address string, system
 		tags["member_id"] = j.MemberID
 		tags["address"] = address
 		tags["name"] = j.Name
+		if j.FanName != "" {
+			tags["name"] = j.FanName
+		}
 		tags["source"] = system.Hostname
 		tags["state"] = j.Status.State
 		tags["health"] = j.Status.Health
@@ -383,6 +388,8 @@ func (r *Redfish) gatherThermal(acc telegraf.Accumulator, address string, system
 			fields["lower_threshold_critical"] = j.LowerThresholdCritical
 			fields["lower_threshold_fatal"] = j.LowerThresholdFatal
 			fields["reading_rpm"] = j.Reading
+		} else if j.CurrentReading != nil {
+			fields["reading_percent"] = j.CurrentReading
 		} else {
 			fields["reading_percent"] = j.Reading
 		}

--- a/plugins/inputs/redfish/redfish.go
+++ b/plugins/inputs/redfish/redfish.go
@@ -273,6 +273,7 @@ func (r *Redfish) getPower(ref string) (*Power, error) {
 func (r *Redfish) getThermal(ref string) (*Thermal, error) {
 	loc := r.baseURL.ResolveReference(&url.URL{Path: ref})
 	thermal := &Thermal{}
+	fmt.Println(loc.String())
 	err := r.getData(loc.String(), thermal)
 	if err != nil {
 		return nil, err
@@ -360,7 +361,9 @@ func (r *Redfish) gatherThermal(acc telegraf.Accumulator, address string, system
 		acc.AddFields("redfish_thermal_temperatures", fields, tags)
 	}
 
+	fmt.Printf("found %d fans\n", len(thermal.Fans))
 	for _, j := range thermal.Fans {
+		fmt.Println(j)
 		tags := map[string]string{}
 		fields := make(map[string]interface{})
 		tags["member_id"] = j.MemberID

--- a/plugins/inputs/redfish/sample.conf
+++ b/plugins/inputs/redfish/sample.conf
@@ -21,6 +21,11 @@
   ## Available sets are: "chassis.location" and "chassis"
   # include_tag_sets = ["chassis.location"]
 
+  ## Workarounds
+  ## Defines workarounds for certain hardware vendors. Choose from:
+  ## * ilo4-thermal - Do not pass 0Data-Version header to Thermal endpoint
+  # workarounds = []
+
   ## Amount of time allowed to complete the HTTP request
   # timeout = "5s"
 

--- a/plugins/inputs/redfish/testdata/hp_thermal_ilo4.json
+++ b/plugins/inputs/redfish/testdata/hp_thermal_ilo4.json
@@ -1,0 +1,72 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#Thermal.Thermal",
+    "@odata.etag": "W/\"14E8662D\"",
+    "@odata.id": "/redfish/v1/Chassis/1/Thermal",
+    "@odata.type": "#Thermal.v1_1_0.Thermal",
+    "Id": "Thermal",
+    "Fans": [
+        {
+            "CurrentReading": 17,
+            "FanName": "Fan 1",
+            "Oem": {
+                "Hp": {
+                    "@odata.type": "#HpServerFan.1.0.0.HpServerFan",
+                    "Location": "System",
+                    "Type": "HpServerFan.1.0.0"
+                }
+            },
+            "Status": {
+                "Health": "OK",
+                "State": "Enabled"
+            },
+            "Units": "Percent"
+        }
+    ],
+    "Name": "Thermal",
+    "Temperatures": [
+      {
+        "@odata.id": "/redfish/v1/Chassis/1/Thermal#Temperatures/0",
+        "MemberId": "0",
+        "Name": "01-Inlet Ambient",
+        "Oem": {
+          "Hpe": {
+            "@odata.context": "/redfish/v1/$metadata#HpeSeaOfSensors.HpeSeaOfSensors",
+            "@odata.type": "#HpeSeaOfSensors.v2_0_0.HpeSeaOfSensors",
+            "LocationXmm": 15,
+            "LocationYmm": 0
+          }
+        },
+        "PhysicalContext": "Intake",
+        "ReadingCelsius": 19,
+        "SensorNumber": 1,
+        "Status": {
+          "Health": "OK",
+          "State": "Enabled"
+        },
+        "UpperThresholdCritical": 42,
+        "UpperThresholdFatal": 47
+      },
+      {
+        "@odata.id": "/redfish/v1/Chassis/1/Thermal#Temperatures/42",
+        "MemberId": "42",
+        "Name": "44-P/S 2 Zone",
+        "Oem": {
+          "Hpe": {
+            "@odata.context": "/redfish/v1/$metadata#HpeSeaOfSensors.HpeSeaOfSensors",
+            "@odata.type": "#HpeSeaOfSensors.v2_0_0.HpeSeaOfSensors",
+            "LocationXmm": 4,
+            "LocationYmm": 7
+          }
+        },
+        "PhysicalContext": "PowerSupply",
+        "ReadingCelsius": 34,
+        "SensorNumber": 43,
+        "Status": {
+          "Health": "OK",
+          "State": "Enabled"
+        },
+        "UpperThresholdCritical": 75,
+        "UpperThresholdFatal": 80
+      }
+    ]
+  }


### PR DESCRIPTION
## Summary
HP's iLO 4 was released before redfish support as present. They have added compatibility along the way and we carry a change to add a header to ensure this compatibility occurs. However, this header is not always needed and explains why iLO 4 devices were not returning fan data.

User's of iLO 4, which we have no way of knowing, will need to enable this workaround to get fan data.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #14488
