### PR TITLE
fix(inputs.docker_log): Use correct name when matching containers

### DIFF
--- a/plugins/inputs/docker_log/docker_log.go
+++ b/plugins/inputs/docker_log/docker_log.go
@@ -185,9 +185,11 @@ func (d *DockerLogs) matchedContainerName(names []string) string {
 	// this array is always of length 1.
 	for _, name := range names {
 		trimmedName := strings.TrimPrefix(name, "/")
-		match := d.containerFilter.Match(trimmedName)
-		if match {
-			return trimmedName
+		if !strings.Contains(trimmedName, "/") {
+			match := d.containerFilter.Match(trimmedName)
+			if match {
+				return trimmedName
+			}
 		}
 	}
 	return ""


### PR DESCRIPTION
Copied the fix from docker.go file.

## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
This fix should change how docker logs plugin searches for the correct container name. 
We found out that there was similar fix done in docker plugin few years ago. 
https://github.com/influxdata/telegraf/issues/4376

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
