### PR TITLE
feat(opcua, opcua_listener): Log info for nodes not in server namespace to Debug

### DIFF
--- a/plugins/common/opcua/input/input_client.go
+++ b/plugins/common/opcua/input/input_client.go
@@ -391,7 +391,7 @@ func (o *OpcUAInputClient) initLastReceivedValues() {
 func (o *OpcUAInputClient) UpdateNodeValue(nodeIdx int, d *ua.DataValue) {
 	o.LastReceivedData[nodeIdx].Quality = d.Status
 	if !o.StatusCodeOK(d.Status) {
-		o.Log.Errorf("status not OK for node %v: %v", o.NodeMetricMapping[nodeIdx].Tag.FieldName, d.Status)
+		o.Log.Errorf("status not OK for node %v (%v): %v", o.NodeMetricMapping[nodeIdx].Tag.FieldName, o.NodeIDs[nodeIdx].String(), d.Status)
 		return
 	}
 

--- a/plugins/inputs/opcua_listener/subscribe_client.go
+++ b/plugins/inputs/opcua_listener/subscribe_client.go
@@ -172,8 +172,9 @@ func (o *SubscribeClient) StartStreamValues(ctx context.Context) (<-chan telegra
 	}
 	o.Log.Debug("Monitoring items")
 
-	for _, res := range resp.Results {
+	for idx, res := range resp.Results {
 		if !o.StatusCodeOK(res.StatusCode) {
+			o.Log.Debugf("Failed to create monitored item for node %v (%v)", o.OpcUAInputClient.NodeMetricMapping[idx].Tag.FieldName, o.OpcUAInputClient.NodeIDs[idx].String())
 			return nil, fmt.Errorf("creating monitored item failed with status code: %w", res.StatusCode)
 		}
 	}


### PR DESCRIPTION
## Summary
Add Debug logging of node name and identifier for nodes that are not in OPC-UA server namespace

## Checklist
- [x ] No AI generated code was used in this PR

## Related issues
resolves #14675 
