### PR TITLE
test(processors.printer): Add unit-test for tracking metrics

### DIFF
--- a/plugins/processors/printer/printer_test.go
+++ b/plugins/processors/printer/printer_test.go
@@ -1,1 +1,93 @@
 package printer
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/metric"
+	"github.com/influxdata/telegraf/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTracking(t *testing.T) {
+	// Setup raw input and expected output
+	inputRaw := []telegraf.Metric{
+		metric.New(
+			"test",
+			map[string]string{},
+			map[string]interface{}{"value": uint64(3)},
+			time.Unix(0, 0),
+		),
+		metric.New(
+			"test",
+			map[string]string{},
+			map[string]interface{}{"value": int64(4)},
+			time.Unix(0, 0),
+		),
+		metric.New(
+			"test",
+			map[string]string{},
+			map[string]interface{}{"value": float64(5.5)},
+			time.Unix(0, 0),
+		),
+	}
+
+	expected := []telegraf.Metric{
+		metric.New(
+			"test",
+			map[string]string{},
+			map[string]interface{}{"value": uint64(3)},
+			time.Unix(0, 0),
+		),
+		metric.New(
+			"test",
+			map[string]string{},
+			map[string]interface{}{"value": int64(4)},
+			time.Unix(0, 0),
+		),
+		metric.New(
+			"test",
+			map[string]string{},
+			map[string]interface{}{"value": float64(5.5)},
+			time.Unix(0, 0),
+		),
+	}
+
+	// Create fake notification for testing
+	var mu sync.Mutex
+	delivered := make([]telegraf.DeliveryInfo, 0, len(inputRaw))
+	notify := func(di telegraf.DeliveryInfo) {
+		mu.Lock()
+		defer mu.Unlock()
+		delivered = append(delivered, di)
+	}
+
+	// Convert raw input to tracking metric
+	input := make([]telegraf.Metric, 0, len(inputRaw))
+	for _, m := range inputRaw {
+		tm, _ := metric.WithTracking(m, notify)
+		input = append(input, tm)
+	}
+
+	// Prepare and start the plugin
+	plugin := &Printer{}
+	require.NoError(t, plugin.Init())
+
+	// Process expected metrics and compare with resulting metrics
+	actual := plugin.Apply(input...)
+	testutil.RequireMetricsEqual(t, expected, actual)
+
+	// Simulate output acknowledging delivery
+	for _, m := range actual {
+		m.Accept()
+	}
+
+	// Check delivery
+	require.Eventuallyf(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(input) == len(delivered)
+	}, time.Second, 100*time.Millisecond, "%d delivered but %d expected", len(delivered), len(expected))
+}


### PR DESCRIPTION
## Summary

Add unit-test for the processor

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #14724 
