### PR TITLE
fix(inputs.prometheus): Remove duplicate response_timeout option

### DIFF
--- a/plugins/inputs/prometheus/README.md
+++ b/plugins/inputs/prometheus/README.md
@@ -141,6 +141,8 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   # timeout = "5s"
 
   ## deprecated in 1.26; use the timeout option
+  ## This option is now used by the HTTP client to set the header response
+  ## timeout, not the overall HTTP timeout.
   # response_timeout = "5s"
 
   ## HTTP Proxy support

--- a/plugins/inputs/prometheus/prometheus.go
+++ b/plugins/inputs/prometheus/prometheus.go
@@ -218,6 +218,15 @@ func (p *Prometheus) Init() error {
 		return err
 	}
 	p.client = client
+	if p.HTTPClientConfig.ResponseHeaderTimeout != 0 {
+		p.Log.Warn(
+			"Config option response_timeout was set to non-zero value. This option's behavior was " +
+				"changed in Telegraf 1.30.2 and now controls the HTTP client's header timeout and " +
+				"not the Prometheus timeout. Users can ignore this warning if that was the intention. " +
+				"Otherwise, please use the timeout config option for the Prometheus timeout.",
+		)
+	}
+
 	p.headers = map[string]string{
 		"User-Agent": internal.ProductToken(),
 		"Accept":     acceptHeader,

--- a/plugins/inputs/prometheus/prometheus.go
+++ b/plugins/inputs/prometheus/prometheus.go
@@ -74,9 +74,8 @@ type Prometheus struct {
 
 	HTTPHeaders map[string]string `toml:"http_headers"`
 
-	ResponseTimeout      config.Duration `toml:"response_timeout" deprecated:"1.26.0;use 'timeout' instead"`
-	ContentLengthLimit   config.Size     `toml:"content_length_limit"`
-	EnableRequestMetrics bool            `toml:"enable_request_metrics"`
+	ContentLengthLimit   config.Size `toml:"content_length_limit"`
+	EnableRequestMetrics bool        `toml:"enable_request_metrics"`
 
 	MetricVersion int `toml:"metric_version"`
 
@@ -213,9 +212,6 @@ func (p *Prometheus) Init() error {
 	}
 
 	ctx := context.Background()
-	if p.ResponseTimeout != 0 {
-		p.HTTPClientConfig.Timeout = p.ResponseTimeout
-	}
 
 	client, err := p.HTTPClientConfig.CreateClient(ctx, p.Log)
 	if err != nil {
@@ -405,9 +401,6 @@ func (p *Prometheus) gatherURL(u URLAndAddress, acc telegraf.Accumulator) (map[s
 					return c, err
 				},
 			},
-		}
-		if p.ResponseTimeout != 0 {
-			uClient.Timeout = time.Duration(p.ResponseTimeout)
 		}
 	} else {
 		if u.URL.Path == "" {

--- a/plugins/inputs/prometheus/prometheus_test.go
+++ b/plugins/inputs/prometheus/prometheus_test.go
@@ -14,7 +14,6 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 
 	"github.com/influxdata/telegraf"
-	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/metric"
 	"github.com/influxdata/telegraf/testutil"
 )
@@ -241,10 +240,12 @@ func TestPrometheusGeneratesMetricsSlowEndpoint(t *testing.T) {
 	defer ts.Close()
 
 	p := &Prometheus{
-		Log:             testutil.Logger{},
-		URLs:            []string{ts.URL},
-		URLTag:          "url",
-		ResponseTimeout: config.Duration(time.Second * 5),
+		Log:    testutil.Logger{},
+		URLs:   []string{ts.URL},
+		URLTag: "url",
+		client: &http.Client{
+			Timeout: time.Second * 5,
+		},
 	}
 	err := p.Init()
 	require.NoError(t, err)
@@ -271,10 +272,12 @@ func TestPrometheusGeneratesMetricsSlowEndpointHitTheTimeout(t *testing.T) {
 	defer ts.Close()
 
 	p := &Prometheus{
-		Log:             testutil.Logger{},
-		URLs:            []string{ts.URL},
-		URLTag:          "url",
-		ResponseTimeout: config.Duration(time.Second * 5),
+		Log:    testutil.Logger{},
+		URLs:   []string{ts.URL},
+		URLTag: "url",
+		client: &http.Client{
+			Timeout: time.Second * 5,
+		},
 	}
 	err := p.Init()
 	require.NoError(t, err)

--- a/plugins/inputs/prometheus/sample.conf
+++ b/plugins/inputs/prometheus/sample.conf
@@ -124,6 +124,8 @@
   # timeout = "5s"
 
   ## deprecated in 1.26; use the timeout option
+  ## This option is now used by the HTTP client to set the header response
+  ## timeout, not the overall HTTP timeout.
   # response_timeout = "5s"
 
   ## HTTP Proxy support


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
In #14153, the HTTP client config struct gained a response timeout config option with TOML tags. This meant that there were two defined for both Prometheus plugin and the HTTP client config struct. 

This removes the one in the Prometheus plugin, which allows users to correctly load previously existing plugins. However, the `response_timeout` option will now set the HTTP Client config's `ResponseHeaderTimeout`, which is the time spent reading the headers of the response. While `timeout` will set the `Timeout`, which sets the timeout for the entire connection.

This would also get rid of the deprecation warning. Because this now sets a different value and there is no deprecation warning, I'm not sure this is the right thing to do, but it does allow a user to correctly load a config. The other option may be not to import HTTPClientConfig and have that locally?

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

fixes: #15076
