### PR TITLE
docs(inputs.jolokia2_agent): Add example configs for table and all table metrics

### DIFF
--- a/plugins/inputs/jolokia2_agent/examples/cassandra.conf
+++ b/plugins/inputs/jolokia2_agent/examples/cassandra.conf
@@ -94,8 +94,7 @@
     tag_keys = ["name", "path", "scope"]
     field_prefix = "$1_"
 
-  # Optional per table and "all" table metrics.
-  # per table produces ~65 metrics per cassandra table
+  # Optional per Table metrics
   #[[inputs.jolokia2_agent.metric]]
   #  name  = "Table"
   #  mbean = "org.apache.cassandra.metrics:name=*,keyspace=*,scope=*,type=Table"

--- a/plugins/inputs/jolokia2_agent/examples/cassandra.conf
+++ b/plugins/inputs/jolokia2_agent/examples/cassandra.conf
@@ -101,6 +101,7 @@
   #  tag_keys = ["name","scope","keyspace"]
   #  field_prefix = "$1_"
 
+  # Optional TableAll metrics
   #[[inputs.jolokia2_agent.metric]]
   #  name  = "TableAll"
   #  mbean = "org.apache.cassandra.metrics:name=*,type=Table"

--- a/plugins/inputs/jolokia2_agent/examples/cassandra.conf
+++ b/plugins/inputs/jolokia2_agent/examples/cassandra.conf
@@ -93,3 +93,17 @@
     mbean = "org.apache.cassandra.metrics:name=*,path=*,scope=*,type=ThreadPools"
     tag_keys = ["name", "path", "scope"]
     field_prefix = "$1_"
+
+  # Optional per table and "all" table metrics.
+  # per table produces ~65 metrics per cassandra table
+  #[[inputs.jolokia2_agent.metric]]
+  #  name  = "Table"
+  #  mbean = "org.apache.cassandra.metrics:name=*,keyspace=*,scope=*,type=Table"
+  #  tag_keys = ["name","scope","keyspace"]
+  #  field_prefix = "$1_"
+
+  #[[inputs.jolokia2_agent.metric]]
+  #  name  = "TableAll"
+  #  mbean = "org.apache.cassandra.metrics:name=*,type=Table"
+  #  tag_keys = ["name"]
+  #  field_prefix = "$1_"


### PR DESCRIPTION

## Summary

#15139 -> pull request to add extra metrics to the example configuration

update the cassandra.conf example jolokia2_agent configuration to include commented out per table and all table metrics configuration.

## Checklist

- [ x ] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #15139 
