### PR TITLE
chore(inputs.disk)!: Remove deprecated 'mountpoints' option

### DIFF
--- a/plugins/inputs/disk/disk.go
+++ b/plugins/inputs/disk/disk.go
@@ -16,15 +16,12 @@ import (
 var sampleConfig string
 
 type DiskStats struct {
+	MountPoints     []string        `toml:"mount_points"`
+	IgnoreFS        []string        `toml:"ignore_fs"`
+	IgnoreMountOpts []string        `toml:"ignore_mount_opts"`
+	Log             telegraf.Logger `toml:"-"`
+
 	ps system.PS
-
-	LegacyMountPoints []string `toml:"mountpoints" deprecated:"0.10.2;1.30.0;use 'mount_points' instead"`
-
-	MountPoints     []string `toml:"mount_points"`
-	IgnoreFS        []string `toml:"ignore_fs"`
-	IgnoreMountOpts []string `toml:"ignore_mount_opts"`
-
-	Log telegraf.Logger `toml:"-"`
 }
 
 func (*DiskStats) SampleConfig() string {
@@ -32,11 +29,6 @@ func (*DiskStats) SampleConfig() string {
 }
 
 func (ds *DiskStats) Init() error {
-	// Legacy support:
-	if len(ds.LegacyMountPoints) != 0 {
-		ds.MountPoints = ds.LegacyMountPoints
-	}
-
 	ps := system.NewSystemPS()
 	ps.Log = ds.Log
 	ds.ps = ps


### PR DESCRIPTION
## Summary

Remove the deprecated plugin option scheduled for removal in v1.30.0

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

related to #13375 
