### PR TITLE
fix(secrets): Avoid returning negative number

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -479,8 +479,9 @@ func (c *Config) LoadAll(configFiles ...string) error {
 
 	// Check if there is enough lockable memory for the secret. This can return
 	// a negative value.
-	if secretCount.Load() > 0 {
-		c.NumberSecrets = uint64(secretCount.Load())
+	secrets := secretCount.Load()
+	if secrets > 0 {
+		c.NumberSecrets = uint64(secrets)
 	}
 
 	// Let's link all secrets to their secret-stores

--- a/config/config.go
+++ b/config/config.go
@@ -477,8 +477,11 @@ func (c *Config) LoadAll(configFiles ...string) error {
 		c.Agent.SnmpTranslator = "netsnmp"
 	}
 
-	// Check if there is enough lockable memory for the secret
-	c.NumberSecrets = uint64(secretCount.Load())
+	// Check if there is enough lockable memory for the secret. This can return
+	// a negative value.
+	if secretCount.Load() > 0 {
+		c.NumberSecrets = uint64(secretCount.Load())
+	}
 
 	// Let's link all secrets to their secret-stores
 	return c.LinkSecrets()


### PR DESCRIPTION


## Summary
This can return a negative value, which will make for a very unhappy unsigned int.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

