### PR TITLE
fix(inputs.phpfpm): Add timeout for fcgi

### DIFF
--- a/plugins/inputs/phpfpm/fcgi_client.go
+++ b/plugins/inputs/phpfpm/fcgi_client.go
@@ -78,6 +78,12 @@ READ_LOOP:
 			}
 			break
 		}
+		if err1 != nil && strings.Contains(err1.Error(), "i/o timeout") {
+			if !errors.Is(err1, io.EOF) {
+				err = err1
+			}
+			break
+		}
 
 		switch {
 		case rec.h.Type == typeStdout:

--- a/plugins/inputs/phpfpm/fcgi_client.go
+++ b/plugins/inputs/phpfpm/fcgi_client.go
@@ -6,10 +6,11 @@ import (
 	"net"
 	"strconv"
 	"strings"
+	"time"
 )
 
 // Create an fcgi client
-func newFcgiClient(h string, args ...interface{}) (*conn, error) {
+func newFcgiClient(timeout time.Duration, h string, args ...interface{}) (*conn, error) {
 	var con net.Conn
 	if len(args) != 1 {
 		return nil, errors.New("fcgi: not enough params")
@@ -19,13 +20,24 @@ func newFcgiClient(h string, args ...interface{}) (*conn, error) {
 	switch args[0].(type) {
 	case int:
 		addr := h + ":" + strconv.FormatInt(int64(args[0].(int)), 10)
-		con, err = net.Dial("tcp", addr)
+		if timeout == 0 {
+			con, err = net.Dial("tcp", addr)
+		} else {
+			con, err = net.DialTimeout("tcp", addr, timeout)
+		}
 	case string:
 		laddr := net.UnixAddr{Name: args[0].(string), Net: h}
 		con, err = net.DialUnix(h, nil, &laddr)
 	default:
 		err = errors.New("fcgi: we only accept int (port) or string (socket) params")
 	}
+
+	if timeout != 0 {
+		if err := con.SetDeadline(time.Now().Add(timeout)); err != nil {
+			return nil, err
+		}
+	}
+
 	fcgi := &conn{
 		rwc: con,
 	}

--- a/plugins/inputs/phpfpm/phpfpm.go
+++ b/plugins/inputs/phpfpm/phpfpm.go
@@ -159,7 +159,7 @@ func (p *phpfpm) gatherServer(addr string, acc telegraf.Accumulator) error {
 		}
 		fcgiIP := socketAddr[0]
 		fcgiPort, _ := strconv.Atoi(socketAddr[1])
-		fcgi, err = newFcgiClient(fcgiIP, fcgiPort)
+		fcgi, err = newFcgiClient(time.Duration(p.Timeout), fcgiIP, fcgiPort)
 		if err != nil {
 			return err
 		}
@@ -173,7 +173,7 @@ func (p *phpfpm) gatherServer(addr string, acc telegraf.Accumulator) error {
 		if statusPath == "" {
 			statusPath = "status"
 		}
-		fcgi, err = newFcgiClient("unix", socketPath)
+		fcgi, err = newFcgiClient(time.Duration(p.Timeout), "unix", socketPath)
 	}
 
 	if err != nil {


### PR DESCRIPTION
## Summary

The input PHP-FPM don't have timeout when talking (F)CGI protocol, which could lead to input blocked forever.

The timeout exists and was used for HTTP, but not for fcgi.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #15035
