### PR TITLE
chore(lint): Add gosec G602 - slice out of bounds

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -174,6 +174,7 @@ linters-settings:
       - G503
       - G505
       - G601
+      - G602
       # G104, G105, G113, G204, G304, G307, G402, G504 were not enabled intentionally
     # To specify the configuration of rules.
     config:


### PR DESCRIPTION
## Summary
Enable G602

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #14633
