### PR TITLE
docs(processors.clone): Clarify filtering applies to all metrics

### DIFF
--- a/plugins/processors/clone/README.md
+++ b/plugins/processors/clone/README.md
@@ -13,7 +13,8 @@ aggregators:
 * tags
 
 Select the metrics to modify using the standard [metric
-filtering](../../../docs/CONFIGURATION.md#metric-filtering) options.
+filtering](../../../docs/CONFIGURATION.md#metric-filtering) options. Filtering
+options apply to both the clone and the original.
 
 Values of *name_override*, *name_prefix*, *name_suffix* and already present
 *tags* with conflicting keys will be overwritten. Absent *tags* will be


### PR DESCRIPTION
## Summary
Clarify that metric filtering applies to both the clone and the original

## Checklist
- [x] No AI generated code was used in this PR

## Related issues

resolves #15116