### PR TITLE
Set http headers to be secrets in the config

### DIFF
--- a/plugins/inputs/http/http.go
+++ b/plugins/inputs/http/http.go
@@ -37,9 +37,9 @@ type HTTP struct {
 	Token       config.Secret `toml:"token"`
 	TokenFile   string        `toml:"token_file"`
 
-	Headers            map[string]string `toml:"headers"`
-	SuccessStatusCodes []int             `toml:"success_status_codes"`
-	Log                telegraf.Logger   `toml:"-"`
+	Headers            map[string]config.Secret `toml:"headers"`
+	SuccessStatusCodes []int                    `toml:"success_status_codes"`
+	Log                telegraf.Logger          `toml:"-"`
 
 	httpconfig.HTTPClientConfig
 
@@ -141,10 +141,16 @@ func (h *HTTP) gatherURL(acc telegraf.Accumulator, url string) error {
 	}
 
 	for k, v := range h.Headers {
+		secret, err := v.Get()
+		if err != nil {
+			return err
+		}
+
+		headerVal := secret.String()
 		if strings.EqualFold(k, "host") {
-			request.Host = v
+			request.Host = headerVal
 		} else {
-			request.Header.Add(k, v)
+			request.Header.Add(k, headerVal)
 		}
 	}
 

--- a/plugins/inputs/http/http_test.go
+++ b/plugins/inputs/http/http_test.go
@@ -3,6 +3,7 @@ package http_test
 import (
 	"compress/gzip"
 	"fmt"
+	"github.com/influxdata/telegraf/config"
 	"io"
 	"math/rand"
 	"net"
@@ -84,7 +85,7 @@ func TestHTTPHeaders(t *testing.T) {
 	address := fakeServer.URL + "/endpoint"
 	plugin := &httpplugin.HTTP{
 		URLs:    []string{address},
-		Headers: map[string]string{header: headerValue},
+		Headers: map[string]config.Secret{header: config.NewSecret([]byte(headerValue))},
 		Log:     testutil.Logger{},
 	}
 
@@ -116,7 +117,7 @@ func TestHTTPContentLengthHeader(t *testing.T) {
 	address := fakeServer.URL + "/endpoint"
 	plugin := &httpplugin.HTTP{
 		URLs:    []string{address},
-		Headers: map[string]string{},
+		Headers: map[string]config.Secret{},
 		Body:    "{}",
 		Log:     testutil.Logger{},
 	}

--- a/plugins/outputs/http/http.go
+++ b/plugins/outputs/http/http.go
@@ -43,15 +43,15 @@ const (
 )
 
 type HTTP struct {
-	URL                     string            `toml:"url"`
-	Method                  string            `toml:"method"`
-	Username                config.Secret     `toml:"username"`
-	Password                config.Secret     `toml:"password"`
-	Headers                 map[string]string `toml:"headers"`
-	ContentEncoding         string            `toml:"content_encoding"`
-	UseBatchFormat          bool              `toml:"use_batch_format"`
-	AwsService              string            `toml:"aws_service"`
-	NonRetryableStatusCodes []int             `toml:"non_retryable_statuscodes"`
+	URL                     string                   `toml:"url"`
+	Method                  string                   `toml:"method"`
+	Username                config.Secret            `toml:"username"`
+	Password                config.Secret            `toml:"password"`
+	Headers                 map[string]config.Secret `toml:"headers"`
+	ContentEncoding         string                   `toml:"content_encoding"`
+	UseBatchFormat          bool                     `toml:"use_batch_format"`
+	AwsService              string                   `toml:"aws_service"`
+	NonRetryableStatusCodes []int                    `toml:"non_retryable_statuscodes"`
 	httpconfig.HTTPClientConfig
 	Log telegraf.Logger `toml:"-"`
 
@@ -204,11 +204,18 @@ func (h *HTTP) writeMetric(reqBody []byte) error {
 	if h.ContentEncoding == "gzip" {
 		req.Header.Set("Content-Encoding", "gzip")
 	}
+
 	for k, v := range h.Headers {
-		if strings.EqualFold(k, "host") {
-			req.Host = v
+		secret, err := v.Get()
+		if err != nil {
+			return err
 		}
-		req.Header.Set(k, v)
+
+		headerVal := secret.String()
+		if strings.EqualFold(k, "host") {
+			req.Host = headerVal
+		}
+		req.Header.Set(k, headerVal)
 	}
 
 	resp, err := h.client.Do(req)

--- a/plugins/outputs/http/http_test.go
+++ b/plugins/outputs/http/http_test.go
@@ -306,7 +306,7 @@ func TestContentType(t *testing.T) {
 			name: "overwrite content_type",
 			plugin: &HTTP{
 				URL:     u.String(),
-				Headers: map[string]string{"Content-Type": "application/json"},
+				Headers: map[string]config.Secret{"Content-Type": config.NewSecret([]byte("application/json"))},
 			},
 			expected: "application/json",
 		},


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Now secrets can be used like for a custom `Authorization` header.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #14701 
