### PR TITLE
chore: Fix readme linter not using correct Go version

### DIFF
--- a/.github/workflows/readme-linter.yml
+++ b/.github/workflows/readme-linter.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-go@v5
+        with:
+          go-version: '1.22.0'
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0

--- a/tools/update_goversion/main.go
+++ b/tools/update_goversion/main.go
@@ -204,6 +204,11 @@ func main() {
 			Regex:    `(GO_VERSION_SHA_amd64)=".*"`,
 			Replace:  fmt.Sprintf("$1=%q", hashes[fmt.Sprintf("go%s.darwin-amd64.tar.gz", version)]),
 		},
+		{
+			FileName: ".github/workflows/readme-linter.yml",
+			Regex:    `(go-version): '\d.\d*.\d'`,
+			Replace:  fmt.Sprintf("$1: '%s'", version),
+		},
 	}
 
 	for _, f := range files {


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Updates readme-linter to Go 1.22 and adds it to the list of files updated by update_goversion

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [X] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
