### PR TITLE
fix(inputs.kafka_consumer): Correctly setting name to `msg_headers_as_tags`

### DIFF
--- a/plugins/inputs/kafka_consumer/README.md
+++ b/plugins/inputs/kafka_consumer/README.md
@@ -66,11 +66,11 @@ to use them.
   ## The list of Kafka message headers that should be pass as metric tags
   ## works only for Kafka version 0.11+, on lower versions the message headers
   ## are not available
-  # msg_headers_to_tags = []
+  # msg_headers_as_tags = []
 
   ## The name of kafka message header which value should override the metric name.
-  ## In case when the same header specified in current option and in msg_headers_to_tags
-  ## option, it will be excluded from the msg_headers_to_tags list.
+  ## In case when the same header specified in current option and in msg_headers_as_tags
+  ## option, it will be excluded from the msg_headers_as_tags list.
   # msg_header_as_metric_name = ""
 
   ## Optional Client id

--- a/plugins/inputs/kafka_consumer/sample.conf
+++ b/plugins/inputs/kafka_consumer/sample.conf
@@ -26,11 +26,11 @@
   ## The list of Kafka message headers that should be pass as metric tags
   ## works only for Kafka version 0.11+, on lower versions the message headers
   ## are not available
-  # msg_headers_to_tags = []
+  # msg_headers_as_tags = []
 
   ## The name of kafka message header which value should override the metric name.
-  ## In case when the same header specified in current option and in msg_headers_to_tags
-  ## option, it will be excluded from the msg_headers_to_tags list.
+  ## In case when the same header specified in current option and in msg_headers_as_tags
+  ## option, it will be excluded from the msg_headers_as_tags list.
   # msg_header_as_metric_name = ""
 
   ## Optional Client id


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Correctly change Kafka telegraf's configuration variable name to `msg_headers_as_tags` from `msg_headers_to_tags`

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
- [x] https://github.com/influxdata/telegraf/issues/14678