### PR TITLE
docs(inputs.syslog): Document change of default read timeout to infinite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,15 @@
 - [#14771](https://github.com/influxdata/telegraf/pull/14771) `deps` Bump tj-actions/changed-files from 41 to 42
 - [#14757](https://github.com/influxdata/telegraf/pull/14757) `deps` Get rid of golang.org/x/exp and use stable versions instead
 - [#14753](https://github.com/influxdata/telegraf/pull/14753) `deps` Use github.com/coreos/go-systemd/v22 instead of git version
+## Unreleased
+
+### Important Changes
+
+- The default read-timeout of `inputs.syslog` of five seconds is not a sensible
+  default as the plugin will close the connection if the time between
+  consecutive messages exceeds the timeout.
+  [#14828](https://github.com/influxdata/telegraf/pull/14828) sets the timeout
+  to infinite (i.e zero) as this is the expected behavior.
 
 ## v1.29.4 [2024-01-31]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 <!-- markdownlint-disable MD024 -->
 # Changelog
 
+## Unreleased
+
+### Important Changes
+
+- The default read-timeout of `inputs.syslog` of five seconds is not a sensible
+  default as the plugin will close the connection if the time between
+  consecutive messages exceeds the timeout.
+  [#14828](https://github.com/influxdata/telegraf/pull/14828) sets the timeout
+  to infinite (i.e zero) as this is the expected behavior.
+
 ## v1.29.5 [2024-02-20]
 
 ### Bugfixes
@@ -48,15 +58,6 @@
 - [#14771](https://github.com/influxdata/telegraf/pull/14771) `deps` Bump tj-actions/changed-files from 41 to 42
 - [#14757](https://github.com/influxdata/telegraf/pull/14757) `deps` Get rid of golang.org/x/exp and use stable versions instead
 - [#14753](https://github.com/influxdata/telegraf/pull/14753) `deps` Use github.com/coreos/go-systemd/v22 instead of git version
-## Unreleased
-
-### Important Changes
-
-- The default read-timeout of `inputs.syslog` of five seconds is not a sensible
-  default as the plugin will close the connection if the time between
-  consecutive messages exceeds the timeout.
-  [#14828](https://github.com/influxdata/telegraf/pull/14828) sets the timeout
-  to infinite (i.e zero) as this is the expected behavior.
 
 ## v1.29.4 [2024-01-31]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - The default read-timeout of `inputs.syslog` of five seconds is not a sensible
   default as the plugin will close the connection if the time between
   consecutive messages exceeds the timeout.
-  [#14828](https://github.com/influxdata/telegraf/pull/14828) sets the timeout
+  [#14837](https://github.com/influxdata/telegraf/pull/14828) sets the timeout
   to infinite (i.e zero) as this is the expected behavior.
 
 ## v1.29.5 [2024-02-20]


### PR DESCRIPTION
## Summary

When setting a read-timeout on stream connections such as TCP, the server (in this case the syslog plugin) reads from an initiated connection. In case no new message arrives during the set period, the read times out and the plugin expects the connection to be dead. As a consequence, the connection is closed.

In case of syslog, this means that the remote logger needs to send logs with a maximum time-distance of the set timeout. By default we set a timeout of 5 seconds which forces the logger to send log every 5 seconds as otherwise the connection times-out and is closed. This causes errors such as
```
Feb  4 22:18:17 logserver rsyslogd: omfwd: remote server at 127.0.0.1:6514 seems to have closed connection. This often happens when the remote peer (or an interim system like a load balancer or firewall) shuts down or aborts a connection. Rsyslog will re-open the connection if configured to do so (we saw a generic IO Error, which usually goes along with that behaviour). [v8.2302.0 try https://www.rsyslog.com/e/2027 ]
Feb  4 22:18:17 logserver rsyslogd: action 'action-0-builtin:omfwd' suspended (module 'builtin:omfwd'), retry 0. There should be messages before this one giving the reason for suspension. [v8.2302.0 try https://www.rsyslog.com/e/2007 ]
Feb  4 22:18:17 logserver rsyslogd: action 'action-0-builtin:omfwd' resumed (module 'builtin:omfwd') [v8.2302.0 try https://www.rsyslog.com/e/2359 ]
```
on the remote side. This is unexpected by the average user and a default of 5 seconds seems unreasonable for logging with potentially long periods of low or no activity.

This PR changes the default read-timeout to zero resulting in connection to never timeout and thus to never be closed from the plugin side. In case a user sets the timeout, we now print a warning to make the user aware of the behavior.
Furthermore, the PR adds a unit-test for issue #10121.

PR #14837 modified the default read timeout.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

