### PR TITLE
feat(agent): Add option to skip re-running processors after aggregators

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -136,7 +136,7 @@ func (a *Agent) Run(ctx context.Context) error {
 	var au *aggregatorUnit
 	if len(a.Config.Aggregators) != 0 {
 		aggC := next
-		if len(a.Config.AggProcessors) != 0 {
+		if len(a.Config.AggProcessors) != 0 && !a.Config.Agent.SkipProcessorsAfterAggregators {
 			aggC, apu, err = a.startProcessors(next, a.Config.AggProcessors)
 			if err != nil {
 				return err
@@ -1013,7 +1013,7 @@ func (a *Agent) runTest(ctx context.Context, wait time.Duration, outputC chan<- 
 	var au *aggregatorUnit
 	if len(a.Config.Aggregators) != 0 {
 		procC := next
-		if len(a.Config.AggProcessors) != 0 {
+		if len(a.Config.AggProcessors) != 0 && !a.Config.Agent.SkipProcessorsAfterAggregators {
 			procC, apu, err = a.startProcessors(next, a.Config.AggProcessors)
 			if err != nil {
 				return err
@@ -1112,7 +1112,7 @@ func (a *Agent) runOnce(ctx context.Context, wait time.Duration) error {
 	var au *aggregatorUnit
 	if len(a.Config.Aggregators) != 0 {
 		procC := next
-		if len(a.Config.AggProcessors) != 0 {
+		if len(a.Config.AggProcessors) != 0 && !a.Config.Agent.SkipProcessorsAfterAggregators {
 			procC, apu, err = a.startProcessors(next, a.Config.AggProcessors)
 			if err != nil {
 				return err

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -222,9 +222,7 @@ func TestCases(t *testing.T) {
 			// Process expected metrics and compare with resulting metrics
 			options := []cmp.Option{
 				testutil.IgnoreTags("host"),
-			}
-			if expected[0].Time().IsZero() {
-				options = append(options, testutil.IgnoreTime())
+				testutil.IgnoreTime(),
 			}
 			testutil.RequireMetricsEqual(t, expected, actual, options...)
 		})

--- a/agent/testcases/aggregators-rerun-processors/expected.out
+++ b/agent/testcases/aggregators-rerun-processors/expected.out
@@ -1,0 +1,2 @@
+metric value=420
+metric value_min=4200,value_max=4200

--- a/agent/testcases/aggregators-rerun-processors/input.influx
+++ b/agent/testcases/aggregators-rerun-processors/input.influx
@@ -1,0 +1,1 @@
+metric value=42.0

--- a/agent/testcases/aggregators-rerun-processors/telegraf.conf
+++ b/agent/testcases/aggregators-rerun-processors/telegraf.conf
@@ -1,0 +1,22 @@
+# Test for not skipping processors after running aggregators
+[agent]
+  omit_hostname = true
+  skip_processors_after_aggregators = false
+
+[[inputs.file]]
+  files = ["testcases/aggregators-rerun-processors/input.influx"]
+  data_format = "influx"
+
+[[processors.starlark]]
+  source = '''
+def apply(metric):
+    for k, v in metric.fields.items():
+        if type(v) == "float":
+            metric.fields[k] = v * 10
+    return metric
+'''
+
+[[aggregators.minmax]]
+  period = "1s"
+  drop_original = false
+

--- a/agent/testcases/aggregators-skip-processors/expected.out
+++ b/agent/testcases/aggregators-skip-processors/expected.out
@@ -1,0 +1,2 @@
+metric value=420
+metric value_min=420,value_max=420

--- a/agent/testcases/aggregators-skip-processors/input.influx
+++ b/agent/testcases/aggregators-skip-processors/input.influx
@@ -1,0 +1,1 @@
+metric value=42.0

--- a/agent/testcases/aggregators-skip-processors/telegraf.conf
+++ b/agent/testcases/aggregators-skip-processors/telegraf.conf
@@ -1,0 +1,22 @@
+# Test for skipping processors after running aggregators
+[agent]
+  omit_hostname = true
+  skip_processors_after_aggregators = true
+
+[[inputs.file]]
+  files = ["testcases/aggregators-skip-processors/input.influx"]
+  data_format = "influx"
+
+[[processors.starlark]]
+  source = '''
+def apply(metric):
+    for k, v in metric.fields.items():
+        if type(v) == "float":
+            metric.fields[k] = v * 10
+    return metric
+'''
+
+[[aggregators.minmax]]
+  period = "1s"
+  drop_original = false
+

--- a/cmd/telegraf/agent.conf
+++ b/cmd/telegraf/agent.conf
@@ -94,3 +94,8 @@
   ## stateful plugins on termination of Telegraf. If the file exists on start,
   ## the state in the file will be restored for the plugins.
   # statefile = ""
+
+	## Flag to skip running processors after aggregators
+	## By default, processors are run a second time after aggregators. Changing
+	## this setting to true will skip the second run of processors.
+	# skip_processors_after_aggregators = false

--- a/config/config.go
+++ b/config/config.go
@@ -265,6 +265,11 @@ type AgentConfig struct {
 	// Flag to always keep tags explicitly defined in the global tags section
 	// and ensure those tags always pass filtering.
 	AlwaysIncludeGlobalTags bool `toml:"always_include_global_tags"`
+
+	// Flag to skip running processors after aggregators
+	// By default, processors are run a second time after aggregators. Changing
+	// this setting to true will skip the second run of processors.
+	SkipProcessorsAfterAggregators bool `toml:"skip_processors_after_aggregators"`
 }
 
 // InputNames returns a list of strings of the configured inputs.


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
By default, after an aggregator is run the processors are run again. This can be helpful for users of aggregators to apply similar rules, however, this can also be very, very unexpected. As this behavior can result in aggregated values from getting scaled or computed against a second time.

While users can use the metric selectors to possibly omit the second run, it is nice to have a flag to remove this behavior entirely when it is not needed.

This introduces the `skip_processors_after_aggregators` config option, false by default.

Using a config with a processor that multiplies a float field by 10 each time it is run, by default:

```
❯ ./telegraf --config config.toml --test
2024-02-22T16:56:48Z I! Loading config: config.toml
2024-02-22T16:56:48Z I! Starting Telegraf 1.30.0-c4069a4b brought to you by InfluxData the makers of InfluxDB
2024-02-22T16:56:48Z I! Available plugins: 241 inputs, 9 aggregators, 30 processors, 24 parsers, 61 outputs, 6 secret-stores
2024-02-22T16:56:48Z I! Loaded inputs: exec
2024-02-22T16:56:48Z I! Loaded aggregators: minmax
2024-02-22T16:56:48Z I! Loaded processors: starlark
2024-02-22T16:56:48Z I! Loaded secretstores: 
2024-02-22T16:56:48Z W! Outputs are not used in testing mode!
2024-02-22T16:56:48Z I! Tags enabled: host=ryzen
2024-02-22T16:56:48Z D! [agent] Initializing plugins
2024-02-22T16:56:48Z D! [agent] Starting service inputs
2024-02-22T16:56:48Z D! [aggregators.minmax] Updated aggregation range [2024-02-22 09:56:30 -0700 MST, 2024-02-22 09:57:00 -0700 MST]
2024-02-22T16:56:48Z D! [agent] Stopping service inputs
2024-02-22T16:56:48Z D! [agent] Input channel closed
2024-02-22T16:56:48Z D! [agent] Processor channel closed
2024-02-22T16:56:48Z D! [aggregators.minmax] Updated aggregation range [2024-02-22 09:57:00 -0700 MST, 2024-02-22 09:57:30 -0700 MST]
2024-02-22T16:56:48Z D! [agent] Aggregator channel closed
> metric,host=ryzen value=420 1708621009000000000
2024-02-22T16:56:48Z D! [agent] Processor channel closed
2024-02-22T16:56:48Z D! [agent] Stopped Successfully
> metric,host=ryzen value_max=4200,value_min=4200 1708621009000000000
```

When set to true, note how the value is no longer scaled again.

```
❯ ./telegraf --config config.toml --test
2024-02-22T16:56:43Z I! Loading config: config.toml
2024-02-22T16:56:43Z I! Starting Telegraf 1.30.0-c4069a4b brought to you by InfluxData the makers of InfluxDB
2024-02-22T16:56:43Z I! Available plugins: 241 inputs, 9 aggregators, 30 processors, 24 parsers, 61 outputs, 6 secret-stores
2024-02-22T16:56:43Z I! Loaded inputs: exec
2024-02-22T16:56:43Z I! Loaded aggregators: minmax
2024-02-22T16:56:43Z I! Loaded processors: starlark
2024-02-22T16:56:43Z I! Loaded secretstores: 
2024-02-22T16:56:43Z W! Outputs are not used in testing mode!
2024-02-22T16:56:43Z I! Tags enabled: host=ryzen
2024-02-22T16:56:43Z D! [agent] Initializing plugins
2024-02-22T16:56:43Z D! [agent] Starting service inputs
2024-02-22T16:56:43Z D! [aggregators.minmax] Updated aggregation range [2024-02-22 09:56:30 -0700 MST, 2024-02-22 09:57:00 -0700 MST]
2024-02-22T16:56:43Z D! [agent] Stopping service inputs
2024-02-22T16:56:43Z D! [agent] Input channel closed
2024-02-22T16:56:43Z D! [agent] Processor channel closed
2024-02-22T16:56:43Z D! [aggregators.minmax] Updated aggregation range [2024-02-22 09:57:00 -0700 MST, 2024-02-22 09:57:30 -0700 MST]
2024-02-22T16:56:43Z D! [agent] Aggregator channel closed
2024-02-22T16:56:43Z D! [agent] Stopped Successfully
> metric,host=ryzen value=420 1708621004000000000
> metric,host=ryzen value_max=420,value_min=420 1708621004000000000
```

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

fixes: #7993
