### PR TITLE
feat(inputs.redfish): Allow secrets for username/password configuration

### DIFF
--- a/plugins/inputs/redfish/README.md
+++ b/plugins/inputs/redfish/README.md
@@ -24,7 +24,7 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## Redfish API Base URL.
   address = "https://127.0.0.1:5000"
 
-  ## Credentials for the Redfish API.
+  ## Credentials for the Redfish API. Can also use secrets.
   username = "root"
   password = "password123456"
 

--- a/plugins/inputs/redfish/README.md
+++ b/plugins/inputs/redfish/README.md
@@ -18,9 +18,9 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 ## Secret-store support
 
-This plugin supports secrets from secret-stores for the `username` and `password`
-options. See the [secret-store documentation][SECRETSTORE] for more details on how
-to use them.
+This plugin supports secrets from secret-stores for the `username` and
+`password` options. See the [secret-store documentation][SECRETSTORE] for more
+details on how to use them.
 
 [SECRETSTORE]: ../../../docs/CONFIGURATION.md#secret-store-secrets
 

--- a/plugins/inputs/redfish/README.md
+++ b/plugins/inputs/redfish/README.md
@@ -16,6 +16,14 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 [CONFIGURATION.md]: ../../../docs/CONFIGURATION.md#plugins
 
+## Secret-store support
+
+This plugin supports secrets from secret-stores for the `username` and `password` options.
+See the [secret-store documentation][SECRETSTORE] for more details on how
+to use them.
+
+[SECRETSTORE]: ../../../docs/CONFIGURATION.md#secret-store-secrets
+
 ## Configuration
 
 ```toml @sample.conf

--- a/plugins/inputs/redfish/README.md
+++ b/plugins/inputs/redfish/README.md
@@ -18,8 +18,8 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 ## Secret-store support
 
-This plugin supports secrets from secret-stores for the `username` and `password` options.
-See the [secret-store documentation][SECRETSTORE] for more details on how
+This plugin supports secrets from secret-stores for the `username` and `password`
+options. See the [secret-store documentation][SECRETSTORE] for more details on how
 to use them.
 
 [SECRETSTORE]: ../../../docs/CONFIGURATION.md#secret-store-secrets

--- a/plugins/inputs/redfish/redfish.go
+++ b/plugins/inputs/redfish/redfish.go
@@ -225,15 +225,17 @@ func (r *Redfish) getData(address string, payload interface{}) error {
 	if err != nil {
 		return fmt.Errorf("getting username failed: %w", err)
 	}
-	defer username.Destroy()
+	user := username.String()
+	username.Destroy()
 
 	password, err := r.Password.Get()
 	if err != nil {
 		return fmt.Errorf("getting password failed: %w", err)
 	}
-	defer password.Destroy()
+	pass := password.String()
+	password.Destroy()
 
-	req.SetBasicAuth(username.String(), password.String())
+	req.SetBasicAuth(user, pass)
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("OData-Version", "4.0")

--- a/plugins/inputs/redfish/redfish_test.go
+++ b/plugins/inputs/redfish/redfish_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/testutil"
 )
 
@@ -422,8 +423,8 @@ func TestDellApis(t *testing.T) {
 	}
 	plugin := &Redfish{
 		Address:          ts.URL,
-		Username:         "test",
-		Password:         "test",
+		Username:         config.NewSecret([]byte("test")),
+		Password:         config.NewSecret([]byte("test")),
 		ComputerSystemID: "System.Embedded.1",
 		IncludeMetrics:   []string{"thermal", "power"},
 	}
@@ -601,8 +602,8 @@ func TestHPApis(t *testing.T) {
 
 	hpPlugin := &Redfish{
 		Address:          ts.URL,
-		Username:         "test",
-		Password:         "test",
+		Username:         config.NewSecret([]byte("test")),
+		Password:         config.NewSecret([]byte("test")),
 		ComputerSystemID: "1",
 		IncludeMetrics:   []string{"thermal", "power"},
 	}
@@ -698,8 +699,8 @@ func TestHPilo4Apis(t *testing.T) {
 
 	hpPlugin := &Redfish{
 		Address:          ts.URL,
-		Username:         "test",
-		Password:         "test",
+		Username:         config.NewSecret([]byte("test")),
+		Password:         config.NewSecret([]byte("test")),
 		ComputerSystemID: "1",
 		IncludeMetrics:   []string{"thermal"},
 	}
@@ -739,8 +740,8 @@ func TestInvalidUsernameorPassword(t *testing.T) {
 
 	r := &Redfish{
 		Address:          ts.URL,
-		Username:         "test",
-		Password:         "test",
+		Username:         config.NewSecret([]byte("test")),
+		Password:         config.NewSecret([]byte("test")),
 		ComputerSystemID: "System.Embedded.1",
 		IncludeMetrics:   []string{"thermal", "power"},
 	}
@@ -841,8 +842,8 @@ func TestInvalidDellJSON(t *testing.T) {
 
 			plugin := &Redfish{
 				Address:          ts.URL,
-				Username:         "test",
-				Password:         "test",
+				Username:         config.NewSecret([]byte("test")),
+				Password:         config.NewSecret([]byte("test")),
 				ComputerSystemID: "System.Embedded.1",
 				IncludeMetrics:   []string{"thermal", "power"},
 			}
@@ -912,8 +913,8 @@ func TestInvalidHPJSON(t *testing.T) {
 
 			plugin := &Redfish{
 				Address:          ts.URL,
-				Username:         "test",
-				Password:         "test",
+				Username:         config.NewSecret([]byte("test")),
+				Password:         config.NewSecret([]byte("test")),
 				ComputerSystemID: "System.Embedded.2",
 				IncludeMetrics:   []string{"thermal", "power"},
 			}
@@ -1196,8 +1197,8 @@ func TestIncludeTagSetsConfiguration(t *testing.T) {
 
 	hpPlugin := &Redfish{
 		Address:          ts.URL,
-		Username:         "test",
-		Password:         "test",
+		Username:         config.NewSecret([]byte("test")),
+		Password:         config.NewSecret([]byte("test")),
 		ComputerSystemID: "1",
 		IncludeTagSets:   []string{"chassis", "chassis.location"},
 		IncludeMetrics:   []string{"thermal", "power"},

--- a/plugins/inputs/redfish/sample.conf
+++ b/plugins/inputs/redfish/sample.conf
@@ -3,7 +3,7 @@
   ## Redfish API Base URL.
   address = "https://127.0.0.1:5000"
 
-  ## Credentials for the Redfish API.
+  ## Credentials for the Redfish API. Can also use secrets.
   username = "root"
   password = "password123456"
 


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Updates the redfish input plugin to allow secrets to be used for the username and password fields.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [X] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #14682 
