### PR TITLE
fix(inputs.postgres*)!: Prevent leaking sensitive data in server tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,9 @@
 - [#14771](https://github.com/influxdata/telegraf/pull/14771) `deps` Bump tj-actions/changed-files from 41 to 42
 - [#14757](https://github.com/influxdata/telegraf/pull/14757) `deps` Get rid of golang.org/x/exp and use stable versions instead
 - [#14753](https://github.com/influxdata/telegraf/pull/14753) `deps` Use github.com/coreos/go-systemd/v22 instead of git version
+- With correctly sanitizing PostgreSQL addresses ([PR #14829](https://github.com/influxdata/telegraf/pull/14829))
+  the `server` tag value for a URI-format address might change in case it
+  contains spaces, backslashes or single-quotes in non-redacted parameters.
 
 ## v1.29.4 [2024-01-31]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@
   consecutive messages exceeds the timeout.
   [#14837](https://github.com/influxdata/telegraf/pull/14828) sets the timeout
   to infinite (i.e zero) as this is the expected behavior.
+- With correctly sanitizing PostgreSQL addresses ([PR #14829](https://github.com/influxdata/telegraf/pull/14829))
+  the `server` tag value for a URI-format address might change in case it
+  contains spaces, backslashes or single-quotes in non-redacted parameters.
 
 ## v1.29.5 [2024-02-20]
 
@@ -72,9 +75,6 @@
 - [#14771](https://github.com/influxdata/telegraf/pull/14771) `deps` Bump tj-actions/changed-files from 41 to 42
 - [#14757](https://github.com/influxdata/telegraf/pull/14757) `deps` Get rid of golang.org/x/exp and use stable versions instead
 - [#14753](https://github.com/influxdata/telegraf/pull/14753) `deps` Use github.com/coreos/go-systemd/v22 instead of git version
-- With correctly sanitizing PostgreSQL addresses ([PR #14829](https://github.com/influxdata/telegraf/pull/14829))
-  the `server` tag value for a URI-format address might change in case it
-  contains spaces, backslashes or single-quotes in non-redacted parameters.
 
 ## v1.29.4 [2024-01-31]
 

--- a/plugins/inputs/postgresql/postgresql_test.go
+++ b/plugins/inputs/postgresql/postgresql_test.go
@@ -375,6 +375,7 @@ func TestSanitizeAddressKeyValue(t *testing.T) {
 			}
 
 			expected := strings.Join(make([]string, len(keys)), "canary=ok ")
+			expected = strings.TrimSpace(expected)
 			actual, err := plugin.SanitizedAddress()
 			require.NoError(t, err)
 			require.Equalf(t, expected, actual, "initial: %s", dsn)
@@ -396,6 +397,7 @@ func TestSanitizeAddressKeyValue(t *testing.T) {
 			}
 
 			expected := strings.Join(make([]string, len(keys)), "canary=ok ")
+			expected = strings.TrimSpace(expected)
 			actual, err := plugin.SanitizedAddress()
 			require.NoError(t, err)
 			require.Equalf(t, expected, actual, "initial: %s", dsn)

--- a/plugins/inputs/postgresql/postgresql_test.go
+++ b/plugins/inputs/postgresql/postgresql_test.go
@@ -379,7 +379,7 @@ func TestURIParsing(t *testing.T) {
 	for _, tt := range tests {
 		// Key value without spaces around equal sign
 		t.Run(tt.name, func(t *testing.T) {
-			actual, err := parseURL(tt.uri)
+			actual, err := toKeyValue(tt.uri)
 			require.NoError(t, err)
 			require.Equalf(t, tt.expected, actual, "initial: %s", tt.uri)
 		})

--- a/plugins/inputs/postgresql/postgresql_test.go
+++ b/plugins/inputs/postgresql/postgresql_test.go
@@ -356,13 +356,13 @@ func TestURIParsing(t *testing.T) {
 		},
 		{
 			name:     "with spaces",
-			uri:      `postgres://jack%20hunter:secret@localhost:5432/mydb?application_name=pgx%20test&search_path=myschema&connect_timeout=5`,
-			expected: "application_name='pgx test' connect_timeout=5 dbname=mydb host=localhost password=secret port=5432 search_path=myschema user='jack hunter'",
+			uri:      `postgres://jack%20hunter:secret@localhost/mydb?application_name=pgx%20test`,
+			expected: "application_name='pgx test' dbname=mydb host=localhost password=secret user='jack hunter'",
 		},
 		{
 			name:     "with equal signs",
-			uri:      `postgres://jack%20hunter:secret@localhost:5432/mydb?application_name=pgx%3Dtest&search_path=myschema&connect_timeout=5`,
-			expected: "application_name='pgx=test' connect_timeout=5 dbname=mydb host=localhost password=secret port=5432 search_path=myschema user='jack hunter'",
+			uri:      `postgres://jack%20hunter:secret@localhost/mydb?application_name=pgx%3Dtest`,
+			expected: "application_name='pgx=test' dbname=mydb host=localhost password=secret user='jack hunter'",
 		},
 		{
 			name:     "multiple hosts",

--- a/plugins/inputs/postgresql/postgresql_test.go
+++ b/plugins/inputs/postgresql/postgresql_test.go
@@ -337,6 +337,10 @@ func TestSanitizeAddressKeyValue(t *testing.T) {
 			value: `'foo bar'`,
 		},
 		{
+			name:  "equal sign in value",
+			value: `'foo=bar'`,
+		},
+		{
 			name:  "escaped quote",
 			value: `'foo\'s bar'`,
 		},

--- a/plugins/inputs/postgresql/postgresql_test.go
+++ b/plugins/inputs/postgresql/postgresql_test.go
@@ -428,6 +428,34 @@ func TestSanitizeAddressKeyValue(t *testing.T) {
 			name:  "two escaped backslashes",
 			value: `'foo bar\\\\'`,
 		},
+		{
+			name:  "multiple inline spaces",
+			value: "'foo     \t bar'",
+		},
+		{
+			name:  "leading space",
+			value: `' foo bar'`,
+		},
+		{
+			name:  "trailing space",
+			value: `'foo bar '`,
+		},
+		{
+			name:  "multiple equal signs",
+			value: `'foo===bar'`,
+		},
+		{
+			name:  "leading equal sign",
+			value: `'=foo bar'`,
+		},
+		{
+			name:  "trailing equal sign",
+			value: `'foo bar='`,
+		},
+		{
+			name:  "mix of equal signs and spaces",
+			value: "'foo = a\t===\tbar'",
+		},
 	}
 
 	for _, tt := range tests {

--- a/plugins/inputs/postgresql/postgresql_test.go
+++ b/plugins/inputs/postgresql/postgresql_test.go
@@ -318,6 +318,74 @@ func TestPostgresqlDatabaseBlacklistTestIntegration(t *testing.T) {
 	require.True(t, foundTemplate1)
 }
 
+func TestURIParsing(t *testing.T) {
+	tests := []struct {
+		name     string
+		uri      string
+		expected string
+	}{
+		{
+			name:     "short",
+			uri:      `postgres://localhost`,
+			expected: "host=localhost",
+		},
+		{
+			name:     "with port",
+			uri:      `postgres://localhost:5432`,
+			expected: "host=localhost port=5432",
+		},
+		{
+			name:     "with database",
+			uri:      `postgres://localhost/mydb`,
+			expected: "dbname=mydb host=localhost",
+		},
+		{
+			name:     "with additional parameters",
+			uri:      `postgres://localhost/mydb?application_name=pgxtest&search_path=myschema&connect_timeout=5`,
+			expected: "application_name=pgxtest connect_timeout=5 dbname=mydb host=localhost search_path=myschema",
+		},
+		{
+			name:     "with database setting in params",
+			uri:      `postgres://localhost:5432/?database=mydb`,
+			expected: "database=mydb host=localhost port=5432",
+		},
+		{
+			name:     "with authentication",
+			uri:      `postgres://jack:secret@localhost:5432/mydb?sslmode=prefer`,
+			expected: "dbname=mydb host=localhost password=secret port=5432 sslmode=prefer user=jack",
+		},
+		{
+			name:     "with spaces",
+			uri:      `postgres://jack%20hunter:secret@localhost:5432/mydb?application_name=pgx%20test&search_path=myschema&connect_timeout=5`,
+			expected: "application_name='pgx test' connect_timeout=5 dbname=mydb host=localhost password=secret port=5432 search_path=myschema user='jack hunter'",
+		},
+		{
+			name:     "with equal signs",
+			uri:      `postgres://jack%20hunter:secret@localhost:5432/mydb?application_name=pgx%3Dtest&search_path=myschema&connect_timeout=5`,
+			expected: "application_name='pgx=test' connect_timeout=5 dbname=mydb host=localhost password=secret port=5432 search_path=myschema user='jack hunter'",
+		},
+		{
+			name:     "multiple hosts",
+			uri:      `postgres://jack:secret@foo:1,bar:2,baz:3/mydb?sslmode=disable`,
+			expected: "dbname=mydb host=foo,bar,baz password=secret port=1,2,3 sslmode=disable user=jack",
+		},
+		{
+			name:     "multiple hosts without ports",
+			uri:      `postgres://jack:secret@foo,bar,baz/mydb?sslmode=disable`,
+			expected: "dbname=mydb host=foo,bar,baz password=secret sslmode=disable user=jack",
+		},
+	}
+
+	for _, tt := range tests {
+		// Key value without spaces around equal sign
+		t.Run(tt.name, func(t *testing.T) {
+			actual, err := parseURL(tt.uri)
+			require.NoError(t, err)
+			require.Equalf(t, tt.expected, actual, "initial: %s", tt.uri)
+		})
+	}
+}
+
 func TestSanitizeAddressKeyValue(t *testing.T) {
 	keys := []string{"password", "sslcert", "sslkey", "sslmode", "sslrootcert"}
 	tests := []struct {

--- a/plugins/inputs/postgresql/service.go
+++ b/plugins/inputs/postgresql/service.go
@@ -165,10 +165,10 @@ func (p *Service) SanitizedAddress() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("getting address for sanitization failed: %w", err)
 	}
-	addr := addrSecret.String()
-	addrSecret.Destroy()
+	defer addrSecret.Destroy()
 
 	// Make sure we convert URI-formatted strings into key-values
+	addr := addrSecret.TemporaryString()
 	if strings.HasPrefix(addr, "postgres://") || strings.HasPrefix(addr, "postgresql://") {
 		if addr, err = toKeyValue(addr); err != nil {
 			return "", err

--- a/plugins/inputs/postgresql/service.go
+++ b/plugins/inputs/postgresql/service.go
@@ -39,7 +39,7 @@ func toKeyValue(uri string) (string, error) {
 	}
 
 	// Extract the parameters
-	var parts []string
+	parts := make([]string, 0, len(u.Query())+5)
 	if u.User != nil {
 		parts = append(parts, "user="+quoteIfNecessary(u.User.Username()))
 		if password, found := u.User.Password(); found {
@@ -48,10 +48,11 @@ func toKeyValue(uri string) (string, error) {
 	}
 
 	// Handle multiple host:port's in url.Host by splitting them into host,host,host and port,port,port.
-	var hosts []string
-	var ports []string
+	hostParts := strings.Split(u.Host, ",")
+	hosts := make([]string, 0, len(hostParts))
+	ports := make([]string, 0, len(hostParts))
 	var anyPortSet bool
-	for _, host := range strings.Split(u.Host, ",") {
+	for _, host := range hostParts {
 		if host == "" {
 			continue
 		}

--- a/plugins/inputs/postgresql/service.go
+++ b/plugins/inputs/postgresql/service.go
@@ -148,7 +148,7 @@ func (p *Service) Stop() {
 	p.DB.Close()
 }
 
-var kvMatcher, _ = regexp.Compile(`(password|sslcert|sslkey|sslmode|sslrootcert)=\S+ ?`)
+var keyValueMatcher = regexp.MustCompile(`(\s|^)((?:password|sslcert|sslkey|sslmode|sslrootcert)\s?=\s?(?:(?:'(?:[^'\\]|\\.)*')|(?:\S+)))(?:\s|$)`)
 
 // SanitizedAddress utility function to strip sensitive information from the connection string.
 func (p *Service) SanitizedAddress() (sanitizedAddress string, err error) {
@@ -171,7 +171,7 @@ func (p *Service) SanitizedAddress() (sanitizedAddress string, err error) {
 		canonicalizedAddress = addr.String()
 	}
 
-	return kvMatcher.ReplaceAllString(canonicalizedAddress, ""), nil
+	return keyValueMatcher.ReplaceAllString(canonicalizedAddress, "$1"), nil
 }
 
 // GetConnectDatabase utility function for getting the database to which the connection was made

--- a/plugins/inputs/postgresql/service.go
+++ b/plugins/inputs/postgresql/service.go
@@ -17,72 +17,75 @@ import (
 	"github.com/influxdata/telegraf/config"
 )
 
-// pulled from lib/pq
-// ParseURL no longer needs to be used by clients of this library since supplying a URL as a
-// connection string to sql.Open() is now supported:
-//
-//	sql.Open("postgres", "postgres://bob:secret@1.2.3.4:5432/mydb?sslmode=verify-full")
-//
-// It remains exported here for backwards-compatibility.
-//
-// ParseURL converts a url to a connection string for driver.Open.
-// Example:
-//
-//	"postgres://bob:secret@1.2.3.4:5432/mydb?sslmode=verify-full"
-//
-// converts to:
-//
-//	"user=bob password=secret host=1.2.3.4 port=5432 dbname=mydb sslmode=verify-full"
-//
-// A minimal example:
-//
-//	"postgres://"
-//
-// This will be blank, causing driver.Open to use all of the defaults
-func parseURL(uri string) (string, error) {
+// Based on parseURLSettings() at https://github.com/jackc/pgx/blob/master/pgconn/config.go
+func toKeyValue(uri string) (string, error) {
 	u, err := url.Parse(uri)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("parsing URI failed: %w", err)
 	}
 
+	// Check the protocol
 	if u.Scheme != "postgres" && u.Scheme != "postgresql" {
 		return "", fmt.Errorf("invalid connection protocol: %s", u.Scheme)
 	}
 
-	var kvs []string
-	escaper := strings.NewReplacer(` `, `\ `, `'`, `\'`, `\`, `\\`)
-	accrue := func(k, v string) {
-		if v != "" {
-			kvs = append(kvs, k+"="+escaper.Replace(v))
+	quoteIfNecessary := func(v string) string {
+		if !strings.ContainsAny(v, ` ='\`) {
+			return v
+		}
+		r := strings.ReplaceAll(v, `\`, `\\`)
+		r = strings.ReplaceAll(r, `'`, `\'`)
+		return "'" + r + "'"
+	}
+
+	// Extract the parameters
+	var parts []string
+	if u.User != nil {
+		parts = append(parts, "user="+quoteIfNecessary(u.User.Username()))
+		if password, found := u.User.Password(); found {
+			parts = append(parts, "password="+quoteIfNecessary(password))
 		}
 	}
 
-	if u.User != nil {
-		v := u.User.Username()
-		accrue("user", v)
+	// Handle multiple host:port's in url.Host by splitting them into host,host,host and port,port,port.
+	var hosts []string
+	var ports []string
+	var anyPortSet bool
+	for _, host := range strings.Split(u.Host, ",") {
+		if host == "" {
+			continue
+		}
 
-		v, _ = u.User.Password()
-		accrue("password", v)
+		h, p, err := net.SplitHostPort(host)
+		if err != nil {
+			if !strings.Contains(err.Error(), "missing port") {
+				return "", fmt.Errorf("failed to process host %q: %w", host, err)
+			}
+			h = host
+		}
+		anyPortSet = anyPortSet || err == nil
+		hosts = append(hosts, h)
+		ports = append(ports, p)
+	}
+	if len(hosts) > 0 {
+		parts = append(parts, "host="+strings.Join(hosts, ","))
+	}
+	if anyPortSet {
+		parts = append(parts, "port="+strings.Join(ports, ","))
 	}
 
-	if host, port, err := net.SplitHostPort(u.Host); err != nil {
-		accrue("host", u.Host)
-	} else {
-		accrue("host", host)
-		accrue("port", port)
+	database := strings.TrimLeft(u.Path, "/")
+	if database != "" {
+		parts = append(parts, "dbname="+quoteIfNecessary(database))
 	}
 
-	if u.Path != "" {
-		accrue("dbname", u.Path[1:])
+	for k, v := range u.Query() {
+		parts = append(parts, k+"="+quoteIfNecessary(strings.Join(v, ",")))
 	}
 
-	q := u.Query()
-	for k := range q {
-		accrue(k, q.Get(k))
-	}
-
-	sort.Strings(kvs) // Makes testing easier (not a performance concern)
-	return strings.Join(kvs, " "), nil
+	// Required to produce a repeatable output e.g. for tags or testing
+	sort.Strings(parts)
+	return strings.Join(parts, " "), nil
 }
 
 // Service common functionality shared between the postgresql and postgresql_extensible
@@ -166,7 +169,7 @@ func (p *Service) SanitizedAddress() (string, error) {
 
 	// Make sure we convert URI-formatted strings into key-values
 	if strings.HasPrefix(addr, "postgres://") || strings.HasPrefix(addr, "postgresql://") {
-		if addr, err = parseURL(addr); err != nil {
+		if addr, err = toKeyValue(addr); err != nil {
 			return "", err
 		}
 	}


### PR DESCRIPTION
## Summary

The current implementation of `SanitizedAddress()` does not handle quoted parameter values containing spaces or equal signs (e.g. `host=localhost user=john password='a secret=good'`). Additionally to those issues, the parsing of URI connection strings is completely broken for spaces and equal signs as values containing those need to be single-quoted  which does not happen. Furthermore, that function escapes "special characters" (space, backslash and single-quote) which subsequently breaks the sanitize function.

This PR adds unit-tests for both of the mentioned functions. It also removes the useless escaping of spaces during URI handling and replaces this part by quoting the value. Finally, the PR improves the regular-expression used to remove sensitive data to correctly handle quoted values, equal-signs and other corner cases.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues
