### PR TITLE
fix(inputs.systemd_units): Reconnect if connection is lost

### DIFF
--- a/plugins/inputs/systemd_units/systemd_units_test.go
+++ b/plugins/inputs/systemd_units/systemd_units_test.go
@@ -209,6 +209,7 @@ func TestListFiles(t *testing.T) {
 			plugin := &SystemdUnits{
 				Pattern: "examp*",
 				Timeout: config.Duration(time.Second),
+				Log:     testutil.Logger{},
 			}
 			require.NoError(t, plugin.Init())
 
@@ -522,6 +523,7 @@ func TestShow(t *testing.T) {
 				Pattern: "examp*",
 				Details: true,
 				Timeout: config.Duration(time.Second),
+				Log:     testutil.Logger{},
 			}
 			require.NoError(t, plugin.Init())
 
@@ -715,6 +717,7 @@ func TestMultiInstance(t *testing.T) {
 			plugin := &SystemdUnits{
 				Pattern: tt.pattern,
 				Timeout: config.Duration(time.Second),
+				Log:     testutil.Logger{},
 			}
 			require.NoError(t, plugin.Init())
 
@@ -825,7 +828,7 @@ func (c *fakeClient) fixPropertyTypes() {
 }
 
 func (c *fakeClient) Connected() bool {
-	return !c.connected
+	return c.connected
 }
 
 func (c *fakeClient) Close() {


### PR DESCRIPTION
## Summary

This PR tries to reconnect to the systemd DBUS daemon in case the connection is lost.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #15111 
