### PR TITLE
fix(inputs.snmp_trap): Enable SHA ciphers

### DIFF
--- a/plugins/inputs/snmp_trap/README.md
+++ b/plugins/inputs/snmp_trap/README.md
@@ -71,7 +71,7 @@ details.
   ##
   ## Security Name.
   # sec_name = "myuser"
-  ## Authentication protocol; one of "MD5", "SHA" or "".
+  ## Authentication protocol; one of "MD5", "SHA", "SHA224", "SHA256", "SHA384", "SHA512" or "".
   # auth_protocol = "MD5"
   ## Authentication password.
   # auth_password = "pass"

--- a/plugins/inputs/snmp_trap/README.md
+++ b/plugins/inputs/snmp_trap/README.md
@@ -65,7 +65,7 @@ details.
   ## Deprecated in 1.20.0; no longer running snmptranslate
   ## Timeout running snmptranslate command
   # timeout = "5s"
-  ## Snmp version
+  ## Snmp version; one of "1", "2c" or "3".
   # version = "2c"
   ## SNMPv3 authentication and encryption options.
   ##

--- a/plugins/inputs/snmp_trap/sample.conf
+++ b/plugins/inputs/snmp_trap/sample.conf
@@ -17,13 +17,13 @@
   ## Deprecated in 1.20.0; no longer running snmptranslate
   ## Timeout running snmptranslate command
   # timeout = "5s"
-  ## Snmp version
+  ## Snmp version; one of "1", "2c" or "3".
   # version = "2c"
   ## SNMPv3 authentication and encryption options.
   ##
   ## Security Name.
   # sec_name = "myuser"
-  ## Authentication protocol; one of "MD5", "SHA" or "".
+  ## Authentication protocol; one of "MD5", "SHA", "SHA224", "SHA256", "SHA384", "SHA512" or "".
   # auth_protocol = "MD5"
   ## Authentication password.
   # auth_password = "pass"

--- a/plugins/inputs/snmp_trap/snmp_trap.go
+++ b/plugins/inputs/snmp_trap/snmp_trap.go
@@ -156,14 +156,14 @@ func (s *SnmpTrap) Start(acc telegraf.Accumulator) error {
 			authenticationProtocol = gosnmp.MD5
 		case "sha":
 			authenticationProtocol = gosnmp.SHA
-		//case "sha224":
-		//	authenticationProtocol = gosnmp.SHA224
-		//case "sha256":
-		//	authenticationProtocol = gosnmp.SHA256
-		//case "sha384":
-		//	authenticationProtocol = gosnmp.SHA384
-		//case "sha512":
-		//	authenticationProtocol = gosnmp.SHA512
+		case "sha224":
+			authenticationProtocol = gosnmp.SHA224
+		case "sha256":
+			authenticationProtocol = gosnmp.SHA256
+		case "sha384":
+			authenticationProtocol = gosnmp.SHA384
+		case "sha512":
+			authenticationProtocol = gosnmp.SHA512
 		case "":
 			authenticationProtocol = gosnmp.NoAuth
 		default:

--- a/plugins/inputs/snmp_trap/snmp_trap_test.go
+++ b/plugins/inputs/snmp_trap/snmp_trap_test.go
@@ -61,14 +61,14 @@ func newUsmSecurityParametersForV3(authProto string, privProto string, username 
 		authenticationProtocol = gosnmp.MD5
 	case "sha":
 		authenticationProtocol = gosnmp.SHA
-	//case "sha224":
-	//	authenticationProtocol = gosnmp.SHA224
-	//case "sha256":
-	//	authenticationProtocol = gosnmp.SHA256
-	//case "sha384":
-	//	authenticationProtocol = gosnmp.SHA384
-	//case "sha512":
-	//	authenticationProtocol = gosnmp.SHA512
+	case "sha224":
+		authenticationProtocol = gosnmp.SHA224
+	case "sha256":
+		authenticationProtocol = gosnmp.SHA256
+	case "sha384":
+		authenticationProtocol = gosnmp.SHA384
+	case "sha512":
+		authenticationProtocol = gosnmp.SHA512
 	case "":
 		authenticationProtocol = gosnmp.NoAuth
 	default:
@@ -501,255 +501,254 @@ func TestReceiveTrap(t *testing.T) {
 				),
 			},
 		},
