### PR TITLE
test(aggregators.valuecounter): Add unit-tests for tracking metrics

### DIFF
--- a/plugins/aggregators/valuecounter/valuecounter.go
+++ b/plugins/aggregators/valuecounter/valuecounter.go
@@ -38,6 +38,7 @@ func (*ValueCounter) SampleConfig() string {
 
 // Add is run on every metric which passes the plugin
 func (vc *ValueCounter) Add(in telegraf.Metric) {
+	in.Accept()
 	id := in.HashID()
 
 	// Check if the cache already has an entry for this metric, if not create it


### PR DESCRIPTION

## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Updates the aggregator to always accept metrics.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

fixes: #14801
