### PR TITLE
docs(processors.scale): Correct example configuration

### DIFF
--- a/plugins/processors/scale/README.md
+++ b/plugins/processors/scale/README.md
@@ -50,15 +50,15 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
     ##   - fields: a list of field names (or filters) to apply this scaling to
 
     ## Example: Scaling with minimum and maximum values
-    # [processors.scale.scaling]
-    #    input_minimum = 0
-    #    input_maximum = 1
-    #    output_minimum = 0
-    #    output_maximum = 100
+    # [[processors.scale.scaling]]
+    #    input_minimum = 0.0
+    #    input_maximum = 1.0
+    #    output_minimum = 0.0
+    #    output_maximum = 100.0
     #    fields = ["temperature1", "temperature2"]
 
     ## Example: Scaling with factor and offset
-    # [processors.scale.scaling]
+    # [[processors.scale.scaling]]
     #    factor = 10.0
     #    offset = -5.0
     #    fields = ["voltage*"]
@@ -69,11 +69,11 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 The example below uses these scaling values:
 
 ```toml
-[processors.scale.scaling]
-    input_minimum = 0
-    input_maximum = 50
-    output_minimum = 50
-    output_maximum = 100
+[[processors.scale.scaling]]
+    input_minimum = 0.0
+    input_maximum = 50.0
+    output_minimum = 50.0
+    output_maximum = 100.0
     fields = ["cpu"]
 ```
 

--- a/plugins/processors/scale/sample.conf
+++ b/plugins/processors/scale/sample.conf
@@ -13,15 +13,15 @@
     ##   - fields: a list of field names (or filters) to apply this scaling to
 
     ## Example: Scaling with minimum and maximum values
-    # [processors.scale.scaling]
-    #    input_minimum = 0
-    #    input_maximum = 1
-    #    output_minimum = 0
-    #    output_maximum = 100
+    # [[processors.scale.scaling]]
+    #    input_minimum = 0.0
+    #    input_maximum = 1.0
+    #    output_minimum = 0.0
+    #    output_maximum = 100.0
     #    fields = ["temperature1", "temperature2"]
 
     ## Example: Scaling with factor and offset
-    # [processors.scale.scaling]
+    # [[processors.scale.scaling]]
     #    factor = 10.0
     #    offset = -5.0
     #    fields = ["voltage*"]


### PR DESCRIPTION
## Summary
The example code caused 2 different types of errors like this

> error parsing scale, unmarshalling failed: line 19: cannot unmarshal TOML table into []scale.Scaling (need struct or map)
> error parsing scale, unmarshalling failed: line 22: (scale.Scaling.OutMin) cannot unmarshal TOML integer into float64


## Checklist
- [x] No AI generated code was used in this PR

## Related issues

resolves #15134
