### PR TITLE
feat(processors.ifname): Deprecate plugin

### DIFF
--- a/plugins/processors/deprecations.go
+++ b/plugins/processors/deprecations.go
@@ -3,4 +3,9 @@ package processors
 import "github.com/influxdata/telegraf"
 
 // Deprecations lists the deprecated plugins
-var Deprecations = map[string]telegraf.DeprecationInfo{}
+var Deprecations = map[string]telegraf.DeprecationInfo{
+	"ifname": {
+		Since:  "1.30.0",
+		Notice: "use 'processors.snmp_lookup' instead",
+	},
+}

--- a/plugins/processors/ifname/README.md
+++ b/plugins/processors/ifname/README.md
@@ -1,8 +1,11 @@
 # Network Interface Name Processor Plugin
 
+**DEPRECATED: As of version 1.30 the `ifname` plugin has been deprecated in
+favor of the [snmp_lookup][] plugin.**
+
 The `ifname` plugin looks up network interface names using SNMP.
 
-Telegraf minimum version: Telegraf 1.15.0
+[snmp_lookup]: ../snmp_lookup/README.md
 
 ## Global configuration options <!-- @/docs/includes/plugin_config.md -->
 


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
With the addition of the `processors.snmp_lookup`, the `processors.ifname` has become redundant, so we are deprecating it.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

- closes #8011
- continues #14223
