### PR TITLE
chore(parsers.xpath): Add tracing mode to output empty-node-selection messages

### DIFF
--- a/plugins/parsers/xpath/README.md
+++ b/plugins/parsers/xpath/README.md
@@ -135,6 +135,10 @@ XPath expressions.
   ## Currently, CBOR, protobuf, msgpack and JSON support native data-types.
   # xpath_native_types = false
 
+  ## Trace empty node selections for debugging
+  ## This will only produce output in debugging mode.
+  # xpath_trace = false
+
   ## Multiple parsing sections are allowed
   [[inputs.file.xpath]]
     ## Optional: XPath-query to select a subset of nodes from the XML document.

--- a/plugins/parsers/xpath/parser.go
+++ b/plugins/parsers/xpath/parser.go
@@ -43,6 +43,7 @@ type Parser struct {
 	PrintDocument       bool              `toml:"xpath_print_document"`
 	AllowEmptySelection bool              `toml:"xpath_allow_empty_selection"`
 	NativeTypes         bool              `toml:"xpath_native_types"`
+	Trace               bool              `toml:"xpath_trace"`
 	Configs             []Config          `toml:"xpath"`
 	DefaultMetricName   string            `toml:"-"`
 	DefaultTags         map[string]string `toml:"-"`
@@ -623,7 +624,7 @@ func (p *Parser) constructFieldName(root, node dataNode, name string, expand boo
 }
 
 func (p *Parser) debugEmptyQuery(operation string, root dataNode, initialquery string) {
-	if p.Log == nil {
+	if p.Log == nil || !p.Trace {
 		return
 	}
 


### PR DESCRIPTION
## Summary

Prevent excessive output in debug mode due to node-selection-path debug messages by introducing a new trace option.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #14922 
