### PR TITLE
test(inputs.syslog): Skip test on Windows

### DIFF
--- a/plugins/inputs/syslog/syslog_test.go
+++ b/plugins/inputs/syslog/syslog_test.go
@@ -287,6 +287,10 @@ func TestCases(t *testing.T) {
 }
 
 func TestSocketClosed(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping test as very flaky on Windows")
+	}
+
 	// Setup the plugin
 	plugin := &Syslog{
 		Address: "tcp://127.0.0.1:0",


### PR DESCRIPTION
## Summary

This test is incredibly flaky on Windows. It possibly has some sort of hang occurring which hits a test timeout.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR
