### PR TITLE
fix(inputs.knx_listener): Reconnect after connection loss

### DIFF
--- a/plugins/inputs/knx_listener/knx_listener.go
+++ b/plugins/inputs/knx_listener/knx_listener.go
@@ -3,9 +3,11 @@ package knx_listener
 
 import (
 	_ "embed"
+	"errors"
 	"fmt"
 	"reflect"
 	"sync"
+	"sync/atomic"
 
 	"github.com/vapourismo/knx-go/knx"
 	"github.com/vapourismo/knx-go/knx/dpt"
@@ -43,22 +45,27 @@ type KNXListener struct {
 	gaTargetMap map[string]addressTarget
 	gaLogbook   map[string]bool
 
-	acc telegraf.Accumulator
-	wg  sync.WaitGroup
+	wg        sync.WaitGroup
+	connected atomic.Bool
 }
 
 func (*KNXListener) SampleConfig() string {
 	return sampleConfig
 }
 
-func (kl *KNXListener) Gather(_ telegraf.Accumulator) error {
+func (kl *KNXListener) Gather(acc telegraf.Accumulator) error {
+	if !kl.connected.Load() {
+		// We got disconnected for some reason, so try to reconnect in every
+		// gather cycle until we are reconnected
+		if err := kl.Start(acc); err != nil {
+			return fmt.Errorf("reconnecting to bus failed: %w", err)
+		}
+	}
+
 	return nil
 }
 
-func (kl *KNXListener) Start(acc telegraf.Accumulator) error {
-	// Store the accumulator for later use
-	kl.acc = acc
-
+func (kl *KNXListener) Init() error {
 	// Setup a logbook to track unknown GAs to avoid log-spamming
 	kl.gaLogbook = make(map[string]bool)
 
@@ -80,6 +87,10 @@ func (kl *KNXListener) Start(acc telegraf.Accumulator) error {
 		}
 	}
 
+	return nil
+}
+
+func (kl *KNXListener) Start(acc telegraf.Accumulator) error {
 	// Connect to the KNX-IP interface
 	kl.Log.Infof("Trying to connect to %q at %q", kl.ServiceType, kl.ServiceAddress)
 	switch kl.ServiceType {
@@ -112,12 +123,15 @@ func (kl *KNXListener) Start(acc telegraf.Accumulator) error {
 		return fmt.Errorf("invalid interface type: %s", kl.ServiceAddress)
 	}
 	kl.Log.Infof("Connected!")
+	kl.connected.Store(true)
 
 	// Listen to the KNX bus
 	kl.wg.Add(1)
 	go func() {
-		kl.wg.Done()
-		kl.listen()
+		defer kl.wg.Done()
+		kl.listen(acc)
+		kl.connected.Store(false)
+		acc.AddError(errors.New("disconnected from bus"))
 	}()
 
 	return nil
@@ -130,7 +144,7 @@ func (kl *KNXListener) Stop() {
 	}
 }
 
-func (kl *KNXListener) listen() {
+func (kl *KNXListener) listen(acc telegraf.Accumulator) {
 	for msg := range kl.client.Inbound() {
 		// Match GA to DataPointType and measurement name
 		ga := msg.Destination.String()
@@ -177,7 +191,7 @@ func (kl *KNXListener) listen() {
 			"unit":         target.datapoint.(dpt.DatapointMeta).Unit(),
 			"source":       msg.Source.String(),
 		}
-		kl.acc.AddFields(target.measurement, fields, tags)
+		acc.AddFields(target.measurement, fields, tags)
 	}
 }
 


### PR DESCRIPTION
## Summary

If the connection to the router or tunnel device is lost for whatever reason, the plugin will make no attempt to reconnect and is thus left dysfunctional. This PR adds a retry logic triggered in every gather cycle to reconnect the plugin.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #14695 
