### PR TITLE
refactor(agent.serializer): Change serializer from influx to json in test mode

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -16,7 +16,7 @@ import (
 	"github.com/influxdata/telegraf/internal/snmp"
 	"github.com/influxdata/telegraf/models"
 	"github.com/influxdata/telegraf/plugins/processors"
-	"github.com/influxdata/telegraf/plugins/serializers/influx"
+	"github.com/influxdata/telegraf/plugins/serializers/json"
 )
 
 // Agent runs a set of plugins.
@@ -974,7 +974,8 @@ func (a *Agent) Test(ctx context.Context, wait time.Duration) error {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		s := &influx.Serializer{SortFields: true}
+		s := &json.Serializer{}
+		s.Init()
 		for metric := range src {
 			octets, err := s.Serialize(metric)
 			if err == nil {


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

Change serializer from influx to json in test mode.
In test mode, telegraf shows generated metric to stdout instead of the output plugin for user's convenience.
Because the influx serializer includes logic that generates the line protocol, you see results that are different from the metrics generated by actual telegraf, causing user confusion.

For example, telegraf metric can have empty string as tag value but influx line protocol do not allowed empty string as tag value.

All telegraf's plugin operate based on telegraf metric not influx line protocol, so i think it is appropriate to show it as is, and the json serializer best suits that purpose.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
