### PR TITLE
feat(inputs.aerospike): Deprecate plugin

### DIFF
--- a/plugins/inputs/aerospike/README.md
+++ b/plugins/inputs/aerospike/README.md
@@ -1,5 +1,9 @@
 # Aerospike Input Plugin
 
+**DEPRECATED: As of version 1.30 the Aerospike plugin has been deprecated in
+favor of the [prometheus plugin](../prometheus/README.md) with the
+Aerospike Prometheus Exporter**
+
 The aerospike plugin queries aerospike server(s) and get node statistics & stats
 for all the configured namespaces.
 

--- a/plugins/inputs/deprecations.go
+++ b/plugins/inputs/deprecations.go
@@ -4,6 +4,10 @@ import "github.com/influxdata/telegraf"
 
 // Deprecations lists the deprecated plugins
 var Deprecations = map[string]telegraf.DeprecationInfo{
+	"aerospike": {
+		Since:  "1.30.0",
+		Notice: "use 'inputs.prometheus' with the Aerospike Prometheus Exporter instead",
+	},
 	"cassandra": {
 		Since:     "1.7.0",
 		RemovalIn: "1.30.0",


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Deprecate the plugin in favor of the use of Prometheus.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

fixes: #14450