### PR TITLE
feat(inputs.prometheus): Add option to limit body length

### DIFF
--- a/plugins/inputs/prometheus/README.md
+++ b/plugins/inputs/prometheus/README.md
@@ -84,9 +84,9 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   # pod_scrape_interval = 60
 
   ## Content length limit
-  ## When set, telegraf will drop responses with length larger than the
-  ## configured value in bytes.
-  # content_length_limit = 0
+  ## When set, telegraf will drop responses with length larger than the configured value.
+  ## Default is "0KB" which means unlimited.
+  # content_length_limit = "0KB"
 
   ## Restricts Kubernetes monitoring to a single namespace
   ##   ex: monitor_kubernetes_pods_namespace = "default"

--- a/plugins/inputs/prometheus/README.md
+++ b/plugins/inputs/prometheus/README.md
@@ -83,6 +83,11 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## Default is 60 seconds.
   # pod_scrape_interval = 60
 
+  ## Content length limit
+  ## When set, telegraf will drop responses with length larger than the
+  ## configured value in bytes.
+  # content_length_limit = 0
+
   ## Restricts Kubernetes monitoring to a single namespace
   ##   ex: monitor_kubernetes_pods_namespace = "default"
   # monitor_kubernetes_pods_namespace = ""

--- a/plugins/inputs/prometheus/prometheus.go
+++ b/plugins/inputs/prometheus/prometheus.go
@@ -440,6 +440,9 @@ func (p *Prometheus) gatherURL(u URLAndAddress, acc telegraf.Accumulator) error 
 
 	var body []byte
 	if p.ContentLengthLimit != 0 {
+		// To determine whether io.ReadAll() ended due to EOF or reached the specified limit,
+		// read up to the specified limit plus one extra byte, and then make a decision based
+		// on the length of the result.
 		lr := io.LimitReader(resp.Body, p.ContentLengthLimit+1)
 
 		body, err = io.ReadAll(lr)

--- a/plugins/inputs/prometheus/prometheus.go
+++ b/plugins/inputs/prometheus/prometheus.go
@@ -76,7 +76,7 @@ type Prometheus struct {
 	HTTPHeaders map[string]string `toml:"http_headers"`
 
 	ResponseTimeout    config.Duration `toml:"response_timeout" deprecated:"1.26.0;use 'timeout' instead"`
-	ContentLengthLimit int64           `toml:"content_length_limit"`
+	ContentLengthLimit config.Size     `toml:"content_length_limit"`
 
 	MetricVersion int `toml:"metric_version"`
 
@@ -440,17 +440,19 @@ func (p *Prometheus) gatherURL(u URLAndAddress, acc telegraf.Accumulator) error 
 
 	var body []byte
 	if p.ContentLengthLimit != 0 {
+		limit := int64(p.ContentLengthLimit)
+
 		// To determine whether io.ReadAll() ended due to EOF or reached the specified limit,
 		// read up to the specified limit plus one extra byte, and then make a decision based
 		// on the length of the result.
-		lr := io.LimitReader(resp.Body, p.ContentLengthLimit+1)
+		lr := io.LimitReader(resp.Body, limit+1)
 
 		body, err = io.ReadAll(lr)
 		if err != nil {
 			return fmt.Errorf("error reading body: %w", err)
 		}
-		if int64(len(body)) > p.ContentLengthLimit {
-			p.Log.Infof("skipping %s: content length exceeded maximum body size (%d)", u.URL, p.ContentLengthLimit)
+		if int64(len(body)) > limit {
+			p.Log.Infof("skipping %s: content length exceeded maximum body size (%d)", u.URL, limit)
 			return nil
 		}
 	} else {

--- a/plugins/inputs/prometheus/prometheus.go
+++ b/plugins/inputs/prometheus/prometheus.go
@@ -75,7 +75,8 @@ type Prometheus struct {
 
 	HTTPHeaders map[string]string `toml:"http_headers"`
 
-	ResponseTimeout config.Duration `toml:"response_timeout" deprecated:"1.26.0;use 'timeout' instead"`
+	ResponseTimeout    config.Duration `toml:"response_timeout" deprecated:"1.26.0;use 'timeout' instead"`
+	ContentLengthLimit int64           `toml:"content_length_limit"`
 
 	MetricVersion int `toml:"metric_version"`
 
@@ -437,9 +438,23 @@ func (p *Prometheus) gatherURL(u URLAndAddress, acc telegraf.Accumulator) error 
 		return fmt.Errorf("%q returned HTTP status %q", u.URL, resp.Status)
 	}
 
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return fmt.Errorf("error reading body: %w", err)
+	var body []byte
+	if p.ContentLengthLimit != 0 {
+		lr := io.LimitReader(resp.Body, p.ContentLengthLimit+1)
+
+		body, err = io.ReadAll(lr)
+		if err != nil {
+			return fmt.Errorf("error reading body: %w", err)
+		}
+		if int64(len(body)) > p.ContentLengthLimit {
+			p.Log.Infof("skipping %s: content length exceeded maximum body size (%d)", u.URL, p.ContentLengthLimit)
+			return nil
+		}
+	} else {
+		body, err = io.ReadAll(resp.Body)
+		if err != nil {
+			return fmt.Errorf("error reading body: %w", err)
+		}
 	}
 
 	// Parse the metrics

--- a/plugins/inputs/prometheus/prometheus_test.go
+++ b/plugins/inputs/prometheus/prometheus_test.go
@@ -342,6 +342,28 @@ func TestPrometheusGeneratesMetricsSlowEndpointHitTheTimeoutNewConfigParameter(t
 	require.ErrorContains(t, err, "error making HTTP request to \""+ts.URL+"/metrics\"")
 }
 
+func TestPrometheusContentLengthLimit(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, err := fmt.Fprintln(w, sampleTextFormat)
+		require.NoError(t, err)
+	}))
+	defer ts.Close()
+
+	p := &Prometheus{
+		Log:                testutil.Logger{},
+		URLs:               []string{ts.URL},
+		URLTag:             "url",
+		ContentLengthLimit: 1,
+	}
+	err := p.Init()
+	require.NoError(t, err)
+
+	var acc testutil.Accumulator
+	err = acc.GatherError(p.Gather)
+	require.NoError(t, err)
+	require.Empty(t, acc.Metrics)
+}
+
 func TestPrometheusGeneratesSummaryMetricsV2(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, err := fmt.Fprintln(w, sampleSummaryTextFormat)

--- a/plugins/inputs/prometheus/prometheus_test.go
+++ b/plugins/inputs/prometheus/prometheus_test.go
@@ -355,8 +355,7 @@ func TestPrometheusContentLengthLimit(t *testing.T) {
 		URLTag:             "url",
 		ContentLengthLimit: 1,
 	}
-	err := p.Init()
-	require.NoError(t, err)
+	require.NoError(t, p.Init())
 
 	var acc testutil.Accumulator
 	require.NoError(t, acc.GatherError(p.Gather))

--- a/plugins/inputs/prometheus/prometheus_test.go
+++ b/plugins/inputs/prometheus/prometheus_test.go
@@ -359,8 +359,7 @@ func TestPrometheusContentLengthLimit(t *testing.T) {
 	require.NoError(t, err)
 
 	var acc testutil.Accumulator
-	err = acc.GatherError(p.Gather)
-	require.NoError(t, err)
+	require.NoError(t, p.Gather())
 	require.Empty(t, acc.Metrics)
 }
 

--- a/plugins/inputs/prometheus/prometheus_test.go
+++ b/plugins/inputs/prometheus/prometheus_test.go
@@ -359,7 +359,7 @@ func TestPrometheusContentLengthLimit(t *testing.T) {
 	require.NoError(t, err)
 
 	var acc testutil.Accumulator
-	require.NoError(t, p.Gather())
+	require.NoError(t, acc.GatherError(p.Gather))
 	require.Empty(t, acc.Metrics)
 }
 

--- a/plugins/inputs/prometheus/sample.conf
+++ b/plugins/inputs/prometheus/sample.conf
@@ -67,9 +67,9 @@
   # pod_scrape_interval = 60
 
   ## Content length limit
-  ## When set, telegraf will drop responses with length larger than the
-  ## configured value in bytes.
-  # content_length_limit = 0
+  ## When set, telegraf will drop responses with length larger than the configured value.
+  ## Default is "0KB" which means unlimited.
+  # content_length_limit = "0KB"
 
   ## Restricts Kubernetes monitoring to a single namespace
   ##   ex: monitor_kubernetes_pods_namespace = "default"

--- a/plugins/inputs/prometheus/sample.conf
+++ b/plugins/inputs/prometheus/sample.conf
@@ -66,6 +66,11 @@
   ## Default is 60 seconds.
   # pod_scrape_interval = 60
 
+  ## Content length limit
+  ## When set, telegraf will drop responses with length larger than the
+  ## configured value in bytes.
+  # content_length_limit = 0
+
   ## Restricts Kubernetes monitoring to a single namespace
   ##   ex: monitor_kubernetes_pods_namespace = "default"
   # monitor_kubernetes_pods_namespace = ""


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Introduce a new config option to ensure that the length of the response body is less than the specified limit.
If the body length exceeds the limit, input.prometheus plugin doesn't send the metrics to subsequent plugins. This can prevent running out of buffer space and dropping metrics when very large data is received.

This is to redo the previous PR(https://github.com/influxdata/telegraf/pull/14548) in order to clean up the commit logs and contain the fix for review comments at the PR.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #14437
