### PR TITLE
feat(outputs.websocket): Allow specifying secrets in headers

### DIFF
--- a/plugins/outputs/websocket/README.md
+++ b/plugins/outputs/websocket/README.md
@@ -15,6 +15,14 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 [CONFIGURATION.md]: ../../../docs/CONFIGURATION.md#plugins
 
+## Secret-store support
+
+This plugin supports secrets from secret-stores for the `headers` option.
+See the [secret-store documentation][SECRETSTORE] for more details on how
+to use them.
+
+[SECRETSTORE]: ../../../docs/CONFIGURATION.md#secret-store-secrets
+
 ## Configuration
 
 ```toml @sample.conf

--- a/plugins/outputs/websocket/websocket.go
+++ b/plugins/outputs/websocket/websocket.go
@@ -30,13 +30,13 @@ const (
 
 // WebSocket can output to WebSocket endpoint.
 type WebSocket struct {
-	URL            string            `toml:"url"`
-	ConnectTimeout config.Duration   `toml:"connect_timeout"`
-	WriteTimeout   config.Duration   `toml:"write_timeout"`
-	ReadTimeout    config.Duration   `toml:"read_timeout"`
-	Headers        map[string]string `toml:"headers"`
-	UseTextFrames  bool              `toml:"use_text_frames"`
-	Log            telegraf.Logger   `toml:"-"`
+	URL            string                    `toml:"url"`
+	ConnectTimeout config.Duration           `toml:"connect_timeout"`
+	WriteTimeout   config.Duration           `toml:"write_timeout"`
+	ReadTimeout    config.Duration           `toml:"read_timeout"`
+	Headers        map[string]*config.Secret `toml:"headers"`
+	UseTextFrames  bool                      `toml:"use_text_frames"`
+	Log            telegraf.Logger           `toml:"-"`
 	proxy.HTTPProxy
 	proxy.Socks5ProxyConfig
 	tls.ClientConfig
@@ -92,7 +92,14 @@ func (w *WebSocket) Connect() error {
 
 	headers := http.Header{}
 	for k, v := range w.Headers {
-		headers.Set(k, v)
+		secret, err := v.Get()
+		if err != nil {
+			return err
+		}
+
+		headerVal := secret.String()
+		headers.Set(k, headerVal)
+		secret.Destroy()
 	}
 
 	conn, resp, err := dialer.Dial(w.URL, headers)

--- a/plugins/outputs/websocket/websocket.go
+++ b/plugins/outputs/websocket/websocket.go
@@ -97,8 +97,7 @@ func (w *WebSocket) Connect() error {
 			return fmt.Errorf("getting header secret %q failed: %w", k, err)
 		}
 
-		headerVal := secret.String()
-		headers.Set(k, headerVal)
+		headers.Set(k, secret.String())
 		secret.Destroy()
 	}
 

--- a/plugins/outputs/websocket/websocket.go
+++ b/plugins/outputs/websocket/websocket.go
@@ -94,7 +94,7 @@ func (w *WebSocket) Connect() error {
 	for k, v := range w.Headers {
 		secret, err := v.Get()
 		if err != nil {
-			return err
+			return fmt.Errorf("getting header secret %q failed: %w", k, err)
 		}
 
 		headerVal := secret.String()

--- a/plugins/outputs/websocket/websocket_test.go
+++ b/plugins/outputs/websocket/websocket_test.go
@@ -101,7 +101,8 @@ func initWebSocket(s *testServer) *WebSocket {
 	w := newWebSocket()
 	w.Log = testutil.Logger{}
 	w.URL = s.URL
-	w.Headers = map[string]string{testHeaderName: testHeaderValue}
+	headerSecret := config.NewSecret([]byte(testHeaderValue))
+	w.Headers = map[string]*config.Secret{testHeaderName: &headerSecret}
 	w.SetSerializer(newTestSerializer())
 	return w
 }


### PR DESCRIPTION
## Summary
Make the header values secrets instead of plain strings to support setting bearer tokens properly.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #14835
