### PR TITLE
fix(windows): Ensure watch-config is passed to service

### DIFF
--- a/cmd/telegraf/telegraf_windows.go
+++ b/cmd/telegraf/telegraf_windows.go
@@ -128,6 +128,10 @@ func (t *Telegraf) runAsWindowsService() error {
 			svcConfig.Arguments = append(svcConfig.Arguments, "--config-directory", fConfigDirectory)
 		}
 
+		if t.watchConfig != "" {
+			svcConfig.Arguments = append(svcConfig.Arguments, "--watch-config", t.watchConfig)
+		}
+
 		//set servicename to service cmd line, to have a custom name after relaunch as a service
 		svcConfig.Arguments = append(svcConfig.Arguments, "--service-name", t.serviceName)
 


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Ensure the watch config option and parameter are passed to the window service arguments.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

fixes: #14696
