### PR TITLE
fix(processors.override): Correct TOML tag name

### DIFF
--- a/plugins/processors/override/override.go
+++ b/plugins/processors/override/override.go
@@ -15,7 +15,7 @@ type Override struct {
 	NameOverride string            `toml:"name_override"`
 	NamePrefix   string            `toml:"name_prefix"`
 	NameSuffix   string            `toml:"name_suffix"`
-	Tags         map[string]string `toml:"tag"`
+	Tags         map[string]string `toml:"tags"`
 }
 
 func (*Override) SampleConfig() string {


### PR DESCRIPTION


## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
TOML tag is incorrectly named.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

fixes: #14879
