### PR TITLE
dependabot: check for updates to GitHub actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,10 @@
 version: 2
 updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -54,7 +54,7 @@ jobs:
       # Run Linter against code base #
       ################################
       - name: Lint Code Base
-        uses: github/super-linter@v5
+        uses: super-linter/super-linter@v6.0.0
         env:
           VALIDATE_ALL_CODEBASE: false
           DEFAULT_BRANCH: master


### PR DESCRIPTION
This PR bumps `super-linter` action to latest released version `v6.0.0`. It also configures dependabot to check for updates of the GitHub actions on a weekly basis.

## Checklist
- [x] No AI generated code was used in this PR