### PR TITLE
chore: Install go on nighlty package testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -386,6 +386,7 @@ jobs:
       - checkout
       - attach_workspace:
           at: '.'
+      - run: sh ./scripts/installgo_linux.sh
       - run: ./scripts/install_incus.sh
       - run: cd tools/package_incus_test && go build
       - run: sudo ./tools/package_incus_test/package_incus_test --package $(find ./dist -name "*_amd64.deb")


### PR DESCRIPTION
## Summary

The nightly package test is failing because go 1.22 is not installed. This adds the script to check the go version and install it to the nightly package test, like other tests already have.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

