### PR TITLE
chore: Fix timezone test case failure on macOS

### DIFF
--- a/internal/internal_test.go
+++ b/internal/internal_test.go
@@ -759,9 +759,9 @@ func TestTimestampAbbrevWarning(t *testing.T) {
 	log.SetOutput(&buf)
 	defer log.SetOutput(backup)
 
-	ts, err := ParseTimestamp("RFC1123", "Mon, 02 Jan 2006 15:04:05 EST", nil)
+	ts, err := ParseTimestamp("RFC1123", "Mon, 02 Jan 2006 15:04:05 MST", nil)
 	require.NoError(t, err)
-	require.EqualValues(t, 1136232245, ts.Unix())
+	require.EqualValues(t, 1136239445, ts.Unix())
 
 	require.Contains(t, buf.String(), "Your config is using abbreviated timezones and parsing was changed in v1.27.0")
 }


### PR DESCRIPTION
## Summary
Fix test failure on macOS with a time zone check resolving differently on macOS and linux

## Checklist

- [X] No AI generated code was used in this PR