### PR TITLE
feat(inputs.sqlserver): Add persistent version store metrics

### DIFF
--- a/plugins/inputs/sqlserver/README.md
+++ b/plugins/inputs/sqlserver/README.md
@@ -450,6 +450,7 @@ ensure to check additional setup section in this documentation.
 - SQLServerAvailabilityReplicaStates: Collects availability replica state information from `sys.dm_hadr_availability_replica_states` for a High Availability / Disaster Recovery (HADR) setup
 - SQLServerDatabaseReplicaStates: Collects database replica state information from `sys.dm_hadr_database_replica_states` for a High Availability / Disaster Recovery (HADR) setup
 - SQLServerRecentBackups: Collects latest full, differential and transaction log backup date and size from `msdb.dbo.backupset`
+- SQLServerPersistentVersionStore: Collects persistent version store information from `sys.dm_tran_persistent_version_store_stats` for databases with Accelerated Database Recovery enabled
 
 ### Output Measures
 

--- a/plugins/inputs/sqlserver/sqlserver.go
+++ b/plugins/inputs/sqlserver/sqlserver.go
@@ -151,6 +151,7 @@ func (s *SQLServer) initQueries() error {
 		queries["SQLServerDatabaseReplicaStates"] =
 			Query{ScriptName: "SQLServerDatabaseReplicaStates", Script: sqlServerDatabaseReplicaStates, ResultByRow: false}
 		queries["SQLServerRecentBackups"] = Query{ScriptName: "SQLServerRecentBackups", Script: sqlServerRecentBackups, ResultByRow: false}
+		queries["SQLServerPersistentVersionStore"] = Query{ScriptName: "SQLServerPersistentVersionStore", Script: sqlServerPersistentVersionStore, ResultByRow: false}
 	} else {
 		// If this is an AzureDB instance, grab some extra metrics
 		if s.AzureDB {

--- a/plugins/inputs/sqlserver/sqlserverqueries.go
+++ b/plugins/inputs/sqlserver/sqlserverqueries.go
@@ -15,6 +15,7 @@ import (
 //   - 1300 --> SQL Server 2016
 //   - 1400 --> SQL Server 2017
 //   - 1500 --> SQL Server 2019
+//   - 1600 --> SQL Server 2022
 
 // Thanks Bob Ward (http://aka.ms/bobwardms)
 // and the folks at Stack Overflow
@@ -1444,4 +1445,37 @@ LEFT JOIN BackupsWithSize bf ON (d.name = bf.[Database] AND (bf.Type = 'Full' OR
 LEFT JOIN BackupsWithSize bd ON (d.name = bd.[Database] AND (bd.Type = 'Differential' OR bd.Type IS NULL))
 LEFT JOIN BackupsWithSize bt ON (d.name = bt.[Database] AND (bt.Type = 'Transaction Log' OR bt.Type IS NULL))
 WHERE d.name <> 'tempdb' AND d.source_database_id IS NULL
+`
+
+// Collects persistent version store information from `sys.dm_tran_persistent_version_store_stats` for Databases where Accelerated Database Recovery is enabled.
+// ADR was added in SQL Server 2019
+const sqlServerPersistentVersionStore string = `
+SET DEADLOCK_PRIORITY -10;
+IF SERVERPROPERTY('EngineEdition') NOT IN (2,3,4) BEGIN /*NOT IN Standard,Enterpris,Express*/
+    DECLARE @ErrorMessage AS nvarchar(500) = 'Telegraf - Connection string Server:'+ @@ServerName + ',Database:' + DB_NAME() +' is not a SQL Server Standard,Enterprise or Express. Check the database_type parameter in the telegraf configuration.';
+    RAISERROR (@ErrorMessage,11,1)
+    RETURN
+END;
+	 
+DECLARE
+	    
+    @MajorMinorVersion AS int = CAST(PARSENAME(CAST(SERVERPROPERTY('ProductVersion') AS nvarchar),4) AS int)*100 + CAST(PARSENAME(CAST(SERVERPROPERTY('ProductVersion') AS nvarchar),3) AS int)
+	 
+IF @MajorMinorVersion >= 1500 BEGIN
+    SELECT
+		'sqlserver_persistent_version_store_stats' AS [measurement]
+		,REPLACE(@@SERVERNAME,'\',':') AS [sql_instance]
+		,db_name(pvs.database_id) as [database_name]
+		,FILEGROUP_NAME(pvs.pvs_filegroup_id) as [filegroup_name]
+		,d.snapshot_isolation_state_desc
+		,pvs.persistent_version_store_size_kb
+		,pvs.online_index_version_store_size_kb
+		,pvs.current_aborted_transaction_count
+		,pvs.pvs_off_row_page_skipped_low_water_mark
+		,pvs.pvs_off_row_page_skipped_min_useful_xts
+	FROM sys.dm_tran_persistent_version_store_stats pvs
+	INNER JOIN sys.databases d
+		on d.database_id = pvs.database_id
+	    and d.is_accelerated_database_recovery_on = 1
+END;
 `


### PR DESCRIPTION
new measurement: sqlserver_persistent_version_store_stats

## Summary
Accelerated Database Recovery (ADR) was added in SQL Server version 2019 and utilizes the Persistent Version Store to store data. Usage of the storage grows and shrinks with use. Monitoring the size and usage is helpful for understanding overall database size and use distribution, as well as identifying and troubleshooting ADR-related performance problems.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #15136
