### PR TITLE
feat(inputs.win_wmi): Add support for remote queries

### DIFF
--- a/plugins/inputs/win_wmi/README.md
+++ b/plugins/inputs/win_wmi/README.md
@@ -19,12 +19,27 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 [CONFIGURATION.md]: ../../../docs/CONFIGURATION.md#plugins
 
+## Secret-store support
+
+This plugin supports secrets from secret-stores for the `username` and
+`password` option.
+See the [secret-store documentation][SECRETSTORE] for more details on how
+to use them.
+
+[SECRETSTORE]: ../../../docs/CONFIGURATION.md#secret-store-secrets
+
 ## Configuration
 
 ```toml @sample.conf
 # Input plugin to query Windows Management Instrumentation
 # This plugin ONLY supports Windows
 [[inputs.win_wmi]]
+  ## Hostname or IP for remote connections, by default the local machine is queried
+  # host = ""
+  ## Credentials for the connection, by default no credentials are used
+  # username = ""
+  # password = ""
+
   [[inputs.win_wmi.query]]
     # a string representing the WMI namespace to be queried
     namespace = "root\\cimv2"

--- a/plugins/inputs/win_wmi/sample.conf
+++ b/plugins/inputs/win_wmi/sample.conf
@@ -1,6 +1,12 @@
 # Input plugin to query Windows Management Instrumentation
 # This plugin ONLY supports Windows
 [[inputs.win_wmi]]
+  ## Hostname or IP for remote connections, by default the local machine is queried
+  # host = ""
+  ## Credentials for the connection, by default no credentials are used
+  # username = ""
+  # password = ""
+
   [[inputs.win_wmi.query]]
     # a string representing the WMI namespace to be queried
     namespace = "root\\cimv2"

--- a/plugins/inputs/win_wmi/win_wmi.go
+++ b/plugins/inputs/win_wmi/win_wmi.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 
 	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/plugins/inputs"
 )
 
@@ -17,8 +18,11 @@ var sampleConfig string
 
 // Wmi struct
 type Wmi struct {
-	Queries []Query         `toml:"query"`
-	Log     telegraf.Logger `toml:"-"`
+	Host     string          `toml:"host"`
+	Username config.Secret   `toml:"username"`
+	Password config.Secret   `toml:"password"`
+	Queries  []Query         `toml:"query"`
+	Log      telegraf.Logger `toml:"-"`
 }
 
 // S_FALSE is returned by CoInitializeEx if it was already called on this thread.
@@ -28,7 +32,7 @@ const sFalse = 0x00000001
 func (w *Wmi) Init() error {
 	for i := range w.Queries {
 		q := &w.Queries[i]
-		if err := q.prepare(); err != nil {
+		if err := q.prepare(w.Host, w.Username, w.Password); err != nil {
 			return fmt.Errorf("preparing query %q failed: %w", q.ClassName, err)
 		}
 	}


### PR DESCRIPTION
## Summary

This PR adds support to query remote hosts via WMI if a host (and credentials) are specified.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #14942 
