### PR TITLE
fix(inputs.prometheus): Initialize logger of parser

### DIFF
--- a/plugins/inputs/prometheus/prometheus.go
+++ b/plugins/inputs/prometheus/prometheus.go
@@ -492,6 +492,7 @@ func (p *Prometheus) gatherURL(u URLAndAddress, acc telegraf.Accumulator) (map[s
 		Header:          resp.Header,
 		MetricVersion:   p.MetricVersion,
 		IgnoreTimestamp: p.IgnoreTimestamp,
+		Log:             p.Log,
 	}
 	metrics, err := metricParser.Parse(body)
 	if err != nil {

--- a/plugins/parsers/prometheus/parser.go
+++ b/plugins/parsers/prometheus/parser.go
@@ -38,7 +38,7 @@ func (p *Parser) Parse(data []byte) ([]telegraf.Metric, error) {
 			data = append(data, []byte("\n")...)
 		}
 	case expfmt.FmtUnknown:
-		p.Log.Warnf("Unknown format %q... Trying to continue...", p.Header.Get("Content-Type"))
+		p.Log.Debugf("Unknown format %q... Trying to continue...", p.Header.Get("Content-Type"))
 	}
 	buf := bytes.NewBuffer(data)
 	decoder := expfmt.NewDecoder(buf, format)


### PR DESCRIPTION
## Summary

Initialize the otherwise uninitialized logger of the underlying prometheus parser. Furthermore, this PR converts the "unknown format" warning in the parser to debug level to prevent spamming the log-file by default.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #15020 
