### PR TITLE
chore(circleci): Use latest mingw

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,11 @@ commands:
             equal: [ "386", << parameters.arch >> ]
           steps:
             - run: echo 'export RACE="-race"' >> $BASH_ENV
+      - when:
+          condition:
+            equal: [ windows, << parameters.os >> ]
+          steps:
+            - run: echo 'export CGO_ENABLED=1' >> $BASH_ENV
       - run: |
           GOARCH=<< parameters.arch >> ./<< parameters.gotestsum >> -- ${RACE} -short ./...
   package-build:
@@ -170,7 +175,8 @@ jobs:
       - run: git config --system core.longpaths true
       - run: choco feature enable -n allowGlobalConfirmation
       - run: 'sh ./scripts/installgo_windows.sh'
-      - run: choco install mingw --version=12.2.0.03042023
+      - run: choco install mingw
+      - run: echo 'export PATH="$PATH:/c/ProgramData/mingw64/mingw64/bin"' >> $BASH_ENV
       - test-go:
           os: windows
           gotestsum: "gotestsum.exe"


### PR DESCRIPTION
## Summary

This reverts PR #14035 to use the latest version of mingw again.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues
