### PR TITLE
fix(inputs.gnmi): Handle canonical field-name correctly

### DIFF
--- a/plugins/inputs/gnmi/handler.go
+++ b/plugins/inputs/gnmi/handler.go
@@ -236,9 +236,9 @@ func (h *handler) handleSubscribeResponseUpdate(acc telegraf.Accumulator, respon
 		var key string
 		if h.canonicalFieldNames {
 			// Strip the origin is any for the field names
-			if parts := strings.SplitN(strings.ReplaceAll(field.path.String(), "-", "_"), ":", 2); len(parts) == 2 {
-				key = parts[1]
-			}
+			field.path.origin = ""
+			key = field.path.String()
+			key = strings.ReplaceAll(key, "-", "_")
 		} else {
 			// If the alias is a subpath of the field path and the alias is
 			// shorter than the full path to avoid an empty key, then strip the

--- a/plugins/inputs/gnmi/testcases/issue_14946_canonical_field_names/expected.out
+++ b/plugins/inputs/gnmi/testcases/issue_14946_canonical_field_names/expected.out
@@ -1,0 +1,4 @@
+gnmi_sys_memory,path=/system/memory/state,source=127.0.0.1 /system/memory/state/reserved=6359478272u,/system/memory/state/used=3479629824u 1709737743568119333
+gnmi_sys_memory,source=127.0.0.1 /system/memory/state/used=3479527424u 1709737753565697718
+gnmi_sys_cpu,index=ALL,source=127.0.0.1 /system/cpus/cpu/state/hardware_interrupt/min_time=1709805333568034887u 1709805333566280930
+gnmi_sys_cpu,index=ALL,path=/system/cpus/cpu/state,source=127.0.0.1 /system/cpus/cpu/state/hardware_interrupt/min_time=1709805343567684412u,/system/cpus/cpu/state/idle/avg=89u,/system/cpus/cpu/state/idle/instant=90u 1709805343565718902

--- a/plugins/inputs/gnmi/testcases/issue_14946_canonical_field_names/responses.json
+++ b/plugins/inputs/gnmi/testcases/issue_14946_canonical_field_names/responses.json
@@ -1,0 +1,182 @@
+[
+    {
+        "update": {
+            "timestamp": "1709737743568119333",
+            "prefix": {
+                "elem": [
+                    {
+                        "name": "system"
+                    },
+                    {
+                        "name": "memory"
+                    },
+                    {
+                        "name": "state"
+                    }
+                ]
+            },
+            "update": [
+                {
+                    "path": {
+                        "elem": [
+                            {
+                                "name": "reserved"
+                            }
+                        ]
+                    },
+                    "val": {
+                        "uintVal": "6359478272"
+                    }
+                },
+                {
+                    "path": {
+                        "elem": [
+                            {
+                                "name": "used"
+                            }
+                        ]
+                    },
+                    "val": {
+                        "uintVal": "3479629824"
+                    }
+                }
+            ]
+        }
+    },
+    {
+        "update": {
+            "timestamp": "1709737753565697718",
+            "update": [
+                {
+                    "path": {
+                        "elem": [
+                            {
+                                "name": "system"
+                            },
+                            {
+                                "name": "memory"
+                            },
+                            {
+                                "name": "state"
+                            },
+                            {
+                                "name": "used"
+                            }
+                        ]
+                    },
+                    "val": {
+                        "uintVal": "3479527424"
+                    }
+                }
+            ]
+        }
+    },
+    {
+        "update": {
+            "timestamp": "1709805333566280930",
+            "update": [
+                {
+                    "path": {
+                        "elem": [
+                            {
+                                "name": "system"
+                            },
+                            {
+                                "name": "cpus"
+                            },
+                            {
+                                "name": "cpu",
+                                "key": {
+                                    "index": "ALL"
+                                }
+                            },
+                            {
+                                "name": "state"
+                            },
+                            {
+                                "name": "hardware-interrupt"
+                            },
+                            {
+                                "name": "min-time"
+                            }
+                        ]
+                    },
+                    "val": {
+                        "uintVal": "1709805333568034887"
+                    }
+                }
+            ]
+        }
+    },
+    {
+        "update": {
+            "timestamp": "1709805343565718902",
+            "prefix": {
+                "elem": [
+                    {
+                        "name": "system"
+                    },
+                    {
+                        "name": "cpus"
+                    },
+                    {
+                        "name": "cpu",
+                        "key": {
+                            "index": "ALL"
+                        }
+                    },
+                    {
+                        "name": "state"
+                    }
+                ]
+            },
+            "update": [
+                {
+                    "path": {
+                        "elem": [
+                            {
+                                "name": "hardware-interrupt"
+                            },
+                            {
+                                "name": "min-time"
+                            }
+                        ]
+                    },
+                    "val": {
+                        "uintVal": "1709805343567684412"
+                    }
+                },
+                {
+                    "path": {
+                        "elem": [
+                            {
+                                "name": "idle"
+                            },
+                            {
+                                "name": "avg"
+                            }
+                        ]
+                    },
+                    "val": {
+                        "uintVal": "89"
+                    }
+                },
+                {
+                    "path": {
+                        "elem": [
+                            {
+                                "name": "idle"
+                            },
+                            {
+                                "name": "instant"
+                            }
+                        ]
+                    },
+                    "val": {
+                        "uintVal": "90"
+                    }
+                }
+            ]
+        }
+    }
+]

--- a/plugins/inputs/gnmi/testcases/issue_14946_canonical_field_names/telegraf.conf
+++ b/plugins/inputs/gnmi/testcases/issue_14946_canonical_field_names/telegraf.conf
@@ -1,0 +1,15 @@
+[[inputs.gnmi]]
+  addresses = ["dummy"]
+  canonical_field_names = true
+
+  [[inputs.gnmi.subscription]]
+    name = "gnmi_sys_cpu"
+    path = "/system/cpus/cpu/state"
+    subscription_mode = "sample"
+    sample_interval = "10s"
+
+  [[inputs.gnmi.subscription]]
+    name = "gnmi_sys_memory"
+    path = "/system/memory/state"
+    subscription_mode = "sample"
+    sample_interval = "10s"


### PR DESCRIPTION
## Summary

PR #14553 fixed path handling for field names. In this course the canonical-field-name handling was overlooked because now the path is no longer a simple string leading to
```
2024-03-07T12:44:38Z E! [inputs.gnmi] Invalid empty path "/system/memory/state/reserved" with alias "/system/memory/state"
2024-03-07T12:44:38Z E! [inputs.gnmi] Invalid empty path "/system/memory/state/used" with alias "/system/memory/state"
```
errors (see #14946).  This PR fixes the issue and restores the previous functionality.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

related to #14946 
