### PR TITLE
test(inputs.procstat): Resolve flaky test when PID exists

### DIFF
--- a/plugins/inputs/procstat/procstat_test.go
+++ b/plugins/inputs/procstat/procstat_test.go
@@ -589,7 +589,7 @@ func TestProcstatLookupMetric(t *testing.T) {
 
 	var acc testutil.Accumulator
 	require.NoError(t, p.Gather(&acc))
-	require.Len(t, acc.GetTelegrafMetrics(), 1)
+	require.NotEmpty(t, acc.GetTelegrafMetrics())
 }
 
 func TestGather_SameTimestamps(t *testing.T) {


### PR DESCRIPTION
## Summary
A user could actually have the PID requested in this test. Meaning that the result is more than one result. Therefore, to ensure this is not flaky, ensure we get at least one metric back.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #14855
