### PR TITLE
fix(agent): add panicRecover func to capture the panics inside plugin executions

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -581,6 +581,7 @@ func (a *Agent) gatherOnce(
 ) error {
 	done := make(chan error)
 	go func() {
+		defer panicRecover(input)
 		done <- input.Gather(acc)
 	}()
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/influxdata/telegraf
 
-go 1.21
+go 1.22
 
 require (
 	cloud.google.com/go/bigquery v1.58.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/influxdata/telegraf
 
-go 1.22
+go 1.21
 
 require (
 	cloud.google.com/go/bigquery v1.58.0


### PR DESCRIPTION
## Summary
The [panicRecover(input)](https://github.com/influxdata/telegraf/blob/master/agent/agent.go#L559) cannot capture the panic inside the Gather method in each plugin because the Gather() method is called in a separate go routine: [this line](https://github.com/influxdata/telegraf/blob/master/agent/agent.go#L583-L585). Adding the panicRecover(input) function inside the go routine just before [done <- input.Gather(acc)](https://github.com/influxdata/telegraf/blob/master/agent/agent.go#L584) can resolve this issue.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues


resolves #14826 
