### PR TITLE
fix(outputs.bigquery): Add scope to bigquery and remove timeout context

### DIFF
--- a/plugins/outputs/bigquery/bigquery.go
+++ b/plugins/outputs/bigquery/bigquery.go
@@ -88,6 +88,8 @@ func (s *BigQuery) Connect() error {
 func (s *BigQuery) setUpDefaultClient() error {
 	var credentialsOption option.ClientOption
 
+	// https://cloud.google.com/go/docs/reference/cloud.google.com/go/0.94.1#hdr-Timeouts_and_Cancellation
+	// Do not attempt to add timeout to this context for the bigquery client.
 	ctx := context.Background()
 
 	if s.CredentialsFile != "" {

--- a/plugins/outputs/bigquery/bigquery.go
+++ b/plugins/outputs/bigquery/bigquery.go
@@ -89,13 +89,11 @@ func (s *BigQuery) setUpDefaultClient() error {
 	var credentialsOption option.ClientOption
 
 	ctx := context.Background()
-	ctx, cancel := context.WithTimeout(ctx, time.Duration(s.Timeout))
-	defer cancel()
 
 	if s.CredentialsFile != "" {
 		credentialsOption = option.WithCredentialsFile(s.CredentialsFile)
 	} else {
-		creds, err := google.FindDefaultCredentials(ctx)
+		creds, err := google.FindDefaultCredentials(ctx, bigquery.Scope)
 		if err != nil {
 			return fmt.Errorf(
 				"unable to find Google Cloud Platform Application Default Credentials: %w. "+


### PR DESCRIPTION
## Summary
- Scope was missing for bigquery Client causing ADC to fail.
- Timeout context needs to be removed from connection init, since the dialing happens asynchronously.  https://cloud.google.com/go/docs/reference/cloud.google.com/go/0.94.1#hdr-Timeouts_and_Cancellation


## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
resolves #14957
