### PR TITLE
feat(inputs.kubernetes): Add option to node metric name

### DIFF
--- a/plugins/inputs/kubernetes/README.md
+++ b/plugins/inputs/kubernetes/README.md
@@ -62,6 +62,12 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## OR
   # bearer_token_string = "abc_123"
 
+  ## Kubernetes Node Metric Name
+  ## The default Kubernetes node metric name (i.e. kubernetes_node) is the same
+  ## for the kubernetes and kube_inventory plugins. To avoid conflicts, set this
+  ## option to a different value.
+  # node_metric_name = "kubernetes_node"
+
   ## Pod labels to be added as tags.  An empty array for both include and
   ## exclude will include all labels.
   # label_include = []

--- a/plugins/inputs/kubernetes/kubernetes_test.go
+++ b/plugins/inputs/kubernetes/kubernetes_test.go
@@ -2,11 +2,11 @@ package kubernetes
 
 import (
 	"fmt"
-	"github.com/influxdata/telegraf/filter"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/influxdata/telegraf/filter"
 	"github.com/influxdata/telegraf/testutil"
 	"github.com/stretchr/testify/require"
 )
@@ -29,8 +29,9 @@ func TestKubernetesStats(t *testing.T) {
 	labelFilter, _ := filter.NewIncludeExcludeFilter([]string{"app", "superkey"}, nil)
 
 	k := &Kubernetes{
-		URL:         ts.URL,
-		labelFilter: labelFilter,
+		URL:            ts.URL,
+		labelFilter:    labelFilter,
+		NodeMetricName: "kubernetes_node",
 	}
 
 	var acc testutil.Accumulator

--- a/plugins/inputs/kubernetes/sample.conf
+++ b/plugins/inputs/kubernetes/sample.conf
@@ -14,6 +14,12 @@
   ## OR
   # bearer_token_string = "abc_123"
 
+  ## Kubernetes Node Metric Name
+  ## The default Kubernetes node metric name (i.e. kubernetes_node) is the same
+  ## for the kubernetes and kube_inventory plugins. To avoid conflicts, set this
+  ## option to a different value.
+  # node_metric_name = "kubernetes_node"
+
   ## Pod labels to be added as tags.  An empty array for both include and
   ## exclude will include all labels.
   # label_include = []


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
The k8s and kube_node plugins produce the same metric name that can conflict. Provide an option in the k8s plugin to change the name.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

fixes: #9451
