### PR TITLE
fix(inputs.postgresql_extensible): Add support for bool tags

### DIFF
--- a/plugins/inputs/postgresql_extensible/postgresql_extensible.go
+++ b/plugins/inputs/postgresql_extensible/postgresql_extensible.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -258,6 +259,8 @@ COLUMN:
 				tags[col] = string(v)
 			case int64, int32, int:
 				tags[col] = fmt.Sprintf("%d", v)
+			case bool:
+				tags[col] = strconv.FormatBool(v)
 			default:
 				p.Log.Debugf("Failed to add %q as additional tag", col)
 			}


### PR DESCRIPTION
## Summary
Fixes postgresql_extensible to support bool tags.

Previous behavior was to silently ignore the provided configuration and convert the tag into a field, which is pretty bad behavior IMHO. While I would argue that if the configuration can't be followed, an error should be emitted and the metric dropped, that's out of scope. This PR only fixes the specific bool issue.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [ ] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
