### PR TITLE
test(processors.snmp_lookup): Fix race in test

### DIFF
--- a/plugins/processors/snmp_lookup/store_test.go
+++ b/plugins/processors/snmp_lookup/store_test.go
@@ -16,14 +16,21 @@ func TestAddBacklog(t *testing.T) {
 	s.notify = func(string, *tagMap) { notifyCount.Add(1) }
 	defer s.destroy()
 
+	s.Lock()
 	require.Empty(t, s.deferredUpdates)
+	s.Unlock()
 
-	s.addBacklog("127.0.0.1", time.Now().Add(10*time.Millisecond))
+	s.addBacklog("127.0.0.1", time.Now().Add(1*time.Second))
+
+	s.Lock()
 	require.Contains(t, s.deferredUpdates, "127.0.0.1")
+	s.Unlock()
 	require.Eventually(t, func() bool {
 		return notifyCount.Load() == 1
-	}, time.Second, time.Millisecond)
+	}, 3*time.Second, 100*time.Millisecond)
+	s.Lock()
 	require.Empty(t, s.deferredUpdates)
+	s.Unlock()
 }
 
 func TestLookup(t *testing.T) {
@@ -57,17 +64,28 @@ func TestLookup(t *testing.T) {
 	require.Equal(t, tmr, entries.rows)
 
 	// Second lookup should be deferred minUpdateInterval
+	s.Lock()
 	require.Empty(t, s.deferredUpdates)
+	s.Unlock()
+
 	s.lookup("127.0.0.1", "999")
+
 	require.EqualValues(t, 2, notifyCount.Load())
+
+	s.Lock()
 	require.Contains(t, s.deferredUpdates, "127.0.0.1")
 	require.WithinDuration(t, time.Now(), s.deferredUpdates["127.0.0.1"], minUpdateInterval)
+	s.Unlock()
 
 	// Wait until resolved
 	require.Eventually(t, func() bool {
 		return notifyCount.Load() == 3
 	}, time.Second, time.Millisecond)
+
+	s.Lock()
 	require.Empty(t, s.deferredUpdates)
+	s.Unlock()
+
 	time.Sleep(minUpdateInterval)
 
 	// Third lookup should directly update


### PR DESCRIPTION
## Summary

This fixes a race-condition in test-cases (see [CI run](https://app.circleci.com/pipelines/github/influxdata/telegraf/20547/workflows/bbb751d7-f400-4da4-8c45-d72c100e4464/jobs/315363)) that do not perform proper locking.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues
