### PR TITLE
test(processors): Fix unit-test for tracking metrics

### DIFF
--- a/plugins/processors/converter/converter_test.go
+++ b/plugins/processors/converter/converter_test.go
@@ -836,6 +836,6 @@ func TestTracking(t *testing.T) {
 	require.Eventuallyf(t, func() bool {
 		mu.Lock()
 		defer mu.Unlock()
-		return len(expected) == len(delivered)
+		return len(input) == len(delivered)
 	}, time.Second, 100*time.Millisecond, "%d delivered but %d expected", len(delivered), len(expected))
 }

--- a/plugins/processors/date/date_test.go
+++ b/plugins/processors/date/date_test.go
@@ -289,6 +289,6 @@ func TestTracking(t *testing.T) {
 	require.Eventuallyf(t, func() bool {
 		mu.Lock()
 		defer mu.Unlock()
-		return len(expected) == len(delivered)
+		return len(input) == len(delivered)
 	}, time.Second, 100*time.Millisecond, "%d delivered but %d expected", len(delivered), len(expected))
 }

--- a/plugins/processors/defaults/defaults_test.go
+++ b/plugins/processors/defaults/defaults_test.go
@@ -195,6 +195,6 @@ func TestTracking(t *testing.T) {
 	require.Eventuallyf(t, func() bool {
 		mu.Lock()
 		defer mu.Unlock()
-		return len(expected) == len(delivered)
+		return len(input) == len(delivered)
 	}, time.Second, 100*time.Millisecond, "%d delivered but %d expected", len(delivered), len(expected))
 }

--- a/plugins/processors/execd/execd_test.go
+++ b/plugins/processors/execd/execd_test.go
@@ -391,6 +391,6 @@ func TestTracking(t *testing.T) {
 	require.Eventuallyf(t, func() bool {
 		mu.Lock()
 		defer mu.Unlock()
-		return len(expected) == len(delivered)
+		return len(input) == len(delivered)
 	}, time.Second, 100*time.Millisecond, "%d delivered but %d expected", len(delivered), len(expected))
 }

--- a/plugins/processors/filepath/filepath_test.go
+++ b/plugins/processors/filepath/filepath_test.go
@@ -129,6 +129,6 @@ func TestTracking(t *testing.T) {
 	require.Eventuallyf(t, func() bool {
 		mu.Lock()
 		defer mu.Unlock()
-		return len(expected) == len(delivered)
+		return len(input) == len(delivered)
 	}, time.Second, 100*time.Millisecond, "%d delivered but %d expected", len(delivered), len(expected))
 }

--- a/plugins/processors/ifname/ifname_test.go
+++ b/plugins/processors/ifname/ifname_test.go
@@ -228,6 +228,6 @@ func TestTracking(t *testing.T) {
 	require.Eventuallyf(t, func() bool {
 		mu.Lock()
 		defer mu.Unlock()
-		return len(expected) == len(delivered)
+		return len(input) == len(delivered)
 	}, time.Second, 100*time.Millisecond, "%d delivered but %d expected", len(delivered), len(expected))
 }

--- a/plugins/processors/lookup/lookup_test.go
+++ b/plugins/processors/lookup/lookup_test.go
@@ -162,7 +162,7 @@ func TestCasesTracking(t *testing.T) {
 			testutil.RequireMetricsEqual(t, expected, actual)
 
 			// Simulate output acknowledging delivery
-			for _, m := range input {
+			for _, m := range actual {
 				m.Accept()
 			}
 
@@ -170,7 +170,7 @@ func TestCasesTracking(t *testing.T) {
 			require.Eventuallyf(t, func() bool {
 				mu.Lock()
 				defer mu.Unlock()
-				return len(expected) == len(delivered)
+				return len(input) == len(delivered)
 			}, time.Second, 100*time.Millisecond, "%d delivered but %d expected", len(delivered), len(expected))
 		})
 	}

