### PR TITLE
feat(inputs.http_response): Add cookie authentication

### DIFF
--- a/plugins/inputs/http_response/README.md
+++ b/plugins/inputs/http_response/README.md
@@ -106,7 +106,26 @@ to use them.
 
   ## Interface to use when dialing an address
   # interface = "eth0"
+
+  ## Optional Cookie authentication
+  # cookie_auth_url = "https://localhost/authMe"
+  # cookie_auth_method = "POST"
+  # cookie_auth_username = "username"
+  # cookie_auth_password = "pa$$word"
+  # cookie_auth_body = '{"username": "user", "password": "pa$$word", "authenticate": "me"}'
+  ## cookie_auth_renewal not set or set to "0" will auth once and never renew the cookie
+  # cookie_auth_renewal = "5m"
 ```
+
+### Optional Cookie Authentication Settings:
+
+The optional Cookie Authentication Settings will retrieve a cookie from the
+given authorization endpoint, and use it in subsequent API requests. This is
+useful for services that do not provide OAuth or Basic Auth authentication,
+e.g. the [Tesla Powerwall API](https://www.tesla.com/support/energy/powerwall/own/monitoring-from-home-network),
+which uses a Cookie Auth Body to retrieve an authorization cookie. The Cookie
+Auth Renewal interval will renew the authorization by retrieving a new cookie
+at the given interval.
 
 ## Metrics
 

--- a/plugins/inputs/http_response/README.md
+++ b/plugins/inputs/http_response/README.md
@@ -117,16 +117,6 @@ to use them.
   # cookie_auth_renewal = "5m"
 ```
 
-### Optional Cookie Authentication Settings:
-
-The optional Cookie Authentication Settings will retrieve a cookie from the
-given authorization endpoint, and use it in subsequent API requests. This is
-useful for services that do not provide OAuth or Basic Auth authentication,
-e.g. the [Tesla Powerwall API](https://www.tesla.com/support/energy/powerwall/own/monitoring-from-home-network),
-which uses a Cookie Auth Body to retrieve an authorization cookie. The Cookie
-Auth Renewal interval will renew the authorization by retrieving a new cookie
-at the given interval.
-
 ## Metrics
 
 - http_response
@@ -169,3 +159,14 @@ a successful connection.
 ```text
 http_response,method=GET,result=success,server=http://github.com,status_code=200 content_length=87878i,http_response_code=200i,response_time=0.937655534,result_code=0i,result_type="success" 1565839598000000000
 ```
+
+## Optional Cookie Authentication Settings
+
+The optional Cookie Authentication Settings will retrieve a cookie from the
+given authorization endpoint, and use it in subsequent API requests.  This is
+useful for services that do not provide OAuth or Basic Auth authentication,
+e.g. the [Tesla Powerwall API][tesla], which uses a Cookie Auth Body to retrieve
+an authorization cookie.  The Cookie Auth Renewal interval will renew the
+authorization by retrieving a new cookie at the given interval.
+
+[tesla]: https://www.tesla.com/support/energy/powerwall/own/monitoring-from-home-network

--- a/plugins/inputs/http_response/http_response.go
+++ b/plugins/inputs/http_response/http_response.go
@@ -16,9 +16,11 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/benbjohnson/clock"
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/internal"
+	"github.com/influxdata/telegraf/plugins/common/cookie"
 	"github.com/influxdata/telegraf/plugins/common/tls"
 	"github.com/influxdata/telegraf/plugins/inputs"
 )
@@ -55,6 +57,7 @@ type HTTPResponse struct {
 	Username config.Secret `toml:"username"`
 	Password config.Secret `toml:"password"`
 	tls.ClientConfig
+	cookie.CookieAuthConfig
 
 	Log telegraf.Logger
 
@@ -114,6 +117,13 @@ func (h *HTTPResponse) createHTTPClient() (*http.Client, error) {
 			return http.ErrUseLastResponse
 		}
 	}
+
+	if h.CookieAuthConfig.URL != "" {
+		if err := h.CookieAuthConfig.Start(client, h.Log, clock.New()); err != nil {
+			return nil, err
+		}
+	}
+
 	return client, nil
 }
 

--- a/plugins/inputs/http_response/sample.conf
+++ b/plugins/inputs/http_response/sample.conf
@@ -81,3 +81,12 @@
 
   ## Interface to use when dialing an address
   # interface = "eth0"
+
+  ## Optional Cookie authentication
+  # cookie_auth_url = "https://localhost/authMe"
+  # cookie_auth_method = "POST"
+  # cookie_auth_username = "username"
+  # cookie_auth_password = "pa$$word"
+  # cookie_auth_body = '{"username": "user", "password": "pa$$word", "authenticate": "me"}'
+  ## cookie_auth_renewal not set or set to "0" will auth once and never renew the cookie
+  # cookie_auth_renewal = "5m"


### PR DESCRIPTION
## Summary
Add http cookie auth to the http_response input plugin, similar to the http input plugin

## Checklist

- [X] No AI generated code was used in this PR

## Related issues

resolves #11913 
