### PR TITLE
feat(inputs.nvidia_smi): Add startup_error_behavior config option

### DIFF
--- a/plugins/inputs/nvidia_smi/README.md
+++ b/plugins/inputs/nvidia_smi/README.md
@@ -23,9 +23,11 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## if it is not found, we will try to locate it on PATH(exec.LookPath), if it is still not found, an error will be returned
   # bin_path = "/usr/bin/nvidia-smi"
 
-  ## Optional: decide if GPU is not found for Telegraf to proceed with other metrics or error out
-  ## Valid values are "error" (the default) and "ignore"
-  # if_not_found = "error"
+  ## Optional: specifies plugin behavior regarding missing nvidia-smi binary
+  ## Available choices:
+  ##   - error: telegraf will return an error on startup
+  ##   - ignore: telegraf will ignore this plugin
+  # startup_error_behavior = "error"
 
   ## Optional: timeout for GPU polling
   # timeout = "5s"

--- a/plugins/inputs/nvidia_smi/README.md
+++ b/plugins/inputs/nvidia_smi/README.md
@@ -23,6 +23,10 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## if it is not found, we will try to locate it on PATH(exec.LookPath), if it is still not found, an error will be returned
   # bin_path = "/usr/bin/nvidia-smi"
 
+  ## Optional: decide if GPU is not found for Telegraf to proceed with other metrics or error out
+  ## Valid values are "error" (the default) and "ignore"
+  # if_not_found = "error"
+
   ## Optional: timeout for GPU polling
   # timeout = "5s"
 ```

--- a/plugins/inputs/nvidia_smi/nvidia_smi.go
+++ b/plugins/inputs/nvidia_smi/nvidia_smi.go
@@ -123,9 +123,9 @@ func (smi *NvidiaSMI) parse(acc telegraf.Accumulator, data []byte) error {
 func init() {
 	inputs.Add("nvidia_smi", func() telegraf.Input {
 		return &NvidiaSMI{
-			BinPath: "/usr/bin/nvidia-smi",
+			BinPath:    "/usr/bin/nvidia-smi",
 			IfNotFound: "error",
-			Timeout: config.Duration(5 * time.Second),
+			Timeout:    config.Duration(5 * time.Second),
 		}
 	})
 }

--- a/plugins/inputs/nvidia_smi/nvidia_smi.go
+++ b/plugins/inputs/nvidia_smi/nvidia_smi.go
@@ -27,10 +27,10 @@ var sampleConfig string
 
 // NvidiaSMI holds the methods for this plugin
 type NvidiaSMI struct {
-	BinPath    string          `toml:"bin_path"`
-	Timeout    config.Duration `toml:"timeout"`
-	IfNotFound string          `toml:"if_not_found"`
-	Log        telegraf.Logger `toml:"-"`
+	BinPath              string          `toml:"bin_path"`
+	Timeout              config.Duration `toml:"timeout"`
+	StartupErrorBehavior string          `toml:"startup_error_behavior"`
+	Log                  telegraf.Logger `toml:"-"`
 
 	once sync.Once
 }
@@ -45,7 +45,7 @@ func (smi *NvidiaSMI) Init() error {
 
 		// fail-fast
 		if err != nil {
-			switch smi.IfNotFound {
+			switch smi.StartupErrorBehavior {
 			case "ignore":
 				// Ignore the error and move on
 				smi.Log.Warnf("GPU SMI not found on the system, ignoring: %s", err)
@@ -123,9 +123,9 @@ func (smi *NvidiaSMI) parse(acc telegraf.Accumulator, data []byte) error {
 func init() {
 	inputs.Add("nvidia_smi", func() telegraf.Input {
 		return &NvidiaSMI{
-			BinPath:    "/usr/bin/nvidia-smi",
-			IfNotFound: "error",
-			Timeout:    config.Duration(5 * time.Second),
+			BinPath:              "/usr/bin/nvidia-smi",
+			StartupErrorBehavior: "error",
+			Timeout:              config.Duration(5 * time.Second),
 		}
 	})
 }

--- a/plugins/inputs/nvidia_smi/nvidia_smi.go
+++ b/plugins/inputs/nvidia_smi/nvidia_smi.go
@@ -48,7 +48,7 @@ func (smi *NvidiaSMI) Init() error {
 			switch smi.IfNotFound {
 			case "ignore":
 				// Ignore the error and move on
-				smi.log.Warnf("GPU SMI not found on the system, ignoring: %s", err)
+				smi.Log.Warnf("GPU SMI not found on the system, ignoring: %s", err)
 				return nil
 			case "", "error":
 			default:

--- a/plugins/inputs/nvidia_smi/nvidia_smi.go
+++ b/plugins/inputs/nvidia_smi/nvidia_smi.go
@@ -57,7 +57,7 @@ func (smi *NvidiaSMI) Init() error {
 		}
 		smi.BinPath = binPath
 	}
-	
+
 	return nil
 }
 

--- a/plugins/inputs/nvidia_smi/nvidia_smi_test.go
+++ b/plugins/inputs/nvidia_smi/nvidia_smi_test.go
@@ -19,7 +19,6 @@ func TestStartPluginIfGPUNotFound(t *testing.T) {
 	plugin.IfNotFound = "ignore"
 	plugin.BinPath = "/random/non-existent/path"
 	require.NoError(t, plugin.Init())
-	require.NoError(t, plugin.Start(acc))
 
 	plugin.IfNotFound = "error"
 	plugin.BinPath = "/random/non-existent/path"
@@ -28,7 +27,6 @@ func TestStartPluginIfGPUNotFound(t *testing.T) {
 	plugin.IfNotFound = "error"
 	plugin.BinPath = "/usr/bin/nvidia-smi"
 	require.NoError(t, plugin.Init())
-	require.NoError(t, plugin.Start(acc))
 }
 
 func TestGatherValidXML(t *testing.T) {

--- a/plugins/inputs/nvidia_smi/nvidia_smi_test.go
+++ b/plugins/inputs/nvidia_smi/nvidia_smi_test.go
@@ -16,18 +16,18 @@ func TestStartPluginIfGPUNotFound(t *testing.T) {
 
 	var acc testutil.Accumulator
 
-	plugin.sampleConfig.IfNotFound = "ignore"
-	plugin.sampleConfig.BinPath = "/random/non-existent/path"
+	plugin.SampleConfig.IfNotFound = "ignore"
+	plugin.SampleConfig.BinPath = "/random/non-existent/path"
 	require.NoError(t, plugin.Init())
 	require.NoError(t, plugin.Start(acc))
 	plugin.Stop()
 
-	plugin.sampleConfig.IfNotFound = "error"
-	plugin.sampleConfig.BinPath = "/random/non-existent/path"
+	plugin.SampleConfig.IfNotFound = "error"
+	plugin.SampleConfig.BinPath = "/random/non-existent/path"
 	require.NoError(t, plugin.Init(), "nvidia-smi not found in /random/non-existent/path and not in PATH; please make sure nvidia-smi is installed and/or is in PATH")
 
-	plugin.sampleConfig.IfNotFound = "error"
-	plugin.sampleConfig.BinPath = "/usr/bin/nvidia-smi"
+	plugin.SampleConfig.IfNotFound = "error"
+	plugin.SampleConfig.BinPath = "/usr/bin/nvidia-smi"
 	require.NoError(t, plugin.Init())
 	require.NoError(t, plugin.Start(acc))
 	plugin.Stop()

--- a/plugins/inputs/nvidia_smi/nvidia_smi_test.go
+++ b/plugins/inputs/nvidia_smi/nvidia_smi_test.go
@@ -16,21 +16,19 @@ func TestStartPluginIfGPUNotFound(t *testing.T) {
 
 	var acc testutil.Accumulator
 
-	plugin.SampleConfig.IfNotFound = "ignore"
-	plugin.SampleConfig.BinPath = "/random/non-existent/path"
+	plugin.IfNotFound = "ignore"
+	plugin.BinPath = "/random/non-existent/path"
 	require.NoError(t, plugin.Init())
 	require.NoError(t, plugin.Start(acc))
-	plugin.Stop()
 
-	plugin.SampleConfig.IfNotFound = "error"
-	plugin.SampleConfig.BinPath = "/random/non-existent/path"
+	plugin.IfNotFound = "error"
+	plugin.BinPath = "/random/non-existent/path"
 	require.NoError(t, plugin.Init(), "nvidia-smi not found in /random/non-existent/path and not in PATH; please make sure nvidia-smi is installed and/or is in PATH")
 
-	plugin.SampleConfig.IfNotFound = "error"
-	plugin.SampleConfig.BinPath = "/usr/bin/nvidia-smi"
+	plugin.IfNotFound = "error"
+	plugin.BinPath = "/usr/bin/nvidia-smi"
 	require.NoError(t, plugin.Init())
 	require.NoError(t, plugin.Start(acc))
-	plugin.Stop()
 }
 
 func TestGatherValidXML(t *testing.T) {

--- a/plugins/inputs/nvidia_smi/nvidia_smi_test.go
+++ b/plugins/inputs/nvidia_smi/nvidia_smi_test.go
@@ -14,18 +14,18 @@ import (
 func TestStartPluginIfGPUNotFound(t *testing.T) {
 	plugin := &NvidiaSMI{Log: &testutil.Logger{}}
 
-	plugin.IfNotFound = "error"
+	plugin.StartupErrorBehavior = "error"
 	plugin.BinPath = "/usr/bin/nvidia-smi"
 	require.NoError(t, plugin.Init())
 
 	// make sure we can't find nvidia-smi in $PATH somewhere
 	os.Unsetenv("PATH")
 
-	plugin.IfNotFound = "ignore"
+	plugin.StartupErrorBehavior = "ignore"
 	plugin.BinPath = "/random/non-existent/path"
 	require.NoError(t, plugin.Init())
 
-	plugin.IfNotFound = "error"
+	plugin.StartupErrorBehavior = "error"
 	plugin.BinPath = "/random/non-existent/path"
 	errMsg := "nvidia-smi not found in /random/non-existent/path and not in PATH; "
 	+"please make sure nvidia-smi is installed and/or is in PATH"

--- a/plugins/inputs/nvidia_smi/nvidia_smi_test.go
+++ b/plugins/inputs/nvidia_smi/nvidia_smi_test.go
@@ -11,6 +11,28 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestStartPluginIfGPUNotFound(t *testing.T) {
+	plugin := &NvidiaSMI{Log: &testutil.Logger{}}
+
+	var acc testutil.Accumulator
+
+	plugin.sampleConfig.IfNotFound = "ignore"
+	plugin.sampleConfig.BinPath = "/random/non-existent/path"
+	require.NoError(t, plugin.Init())
+	require.NoError(t, plugin.Start(acc))
+	plugin.Stop()
+
+	plugin.sampleConfig.IfNotFound = "error"
+	plugin.sampleConfig.BinPath = "/random/non-existent/path"
+	require.NoError(t, plugin.Init(), "nvidia-smi not found in /random/non-existent/path and not in PATH; please make sure nvidia-smi is installed and/or is in PATH")
+
+	plugin.sampleConfig.IfNotFound = "error"
+	plugin.sampleConfig.BinPath = "/usr/bin/nvidia-smi"
+	require.NoError(t, plugin.Init())
+	require.NoError(t, plugin.Start(acc))
+	plugin.Stop()
+}
+
 func TestGatherValidXML(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/plugins/inputs/nvidia_smi/nvidia_smi_test.go
+++ b/plugins/inputs/nvidia_smi/nvidia_smi_test.go
@@ -14,17 +14,22 @@ import (
 func TestStartPluginIfGPUNotFound(t *testing.T) {
 	plugin := &NvidiaSMI{Log: &testutil.Logger{}}
 
+	plugin.IfNotFound = "error"
+	plugin.BinPath = "/usr/bin/nvidia-smi"
+	require.NoError(t, plugin.Init())
+
+	// make sure we can't find nvidia-smi in $PATH somewhere
+	os.Unsetenv("PATH")
+
 	plugin.IfNotFound = "ignore"
 	plugin.BinPath = "/random/non-existent/path"
 	require.NoError(t, plugin.Init())
 
 	plugin.IfNotFound = "error"
 	plugin.BinPath = "/random/non-existent/path"
-	require.NoError(t, plugin.Init(), "nvidia-smi not found in /random/non-existent/path and not in PATH; please make sure nvidia-smi is installed and/or is in PATH")
-
-	plugin.IfNotFound = "error"
-	plugin.BinPath = "/usr/bin/nvidia-smi"
-	require.NoError(t, plugin.Init())
+	errMsg := "nvidia-smi not found in /random/non-existent/path and not in PATH; "
+	+"please make sure nvidia-smi is installed and/or is in PATH"
+	require.NoError(t, plugin.Init(), errMsg)
 }
 
 func TestGatherValidXML(t *testing.T) {

--- a/plugins/inputs/nvidia_smi/nvidia_smi_test.go
+++ b/plugins/inputs/nvidia_smi/nvidia_smi_test.go
@@ -14,8 +14,6 @@ import (
 func TestStartPluginIfGPUNotFound(t *testing.T) {
 	plugin := &NvidiaSMI{Log: &testutil.Logger{}}
 
-	var acc testutil.Accumulator
-
 	plugin.IfNotFound = "ignore"
 	plugin.BinPath = "/random/non-existent/path"
 	require.NoError(t, plugin.Init())

--- a/plugins/inputs/nvidia_smi/nvidia_smi_test.go
+++ b/plugins/inputs/nvidia_smi/nvidia_smi_test.go
@@ -27,8 +27,8 @@ func TestStartPluginIfGPUNotFound(t *testing.T) {
 
 	plugin.StartupErrorBehavior = "error"
 	plugin.BinPath = "/random/non-existent/path"
-	errMsg := "nvidia-smi not found in /random/non-existent/path and not in PATH; "
-	+"please make sure nvidia-smi is installed and/or is in PATH"
+	errMsg := "nvidia-smi not found in /random/non-existent/path and not in PATH; " +
+		"please make sure nvidia-smi is installed and/or is in PATH"
 	require.NoError(t, plugin.Init(), errMsg)
 }
 

--- a/plugins/inputs/nvidia_smi/sample.conf
+++ b/plugins/inputs/nvidia_smi/sample.conf
@@ -5,5 +5,9 @@
   ## if it is not found, we will try to locate it on PATH(exec.LookPath), if it is still not found, an error will be returned
   # bin_path = "/usr/bin/nvidia-smi"
 
+  ## Optional: decide if GPU is not found for Telegraf to proceed with other metrics or error out
+  ## Valid values are "error" (the default) and "ignore"
+  # if_not_found = "error"
+
   ## Optional: timeout for GPU polling
   # timeout = "5s"

--- a/plugins/inputs/nvidia_smi/sample.conf
+++ b/plugins/inputs/nvidia_smi/sample.conf
@@ -5,9 +5,11 @@
   ## if it is not found, we will try to locate it on PATH(exec.LookPath), if it is still not found, an error will be returned
   # bin_path = "/usr/bin/nvidia-smi"
 
-  ## Optional: decide if GPU is not found for Telegraf to proceed with other metrics or error out
-  ## Valid values are "error" (the default) and "ignore"
-  # if_not_found = "error"
+  ## Optional: specifies plugin behavior regarding missing nvidia-smi binary
+  ## Available choices:
+  ##   - error: telegraf will return an error on startup
+  ##   - ignore: telegraf will ignore this plugin
+  # startup_error_behavior = "error"
 
   ## Optional: timeout for GPU polling
   # timeout = "5s"


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

As per #14603 adding a capability to ignore absence of GPUs e.g. in compute clusters that share a `telegraf.conf` file across multiple nodes via an optional `startup_error_behavior` parameter. The default is to error out as before.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

addresses NVIDIA part of #14603
Once accepted the AMDGPU one will follow