### PR TITLE
feat(processors.timestamp): Introduce timestamp processor

### DIFF
--- a/plugins/processors/all/processors.go
+++ b/plugins/processors/all/processors.go
@@ -1,0 +1,5 @@
+//go:build !custom || processors || processors.timestamp
+
+package all
+
+import _ "github.com/influxdata/telegraf/plugins/processors/timestamp" // register plugin

--- a/plugins/processors/timestamp/README.md
+++ b/plugins/processors/timestamp/README.md
@@ -20,7 +20,7 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## Timestamp key to convert
   ## Specify the field name that contains the timestamp to convert. The result
   ## will replace the current field value.
-  source_timestamp_field = ""
+  field = ""
 
   ## Timestamp Format
   ## This defines the time layout used to interpret the source timestamp field.
@@ -28,11 +28,6 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## "reference time". For more information on Go "reference time". For more
   ## see: https://golang.org/pkg/time/#Time.Format
   source_timestamp_format = ""
-
-  ## Target timestamp format
-  ## This defines the destination timestmap format. It also can accept either
-  ## `unix`, `unix_ms`, `unix_us`, `unix_ns`, or a time in Go "reference time".
-  destination_timestamp_format = ""
 
   ## Timestamp Timezone
   ## Source timestamp timezone. If not set, assumed to be in UTC.
@@ -42,6 +37,20 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ##   3. "America/New_York"  -- Unix TZ values like those found in
   ##        https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
   # source_timestamp_timezone = ""
