### PR TITLE
chore(linters): Bump golangci-lint to v1.56.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,7 +96,7 @@ jobs:
       - run: 'make check-deps'
       - run:
           name: "Install golangci-lint"
-          command: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.56.0
+          command: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.56.1
       - run:
           name: "golangci-lint/Linux"
           command: GOGC=80 GOMEMLIMIT=6656MiB /go/bin/golangci-lint run --verbose
@@ -107,7 +107,7 @@ jobs:
       - check-changed-files-or-halt
       - run:
           name: "Install golangci-lint"
-          command: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.56.0
+          command: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.56.1
       - run:
           name: "golangci-lint/macOS"
           command: GOGC=80 GOMEMLIMIT=6656MiB GOOS=darwin /go/bin/golangci-lint run --verbose --timeout=30m
@@ -119,7 +119,7 @@ jobs:
       - check-changed-files-or-halt
       - run:
           name: "Install golangci-lint"
-          command: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.56.0
+          command: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.56.1
       - run:
           name: "golangci-lint/Windows"
           command: GOGC=80 GOMEMLIMIT=6656MiB GOOS=windows /go/bin/golangci-lint run --verbose --timeout=30m

--- a/Makefile
+++ b/Makefile
@@ -174,7 +174,7 @@ vet:
 .PHONY: lint-install
 lint-install:
 	@echo "Installing golangci-lint"
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.56.0
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.56.1
 
 	@echo "Installing markdownlint"
 	npm install -g markdownlint-cli

--- a/cmd/telegraf/main.go
+++ b/cmd/telegraf/main.go
@@ -362,7 +362,7 @@ func runApp(args []string, outputBuffer io.Writer, pprof Server, c TelegrafConfi
 			{
 				Name:  "version",
 				Usage: "print current version to stdout",
-				Action: func(cCtx *cli.Context) error {
+				Action: func(*cli.Context) error {
 					fmt.Fprintf(outputBuffer, "%s\n", internal.FormatFullVersion())
 					return nil
 				},

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -497,7 +497,7 @@ func TestConfig_AzureMonitorNamespacePrefix(t *testing.T) {
 }
 
 func TestGetDefaultConfigPathFromEnvURL(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("[agent]\ndebug = true"))
 	}))

--- a/config/internal_test.go
+++ b/config/internal_test.go
@@ -377,7 +377,7 @@ func TestRemoveComments(t *testing.T) {
 func TestURLRetries3Fails(t *testing.T) {
 	httpLoadConfigRetryInterval = 0 * time.Second
 	responseCounter := 0
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
 		responseCounter++
 	}))
