### PR TITLE
feat(inputs.dns_query): Allow ignoring errors of specific types

### DIFF
--- a/plugins/inputs/dns_query/dns_query_test.go
+++ b/plugins/inputs/dns_query/dns_query_test.go
@@ -37,6 +37,23 @@ func TestGathering(t *testing.T) {
 	require.NotEqual(t, float64(0), queryTime)
 }
 
+func TestGatherInvalid(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping network-dependent test in short mode.")
+	}
+
+	dnsConfig := DNSQuery{
+		Servers: servers,
+		Domains: []string{"qwerty123.example.com"},
+		Timeout: config.Duration(1 * time.Second),
+	}
+
+	var acc testutil.Accumulator
+	require.NoError(t, dnsConfig.Init())
+	require.NoError(t, dnsConfig.Gather(&acc))
+	require.Empty(t, acc.Errors)
+}
+
 func TestGatheringMxRecord(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping network-dependent test in short mode.")


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Allows the user to specify ignoring certain error types from printing in the logs.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

fixes: #14941
