### PR TITLE
feat(inputs.opcua): Implement browsing tags on initial connect

### DIFF
--- a/plugins/inputs/opcua/README.md
+++ b/plugins/inputs/opcua/README.md
@@ -89,6 +89,11 @@ to use them.
   ## identifier        - OPC UA ID (tag as shown in opcua browser)
   ## tags              - extra tags to be added to the output metric (optional); deprecated in 1.25.0; use default_tags
   ## default_tags      - extra tags to be added to the output metric (optional)
+  ## browse            - browse the OPC tag using BrowseName attributes (optional).
+  ##                     identifier_type must be "s" and identifier must be set to a valid browse path according to OPC UA Part 4, Annex A,
+  ##                     e.g.: 3:Folder/4:SubFolder/4:Object.Member.Value 
+  ##                     Objects are browsed starting from the ObjectsFolder folder.
+  ##                     The namespace in the namespace field is used as the initial namespace, but may be overridden by the browse path
   ##
   ## Use either the inline notation or the bracketed notation, not both.
   #
@@ -96,6 +101,7 @@ to use them.
   # nodes = [
   #   {name="", namespace="", identifier_type="", identifier="", tags=[["tag1", "value1"], ["tag2", "value2"]},
   #   {name="", namespace="", identifier_type="", identifier=""},
+  #   {name="", namespace="", identifier_type="s", identifier="3:Folder/4:SubFolder/4:Object.Member.Value", browse=true}
   # ]
   #
   ## Bracketed notation
@@ -104,6 +110,7 @@ to use them.
   #   namespace = ""
   #   identifier_type = ""
   #   identifier = ""
+  #   browse = false
   #   default_tags = { tag1 = "value1", tag2 = "value2" }
   #
   # [[inputs.opcua.nodes]]

--- a/plugins/inputs/opcua/read_client.go
+++ b/plugins/inputs/opcua/read_client.go
@@ -61,7 +61,7 @@ func (o *ReadClient) Connect() error {
 
 	// Make sure we setup the node-ids correctly after reconnect
 	// as the server might be restarted and IDs changed
-	if err := o.OpcUAInputClient.InitNodeIDs(); err != nil {
+	if err := o.OpcUAInputClient.InitNodeIDs(o.ctx); err != nil {
 		return fmt.Errorf("initializing node IDs failed: %w", err)
 	}
 

--- a/plugins/inputs/opcua/sample.conf
+++ b/plugins/inputs/opcua/sample.conf
@@ -61,6 +61,11 @@
   ## identifier        - OPC UA ID (tag as shown in opcua browser)
   ## tags              - extra tags to be added to the output metric (optional); deprecated in 1.25.0; use default_tags
   ## default_tags      - extra tags to be added to the output metric (optional)
+  ## browse            - browse the OPC tag using BrowseName attributes (optional).
+  ##                     identifier_type must be "s" and identifier must be set to a valid browse path according to OPC UA Part 4, Annex A,
+  ##                     e.g.: 3:Folder/4:SubFolder/4:Object.Member.Value 
+  ##                     Objects are browsed starting from the ObjectsFolder folder.
+  ##                     The namespace in the namespace field is used as the initial namespace, but may be overridden by the browse path
   ##
   ## Use either the inline notation or the bracketed notation, not both.
   #
@@ -68,6 +73,7 @@
   # nodes = [
   #   {name="", namespace="", identifier_type="", identifier="", tags=[["tag1", "value1"], ["tag2", "value2"]},
   #   {name="", namespace="", identifier_type="", identifier=""},
+  #   {name="", namespace="", identifier_type="s", identifier="3:Folder/4:SubFolder/4:Object.Member.Value", browse=true}
   # ]
   #
   ## Bracketed notation
@@ -76,6 +82,7 @@
   #   namespace = ""
   #   identifier_type = ""
   #   identifier = ""
+  #   browse = false
   #   default_tags = { tag1 = "value1", tag2 = "value2" }
   #
   # [[inputs.opcua.nodes]]

--- a/plugins/inputs/opcua_listener/README.md
+++ b/plugins/inputs/opcua_listener/README.md
@@ -218,6 +218,7 @@ to use them.
   # nodes = [
   #  {name="node1", namespace="", identifier_type="", identifier="",}
   #  {name="node2", namespace="", identifier_type="", identifier="", monitoring_params={sampling_interval="0s", queue_size=10, discard_oldest=true, data_change_filter={trigger="Status", deadband_type="Absolute", deadband_value=0.0}}},
+  #  {name="node3", namespace="3", identifier_type="s" identifier=3:Folder/4.Object.Member.Field"}
   #]
   #
   ## Bracketed notation

--- a/plugins/inputs/opcua_listener/opcua_listener_test.go
+++ b/plugins/inputs/opcua_listener/opcua_listener_test.go
@@ -800,6 +800,7 @@ func TestSubscribeClientConfigValidMonitoringParams(t *testing.T) {
 	})
 
 	subClient, err := subscribeConfig.CreateSubscribeClient(testutil.Logger{})
+	subClient.Connect()
 	require.NoError(t, err)
 	require.Equal(t, &ua.MonitoringParameters{
 		SamplingInterval: 50,

--- a/plugins/inputs/opcua_listener/sample.conf
+++ b/plugins/inputs/opcua_listener/sample.conf
@@ -179,6 +179,7 @@
   # nodes = [
   #  {name="node1", namespace="", identifier_type="", identifier="",}
   #  {name="node2", namespace="", identifier_type="", identifier="", monitoring_params={sampling_interval="0s", queue_size=10, discard_oldest=true, data_change_filter={trigger="Status", deadband_type="Absolute", deadband_value=0.0}}},
+  #  {name="node3", namespace="3", identifier_type="s" identifier=3:Folder/4.Object.Member.Field"}
   #]
   #
   ## Bracketed notation


### PR DESCRIPTION
## Summary
This is a proposed implementation in order to implement tag browsing for OPC-UA tags on initial connect as described in #15001.
This pull request is for review purposes, some tests are still failing on this because a connection to an OPC server is now required in order initialize all NodeIDs. I'm still working on that part.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #15001 
