### PR TITLE
chore(outputs.influxdb)!: Remove deprecated 'url' option

### DIFF
--- a/plugins/outputs/influxdb/http_test.go
+++ b/plugins/outputs/influxdb/http_test.go
@@ -1062,7 +1062,7 @@ func TestDBRPTagsCreateDatabaseNotCalledOnRetryAfterForbidden(t *testing.T) {
 	}
 
 	output := influxdb.InfluxDB{
-		URL:         u.String(),
+		URLs:        []string{u.String()},
 		Database:    "telegraf",
 		DatabaseTag: "database",
 		Log:         testutil.Logger{},
@@ -1149,7 +1149,7 @@ func TestDBRPTagsCreateDatabaseCalledOnDatabaseNotFound(t *testing.T) {
 	}
 
 	output := influxdb.InfluxDB{
-		URL:         u.String(),
+		URLs:        []string{u.String()},
 		Database:    "telegraf",
 		DatabaseTag: "database",
 		Log:         testutil.Logger{},
@@ -1203,7 +1203,7 @@ func TestDBNotFoundShouldDropMetricWhenSkipDatabaseCreateIsTrue(t *testing.T) {
 
 	logger := &testutil.CaptureLogger{}
 	output := influxdb.InfluxDB{
-		URL:                  u.String(),
+		URLs:                 []string{u.String()},
 		Database:             "telegraf",
 		DatabaseTag:          "database",
 		SkipDatabaseCreation: true,

--- a/plugins/outputs/influxdb/influxdb_test.go
+++ b/plugins/outputs/influxdb/influxdb_test.go
@@ -53,8 +53,7 @@ func (c *MockClient) SetLogger(log telegraf.Logger) {
 func TestDeprecatedURLSupport(t *testing.T) {
 	var actual *influxdb.UDPConfig
 	output := influxdb.InfluxDB{
-		URL: "udp://localhost:8089",
-
+		URLs: []string{"udp://localhost:8089"},
 		CreateUDPClientF: func(config *influxdb.UDPConfig) (influxdb.Client, error) {
 			actual = config
 			return &MockClient{}, nil


### PR DESCRIPTION
## Summary

Remove the deprecated plugin option scheduled for removal in v1.30.0

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

related to #13375 
