### PR TITLE
feat(inputs.s7comm):  Add optional connection type setting

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -165,7 +165,7 @@ require (
 	github.com/redis/go-redis/v9 v9.2.1
 	github.com/riemann/riemann-go-client v0.5.1-0.20211206220514-f58f10cdce16
 	github.com/robbiet480/go.nut v0.0.0-20220219091450-bd8f121e1fa1
-	github.com/robinson/gos7 v0.0.0-20231031082500-fb5a72fd499e
+	github.com/robinson/gos7 v0.0.0-20240315073918-1f14519e4846
 	github.com/safchain/ethtool v0.3.0
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/sensu/sensu-go/api/core/v2 v2.16.0

--- a/go.sum
+++ b/go.sum
@@ -2071,8 +2071,8 @@ github.com/robertkrimen/otto v0.0.0-20191219234010-c382bd3c16ff h1:+6NUiITWwE5q1
 github.com/robertkrimen/otto v0.0.0-20191219234010-c382bd3c16ff/go.mod h1:xvqspoSXJTIpemEonrMDFq6XzwHYYgToXWj5eRX1OtY=
 github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
 github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
-github.com/robinson/gos7 v0.0.0-20231031082500-fb5a72fd499e h1:Ofp6C2iX58K698sGpIXZFp3furntNlhIjeyLkcrAiek=
-github.com/robinson/gos7 v0.0.0-20231031082500-fb5a72fd499e/go.mod h1:AMHIeh1KJ7Xa2RVOMHdv9jXKrpw0D4EWGGQMHLb2doc=
+github.com/robinson/gos7 v0.0.0-20240315073918-1f14519e4846 h1:CnAbtX0j07ZVR/TnD5V6ypFTrASJlfr+fc4OY2da9eg=
+github.com/robinson/gos7 v0.0.0-20240315073918-1f14519e4846/go.mod h1:AMHIeh1KJ7Xa2RVOMHdv9jXKrpw0D4EWGGQMHLb2doc=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.1.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=

--- a/plugins/inputs/s7comm/README.md
+++ b/plugins/inputs/s7comm/README.md
@@ -22,9 +22,11 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   server = "127.0.0.1:102"
   rack = 0
   slot = 0
-  
-  ## connectionType(driveType/driveGroup in s7 protocol) : 1 connect as PG/PC ;2 connect as OP ; 3 connect as S7 basic
-  # connect_type = 2
+
+  ## Connection or drive type of S7 protocol
+  ## Available options are "PD" (programming  device), "OP" (operator panel) or "basic" (S7 basic communication).
+  # connection_type = "PD"
+
 
   ## Max count of fields to be bundled in one batch-request. (PDU size)
   # pdu_size = 20

--- a/plugins/inputs/s7comm/README.md
+++ b/plugins/inputs/s7comm/README.md
@@ -22,6 +22,9 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   server = "127.0.0.1:102"
   rack = 0
   slot = 0
+  
+  ## connectionType(driveType/driveGroup in s7 protocol) : 1 connect as PG/PC ;2 connect as OP ; 3 connect as S7 basic
+  # connect_type = 2
 
   ## Max count of fields to be bundled in one batch-request. (PDU size)
   # pdu_size = 20

--- a/plugins/inputs/s7comm/README.md
+++ b/plugins/inputs/s7comm/README.md
@@ -27,7 +27,6 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## Available options are "PD" (programming  device), "OP" (operator panel) or "basic" (S7 basic communication).
   # connection_type = "PD"
 
-
   ## Max count of fields to be bundled in one batch-request. (PDU size)
   # pdu_size = 20
 

--- a/plugins/inputs/s7comm/s7comm.go
+++ b/plugins/inputs/s7comm/s7comm.go
@@ -52,6 +52,10 @@ var (
 		// see https://support.industry.siemens.com/cs/document/36479/date_and_time-format-for-s7-?dti=0&lc=en-DE
 		"DT": 0x0F, // Date and time (7 byte)
 	}
+
+	ConnectTypePG      = 1
+	ConnectTypeOP      = 2
+	ConnectTypeS7Basic = 3
 )
 
 type metricFieldDefinition struct {
@@ -84,6 +88,7 @@ type S7comm struct {
 	Server          string             `toml:"server"`
 	Rack            int                `toml:"rack"`
 	Slot            int                `toml:"slot"`
+	ConnectType     int                `toml:"connect_type"`
 	BatchMaxSize    int                `toml:"pdu_size"`
 	Timeout         config.Duration    `toml:"timeout"`
 	DebugConnection bool               `toml:"debug_connection"`
@@ -113,6 +118,13 @@ func (s *S7comm) Init() error {
 	if s.Slot < 0 {
 		return errors.New("'slot' has to be specified")
 	}
+	if s.ConnectType < 0 || s.ConnectType > 3 {
+		return errors.New("'connectType' unrecognizable")
+	}
+	if s.ConnectType == 0 {
+		//Compatible with the problem of not having this parameter in the old config
+		s.ConnectType = ConnectTypePG
+	}
 	if len(s.Configs) == 0 {
 		return errors.New("no metric defined")
 	}
@@ -127,7 +139,7 @@ func (s *S7comm) Init() error {
 	}
 
 	// Create handler for the connection
-	s.handler = gos7.NewTCPClientHandler(s.Server, s.Rack, s.Slot)
+	s.handler = gos7.NewTCPClientHandlerWithConnectType(s.Server, s.Rack, s.Slot, s.ConnectType)
 	s.handler.Timeout = time.Duration(s.Timeout)
 	if s.DebugConnection {
 		s.handler.Logger = log.New(os.Stderr, "D! [inputs.s7comm]", log.LstdFlags)

--- a/plugins/inputs/s7comm/sample.conf
+++ b/plugins/inputs/s7comm/sample.conf
@@ -7,8 +7,10 @@
   rack = 0
   slot = 0
 
-  ## connectionType(driveType/driveGroup in s7 protocol) : 1 connect as PG/PC ;2 connect as OP ; 3 connect as S7 basic
-  # connect_type = 2
+  ## Connection or drive type of S7 protocol
+  ## Available options are "PD" (programming  device), "OP" (operator panel) or "basic" (S7 basic communication).
+  # connection_type = "PD"
+
 
   ## Max count of fields to be bundled in one batch-request. (PDU size)
   # pdu_size = 20

--- a/plugins/inputs/s7comm/sample.conf
+++ b/plugins/inputs/s7comm/sample.conf
@@ -7,6 +7,9 @@
   rack = 0
   slot = 0
 
+  ## connectionType(driveType/driveGroup in s7 protocol) : 1 connect as PG/PC ;2 connect as OP ; 3 connect as S7 basic
+  # connect_type = 2
+
   ## Max count of fields to be bundled in one batch-request. (PDU size)
   # pdu_size = 20
 

--- a/plugins/inputs/s7comm/sample.conf
+++ b/plugins/inputs/s7comm/sample.conf
@@ -11,7 +11,6 @@
   ## Available options are "PD" (programming  device), "OP" (operator panel) or "basic" (S7 basic communication).
   # connection_type = "PD"
 
-
   ## Max count of fields to be bundled in one batch-request. (PDU size)
   # pdu_size = 20
 


### PR DESCRIPTION
## Summary
When we use the S7 protocol to access the PLC, we can do so by modifying the
the third byte in the Called (Dst) TSAP (in COTP) to select whether to connect as PG( a program) or OP ( monitor.....) or S7_basic_communication.

But the existing S7Comm plugin can only be used as a PG connection because of this parameter fixed in the robinson/gos7 NewTCPClientHandler() function。

I often encountered when using telegraf to connect to Siemens PLCs that the PLC supports fewer PG connections and more OP connections, so I'd like to add a parameter to change this connect parameter.

In order to be able to change this connect_type when connecting again I've submitted the new connection function NewTCPClientHandlerWithConnectType to robinson/gos7 and have merged the
https://github.com/robinson/gos7/pull/67
## Checklist
- [x] No AI generated code was used in this PR

## Related issues

resolves #14994 
