### PR TITLE
fix(inputs.knx_listener): Ignore GroupValueRead requests

### DIFF
--- a/plugins/inputs/knx_listener/knx_listener.go
+++ b/plugins/inputs/knx_listener/knx_listener.go
@@ -132,6 +132,12 @@ func (kl *KNXListener) Stop() {
 
 func (kl *KNXListener) listen() {
 	for msg := range kl.client.Inbound() {
+		if msg.Command == knx.GroupRead {
+			// Ignore GroupValue_Read requests as they would either
+			// - fail to unpack due to invalid data length (DPT != 1) or
+			// - create invalid `false` values as their data always unpacks `0` (DPT 1)
+			continue
+		}
 		// Match GA to DataPointType and measurement name
 		ga := msg.Destination.String()
 		target, ok := kl.gaTargetMap[ga]
@@ -140,10 +146,6 @@ func (kl *KNXListener) listen() {
 				kl.Log.Infof("Ignoring message %+v for unknown GA %q", msg, ga)
 				kl.gaLogbook[ga] = true
 			}
-			continue
-		}
-		if msg.Command == knx.GroupRead {
-			kl.Log.Debugf("Ignoring GroupRead for GA %q from %q", ga, msg.Source.String())
 			continue
 		}
 

--- a/plugins/inputs/knx_listener/knx_listener.go
+++ b/plugins/inputs/knx_listener/knx_listener.go
@@ -134,16 +134,16 @@ func (kl *KNXListener) listen() {
 	for msg := range kl.client.Inbound() {
 		// Match GA to DataPointType and measurement name
 		ga := msg.Destination.String()
-		if msg.Command == knx.GroupRead {
-			kl.Log.Debugf("Ignoring GroupRead for GA %q from %q", ga, msg.Source.String())
-			continue
-		}
 		target, ok := kl.gaTargetMap[ga]
 		if !ok {
 			if !kl.gaLogbook[ga] {
 				kl.Log.Infof("Ignoring message %+v for unknown GA %q", msg, ga)
 				kl.gaLogbook[ga] = true
 			}
+			continue
+		}
+		if msg.Command == knx.GroupRead {
+			kl.Log.Debugf("Ignoring GroupRead for GA %q from %q", ga, msg.Source.String())
 			continue
 		}
 

--- a/plugins/inputs/knx_listener/knx_listener.go
+++ b/plugins/inputs/knx_listener/knx_listener.go
@@ -134,6 +134,10 @@ func (kl *KNXListener) listen() {
 	for msg := range kl.client.Inbound() {
 		// Match GA to DataPointType and measurement name
 		ga := msg.Destination.String()
+		if msg.Command == knx.GroupRead {
+			kl.Log.Debugf("Ignoring GroupRead for GA %q from %q", ga, msg.Source.String())
+			continue
+		}
 		target, ok := kl.gaTargetMap[ga]
 		if !ok {
 			if !kl.gaLogbook[ga] {


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Ignore KNX GroupValueRead requests as they don't contain any value. Yet DPT 1 typed requests are treated as telegrams with `0` value.

These are my first lines of Go, so please be patient with me 😬

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #15006