--- a/plugins/processors/rename/rename_test.go
+++ b/plugins/processors/rename/rename_test.go
@@ -124,6 +124,6 @@ func TestTracking(t *testing.T) {
 	require.Eventuallyf(t, func() bool {
 		mu.Lock()
 		defer mu.Unlock()
-		return len(expected) == len(delivered)
+		return len(input) == len(delivered)
 	}, time.Second, 100*time.Millisecond, "%d delivered but %d expected", len(delivered), len(expected))
 }

--- a/plugins/processors/reverse_dns/reverse_dns_test.go
+++ b/plugins/processors/reverse_dns/reverse_dns_test.go
@@ -128,6 +128,6 @@ func TestTracking(t *testing.T) {
 	require.Eventuallyf(t, func() bool {
 		mu.Lock()
 		defer mu.Unlock()
-		return len(expected) == len(delivered)
+		return len(input) == len(delivered)
 	}, time.Second, 100*time.Millisecond, "%d delivered but %d expected", len(delivered), len(expected))
 }

--- a/plugins/processors/s2geo/s2geo_test.go
+++ b/plugins/processors/s2geo/s2geo_test.go
@@ -118,6 +118,6 @@ func TestTracking(t *testing.T) {
 	require.Eventuallyf(t, func() bool {
 		mu.Lock()
 		defer mu.Unlock()
-		return len(expected) == len(delivered)
+		return len(input) == len(delivered)
 	}, time.Second, 100*time.Millisecond, "%d delivered but %d expected", len(delivered), len(expected))
 }

--- a/plugins/processors/scale/scale_test.go
+++ b/plugins/processors/scale/scale_test.go
@@ -546,6 +546,6 @@ func TestTracking(t *testing.T) {
 	require.Eventuallyf(t, func() bool {
 		mu.Lock()
 		defer mu.Unlock()
-		return len(expected) == len(delivered)
+		return len(input) == len(delivered)
 	}, time.Second, 100*time.Millisecond, "%d delivered but %d expected", len(delivered), len(expected))
 }

--- a/plugins/processors/tag_limit/tag_limit_test.go
+++ b/plugins/processors/tag_limit/tag_limit_test.go
@@ -148,6 +148,6 @@ func TestTracking(t *testing.T) {
 	require.Eventuallyf(t, func() bool {
 		mu.Lock()
 		defer mu.Unlock()
-		return len(expected) == len(delivered)
+		return len(input) == len(delivered)
 	}, time.Second, 100*time.Millisecond, "%d delivered but %d expected", len(delivered), len(expected))
 }

--- a/plugins/processors/template/template_test.go
+++ b/plugins/processors/template/template_test.go
@@ -292,12 +292,16 @@ func TestTracking(t *testing.T) {
 	testutil.RequireMetricsEqual(t, expected, actual)
 
 	// Simulate output acknowledging delivery
-	input.Accept()
+	for _, m := range actual {
+		m.Accept()
+	}
+
+	// Check delivery
 
 	// Check delivery
 	require.Eventuallyf(t, func() bool {
 		mu.Lock()
 		defer mu.Unlock()
-		return len(delivered) > 0
+		return len(delivered) == 1
 	}, time.Second, 100*time.Millisecond, "%d delivered but 1 expected", len(delivered))
 }

--- a/plugins/processors/topk/topk_test.go
+++ b/plugins/processors/topk/topk_test.go
@@ -576,6 +576,6 @@ func TestTracking(t *testing.T) {
 	require.Eventuallyf(t, func() bool {
 		mu.Lock()
 		defer mu.Unlock()
-		return len(expected) == len(delivered)
+		return len(input) == len(delivered)
 	}, time.Second, 100*time.Millisecond, "%d delivered but %d expected", len(delivered), len(expected))
 }


### PR DESCRIPTION
## Summary

When checking tracking metrics' acknowledgement, we need to

1. Accept all **outputs** of the processor as this is what the output will do.
2. Check if we get the delivery information for all **inputs** of the processor.

However, some processors use the number of expected output when checking the number of delivered/acknowledged metrics, one even directly acknowledges the input, which defeats the purpose of the test.

This PR makes sure, we do the right thing when testing tracking metrics.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues
