### PR TITLE
fix(inputs.smart): Improve regexp to support flags with a plus

### DIFF
--- a/plugins/inputs/smart/smart.go
+++ b/plugins/inputs/smart/smart.go
@@ -56,7 +56,12 @@ var (
 	//   1 Raw_Read_Error_Rate     -O-RC-   200   200   000    -    0
 	//   5 Reallocated_Sector_Ct   PO--CK   100   100   000    -    0
 	// 192 Power-Off_Retract_Count -O--C-   097   097   000    -    14716
-	attribute = regexp.MustCompile(`^\s*([0-9]+)\s(\S+)\s+([-P][-O][-S][-R][-C][-K])\s+([0-9]+)\s+([0-9]+)\s+([0-9-]+)\s+([-\w]+)\s+([\w\+\.]+).*$`)
+
+	// ID# ATTRIBUTE_NAME          FLAGS    VALUE WORST THRESH FAIL RAW_VALUE
+	//   1 Raw_Read_Error_Rate     PO-RC-+  200   200   051    -    30
+	//   5 Reallocated_Sector_Ct   POS-C-+  200   200   140    -    0
+	// 192 Power-Off_Retract_Count -O-RCK+  200   200   000    -    4
+	attribute = regexp.MustCompile(`^\s*([0-9]+)\s(\S+)\s+([-P][-O][-S][-R][-C][-K])[\+]?\s+([0-9]+)\s+([0-9]+)\s+([0-9-]+)\s+([-\w]+)\s+([\w\+\.]+).*$`)
 
 	//  Additional Smart Log for NVME device:nvme0 namespace-id:ffffffff
 	// nvme version 1.14+ metrics:


### PR DESCRIPTION
change attribute regexp to support flags like this kind PO-RC-+

## Summary
support smart attitudes data like this
```
SMART Attributes Data Structure revision number: 16
Vendor Specific SMART Attributes with Thresholds:
ID# ATTRIBUTE_NAME          FLAGS    VALUE WORST THRESH FAIL RAW_VALUE
  1 Raw_Read_Error_Rate     PO-RC-+  200   200   051    -    30
  3 Spin_Up_Time            POSRCK+  230   230   021    -    5466
  4 Start_Stop_Count        -OS-CK+  100   100   000    -    6
  5 Reallocated_Sector_Ct   POS-C-+  200   200   140    -    0
  7 Seek_Error_Rate         PO-RCK+  200   200   051    -    0
  9 Power_On_Hours          -OSRCK+  092   092   000    -    5867
 10 Spin_Retry_Count        POS-CK+  100   253   051    -    0
 11 Calibration_Retry_Count -OSRCK+  100   253   051    -    0
 12 Power_Cycle_Count       -OSRCK+  100   100   000    -    6
184 End-to-End_Error        POSRCK+  100   100   097    -    0
187 Reported_Uncorrect      -OS-CK+  100   088   000    -    24
188 Command_Timeout         -OS--K+  100   100   000    -    0
190 Airflow_Temperature_Cel -O-RCK+  058   046   000    -    42
192 Power-Off_Retract_Count -O-RCK+  200   200   000    -    4
193 Load_Cycle_Count        --S-CK+  200   200   000    -    2
194 Temperature_Celsius     -OSRCK+  110   098   000    -    42
195 Hardware_ECC_Recovered  -OSRC-+  200   200   000    -    0
196 Reallocated_Event_Count -O-RCK+  200   200   000    -    0
197 Current_Pending_Sector  -OS-CK+  200   200   000    -    0
198 Offline_Uncorrectable   -OSRCK+  100   253   000    -    0
199 UDMA_CRC_Error_Count    -OS--K+  200   200   000    -    0
200 Multi_Zone_Error_Rate   POSRCK+  100   253   051    -    0
                            ||||||_ K auto-keep
                            |||||__ C event count
                            ||||___ R error rate
                            |||____ S speed/performance
                            ||_____ O updated online
                            |______ P prefailure warning
```

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #14995
