### PR TITLE
feat(inputs.chrony): Remove chronyc depdendency in documentation

### DIFF
--- a/plugins/inputs/chrony/README.md
+++ b/plugins/inputs/chrony/README.md
@@ -17,7 +17,7 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 ## Configuration
 
 ```toml @sample.conf
-# Get standard chrony metrics, requires chronyc executable.
+# Get standard chrony metrics.
 [[inputs.chrony]]
   ## Server address of chronyd with address scheme
   ## If empty or not set, the plugin will mimic the behavior of chronyc and

--- a/plugins/inputs/chrony/sample.conf
+++ b/plugins/inputs/chrony/sample.conf
@@ -1,4 +1,4 @@
-# Get standard chrony metrics, requires chronyc executable.
+# Get standard chrony metrics.
 [[inputs.chrony]]
   ## Server address of chronyd with address scheme
   ## If empty or not set, the plugin will mimic the behavior of chronyc and


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
This updates the documentation and sample code of the `chrony` input plugin to reflect the code changes done in PR #14629 which was dropping the runtime dependency on a locally installed `chronyc` executable.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #14964
