### PR TITLE
test(processors.override): Add unit-test for tracking metrics

### DIFF
--- a/plugins/processors/override/override.go
+++ b/plugins/processors/override/override.go
@@ -12,10 +12,10 @@ import (
 var sampleConfig string
 
 type Override struct {
-	NameOverride string
-	NamePrefix   string
-	NameSuffix   string
-	Tags         map[string]string
+	NameOverride string            `toml:"name_override"`
+	NamePrefix   string            `toml:"name_prefix"`
+	NameSuffix   string            `toml:"name_suffix"`
+	Tags         map[string]string `toml:"tag"`
 }
 
 func (*Override) SampleConfig() string {

--- a/plugins/processors/override/override_test.go
+++ b/plugins/processors/override/override_test.go
@@ -1,6 +1,7 @@
 package override
 
 import (
+	"sync"
 	"testing"
 	"time"
 
@@ -8,6 +9,7 @@ import (
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/metric"
+	"github.com/influxdata/telegraf/testutil"
 )
 
 func createTestMetric() telegraf.Metric {
@@ -78,4 +80,85 @@ func TestNameSuffix(t *testing.T) {
 	processed := processor.Apply(createTestMetric())
 
 	require.Equal(t, "m1-suff", processed[0].Name(), "Suffix was not applied")
+}
+func TestTracking(t *testing.T) {
+	// Setup raw input and expected output
+	inputRaw := []telegraf.Metric{
+		metric.New(
+			"zero_uint64",
+			map[string]string{},
+			map[string]interface{}{"value": uint64(3)},
+			time.Unix(0, 0),
+		),
+		metric.New(
+			"zero_int64",
+			map[string]string{},
+			map[string]interface{}{"value": int64(4)},
+			time.Unix(0, 0),
+		),
+		metric.New(
+			"zero_float",
+			map[string]string{},
+			map[string]interface{}{"value": float64(5.5)},
+			time.Unix(0, 0),
+		),
+	}
+
+	expected := []telegraf.Metric{
+		metric.New(
+			"test",
+			map[string]string{},
+			map[string]interface{}{"value": uint64(3)},
+			time.Unix(0, 0),
+		),
+		metric.New(
+			"test",
+			map[string]string{},
+			map[string]interface{}{"value": int64(4)},
+			time.Unix(0, 0),
+		),
+		metric.New(
+			"test",
+			map[string]string{},
+			map[string]interface{}{"value": float64(5.5)},
+			time.Unix(0, 0),
+		),
+	}
+
+	// Create fake notification for testing
+	var mu sync.Mutex
+	delivered := make([]telegraf.DeliveryInfo, 0, len(inputRaw))
+	notify := func(di telegraf.DeliveryInfo) {
+		mu.Lock()
+		defer mu.Unlock()
+		delivered = append(delivered, di)
+	}
+
+	// Convert raw input to tracking metric
+	input := make([]telegraf.Metric, 0, len(inputRaw))
+	for _, m := range inputRaw {
+		tm, _ := metric.WithTracking(m, notify)
+		input = append(input, tm)
+	}
+
+	// Prepare and start the plugin
+	plugin := &Override{
+		NameOverride: "test",
+	}
+
+	// Process expected metrics and compare with resulting metrics
+	actual := plugin.Apply(input...)
+	testutil.RequireMetricsEqual(t, expected, actual)
+
+	// Simulate output acknowledging delivery
+	for _, m := range actual {
+		m.Accept()
+	}
+
+	// Check delivery
+	require.Eventuallyf(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(input) == len(delivered)
+	}, time.Second, 100*time.Millisecond, "%d delivered but %d expected", len(delivered), len(expected))
 }


### PR DESCRIPTION
## Summary

Add unit-test for the processor


## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #14720 
