### PR TITLE
feat(inputs.lustre2): Add eviction_count field

### DIFF
--- a/plugins/inputs/lustre2/README.md
+++ b/plugins/inputs/lustre2/README.md
@@ -24,6 +24,9 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## An array of /proc globs to search for Lustre stats
   ## If not specified, the default will work on Lustre 2.12.x
   ##
+  # mgs_procfiles = [
+  #   "/sys/fs/lustre/mgs/*/eviction_count",
+  # ]
   # ost_procfiles = [
   #   "/proc/fs/lustre/obdfilter/*/stats",
   #   "/proc/fs/lustre/osd-ldiskfs/*/stats",
@@ -31,6 +34,7 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   #   "/proc/fs/lustre/obdfilter/*/exports/*/stats",
   #   "/proc/fs/lustre/osd-ldiskfs/*/brw_stats",
   #   "/proc/fs/lustre/osd-zfs/*/brw_stats",
+  #   "/sys/fs/lustre/odbfilter/*/eviction_count",
   # ]
   # mds_procfiles = [
   #   "/proc/fs/lustre/mdt/*/md_stats",
@@ -38,6 +42,7 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   #   "/proc/fs/lustre/mdt/*/exports/*/stats",
   #   "/proc/fs/lustre/osd-ldiskfs/*/brw_stats",
   #   "/proc/fs/lustre/osd-zfs/*/brw_stats",
+  #   "/sys/fs/lustre/mdt/*/eviction_count",
   # ]
 ```
 
@@ -173,6 +178,14 @@ From `/proc/fs/lustre/mdt/*/job_stats`:
     - jobstats_statfs
     - jobstats_sync
     - jobstats_unlink
+
+From `/proc/fs/lustre/*/*/eviction_count`:
+
+- lustre2
+  - tags:
+    - name
+  - fields:
+    - evictions
 
 ## Troubleshooting
 

--- a/plugins/inputs/lustre2/lustre2.go
+++ b/plugins/inputs/lustre2/lustre2.go
@@ -636,7 +636,6 @@ func (l *Lustre2) getLustreEvictionCount(fileglob string) error {
 		fields["evictions"] = value
 	}
 	return nil
-
 }
 
 // Gather reads stats from all lustre targets
@@ -684,13 +683,12 @@ func (l *Lustre2) Gather(acc telegraf.Accumulator) error {
 	}
 
 	for _, procfile := range l.MgsProcfiles {
-		if strings.HasSuffix(procfile, "eviction_count") {
-			err := l.getLustreEvictionCount(procfile)
-			if err != nil {
-				return err
-			}
-		} else {
+		if !strings.HasSuffix(procfile, "eviction_count") {
 			return fmt.Errorf("no handler found for mgs procfile pattern \"%s\"", procfile)
+		}
+		err := l.getLustreEvictionCount(procfile)
+		if err != nil {
+			return err
 		}
 	}
 	for _, procfile := range l.OstProcfiles {

--- a/plugins/inputs/lustre2/lustre2_test.go
+++ b/plugins/inputs/lustre2/lustre2_test.go
@@ -590,7 +590,7 @@ func TestLustre2GeneratesEvictionMetrics(t *testing.T) {
 		{"obdfilter", "fs-OST0001", 303},
 	}
 	for _, f := range fileEntries {
-		d := filepath.Join(rootdir, "sys/fs/lustre", f.targetType, f.targetName)
+		d := filepath.Join(rootdir, "sys", "fs", "lustre", f.targetType, f.targetName)
 		err := os.MkdirAll(d, 0750)
 		require.NoError(t, err)
 		err = os.WriteFile(filepath.Join(d, "eviction_count"), []byte(fmt.Sprintf("%d\n", f.value)), 0640)

--- a/plugins/inputs/lustre2/sample.conf
+++ b/plugins/inputs/lustre2/sample.conf
@@ -4,6 +4,9 @@
   ## An array of /proc globs to search for Lustre stats
   ## If not specified, the default will work on Lustre 2.12.x
   ##
+  # mgs_procfiles = [
+  #   "/sys/fs/lustre/mgs/*/eviction_count",
+  # ]
   # ost_procfiles = [
   #   "/proc/fs/lustre/obdfilter/*/stats",
   #   "/proc/fs/lustre/osd-ldiskfs/*/stats",
@@ -11,6 +14,7 @@
   #   "/proc/fs/lustre/obdfilter/*/exports/*/stats",
   #   "/proc/fs/lustre/osd-ldiskfs/*/brw_stats",
   #   "/proc/fs/lustre/osd-zfs/*/brw_stats",
+  #   "/sys/fs/lustre/odbfilter/*/eviction_count",
   # ]
   # mds_procfiles = [
   #   "/proc/fs/lustre/mdt/*/md_stats",
@@ -18,4 +22,5 @@
   #   "/proc/fs/lustre/mdt/*/exports/*/stats",
   #   "/proc/fs/lustre/osd-ldiskfs/*/brw_stats",
   #   "/proc/fs/lustre/osd-zfs/*/brw_stats",
+  #   "/sys/fs/lustre/mdt/*/eviction_count",
   # ]


### PR DESCRIPTION
Adds support for https://review.whamcloud.com/c/fs/lustre-release/+/40528.

I'll rebase after https://github.com/influxdata/telegraf/pull/15042 is merged.

NOTE: according to https://wiki.lustre.org/Lustre_Monitoring_and_Statistics_Guide#Reading_/proc_vs_lctl it is technically safer to use `lctl get_param *.*.eviction_count` than parsing files in sysfs/procfs. In this MR I am simply following the existing convention for the plugin. Perhaps in the future we should switch to using `lctl get_param` for maximum portability. Tests would require mocking the `exec.Command` output, as is done for other plugins.