### PR TITLE
feat(outputs.cratedb): Allow configuration of startup error handling

### DIFF
--- a/plugins/outputs/cratedb/README.md
+++ b/plugins/outputs/cratedb/README.md
@@ -36,15 +36,20 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 ```toml @sample.conf
 # Configuration for CrateDB to send metrics to.
 [[outputs.cratedb]]
-  # A github.com/jackc/pgx/v4 connection string.
-  # See https://pkg.go.dev/github.com/jackc/pgx/v4#ParseConfig
+  ## Connection parameters for accessing the database see
+  ##   https://pkg.go.dev/github.com/jackc/pgx/v4#ParseConfig
+  ## for available options
   url = "postgres://user:password@localhost/schema?sslmode=disable"
-  # Timeout for all CrateDB queries.
-  timeout = "5s"
-  # Name of the table to store metrics in.
-  table = "metrics"
-  # If true, and the metrics table does not exist, create it automatically.
-  table_create = true
-  # The character(s) to replace any '.' in an object key with
-  key_separator = "_"
+
+  ## Timeout for all CrateDB queries.
+  # timeout = "5s"
+
+  ## Name of the table to store metrics in.
+  # table = "metrics"
+
+  ## If true, and the metrics table does not exist, create it automatically.
+  # table_create = false
+
+  ## The character(s) to replace any '.' in an object key with
+  # key_separator = "_"
 ```

--- a/plugins/outputs/cratedb/cratedb.go
+++ b/plugins/outputs/cratedb/cratedb.go
@@ -26,16 +26,28 @@ var sampleConfig string
 const MaxInt64 = int64(^uint64(0) >> 1)
 
 type CrateDB struct {
-	URL          string
-	Timeout      config.Duration
-	Table        string
-	TableCreate  bool   `toml:"table_create"`
-	KeySeparator string `toml:"key_separator"`
+	URL          string          `toml:"url"`
+	Timeout      config.Duration `toml:"timeout"`
+	Table        string          `toml:"table"`
+	TableCreate  bool            `toml:"table_create"`
+	KeySeparator string          `toml:"key_separator"`
 	DB           *sql.DB
 }
 
 func (*CrateDB) SampleConfig() string {
 	return sampleConfig
+}
+
+func (c *CrateDB) Init() error {
+	// Set defaults
+	if c.KeySeparator == "" {
+		c.KeySeparator = "_"
+	}
+	if c.Table == "" {
+		c.Table = "metrics"
+	}
+
+	return nil
 }
 
 func (c *CrateDB) Connect() error {

--- a/plugins/outputs/cratedb/cratedb.go
+++ b/plugins/outputs/cratedb/cratedb.go
@@ -31,7 +31,8 @@ type CrateDB struct {
 	Table        string          `toml:"table"`
 	TableCreate  bool            `toml:"table_create"`
 	KeySeparator string          `toml:"key_separator"`
-	DB           *sql.DB
+
+	db *sql.DB
 }
 
 func (*CrateDB) SampleConfig() string {
@@ -72,7 +73,7 @@ CREATE TABLE IF NOT EXISTS ` + c.Table + ` (
 			return err
 		}
 	}
-	c.DB = db
+	c.db = db
 	return nil
 }
 
@@ -85,7 +86,7 @@ func (c *CrateDB) Write(metrics []telegraf.Metric) error {
 		return err
 	}
 
-	_, err = c.DB.ExecContext(ctx, generatedSQL)
+	_, err = c.db.ExecContext(ctx, generatedSQL)
 	if err != nil {
 		return err
 	}
@@ -237,7 +238,7 @@ func hashID(m telegraf.Metric) int64 {
 }
 
 func (c *CrateDB) Close() error {
-	return c.DB.Close()
+	return c.db.Close()
 }
 
 func init() {

--- a/plugins/outputs/cratedb/sample.conf
+++ b/plugins/outputs/cratedb/sample.conf
@@ -1,13 +1,18 @@
 # Configuration for CrateDB to send metrics to.
 [[outputs.cratedb]]
-  # A github.com/jackc/pgx/v4 connection string.
-  # See https://pkg.go.dev/github.com/jackc/pgx/v4#ParseConfig
+  ## Connection parameters for accessing the database see
+  ##   https://pkg.go.dev/github.com/jackc/pgx/v4#ParseConfig
+  ## for available options
   url = "postgres://user:password@localhost/schema?sslmode=disable"
-  # Timeout for all CrateDB queries.
-  timeout = "5s"
-  # Name of the table to store metrics in.
-  table = "metrics"
-  # If true, and the metrics table does not exist, create it automatically.
-  table_create = true
-  # The character(s) to replace any '.' in an object key with
-  key_separator = "_"
+
+  ## Timeout for all CrateDB queries.
+  # timeout = "5s"
+
+  ## Name of the table to store metrics in.
+  # table = "metrics"
+
+  ## If true, and the metrics table does not exist, create it automatically.
+  # table_create = false
+
+  ## The character(s) to replace any '.' in an object key with
+  # key_separator = "_"

--- a/testutil/container.go
+++ b/testutil/container.go
@@ -156,3 +156,21 @@ func (c *Container) Terminate() {
 
 	c.PrintLogs()
 }
+
+func (c *Container) Pause() error {
+	provider, err := testcontainers.NewDockerProvider()
+	if err != nil {
+		return fmt.Errorf("getting provider failed: %w", err)
+	}
+
+	return provider.Client().ContainerPause(c.ctx, c.container.GetContainerID())
+}
+
+func (c *Container) Resume() error {
+	provider, err := testcontainers.NewDockerProvider()
+	if err != nil {
+		return fmt.Errorf("getting provider failed: %w", err)
+	}
+
+	return provider.Client().ContainerUnpause(c.ctx, c.container.GetContainerID())
+}


### PR DESCRIPTION
## Summary

This PR allows to define the behavior for startup errors of the cratedb output plugin. If `startup_error_behavior = "retry"` is specified, errors for table creation will not lead to a startup error.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #13278
