### PR TITLE
fix(inputs.ping): Add option to force ipv4

### DIFF
--- a/plugins/inputs/ping/README.md
+++ b/plugins/inputs/ping/README.md
@@ -80,6 +80,9 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## etc) will be ignored.
   # arguments = ["-c", "3"]
 
+  ## Use only IPv4 addresses when resolving a hostname.
+  # ipv4 = false
+
   ## Use only IPv6 addresses when resolving a hostname.
   # ipv6 = false
 

--- a/plugins/inputs/ping/README.md
+++ b/plugins/inputs/ping/README.md
@@ -80,10 +80,12 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## etc) will be ignored.
   # arguments = ["-c", "3"]
 
-  ## Use only IPv4 addresses when resolving a hostname.
+  ## Use only IPv4 addresses when resolving a hostname. By default, both IPv4
+  ## and IPv6 can be used.
   # ipv4 = false
 
-  ## Use only IPv6 addresses when resolving a hostname.
+  ## Use only IPv6 addresses when resolving a hostname. By default, both IPv4
+  ## and IPv6 can be used.
   # ipv6 = false
 
   ## Number of data bytes to be sent. Corresponds to the "-s"

--- a/plugins/inputs/ping/ping.go
+++ b/plugins/inputs/ping/ping.go
@@ -73,6 +73,9 @@ type Ping struct {
 	// other options (ping_interval, timeout, etc.) will be ignored
 	Arguments []string
 
+	// Whether to resolve addresses using ipv4 or not.
+	IPv4 bool
+
 	// Whether to resolve addresses using ipv6 or not.
 	IPv6 bool
 
@@ -129,6 +132,9 @@ func (p *Ping) nativePing(destination string) (*pingStats, error) {
 
 	pinger.SetPrivileged(true)
 
+	if p.IPv4 {
+		pinger.SetNetwork("ip4")
+	}
 	if p.IPv6 {
 		pinger.SetNetwork("ip6")
 	}
@@ -301,6 +307,10 @@ func (p *Ping) Init() error {
 			}
 			p.sourceAddress = addrs[0].(*net.IPNet).IP.String()
 		}
+	}
+
+	if p.IPv4 && p.IPv6 {
+		return errors.New("both ipv4 and ipv6 cannot be true at the same time")
 	}
 
 	return nil

--- a/plugins/inputs/ping/ping.go
+++ b/plugins/inputs/ping/ping.go
@@ -132,10 +132,11 @@ func (p *Ping) nativePing(destination string) (*pingStats, error) {
 
 	pinger.SetPrivileged(true)
 
-	if p.IPv4 {
+	if p.IPv4 && p.IPv6 {
+		pinger.SetNetwork("ip")
+	} else if p.IPv4 {
 		pinger.SetNetwork("ip4")
-	}
-	if p.IPv6 {
+	} else if p.IPv6 {
 		pinger.SetNetwork("ip6")
 	}
 
@@ -307,10 +308,6 @@ func (p *Ping) Init() error {
 			}
 			p.sourceAddress = addrs[0].(*net.IPNet).IP.String()
 		}
-	}
-
-	if p.IPv4 && p.IPv6 {
-		return errors.New("both ipv4 and ipv6 cannot be true at the same time")
 	}
 
 	return nil

--- a/plugins/inputs/ping/sample.conf
+++ b/plugins/inputs/ping/sample.conf
@@ -43,6 +43,9 @@
   ## etc) will be ignored.
   # arguments = ["-c", "3"]
 
+  ## Use only IPv4 addresses when resolving a hostname.
+  # ipv4 = false
+
   ## Use only IPv6 addresses when resolving a hostname.
   # ipv6 = false
 

--- a/plugins/inputs/ping/sample.conf
+++ b/plugins/inputs/ping/sample.conf
@@ -43,10 +43,12 @@
   ## etc) will be ignored.
   # arguments = ["-c", "3"]
 
-  ## Use only IPv4 addresses when resolving a hostname.
+  ## Use only IPv4 addresses when resolving a hostname. By default, both IPv4
+  ## and IPv6 can be used.
   # ipv4 = false
 
-  ## Use only IPv6 addresses when resolving a hostname.
+  ## Use only IPv6 addresses when resolving a hostname. By default, both IPv4
+  ## and IPv6 can be used.
   # ipv6 = false
 
   ## Number of data bytes to be sent. Corresponds to the "-s"


### PR DESCRIPTION


## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Similar to ipv6 option, add ipv4 option and ensure both are not true.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

fixes: #15005
