### PR TITLE
chore(deps): Get rid of golang.org/x/exp and use stable versions instead

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -475,7 +475,7 @@ require (
 	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.24.0 // indirect
-	golang.org/x/exp v0.0.0-20231219180239-dc181d75b848
+	golang.org/x/exp v0.0.0-20231219180239-dc181d75b848 // indirect
 	golang.org/x/time v0.5.0 // indirect
 	golang.org/x/tools v0.16.1 // indirect
 	golang.org/x/xerrors v0.0.0-20231012003039-104605ab7028 // indirect

--- a/plugins/inputs/intel_pmt/filtering.go
+++ b/plugins/inputs/intel_pmt/filtering.go
@@ -5,8 +5,7 @@ package intel_pmt
 import (
 	"errors"
 	"regexp"
-
-	"golang.org/x/exp/slices"
+	"slices"
 )
 
 var metricPatternRegex = regexp.MustCompile(`(?P<class>(C|CHA))\d+_(?P<var>[A-Z0-9_]+)$`)

--- a/plugins/inputs/intel_powerstat/intel_powerstat.go
+++ b/plugins/inputs/intel_powerstat/intel_powerstat.go
@@ -15,7 +15,6 @@ import (
 
 	ptel "github.com/intel/powertelemetry"
 	cpuUtil "github.com/shirou/gopsutil/v3/cpu"
-	"golang.org/x/exp/constraints"
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
@@ -322,7 +321,7 @@ func (p *PowerStat) parsePackageMsrMetrics() {
 
 // hasDuplicate takes a slice of a generic type, and returns true
 // if the slice contains duplicates. Otherwise, it returns false.
-func hasDuplicate[S ~[]E, E constraints.Ordered](s S) bool {
+func hasDuplicate[S ~[]E, E comparable](s S) bool {
 	m := make(map[E]struct{}, len(s))
 	for _, v := range s {
 		if _, ok := m[v]; ok {

--- a/plugins/inputs/p4runtime/p4runtime.go
+++ b/plugins/inputs/p4runtime/p4runtime.go
@@ -8,11 +8,11 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"slices"
 	"sync"
 
 	p4ConfigV1 "github.com/p4lang/p4runtime/go/p4/config/v1"
 	p4v1 "github.com/p4lang/p4runtime/go/p4/v1"
-	"golang.org/x/exp/slices"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"

--- a/plugins/outputs/clarify/clarify_test.go
+++ b/plugins/outputs/clarify/clarify_test.go
@@ -5,17 +5,18 @@ import (
 	"encoding/json"
 	"errors"
 	"math"
+	"slices"
 	"testing"
 	"time"
 
 	"github.com/clarify/clarify-go"
 	"github.com/clarify/clarify-go/jsonrpc"
 	"github.com/clarify/clarify-go/views"
+	"github.com/stretchr/testify/require"
+
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/testutil"
-	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/slices"
 )
 
 var errTimeout = errors.New("timeout: operation timed out")


### PR DESCRIPTION
## Summary

Use the built-in "slices" version instead of referencing the experimental implementation.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues
