### PR TITLE
feat: Adding Modbus workaround fields to skip Modbus Address errors

### DIFF
--- a/plugins/inputs/modbus/modbus.go
+++ b/plugins/inputs/modbus/modbus.go
@@ -31,6 +31,7 @@ type ModbusWorkarounds struct {
 	CloseAfterGather        bool            `toml:"close_connection_after_gather"`
 	OnRequestPerField       bool            `toml:"one_request_per_field"`
 	ReadCoilsStartingAtZero bool            `toml:"read_coils_starting_at_zero"`
+	SkipAddressErrors       bool            `toml:"skip_address_errors"`
 }
 
 // According to github.com/grid-x/serial
@@ -404,6 +405,11 @@ func (m *Modbus) gatherRequestsCoil(requests []request) error {
 		m.Log.Debugf("trying to read coil@%v[%v]...", request.address, request.length)
 		bytes, err := m.client.ReadCoils(request.address, request.length)
 		if err != nil {
+
+			if m.Workarounds.SkipAddressErrors {
+				m.Log.Debugf("got coil@%v[%v]: %v", request.address, request.length, err)
+				continue
+			}
 			return err
 		}
 		nextRequest := time.Now().Add(time.Duration(m.Workarounds.PollPause))
@@ -431,6 +437,12 @@ func (m *Modbus) gatherRequestsDiscrete(requests []request) error {
 		m.Log.Debugf("trying to read discrete@%v[%v]...", request.address, request.length)
 		bytes, err := m.client.ReadDiscreteInputs(request.address, request.length)
 		if err != nil {
+
+			if m.Workarounds.SkipAddressErrors {
+				m.Log.Debugf("got coil@%v[%v]: %v", request.address, request.length, err)
+				continue
+			}
+
 			return err
 		}
 		nextRequest := time.Now().Add(time.Duration(m.Workarounds.PollPause))
@@ -458,6 +470,12 @@ func (m *Modbus) gatherRequestsHolding(requests []request) error {
 		m.Log.Debugf("trying to read holding@%v[%v]...", request.address, request.length)
 		bytes, err := m.client.ReadHoldingRegisters(request.address, request.length)
 		if err != nil {
+
+			if m.Workarounds.SkipAddressErrors {
+				m.Log.Debugf("got coil@%v[%v]: %v", request.address, request.length, err)
+				continue
+			}
+
 			return err
 		}
 		nextRequest := time.Now().Add(time.Duration(m.Workarounds.PollPause))
@@ -485,6 +503,12 @@ func (m *Modbus) gatherRequestsInput(requests []request) error {
 		m.Log.Debugf("trying to read input@%v[%v]...", request.address, request.length)
 		bytes, err := m.client.ReadInputRegisters(request.address, request.length)
 		if err != nil {
+
+			if m.Workarounds.SkipAddressErrors {
+				m.Log.Debugf("got coil@%v[%v]: %v", request.address, request.length, err)
+				continue
+			}
+
 			return err
 		}
 		nextRequest := time.Now().Add(time.Duration(m.Workarounds.PollPause))


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
This change has been made to accomplish two elements. 
1. Other Telegraf Plugins, like CSV has "Skip Errors". I think from a design perspective, it would be good if all adapters have a skip error flag.
2. I agree that generally, I would like to know if there is an issue with a modbus register. However, I would want to know this in debug/testing/development phase only. 
3. In Production systems, I rather skip errors and still import data instead of having no data at all because of an error. 

To maybe give you a bit more context:
I am using this modbus input plugin to monitor batteries from Battery Energy Storage Systems. Those have multiple racks of batteries per technical unit. 
If we update now racks to get a new firmware and one rack is not able to get a new firmware, it will not be able to respond with the registers. 
However, the telegraf integration would already harvest all other racks successfully.... 
Without the fix, it will now harvest nothing. 

We cannot make multiple telegraf processes - half of the battery management systems are simply too old and only allow two clients to read information from.
The other batteries support multiple reads, however we require additional physical hardware for that. 

This fix allows us to utilize telegraf even for those "funky" scenarios. Hence also added it as workaround :-) 

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [X] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->
Telegraf - Input Modbus Plugin crashes Telegraf if it hits an "illegal address" #14671

resolves #14671 
