### PR TITLE
chore(readme_linter): Update plugin type guess logic

### DIFF
--- a/tools/readme_linter/plugin.go
+++ b/tools/readme_linter/plugin.go
@@ -16,7 +16,7 @@ const (
 )
 
 func guessPluginType(filename string) plugin {
-	// Switch takes `plugins/inputs/amd_rocm_smi/README.md`` and converts it to
+	// Switch takes `plugins/inputs/amd_rocm_smi/README.md` and converts it to
 	// `plugins/inputs`. This avoids parsing READMEs that are under a plugin
 	// like those found in test folders as actual plugin readmes.
 	switch filepath.Dir(filepath.Dir(filename)) {

--- a/tools/readme_linter/plugin.go
+++ b/tools/readme_linter/plugin.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"strings"
+	"path/filepath"
 )
 
 type plugin int
@@ -16,16 +16,19 @@ const (
 )
 
 func guessPluginType(filename string) plugin {
-	switch {
-	case strings.Contains(filename, "plugins/inputs/"):
+	// Switch takes `plugins/inputs/amd_rocm_smi/README.md`` and converts it to
+	// `plugins/inputs`. This avoids parsing READMEs that are under a plugin
+	// like those found in test folders as actual plugin readmes.
+	switch filepath.Dir(filepath.Dir(filename)) {
+	case "plugins/inputs":
 		return pluginInput
-	case strings.Contains(filename, "plugins/outputs/"):
+	case "plugins/outputs":
 		return pluginOutput
-	case strings.Contains(filename, "plugins/processors/"):
+	case "plugins/processors":
 		return pluginProcessor
-	case strings.Contains(filename, "plugins/aggregators/"):
+	case "plugins/aggregators":
 		return pluginAggregator
-	case strings.Contains(filename, "plugins/parsers/"):
+	case "plugins/parsers":
 		return pluginParser
 	default:
 		return pluginNone


### PR DESCRIPTION
## Summary
To avoid parsing readmes that are below the plugin directory (e.g. a readme in a testcase) as a plugin readme, let's only mark plugin readmes if they are in the immediate folder under a plugin folder.

## Checklist
- [x] No AI generated code was used in this PR
