### PR TITLE
fix(processors.execd): Accept tracking metrics instead of dropping them

### DIFF
--- a/plugins/processors/execd/execd.go
+++ b/plugins/processors/execd/execd.go
@@ -92,7 +92,7 @@ func (e *Execd) Add(m telegraf.Metric, _ telegraf.Accumulator) error {
 	// We cannot maintain tracking metrics at the moment because input/output
 	// is done asynchronously and we don't have any metric metadata to tie the
 	// output metric back to the original input metric.
-	m.Drop()
+	m.Accept()
 	return nil
 }
 

--- a/plugins/processors/execd/execd_test.go
+++ b/plugins/processors/execd/execd_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -274,4 +275,122 @@ func TestCases(t *testing.T) {
 			testutil.RequireMetricsEqual(t, expected, actual)
 		})
 	}
+}
+
+func TestTracking(t *testing.T) {
+	now := time.Now()
+
+	// Setup the raw  input and expected output data
+	inputRaw := []telegraf.Metric{
+		metric.New(
+			"test",
+			map[string]string{
+				"city": "Toronto",
+			},
+			map[string]interface{}{
+				"population": 6000000,
+				"count":      1,
+			},
+			now,
+		),
+		metric.New(
+			"test",
+			map[string]string{
+				"city": "Tokio",
+			},
+			map[string]interface{}{
+				"population": 14000000,
+				"count":      8,
+			},
+			now,
+		),
+	}
+
+	expected := []telegraf.Metric{
+		metric.New(
+			"test",
+			map[string]string{
+				"city": "Toronto",
+			},
+			map[string]interface{}{
+				"population": 6000000,
+				"count":      2,
+			},
+			now,
+		),
+		metric.New(
+			"test",
+			map[string]string{
+				"city": "Tokio",
+			},
+			map[string]interface{}{
+				"population": 14000000,
+				"count":      16,
+			},
+			now,
+		),
+	}
+
+	// Create a testing notifier
+	var mu sync.Mutex
+	delivered := make([]telegraf.DeliveryInfo, 0, len(inputRaw))
+	notify := func(di telegraf.DeliveryInfo) {
+		mu.Lock()
+		defer mu.Unlock()
+		delivered = append(delivered, di)
+	}
+
+	// Convert raw input to tracking metrics
+	input := make([]telegraf.Metric, 0, len(inputRaw))
+	for _, m := range inputRaw {
+		tm, _ := metric.WithTracking(m, notify)
+		input = append(input, tm)
+	}
+
+	// Setup the plugin
+	exe, err := os.Executable()
+	require.NoError(t, err)
+
+	plugin := &Execd{
+		Command:      []string{exe, "-countmultiplier"},
+		Environment:  []string{"PLUGINS_PROCESSORS_EXECD_MODE=application", "FIELD_NAME=count"},
+		RestartDelay: config.Duration(5 * time.Second),
+		Log:          testutil.Logger{},
+	}
+	require.NoError(t, plugin.Init())
+
+	parser := &influx.Parser{}
+	require.NoError(t, parser.Init())
+	plugin.SetParser(parser)
+
+	serializer := &influxSerializer.Serializer{}
+	require.NoError(t, serializer.Init())
+	plugin.SetSerializer(serializer)
+
+	var acc testutil.Accumulator
+	require.NoError(t, plugin.Start(&acc))
+	defer plugin.Stop()
+
+	// Process expected metrics and compare with resulting metrics
+	for _, in := range input {
+		require.NoError(t, plugin.Add(in, &acc))
+	}
+	require.Eventually(t, func() bool {
+		return int(acc.NMetrics()) >= len(expected)
+	}, 3*time.Second, 100*time.Millisecond)
+
+	actual := acc.GetTelegrafMetrics()
+	testutil.RequireMetricsEqual(t, expected, actual)
+
+	// Simulate output acknowledging delivery
+	for _, m := range actual {
+		m.Accept()
+	}
+
+	// Check delivery
+	require.Eventuallyf(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(expected) == len(delivered)
+	}, time.Second, 100*time.Millisecond, "%d delivered but %d expected", len(delivered), len(expected))
 }


### PR DESCRIPTION
## Summary

Currently, this plugin drops incoming metrics as we cannot decide if a metric passes the processor or not. However, it is very likely that the metric passes the processor. In any case, the processor does something with the metric and thus we should accept it.

The PR also adds a unit-test for tracking metrics.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #14715 
