### PR TITLE
fix(inputs.modbus): Avoid overflow when calculating with uint16 addresses

### DIFF
--- a/plugins/inputs/modbus/configuration_metric.go
+++ b/plugins/inputs/modbus/configuration_metric.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"hash/maphash"
+	"math"
 
 	"github.com/influxdata/telegraf"
 )
@@ -247,6 +248,11 @@ func (c *ConfigurationPerMetric) newField(def metricFieldDefinition, mdef metric
 		if fieldLength, err = c.determineFieldLength(def.InputType, def.Length); err != nil {
 			return field{}, err
 		}
+	}
+
+	// Check for address overflow
+	if def.Address > math.MaxUint16-fieldLength {
+		return field{}, fmt.Errorf("%w for field %q", errAddressOverflow, def.Name)
 	}
 
 	// Initialize the field

--- a/plugins/inputs/modbus/configuration_request.go
+++ b/plugins/inputs/modbus/configuration_request.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"hash/maphash"
+	"math"
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/models"
@@ -293,6 +294,11 @@ func (c *ConfigurationPerRequest) newFieldFromDefinition(def requestFieldDefinit
 		if fieldLength, err = c.determineFieldLength(def.InputType, def.Length); err != nil {
 			return field{}, err
 		}
+	}
+
+	// Check for address overflow
+	if def.Address > math.MaxUint16-fieldLength {
+		return field{}, fmt.Errorf("%w for field %q", errAddressOverflow, def.Name)
 	}
 
 	// Initialize the field

--- a/plugins/inputs/modbus/modbus.go
+++ b/plugins/inputs/modbus/modbus.go
@@ -25,6 +25,8 @@ var sampleConfigStart string
 //go:embed sample_general_end.conf
 var sampleConfigEnd string
 
+var errAddressOverflow = errors.New("address overflow")
+
 type ModbusWorkarounds struct {
 	AfterConnectPause       config.Duration `toml:"pause_after_connect"`
 	PollPause               config.Duration `toml:"pause_between_requests"`

--- a/plugins/inputs/modbus/request.go
+++ b/plugins/inputs/modbus/request.go
@@ -1,6 +1,7 @@
 package modbus
 
 import (
+	"math"
 	"sort"
 
 	"github.com/influxdata/telegraf"
@@ -33,10 +34,16 @@ func splitMaxBatchSize(g request, maxBatchSize uint16) []request {
 
 		// Initialize the end to a safe value avoiding infinite loops
 		end := g.address + g.length
+		var batchEnd uint16
+		if start >= math.MaxUint16-maxBatchSize {
+			batchEnd = math.MaxUint16
+		} else {
+			batchEnd = start + maxBatchSize
+		}
 		for _, f := range g.fields[idx:] {
 			// If the current field exceeds the batch size we need to split
 			// the request here
-			if f.address+f.length > start+maxBatchSize {
+			if f.address+f.length > batchEnd {
 				break
 			}
 			// End of field still fits into the batch so add it to the request


### PR DESCRIPTION
## Summary

When using addresses at the end of the address range, the batch-limitation calculation might overflow the `uint16` range.  This PR checks the range now before doing the computation to make sure we do not overflow.

Furthermore, users might provide invalid configuration by using an address at the end of the address-range with a too-large data-type in `metric` and `request` configuration-styles. This PR also checks this overflow.
Note: The `register` style is safe as there you explicitly need to specify the addresses.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #15138 
