### PR TITLE
test(processors.enum): Add unit-test for tracking metrics

### DIFF
--- a/plugins/processors/enum/enum_test.go
+++ b/plugins/processors/enum/enum_test.go
@@ -196,3 +196,24 @@ func TestTagGlobMatching(t *testing.T) {
 
 	assertTagValue(t, "glob", "tag", tags)
 }
+
+func TestTracking(t *testing.T) {
+	m := createTestMetric()
+	var delivered bool
+	notify := func(di telegraf.DeliveryInfo) {
+		delivered = true
+	}
+	m, _ = metric.WithTracking(m, notify)
+
+	mapper := EnumMapper{Mappings: []Mapping{{Tag: "*", ValueMappings: map[string]interface{}{"tag_value": "glob"}}}}
+	err := mapper.Init()
+	require.NoError(t, err)
+
+	actual := mapper.Apply(m)[0]
+	assertTagValue(t, "glob", "tag", actual.Tags())
+
+	actual.Accept()
+	require.Eventually(t, func() bool {
+		return delivered
+	}, time.Second, 100*time.Millisecond, "no metrics delivered")
+}


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Adds test case for tracking metrics in the enum processor. No code changes needed

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [X] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #14714