+
+  ## Target timestamp format
+  ## This defines the destination timestmap format. It also can accept either
+  ## `unix`, `unix_ms`, `unix_us`, `unix_ns`, or a time in Go "reference time".
+  destination_timestamp_format = ""
+
+  ## Target Timestamp Timezone
+  ## Source timestamp timezone. If not set, assumed to be in UTC.
+  ## Options are as follows:
+  ##   1. UTC                 -- or unspecified will return timestamp in UTC
+  ##   2. Local               -- interpret based on machine localtime
+  ##   3. "America/New_York"  -- Unix TZ values like those found in
+  ##        https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+  # destination_timestamp_timezone = ""
 ```
 
 ## Example

--- a/plugins/processors/timestamp/README.md
+++ b/plugins/processors/timestamp/README.md
@@ -1,0 +1,89 @@
+# Timestamp Processor Plugin
+
+Use the timestamp processor to parse fields containing timestamps into
+timestamps of other formats.
+
+## Global configuration options <!-- @/docs/includes/plugin_config.md -->
+
+In addition to the plugin-specific configuration settings, plugins support
+additional global and plugin configuration settings. These settings are used to
+modify metrics, tags, and field or create aliases and configure ordering, etc.
+See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
+
+[CONFIGURATION.md]: ../../../docs/CONFIGURATION.md#plugins
+
+## Configuration
+
+```toml @sample.conf
+# Convert a timestamp field to other timestamp format
+[[processors.timestamp]]
+  ## Timestamp key to convert
+  ## Specify the field name that contains the timestamp to convert. The result
+  ## will replace the current field value.
+  source_timestamp_field = ""
+
+  ## Timestamp Format
+  ## This defines the time layout used to interpret the source timestamp field.
+  ## The time must be `unix`, `unix_ms`, `unix_us`, `unix_ns`, or a time in Go
+  ## "reference time". For more information on Go "reference time". For more
+  ## see: https://golang.org/pkg/time/#Time.Format
+  source_timestamp_format = ""
+
+  ## Target timestamp format
+  ## This defines the destination timestmap format. It also can accept either
+  ## `unix`, `unix_ms`, `unix_us`, `unix_ns`, or a time in Go "reference time".
+  destination_timestamp_format = ""
+
+  ## Timestamp Timezone
+  ## Source timestamp timezone. If not set, assumed to be in UTC.
+  ## Options are as follows:
+  ##   1. UTC                 -- or unspecified will return timestamp in UTC
+  ##   2. Local               -- interpret based on machine localtime
+  ##   3. "America/New_York"  -- Unix TZ values like those found in
+  ##        https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+  # source_timestamp_timezone = ""
+```
+
+## Example
+
+Convert a timestamp to unix timestamp:
+
+```toml
+[[processors.timestamp]]
+  source_timestamp_field = "timestamp"
+  source_timestamp_format = "2006-01-02T15:04:05.999999999Z"
+  destination_timestamp_format = "unix"
+```
+
+```diff
+- metric value=42i,timestamp="2024-03-04T10:10:32.123456Z" 1560540094000000000
++ metric value=42i,timestamp=1709547032 1560540094000000000
+```
+
+Convert the same timestamp to a nanosecond unix timestamp:
+
+```toml
+[[processors.timestamp]]
+  source_timestamp_field = "timestamp"
+  source_timestamp_format = "2006-01-02T15:04:05.999999999Z"
+  destination_timestamp_format = "unix_ns"
+```
+
+```diff
+- metric value=42i,timestamp="2024-03-04T10:10:32.123456789Z" 1560540094000000000
++ metric value=42i,timestamp=1709547032123456789 1560540094000000000
+```
+
+Convert the timestamp to another timestamp format:
+
+```toml
+[[processors.timestamp]]
+  source_timestamp_field = "timestamp"
+  source_timestamp_format = "2006-01-02T15:04:05.999999999Z"
+  destination_timestamp_format = "2006-01-02T15:04"
+```
+
+```diff
+- metric value=42i,timestamp="2024-03-04T10:10:32.123456Z" 1560540094000000000
++ metric value=42i,timestamp="2024-03-04T10:10" 1560540094000000000
+```

--- a/plugins/processors/timestamp/sample.conf
+++ b/plugins/processors/timestamp/sample.conf
@@ -3,7 +3,7 @@
   ## Timestamp key to convert
   ## Specify the field name that contains the timestamp to convert. The result
   ## will replace the current field value.
-  source_timestamp_field = ""
+  field = ""
 
   ## Timestamp Format
   ## This defines the time layout used to interpret the source timestamp field.
@@ -11,11 +11,6 @@
   ## "reference time". For more information on Go "reference time". For more
   ## see: https://golang.org/pkg/time/#Time.Format
   source_timestamp_format = ""
-
-  ## Target timestamp format
-  ## This defines the destination timestmap format. It also can accept either
-  ## `unix`, `unix_ms`, `unix_us`, `unix_ns`, or a time in Go "reference time".
-  destination_timestamp_format = ""
 
   ## Timestamp Timezone
   ## Source timestamp timezone. If not set, assumed to be in UTC.
@@ -25,3 +20,17 @@
   ##   3. "America/New_York"  -- Unix TZ values like those found in
   ##        https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
   # source_timestamp_timezone = ""
+
+  ## Target timestamp format
+  ## This defines the destination timestmap format. It also can accept either
+  ## `unix`, `unix_ms`, `unix_us`, `unix_ns`, or a time in Go "reference time".
+  destination_timestamp_format = ""
+
+  ## Target Timestamp Timezone
+  ## Source timestamp timezone. If not set, assumed to be in UTC.
+  ## Options are as follows:
+  ##   1. UTC                 -- or unspecified will return timestamp in UTC
+  ##   2. Local               -- interpret based on machine localtime
+  ##   3. "America/New_York"  -- Unix TZ values like those found in
+  ##        https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+  # destination_timestamp_timezone = ""

--- a/plugins/processors/timestamp/sample.conf
+++ b/plugins/processors/timestamp/sample.conf
@@ -1,0 +1,27 @@
+# Convert a timestamp field to other timestamp format
+[[processors.timestamp]]
+  ## Timestamp key to convert
+  ## Specify the field name that contains the timestamp to convert. The result
+  ## will replace the current field value.
+  source_timestamp_field = ""
+
+  ## Timestamp Format
+  ## This defines the time layout used to interpret the source timestamp field.
+  ## The time must be `unix`, `unix_ms`, `unix_us`, `unix_ns`, or a time in Go
+  ## "reference time". For more information on Go "reference time". For more
+  ## see: https://golang.org/pkg/time/#Time.Format
+  source_timestamp_format = ""
+
+  ## Target timestamp format
+  ## This defines the destination timestmap format. It also can accept either
+  ## `unix`, `unix_ms`, `unix_us`, `unix_ns`, or a time in Go "reference time".
+  destination_timestamp_format = ""
+
+  ## Timestamp Timezone
+  ## Source timestamp timezone. If not set, assumed to be in UTC.
+  ## Options are as follows:
+  ##   1. UTC                 -- or unspecified will return timestamp in UTC
+  ##   2. Local               -- interpret based on machine localtime
+  ##   3. "America/New_York"  -- Unix TZ values like those found in
+  ##        https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+  # source_timestamp_timezone = ""

--- a/plugins/processors/timestamp/timestamp.go
+++ b/plugins/processors/timestamp/timestamp.go
@@ -1,0 +1,122 @@
+//go:generate ../../../tools/readme_config_includer/generator
+package timestamp
+
+import (
+	_ "embed"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/internal"
+	"github.com/influxdata/telegraf/plugins/processors"
+)
+
+//go:embed sample.conf
+var sampleConfig string
+
+type Timestamp struct {
+	SourceField       string `toml:"source_timestamp_field"`
+	SourceFormat      string `toml:"source_timestamp_format"`
+	SourceTimezone    string `toml:"source_timestamp_timezone"`
+	DestinationFormat string `toml:"destination_timestamp_format"`
+
+	location *time.Location
+}
+
+func (*Timestamp) SampleConfig() string {
+	return sampleConfig
+}
+
+func (t *Timestamp) Init() error {
+	switch t.SourceFormat {
+	case "":
+		return errors.New("source_timestamp_format is required")
+	case "unix", "unix_ms", "unix_us", "unix_ns":
+	default:
+		if time.Now().Format(t.SourceFormat) == t.SourceFormat {
+			return fmt.Errorf("invalid timestamp format %q", t.SourceFormat)
+		}
+	}
+
+	switch t.DestinationFormat {
+	case "":
+		return errors.New("source_timestamp_format is required")
+	case "unix", "unix_ms", "unix_us", "unix_ns":
+	default:
+		if time.Now().Format(t.DestinationFormat) == t.DestinationFormat {
+			return fmt.Errorf("invalid timestamp format %q", t.DestinationFormat)
+		}
+	}
+
+	// LoadLocation returns UTC if timezone is the empty string.
+	var err error
+	t.location, err = time.LoadLocation(t.SourceTimezone)
+	return err
+}
+
+func (t *Timestamp) Apply(in ...telegraf.Metric) []telegraf.Metric {
+	for _, point := range in {
+		if field, ok := point.GetField(t.SourceField); ok {
+			var timestamp time.Time
+			switch t.SourceFormat {
+			case "unix":
+				ts, err := internal.ToInt64(field)
+				if err != nil {
+					continue
+				}
+				timestamp = time.Unix(ts, 0)
+			case "unix_ms":
+				ts, err := internal.ToInt64(field)
+				if err != nil {
+					continue
+				}
+				timestamp = time.UnixMilli(ts)
+			case "unix_us":
+				ts, err := internal.ToInt64(field)
+				if err != nil {
+					continue
+				}
+				timestamp = time.UnixMilli(ts)
+			case "unix_ns":
+				ts, err := internal.ToInt64(field)
+				if err != nil {
+					continue
+				}
+				timestamp = time.Unix(0, ts)
+			default:
+				stringField, err := internal.ToString(field)
+				if err != nil {
+					continue
+				}
+				timestamp, err = time.ParseInLocation(t.SourceFormat, stringField, t.location)
+				if err != nil {
+					continue
+				}
+			}
+
+			switch t.DestinationFormat {
+			case "unix":
+				point.AddField(t.SourceField, timestamp.Unix())
+			case "unix_ms":
+				point.AddField(t.SourceField, timestamp.UnixNano()/1000000)
+			case "unix_us":
+				point.AddField(t.SourceField, timestamp.UnixNano()/1000)
+			case "unix_ns":
+				point.AddField(t.SourceField, timestamp.UnixNano())
+			default:
+				point.AddField(t.SourceField, timestamp.Format(t.DestinationFormat))
+			}
+		}
+	}
+
+	return in
+}
+
+func init() {
+	processors.Add("timestamp", func() telegraf.Processor {
+		return &Timestamp{
+			SourceTimezone: "UTC",
+		}
+	})
+}

--- a/plugins/processors/timestamp/timestamp_test.go
+++ b/plugins/processors/timestamp/timestamp_test.go
@@ -22,7 +22,7 @@ func TestCases(t *testing.T) {
 		{
 			name: "field does not exist",
 			timestamp: Timestamp{
-				SourceField:       "timestamp",
+				Field:             "timestamp",
 				SourceFormat:      "2006-01-02T15:04:05Z",
 				DestinationFormat: "unix",
 			},
@@ -32,7 +32,7 @@ func TestCases(t *testing.T) {
 		{
 			name: "field to unix",
 			timestamp: Timestamp{
-				SourceField:       "timestamp",
+				Field:             "timestamp",
 				SourceFormat:      "2006-01-02T15:04:05Z",
 				DestinationFormat: "unix",
 			},
@@ -52,7 +52,7 @@ func TestCases(t *testing.T) {
 		{
 			name: "field to unix_ms",
 			timestamp: Timestamp{
-				SourceField:       "timestamp",
+				Field:             "timestamp",
 				SourceFormat:      "2006-01-02T15:04:05Z",
 				DestinationFormat: "unix_ms",
 			},
@@ -72,7 +72,7 @@ func TestCases(t *testing.T) {
 		{
 			name: "field to unix_us",
 			timestamp: Timestamp{
-				SourceField:       "timestamp",
+				Field:             "timestamp",
 				SourceFormat:      "2006-01-02T15:04:05Z",
 				DestinationFormat: "unix_us",
 			},
@@ -92,7 +92,7 @@ func TestCases(t *testing.T) {
 		{
 			name: "field to unix_ns",
 			timestamp: Timestamp{
-				SourceField:       "timestamp",
+				Field:             "timestamp",
 				SourceFormat:      "2006-01-02T15:04:05Z",
 				DestinationFormat: "unix_ns",
 			},
@@ -112,7 +112,7 @@ func TestCases(t *testing.T) {
 		{
 			name: "field to custom format",
 			timestamp: Timestamp{
-				SourceField:       "timestamp",
+				Field:             "timestamp",
 				SourceFormat:      "2006-01-02T15:04:05Z",
 				DestinationFormat: "2006-01-02T15:04:05",
 			},
@@ -132,7 +132,7 @@ func TestCases(t *testing.T) {
 		{
 			name: "unix_ns to unix",
 			timestamp: Timestamp{
-				SourceField:       "timestamp",
+				Field:             "timestamp",
 				SourceFormat:      "unix_ns",
 				DestinationFormat: "unix",
 			},

--- a/plugins/processors/timestamp/timestamp_test.go
+++ b/plugins/processors/timestamp/timestamp_test.go
@@ -1,0 +1,164 @@
+package timestamp
+
+import (
+	"testing"
+	"time"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/metric"
+	"github.com/influxdata/telegraf/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCases(t *testing.T) {
+	type testcase struct {
+		name      string
+		timestamp Timestamp
+		input     telegraf.Metric
+		expected  telegraf.Metric
+	}
+
+	testcases := []testcase{
+		{
+			name: "field does not exist",
+			timestamp: Timestamp{
+				SourceField:       "timestamp",
+				SourceFormat:      "2006-01-02T15:04:05Z",
+				DestinationFormat: "unix",
+			},
+			input:    metric.New("test", map[string]string{}, map[string]any{}, time.Unix(0, 0)),
+			expected: metric.New("test", map[string]string{}, map[string]any{}, time.Unix(0, 0)),
+		},
+		{
+			name: "field to unix",
+			timestamp: Timestamp{
+				SourceField:       "timestamp",
+				SourceFormat:      "2006-01-02T15:04:05Z",
+				DestinationFormat: "unix",
+			},
+			input: metric.New(
+				"test",
+				map[string]string{},
+				map[string]any{"timestamp": "2024-03-04T10:10:32.123456789Z"},
+				time.Unix(0, 0),
+			),
+			expected: metric.New(
+				"test",
+				map[string]string{},
+				map[string]any{"timestamp": int64(1709547032)},
+				time.Unix(0, 0),
+			),
+		},
+		{
+			name: "field to unix_ms",
+			timestamp: Timestamp{
+				SourceField:       "timestamp",
+				SourceFormat:      "2006-01-02T15:04:05Z",
+				DestinationFormat: "unix_ms",
+			},
+			input: metric.New(
+				"test",
+				map[string]string{},
+				map[string]any{"timestamp": "2024-03-04T10:10:32.123456789Z"},
+				time.Unix(0, 0),
+			),
+			expected: metric.New(
+				"test",
+				map[string]string{},
+				map[string]any{"timestamp": int64(1709547032123)},
+				time.Unix(0, 0),
+			),
+		},
+		{
+			name: "field to unix_us",
+			timestamp: Timestamp{
+				SourceField:       "timestamp",
+				SourceFormat:      "2006-01-02T15:04:05Z",
+				DestinationFormat: "unix_us",
+			},
+			input: metric.New(
+				"test",
+				map[string]string{},
+				map[string]any{"timestamp": "2024-03-04T10:10:32.123456789Z"},
+				time.Unix(0, 0),
+			),
+			expected: metric.New(
+				"test",
+				map[string]string{},
+				map[string]any{"timestamp": int64(1709547032123456)},
+				time.Unix(0, 0),
+			),
+		},
+		{
+			name: "field to unix_ns",
+			timestamp: Timestamp{
+				SourceField:       "timestamp",
+				SourceFormat:      "2006-01-02T15:04:05Z",
+				DestinationFormat: "unix_ns",
+			},
+			input: metric.New(
+				"test",
+				map[string]string{},
+				map[string]any{"timestamp": "2024-03-04T10:10:32.123456789Z"},
+				time.Unix(0, 0),
+			),
+			expected: metric.New(
+				"test",
+				map[string]string{},
+				map[string]any{"timestamp": int64(1709547032123456789)},
+				time.Unix(0, 0),
+			),
+		},
+		{
+			name: "field to custom format",
+			timestamp: Timestamp{
+				SourceField:       "timestamp",
+				SourceFormat:      "2006-01-02T15:04:05Z",
+				DestinationFormat: "2006-01-02T15:04:05",
+			},
+			input: metric.New(
+				"test",
+				map[string]string{},
+				map[string]any{"timestamp": "2024-03-04T10:10:32.123456789Z"},
+				time.Unix(0, 0),
+			),
+			expected: metric.New(
+				"test",
+				map[string]string{},
+				map[string]any{"timestamp": "2024-03-04T10:10:32"},
+				time.Unix(0, 0),
+			),
+		},
+		{
+			name: "unix_ns to unix",
+			timestamp: Timestamp{
+				SourceField:       "timestamp",
+				SourceFormat:      "unix_ns",
+				DestinationFormat: "unix",
+			},
+			input: metric.New(
+				"test",
+				map[string]string{},
+				map[string]any{"timestamp": int64(1709547032123456789)},
+				time.Unix(0, 0),
+			),
+			expected: metric.New(
+				"test",
+				map[string]string{},
+				map[string]any{"timestamp": int64(1709547032)},
+				time.Unix(0, 0),
+			),
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			processor := tc.timestamp
+			require.NoError(t, processor.Init())
+
+			output := processor.Apply(tc.input)
+			require.Len(t, output, 1)
+			testutil.RequireMetricsEqual(t, []telegraf.Metric{tc.expected}, output)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
The following introduces a new timestamp processor. This allows a user to specify a field which contains a timestamp and convert it from one format to another. Traditionally telegraf assumes data has a single timestamp and uses that as the timestamp for the metric itself. However, if a user's data contains additional timestamps that they also wish to parse into a different format, there was no existing method for that.

The date processor exists today to take a metric's timestamp and add a tag or field with a subset of that timestamp. Trying to adapt that config to do both features made for a complex configuration that was not straightforward and error prone.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #10524
