### PR TITLE
feat(inputs.knx_listener): Allow usage of DPT string representation

### DIFF
--- a/plugins/inputs/knx_listener/README.md
+++ b/plugins/inputs/knx_listener/README.md
@@ -43,6 +43,9 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   #   name = "temperature"
   #   ## Datapoint-Type (DPT) of the KNX messages
   #   dpt = "9.001"
+  #   ## Use the string representation instead of the numerical value for the
+  #   ## datapoint-type and the addresses below
+  #   # as_string = false
   #   ## List of Group-Addresses (GAs) assigned to the measurement
   #   addresses = ["5/5/1"]
 

--- a/plugins/inputs/knx_listener/sample.conf
+++ b/plugins/inputs/knx_listener/sample.conf
@@ -13,6 +13,9 @@
   #   name = "temperature"
   #   ## Datapoint-Type (DPT) of the KNX messages
   #   dpt = "9.001"
+  #   ## Use the string representation instead of the numerical value for the
+  #   ## datapoint-type and the addresses below
+  #   # as_string = false
   #   ## List of Group-Addresses (GAs) assigned to the measurement
   #   addresses = ["5/5/1"]
 


### PR DESCRIPTION
## Summary

Some DPT's, especially DPT1.xxx, do have more speaking values in their string representation. Allow the user to choose between the two by introducing a new `as_string` flag.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #15039 
