### PR TITLE
fix(inputs.win_eventlog): Handle empty query correctly

### DIFF
--- a/plugins/inputs/win_eventlog/win_eventlog.go
+++ b/plugins/inputs/win_eventlog/win_eventlog.go
@@ -62,6 +62,10 @@ func (w *WinEventLog) Init() error {
 		w.subscriptionFlag = EvtSubscribeStartAtOldestRecord
 	}
 
+	if w.Query == "" {
+		w.Query = "*"
+	}
+
 	bookmark, err := _EvtCreateBookmark(nil)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary

And empty query should return all results, so this PR set a suitable default, i.e. `*`.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #15115 
