### PR TITLE
docs(inputs.upsd): Document pitfalls

### DIFF
--- a/plugins/inputs/upsd/README.md
+++ b/plugins/inputs/upsd/README.md
@@ -1,11 +1,11 @@
 # UPSD Input Plugin
 
 This plugin reads data of one or more Uninterruptible Power Supplies
-from an upsd daemon using its NUT network protocol.
+from an `upsd` daemon using its NUT network protocol.
 
 ## Requirements
 
-upsd should be installed and it's daemon should be running.
+`upsd` should be installed and it's daemon should be running.
 
 ## Global configuration options <!-- @/docs/includes/plugin_config.md -->
 
@@ -47,6 +47,29 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## Please attach this information when reporting issues!
   # dump_raw_variables = false
 ```
+
+## Pitfalls
+
+Please note that field types are automatically determined based on the values.
+Especially the strings `enabled` and `disabled` are automatically converted to
+`boolean` values. This might lead to trouble for fields that can contain
+non-binary values like `enabled`, `disabled` and `muted` as the output field
+will be `boolean` for the first two values but `string` for the latter. To
+convert `enabled` and `disabled` values back to `string` for those fields, use
+the [enum processor][enum_processor] with
+
+```toml
+[[processors.enum]]
+  [[processors.enum.mapping]]
+    field = "ups_beeper_status"
+    [processors.enum.mapping.value_mappings]
+      true = "enabled"
+      false = "disabled"
+```
+
+Alternatively, you can also map the non-binary value to a `boolean`.
+
+[enum_processor]: ../../processors/enum/README.md
 
 ## Metrics
 


### PR DESCRIPTION
## Summary

Document pitfall when encountering variables that are multi-state containing `enabled` and `disabled`.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #14908 
