### PR TITLE
feat(inputs.win_services): Make service selection case-insensitive

### DIFF
--- a/plugins/inputs/win_services/win_services.go
+++ b/plugins/inputs/win_services/win_services.go
@@ -123,16 +123,16 @@ func (*WinServices) SampleConfig() string {
 func (m *WinServices) Init() error {
 	// For case insensitive comparision (see issue #8796) we need to transform the services
 	// to lowercase
-	services_include := make([]string, 0, len(m.ServiceNames))
+	servicesInclude := make([]string, 0, len(m.ServiceNames))
 	for _, s := range m.ServiceNames {
-		services_include = append(services_include, strings.ToLower(s))
+		servicesInclude = append(servicesInclude, strings.ToLower(s))
 	}
-	services_exclude := make([]string, 0, len(m.ServiceNamesExcluded))
+	servicesExclude := make([]string, 0, len(m.ServiceNamesExcluded))
 	for _, s := range m.ServiceNamesExcluded {
-		services_exclude = append(services_exclude, strings.ToLower(s))
+		servicesExclude = append(servicesExclude, strings.ToLower(s))
 	}
 
-	f, err := filter.NewIncludeExcludeFilter(services_include, services_exclude)
+	f, err := filter.NewIncludeExcludeFilter(servicesInclude, servicesExclude)
 	if err != nil {
 		return err
 	}

--- a/plugins/inputs/win_services/win_services.go
+++ b/plugins/inputs/win_services/win_services.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"strings"
 	"syscall"
 
 	"golang.org/x/sys/windows"
@@ -120,11 +121,22 @@ func (*WinServices) SampleConfig() string {
 }
 
 func (m *WinServices) Init() error {
-	var err error
-	m.servicesFilter, err = filter.NewIncludeExcludeFilter(m.ServiceNames, m.ServiceNamesExcluded)
+	// For case insensitive comparision (see issue #8796) we need to transform the services
+	// to lowercase
+	services_include := make([]string, 0, len(m.ServiceNames))
+	for _, s := range m.ServiceNames {
+		services_include = append(services_include, strings.ToLower(s))
+	}
+	services_exclude := make([]string, 0, len(m.ServiceNamesExcluded))
+	for _, s := range m.ServiceNamesExcluded {
+		services_exclude = append(services_exclude, strings.ToLower(s))
+	}
+
+	f, err := filter.NewIncludeExcludeFilter(services_include, services_exclude)
 	if err != nil {
 		return err
 	}
+	m.servicesFilter = f
 
 	return nil
 }
@@ -178,9 +190,11 @@ func (m *WinServices) listServices(scmgr WinServiceManager) ([]string, error) {
 	}
 
 	var services []string
-	for _, n := range names {
+	for _, name := range names {
+		// Compare case-insensitive. Use lowercase as we already converted the filter to use it.
+		n := strings.ToLower(name)
 		if m.servicesFilter.Match(n) {
-			services = append(services, n)
+			services = append(services, name)
 		}
 	}
 


### PR DESCRIPTION
## Summary

This PR allows to specify the services to include or exclude in a case-insensitive way.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #8796 
