### PR TITLE
chore!(inputs.io): Remove deprecated plugin

### DIFF
--- a/plugins/inputs/diskio/diskio.go
+++ b/plugins/inputs/diskio/diskio.go
@@ -176,8 +176,4 @@ func init() {
 	inputs.Add("diskio", func() telegraf.Input {
 		return &DiskIO{ps: ps, SkipSerialNumber: true}
 	})
-	// Backwards compatible alias
-	inputs.Add("io", func() telegraf.Input {
-		return &DiskIO{ps: ps, SkipSerialNumber: true}
-	})
 }


### PR DESCRIPTION
## Summary

Remove the deprecated plugin scheduled for removal in v1.30.0

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

related to #13376