@@ -395,7 +395,7 @@ func TestURLRetries3Fails(t *testing.T) {
 func TestURLRetries3FailsThenPasses(t *testing.T) {
 	httpLoadConfigRetryInterval = 0 * time.Second
 	responseCounter := 0
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		if responseCounter <= 2 {
 			w.WriteHeader(http.StatusNotFound)
 		} else {

--- a/config/secret_test.go
+++ b/config/secret_test.go
@@ -814,7 +814,7 @@ func (s *MockupSecretStore) GetResolver(key string) (telegraf.ResolveFunc, error
 func init() {
 	// Register the mockup input plugin for the required names
 	inputs.Add("mockup", func() telegraf.Input { return &MockupSecretPlugin{} })
-	secretstores.Add("mockup", func(id string) telegraf.SecretStore {
+	secretstores.Add("mockup", func(string) telegraf.SecretStore {
 		return &MockupSecretStore{}
 	})
 }

--- a/plugins/common/kafka/config.go
+++ b/plugins/common/kafka/config.go
@@ -73,7 +73,7 @@ type Config struct {
 type BackoffFunc func(retries, maxRetries int) time.Duration
 
 func makeBackoffFunc(backoff, maxDuration time.Duration) BackoffFunc {
-	return func(retries, maxRetries int) time.Duration {
+	return func(retries, _ int) time.Duration {
 		d := time.Duration(math.Pow(2, float64(retries))) * backoff
 		if maxDuration != 0 && d > maxDuration {
 			return maxDuration

--- a/plugins/common/starlark/builtins.go
+++ b/plugins/common/starlark/builtins.go
@@ -89,7 +89,7 @@ func builtinAttr(recv starlark.Value, name string, methods map[string]builtinMet
 	}
 
 	// Allocate a closure over 'method'.
-	impl := func(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	impl := func(_ *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 		return method(b, args, kwargs)
 	}
 	return starlark.NewBuiltin(name, impl).BindReceiver(recv), nil

--- a/plugins/common/starlark/logging.go
+++ b/plugins/common/starlark/logging.go
@@ -12,7 +12,7 @@ import (
 
 // Builds a module that defines all the supported logging functions which will log using the provided logger
 func LogModule(logger telegraf.Logger) *starlarkstruct.Module {
-	var logFunc = func(t *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var logFunc = func(_ *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 		return log(b, args, kwargs, logger)
 	}
 	return &starlarkstruct.Module{

--- a/plugins/common/starlark/starlark.go
+++ b/plugins/common/starlark/starlark.go
@@ -38,7 +38,7 @@ func (s *Common) Init() error {
 
 	s.thread = &starlark.Thread{
 		Print: func(_ *starlark.Thread, msg string) { s.Log.Debug(msg) },
-		Load: func(thread *starlark.Thread, module string) (starlark.StringDict, error) {
+		Load: func(_ *starlark.Thread, module string) (starlark.StringDict, error) {
 			return s.StarlarkLoadFunc(module, s.Log)
 		},
 	}

--- a/plugins/common/tls/config_test.go
+++ b/plugins/common/tls/config_test.go
@@ -376,7 +376,7 @@ func TestConnect(t *testing.T) {
 	serverTLSConfig, err := serverConfig.TLSConfig()
 	require.NoError(t, err)
 
-	ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 	ts.TLS = serverTLSConfig
@@ -499,7 +499,7 @@ func TestConnectClientMinTLSVersion(t *testing.T) {
 				serverTLSConfig.MaxVersion = serverTLSMaxVersion
 
 				// Start the server
-				ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 					w.WriteHeader(http.StatusOK)
 				}))
 				ts.TLS = serverTLSConfig
@@ -553,7 +553,7 @@ func TestConnectWrongDNS(t *testing.T) {
 	serverTLSConfig, err := serverConfig.TLSConfig()
 	require.NoError(t, err)
 
-	ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 	ts.TLS = serverTLSConfig

--- a/plugins/inputs/apache/apache_test.go
+++ b/plugins/inputs/apache/apache_test.go
@@ -30,7 +30,7 @@ Scoreboard: WW_____W_RW_R_W__RRR____WR_W___WW________W_WW_W_____R__R_WR__WRWR_RR
 `
 
 func TestHTTPApache(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		_, err := fmt.Fprintln(w, apacheStatus)
 		require.NoError(t, err)

--- a/plugins/inputs/aurora/aurora_test.go
+++ b/plugins/inputs/aurora/aurora_test.go
@@ -34,10 +34,10 @@ func TestAurora(t *testing.T) {
 	}{
 		{
 			name: "minimal",
-			leaderhealth: func(t *testing.T, w http.ResponseWriter, r *http.Request) {
+			leaderhealth: func(_ *testing.T, w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusOK)
 			},
-			varsjson: func(t *testing.T, w http.ResponseWriter, r *http.Request) {
+			varsjson: func(t *testing.T, w http.ResponseWriter, _ *http.Request) {
 				body := `{
 					"variable_scrape_events": 2958,
 					"variable_scrape_events_per_sec": 1.0,
@@ -71,7 +71,7 @@ func TestAurora(t *testing.T) {
 		{
 			name:  "disabled role",
 			roles: []string{"leader"},
-			leaderhealth: func(t *testing.T, w http.ResponseWriter, r *http.Request) {
+			leaderhealth: func(_ *testing.T, w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusServiceUnavailable)
 			},
 			check: func(t *testing.T, err error, acc *testutil.Accumulator) {
@@ -82,10 +82,10 @@ func TestAurora(t *testing.T) {
 		},
 		{
 			name: "no metrics available",
-			leaderhealth: func(t *testing.T, w http.ResponseWriter, r *http.Request) {
+			leaderhealth: func(_ *testing.T, w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusOK)
 			},
-			varsjson: func(t *testing.T, w http.ResponseWriter, r *http.Request) {
+			varsjson: func(t *testing.T, w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusOK)
 				_, err := w.Write([]byte("{}"))
 				require.NoError(t, err)
@@ -98,10 +98,10 @@ func TestAurora(t *testing.T) {
 		},
 		{
 			name: "string metrics skipped",
-			leaderhealth: func(t *testing.T, w http.ResponseWriter, r *http.Request) {
+			leaderhealth: func(_ *testing.T, w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusOK)
 			},
-			varsjson: func(t *testing.T, w http.ResponseWriter, r *http.Request) {
+			varsjson: func(t *testing.T, w http.ResponseWriter, _ *http.Request) {
 				body := `{
 					"foo": "bar"
 				}`
@@ -117,10 +117,10 @@ func TestAurora(t *testing.T) {
 		},
 		{
 			name: "float64 unparseable",
-			leaderhealth: func(t *testing.T, w http.ResponseWriter, r *http.Request) {
+			leaderhealth: func(_ *testing.T, w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusOK)
 			},
-			varsjson: func(t *testing.T, w http.ResponseWriter, r *http.Request) {
+			varsjson: func(t *testing.T, w http.ResponseWriter, _ *http.Request) {
 				// too large
 				body := `{
 					"foo": 1e309
@@ -137,10 +137,10 @@ func TestAurora(t *testing.T) {
 		},
 		{
 			name: "int64 unparseable",
-			leaderhealth: func(t *testing.T, w http.ResponseWriter, r *http.Request) {
+			leaderhealth: func(_ *testing.T, w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusOK)
 			},
-			varsjson: func(t *testing.T, w http.ResponseWriter, r *http.Request) {
+			varsjson: func(t *testing.T, w http.ResponseWriter, _ *http.Request) {
 				// too large
 				body := `{
 					"foo": 9223372036854775808
@@ -157,10 +157,10 @@ func TestAurora(t *testing.T) {
 		},
 		{
 			name: "bad json",
-			leaderhealth: func(t *testing.T, w http.ResponseWriter, r *http.Request) {
+			leaderhealth: func(_ *testing.T, w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusOK)
 			},
-			varsjson: func(t *testing.T, w http.ResponseWriter, r *http.Request) {
+			varsjson: func(t *testing.T, w http.ResponseWriter, _ *http.Request) {
 				body := `{]`
 				w.WriteHeader(http.StatusOK)
 				_, err := w.Write([]byte(body))
@@ -174,10 +174,10 @@ func TestAurora(t *testing.T) {
 		},
 		{
 			name: "wrong status code",
-			leaderhealth: func(t *testing.T, w http.ResponseWriter, r *http.Request) {
+			leaderhealth: func(_ *testing.T, w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusOK)
 			},
-			varsjson: func(t *testing.T, w http.ResponseWriter, r *http.Request) {
+			varsjson: func(t *testing.T, w http.ResponseWriter, _ *http.Request) {
 				body := `{
 					"value": 42
 				}`

--- a/plugins/inputs/ceph/ceph_test.go
+++ b/plugins/inputs/ceph/ceph_test.go
@@ -107,11 +107,11 @@ func TestGather(t *testing.T) {
 		perfDump = saveDump
 	}()
 
-	findSockets = func(c *Ceph) ([]*socket, error) {
+	findSockets = func(*Ceph) ([]*socket, error) {
 		return []*socket{{"osd.1", typeOsd, ""}}, nil
 	}
 
-	perfDump = func(binary string, s *socket) (string, error) {
+	perfDump = func(string, *socket) (string, error) {
 		return osdPerfDump, nil
 	}
 

--- a/plugins/inputs/clickhouse/clickhouse_test.go
+++ b/plugins/inputs/clickhouse/clickhouse_test.go
@@ -536,7 +536,7 @@ func TestGatherClickhouseCloud(t *testing.T) {
 
 func TestWrongJSONMarshalling(t *testing.T) {
 	var (
-		ts = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ts = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			type result struct {
 				Data interface{} `json:"data"`
 			}

--- a/plugins/inputs/cloud_pubsub/subscription_stub.go
+++ b/plugins/inputs/cloud_pubsub/subscription_stub.go
@@ -23,7 +23,7 @@ func (s *stubSub) Receive(ctx context.Context, f func(context.Context, message))
 type receiveFunc func(ctx context.Context, f func(context.Context, message)) error
 
 func testMessagesError(expectedErr error) receiveFunc {
-	return func(ctx context.Context, f func(context.Context, message)) error {
+	return func(context.Context, func(context.Context, message)) error {
 		return expectedErr
 	}
 }

--- a/plugins/inputs/dcos/client_test.go
+++ b/plugins/inputs/dcos/client_test.go
@@ -8,7 +8,7 @@ import (
 	"net/url"
 	"testing"
 
-	jwt "github.com/golang-jwt/jwt/v5"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/require"
 
 	"github.com/influxdata/telegraf/testutil"
@@ -53,7 +53,7 @@ func TestLogin(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ts.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ts.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(tt.responseCode)
 				fmt.Fprintln(w, tt.responseBody)
 			})
@@ -126,7 +126,7 @@ func TestGetSummary(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ts.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ts.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				// check the path
 				w.WriteHeader(tt.responseCode)
 				fmt.Fprintln(w, tt.responseBody)
@@ -167,7 +167,7 @@ func TestGetNodeMetrics(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ts.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ts.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				// check the path
 				w.WriteHeader(tt.responseCode)
 				fmt.Fprintln(w, tt.responseBody)
@@ -208,7 +208,7 @@ func TestGetContainerMetrics(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ts.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ts.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				// check the path
 				w.WriteHeader(tt.responseCode)
 				fmt.Fprintln(w, tt.responseBody)

--- a/plugins/inputs/dcos/dcos_test.go
+++ b/plugins/inputs/dcos/dcos_test.go
@@ -11,33 +11,33 @@ import (
 )
 
 type mockClient struct {
-	SetTokenF            func(token string)
+	SetTokenF            func()
 	LoginF               func(ctx context.Context, sa *ServiceAccount) (*AuthToken, error)
-	GetSummaryF          func(ctx context.Context) (*Summary, error)
-	GetContainersF       func(ctx context.Context, node string) ([]Container, error)
-	GetNodeMetricsF      func(ctx context.Context, node string) (*Metrics, error)
+	GetSummaryF          func() (*Summary, error)
+	GetContainersF       func() ([]Container, error)
+	GetNodeMetricsF      func() (*Metrics, error)
 	GetContainerMetricsF func(ctx context.Context, node, container string) (*Metrics, error)
 	GetAppMetricsF       func(ctx context.Context, node, container string) (*Metrics, error)
 }
 
-func (c *mockClient) SetToken(token string) {
-	c.SetTokenF(token)
+func (c *mockClient) SetToken(string) {
+	c.SetTokenF()
 }
 
 func (c *mockClient) Login(ctx context.Context, sa *ServiceAccount) (*AuthToken, error) {
 	return c.LoginF(ctx, sa)
 }
 
-func (c *mockClient) GetSummary(ctx context.Context) (*Summary, error) {
-	return c.GetSummaryF(ctx)
+func (c *mockClient) GetSummary(context.Context) (*Summary, error) {
+	return c.GetSummaryF()
 }
 
-func (c *mockClient) GetContainers(ctx context.Context, node string) ([]Container, error) {
-	return c.GetContainersF(ctx, node)
+func (c *mockClient) GetContainers(context.Context, string) ([]Container, error) {
+	return c.GetContainersF()
 }
 
-func (c *mockClient) GetNodeMetrics(ctx context.Context, node string) (*Metrics, error) {
-	return c.GetNodeMetricsF(ctx, node)
+func (c *mockClient) GetNodeMetrics(context.Context, string) (*Metrics, error) {
+	return c.GetNodeMetricsF()
 }
 
 func (c *mockClient) GetContainerMetrics(ctx context.Context, node, container string) (*Metrics, error) {
@@ -362,8 +362,8 @@ func TestGatherFilterNode(t *testing.T) {
 		{
 			name: "cluster without nodes has no metrics",
 			client: &mockClient{
-				SetTokenF: func(token string) {},
-				GetSummaryF: func(ctx context.Context) (*Summary, error) {
+				SetTokenF: func() {},
+				GetSummaryF: func() (*Summary, error) {
 					return &Summary{
 						Cluster: "a",
 						Slaves:  []Slave{},
@@ -380,8 +380,8 @@ func TestGatherFilterNode(t *testing.T) {
 			name:        "node include",
 			nodeInclude: []string{"x"},
 			client: &mockClient{
-				SetTokenF: func(token string) {},
-				GetSummaryF: func(ctx context.Context) (*Summary, error) {
+				SetTokenF: func() {},
+				GetSummaryF: func() (*Summary, error) {
 					return &Summary{
 						Cluster: "a",
 						Slaves: []Slave{
@@ -390,10 +390,10 @@ func TestGatherFilterNode(t *testing.T) {
 						},
 					}, nil
 				},
-				GetContainersF: func(ctx context.Context, node string) ([]Container, error) {
+				GetContainersF: func() ([]Container, error) {
 					return []Container{}, nil
 				},
-				GetNodeMetricsF: func(ctx context.Context, node string) (*Metrics, error) {
+				GetNodeMetricsF: func() (*Metrics, error) {
 					return &Metrics{
 						Datapoints: []DataPoint{
 							{

--- a/plugins/inputs/directory_monitor/directory_monitor.go
+++ b/plugins/inputs/directory_monitor/directory_monitor.go
@@ -98,7 +98,7 @@ func (monitor *DirectoryMonitor) Gather(_ telegraf.Accumulator) error {
 
 	if monitor.Recursive {
 		err := filepath.Walk(monitor.Directory,
-			func(path string, info os.FileInfo, err error) error {
+			func(path string, _ os.FileInfo, err error) error {
 				if err != nil {
 					return err
 				}

--- a/plugins/inputs/docker/docker_test.go
+++ b/plugins/inputs/docker/docker_test.go
@@ -22,70 +22,48 @@ import (
 )
 
 type MockClient struct {
-	InfoF             func(ctx context.Context) (system.Info, error)
-	ContainerListF    func(ctx context.Context, options typeContainer.ListOptions) ([]types.Container, error)
-	ContainerStatsF   func(ctx context.Context, containerID string, stream bool) (types.ContainerStats, error)
-	ContainerInspectF func(ctx context.Context, containerID string) (types.ContainerJSON, error)
-	ServiceListF      func(ctx context.Context, options types.ServiceListOptions) ([]swarm.Service, error)
-	TaskListF         func(ctx context.Context, options types.TaskListOptions) ([]swarm.Task, error)
-	NodeListF         func(ctx context.Context, options types.NodeListOptions) ([]swarm.Node, error)
-	DiskUsageF        func(ctx context.Context, options types.DiskUsageOptions) (types.DiskUsage, error)
+	InfoF             func() (system.Info, error)
+	ContainerListF    func(options typeContainer.ListOptions) ([]types.Container, error)
+	ContainerStatsF   func(containerID string) (types.ContainerStats, error)
+	ContainerInspectF func() (types.ContainerJSON, error)
+	ServiceListF      func() ([]swarm.Service, error)
+	TaskListF         func() ([]swarm.Task, error)
+	NodeListF         func() ([]swarm.Node, error)
+	DiskUsageF        func() (types.DiskUsage, error)
 	ClientVersionF    func() string
 	CloseF            func() error
 }
 
-func (c *MockClient) Info(ctx context.Context) (system.Info, error) {
-	return c.InfoF(ctx)
+func (c *MockClient) Info(context.Context) (system.Info, error) {
+	return c.InfoF()
 }
 
-func (c *MockClient) ContainerList(
-	ctx context.Context,
-	options typeContainer.ListOptions,
-) ([]types.Container, error) {
-	return c.ContainerListF(ctx, options)
+func (c *MockClient) ContainerList(_ context.Context, options typeContainer.ListOptions) ([]types.Container, error) {
+	return c.ContainerListF(options)
 }
 
-func (c *MockClient) ContainerStats(
-	ctx context.Context,
-	containerID string,
-	stream bool,
-) (types.ContainerStats, error) {
-	return c.ContainerStatsF(ctx, containerID, stream)
+func (c *MockClient) ContainerStats(_ context.Context, containerID string, _ bool) (types.ContainerStats, error) {
+	return c.ContainerStatsF(containerID)
 }
 
-func (c *MockClient) ContainerInspect(
-	ctx context.Context,
-	containerID string,
-) (types.ContainerJSON, error) {
-	return c.ContainerInspectF(ctx, containerID)
+func (c *MockClient) ContainerInspect(context.Context, string) (types.ContainerJSON, error) {
+	return c.ContainerInspectF()
 }
 
-func (c *MockClient) ServiceList(
-	ctx context.Context,
-	options types.ServiceListOptions,
-) ([]swarm.Service, error) {
-	return c.ServiceListF(ctx, options)
+func (c *MockClient) ServiceList(context.Context, types.ServiceListOptions) ([]swarm.Service, error) {
+	return c.ServiceListF()
 }
 
-func (c *MockClient) TaskList(
-	ctx context.Context,
-	options types.TaskListOptions,
-) ([]swarm.Task, error) {
-	return c.TaskListF(ctx, options)
+func (c *MockClient) TaskList(context.Context, types.TaskListOptions) ([]swarm.Task, error) {
+	return c.TaskListF()
 }
 
-func (c *MockClient) NodeList(
-	ctx context.Context,
-	options types.NodeListOptions,
-) ([]swarm.Node, error) {
-	return c.NodeListF(ctx, options)
+func (c *MockClient) NodeList(context.Context, types.NodeListOptions) ([]swarm.Node, error) {
+	return c.NodeListF()
 }
 
-func (c *MockClient) DiskUsage(
-	ctx context.Context,
-	options types.DiskUsageOptions,
-) (types.DiskUsage, error) {
-	return c.DiskUsageF(ctx, options)
+func (c *MockClient) DiskUsage(context.Context, types.DiskUsageOptions) (types.DiskUsage, error) {
+	return c.DiskUsageF()
 }
 
 func (c *MockClient) ClientVersion() string {
@@ -97,28 +75,28 @@ func (c *MockClient) Close() error {
 }
 
 var baseClient = MockClient{
-	InfoF: func(context.Context) (system.Info, error) {
+	InfoF: func() (system.Info, error) {
 		return info, nil
 	},
-	ContainerListF: func(context.Context, typeContainer.ListOptions) ([]types.Container, error) {
+	ContainerListF: func(typeContainer.ListOptions) ([]types.Container, error) {
 		return containerList, nil
 	},
-	ContainerStatsF: func(c context.Context, s string, b bool) (types.ContainerStats, error) {
+	ContainerStatsF: func(s string) (types.ContainerStats, error) {
 		return containerStats(s), nil
 	},
-	ContainerInspectF: func(context.Context, string) (types.ContainerJSON, error) {
+	ContainerInspectF: func() (types.ContainerJSON, error) {
 		return containerInspect(), nil
 	},
-	ServiceListF: func(context.Context, types.ServiceListOptions) ([]swarm.Service, error) {
+	ServiceListF: func() ([]swarm.Service, error) {
 		return ServiceList, nil
 	},
-	TaskListF: func(context.Context, types.TaskListOptions) ([]swarm.Task, error) {
+	TaskListF: func() ([]swarm.Task, error) {
 		return TaskList, nil
 	},
-	NodeListF: func(context.Context, types.NodeListOptions) ([]swarm.Node, error) {
+	NodeListF: func() ([]swarm.Node, error) {
 		return NodeList, nil
 	},
-	DiskUsageF: func(context.Context, types.DiskUsageOptions) (types.DiskUsage, error) {
+	DiskUsageF: func() (types.DiskUsage, error) {
 		return diskUsage, nil
 	},
 	ClientVersionF: func() string {
@@ -445,28 +423,28 @@ func TestDocker_WindowsMemoryContainerStats(t *testing.T) {
 		Log: testutil.Logger{},
 		newClient: func(string, *tls.Config) (Client, error) {
 			return &MockClient{
-				InfoF: func(ctx context.Context) (system.Info, error) {
+				InfoF: func() (system.Info, error) {
 					return info, nil
 				},
-				ContainerListF: func(ctx context.Context, options typeContainer.ListOptions) ([]types.Container, error) {
+				ContainerListF: func(typeContainer.ListOptions) ([]types.Container, error) {
 					return containerList, nil
 				},
-				ContainerStatsF: func(ctx context.Context, containerID string, stream bool) (types.ContainerStats, error) {
+				ContainerStatsF: func(string) (types.ContainerStats, error) {
 					return containerStatsWindows(), nil
 				},
-				ContainerInspectF: func(ctx context.Context, containerID string) (types.ContainerJSON, error) {
+				ContainerInspectF: func() (types.ContainerJSON, error) {
 					return containerInspect(), nil
 				},
-				ServiceListF: func(context.Context, types.ServiceListOptions) ([]swarm.Service, error) {
+				ServiceListF: func() ([]swarm.Service, error) {
 					return ServiceList, nil
 				},
-				TaskListF: func(context.Context, types.TaskListOptions) ([]swarm.Task, error) {
+				TaskListF: func() ([]swarm.Task, error) {
 					return TaskList, nil
 				},
-				NodeListF: func(context.Context, types.NodeListOptions) ([]swarm.Node, error) {
+				NodeListF: func() ([]swarm.Node, error) {
 					return NodeList, nil
 				},
-				DiskUsageF: func(context.Context, types.DiskUsageOptions) (types.DiskUsage, error) {
+				DiskUsageF: func() (types.DiskUsage, error) {
 					return diskUsage, nil
 				},
 				ClientVersionF: func() string {
@@ -581,9 +559,9 @@ func TestContainerLabels(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var acc testutil.Accumulator
 
-			newClientFunc := func(host string, tlsConfig *tls.Config) (Client, error) {
+			newClientFunc := func(string, *tls.Config) (Client, error) {
 				client := baseClient
-				client.ContainerListF = func(context.Context, typeContainer.ListOptions) ([]types.Container, error) {
+				client.ContainerListF = func(typeContainer.ListOptions) ([]types.Container, error) {
 					return []types.Container{tt.container}, nil
 				}
 				return &client, nil
@@ -701,12 +679,12 @@ func TestContainerNames(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var acc testutil.Accumulator
 
-			newClientFunc := func(host string, tlsConfig *tls.Config) (Client, error) {
+			newClientFunc := func(string, *tls.Config) (Client, error) {
 				client := baseClient
-				client.ContainerListF = func(context.Context, typeContainer.ListOptions) ([]types.Container, error) {
+				client.ContainerListF = func(typeContainer.ListOptions) ([]types.Container, error) {
 					return containerList, nil
 				}
-				client.ContainerStatsF = func(c context.Context, s string, b bool) (types.ContainerStats, error) {
+				client.ContainerStatsF = func(s string) (types.ContainerStats, error) {
 					return containerStats(s), nil
 				}
 
@@ -913,10 +891,10 @@ func TestContainerStatus(t *testing.T) {
 				acc           testutil.Accumulator
 				newClientFunc = func(string, *tls.Config) (Client, error) {
 					client := baseClient
-					client.ContainerListF = func(context.Context, typeContainer.ListOptions) ([]types.Container, error) {
+					client.ContainerListF = func(typeContainer.ListOptions) ([]types.Container, error) {
 						return containerList[:1], nil
 					}
-					client.ContainerInspectF = func(c context.Context, s string) (types.ContainerJSON, error) {
+					client.ContainerInspectF = func() (types.ContainerJSON, error) {
 						return tt.inspect, nil
 					}
 
@@ -1196,9 +1174,9 @@ func TestContainerStateFilter(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var acc testutil.Accumulator
 
-			newClientFunc := func(host string, tlsConfig *tls.Config) (Client, error) {
+			newClientFunc := func(string, *tls.Config) (Client, error) {
 				client := baseClient
-				client.ContainerListF = func(ctx context.Context, options typeContainer.ListOptions) ([]types.Container, error) {
+				client.ContainerListF = func(options typeContainer.ListOptions) ([]types.Container, error) {
 					for k, v := range tt.expected {
 						actual := options.Filters.Get(k)
 						sort.Strings(actual)
@@ -1232,16 +1210,16 @@ func TestContainerName(t *testing.T) {
 	}{
 		{
 			name: "container stats name is preferred",
-			clientFunc: func(host string, tlsConfig *tls.Config) (Client, error) {
+			clientFunc: func(string, *tls.Config) (Client, error) {
 				client := baseClient
-				client.ContainerListF = func(context.Context, typeContainer.ListOptions) ([]types.Container, error) {
+				client.ContainerListF = func(typeContainer.ListOptions) ([]types.Container, error) {
 					var containers []types.Container
 					containers = append(containers, types.Container{
 						Names: []string{"/logspout/foo"},
 					})
 					return containers, nil
 				}
-				client.ContainerStatsF = func(ctx context.Context, containerID string, stream bool) (types.ContainerStats, error) {
+				client.ContainerStatsF = func(string) (types.ContainerStats, error) {
 					return types.ContainerStats{
 						Body: io.NopCloser(strings.NewReader(`{"name": "logspout"}`)),
 					}, nil
@@ -1252,16 +1230,16 @@ func TestContainerName(t *testing.T) {
 		},
 		{
 			name: "container stats without name uses container list name",
-			clientFunc: func(host string, tlsConfig *tls.Config) (Client, error) {
+			clientFunc: func(string, *tls.Config) (Client, error) {
 				client := baseClient
-				client.ContainerListF = func(context.Context, typeContainer.ListOptions) ([]types.Container, error) {
+				client.ContainerListF = func(typeContainer.ListOptions) ([]types.Container, error) {
 					var containers []types.Container
 					containers = append(containers, types.Container{
 						Names: []string{"/logspout"},
 					})
 					return containers, nil
 				}
-				client.ContainerStatsF = func(ctx context.Context, containerID string, stream bool) (types.ContainerStats, error) {
+				client.ContainerStatsF = func(string) (types.ContainerStats, error) {
 					return types.ContainerStats{
 						Body: io.NopCloser(strings.NewReader(`{}`)),
 					}, nil

--- a/plugins/inputs/docker_log/docker_log_test.go
+++ b/plugins/inputs/docker_log/docker_log_test.go
@@ -11,38 +11,29 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/pkg/stdcopy"
+	"github.com/stretchr/testify/require"
+
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/testutil"
-	"github.com/stretchr/testify/require"
 )
 
 type MockClient struct {
-	ContainerListF    func(ctx context.Context, options container.ListOptions) ([]types.Container, error)
-	ContainerInspectF func(ctx context.Context, containerID string) (types.ContainerJSON, error)
-	ContainerLogsF    func(ctx context.Context, containerID string, options container.LogsOptions) (io.ReadCloser, error)
+	ContainerListF    func() ([]types.Container, error)
+	ContainerInspectF func() (types.ContainerJSON, error)
+	ContainerLogsF    func() (io.ReadCloser, error)
 }
 
-func (c *MockClient) ContainerList(
-	ctx context.Context,
-	options container.ListOptions,
-) ([]types.Container, error) {
-	return c.ContainerListF(ctx, options)
+func (c *MockClient) ContainerList(context.Context, container.ListOptions) ([]types.Container, error) {
+	return c.ContainerListF()
 }
 
-func (c *MockClient) ContainerInspect(
-	ctx context.Context,
-	containerID string,
-) (types.ContainerJSON, error) {
-	return c.ContainerInspectF(ctx, containerID)
+func (c *MockClient) ContainerInspect(context.Context, string) (types.ContainerJSON, error) {
+	return c.ContainerInspectF()
 }
 
-func (c *MockClient) ContainerLogs(
-	ctx context.Context,
-	containerID string,
-	options container.LogsOptions,
-) (io.ReadCloser, error) {
-	return c.ContainerLogsF(ctx, containerID, options)
+func (c *MockClient) ContainerLogs(context.Context, string, container.LogsOptions) (io.ReadCloser, error) {
+	return c.ContainerLogsF()
 }
 
 type Response struct {
@@ -70,7 +61,7 @@ func Test(t *testing.T) {
 		{
 			name: "no containers",
 			client: &MockClient{
-				ContainerListF: func(ctx context.Context, options container.ListOptions) ([]types.Container, error) {
+				ContainerListF: func() ([]types.Container, error) {
 					return nil, nil
 				},
 			},
@@ -78,7 +69,7 @@ func Test(t *testing.T) {
 		{
 			name: "one container tty",
 			client: &MockClient{
-				ContainerListF: func(ctx context.Context, options container.ListOptions) ([]types.Container, error) {
+				ContainerListF: func() ([]types.Container, error) {
 					return []types.Container{
 						{
 							ID:    "deadbeef",
@@ -87,14 +78,14 @@ func Test(t *testing.T) {
 						},
 					}, nil
 				},
-				ContainerInspectF: func(ctx context.Context, containerID string) (types.ContainerJSON, error) {
+				ContainerInspectF: func() (types.ContainerJSON, error) {
 					return types.ContainerJSON{
 						Config: &container.Config{
 							Tty: true,
 						},
 					}, nil
 				},
-				ContainerLogsF: func(ctx context.Context, containerID string, options container.LogsOptions) (io.ReadCloser, error) {
+				ContainerLogsF: func() (io.ReadCloser, error) {
 					return &Response{Reader: bytes.NewBuffer([]byte("2020-04-28T18:43:16.432691200Z hello\n"))}, nil
 				},
 			},
@@ -119,7 +110,7 @@ func Test(t *testing.T) {
 		{
 			name: "one container multiplex",
 			client: &MockClient{
-				ContainerListF: func(ctx context.Context, options container.ListOptions) ([]types.Container, error) {
+				ContainerListF: func() ([]types.Container, error) {
 					return []types.Container{
 						{
 							ID:    "deadbeef",
@@ -128,14 +119,14 @@ func Test(t *testing.T) {
 						},
 					}, nil
 				},
-				ContainerInspectF: func(ctx context.Context, containerID string) (types.ContainerJSON, error) {
+				ContainerInspectF: func() (types.ContainerJSON, error) {
 					return types.ContainerJSON{
 						Config: &container.Config{
 							Tty: false,
 						},
 					}, nil
 				},
-				ContainerLogsF: func(ctx context.Context, containerID string, options container.LogsOptions) (io.ReadCloser, error) {
+				ContainerLogsF: func() (io.ReadCloser, error) {
 					var buf bytes.Buffer
 					w := stdcopy.NewStdWriter(&buf, stdcopy.Stdout)
 					_, err := w.Write([]byte("2020-04-28T18:42:16.432691200Z hello from stdout"))

--- a/plugins/inputs/ecs/client_test.go
+++ b/plugins/inputs/ecs/client_test.go
@@ -87,11 +87,11 @@ func TestEcsClient_PollSync(t *testing.T) {
 }
 
 type mockDo struct {
-	do func(req *http.Request) (*http.Response, error)
+	do func() (*http.Response, error)
 }
 
-func (m mockDo) Do(req *http.Request) (*http.Response, error) {
-	return m.do(req)
+func (m mockDo) Do(*http.Request) (*http.Response, error) {
+	return m.do()
 }
 
 func TestEcsClient_Task(t *testing.T) {
@@ -105,7 +105,7 @@ func TestEcsClient_Task(t *testing.T) {
 		{
 			name: "happy",
 			client: mockDo{
-				do: func(req *http.Request) (*http.Response, error) {
+				do: func() (*http.Response, error) {
 					return &http.Response{
 						StatusCode: http.StatusOK,
 						Body:       io.NopCloser(rc),
@@ -117,7 +117,7 @@ func TestEcsClient_Task(t *testing.T) {
 		{
 			name: "do err",
 			client: mockDo{
-				do: func(req *http.Request) (*http.Response, error) {
+				do: func() (*http.Response, error) {
 					return nil, errors.New("err")
 				},
 			},
@@ -126,7 +126,7 @@ func TestEcsClient_Task(t *testing.T) {
 		{
 			name: "malformed 500 resp",
 			client: mockDo{
-				do: func(req *http.Request) (*http.Response, error) {
+				do: func() (*http.Response, error) {
 					return &http.Response{
 						StatusCode: http.StatusInternalServerError,
 						Body:       io.NopCloser(bytes.NewReader([]byte("foo"))),
@@ -138,7 +138,7 @@ func TestEcsClient_Task(t *testing.T) {
 		{
 			name: "malformed 200 resp",
 			client: mockDo{
-				do: func(req *http.Request) (*http.Response, error) {
+				do: func() (*http.Response, error) {
 					return &http.Response{
 						StatusCode: http.StatusOK,
 						Body:       io.NopCloser(bytes.NewReader([]byte("foo"))),
@@ -176,7 +176,7 @@ func TestEcsClient_ContainerStats(t *testing.T) {
 		{
 			name: "happy",
 			client: mockDo{
-				do: func(req *http.Request) (*http.Response, error) {
+				do: func() (*http.Response, error) {
 					return &http.Response{
 						StatusCode: http.StatusOK,
 						Body:       io.NopCloser(rc),
@@ -188,7 +188,7 @@ func TestEcsClient_ContainerStats(t *testing.T) {
 		{
 			name: "do err",
 			client: mockDo{
-				do: func(req *http.Request) (*http.Response, error) {
+				do: func() (*http.Response, error) {
 					return nil, errors.New("err")
 				},
 			},
@@ -198,7 +198,7 @@ func TestEcsClient_ContainerStats(t *testing.T) {
 		{
 			name: "malformed 200 resp",
 			client: mockDo{
-				do: func(req *http.Request) (*http.Response, error) {
+				do: func() (*http.Response, error) {
 					return &http.Response{
 						StatusCode: http.StatusOK,
 						Body:       io.NopCloser(bytes.NewReader([]byte("foo"))),
@@ -211,7 +211,7 @@ func TestEcsClient_ContainerStats(t *testing.T) {
 		{
 			name: "malformed 500 resp",
 			client: mockDo{
-				do: func(req *http.Request) (*http.Response, error) {
+				do: func() (*http.Response, error) {
 					return &http.Response{
 						StatusCode: http.StatusInternalServerError,
 						Body:       io.NopCloser(bytes.NewReader([]byte("foo"))),

--- a/plugins/inputs/ecs/types_test.go
+++ b/plugins/inputs/ecs/types_test.go
@@ -42,7 +42,6 @@ func Test_mergeTaskStats(t *testing.T) {
 	mergeTaskStats(parsedMetadata, parsedStats)
 
 	for i := range parsedMetadata.Containers {
-		//nolint:testifylint // values are in proper order (expected, actual)
 		require.Equal(t, validStats[parsedMetadata.Containers[i].ID], &parsedMetadata.Containers[i].Stats)
 	}
 }

--- a/plugins/inputs/fibaro/fibaro_test.go
+++ b/plugins/inputs/fibaro/fibaro_test.go
@@ -9,14 +9,15 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/testutil"
-	"github.com/stretchr/testify/require"
 )
 
 // TestUnauthorized validates that 401 (wrong credentials) is managed properly
 func TestUnauthorized(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusUnauthorized)
 	}))
 	defer ts.Close()

--- a/plugins/inputs/filecount/filecount.go
+++ b/plugins/inputs/filecount/filecount.go
@@ -125,7 +125,7 @@ func (fc *FileCount) count(acc telegraf.Accumulator, basedir string, glob globpa
 	oldestFileTimestamp := make(map[string]int64)
 	newestFileTimestamp := make(map[string]int64)
 
-	walkFn := func(path string, de *godirwalk.Dirent) error {
+	walkFn := func(path string, _ *godirwalk.Dirent) error {
 		rel, err := filepath.Rel(basedir, path)
 		if err == nil && rel == "." {
 			return nil
@@ -159,7 +159,7 @@ func (fc *FileCount) count(acc telegraf.Accumulator, basedir string, glob globpa
 		return nil
 	}
 
-	postChildrenFn := func(path string, de *godirwalk.Dirent) error {
+	postChildrenFn := func(path string, _ *godirwalk.Dirent) error {
 		if glob.MatchString(path) {
 			gauge := map[string]interface{}{
 				"count":      childCount[path],
@@ -195,7 +195,7 @@ func (fc *FileCount) count(acc telegraf.Accumulator, basedir string, glob globpa
 		PostChildrenCallback: postChildrenFn,
 		Unsorted:             true,
 		FollowSymbolicLinks:  fc.FollowSymlinks,
-		ErrorCallback: func(osPathname string, err error) godirwalk.ErrorAction {
+		ErrorCallback: func(_ string, err error) godirwalk.ErrorAction {
 			if errors.Is(err, fs.ErrPermission) {
 				fc.Log.Debug(err)
 				return godirwalk.SkipNode

--- a/plugins/inputs/fireboard/fireboard_test.go
+++ b/plugins/inputs/fireboard/fireboard_test.go
@@ -8,13 +8,14 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/influxdata/telegraf/testutil"
 	"github.com/stretchr/testify/require"
+
+	"github.com/influxdata/telegraf/testutil"
 )
 
 func TestFireboard(t *testing.T) {
 	// Create a test server with the const response JSON
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		_, err := fmt.Fprintln(w, response)
 		require.NoError(t, err)

--- a/plugins/inputs/fluentd/fluentd_test.go
+++ b/plugins/inputs/fluentd/fluentd_test.go
@@ -169,7 +169,7 @@ func Test_parse(t *testing.T) {
 func Test_Gather(t *testing.T) {
 	t.Logf("Start HTTP mock (%s) with sampleJSON", fluentdTest.Endpoint)
 
-	ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, err := fmt.Fprintf(w, "%s", string(sampleJSON))
 		require.NoError(t, err)

--- a/plugins/inputs/gnmi/gnmi_test.go
+++ b/plugins/inputs/gnmi/gnmi_test.go
@@ -73,7 +73,7 @@ func TestWaitError(t *testing.T) {
 
 	grpcServer := grpc.NewServer()
 	gnmiServer := &MockServer{
-		SubscribeF: func(server gnmiLib.GNMI_SubscribeServer) error {
+		SubscribeF: func(gnmiLib.GNMI_SubscribeServer) error {
 			return errors.New("testerror")
 		},
 		GRPCServer: grpcServer,

--- a/plugins/inputs/haproxy/haproxy_test.go
+++ b/plugins/inputs/haproxy/haproxy_test.go
@@ -92,7 +92,7 @@ func TestHaproxyGeneratesMetricsWithAuthentication(t *testing.T) {
 }
 
 func TestHaproxyGeneratesMetricsWithoutAuthentication(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, err := fmt.Fprint(w, string(csvOutputSample))
 		require.NoError(t, err)
 	}))
@@ -213,7 +213,7 @@ func TestHaproxyDefaultGetFromLocalhost(t *testing.T) {
 }
 
 func TestHaproxyKeepFieldNames(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, err := fmt.Fprint(w, string(csvOutputSample))
 		require.NoError(t, err)
 	}))

--- a/plugins/inputs/http/http_test.go
+++ b/plugins/inputs/http/http_test.go
@@ -133,7 +133,7 @@ func TestHTTPContentLengthHeader(t *testing.T) {
 }
 
 func TestInvalidStatusCode(t *testing.T) {
-	fakeServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	fakeServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
 	}))
 	defer fakeServer.Close()
@@ -156,7 +156,7 @@ func TestInvalidStatusCode(t *testing.T) {
 }
 
 func TestSuccessStatusCodes(t *testing.T) {
-	fakeServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	fakeServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusAccepted)
 	}))
 	defer fakeServer.Close()
@@ -354,7 +354,7 @@ func TestOAuthClientCredentialsGrant(t *testing.T) {
 				},
 				Log: testutil.Logger{},
 			},
-			tokenHandler: func(t *testing.T, w http.ResponseWriter, r *http.Request) {
+			tokenHandler: func(t *testing.T, w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusOK)
 				values := url.Values{}
 				values.Add("access_token", token)

--- a/plugins/inputs/http_response/http_response.go
+++ b/plugins/inputs/http_response/http_response.go
@@ -77,7 +77,7 @@ func getProxyFunc(httpProxy string) func(*http.Request) (*url.URL, error) {
 			return nil, errors.New("bad proxy: " + err.Error())
 		}
 	}
-	return func(r *http.Request) (*url.URL, error) {
+	return func(*http.Request) (*url.URL, error) {
 		return proxyURL, nil
 	}
 }
@@ -110,7 +110,7 @@ func (h *HTTPResponse) createHTTPClient() (*http.Client, error) {
 	}
 
 	if !h.FollowRedirects {
-		client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		client.CheckRedirect = func(*http.Request, []*http.Request) error {
 			return http.ErrUseLastResponse
 		}
 	}

--- a/plugins/inputs/http_response/http_response_test.go
+++ b/plugins/inputs/http_response/http_response_test.go
@@ -93,7 +93,7 @@ func setUpTestMux() http.Handler {
 	mux.HandleFunc("/redirect", func(w http.ResponseWriter, req *http.Request) {
 		http.Redirect(w, req, "/good", http.StatusMovedPermanently)
 	})
-	mux.HandleFunc("/good", func(w http.ResponseWriter, req *http.Request) {
+	mux.HandleFunc("/good", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Server", "MyTestServer")
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		fmt.Fprintf(w, "hit the good page!")
@@ -112,13 +112,13 @@ func setUpTestMux() http.Handler {
 			w.WriteHeader(http.StatusOK)
 		}
 	})
-	mux.HandleFunc("/invalidUTF8", func(w http.ResponseWriter, req *http.Request) {
+	mux.HandleFunc("/invalidUTF8", func(w http.ResponseWriter, _ *http.Request) {
 		w.Write([]byte{0xff, 0xfe, 0xfd}) //nolint:errcheck // ignore the returned error as the test will fail anyway
 	})
-	mux.HandleFunc("/noheader", func(w http.ResponseWriter, req *http.Request) {
+	mux.HandleFunc("/noheader", func(w http.ResponseWriter, _ *http.Request) {
 		fmt.Fprintf(w, "hit the good page!")
 	})
-	mux.HandleFunc("/jsonresponse", func(w http.ResponseWriter, req *http.Request) {
+	mux.HandleFunc("/jsonresponse", func(w http.ResponseWriter, _ *http.Request) {
 		fmt.Fprintf(w, "\"service_status\": \"up\", \"healthy\" : \"true\"")
 	})
 	mux.HandleFunc("/badredirect", func(w http.ResponseWriter, req *http.Request) {
@@ -144,7 +144,7 @@ func setUpTestMux() http.Handler {
 		}
 		fmt.Fprintf(w, "sent a body!")
 	})
-	mux.HandleFunc("/twosecondnap", func(w http.ResponseWriter, req *http.Request) {
+	mux.HandleFunc("/twosecondnap", func(http.ResponseWriter, *http.Request) {
 		time.Sleep(time.Second * 2)
 	})
 	mux.HandleFunc("/nocontent", func(w http.ResponseWriter, _ *http.Request) {
@@ -1109,7 +1109,7 @@ func TestRedirect(t *testing.T) {
 	ts := httptest.NewServer(http.NotFoundHandler())
 	defer ts.Close()
 
-	ts.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Add("Location", "http://example.org")
 		w.WriteHeader(http.StatusMovedPermanently)
 		_, err := w.Write([]byte("test"))

--- a/plugins/inputs/influxdb/influxdb_test.go
+++ b/plugins/inputs/influxdb/influxdb_test.go
@@ -211,7 +211,7 @@ func TestErrorHandling404(t *testing.T) {
 }
 
 func TestErrorResponse(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusUnauthorized)
 		_, err := w.Write([]byte(`{"error": "unable to parse authentication credentials"}`))
 		require.NoError(t, err)

--- a/plugins/inputs/influxdb_listener/influxdb_listener.go
+++ b/plugins/inputs/influxdb_listener/influxdb_listener.go
@@ -197,7 +197,7 @@ func (h *InfluxDBListener) ServeHTTP(res http.ResponseWriter, req *http.Request)
 }
 
 func (h *InfluxDBListener) handleQuery() http.HandlerFunc {
-	return func(res http.ResponseWriter, req *http.Request) {
+	return func(res http.ResponseWriter, _ *http.Request) {
 		defer h.queriesServed.Incr(1)
 		// Deliver a dummy response to the query endpoint, as some InfluxDB
 		// clients test endpoint availability with a query

--- a/plugins/inputs/influxdb_v2_listener/influxdb_v2_listener.go
+++ b/plugins/inputs/influxdb_v2_listener/influxdb_v2_listener.go
@@ -193,7 +193,7 @@ func (h *InfluxDBV2Listener) ServeHTTP(res http.ResponseWriter, req *http.Reques
 }
 
 func (h *InfluxDBV2Listener) handleReady() http.HandlerFunc {
-	return func(res http.ResponseWriter, req *http.Request) {
+	return func(res http.ResponseWriter, _ *http.Request) {
 		defer h.readysServed.Incr(1)
 
 		// respond to ready requests

--- a/plugins/inputs/ipset/ipset_test.go
+++ b/plugins/inputs/ipset/ipset_test.go
@@ -95,7 +95,7 @@ func TestIpset(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			i++
 			ips := &Ipset{
-				lister: func(timeout config.Duration, useSudo bool) (*bytes.Buffer, error) {
+				lister: func(config.Duration, bool) (*bytes.Buffer, error) {
 					return bytes.NewBufferString(tt.value), nil
 				},
 			}
@@ -138,7 +138,7 @@ func TestIpset(t *testing.T) {
 func TestIpset_Gather_listerError(t *testing.T) {
 	errFoo := errors.New("error foobar")
 	ips := &Ipset{
-		lister: func(timeout config.Duration, useSudo bool) (*bytes.Buffer, error) {
+		lister: func(config.Duration, bool) (*bytes.Buffer, error) {
 			return new(bytes.Buffer), errFoo
 		},
 	}

--- a/plugins/inputs/iptables/iptables_test.go
+++ b/plugins/inputs/iptables/iptables_test.go
@@ -177,7 +177,7 @@ func TestIptables_Gather(t *testing.T) {
 			ipt := &Iptables{
 				Table:  tt.table,
 				Chains: tt.chains,
-				lister: func(table, chain string) (string, error) {
+				lister: func(string, string) (string, error) {
 					if len(tt.values) > 0 {
 						v := tt.values[0]
 						tt.values = tt.values[1:]
@@ -241,7 +241,7 @@ func TestIptables_Gather_listerError(t *testing.T) {
 	ipt := &Iptables{
 		Table:  "nat",
 		Chains: []string{"foo", "bar"},
-		lister: func(table, chain string) (string, error) {
+		lister: func(string, string) (string, error) {
 			return "", errFoo
 		},
 	}

--- a/plugins/inputs/jolokia2_agent/jolokia2_agent_test.go
+++ b/plugins/inputs/jolokia2_agent/jolokia2_agent_test.go
@@ -830,7 +830,7 @@ func TestIntegrationArtemis(t *testing.T) {
 }
 
 func setupServer(resp string) *httptest.Server {
-	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprintln(w, resp)
 	}))

--- a/plugins/inputs/jolokia2_proxy/jolokia2_proxy_test.go
+++ b/plugins/inputs/jolokia2_proxy/jolokia2_proxy_test.go
@@ -149,7 +149,7 @@ func TestFillFields(t *testing.T) {
 }
 
 func setupServer(resp string) *httptest.Server {
-	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprintln(w, resp)
 	}))

--- a/plugins/inputs/kapacitor/kapacitor_test.go
+++ b/plugins/inputs/kapacitor/kapacitor_test.go
@@ -78,7 +78,7 @@ func TestKapacitor(t *testing.T) {
 }
 
 func TestMissingStats(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, err := w.Write([]byte(`{}`))
 		require.NoError(t, err)
 	}))
@@ -117,7 +117,7 @@ func TestErrorHandling(t *testing.T) {
 }
 
 func TestErrorHandling404(t *testing.T) {
-	badServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	badServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
 	}))
 	defer badServer.Close()

--- a/plugins/inputs/kubernetes/kubernetes.go
+++ b/plugins/inputs/kubernetes/kubernetes.go
@@ -252,7 +252,7 @@ func (k *Kubernetes) LoadJSON(url string, v interface{}) error {
 			Transport: &http.Transport{
 				TLSClientConfig: tlsCfg,
 			},
-			CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			CheckRedirect: func(*http.Request, []*http.Request) error {
 				return http.ErrUseLastResponse
 			},
 			Timeout: time.Duration(k.ResponseTimeout),

--- a/plugins/inputs/libvirt/libvirt_test.go
+++ b/plugins/inputs/libvirt/libvirt_test.go
@@ -313,10 +313,6 @@ func TestLibvirt_filterDomains(t *testing.T) {
 		result := l.filterDomains(domains)
 		require.NotEmpty(t, result)
 	})
-
-	t.Run("failed on something", func(t *testing.T) {
-
-	})
 }
 
 var (

--- a/plugins/inputs/logstash/logstash_test.go
+++ b/plugins/inputs/logstash/logstash_test.go
@@ -8,8 +8,9 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/influxdata/telegraf/testutil"
 	"github.com/stretchr/testify/require"
+
+	"github.com/influxdata/telegraf/testutil"
 )
 
 var logstashTest = NewLogstash()
@@ -25,7 +26,7 @@ var (
 )
 
 func Test_Logstash5GatherProcessStats(test *testing.T) {
-	fakeServer := httptest.NewUnstartedServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+	fakeServer := httptest.NewUnstartedServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
 		writer.Header().Set("Content-Type", "application/json")
 		_, err := fmt.Fprintf(writer, "%s", string(logstash5ProcessJSON))
 		require.NoError(test, err)
@@ -70,7 +71,7 @@ func Test_Logstash5GatherProcessStats(test *testing.T) {
 }
 
 func Test_Logstash6GatherProcessStats(test *testing.T) {
-	fakeServer := httptest.NewUnstartedServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+	fakeServer := httptest.NewUnstartedServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
 		writer.Header().Set("Content-Type", "application/json")
 		_, err := fmt.Fprintf(writer, "%s", string(logstash6ProcessJSON))
 		require.NoError(test, err)
@@ -116,7 +117,7 @@ func Test_Logstash6GatherProcessStats(test *testing.T) {
 
 func Test_Logstash5GatherPipelineStats(test *testing.T) {
 	logstash5accPipelineStats.SetDebug(true)
-	fakeServer := httptest.NewUnstartedServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+	fakeServer := httptest.NewUnstartedServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
 		writer.Header().Set("Content-Type", "application/json")
 		_, err := fmt.Fprintf(writer, "%s", string(logstash5PipelineJSON))
 		require.NoError(test, err)
@@ -214,7 +215,7 @@ func Test_Logstash5GatherPipelineStats(test *testing.T) {
 
 func Test_Logstash6GatherPipelinesStats(test *testing.T) {
 	logstash6accPipelinesStats.SetDebug(true)
-	fakeServer := httptest.NewUnstartedServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+	fakeServer := httptest.NewUnstartedServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
 		writer.Header().Set("Content-Type", "application/json")
 		_, err := fmt.Fprintf(writer, "%s", string(logstash6PipelinesJSON))
 		require.NoError(test, err)
@@ -556,7 +557,7 @@ func Test_Logstash6GatherPipelinesStats(test *testing.T) {
 }
 
 func Test_Logstash5GatherJVMStats(test *testing.T) {
-	fakeServer := httptest.NewUnstartedServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+	fakeServer := httptest.NewUnstartedServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
 		writer.Header().Set("Content-Type", "application/json")
 		_, err := fmt.Fprintf(writer, "%s", string(logstash5JvmJSON))
 		require.NoError(test, err)
@@ -620,7 +621,7 @@ func Test_Logstash5GatherJVMStats(test *testing.T) {
 }
 
 func Test_Logstash6GatherJVMStats(test *testing.T) {
-	fakeServer := httptest.NewUnstartedServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+	fakeServer := httptest.NewUnstartedServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
 		writer.Header().Set("Content-Type", "application/json")
 		_, err := fmt.Fprintf(writer, "%s", string(logstash6JvmJSON))
 		require.NoError(test, err)
@@ -684,7 +685,7 @@ func Test_Logstash6GatherJVMStats(test *testing.T) {
 }
 
 func Test_Logstash7GatherPipelinesQueueStats(test *testing.T) {
-	fakeServer := httptest.NewUnstartedServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+	fakeServer := httptest.NewUnstartedServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
 		writer.Header().Set("Content-Type", "application/json")
 		_, err := fmt.Fprintf(writer, "%s", string(logstash7PipelinesJSON))
 		if err != nil {

--- a/plugins/inputs/mailchimp/mailchimp_test.go
+++ b/plugins/inputs/mailchimp/mailchimp_test.go
@@ -15,7 +15,7 @@ import (
 func TestMailChimpGatherReports(t *testing.T) {
 	ts := httptest.NewServer(
 		http.HandlerFunc(
-			func(w http.ResponseWriter, r *http.Request) {
+			func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusOK)
 				_, err := fmt.Fprintln(w, sampleReports)
 				require.NoError(t, err)
@@ -80,7 +80,7 @@ func TestMailChimpGatherReports(t *testing.T) {
 func TestMailChimpGatherReport(t *testing.T) {
 	ts := httptest.NewServer(
 		http.HandlerFunc(
-			func(w http.ResponseWriter, r *http.Request) {
+			func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusOK)
 				_, err := fmt.Fprintln(w, sampleReport)
 				require.NoError(t, err)
@@ -146,7 +146,7 @@ func TestMailChimpGatherReport(t *testing.T) {
 func TestMailChimpGatherError(t *testing.T) {
 	ts := httptest.NewServer(
 		http.HandlerFunc(
-			func(w http.ResponseWriter, r *http.Request) {
+			func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusOK)
 				_, err := fmt.Fprintln(w, sampleError)
 				require.NoError(t, err)

--- a/plugins/inputs/marklogic/marklogic_test.go
+++ b/plugins/inputs/marklogic/marklogic_test.go
@@ -7,13 +7,14 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/influxdata/telegraf/testutil"
 	"github.com/stretchr/testify/require"
+
+	"github.com/influxdata/telegraf/testutil"
 )
 
 func TestMarklogic(t *testing.T) {
 	// Create a test server with the const response JSON
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		_, err := fmt.Fprintln(w, response)
 		require.NoError(t, err)

--- a/plugins/inputs/mesos/mesos_test.go
+++ b/plugins/inputs/mesos/mesos_test.go
@@ -285,7 +285,7 @@ func TestMain(m *testing.M) {
 	generateMetrics()
 
 	masterRouter := http.NewServeMux()
-	masterRouter.HandleFunc("/metrics/snapshot", func(w http.ResponseWriter, r *http.Request) {
+	masterRouter.HandleFunc("/metrics/snapshot", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(masterMetrics) //nolint:errcheck // ignore the returned error as we cannot do anything about it anyway
@@ -293,7 +293,7 @@ func TestMain(m *testing.M) {
 	masterTestServer = httptest.NewServer(masterRouter)
 
 	slaveRouter := http.NewServeMux()
-	slaveRouter.HandleFunc("/metrics/snapshot", func(w http.ResponseWriter, r *http.Request) {
+	slaveRouter.HandleFunc("/metrics/snapshot", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(slaveMetrics) //nolint:errcheck // ignore the returned error as we cannot do anything about it anyway

--- a/plugins/inputs/modbus/configuration_request_test.go
+++ b/plugins/inputs/modbus/configuration_request_test.go
@@ -7,10 +7,11 @@ import (
 	"time"
 
 	mb "github.com/grid-x/modbus"
-	"github.com/influxdata/telegraf"
-	"github.com/influxdata/telegraf/testutil"
 	"github.com/stretchr/testify/require"
 	"github.com/tbrandon/mbserver"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/testutil"
 )
 
 func TestRequest(t *testing.T) {
@@ -2300,7 +2301,7 @@ func TestRequestMultipleSlavesOneFail(t *testing.T) {
 	defer serv.Close()
 
 	serv.RegisterFunctionHandler(3,
-		func(s *mbserver.Server, frame mbserver.Framer) ([]byte, *mbserver.Exception) {
+		func(_ *mbserver.Server, frame mbserver.Framer) ([]byte, *mbserver.Exception) {
 			tcpframe, ok := frame.(*mbserver.TCPFrame)
 			if !ok {
 				return nil, &mbserver.IllegalFunction

--- a/plugins/inputs/modbus/modbus_test.go
+++ b/plugins/inputs/modbus/modbus_test.go
@@ -159,10 +159,9 @@ func TestRetrySuccessful(t *testing.T) {
 	require.NoError(t, serv.ListenTCP("localhost:1502"))
 	defer serv.Close()
 
-	// Make read on coil-registers fail for some trials by making the device
-	// to appear busy
+	// Make read on coil-registers fail for some trials by making the device to appear busy
 	serv.RegisterFunctionHandler(1,
-		func(s *mbserver.Server, frame mbserver.Framer) ([]byte, *mbserver.Exception) {
+		func(*mbserver.Server, mbserver.Framer) ([]byte, *mbserver.Exception) {
 			data := make([]byte, 2)
 			data[0] = byte(1)
 			data[1] = byte(value)
@@ -221,7 +220,7 @@ func TestRetryFailExhausted(t *testing.T) {
 
 	// Make the read on coils fail with busy
 	serv.RegisterFunctionHandler(1,
-		func(s *mbserver.Server, frame mbserver.Framer) ([]byte, *mbserver.Exception) {
+		func(*mbserver.Server, mbserver.Framer) ([]byte, *mbserver.Exception) {
 			data := make([]byte, 2)
 			data[0] = byte(1)
 			data[1] = byte(0)
@@ -262,7 +261,7 @@ func TestRetryFailIllegal(t *testing.T) {
 	// Make the read on coils fail with illegal function preventing retry
 	counter := 0
 	serv.RegisterFunctionHandler(1,
-		func(s *mbserver.Server, frame mbserver.Framer) ([]byte, *mbserver.Exception) {
+		func(*mbserver.Server, mbserver.Framer) ([]byte, *mbserver.Exception) {
 			counter++
 			data := make([]byte, 2)
 			data[0] = byte(1)
@@ -315,7 +314,7 @@ func TestCases(t *testing.T) {
 	inputs.Add("modbus", func() telegraf.Input { return &Modbus{} })
 
 	// Define a function to return the register value as data
-	readFunc := func(s *mbserver.Server, frame mbserver.Framer) ([]byte, *mbserver.Exception) {
+	readFunc := func(_ *mbserver.Server, frame mbserver.Framer) ([]byte, *mbserver.Exception) {
 		data := frame.GetData()
 		register := binary.BigEndian.Uint16(data[0:2])
 		numRegs := binary.BigEndian.Uint16(data[2:4])

--- a/plugins/inputs/mqtt_consumer/mqtt_consumer_test.go
+++ b/plugins/inputs/mqtt_consumer/mqtt_consumer_test.go
@@ -15,9 +15,9 @@ import (
 
 type FakeClient struct {
 	ConnectF           func() mqtt.Token
-	SubscribeMultipleF func(filters map[string]byte, callback mqtt.MessageHandler) mqtt.Token
-	AddRouteF          func(topic string, callback mqtt.MessageHandler)
-	DisconnectF        func(quiesce uint)
+	SubscribeMultipleF func() mqtt.Token
+	AddRouteF          func(callback mqtt.MessageHandler)
+	DisconnectF        func()
 
 	connectCallCount    int
 	subscribeCallCount  int
@@ -30,19 +30,19 @@ func (c *FakeClient) Connect() mqtt.Token {
 	return c.ConnectF()
 }
 
-func (c *FakeClient) SubscribeMultiple(filters map[string]byte, callback mqtt.MessageHandler) mqtt.Token {
+func (c *FakeClient) SubscribeMultiple(map[string]byte, mqtt.MessageHandler) mqtt.Token {
 	c.subscribeCallCount++
-	return c.SubscribeMultipleF(filters, callback)
+	return c.SubscribeMultipleF()
 }
 
-func (c *FakeClient) AddRoute(topic string, callback mqtt.MessageHandler) {
+func (c *FakeClient) AddRoute(_ string, callback mqtt.MessageHandler) {
 	c.addRouteCallCount++
-	c.AddRouteF(topic, callback)
+	c.AddRouteF(callback)
 }
 
-func (c *FakeClient) Disconnect(quiesce uint) {
+func (c *FakeClient) Disconnect(uint) {
 	c.disconnectCallCount++
-	c.DisconnectF(quiesce)
+	c.DisconnectF()
 }
 
 type FakeParser struct {
@@ -95,17 +95,17 @@ func (t *FakeToken) Done() <-chan struct{} {
 func TestLifecycleSanity(t *testing.T) {
 	var acc testutil.Accumulator
 
-	plugin := New(func(o *mqtt.ClientOptions) Client {
+	plugin := New(func(*mqtt.ClientOptions) Client {
 		return &FakeClient{
 			ConnectF: func() mqtt.Token {
 				return &FakeToken{}
 			},
-			AddRouteF: func(topic string, callback mqtt.MessageHandler) {
+			AddRouteF: func(mqtt.MessageHandler) {
 			},
-			SubscribeMultipleF: func(filters map[string]byte, callback mqtt.MessageHandler) mqtt.Token {
+			SubscribeMultipleF: func() mqtt.Token {
 				return &FakeToken{}
 			},
-			DisconnectF: func(quiesce uint) {
+			DisconnectF: func() {
 			},
 		}
 	})
@@ -455,17 +455,17 @@ func TestTopicTag(t *testing.T) {
 				ConnectF: func() mqtt.Token {
 					return &FakeToken{}
 				},
-				AddRouteF: func(topic string, callback mqtt.MessageHandler) {
+				AddRouteF: func(callback mqtt.MessageHandler) {
 					handler = callback
 				},
-				SubscribeMultipleF: func(filters map[string]byte, callback mqtt.MessageHandler) mqtt.Token {
+				SubscribeMultipleF: func() mqtt.Token {
 					return &FakeToken{}
 				},
-				DisconnectF: func(quiesce uint) {
+				DisconnectF: func() {
 				},
 			}
 
-			plugin := New(func(o *mqtt.ClientOptions) Client {
+			plugin := New(func(*mqtt.ClientOptions) Client {
 				return client
 			})
 			plugin.Log = testutil.Logger{}
@@ -505,15 +505,15 @@ func TestAddRouteCalledForEachTopic(t *testing.T) {
 		ConnectF: func() mqtt.Token {
 			return &FakeToken{}
 		},
-		AddRouteF: func(topic string, callback mqtt.MessageHandler) {
+		AddRouteF: func(mqtt.MessageHandler) {
 		},
-		SubscribeMultipleF: func(filters map[string]byte, callback mqtt.MessageHandler) mqtt.Token {
+		SubscribeMultipleF: func() mqtt.Token {
 			return &FakeToken{}
 		},
-		DisconnectF: func(quiesce uint) {
+		DisconnectF: func() {
 		},
 	}
-	plugin := New(func(o *mqtt.ClientOptions) Client {
+	plugin := New(func(*mqtt.ClientOptions) Client {
 		return client
 	})
 	plugin.Log = testutil.Logger{}
@@ -536,15 +536,15 @@ func TestSubscribeCalledIfNoSession(t *testing.T) {
 		ConnectF: func() mqtt.Token {
 			return &FakeToken{}
 		},
-		AddRouteF: func(topic string, callback mqtt.MessageHandler) {
+		AddRouteF: func(mqtt.MessageHandler) {
 		},
-		SubscribeMultipleF: func(filters map[string]byte, callback mqtt.MessageHandler) mqtt.Token {
+		SubscribeMultipleF: func() mqtt.Token {
 			return &FakeToken{}
 		},
-		DisconnectF: func(quiesce uint) {
+		DisconnectF: func() {
 		},
 	}
-	plugin := New(func(o *mqtt.ClientOptions) Client {
+	plugin := New(func(*mqtt.ClientOptions) Client {
 		return client
 	})
 	plugin.Log = testutil.Logger{}
@@ -567,15 +567,15 @@ func TestSubscribeNotCalledIfSession(t *testing.T) {
 		ConnectF: func() mqtt.Token {
 			return &FakeToken{sessionPresent: true}
 		},
-		AddRouteF: func(topic string, callback mqtt.MessageHandler) {
+		AddRouteF: func(mqtt.MessageHandler) {
 		},
-		SubscribeMultipleF: func(filters map[string]byte, callback mqtt.MessageHandler) mqtt.Token {
+		SubscribeMultipleF: func() mqtt.Token {
 			return &FakeToken{}
 		},
-		DisconnectF: func(quiesce uint) {
+		DisconnectF: func() {
 		},
 	}
-	plugin := New(func(o *mqtt.ClientOptions) Client {
+	plugin := New(func(*mqtt.ClientOptions) Client {
 		return client
 	})
 	plugin.Log = testutil.Logger{}

--- a/plugins/inputs/neptune_apex/neptune_apex_test.go
+++ b/plugins/inputs/neptune_apex/neptune_apex_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestGather(t *testing.T) {
-	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	h := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
 		_, err := w.Write([]byte("data"))
 		require.NoError(t, err)
@@ -407,7 +407,7 @@ func TestSendRequest(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			h := http.HandlerFunc(func(
-				w http.ResponseWriter, r *http.Request) {
+				w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(test.statusCode)
 				_, err := w.Write([]byte("data"))
 				require.NoError(t, err)

--- a/plugins/inputs/nginx_plus_api/nginx_plus_api_metrics_test.go
+++ b/plugins/inputs/nginx_plus_api/nginx_plus_api_metrics_test.go
@@ -1458,7 +1458,7 @@ func TestGatherStreamServerZonesMetrics(t *testing.T) {
 }
 
 func TestUnavailableEndpoints(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
 	}))
 	defer ts.Close()
@@ -1476,7 +1476,7 @@ func TestUnavailableEndpoints(t *testing.T) {
 }
 
 func TestServerError(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 	}))
 	defer ts.Close()
@@ -1494,7 +1494,7 @@ func TestServerError(t *testing.T) {
 }
 
 func TestMalformedJSON(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		_, err := fmt.Fprintln(w, "this is not JSON")
 		require.NoError(t, err)
@@ -1514,7 +1514,7 @@ func TestMalformedJSON(t *testing.T) {
 }
 
 func TestUnknownContentType(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "text/plain")
 	}))
 	defer ts.Close()

--- a/plugins/inputs/nsq/nsq_test.go
+++ b/plugins/inputs/nsq/nsq_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestNSQStatsV1(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		_, err := fmt.Fprintln(w, responseV1)
 		require.NoError(t, err)
@@ -270,7 +270,7 @@ var responseV1 = `
 
 // TestNSQStatsPreV1 is for backwards compatibility with nsq versions < 1.0
 func TestNSQStatsPreV1(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		_, err := fmt.Fprintln(w, responsePreV1)
 		require.NoError(t, err)

--- a/plugins/inputs/opcua/read_client.go
+++ b/plugins/inputs/opcua/read_client.go
@@ -65,10 +65,10 @@ func (o *ReadClient) Connect() error {
 		return fmt.Errorf("initializing node IDs failed: %w", err)
 	}
 
-	readValueIds := make([]*ua.ReadValueID, 0, len(o.NodeIDs))
+	readValueIDs := make([]*ua.ReadValueID, 0, len(o.NodeIDs))
 	if o.Workarounds.UseUnregisteredReads {
 		for _, nid := range o.NodeIDs {
-			readValueIds = append(readValueIds, &ua.ReadValueID{NodeID: nid})
+			readValueIDs = append(readValueIDs, &ua.ReadValueID{NodeID: nid})
 		}
 	} else {
 		regResp, err := o.Client.RegisterNodes(o.ctx, &ua.RegisterNodesRequest{
@@ -79,14 +79,14 @@ func (o *ReadClient) Connect() error {
 		}
 
 		for _, v := range regResp.RegisteredNodeIDs {
-			readValueIds = append(readValueIds, &ua.ReadValueID{NodeID: v})
+			readValueIDs = append(readValueIDs, &ua.ReadValueID{NodeID: v})
 		}
 	}
 
 	o.req = &ua.ReadRequest{
 		MaxAge:             2000,
 		TimestampsToReturn: ua.TimestampsToReturnBoth,
-		NodesToRead:        readValueIds,
+		NodesToRead:        readValueIDs,
 	}
 
 	if err := o.read(); err != nil {

--- a/plugins/inputs/p4runtime/p4runtime_fake_client_test.go
+++ b/plugins/inputs/p4runtime/p4runtime_fake_client_test.go
@@ -15,9 +15,7 @@ type fakeP4RuntimeClient struct {
 	) (*p4v1.WriteResponse, error)
 
 	readFn func(
-		ctx context.Context,
 		in *p4v1.ReadRequest,
-		opts ...grpc.CallOption,
 	) (p4v1.P4Runtime_ReadClient, error)
 
 	setForwardingPipelineConfigFn func(
@@ -26,11 +24,7 @@ type fakeP4RuntimeClient struct {
 		opts ...grpc.CallOption,
 	) (*p4v1.SetForwardingPipelineConfigResponse, error)
 
-	getForwardingPipelineConfigFn func(
-		ctx context.Context,
-		in *p4v1.GetForwardingPipelineConfigRequest,
-		opts ...grpc.CallOption,
-	) (*p4v1.GetForwardingPipelineConfigResponse, error)
+	getForwardingPipelineConfigFn func() (*p4v1.GetForwardingPipelineConfigResponse, error)
 
 	streamChannelFn func(
 		ctx context.Context,
@@ -59,14 +53,14 @@ func (c *fakeP4RuntimeClient) Write(
 }
 
 func (c *fakeP4RuntimeClient) Read(
-	ctx context.Context,
+	_ context.Context,
 	in *p4v1.ReadRequest,
-	opts ...grpc.CallOption,
+	_ ...grpc.CallOption,
 ) (p4v1.P4Runtime_ReadClient, error) {
 	if c.readFn == nil {
 		panic("No mock defined for Read RPC")
 	}
-	return c.readFn(ctx, in, opts...)
+	return c.readFn(in)
 }
 
 func (c *fakeP4RuntimeClient) SetForwardingPipelineConfig(
@@ -81,14 +75,14 @@ func (c *fakeP4RuntimeClient) SetForwardingPipelineConfig(
 }
 
 func (c *fakeP4RuntimeClient) GetForwardingPipelineConfig(
-	ctx context.Context,
-	in *p4v1.GetForwardingPipelineConfigRequest,
-	opts ...grpc.CallOption,
+	context.Context,
+	*p4v1.GetForwardingPipelineConfigRequest,
+	...grpc.CallOption,
 ) (*p4v1.GetForwardingPipelineConfigResponse, error) {
 	if c.getForwardingPipelineConfigFn == nil {
 		panic("No mock defined for GetForwardingPipelineConfig RPC")
 	}
-	return c.getForwardingPipelineConfigFn(ctx, in, opts...)
+	return c.getForwardingPipelineConfigFn()
 }
 
 func (c *fakeP4RuntimeClient) StreamChannel(

--- a/plugins/inputs/p4runtime/p4runtime_test.go
+++ b/plugins/inputs/p4runtime/p4runtime_test.go
@@ -1,7 +1,6 @@
 package p4runtime
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"net"
@@ -93,11 +92,7 @@ func TestErrorGetP4Info(t *testing.T) {
 
 	for _, response := range responses {
 		p4RtClient := &fakeP4RuntimeClient{
-			getForwardingPipelineConfigFn: func(
-				ctx context.Context,
-				in *p4v1.GetForwardingPipelineConfigRequest,
-				opts ...grpc.CallOption,
-			) (*p4v1.GetForwardingPipelineConfigResponse, error) {
+			getForwardingPipelineConfigFn: func() (*p4v1.GetForwardingPipelineConfigResponse, error) {
 				return response.getForwardingPipelineConfigResponse, response.getForwardingPipelineConfigResponseError
 			},
 		}
@@ -235,14 +230,10 @@ func TestOneCounterRead(t *testing.T) {
 		}
 
 		p4RtClient := &fakeP4RuntimeClient{
-			readFn: func(ctx context.Context, in *p4v1.ReadRequest, opts ...grpc.CallOption) (p4v1.P4Runtime_ReadClient, error) {
+			readFn: func(*p4v1.ReadRequest) (p4v1.P4Runtime_ReadClient, error) {
 				return p4RtReadClient, nil
 			},
-			getForwardingPipelineConfigFn: func(
-				ctx context.Context,
-				in *p4v1.GetForwardingPipelineConfigRequest,
-				opts ...grpc.CallOption,
-			) (*p4v1.GetForwardingPipelineConfigResponse, error) {
+			getForwardingPipelineConfigFn: func() (*p4v1.GetForwardingPipelineConfigResponse, error) {
 				return &p4v1.GetForwardingPipelineConfigResponse{
 					Config: tt.forwardingPipelineConfig,
 				}, nil
@@ -327,14 +318,10 @@ func TestMultipleEntitiesSingleCounterRead(t *testing.T) {
 		}
 
 		p4RtClient := &fakeP4RuntimeClient{
-			readFn: func(ctx context.Context, in *p4v1.ReadRequest, opts ...grpc.CallOption) (p4v1.P4Runtime_ReadClient, error) {
+			readFn: func(*p4v1.ReadRequest) (p4v1.P4Runtime_ReadClient, error) {
 				return p4RtReadClient, nil
 			},
-			getForwardingPipelineConfigFn: func(
-				ctx context.Context,
-				in *p4v1.GetForwardingPipelineConfigRequest,
-				opts ...grpc.CallOption,
-			) (*p4v1.GetForwardingPipelineConfigResponse, error) {
+			getForwardingPipelineConfigFn: func() (*p4v1.GetForwardingPipelineConfigResponse, error) {
 				return &p4v1.GetForwardingPipelineConfigResponse{
 					Config: forwardingPipelineConfig,
 				}, nil
@@ -407,7 +394,7 @@ func TestSingleEntitiesMultipleCounterRead(t *testing.T) {
 		}
 
 		p4RtClient := &fakeP4RuntimeClient{
-			readFn: func(ctx context.Context, in *p4v1.ReadRequest, opts ...grpc.CallOption) (p4v1.P4Runtime_ReadClient, error) {
+			readFn: func(in *p4v1.ReadRequest) (p4v1.P4Runtime_ReadClient, error) {
 				counterID := in.Entities[0].GetCounterEntry().CounterId
 				return &fakeP4RuntimeReadClient{
 					recvFn: func() (*p4v1.ReadResponse, error) {
@@ -426,11 +413,7 @@ func TestSingleEntitiesMultipleCounterRead(t *testing.T) {
 					},
 				}, nil
 			},
-			getForwardingPipelineConfigFn: func(
-				ctx context.Context,
-				in *p4v1.GetForwardingPipelineConfigRequest,
-				opts ...grpc.CallOption,
-			) (*p4v1.GetForwardingPipelineConfigResponse, error) {
+			getForwardingPipelineConfigFn: func() (*p4v1.GetForwardingPipelineConfigResponse, error) {
 				return &p4v1.GetForwardingPipelineConfigResponse{
 					Config: forwardingPipelineConfig,
 				}, nil
@@ -462,11 +445,7 @@ func TestNoCountersAvailable(t *testing.T) {
 	}
 
 	p4RtClient := &fakeP4RuntimeClient{
-		getForwardingPipelineConfigFn: func(
-			ctx context.Context,
-			in *p4v1.GetForwardingPipelineConfigRequest,
-			opts ...grpc.CallOption,
-		) (*p4v1.GetForwardingPipelineConfigResponse, error) {
+		getForwardingPipelineConfigFn: func() (*p4v1.GetForwardingPipelineConfigResponse, error) {
 			return &p4v1.GetForwardingPipelineConfigResponse{
 				Config: forwardingPipelineConfig,
 			}, nil
@@ -493,11 +472,7 @@ func TestFilterCounters(t *testing.T) {
 	}
 
 	p4RtClient := &fakeP4RuntimeClient{
-		getForwardingPipelineConfigFn: func(
-			ctx context.Context,
-			in *p4v1.GetForwardingPipelineConfigRequest,
-			opts ...grpc.CallOption,
-		) (*p4v1.GetForwardingPipelineConfigResponse, error) {
+		getForwardingPipelineConfigFn: func() (*p4v1.GetForwardingPipelineConfigResponse, error) {
 			return &p4v1.GetForwardingPipelineConfigResponse{
 				Config: forwardingPipelineConfig,
 			}, nil
@@ -533,14 +508,10 @@ func TestFailReadCounterEntryFromEntry(t *testing.T) {
 	}
 
 	p4RtClient := &fakeP4RuntimeClient{
-		readFn: func(ctx context.Context, in *p4v1.ReadRequest, opts ...grpc.CallOption) (p4v1.P4Runtime_ReadClient, error) {
+		readFn: func(*p4v1.ReadRequest) (p4v1.P4Runtime_ReadClient, error) {
 			return p4RtReadClient, nil
 		},
-		getForwardingPipelineConfigFn: func(
-			ctx context.Context,
-			in *p4v1.GetForwardingPipelineConfigRequest,
-			opts ...grpc.CallOption,
-		) (*p4v1.GetForwardingPipelineConfigResponse, error) {
+		getForwardingPipelineConfigFn: func() (*p4v1.GetForwardingPipelineConfigResponse, error) {
 			return &p4v1.GetForwardingPipelineConfigResponse{
 				Config: &p4v1.ForwardingPipelineConfig{
 					P4Info: &p4ConfigV1.P4Info{
@@ -580,14 +551,10 @@ func TestFailReadCounterEntryFromEntry(t *testing.T) {
 
 func TestFailReadAllEntries(t *testing.T) {
 	p4RtClient := &fakeP4RuntimeClient{
-		readFn: func(ctx context.Context, in *p4v1.ReadRequest, opts ...grpc.CallOption) (p4v1.P4Runtime_ReadClient, error) {
+		readFn: func(*p4v1.ReadRequest) (p4v1.P4Runtime_ReadClient, error) {
 			return nil, errors.New("connection error")
 		},
-		getForwardingPipelineConfigFn: func(
-			ctx context.Context,
-			in *p4v1.GetForwardingPipelineConfigRequest,
-			opts ...grpc.CallOption,
-		) (*p4v1.GetForwardingPipelineConfigResponse, error) {
+		getForwardingPipelineConfigFn: func() (*p4v1.GetForwardingPipelineConfigResponse, error) {
 			return &p4v1.GetForwardingPipelineConfigResponse{
 				Config: &p4v1.ForwardingPipelineConfig{
 					P4Info: &p4ConfigV1.P4Info{

--- a/plugins/inputs/phpfpm/fcgi_test.go
+++ b/plugins/inputs/phpfpm/fcgi_test.go
@@ -239,7 +239,7 @@ func TestChildServeCleansUp(t *testing.T) {
 		rc := nopWriteCloser{bytes.NewBuffer(input)}
 		done := make(chan bool)
 		c := newChild(rc, http.HandlerFunc(func(
-			w http.ResponseWriter,
+			_ http.ResponseWriter,
 			r *http.Request,
 		) {
 			// block on reading body of request

--- a/plugins/inputs/phpfpm/phpfpm_test.go
+++ b/plugins/inputs/phpfpm/phpfpm_test.go
@@ -80,7 +80,7 @@ func TestPhpFpmGeneratesMetrics_From_Http(t *testing.T) {
 }
 
 func TestPhpFpmGeneratesJSONMetrics_From_Http(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "text/json")
 		w.Header().Set("Content-Length", strconv.Itoa(len(outputSampleJSON)))
 		_, err := fmt.Fprint(w, string(outputSampleJSON))

--- a/plugins/inputs/ping/ping_test.go
+++ b/plugins/inputs/ping/ping_test.go
@@ -225,7 +225,7 @@ func TestArguments(t *testing.T) {
 	}
 }
 
-func mockHostPinger(_ string, _ float64, _ ...string) (string, error) {
+func mockHostPinger(string, float64, ...string) (string, error) {
 	return linuxPingOutput, nil
 }
 
@@ -283,7 +283,7 @@ PING www.google.com (216.58.218.164) 56(84) bytes of data.
 rtt min/avg/max/mdev = 35.225/44.033/51.806/5.325 ms
 `
 
-func mockLossyHostPinger(_ string, _ float64, _ ...string) (string, error) {
+func mockLossyHostPinger(string, float64, ...string) (string, error) {
 	return lossyPingOutput, nil
 }
 
@@ -319,7 +319,7 @@ Request timeout for icmp_seq 0
 2 packets transmitted, 0 packets received, 100.0% packet loss
 `
 
-func mockErrorHostPinger(_ string, _ float64, _ ...string) (string, error) {
+func mockErrorHostPinger(string, float64, ...string) (string, error) {
 	// This error will not trigger correct error paths
 	return errorPingOutput, nil
 }
@@ -344,7 +344,7 @@ func TestBadPingGather(t *testing.T) {
 	acc.AssertContainsTaggedFields(t, "ping", fields, tags)
 }
 
-func mockFatalHostPinger(_ string, _ float64, _ ...string) (string, error) {
+func mockFatalHostPinger(string, float64, ...string) (string, error) {
 	return fatalPingOutput, errors.New("so very bad")
 }
 
@@ -388,7 +388,7 @@ func TestErrorWithHostNamePingGather(t *testing.T) {
 		var acc testutil.Accumulator
 		p := Ping{
 			Urls: []string{"www.amazon.com"},
-			pingHost: func(binary string, timeout float64, args ...string) (string, error) {
+			pingHost: func(string, float64, ...string) (string, error) {
 				return param.out, errors.New("so very bad")
 			},
 		}
@@ -403,7 +403,7 @@ func TestPingBinary(t *testing.T) {
 	p := Ping{
 		Urls:   []string{"www.google.com"},
 		Binary: "ping6",
-		pingHost: func(binary string, timeout float64, args ...string) (string, error) {
+		pingHost: func(binary string, _ float64, _ ...string) (string, error) {
 			require.Equal(t, "ping6", binary)
 			return "", nil
 		},
@@ -419,7 +419,7 @@ func TestPingGatherNative(t *testing.T) {
 		P *Ping
 	}
 
-	fakePingFunc := func(destination string) (*pingStats, error) {
+	fakePingFunc := func(string) (*pingStats, error) {
 		s := &pingStats{
 			Statistics: ping.Statistics{
 				PacketsSent: 5,
@@ -487,7 +487,7 @@ func TestNoPacketsSent(t *testing.T) {
 		Method:      "native",
 		Count:       5,
 		Percentiles: []int{50, 95, 99},
-		nativePingFunc: func(destination string) (*pingStats, error) {
+		nativePingFunc: func(string) (*pingStats, error) {
 			s := &pingStats{
 				Statistics: ping.Statistics{
 					PacketsSent: 0,
@@ -516,7 +516,7 @@ func TestDNSLookupError(t *testing.T) {
 		Urls:   []string{"localhost"},
 		Method: "native",
 		IPv6:   false,
-		nativePingFunc: func(destination string) (*pingStats, error) {
+		nativePingFunc: func(string) (*pingStats, error) {
 			return nil, errors.New("unknown")
 		},
 	}

--- a/plugins/inputs/ping/ping_windows_test.go
+++ b/plugins/inputs/ping/ping_windows_test.go
@@ -60,7 +60,7 @@ func TestHost(t *testing.T) {
 	require.Equal(t, 52, stats.max, "Max 52")
 }
 
-func mockHostPinger(_ string, _ float64, _ ...string) (string, error) {
+func mockHostPinger(string, float64, ...string) (string, error) {
 	return winENPingOutput, nil
 }
 
@@ -103,7 +103,7 @@ Statystyka badania ping dla 195.187.242.157:
              (100% straty),
 `
 
-func mockErrorHostPinger(_ string, _ float64, _ ...string) (string, error) {
+func mockErrorHostPinger(string, float64, ...string) (string, error) {
 	return errorPingOutput, errors.New("No packets received")
 }
 
@@ -164,7 +164,7 @@ Szacunkowy czas błądzenia pakietów w millisekundach:
     Minimum = 114 ms, Maksimum = 119 ms, Czas średni = 115 ms
 `
 
-func mockLossyHostPinger(_ string, _ float64, _ ...string) (string, error) {
+func mockLossyHostPinger(string, float64, ...string) (string, error) {
 	return lossyPingOutput, nil
 }
 
@@ -227,7 +227,7 @@ Options:
 
 `
 
-func mockFatalHostPinger(_ string, _ float64, _ ...string) (string, error) {
+func mockFatalHostPinger(string, float64, ...string) (string, error) {
 	return fatalPingOutput, errors.New("So very bad")
 }
 
@@ -272,7 +272,7 @@ Ping statistics for 8.8.8.8:
     Packets: Sent = 4, Received = 1, Lost = 3 (75% loss),
 `
 
-func mockUnreachableHostPinger(_ string, _ float64, _ ...string) (string, error) {
+func mockUnreachableHostPinger(string, float64, ...string) (string, error) {
 	return UnreachablePingOutput, errors.New("So very bad")
 }
 
@@ -323,7 +323,7 @@ Ping statistics for 8.8.8.8:
     Packets: Sent = 4, Received = 1, Lost = 3 (75% loss),
 `
 
-func mockTTLExpiredPinger(_ string, _ float64, _ ...string) (string, error) {
+func mockTTLExpiredPinger(string, float64, ...string) (string, error) {
 	return TTLExpiredPingOutput, errors.New("So very bad")
 }
 
@@ -367,7 +367,7 @@ func TestPingBinary(t *testing.T) {
 		Log:    testutil.Logger{},
 		Urls:   []string{"www.google.com"},
 		Binary: "ping6",
-		pingHost: func(binary string, timeout float64, args ...string) (string, error) {
+		pingHost: func(binary string, _ float64, _ ...string) (string, error) {
 			require.Equal(t, "ping6", binary)
 			return "", nil
 		},

--- a/plugins/inputs/prometheus/prometheus.go
+++ b/plugins/inputs/prometheus/prometheus.go
@@ -15,16 +15,15 @@ import (
 	"sync"
 	"time"
 
-	"github.com/influxdata/telegraf/filter"
-	"github.com/influxdata/telegraf/models"
-	"k8s.io/client-go/tools/cache"
-
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/tools/cache"
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
+	"github.com/influxdata/telegraf/filter"
 	"github.com/influxdata/telegraf/internal"
+	"github.com/influxdata/telegraf/models"
 	httpconfig "github.com/influxdata/telegraf/plugins/common/http"
 	"github.com/influxdata/telegraf/plugins/inputs"
 	parser "github.com/influxdata/telegraf/plugins/parsers/prometheus"
@@ -382,7 +381,7 @@ func (p *Prometheus) gatherURL(u URLAndAddress, acc telegraf.Accumulator) error 
 			Transport: &http.Transport{
 				TLSClientConfig:   tlsCfg,
 				DisableKeepAlives: true,
-				Dial: func(network, addr string) (net.Conn, error) {
+				Dial: func(string, string) (net.Conn, error) {
 					c, err := net.Dial("unix", u.URL.Path)
 					return c, err
 				},

--- a/plugins/inputs/prometheus/prometheus_test.go
+++ b/plugins/inputs/prometheus/prometheus_test.go
@@ -51,7 +51,7 @@ const sampleGaugeTextFormat = `
 go_goroutines 15 1490802350000`
 
 func TestPrometheusGeneratesMetrics(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, err := fmt.Fprintln(w, sampleTextFormat)
 		require.NoError(t, err)
 	}))
@@ -137,7 +137,7 @@ func TestPrometheusCustomHeader(t *testing.T) {
 }
 
 func TestPrometheusGeneratesMetricsWithHostNameTag(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, err := fmt.Fprintln(w, sampleTextFormat)
 		require.NoError(t, err)
 	}))
@@ -171,7 +171,7 @@ func TestPrometheusWithTimestamp(t *testing.T) {
 	prommetric := `# HELP test_counter A sample test counter.
 # TYPE test_counter counter
 test_counter{label="test"} 1 1685443805885`
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, err := fmt.Fprintln(w, prommetric)
 		require.NoError(t, err)
 	}))
@@ -207,7 +207,7 @@ func TestPrometheusGeneratesMetricsAlthoughFirstDNSFailsIntegration(t *testing.T
 		t.Skip("Skipping integration test in short mode")
 	}
 
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, err := fmt.Fprintln(w, sampleTextFormat)
 		require.NoError(t, err)
 	}))
@@ -233,7 +233,7 @@ func TestPrometheusGeneratesMetricsAlthoughFirstDNSFailsIntegration(t *testing.T
 }
 
 func TestPrometheusGeneratesMetricsSlowEndpoint(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		time.Sleep(4 * time.Second)
 		_, err := fmt.Fprintln(w, sampleTextFormat)
 		require.NoError(t, err)
@@ -263,7 +263,7 @@ func TestPrometheusGeneratesMetricsSlowEndpoint(t *testing.T) {
 }
 
 func TestPrometheusGeneratesMetricsSlowEndpointHitTheTimeout(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		time.Sleep(6 * time.Second)
 		_, err := fmt.Fprintln(w, sampleTextFormat)
 		require.NoError(t, err)
@@ -290,7 +290,7 @@ func TestPrometheusGeneratesMetricsSlowEndpointHitTheTimeout(t *testing.T) {
 }
 
 func TestPrometheusGeneratesMetricsSlowEndpointNewConfigParameter(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		time.Sleep(4 * time.Second)
 		_, err := fmt.Fprintln(w, sampleTextFormat)
 		require.NoError(t, err)
@@ -320,7 +320,7 @@ func TestPrometheusGeneratesMetricsSlowEndpointNewConfigParameter(t *testing.T) 
 }
 
 func TestPrometheusGeneratesMetricsSlowEndpointHitTheTimeoutNewConfigParameter(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		time.Sleep(6 * time.Second)
 		_, err := fmt.Fprintln(w, sampleTextFormat)
 		require.NoError(t, err)
@@ -343,7 +343,7 @@ func TestPrometheusGeneratesMetricsSlowEndpointHitTheTimeoutNewConfigParameter(t
 }
 
 func TestPrometheusContentLengthLimit(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, err := fmt.Fprintln(w, sampleTextFormat)
 		require.NoError(t, err)
 	}))
@@ -363,7 +363,7 @@ func TestPrometheusContentLengthLimit(t *testing.T) {
 }
 
 func TestPrometheusGeneratesSummaryMetricsV2(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, err := fmt.Fprintln(w, sampleSummaryTextFormat)
 		require.NoError(t, err)
 	}))
@@ -397,7 +397,7 @@ go_gc_duration_seconds{quantile="1"} NaN
 go_gc_duration_seconds_sum 42.0
 go_gc_duration_seconds_count 42`
 
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, err := fmt.Fprintln(w, data)
 		require.NoError(t, err)
 	}))
@@ -457,7 +457,7 @@ go_gc_duration_seconds_count 42`
 }
 
 func TestPrometheusGeneratesGaugeMetricsV2(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, err := fmt.Fprintln(w, sampleGaugeTextFormat)
 		require.NoError(t, err)
 	}))
@@ -483,7 +483,7 @@ func TestPrometheusGeneratesGaugeMetricsV2(t *testing.T) {
 }
 
 func TestPrometheusGeneratesMetricsWithIgnoreTimestamp(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, err := fmt.Fprintln(w, sampleTextFormat)
 		require.NoError(t, err)
 	}))

--- a/plugins/inputs/riak/riak_test.go
+++ b/plugins/inputs/riak/riak_test.go
@@ -7,13 +7,14 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/influxdata/telegraf/testutil"
 	"github.com/stretchr/testify/require"
+
+	"github.com/influxdata/telegraf/testutil"
 )
 
 func TestRiak(t *testing.T) {
 	// Create a test server with the const response JSON
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		_, err := fmt.Fprintln(w, response)
 		require.NoError(t, err)

--- a/plugins/inputs/s7comm/s7comm_test.go
+++ b/plugins/inputs/s7comm/s7comm_test.go
@@ -8,9 +8,10 @@ import (
 	"sync/atomic"
 	"testing"
 
-	"github.com/influxdata/telegraf/testutil"
 	"github.com/robinson/gos7"
 	"github.com/stretchr/testify/require"
+
+	"github.com/influxdata/telegraf/testutil"
 )
 
 func TestSampleConfig(t *testing.T) {
@@ -273,7 +274,7 @@ func TestFieldMappings(t *testing.T) {
 						{
 							measurement: "test",
 							field:       "foo",
-							convert:     func(b []byte) interface{} { return false },
+							convert:     func([]byte) interface{} { return false },
 						},
 					},
 				},
@@ -308,7 +309,7 @@ func TestFieldMappings(t *testing.T) {
 						{
 							measurement: "test",
 							field:       "foo",
-							convert:     func(b []byte) interface{} { return byte(0) },
+							convert:     func([]byte) interface{} { return byte(0) },
 						},
 					},
 				},
@@ -343,7 +344,7 @@ func TestFieldMappings(t *testing.T) {
 						{
 							measurement: "test",
 							field:       "foo",
-							convert:     func(b []byte) interface{} { return string([]byte{0}) },
+							convert:     func([]byte) interface{} { return string([]byte{0}) },
 						},
 					},
 				},
@@ -378,7 +379,7 @@ func TestFieldMappings(t *testing.T) {
 						{
 							measurement: "test",
 							field:       "foo",
-							convert:     func(b []byte) interface{} { return "" },
+							convert:     func([]byte) interface{} { return "" },
 						},
 					},
 				},
@@ -413,7 +414,7 @@ func TestFieldMappings(t *testing.T) {
 						{
 							measurement: "test",
 							field:       "foo",
-							convert:     func(b []byte) interface{} { return uint16(0) },
+							convert:     func([]byte) interface{} { return uint16(0) },
 						},
 					},
 				},
@@ -448,7 +449,7 @@ func TestFieldMappings(t *testing.T) {
 						{
 							measurement: "test",
 							field:       "foo",
-							convert:     func(b []byte) interface{} { return int16(0) },
+							convert:     func([]byte) interface{} { return int16(0) },
 						},
 					},
 				},
@@ -483,7 +484,7 @@ func TestFieldMappings(t *testing.T) {
 						{
 							measurement: "test",
 							field:       "foo",
-							convert:     func(b []byte) interface{} { return uint32(0) },
+							convert:     func([]byte) interface{} { return uint32(0) },
 						},
 					},
 				},
@@ -518,7 +519,7 @@ func TestFieldMappings(t *testing.T) {
 						{
 							measurement: "test",
 							field:       "foo",
-							convert:     func(b []byte) interface{} { return int32(0) },
+							convert:     func([]byte) interface{} { return int32(0) },
 						},
 					},
 				},
@@ -553,7 +554,7 @@ func TestFieldMappings(t *testing.T) {
 						{
 							measurement: "test",
 							field:       "foo",
-							convert:     func(b []byte) interface{} { return float32(0) },
+							convert:     func([]byte) interface{} { return float32(0) },
 						},
 					},
 				},

--- a/plugins/inputs/salesforce/salesforce_test.go
+++ b/plugins/inputs/salesforce/salesforce_test.go
@@ -6,13 +6,14 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/influxdata/telegraf/plugins/inputs/salesforce"
 	"github.com/influxdata/telegraf/testutil"
-	"github.com/stretchr/testify/require"
 )
 
 func Test_Gather(t *testing.T) {
-	fakeServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	fakeServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Add("Content-Type", "application/json")
 		_, _ = w.Write([]byte(testJSON))
 	}))

--- a/plugins/inputs/smart/smart.go
+++ b/plugins/inputs/smart/smart.go
@@ -79,7 +79,7 @@ var (
 	// 0xab    program_fail_count
 	nvmeIDSeparatePattern = regexp.MustCompile(`^([A-Za-z0-9_]+)(.+)`)
 
-	deviceFieldIds = map[string]string{
+	deviceFieldIDs = map[string]string{
 		"1":   "read_error_rate",
 		"5":   "reallocated_sectors_count",
 		"7":   "seek_error_rate",
@@ -842,9 +842,9 @@ func (m *Smart) gatherDisk(acc telegraf.Accumulator, device string, wg *sync.Wai
 				acc.AddFields("smart_attribute", fields, tags)
 			}
 
-			// If the attribute matches on the one in deviceFieldIds
+			// If the attribute matches on the one in deviceFieldIDs
 			// save the raw value to a field.
-			if field, ok := deviceFieldIds[attr[1]]; ok {
+			if field, ok := deviceFieldIDs[attr[1]]; ok {
 				if val, err := parseRawValue(attr[8]); err == nil {
 					deviceFields[field] = val
 				}

--- a/plugins/inputs/smart/smart_test.go
+++ b/plugins/inputs/smart/smart_test.go
@@ -20,7 +20,7 @@ func TestGatherAttributes(t *testing.T) {
 
 	require.Equal(t, time.Second*30, time.Duration(s.Timeout))
 
-	runCmd = func(timeout config.Duration, sudo bool, command string, args ...string) ([]byte, error) {
+	runCmd = func(_ config.Duration, _ bool, _ string, args ...string) ([]byte, error) {
 		if len(args) > 0 {
 			if args[0] == "--info" && args[7] == "/dev/ada0" {
 				return []byte(mockInfoAttributeData), nil
@@ -86,7 +86,7 @@ func TestGatherInParallelMode(t *testing.T) {
 	s.EnableExtensions = append(s.EnableExtensions, "auto-on")
 	s.Devices = []string{"/dev/nvme0"}
 
-	runCmd = func(timeout config.Duration, sudo bool, command string, args ...string) ([]byte, error) {
+	runCmd = func(_ config.Duration, _ bool, _ string, args ...string) ([]byte, error) {
 		if len(args) > 0 {
 			if args[0] == "--info" && args[7] == "/dev/ada0" {
 				return []byte(mockInfoAttributeData), nil
@@ -150,7 +150,7 @@ func TestGatherNoAttributes(t *testing.T) {
 
 	require.Equal(t, time.Second*30, time.Duration(s.Timeout))
 
-	runCmd = func(timeout config.Duration, sudo bool, command string, args ...string) ([]byte, error) {
+	runCmd = func(_ config.Duration, _ bool, _ string, args ...string) ([]byte, error) {
 		if len(args) > 0 {
 			if args[0] == "--scan" && len(args) == 1 {
 				return []byte(mockScanData), nil
@@ -201,7 +201,7 @@ var (
 )
 
 func TestGatherSATAInfo(t *testing.T) {
-	runCmd = func(timeout config.Duration, sudo bool, command string, args ...string) ([]byte, error) {
+	runCmd = func(config.Duration, bool, string, ...string) ([]byte, error) {
 		return []byte(hgstSATAInfoData), nil
 	}
 
@@ -218,7 +218,7 @@ func TestGatherSATAInfo(t *testing.T) {
 }
 
 func TestGatherSATAInfo65(t *testing.T) {
-	runCmd = func(timeout config.Duration, sudo bool, command string, args ...string) ([]byte, error) {
+	runCmd = func(config.Duration, bool, string, ...string) ([]byte, error) {
 		return []byte(hgstSATAInfoData65), nil
 	}
 
@@ -234,7 +234,7 @@ func TestGatherSATAInfo65(t *testing.T) {
 }
 
 func TestGatherHgstSAS(t *testing.T) {
-	runCmd = func(timeout config.Duration, sudo bool, command string, args ...string) ([]byte, error) {
+	runCmd = func(config.Duration, bool, string, ...string) ([]byte, error) {
 		return []byte(hgstSASInfoData), nil
 	}
 
@@ -250,7 +250,7 @@ func TestGatherHgstSAS(t *testing.T) {
 }
 
 func TestGatherHtSAS(t *testing.T) {
-	runCmd = func(timeout config.Duration, sudo bool, command string, args ...string) ([]byte, error) {
+	runCmd = func(config.Duration, bool, string, ...string) ([]byte, error) {
 		return []byte(htSASInfoData), nil
 	}
 
@@ -266,7 +266,7 @@ func TestGatherHtSAS(t *testing.T) {
 }
 
 func TestGatherLongFormEnduranceAttrib(t *testing.T) {
-	runCmd = func(timeout config.Duration, sudo bool, command string, args ...string) ([]byte, error) {
+	runCmd = func(config.Duration, bool, string, ...string) ([]byte, error) {
 		return []byte(mockHGST), nil
 	}
 
@@ -283,7 +283,7 @@ func TestGatherLongFormEnduranceAttrib(t *testing.T) {
 }
 
 func TestGatherSSD(t *testing.T) {
-	runCmd = func(timeout config.Duration, sudo bool, command string, args ...string) ([]byte, error) {
+	runCmd = func(config.Duration, bool, string, ...string) ([]byte, error) {
 		return []byte(ssdInfoData), nil
 	}
 
@@ -299,7 +299,7 @@ func TestGatherSSD(t *testing.T) {
 }
 
 func TestGatherSSDRaid(t *testing.T) {
-	runCmd = func(timeout config.Duration, sudo bool, command string, args ...string) ([]byte, error) {
+	runCmd = func(config.Duration, bool, string, ...string) ([]byte, error) {
 		return []byte(ssdRaidInfoData), nil
 	}
 
@@ -315,7 +315,7 @@ func TestGatherSSDRaid(t *testing.T) {
 }
 
 func TestGatherDeviceTypeTag(t *testing.T) {
-	runCmd = func(timeout config.Duration, sudo bool, command string, args ...string) ([]byte, error) {
+	runCmd = func(_ config.Duration, _ bool, _ string, args ...string) ([]byte, error) {
 		switch args[0] {
 		case "--scan":
 			return nil, errors.New("scan command should not be run, since devices are provided in config")
@@ -348,7 +348,7 @@ func TestGatherDeviceTypeTag(t *testing.T) {
 }
 
 func TestGatherNVMe(t *testing.T) {
-	runCmd = func(timeout config.Duration, sudo bool, command string, args ...string) ([]byte, error) {
+	runCmd = func(config.Duration, bool, string, ...string) ([]byte, error) {
 		return []byte(smartctlNVMeInfoData), nil
 	}
 
@@ -365,7 +365,7 @@ func TestGatherNVMe(t *testing.T) {
 }
 
 func TestGatherNVMeWindows(t *testing.T) {
-	runCmd = func(timeout config.Duration, sudo bool, command string, args ...string) ([]byte, error) {
+	runCmd = func(config.Duration, bool, string, ...string) ([]byte, error) {
 		return []byte(smartctlNVMeInfoDataWindows), nil
 	}
 
@@ -383,7 +383,7 @@ func TestGatherNVMeWindows(t *testing.T) {
 }
 
 func TestGatherIntelNVMeMetrics(t *testing.T) {
-	runCmd = func(timeout config.Duration, sudo bool, command string, args ...string) ([]byte, error) {
+	runCmd = func(config.Duration, bool, string, ...string) ([]byte, error) {
 		return []byte(nvmeIntelInfoDataMetricsFormat), nil
 	}
 
@@ -406,7 +406,7 @@ func TestGatherIntelNVMeMetrics(t *testing.T) {
 }
 
 func TestGatherIntelNVMeDeprecatedFormatMetrics(t *testing.T) {
-	runCmd = func(timeout config.Duration, sudo bool, command string, args ...string) ([]byte, error) {
+	runCmd = func(config.Duration, bool, string, ...string) ([]byte, error) {
 		return []byte(nvmeIntelInfoDataDeprecatedMetricsFormat), nil
 	}
 
@@ -461,7 +461,7 @@ func Test_difference(t *testing.T) {
 }
 
 func Test_integerOverflow(t *testing.T) {
-	runCmd = func(timeout config.Duration, sudo bool, command string, args ...string) ([]byte, error) {
+	runCmd = func(config.Duration, bool, string, ...string) ([]byte, error) {
 		return []byte(smartctlNVMeInfoDataWithOverflow), nil
 	}
 

--- a/plugins/inputs/socketstat/socketstat_test.go
+++ b/plugins/inputs/socketstat/socketstat_test.go
@@ -116,7 +116,7 @@ func TestSocketstat_Gather(t *testing.T) {
 			if err != nil {
 				require.EqualError(t, err, "exec: \"ss\": executable file not found in $PATH")
 			}
-			ss.lister = func(cmdName string, proto string, timeout config.Duration) (*bytes.Buffer, error) {
+			ss.lister = func(string, string, config.Duration) (*bytes.Buffer, error) {
 				return bytes.NewBuffer(octets), nil
 			}
 
@@ -153,7 +153,7 @@ func TestSocketstat_Gather_listerError(t *testing.T) {
 	ss := &Socketstat{
 		SocketProto: []string{"foobar"},
 	}
-	ss.lister = func(cmdName string, proto string, timeout config.Duration) (*bytes.Buffer, error) {
+	ss.lister = func(string, string, config.Duration) (*bytes.Buffer, error) {
 		return new(bytes.Buffer), errFoo
 	}
 	acc := new(testutil.Accumulator)

--- a/plugins/inputs/tengine/tengine_test.go
+++ b/plugins/inputs/tengine/tengine_test.go
@@ -27,7 +27,7 @@ func TestTengineTags(t *testing.T) {
 }
 
 func TestTengineGeneratesMetrics(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, err := fmt.Fprintln(w, tengineSampleResponse)
 		require.NoError(t, err)
 	}))

--- a/plugins/inputs/tomcat/tomcat_test.go
+++ b/plugins/inputs/tomcat/tomcat_test.go
@@ -39,7 +39,7 @@ var tomcatStatus8 = `<?xml version="1.0" encoding="UTF-8"?>
 </status>`
 
 func TestHTTPTomcat8(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		_, err := fmt.Fprintln(w, tomcatStatus8)
 		require.NoError(t, err)
@@ -124,7 +124,7 @@ var tomcatStatus6 = `<?xml version="1.0" encoding="utf-8"?>
 </status>`
 
 func TestHTTPTomcat6(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		_, err := fmt.Fprintln(w, tomcatStatus6)
 		require.NoError(t, err)

--- a/plugins/inputs/unbound/unbound_test.go
+++ b/plugins/inputs/unbound/unbound_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/influxdata/telegraf/testutil"
 )
 
-func UnboundControl(output string) func(unbound Unbound) (*bytes.Buffer, error) {
-	return func(unbound Unbound) (*bytes.Buffer, error) {
+func UnboundControl(output string) func(Unbound) (*bytes.Buffer, error) {
+	return func(Unbound) (*bytes.Buffer, error) {
 		return bytes.NewBuffer([]byte(output)), nil
 	}
 }

--- a/plugins/inputs/x509_cert/x509_cert_test.go
+++ b/plugins/inputs/x509_cert/x509_cert_test.go
@@ -78,7 +78,7 @@ func TestGatherRemoteIntegration(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			if test.unset {
 				cfg.Certificates = nil
-				cfg.GetCertificate = func(i *tls.ClientHelloInfo) (*tls.Certificate, error) {
+				cfg.GetCertificate = func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
 					return nil, nil
 				}
 			}
@@ -336,7 +336,7 @@ func TestGatherUDPCertIntegration(t *testing.T) {
 }
 
 func TestGatherTCPCert(t *testing.T) {
-	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer ts.Close()

--- a/plugins/inputs/xtremio/xtremio_test.go
+++ b/plugins/inputs/xtremio/xtremio_test.go
@@ -153,7 +153,7 @@ func TestFixedValue(t *testing.T) {
 func TestAuthenticationFailed(t *testing.T) {
 	ts := httptest.NewServer(
 		http.HandlerFunc(
-			func(w http.ResponseWriter, r *http.Request) {
+			func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusBadRequest)
 				_, err := fmt.Fprintln(w, "bad request")
 				require.NoError(t, err)

--- a/plugins/outputs/amqp/amqp_test.go
+++ b/plugins/outputs/amqp/amqp_test.go
@@ -11,16 +11,16 @@ import (
 )
 
 type MockClient struct {
-	PublishF func(key string, body []byte) error
+	PublishF func() error
 	CloseF   func() error
 
 	PublishCallCount int
 	CloseCallCount   int
 }
 
-func (c *MockClient) Publish(key string, body []byte) error {
+func (c *MockClient) Publish(string, []byte) error {
 	c.PublishCallCount++
-	return c.PublishF(key, body)
+	return c.PublishF()
 }
 
 func (c *MockClient) Close() error {
@@ -30,7 +30,7 @@ func (c *MockClient) Close() error {
 
 func NewMockClient() Client {
 	return &MockClient{
-		PublishF: func(key string, body []byte) error {
+		PublishF: func() error {
 			return nil
 		},
 		CloseF: func() error {

--- a/plugins/outputs/azure_monitor/azure_monitor_test.go
+++ b/plugins/outputs/azure_monitor/azure_monitor_test.go
@@ -69,7 +69,7 @@ func TestAggregate(t *testing.T) {
 			},
 			addTime:  time.Unix(0, 0),
 			pushTime: time.Unix(0, 0),
-			check: func(t *testing.T, plugin *AzureMonitor, metrics []telegraf.Metric) {
+			check: func(t *testing.T, _ *AzureMonitor, metrics []telegraf.Metric) {
 				require.Empty(t, metrics)
 			},
 		},
@@ -96,7 +96,7 @@ func TestAggregate(t *testing.T) {
 			},
 			addTime:  time.Unix(0, 0),
 			pushTime: time.Unix(3600, 0),
-			check: func(t *testing.T, plugin *AzureMonitor, metrics []telegraf.Metric) {
+			check: func(t *testing.T, _ *AzureMonitor, metrics []telegraf.Metric) {
 				expected := []telegraf.Metric{
 					testutil.MustMetric(
 						"cpu-value",
@@ -136,7 +136,7 @@ func TestAggregate(t *testing.T) {
 			},
 			addTime:  time.Unix(0, 0),
 			pushTime: time.Unix(3600, 0),
-			check: func(t *testing.T, plugin *AzureMonitor, metrics []telegraf.Metric) {
+			check: func(t *testing.T, _ *AzureMonitor, metrics []telegraf.Metric) {
 				expected := []telegraf.Metric{
 					testutil.MustMetric(
 						"cpu-value",
@@ -190,7 +190,7 @@ func TestAggregate(t *testing.T) {
 			},
 			addTime:  time.Unix(0, 0),
 			pushTime: time.Unix(3600, 0),
-			check: func(t *testing.T, plugin *AzureMonitor, metrics []telegraf.Metric) {
+			check: func(t *testing.T, _ *AzureMonitor, metrics []telegraf.Metric) {
 				expected := []telegraf.Metric{
 					testutil.MustMetric(
 						"cpu-value",
@@ -292,7 +292,7 @@ func TestWrite(t *testing.T) {
 					time.Unix(0, 0),
 				),
 			},
-			handler: func(t *testing.T, w http.ResponseWriter, r *http.Request) {
+			handler: func(t *testing.T, _ http.ResponseWriter, _ *http.Request) {
 				t.Fatal("should not call")
 			},
 		},

--- a/plugins/outputs/cloud_pubsub/topic_stubbed.go
+++ b/plugins/outputs/cloud_pubsub/topic_stubbed.go
@@ -36,7 +36,7 @@ type (
 	}
 
 	stubResult struct {
-		metricIds []string
+		metricIDs []string
 
 		sendError bool
 		err       chan error
@@ -123,7 +123,7 @@ func (t *stubTopic) Publish(ctx context.Context, msg *pubsub.Message) publishRes
 
 	ids := t.parseIDs(msg)
 	r := &stubResult{
-		metricIds: ids,
+		metricIDs: ids,
 		err:       make(chan error, 1),
 		done:      make(chan struct{}, 1),
 	}
@@ -172,7 +172,7 @@ func (t *stubTopic) sendBundle() func(items interface{}) {
 
 		for _, msg := range bundled {
 			r := msg.stubResult
-			for _, id := range r.metricIds {
+			for _, id := range r.metricIDs {
 				t.published[id] = msg.Message
 			}
 
@@ -224,7 +224,7 @@ func (r *stubResult) Get(ctx context.Context) (string, error) {
 	case err := <-r.err:
 		return "", err
 	case <-r.done:
-		return "id-" + r.metricIds[0], nil
+		return "id-" + r.metricIDs[0], nil
 	}
 }
 

--- a/plugins/outputs/cloudwatch_logs/cloudwatch_logs.go
+++ b/plugins/outputs/cloudwatch_logs/cloudwatch_logs.go
@@ -155,7 +155,7 @@ func (c *CloudWatchLogs) Connect() error {
 		return err
 	}
 	if c.CredentialConfig.EndpointURL != "" && c.CredentialConfig.Region != "" {
-		customResolver := aws.EndpointResolverWithOptionsFunc(func(service, region string, options ...interface{}) (aws.Endpoint, error) {
+		customResolver := aws.EndpointResolverWithOptionsFunc(func(string, string, ...interface{}) (aws.Endpoint, error) {
 			return aws.Endpoint{
 				PartitionID:   "aws",
 				URL:           c.CredentialConfig.EndpointURL,

--- a/plugins/outputs/cloudwatch_logs/cloudwatch_logs_test.go
+++ b/plugins/outputs/cloudwatch_logs/cloudwatch_logs_test.go
@@ -258,7 +258,7 @@ func TestInit(t *testing.T) {
 
 func TestConnect(t *testing.T) {
 	//mock cloudwatch logs endpoint that is used only in plugin.Connect
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		fmt.Fprintln(w,
 			`{
 				   "logGroups": [
@@ -298,7 +298,7 @@ func TestConnect(t *testing.T) {
 
 func TestWrite(t *testing.T) {
 	//mock cloudwatch logs endpoint that is used only in plugin.Connect
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		fmt.Fprintln(w,
 			`{
 				   "logGroups": [

--- a/plugins/outputs/datadog/datadog_test.go
+++ b/plugins/outputs/datadog/datadog_test.go
@@ -35,7 +35,7 @@ func fakeDatadog() *Datadog {
 }
 
 func TestUriOverride(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		json.NewEncoder(w).Encode(`{"status":"ok"}`) //nolint:errcheck // Ignore the returned error as the test will fail anyway
 	}))
@@ -50,7 +50,7 @@ func TestUriOverride(t *testing.T) {
 }
 
 func TestCompressionOverride(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		json.NewEncoder(w).Encode(`{"status":"ok"}`) //nolint:errcheck // Ignore the returned error as the test will fail anyway
 	}))
@@ -67,7 +67,7 @@ func TestCompressionOverride(t *testing.T) {
 
 func TestBadStatusCode(t *testing.T) {
 	errorString := `{"errors": ["Something bad happened to the server.", "Your query made the server very sad."]}`
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 		fmt.Fprint(w, errorString)
 	}))

--- a/plugins/outputs/dynatrace/dynatrace_test.go
+++ b/plugins/outputs/dynatrace/dynatrace_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestNilMetrics(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		err := json.NewEncoder(w).Encode(`{"linesOk":10,"linesInvalid":0,"error":null}`)
 		require.NoError(t, err)
@@ -48,7 +48,7 @@ func TestNilMetrics(t *testing.T) {
 }
 
 func TestEmptyMetricsSlice(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		err := json.NewEncoder(w).Encode(`{"linesOk":10,"linesInvalid":0,"error":null}`)
 		require.NoError(t, err)
@@ -72,7 +72,7 @@ func TestEmptyMetricsSlice(t *testing.T) {
 }
 
 func TestMockURL(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		err := json.NewEncoder(w).Encode(`{"linesOk":10,"linesInvalid":0,"error":null}`)
 		require.NoError(t, err)
@@ -529,7 +529,7 @@ func (l loggerStub) Warnf(_ string, _ ...interface{}) {
 
 func TestSendUnsupportedMetric(t *testing.T) {
 	warnfCalledTimes = 0
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
 		t.Fatal("should not export because the only metric is an invalid type")
 	}))
 	defer ts.Close()

--- a/plugins/outputs/event_hubs/event_hubs_test.go
+++ b/plugins/outputs/event_hubs/event_hubs_test.go
@@ -129,7 +129,7 @@ func TestInitAndWriteIntegration(t *testing.T) {
 	require.NoError(t, err)
 
 	// The handler function will pass received messages via the channel
-	handler := func(ctx context.Context, event *eventhub.Event) error {
+	handler := func(_ context.Context, event *eventhub.Event) error {
 		exit <- string(event.Data)
 		return nil
 	}

--- a/plugins/outputs/http/http_test.go
+++ b/plugins/outputs/http/http_test.go
@@ -172,7 +172,7 @@ func TestHTTPClientConfig(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ts.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ts.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusOK)
 			})
 
@@ -265,7 +265,7 @@ func TestStatusCode(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ts.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ts.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(tt.statusCode)
 			})
 
@@ -485,7 +485,7 @@ func TestOAuthClientCredentialsGrant(t *testing.T) {
 					},
 				},
 			},
-			tokenHandler: func(t *testing.T, w http.ResponseWriter, r *http.Request) {
+			tokenHandler: func(t *testing.T, w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusOK)
 				values := url.Values{}
 				values.Add("access_token", token)
@@ -513,7 +513,7 @@ func TestOAuthClientCredentialsGrant(t *testing.T) {
 					},
 				},
 			},
-			tokenHandler: func(t *testing.T, w http.ResponseWriter, r *http.Request) {
+			tokenHandler: func(t *testing.T, w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusOK)
 				values := url.Values{}
 				values.Add("access_token", token)
@@ -616,7 +616,7 @@ func TestOAuthAuthorizationCodeGrant(t *testing.T) {
 				URL:             u.String() + "/write",
 				CredentialsFile: tmpFile.Name(),
 			},
-			tokenHandler: func(t *testing.T, w http.ResponseWriter, r *http.Request) {
+			tokenHandler: func(t *testing.T, w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusOK)
 				authHeader := fmt.Sprintf(`{"id_token":%q}`, token)
 				_, err = w.Write([]byte(authHeader))
@@ -704,7 +704,7 @@ func TestBatchedUnbatched(t *testing.T) {
 
 	for name, serializer := range s {
 		var requests int
-		ts.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ts.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			requests++
 			w.WriteHeader(http.StatusOK)
 		})

--- a/plugins/outputs/influxdb/http_test.go
+++ b/plugins/outputs/influxdb/http_test.go
@@ -175,7 +175,7 @@ func TestHTTP_CreateDatabase(t *testing.T) {
 				URL:      u,
 				Database: `a \\ b`,
 			},
-			queryHandlerFunc: func(t *testing.T, w http.ResponseWriter, r *http.Request) {
+			queryHandlerFunc: func(t *testing.T, w http.ResponseWriter, _ *http.Request) {
 				// Yes, 200 OK is the correct response...
 				w.WriteHeader(http.StatusOK)
 				_, err = w.Write([]byte(`{"results": [{"error": "invalid name", "statement_id": 0}]}`))
@@ -197,7 +197,7 @@ func TestHTTP_CreateDatabase(t *testing.T) {
 				URL:      u,
 				Database: "telegraf",
 			},
-			queryHandlerFunc: func(t *testing.T, w http.ResponseWriter, r *http.Request) {
+			queryHandlerFunc: func(_ *testing.T, w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusNotFound)
 			},
 			errFunc: func(t *testing.T, err error) {
@@ -215,7 +215,7 @@ func TestHTTP_CreateDatabase(t *testing.T) {
 				URL:      u,
 				Database: "telegraf",
 			},
-			queryHandlerFunc: func(t *testing.T, w http.ResponseWriter, r *http.Request) {
+			queryHandlerFunc: func(_ *testing.T, w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusOK)
 			},
 		},
@@ -225,7 +225,7 @@ func TestHTTP_CreateDatabase(t *testing.T) {
 				URL:      u,
 				Database: `database`,
 			},
-			queryHandlerFunc: func(t *testing.T, w http.ResponseWriter, r *http.Request) {
+			queryHandlerFunc: func(t *testing.T, w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusBadRequest)
 				_, err = w.Write([]byte(`invalid response`))
 				require.NoError(t, err)
@@ -400,7 +400,7 @@ func TestHTTP_Write(t *testing.T) {
 				Database: "telegraf",
 				Log:      testutil.Logger{},
 			},
-			queryHandlerFunc: func(t *testing.T, w http.ResponseWriter, r *http.Request) {
+			queryHandlerFunc: func(t *testing.T, w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusBadRequest)
 				_, err = w.Write([]byte(`{"error": "write failed: hinted handoff queue not empty"}`))
 				require.NoError(t, err)
@@ -416,7 +416,7 @@ func TestHTTP_Write(t *testing.T) {
 				Database: "telegraf",
 				Log:      testutil.Logger{},
 			},
-			queryHandlerFunc: func(t *testing.T, w http.ResponseWriter, r *http.Request) {
+			queryHandlerFunc: func(t *testing.T, w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusBadRequest)
 				_, err = w.Write([]byte(`{"error": "partial write: field type conflict:"}`))
 				require.NoError(t, err)
@@ -432,7 +432,7 @@ func TestHTTP_Write(t *testing.T) {
 				Database: "telegraf",
 				Log:      testutil.Logger{},
 			},
-			queryHandlerFunc: func(t *testing.T, w http.ResponseWriter, r *http.Request) {
+			queryHandlerFunc: func(t *testing.T, w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusBadRequest)
 				_, err = w.Write([]byte(`{"error": "unable to parse 'cpu value': invalid field format"}`))
 				require.NoError(t, err)
@@ -448,7 +448,7 @@ func TestHTTP_Write(t *testing.T) {
 				Database: "telegraf",
 				Log:      testutil.Logger{},
 			},
-			queryHandlerFunc: func(t *testing.T, w http.ResponseWriter, r *http.Request) {
+			queryHandlerFunc: func(_ *testing.T, w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusBadGateway)
 			},
 			errFunc: func(t *testing.T, err error) {
@@ -466,7 +466,7 @@ func TestHTTP_Write(t *testing.T) {
 				Database: "telegraf",
 				Log:      testutil.Logger{},
 			},
-			queryHandlerFunc: func(t *testing.T, w http.ResponseWriter, r *http.Request) {
+			queryHandlerFunc: func(t *testing.T, w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusServiceUnavailable)
 				_, err = w.Write([]byte(`{"error": "unknown error"}`))
 				require.NoError(t, err)
@@ -664,7 +664,7 @@ func TestHTTP_UnixSocket(t *testing.T) {
 				_, err = w.Write(successResponse)
 				require.NoError(t, err)
 			},
-			writeHandlerFunc: func(t *testing.T, w http.ResponseWriter, r *http.Request) {
+			writeHandlerFunc: func(t *testing.T, w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusNoContent)
 				_, err = w.Write(successResponse)
 				require.NoError(t, err)

--- a/plugins/outputs/influxdb/influxdb_test.go
+++ b/plugins/outputs/influxdb/influxdb_test.go
@@ -6,19 +6,20 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/metric"
 	"github.com/influxdata/telegraf/plugins/common/tls"
 	"github.com/influxdata/telegraf/plugins/outputs/influxdb"
 	"github.com/influxdata/telegraf/testutil"
-	"github.com/stretchr/testify/require"
 )
 
 type MockClient struct {
 	URLF            func() string
-	WriteF          func(context.Context, []telegraf.Metric) error
-	CreateDatabaseF func(ctx context.Context, database string) error
+	WriteF          func() error
+	CreateDatabaseF func() error
 	DatabaseF       func() string
 	CloseF          func()
 
@@ -29,12 +30,12 @@ func (c *MockClient) URL() string {
 	return c.URLF()
 }
 
-func (c *MockClient) Write(ctx context.Context, metrics []telegraf.Metric) error {
-	return c.WriteF(ctx, metrics)
+func (c *MockClient) Write(context.Context, []telegraf.Metric) error {
+	return c.WriteF()
 }
 
-func (c *MockClient) CreateDatabase(ctx context.Context, database string) error {
-	return c.CreateDatabaseF(ctx, database)
+func (c *MockClient) CreateDatabase(context.Context, string) error {
+	return c.CreateDatabaseF()
 }
 
 func (c *MockClient) Database() string {
@@ -76,7 +77,7 @@ func TestDefaultURL(t *testing.T) {
 				DatabaseF: func() string {
 					return "telegraf"
 				},
-				CreateDatabaseF: func(ctx context.Context, database string) error {
+				CreateDatabaseF: func() error {
 					return nil
 				},
 			}, nil
@@ -139,7 +140,7 @@ func TestConnectHTTPConfig(t *testing.T) {
 				DatabaseF: func() string {
 					return "telegraf"
 				},
-				CreateDatabaseF: func(ctx context.Context, database string) error {
+				CreateDatabaseF: func() error {
 					return nil
 				},
 			}, nil
@@ -171,15 +172,15 @@ func TestConnectHTTPConfig(t *testing.T) {
 func TestWriteRecreateDatabaseIfDatabaseNotFound(t *testing.T) {
 	output := influxdb.InfluxDB{
 		URLs: []string{"http://localhost:8086"},
-		CreateHTTPClientF: func(config *influxdb.HTTPConfig) (influxdb.Client, error) {
+		CreateHTTPClientF: func(*influxdb.HTTPConfig) (influxdb.Client, error) {
 			return &MockClient{
 				DatabaseF: func() string {
 					return "telegraf"
 				},
-				CreateDatabaseF: func(ctx context.Context, database string) error {
+				CreateDatabaseF: func() error {
 					return nil
 				},
-				WriteF: func(ctx context.Context, metrics []telegraf.Metric) error {
+				WriteF: func() error {
 					return &influxdb.DatabaseNotFoundError{
 						APIError: influxdb.APIError{
 							StatusCode:  http.StatusNotFound,

--- a/plugins/outputs/influxdb/udp_test.go
+++ b/plugins/outputs/influxdb/udp_test.go
@@ -59,11 +59,11 @@ func (c *MockConn) Close() error {
 }
 
 type MockDialer struct {
-	DialContextF func(network, address string) (influxdb.Conn, error)
+	DialContextF func() (influxdb.Conn, error)
 }
 
-func (d *MockDialer) DialContext(_ context.Context, network string, address string) (influxdb.Conn, error) {
-	return d.DialContextF(network, address)
+func (d *MockDialer) DialContext(context.Context, string, string) (influxdb.Conn, error) {
+	return d.DialContextF()
 }
 
 func TestUDP_NewUDPClientNoURL(t *testing.T) {
@@ -90,7 +90,7 @@ func TestUDP_Simple(t *testing.T) {
 	config := influxdb.UDPConfig{
 		URL: getURL(),
 		Dialer: &MockDialer{
-			DialContextF: func(network, address string) (influxdb.Conn, error) {
+			DialContextF: func() (influxdb.Conn, error) {
 				conn := &MockConn{
 					WriteF: func(b []byte) (n int, err error) {
 						buffer.Write(b)
@@ -121,7 +121,7 @@ func TestUDP_DialError(t *testing.T) {
 	config := influxdb.UDPConfig{
 		URL: u,
 		Dialer: &MockDialer{
-			DialContextF: func(network, address string) (influxdb.Conn, error) {
+			DialContextF: func() (influxdb.Conn, error) {
 				return nil, errors.New(`unsupported scheme [invalid://localhost:9999]: "invalid"`)
 			},
 		},
@@ -140,9 +140,9 @@ func TestUDP_WriteError(t *testing.T) {
 	config := influxdb.UDPConfig{
 		URL: getURL(),
 		Dialer: &MockDialer{
-			DialContextF: func(network, address string) (influxdb.Conn, error) {
+			DialContextF: func() (influxdb.Conn, error) {
 				conn := &MockConn{
-					WriteF: func(b []byte) (n int, err error) {
+					WriteF: func(_ []byte) (n int, err error) {
 						return 0, errors.New("write udp 127.0.0.1:52190->127.0.0.1:9999: write: connection refused")
 					},
 					CloseF: func() error {
@@ -176,7 +176,7 @@ func TestUDP_ErrorLogging(t *testing.T) {
 				MaxPayloadSize: 1,
 				URL:            getURL(),
 				Dialer: &MockDialer{
-					DialContextF: func(network, address string) (influxdb.Conn, error) {
+					DialContextF: func() (influxdb.Conn, error) {
 						conn := &MockConn{}
 						return conn, nil
 					},
@@ -191,7 +191,7 @@ func TestUDP_ErrorLogging(t *testing.T) {
 			config: influxdb.UDPConfig{
 				URL: getURL(),
 				Dialer: &MockDialer{
-					DialContextF: func(network, address string) (influxdb.Conn, error) {
+					DialContextF: func() (influxdb.Conn, error) {
 						conn := &MockConn{}
 						return conn, nil
 					},

--- a/plugins/outputs/librato/librato_test.go
+++ b/plugins/outputs/librato/librato_test.go
@@ -29,7 +29,7 @@ func newTestLibrato(testURL string) *Librato {
 func TestUriOverride(t *testing.T) {
 	ts := httptest.NewServer(
 		http.HandlerFunc(
-			func(w http.ResponseWriter, r *http.Request) {
+			func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusOK)
 			}))
 	defer ts.Close()
@@ -43,7 +43,7 @@ func TestUriOverride(t *testing.T) {
 
 func TestBadStatusCode(t *testing.T) {
 	ts := httptest.NewServer(
-		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusServiceUnavailable)
 		}))
 	defer ts.Close()

--- a/plugins/outputs/logzio/logzio_test.go
+++ b/plugins/outputs/logzio/logzio_test.go
@@ -10,10 +10,11 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/testutil"
-	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -52,7 +53,7 @@ func TestParseMetric(t *testing.T) {
 }
 
 func TestBadStatusCode(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 	}))
 	defer ts.Close()

--- a/plugins/outputs/loki/loki_test.go
+++ b/plugins/outputs/loki/loki_test.go
@@ -116,7 +116,7 @@ func TestStatusCode(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ts.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ts.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(tt.statusCode)
 			})
 
@@ -368,7 +368,7 @@ func TestOAuthClientCredentialsGrant(t *testing.T) {
 				TokenURL:     u.String() + "/token",
 				Scopes:       []string{"urn:opc:idm:__myscopes__"},
 			},
-			tokenHandler: func(t *testing.T, w http.ResponseWriter, r *http.Request) {
+			tokenHandler: func(t *testing.T, w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusOK)
 				values := url.Values{}
 				values.Add("access_token", token)

--- a/plugins/outputs/opensearch/opensearch.go
+++ b/plugins/outputs/opensearch/opensearch.go
@@ -98,10 +98,10 @@ func (o *Opensearch) Init() error {
 	}
 	o.pipelineTmpl = pipelineTmpl
 
-	o.onSucc = func(ctx context.Context, item opensearchutil.BulkIndexerItem, res opensearchutil.BulkIndexerResponseItem) {
+	o.onSucc = func(_ context.Context, _ opensearchutil.BulkIndexerItem, res opensearchutil.BulkIndexerResponseItem) {
 		o.Log.Debugf("Indexed to OpenSearch with status- [%d] Result- %s DocumentID- %s ", res.Status, res.Result, res.DocumentID)
 	}
-	o.onFail = func(ctx context.Context, item opensearchutil.BulkIndexerItem, res opensearchutil.BulkIndexerResponseItem, err error) {
+	o.onFail = func(_ context.Context, _ opensearchutil.BulkIndexerItem, res opensearchutil.BulkIndexerResponseItem, err error) {
 		if err != nil {
 			o.Log.Errorf("error while OpenSearch bulkIndexing: %v", err)
 		} else {

--- a/plugins/outputs/opentsdb/opentsdb_test.go
+++ b/plugins/outputs/opentsdb/opentsdb_test.go
@@ -133,7 +133,7 @@ func BenchmarkHttpSend(b *testing.B) {
 		metrics = append(metrics, testutil.TestMetric(1.0))
 	}
 
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		fmt.Fprintln(w, "{}")
 	}))

--- a/plugins/outputs/prometheus_client/prometheus_client.go
+++ b/plugins/outputs/prometheus_client/prometheus_client.go
@@ -153,7 +153,7 @@ func (p *PrometheusClient) Init() error {
 	authHandler := internal.BasicAuthHandler(p.BasicUsername, password, "prometheus", onAuthError)
 	rangeHandler := internal.IPRangeHandler(ipRange, onError)
 	promHandler := promhttp.HandlerFor(registry, promhttp.HandlerOpts{ErrorHandling: promhttp.ContinueOnError})
-	landingPageHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	landingPageHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, err := w.Write([]byte("Telegraf Output Plugin: Prometheus Client "))
 		if err != nil {
 			p.Log.Errorf("Error occurred when writing HTTP reply: %v", err)

--- a/plugins/outputs/prometheus_client/prometheus_client_v1_test.go
+++ b/plugins/outputs/prometheus_client/prometheus_client_v1_test.go
@@ -435,7 +435,7 @@ rpc_duration_seconds_count 2693
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ts.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ts.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusOK)
 				_, err := w.Write(tt.data)
 				require.NoError(t, err)

--- a/plugins/outputs/prometheus_client/prometheus_client_v2_test.go
+++ b/plugins/outputs/prometheus_client/prometheus_client_v2_test.go
@@ -465,7 +465,7 @@ rpc_duration_seconds_count 2693
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ts.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ts.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusOK)
 				_, err := w.Write(tt.data)
 				require.NoError(t, err)

--- a/plugins/outputs/sumologic/sumologic_test.go
+++ b/plugins/outputs/sumologic/sumologic_test.go
@@ -169,7 +169,7 @@ func TestStatusCode(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ts.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ts.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(tt.statusCode)
 			})
 

--- a/plugins/outputs/timestream/timestream.go
+++ b/plugins/outputs/timestream/timestream.go
@@ -88,7 +88,7 @@ var WriteFactory = func(credentialConfig *internalaws.CredentialConfig) (WriteCl
 	}
 
 	if credentialConfig.EndpointURL != "" && credentialConfig.Region != "" {
-		customResolver := aws.EndpointResolverWithOptionsFunc(func(service, region string, options ...interface{}) (aws.Endpoint, error) {
+		customResolver := aws.EndpointResolverWithOptionsFunc(func(string, string, ...interface{}) (aws.Endpoint, error) {
 			return aws.Endpoint{
 				PartitionID:   "aws",
 				URL:           credentialConfig.EndpointURL,

--- a/plugins/outputs/timestream/timestream_test.go
+++ b/plugins/outputs/timestream/timestream_test.go
@@ -69,7 +69,7 @@ func (m *mockTimestreamClient) DescribeDatabase(
 }
 
 func TestConnectValidatesConfigParameters(t *testing.T) {
-	WriteFactory = func(credentialConfig *internalaws.CredentialConfig) (WriteClient, error) {
+	WriteFactory = func(*internalaws.CredentialConfig) (WriteClient, error) {
 		return &mockTimestreamClient{}, nil
 	}
 	// checking base arguments
@@ -227,7 +227,7 @@ func TestWriteMultiMeasuresSingleTableMode(t *testing.T) {
 	const recordCount = 100
 	mockClient := &mockTimestreamClient{0}
 
-	WriteFactory = func(credentialConfig *internalaws.CredentialConfig) (WriteClient, error) {
+	WriteFactory = func(*internalaws.CredentialConfig) (WriteClient, error) {
 		return mockClient, nil
 	}
 
@@ -284,7 +284,7 @@ func TestWriteMultiMeasuresMultiTableMode(t *testing.T) {
 	const recordCount = 100
 	mockClient := &mockTimestreamClient{0}
 
-	WriteFactory = func(credentialConfig *internalaws.CredentialConfig) (WriteClient, error) {
+	WriteFactory = func(*internalaws.CredentialConfig) (WriteClient, error) {
 		return mockClient, nil
 	}
 
@@ -553,7 +553,7 @@ func (m *mockTimestreamErrorClient) DescribeDatabase(
 }
 
 func TestThrottlingErrorIsReturnedToTelegraf(t *testing.T) {
-	WriteFactory = func(credentialConfig *internalaws.CredentialConfig) (WriteClient, error) {
+	WriteFactory = func(*internalaws.CredentialConfig) (WriteClient, error) {
 		return &mockTimestreamErrorClient{
 			ErrorToReturnOnWriteRecords: &types.ThrottlingException{Message: aws.String("Throttling Test")},
 		}, nil
@@ -579,7 +579,7 @@ func TestThrottlingErrorIsReturnedToTelegraf(t *testing.T) {
 }
 
 func TestRejectedRecordsErrorResultsInMetricsBeingSkipped(t *testing.T) {
-	WriteFactory = func(credentialConfig *internalaws.CredentialConfig) (WriteClient, error) {
+	WriteFactory = func(*internalaws.CredentialConfig) (WriteClient, error) {
 		return &mockTimestreamErrorClient{
 			ErrorToReturnOnWriteRecords: &types.RejectedRecordsException{Message: aws.String("RejectedRecords Test")},
 		}, nil
@@ -610,7 +610,7 @@ func TestWriteWhenRequestsGreaterThanMaxWriteGoRoutinesCount(t *testing.T) {
 	const totalRecords = maxWriteRecordsCalls * maxRecordsInWriteRecordsCall
 	mockClient := &mockTimestreamClient{0}
 
-	WriteFactory = func(credentialConfig *internalaws.CredentialConfig) (WriteClient, error) {
+	WriteFactory = func(*internalaws.CredentialConfig) (WriteClient, error) {
 		return mockClient, nil
 	}
 
@@ -649,7 +649,7 @@ func TestWriteWhenRequestsLesserThanMaxWriteGoRoutinesCount(t *testing.T) {
 	const totalRecords = maxWriteRecordsCalls * maxRecordsInWriteRecordsCall
 	mockClient := &mockTimestreamClient{0}
 
-	WriteFactory = func(credentialConfig *internalaws.CredentialConfig) (WriteClient, error) {
+	WriteFactory = func(*internalaws.CredentialConfig) (WriteClient, error) {
 		return mockClient, nil
 	}
 

--- a/plugins/parsers/collectd/parser.go
+++ b/plugins/parsers/collectd/parser.go
@@ -200,7 +200,7 @@ func LoadTypesDB(path string) (*api.TypesDB, error) {
 
 func init() {
 	parsers.Add("collectd",
-		func(_ string) telegraf.Parser {
+		func(string) telegraf.Parser {
 			return &Parser{
 				AuthFile: DefaultAuthFile,
 			}

--- a/plugins/parsers/dropwizard/parser.go
+++ b/plugins/parsers/dropwizard/parser.go
@@ -233,7 +233,7 @@ func (p *Parser) Init() error {
 
 func init() {
 	parsers.Add("dropwizard",
-		func(defaultMetricName string) telegraf.Parser {
+		func(string) telegraf.Parser {
 			return &Parser{}
 		})
 }

--- a/plugins/parsers/graphite/parser.go
+++ b/plugins/parsers/graphite/parser.go
@@ -194,5 +194,5 @@ func (p *Parser) SetDefaultTags(tags map[string]string) {
 }
 
 func init() {
-	parsers.Add("graphite", func(_ string) telegraf.Parser { return &Parser{} })
+	parsers.Add("graphite", func(string) telegraf.Parser { return &Parser{} })
 }

--- a/plugins/parsers/influx/influx_upstream/parser.go
+++ b/plugins/parsers/influx/influx_upstream/parser.go
@@ -201,7 +201,7 @@ func (p *Parser) Init() error {
 
 func init() {
 	parsers.Add("influx_upstream",
-		func(_ string) telegraf.Parser {
+		func(string) telegraf.Parser {
 			return &Parser{}
 		},
 	)

--- a/plugins/parsers/influx/influx_upstream/parser_test.go
+++ b/plugins/parsers/influx/influx_upstream/parser_test.go
@@ -976,11 +976,11 @@ func TestStreamParserErrorString(t *testing.T) {
 }
 
 type MockReader struct {
-	ReadF func(p []byte) (int, error)
+	ReadF func() (int, error)
 }
 
-func (r *MockReader) Read(p []byte) (int, error) {
-	return r.ReadF(p)
+func (r *MockReader) Read([]byte) (int, error) {
+	return r.ReadF()
 }
 
 // Errors from the Reader are returned from the Parser
@@ -988,7 +988,7 @@ func TestStreamParserReaderError(t *testing.T) {
 	readerErr := errors.New("error but not eof")
 
 	parser := NewStreamParser(&MockReader{
-		ReadF: func(p []byte) (int, error) {
+		ReadF: func() (int, error) {
 			return 0, readerErr
 		},
 	})

--- a/plugins/parsers/influx/machine_test.go
+++ b/plugins/parsers/influx/machine_test.go
@@ -1946,10 +1946,10 @@ func TestSeriesMachine(t *testing.T) {
 }
 
 type MockHandler struct {
-	SetMeasurementF func(name []byte) error
+	SetMeasurementF func() error
 	AddTagF         func(key []byte, value []byte) error
-	AddIntF         func(key []byte, value []byte) error
-	AddUintF        func(key []byte, value []byte) error
+	AddIntF         func(value []byte) error
+	AddUintF        func(value []byte) error
 	AddFloatF       func(key []byte, value []byte) error
 	AddStringF      func(key []byte, value []byte) error
 	AddBoolF        func(key []byte, value []byte) error
@@ -1963,7 +1963,7 @@ func (h *MockHandler) SetMeasurement(name []byte) error {
 	if err != nil {
 		return err
 	}
-	return h.SetMeasurementF(name)
+	return h.SetMeasurementF()
 }
 
 func (h *MockHandler) AddTag(name, value []byte) error {
@@ -1971,7 +1971,7 @@ func (h *MockHandler) AddTag(name, value []byte) error {
 }
 
 func (h *MockHandler) AddInt(name, value []byte) error {
-	err := h.AddIntF(name, value)
+	err := h.AddIntF(value)
 	if err != nil {
 		return err
 	}
@@ -1979,7 +1979,7 @@ func (h *MockHandler) AddInt(name, value []byte) error {
 }
 
 func (h *MockHandler) AddUint(name, value []byte) error {
-	err := h.AddUintF(name, value)
+	err := h.AddUintF(value)
 	if err != nil {
 		return err
 	}
@@ -2012,10 +2012,10 @@ var errorRecoveryTests = []struct {
 		name:  "integer",
 		input: []byte("cpu value=43i\ncpu value=42i"),
 		handler: &MockHandler{
-			SetMeasurementF: func(name []byte) error {
+			SetMeasurementF: func() error {
 				return nil
 			},
-			AddIntF: func(name, value []byte) error {
+			AddIntF: func(value []byte) error {
 				if string(value) != "42i" {
 					return errors.New("handler error")
 				}
@@ -2052,10 +2052,10 @@ var errorRecoveryTests = []struct {
 		name:  "integer with timestamp",
 		input: []byte("cpu value=43i 1516241192000000000\ncpu value=42i"),
 		handler: &MockHandler{
-			SetMeasurementF: func(name []byte) error {
+			SetMeasurementF: func() error {
 				return nil
 			},
-			AddIntF: func(name, value []byte) error {
+			AddIntF: func(value []byte) error {
 				if string(value) != "42i" {
 					return errors.New("handler error")
 				}
@@ -2092,10 +2092,10 @@ var errorRecoveryTests = []struct {
 		name:  "unsigned",
 		input: []byte("cpu value=43u\ncpu value=42u"),
 		handler: &MockHandler{
-			SetMeasurementF: func(name []byte) error {
+			SetMeasurementF: func() error {
 				return nil
 			},
-			AddUintF: func(name, value []byte) error {
+			AddUintF: func(value []byte) error {
 				if string(value) != "42u" {
 					return errors.New("handler error")
 				}

--- a/plugins/parsers/influx/parser.go
+++ b/plugins/parsers/influx/parser.go
@@ -171,7 +171,7 @@ func (p *Parser) Init() error {
 
 func init() {
 	parsers.Add("influx",
-		func(_ string) telegraf.Parser {
+		func(string) telegraf.Parser {
 			return &Parser{}
 		},
 	)

--- a/plugins/parsers/influx/parser_test.go
+++ b/plugins/parsers/influx/parser_test.go
@@ -943,11 +943,11 @@ func TestStreamParserErrorString(t *testing.T) {
 }
 
 type MockReader struct {
-	ReadF func(p []byte) (int, error)
+	ReadF func() (int, error)
 }
 
-func (r *MockReader) Read(p []byte) (int, error) {
-	return r.ReadF(p)
+func (r *MockReader) Read([]byte) (int, error) {
+	return r.ReadF()
 }
 
 // Errors from the Reader are returned from the Parser
@@ -955,7 +955,7 @@ func TestStreamParserReaderError(t *testing.T) {
 	readerErr := errors.New("error but not eof")
 
 	parser := NewStreamParser(&MockReader{
-		ReadF: func(p []byte) (int, error) {
+		ReadF: func() (int, error) {
 			return 0, readerErr
 		},
 	})

--- a/plugins/parsers/json/parser_test.go
+++ b/plugins/parsers/json/parser_test.go
@@ -1488,7 +1488,7 @@ func FuzzParserJSON(f *testing.F) {
 	parser := &Parser{MetricName: "testing"}
 	require.NoError(f, parser.Init())
 
-	f.Fuzz(func(t *testing.T, input []byte) {
+	f.Fuzz(func(_ *testing.T, input []byte) {
 		_, _ = parser.Parse(input)
 	})
 }

--- a/plugins/parsers/opentsdb/parser.go
+++ b/plugins/parsers/opentsdb/parser.go
@@ -115,7 +115,7 @@ func (p *Parser) SetDefaultTags(tags map[string]string) {
 
 func init() {
 	parsers.Add("opentsdb",
-		func(defaultMetricName string) telegraf.Parser {
+		func(string) telegraf.Parser {
 			return &Parser{}
 		})
 }

--- a/plugins/parsers/prometheus/parser.go
+++ b/plugins/parsers/prometheus/parser.go
@@ -85,7 +85,7 @@ func (p *Parser) ParseLine(line string) (telegraf.Metric, error) {
 
 func init() {
 	parsers.Add("prometheus",
-		func(defaultMetricName string) telegraf.Parser {
+		func(string) telegraf.Parser {
 			return &Parser{}
 		},
 	)

--- a/plugins/parsers/prometheusremotewrite/parser.go
+++ b/plugins/parsers/prometheusremotewrite/parser.go
@@ -87,7 +87,7 @@ func (p *Parser) SetDefaultTags(tags map[string]string) {
 
 func init() {
 	parsers.Add("prometheusremotewrite",
-		func(defaultMetricName string) telegraf.Parser {
+		func(string) telegraf.Parser {
 			return &Parser{}
 		})
 }

--- a/plugins/parsers/wavefront/parser.go
+++ b/plugins/parsers/wavefront/parser.go
@@ -217,7 +217,7 @@ func (p *PointParser) reset(buf []byte) {
 
 func init() {
 	parsers.Add("wavefront",
-		func(_ string) telegraf.Parser {
+		func(string) telegraf.Parser {
 			return &Parser{}
 		})
 }

--- a/plugins/processors/enum/enum_test.go
+++ b/plugins/processors/enum/enum_test.go
@@ -200,7 +200,7 @@ func TestTagGlobMatching(t *testing.T) {
 func TestTracking(t *testing.T) {
 	m := createTestMetric()
 	var delivered bool
-	notify := func(di telegraf.DeliveryInfo) {
+	notify := func(telegraf.DeliveryInfo) {
 		delivered = true
 	}
 	m, _ = metric.WithTracking(m, notify)

--- a/plugins/processors/ifname/ifname_test.go
+++ b/plugins/processors/ifname/ifname_test.go
@@ -104,7 +104,7 @@ func TestGetMap(t *testing.T) {
 	}
 
 	// Don't run net-snmp commands to look up table names.
-	d.makeTable = func(agent string) (*si.Table, error) {
+	d.makeTable = func(string) (*si.Table, error) {
 		return &si.Table{}, nil
 	}
 	err := d.Init()
@@ -118,7 +118,7 @@ func TestGetMap(t *testing.T) {
 	var remoteCalls int32
 
 	// Mock the snmp transaction
-	d.getMapRemote = func(agent string) (nameMap, error) {
+	d.getMapRemote = func(string) (nameMap, error) {
 		atomic.AddInt32(&remoteCalls, 1)
 		return expected, nil
 	}

--- a/plugins/processors/regex/regex_test.go
+++ b/plugins/processors/regex/regex_test.go
@@ -1027,7 +1027,7 @@ func TestTrackedMetricNotLost(t *testing.T) {
 
 	m := newM2().Copy()
 	var delivered bool
-	notify := func(di telegraf.DeliveryInfo) {
+	notify := func(telegraf.DeliveryInfo) {
 		delivered = true
 	}
 	m, _ = metric.WithTracking(m, notify)

--- a/plugins/processors/starlark/starlark_test.go
+++ b/plugins/processors/starlark/starlark_test.go
@@ -3293,7 +3293,7 @@ func TestAllScriptTestData(t *testing.T) {
 	// can be run from multiple folders
 	paths := []string{"testdata", "plugins/processors/starlark/testdata"}
 	for _, testdataPath := range paths {
-		err := filepath.Walk(testdataPath, func(path string, info os.FileInfo, err error) error {
+		err := filepath.Walk(testdataPath, func(path string, info os.FileInfo, _ error) error {
 			if info == nil || info.IsDir() {
 				return nil
 			}

--- a/plugins/secretstores/http/http.go
+++ b/plugins/secretstores/http/http.go
@@ -226,7 +226,7 @@ func (h *HTTP) setRequestAuth(request *http.Request) error {
 
 // Register the secret-store on load.
 func init() {
-	secretstores.Add("http", func(id string) telegraf.SecretStore {
+	secretstores.Add("http", func(string) telegraf.SecretStore {
 		return &HTTP{}
 	})
 }

--- a/plugins/secretstores/http/http_test.go
+++ b/plugins/secretstores/http/http_test.go
@@ -28,7 +28,7 @@ func TestCases(t *testing.T) {
 	require.NotEmpty(t, folders)
 
 	// Set up for file inputs
-	secretstores.Add("http", func(id string) telegraf.SecretStore {
+	secretstores.Add("http", func(string) telegraf.SecretStore {
 		return &HTTP{Log: testutil.Logger{}}
 	})
 
@@ -154,7 +154,7 @@ func TestGetErrors(t *testing.T) {
 }
 
 func TestResolver(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write([]byte(`{"test": "aedMZXaLR246OHHjVtJKXQ=="}`))
 	}))
 	defer server.Close()
@@ -195,7 +195,7 @@ func TestGetResolverErrors(t *testing.T) {
 	require.ErrorContains(t, err, "context deadline exceeded")
 	dummy.Close()
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write([]byte(`[{"test": "aedMZXaLR246OHHjVtJKXQ=="}]`))
 	}))
 	defer server.Close()
@@ -228,7 +228,7 @@ func TestInvalidServerResponse(t *testing.T) {
 	require.NoError(t, err)
 	defer dummy.Close()
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write([]byte(`[somerandomebytes`))
 	}))
 	defer server.Close()

--- a/plugins/secretstores/oauth2/oauth2_test.go
+++ b/plugins/secretstores/oauth2/oauth2_test.go
@@ -9,8 +9,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/influxdata/telegraf/config"
 	"github.com/stretchr/testify/require"
+
+	"github.com/influxdata/telegraf/config"
 )
 
 func TestSampleConfig(t *testing.T) {
@@ -125,7 +126,7 @@ func TestGetNonExisting(t *testing.T) {
 
 func TestResolver404(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(
-		func(w http.ResponseWriter, r *http.Request) {
+		func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusNotFound)
 		}))
 	defer server.Close()

--- a/tools/package_incus_test/main.go
+++ b/tools/package_incus_test/main.go
@@ -40,7 +40,7 @@ func main() {
 				Destination: &image,
 			},
 		},
-		Action: func(c *cli.Context) error {
+		Action: func(*cli.Context) error {
 			if _, err := os.Stat(packageFile); err != nil {
 				return fmt.Errorf("unknown package file: %w", err)
 			}


### PR DESCRIPTION
- `golangci-lint` bumped to `v1.56.1`
- addressing numerous findings caused by updates in several linters:
  - `revive.unused-parameter` - now includes anonymous functions
  - `revive.var-naming` - `Ids` in names should be changed to `IDs`
  - `testifylint.expected-actual` - false positive no longer exists
