### PR TITLE
fix(agent): Ensure import of required package for pprof support

### DIFF
--- a/cmd/telegraf/pprof.go
+++ b/cmd/telegraf/pprof.go
@@ -3,7 +3,7 @@ package main
 import (
 	"log"
 	"net/http"
-	_ "net/http/pprof"
+	_ "net/http/pprof" //nolint:gosec // Import for pprof, only enabled via CLI flag
 	"strings"
 	"time"
 )

--- a/cmd/telegraf/pprof.go
+++ b/cmd/telegraf/pprof.go
@@ -3,6 +3,7 @@ package main
 import (
 	"log"
 	"net/http"
+	_ "net/http/pprof"
 	"strings"
 	"time"
 )


### PR DESCRIPTION
## Summary
Pretty sure net/http/pprof got accidentally lost in this commit bd516ae587a27d040b457c593e3d5fa6aaf40269
This MR adds it back in

## Checklist

- [x] No AI generated code was used in this PR

## Related issues
resolves #15053 
