### PR TITLE
fix(inputs.filecount): Respect symlink files with FollowSymLinks

### DIFF
--- a/plugins/inputs/filecount/filesystem_helpers.go
+++ b/plugins/inputs/filecount/filesystem_helpers.go
@@ -14,6 +14,7 @@ import (
 type fileSystem interface {
 	Open(name string) (file, error)
 	Stat(name string) (os.FileInfo, error)
+	Lstat(name string) (os.FileInfo, error)
 }
 
 type file interface {
@@ -27,5 +28,6 @@ type file interface {
 // osFS implements fileSystem using the local disk
 type osFS struct{}
 
-func (osFS) Open(name string) (file, error)        { return os.Open(name) }
-func (osFS) Stat(name string) (os.FileInfo, error) { return os.Stat(name) }
+func (osFS) Open(name string) (file, error)         { return os.Open(name) }
+func (osFS) Stat(name string) (os.FileInfo, error)  { return os.Stat(name) }
+func (osFS) Lstat(name string) (os.FileInfo, error) { return os.Lstat(name) }

--- a/plugins/inputs/filecount/filesystem_helpers_notwindows.go
+++ b/plugins/inputs/filecount/filesystem_helpers_notwindows.go
@@ -50,3 +50,8 @@ func (f fakeFileSystem) Stat(name string) (os.FileInfo, error) {
 	}
 	return nil, &os.PathError{Op: "Stat", Path: name, Err: errors.New("no such file or directory")}
 }
+
+func (f fakeFileSystem) Lstat(name string) (os.FileInfo, error) {
+	// not able to test with symlinks currently
+	return f.Stat(name)
+}


### PR DESCRIPTION
## Summary
`godirwalk` does not automatically filter out symlink files with its `FollowSymbolicLinks` config option. Changes to calling `Fstat` if needed to respect the settings, where before it would call `Stat` and automatically follow the link

## Checklist

- [X] No AI generated code was used in this PR

## Related issues
resolves #13250
