### PR TITLE
docs(outputs.cratedb): Document startup error behavior options

### DIFF
--- a/plugins/outputs/cratedb/README.md
+++ b/plugins/outputs/cratedb/README.md
@@ -31,6 +31,20 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 [CONFIGURATION.md]: ../../../docs/CONFIGURATION.md#plugins
 
+## Startup error behavior options <!-- @/docs/includes/startup_error_behavior.md -->
+
+In addition to the plugin-specific and global configuration settings the plugin
+supports options for specifying the behavior when experiencing startup errors
+using the `startup_error_behavior` setting. Available values are:
+
+- `error`:  Telegraf with stop and exit in case of startup errors. This is the
+            default behavior.
+- `ignore`: Telegraf will ignore startup errors for this plugin and disables it
+            but continues processing for all other plugins.
+- `retry`:  Telegraf will try to startup the plugin in every gather or write
+            cycle in case of startup errors. The plugin is disabled until
+            the startup succeeds.
+
 ## Configuration
 
 ```toml @sample.conf


### PR DESCRIPTION
## Summary

Document the newly available options for the output plugin.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues
