### PR TITLE
fix(inputs.systemd_units): Handle disabled multi-instance units correctly

### DIFF
--- a/plugins/inputs/systemd_units/README.md
+++ b/plugins/inputs/systemd_units/README.md
@@ -35,7 +35,7 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   # details = false
 
   ## Timeout for state-collection
-  # timeout = "1s"
+  # timeout = "5s"
 ```
 
 This plugin supports two modes of operation:

--- a/plugins/inputs/systemd_units/sample.conf
+++ b/plugins/inputs/systemd_units/sample.conf
@@ -16,4 +16,4 @@
   # details = false
 
   ## Timeout for state-collection
-  # timeout = "1s"
+  # timeout = "5s"

--- a/plugins/inputs/systemd_units/systemd_units.go
+++ b/plugins/inputs/systemd_units/systemd_units.go
@@ -29,6 +29,6 @@ func (*SystemdUnits) SampleConfig() string {
 
 func init() {
 	inputs.Add("systemd_units", func() telegraf.Input {
-		return &SystemdUnits{Timeout: config.Duration(time.Second)}
+		return &SystemdUnits{Timeout: config.Duration(5 * time.Second)}
 	})
 }


### PR DESCRIPTION
## Summary

Current systemd DBUS implementation cannot be queried for disabled multi-instance data such as for example `serial-getty@.service` if not enabled for a specific `serial`.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #14980
