### PR TITLE
fix(secrets): Avoid count underflow by only counting initialized secrets

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -478,7 +478,12 @@ func (c *Config) LoadAll(configFiles ...string) error {
 	}
 
 	// Check if there is enough lockable memory for the secret
-	c.NumberSecrets = uint64(secretCount.Load())
+	count := secretCount.Load()
+	if count < 0 {
+		log.Printf("E! Invalid secret count %d, please report this incident including your configuration!", count)
+		count = 0
+	}
+	c.NumberSecrets = uint64(count)
 
 	// Let's link all secrets to their secret-stores
 	return c.LinkSecrets()

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1293,6 +1293,7 @@ type MockupInputPlugin struct {
 	MaxBodySize  config.Size     `toml:"max_body_size"`
 	Paths        []string        `toml:"paths"`
 	Port         int             `toml:"port"`
+	Password     config.Secret   `toml:"password"`
 	Command      string
 	Files        []string
 	PidFile      string

--- a/config/secret.go
+++ b/config/secret.go
@@ -155,10 +155,10 @@ func (s *Secret) Destroy() {
 	if s.container != nil {
 		s.container.Destroy()
 		s.container = nil
-	}
 
-	// Keep track of the number of secrets...
-	secretCount.Add(-1)
+		// Keep track of the number of used secrets...
+		secretCount.Add(-1)
+	}
 }
 
 // Empty return if the secret is completely empty

--- a/config/secret_test.go
+++ b/config/secret_test.go
@@ -352,6 +352,7 @@ func TestSecretEnvironmentVariable(t *testing.T) {
 }
 
 func TestSecretCount(t *testing.T) {
+	secretCount.Store(0)
 	cfg := []byte(`
 [[inputs.mockup]]
 

--- a/config/secret_test.go
+++ b/config/secret_test.go
@@ -351,6 +351,30 @@ func TestSecretEnvironmentVariable(t *testing.T) {
 	require.EqualValues(t, "an env secret", secret.TemporaryString())
 }
 
+func TestSecretCount(t *testing.T) {
+	cfg := []byte(`
+[[inputs.mockup]]
+
+[[inputs.mockup]]
+  secret = "a secret"
+
+[[inputs.mockup]]
+  secret = "another secret"
+`)
+
+	c := NewConfig()
+	require.NoError(t, c.LoadConfigData(cfg))
+	require.Len(t, c.Inputs, 3)
+	require.Equal(t, int64(2), secretCount.Load())
+
+	// Remove all secrets and check
+	for _, ri := range c.Inputs {
+		input := ri.Input.(*MockupSecretPlugin)
+		input.Secret.Destroy()
+	}
+	require.Equal(t, int64(0), secretCount.Load())
+}
+
 func TestSecretStoreStatic(t *testing.T) {
 	cfg := []byte(
 		`


### PR DESCRIPTION
## Summary

Currently, a secret-count underflow can occur if uninitialized secrets are destroyed. This can for example be triggered by the following config part
```tom
[[secretstores.os]]
  id = "secrets"
  keyring = "telegraf"
```
without actually referencing any secret. In this example, the `password` setting of the secret-store is not set and thus the struct's "secret" member is not initialized (`init(...)` is not called). As a consequence we do not count the secret. However, when the `Init()` function in the OS secret-store terminates it calls `Destroy()` on the `password` secret which unconditionally subtracts one from the secret count. Remember, the `password` secret was not initialized and thus not counted in the first place! As a result, the count underflows.

This PR only counts _initialized_ secrets (as only those use locked memory) in both positive and negative direction. Furthermore, we provide a safety-net telling the user to report unusual (negative) values and clip the count to not confuse users.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

superseeds #14986 
