### PR TITLE
fix(inputs.dns_query): Include the canonical CNAME target

### DIFF
--- a/plugins/inputs/dns_query/dns_query.go
+++ b/plugins/inputs/dns_query/dns_query.go
@@ -158,14 +158,22 @@ func (d *DNSQuery) query(domain string, server string) (map[string]interface{}, 
 	// Fill out custom fields for specific record types
 	for _, record := range r.Answer {
 		switch x := record.(type) {
+		case *dns.A:
+			fields["name"] = x.Hdr.Name
+		case *dns.AAAA:
+			fields["name"] = x.Hdr.Name
+		case *dns.CNAME:
+			fields["name"] = x.Hdr.Name
 		case *dns.MX:
+			fields["name"] = x.Hdr.Name
 			fields["preference"] = x.Preference
 		case *dns.SOA:
-			fields["serial"] = x.Serial
-			fields["refresh"] = x.Refresh
-			fields["retry"] = x.Retry
 			fields["expire"] = x.Expire
 			fields["minttl"] = x.Minttl
+			fields["name"] = x.Hdr.Name
+			fields["refresh"] = x.Refresh
+			fields["retry"] = x.Retry
+			fields["serial"] = x.Serial
 		}
 	}
 


### PR DESCRIPTION


## Summary
This includes the canonical name as a result of a DNS lookup as an additional field. For example, if you look up `gmail.google.com`, the canonical result is `www3.l.google.com.`.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

fixes: #11116
