### PR TITLE
test(processors.reverse_dns): Add unit-tests for tracking metrics

### DIFF
--- a/plugins/processors/reverse_dns/reverse_dns_test.go
+++ b/plugins/processors/reverse_dns/reverse_dns_test.go
@@ -1,11 +1,14 @@
 package reverse_dns
 
 import (
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/metric"
 	"github.com/influxdata/telegraf/testutil"
 )
@@ -49,4 +52,82 @@ func TestSimpleReverseLookupIntegration(t *testing.T) {
 	tag, ok := processedMetric.GetTag("dest_name")
 	require.True(t, ok)
 	require.EqualValues(t, "one.one.one.one.", tag)
+}
+
+func TestTracking(t *testing.T) {
+	inputRaw := []telegraf.Metric{
+		metric.New("foo", map[string]string{}, map[string]interface{}{"ip": "1.1.1.1"}, time.Unix(0, 0)),
+		metric.New("bar", map[string]string{}, map[string]interface{}{"ip": "1.1.1.1"}, time.Unix(0, 0)),
+		metric.New("baz", map[string]string{}, map[string]interface{}{"ip": "1.1.1.1"}, time.Unix(0, 0)),
+	}
+
+	var mu sync.Mutex
+	delivered := make([]telegraf.DeliveryInfo, 0, len(inputRaw))
+	notify := func(di telegraf.DeliveryInfo) {
+		mu.Lock()
+		defer mu.Unlock()
+		delivered = append(delivered, di)
+	}
+
+	input := make([]telegraf.Metric, 0, len(inputRaw))
+	for _, m := range inputRaw {
+		tm, _ := metric.WithTracking(m, notify)
+		input = append(input, tm)
+	}
+
+	expected := []telegraf.Metric{
+		metric.New(
+			"foo",
+			map[string]string{},
+			map[string]interface{}{"ip": "1.1.1.1", "name": "one.one.one.one."},
+			time.Unix(0, 0),
+		),
+		metric.New(
+			"bar",
+			map[string]string{},
+			map[string]interface{}{"ip": "1.1.1.1", "name": "one.one.one.one."},
+			time.Unix(0, 0),
+		),
+		metric.New(
+			"baz",
+			map[string]string{},
+			map[string]interface{}{"ip": "1.1.1.1", "name": "one.one.one.one."},
+			time.Unix(0, 0),
+		),
+	}
+
+	plugin := &ReverseDNS{
+		CacheTTL:           config.Duration(24 * time.Hour),
+		LookupTimeout:      config.Duration(1 * time.Minute),
+		MaxParallelLookups: 10,
+		Log:                &testutil.Logger{},
+		Lookups: []lookupEntry{
+			{
+				Field: "ip",
+				Dest:  "name",
+			},
+		},
+	}
+
+	// Process expected metrics and compare with resulting metrics
+	acc := &testutil.Accumulator{}
+	require.NoError(t, plugin.Start(acc))
+	for _, m := range input {
+		require.NoError(t, plugin.Add(m, acc))
+	}
+	plugin.Stop()
+	actual := acc.GetTelegrafMetrics()
+	testutil.RequireMetricsEqual(t, expected, actual, testutil.SortMetrics())
+
+	// Simulate output acknowledging delivery
+	for _, m := range actual {
+		m.Accept()
+	}
+
+	// Check delivery
+	require.Eventuallyf(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(expected) == len(delivered)
+	}, time.Second, 100*time.Millisecond, "%d delivered but %d expected", len(delivered), len(expected))
 }


### PR DESCRIPTION

## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
I am a little concerned about this one running every time given the need to use the network. The other unit test is considered an integration test.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

fixes: #14727
