### PR TITLE
chore(inputs.diskio): Add udev properties only if available

### DIFF
--- a/plugins/inputs/diskio/diskio_linux.go
+++ b/plugins/inputs/diskio/diskio_linux.go
@@ -59,7 +59,7 @@ func (d *DiskIO) diskInfo(devName string) (map[string]string, error) {
 		return nil, err
 	}
 
-	// Read additional device properties
+	// Read additional (optional) device properties
 	var sysBlockPath string
 	if ok && len(ic.sysBlockPath) > 0 {
 		// We can reuse the /sys block path from a "previous" entry.
@@ -67,17 +67,13 @@ func (d *DiskIO) diskInfo(devName string) (map[string]string, error) {
 		sysBlockPath = ic.sysBlockPath
 	} else {
 		sysBlockPath = "/sys/block/" + devName
-		if _, err := os.Stat(sysBlockPath); err != nil {
-			// Giving up, cannot retrieve additional info
-			return nil, err
-		}
 	}
+
 	devInfo, err := readDevData(sysBlockPath)
-	if err != nil {
-		return nil, err
-	}
-	for k, v := range devInfo {
-		info[k] = v
+	if err == nil {
+		for k, v := range devInfo {
+			info[k] = v
+		}
 	}
 
 	d.infoCache[devName] = diskInfoCache{

--- a/plugins/inputs/diskio/diskio_linux.go
+++ b/plugins/inputs/diskio/diskio_linux.go
@@ -74,6 +74,8 @@ func (d *DiskIO) diskInfo(devName string) (map[string]string, error) {
 		for k, v := range devInfo {
 			info[k] = v
 		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return nil, err
 	}
 
 	d.infoCache[devName] = diskInfoCache{


### PR DESCRIPTION
## Summary

Avoid spamming the log with warnings if optional udev properties are not available.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #15113 