-		/*
-			//ordinary v3 coldstart trap SHA224 auth and no priv
-			{
-				name:      "v3 coldStart authShaNoPriv",
-				version:   gosnmp.Version3,
-				secName:   "authSha224NoPriv",
-				secLevel:  "authNoPriv",
-				authProto: "SHA224",
-				authPass:  "passpass",
-				trap: gosnmp.SnmpTrap{
-					Variables: []gosnmp.SnmpPDU{
-						{
-							Name:  ".1.3.6.1.2.1.1.3.0",
-							Type:  gosnmp.TimeTicks,
-							Value: now,
-						},
-						{
-							Name:  ".1.3.6.1.6.3.1.1.4.1.0", // SNMPv2-MIB::snmpTrapOID.0
-							Type:  gosnmp.ObjectIdentifier,
-							Value: ".1.3.6.1.6.3.1.1.5.1", // coldStart
-						},
-					},
-				},
-				entries: []entry{
+		//ordinary v3 coldstart trap SHA224 auth and no priv
+		{
+			name:      "v3 coldStart authShaNoPriv",
+			version:   gosnmp.Version3,
+			secName:   "authSha224NoPriv",
+			secLevel:  "authNoPriv",
+			authProto: "SHA224",
+			authPass:  "passpass",
+			trap: gosnmp.SnmpTrap{
+				Variables: []gosnmp.SnmpPDU{
 					{
-						oid: ".1.3.6.1.6.3.1.1.4.1.0",
-						e: snmp.MibEntry{
-							MibName: "SNMPv2-MIB",
-							OidText: "snmpTrapOID.0",
-						},
+						Name:  ".1.3.6.1.2.1.1.3.0",
+						Type:  gosnmp.TimeTicks,
+						Value: now,
 					},
 					{
-						oid: ".1.3.6.1.6.3.1.1.5.1",
-						e: snmp.MibEntry{
-							MibName: "SNMPv2-MIB",
-							OidText: "coldStart",
-						},
+						Name:  ".1.3.6.1.6.3.1.1.4.1.0", // SNMPv2-MIB::snmpTrapOID.0
+						Type:  gosnmp.ObjectIdentifier,
+						Value: ".1.3.6.1.6.3.1.1.5.1", // coldStart
 					},
-					{
-						oid: ".1.3.6.1.2.1.1.3.0",
-						e: snmp.MibEntry{
-							MibName: "UNUSED_MIB_NAME",
-							OidText: "sysUpTimeInstance",
-						},
-					},
-				},
-				metrics: []telegraf.Metric{
-					testutil.MustMetric(
-						"snmp_trap", // name
-						map[string]string{ // tags
-							"oid":     ".1.3.6.1.6.3.1.1.5.1",
-							"name":    "coldStart",
-							"mib":     "SNMPv2-MIB",
-							"version": "3",
-							"source":  "127.0.0.1",
-						},
-						map[string]interface{}{ // fields
-							"sysUpTimeInstance": now,
-						},
-						fakeTime,
-					),
 				},
 			},
-			//ordinary v3 coldstart trap SHA256 auth and no priv
-			{
-				name:      "v3 coldStart authSha256NoPriv",
-				version:   gosnmp.Version3,
-				secName:   "authSha256NoPriv",
-				secLevel:  "authNoPriv",
-				authProto: "SHA256",
-				authPass:  "passpass",
-				trap: gosnmp.SnmpTrap{
-					Variables: []gosnmp.SnmpPDU{
-						{
-							Name:  ".1.3.6.1.2.1.1.3.0",
-							Type:  gosnmp.TimeTicks,
-							Value: now,
-						},
-						{
-							Name:  ".1.3.6.1.6.3.1.1.4.1.0", // SNMPv2-MIB::snmpTrapOID.0
-							Type:  gosnmp.ObjectIdentifier,
-							Value: ".1.3.6.1.6.3.1.1.5.1", // coldStart
-						},
+			entries: []entry{
+				{
+					oid: ".1.3.6.1.6.3.1.1.4.1.0",
+					e: snmp.MibEntry{
+						MibName: "SNMPv2-MIB",
+						OidText: "snmpTrapOID.0",
 					},
 				},
-				entries: []entry{
-					{
-						oid: ".1.3.6.1.6.3.1.1.4.1.0",
-						e: snmp.MibEntry{
-							MibName: "SNMPv2-MIB",
-							OidText: "snmpTrapOID.0",
-						},
-					},
-					{
-						oid: ".1.3.6.1.6.3.1.1.5.1",
-						e: snmp.MibEntry{
-							MibName: "SNMPv2-MIB",
-							OidText: "coldStart",
-						},
-					},
-					{
-						oid: ".1.3.6.1.2.1.1.3.0",
-						e: snmp.MibEntry{
-							MibName: "UNUSED_MIB_NAME",
-							OidText: "sysUpTimeInstance",
-						},
+				{
+					oid: ".1.3.6.1.6.3.1.1.5.1",
+					e: snmp.MibEntry{
+						MibName: "SNMPv2-MIB",
+						OidText: "coldStart",
 					},
 				},
-				metrics: []telegraf.Metric{
-					testutil.MustMetric(
-						"snmp_trap", // name
-						map[string]string{ // tags
-							"oid":     ".1.3.6.1.6.3.1.1.5.1",
-							"name":    "coldStart",
-							"mib":     "SNMPv2-MIB",
-							"version": "3",
-							"source":  "127.0.0.1",
-						},
-						map[string]interface{}{ // fields
-							"sysUpTimeInstance": now,
-						},
-						fakeTime,
-					),
+				{
+					oid: ".1.3.6.1.2.1.1.3.0",
+					e: snmp.MibEntry{
+						MibName: "UNUSED_MIB_NAME",
+						OidText: "sysUpTimeInstance",
+					},
 				},
 			},
-			//ordinary v3 coldstart trap SHA384 auth and no priv
-			{
-				name:      "v3 coldStart authSha384NoPriv",
-				version:   gosnmp.Version3,
-				secName:   "authSha384NoPriv",
-				secLevel:  "authNoPriv",
-				authProto: "SHA384",
-				authPass:  "passpass",
-				trap: gosnmp.SnmpTrap{
-					Variables: []gosnmp.SnmpPDU{
-						{
-							Name:  ".1.3.6.1.2.1.1.3.0",
-							Type:  gosnmp.TimeTicks,
-							Value: now,
-						},
-						{
-							Name:  ".1.3.6.1.6.3.1.1.4.1.0", // SNMPv2-MIB::snmpTrapOID.0
-							Type:  gosnmp.ObjectIdentifier,
-							Value: ".1.3.6.1.6.3.1.1.5.1", // coldStart
-						},
+			metrics: []telegraf.Metric{
+				testutil.MustMetric(
+					"snmp_trap", // name
+					map[string]string{ // tags
+						"oid":     ".1.3.6.1.6.3.1.1.5.1",
+						"name":    "coldStart",
+						"mib":     "SNMPv2-MIB",
+						"version": "3",
+						"source":  "127.0.0.1",
 					},
-				},
-				entries: []entry{
-					{
-						oid: ".1.3.6.1.6.3.1.1.4.1.0",
-						e: snmp.MibEntry{
-							MibName: "SNMPv2-MIB",
-							OidText: "snmpTrapOID.0",
-						},
+					map[string]interface{}{ // fields
+						"sysUpTimeInstance": now,
 					},
+					fakeTime,
+				),
+			},
+		},
+		//ordinary v3 coldstart trap SHA256 auth and no priv
+		{
+			name:      "v3 coldStart authSha256NoPriv",
+			version:   gosnmp.Version3,
+			secName:   "authSha256NoPriv",
+			secLevel:  "authNoPriv",
+			authProto: "SHA256",
+			authPass:  "passpass",
+			trap: gosnmp.SnmpTrap{
+				Variables: []gosnmp.SnmpPDU{
 					{
-						oid: ".1.3.6.1.6.3.1.1.5.1",
-						e: snmp.MibEntry{
-							MibName: "SNMPv2-MIB",
-							OidText: "coldStart",
-						},
+						Name:  ".1.3.6.1.2.1.1.3.0",
+						Type:  gosnmp.TimeTicks,
+						Value: now,
 					},
 					{
-						oid: ".1.3.6.1.2.1.1.3.0",
-						e: snmp.MibEntry{
-							MibName: "UNUSED_MIB_NAME",
-							OidText: "sysUpTimeInstance",
-						},
+						Name:  ".1.3.6.1.6.3.1.1.4.1.0", // SNMPv2-MIB::snmpTrapOID.0
+						Type:  gosnmp.ObjectIdentifier,
+						Value: ".1.3.6.1.6.3.1.1.5.1", // coldStart
 					},
-				},
-				metrics: []telegraf.Metric{
-					testutil.MustMetric(
-						"snmp_trap", // name
-						map[string]string{ // tags
-							"oid":     ".1.3.6.1.6.3.1.1.5.1",
-							"name":    "coldStart",
-							"mib":     "SNMPv2-MIB",
-							"version": "3",
-							"source":  "127.0.0.1",
-						},
-						map[string]interface{}{ // fields
-							"sysUpTimeInstance": now,
-						},
-						fakeTime,
-					),
 				},
 			},
-			//ordinary v3 coldstart trap SHA512 auth and no priv
-			{
-				name:      "v3 coldStart authShaNoPriv",
-				version:   gosnmp.Version3,
-				secName:   "authSha512NoPriv",
-				secLevel:  "authNoPriv",
-				authProto: "SHA512",
-				authPass:  "passpass",
-				trap: gosnmp.SnmpTrap{
-					Variables: []gosnmp.SnmpPDU{
-						{
-							Name:  ".1.3.6.1.2.1.1.3.0",
-							Type:  gosnmp.TimeTicks,
-							Value: now,
-						},
-						{
-							Name:  ".1.3.6.1.6.3.1.1.4.1.0", // SNMPv2-MIB::snmpTrapOID.0
-							Type:  gosnmp.ObjectIdentifier,
-							Value: ".1.3.6.1.6.3.1.1.5.1", // coldStart
-						},
+			entries: []entry{
+				{
+					oid: ".1.3.6.1.6.3.1.1.4.1.0",
+					e: snmp.MibEntry{
+						MibName: "SNMPv2-MIB",
+						OidText: "snmpTrapOID.0",
 					},
 				},
-				entries: []entry{
-					{
-						oid: ".1.3.6.1.6.3.1.1.4.1.0",
-						e: snmp.MibEntry{
-							MibName: "SNMPv2-MIB",
-							OidText: "snmpTrapOID.0",
-						},
-					},
-					{
-						oid: ".1.3.6.1.6.3.1.1.5.1",
-						e: snmp.MibEntry{
-							MibName: "SNMPv2-MIB",
-							OidText: "coldStart",
-						},
-					},
-					{
-						oid: ".1.3.6.1.2.1.1.3.0",
-						e: snmp.MibEntry{
-							MibName: "UNUSED_MIB_NAME",
-							OidText: "sysUpTimeInstance",
-						},
+				{
+					oid: ".1.3.6.1.6.3.1.1.5.1",
+					e: snmp.MibEntry{
+						MibName: "SNMPv2-MIB",
+						OidText: "coldStart",
 					},
 				},
-				metrics: []telegraf.Metric{
-					testutil.MustMetric(
-						"snmp_trap", // name
-						map[string]string{ // tags
-							"oid":     ".1.3.6.1.6.3.1.1.5.1",
-							"name":    "coldStart",
-							"mib":     "SNMPv2-MIB",
-							"version": "3",
-							"source":  "127.0.0.1",
-						},
-						map[string]interface{}{ // fields
-							"sysUpTimeInstance": now,
-						},
-						fakeTime,
-					),
+				{
+					oid: ".1.3.6.1.2.1.1.3.0",
+					e: snmp.MibEntry{
+						MibName: "UNUSED_MIB_NAME",
+						OidText: "sysUpTimeInstance",
+					},
 				},
-			},*/
+			},
+			metrics: []telegraf.Metric{
+				testutil.MustMetric(
+					"snmp_trap", // name
+					map[string]string{ // tags
+						"oid":     ".1.3.6.1.6.3.1.1.5.1",
+						"name":    "coldStart",
+						"mib":     "SNMPv2-MIB",
+						"version": "3",
+						"source":  "127.0.0.1",
+					},
+					map[string]interface{}{ // fields
+						"sysUpTimeInstance": now,
+					},
+					fakeTime,
+				),
+			},
+		},
+		//ordinary v3 coldstart trap SHA384 auth and no priv
+		{
+			name:      "v3 coldStart authSha384NoPriv",
+			version:   gosnmp.Version3,
+			secName:   "authSha384NoPriv",
+			secLevel:  "authNoPriv",
+			authProto: "SHA384",
+			authPass:  "passpass",
+			trap: gosnmp.SnmpTrap{
+				Variables: []gosnmp.SnmpPDU{
+					{
+						Name:  ".1.3.6.1.2.1.1.3.0",
+						Type:  gosnmp.TimeTicks,
+						Value: now,
+					},
+					{
+						Name:  ".1.3.6.1.6.3.1.1.4.1.0", // SNMPv2-MIB::snmpTrapOID.0
+						Type:  gosnmp.ObjectIdentifier,
+						Value: ".1.3.6.1.6.3.1.1.5.1", // coldStart
+					},
+				},
+			},
+			entries: []entry{
+				{
+					oid: ".1.3.6.1.6.3.1.1.4.1.0",
+					e: snmp.MibEntry{
+						MibName: "SNMPv2-MIB",
+						OidText: "snmpTrapOID.0",
+					},
+				},
+				{
+					oid: ".1.3.6.1.6.3.1.1.5.1",
+					e: snmp.MibEntry{
+						MibName: "SNMPv2-MIB",
+						OidText: "coldStart",
+					},
+				},
+				{
+					oid: ".1.3.6.1.2.1.1.3.0",
+					e: snmp.MibEntry{
+						MibName: "UNUSED_MIB_NAME",
+						OidText: "sysUpTimeInstance",
+					},
+				},
+			},
+			metrics: []telegraf.Metric{
+				testutil.MustMetric(
+					"snmp_trap", // name
+					map[string]string{ // tags
+						"oid":     ".1.3.6.1.6.3.1.1.5.1",
+						"name":    "coldStart",
+						"mib":     "SNMPv2-MIB",
+						"version": "3",
+						"source":  "127.0.0.1",
+					},
+					map[string]interface{}{ // fields
+						"sysUpTimeInstance": now,
+					},
+					fakeTime,
+				),
+			},
+		},
+		//ordinary v3 coldstart trap SHA512 auth and no priv
+		{
+			name:      "v3 coldStart authShaNoPriv",
+			version:   gosnmp.Version3,
+			secName:   "authSha512NoPriv",
+			secLevel:  "authNoPriv",
+			authProto: "SHA512",
+			authPass:  "passpass",
+			trap: gosnmp.SnmpTrap{
+				Variables: []gosnmp.SnmpPDU{
+					{
+						Name:  ".1.3.6.1.2.1.1.3.0",
+						Type:  gosnmp.TimeTicks,
+						Value: now,
+					},
+					{
+						Name:  ".1.3.6.1.6.3.1.1.4.1.0", // SNMPv2-MIB::snmpTrapOID.0
+						Type:  gosnmp.ObjectIdentifier,
+						Value: ".1.3.6.1.6.3.1.1.5.1", // coldStart
+					},
+				},
+			},
+			entries: []entry{
+				{
+					oid: ".1.3.6.1.6.3.1.1.4.1.0",
+					e: snmp.MibEntry{
+						MibName: "SNMPv2-MIB",
+						OidText: "snmpTrapOID.0",
+					},
+				},
+				{
+					oid: ".1.3.6.1.6.3.1.1.5.1",
+					e: snmp.MibEntry{
+						MibName: "SNMPv2-MIB",
+						OidText: "coldStart",
+					},
+				},
+				{
+					oid: ".1.3.6.1.2.1.1.3.0",
+					e: snmp.MibEntry{
+						MibName: "UNUSED_MIB_NAME",
+						OidText: "sysUpTimeInstance",
+					},
+				},
+			},
+			metrics: []telegraf.Metric{
+				testutil.MustMetric(
+					"snmp_trap", // name
+					map[string]string{ // tags
+						"oid":     ".1.3.6.1.6.3.1.1.5.1",
+						"name":    "coldStart",
+						"mib":     "SNMPv2-MIB",
+						"version": "3",
+						"source":  "127.0.0.1",
+					},
+					map[string]interface{}{ // fields
+						"sysUpTimeInstance": now,
+					},
+					fakeTime,
+				),
+			},
+		},
 		//ordinary v3 coldstart trap SHA auth and no priv
 		{
 			name:      "v3 coldStart authShaNoPriv",


### PR DESCRIPTION
## Summary
SHA224, SHA256, SHA384 and SHA512 ciphers had been commented out when SNMPv3 support was implemented because they were not at that time yet sufficiently supported by gosnmp. Gosnmp has advanced and the ciphers are now fully working, so they can be added to the list of valid options for the snmp_trap plugin

## Checklist

- [X] No AI generated code was used in this PR

## Related issues

resolves #14664 
