### PR TITLE
feat(inputs.s7comm): s7comm connect_type

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -165,7 +165,7 @@ require (
 	github.com/redis/go-redis/v9 v9.2.1
 	github.com/riemann/riemann-go-client v0.5.1-0.20211206220514-f58f10cdce16
 	github.com/robbiet480/go.nut v0.0.0-20220219091450-bd8f121e1fa1
-	github.com/robinson/gos7 v0.0.0-20231031082500-fb5a72fd499e
+	github.com/robinson/gos7 v0.0.0-20240315073918-1f14519e4846
 	github.com/safchain/ethtool v0.3.0
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/sensu/sensu-go/api/core/v2 v2.16.0

--- a/go.sum
+++ b/go.sum
@@ -2071,8 +2071,8 @@ github.com/robertkrimen/otto v0.0.0-20191219234010-c382bd3c16ff h1:+6NUiITWwE5q1
 github.com/robertkrimen/otto v0.0.0-20191219234010-c382bd3c16ff/go.mod h1:xvqspoSXJTIpemEonrMDFq6XzwHYYgToXWj5eRX1OtY=
 github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
 github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
-github.com/robinson/gos7 v0.0.0-20231031082500-fb5a72fd499e h1:Ofp6C2iX58K698sGpIXZFp3furntNlhIjeyLkcrAiek=
-github.com/robinson/gos7 v0.0.0-20231031082500-fb5a72fd499e/go.mod h1:AMHIeh1KJ7Xa2RVOMHdv9jXKrpw0D4EWGGQMHLb2doc=
+github.com/robinson/gos7 v0.0.0-20240315073918-1f14519e4846 h1:CnAbtX0j07ZVR/TnD5V6ypFTrASJlfr+fc4OY2da9eg=
+github.com/robinson/gos7 v0.0.0-20240315073918-1f14519e4846/go.mod h1:AMHIeh1KJ7Xa2RVOMHdv9jXKrpw0D4EWGGQMHLb2doc=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.1.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=

--- a/plugins/inputs/s7comm/README.md
+++ b/plugins/inputs/s7comm/README.md
@@ -22,6 +22,9 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   server = "127.0.0.1:102"
   rack = 0
   slot = 0
+  
+  ## connectionType(driveType/driveGroup in s7 protocol) : 1 connect as PG/PC ;2 connect as OP ; 3 connect as S7 basic
+  # connect_type = 2
 
   ## Max count of fields to be bundled in one batch-request. (PDU size)
   # pdu_size = 20

--- a/plugins/inputs/s7comm/sample.conf
+++ b/plugins/inputs/s7comm/sample.conf
@@ -7,6 +7,9 @@
   rack = 0
   slot = 0
 
+  ## connectionType(driveType/driveGroup in s7 protocol) : 1 connect as PG/PC ;2 connect as OP ; 3 connect as S7 basic
+  # connect_type = 2
+
   ## Max count of fields to be bundled in one batch-request. (PDU size)
   # pdu_size = 20
 


### PR DESCRIPTION
## Summary
When we use the S7 protocol to access the PLC, we can do so by modifying the
the third byte in the Called (Dst) TSAP (in COTP) to select whether to connect as PG( a program) or OP ( monitor.....) or S7_basic_communication.

But the existing S7Comm plugin can only be used as a PG connection because of this parameter fixed in the robinson/gos7 NewTCPClientHandler() function。

I often encountered when using telegraf to connect to Siemens PLCs that the PLC supports fewer PG connections and more OP connections, so I'd like to add a parameter to change this connect parameter.

In order to be able to change this connect_type when connecting again I've submitted the new connection function NewTCPClientHandlerWithConnectType to robinson/gos7 and have merged the
https://github.com/robinson/gos7/pull/67

## Checklist
- [x] No AI generated code was used in this PR

## Related issues
#14994 
resolves #
