### PR TITLE
feat(inputs.gnmi): Add keepalive settings

### DIFF
--- a/plugins/inputs/gnmi/README.md
+++ b/plugins/inputs/gnmi/README.md
@@ -52,6 +52,26 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## redial in case of failures after
   # redial = "10s"
 
+  ## gRPC Keepalive settings
+  ## See https://pkg.go.dev/google.golang.org/grpc/keepalive
+  ## After a duration of this time if the client doesn't see any activity it
+  ## pings the server to see if the transport is still alive.
+  ## If set and set below 10s, a minimum value of 10s will be used instead.
+  ## If not set, none of the other keepalive values will be configured.
+  # keepalive_time = "10s"
+
+  ## After having pinged for keepalive check, the client waits for a duration
+  ## of Timeout and if no activity is seen even after that the connection is
+  ## closed.
+  ## The current default value in GRPC is 20 seconds.
+  ## keepalive_timeout = "20s"
+
+  ## If true, client sends keepalive pings even with no active RPCs. If false,
+  ## when there are no active RPCs, Time and Timeout will be ignored and no
+  ## keepalive pings will be sent.
+  ## false by default in GRPC
+  # keepalive_permit_without_stream = false
+
   ## gRPC Maximum Message Size
   # max_msg_size = "4MB"
 

--- a/plugins/inputs/gnmi/README.md
+++ b/plugins/inputs/gnmi/README.md
@@ -56,13 +56,13 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## See https://pkg.go.dev/google.golang.org/grpc/keepalive
   ## The client will ping the server to see if the transport is still alive if it has
   ## not see any activity for the given time.
-  ## If set below 10 seconds, a minimum value of 10s will be used instead.
   ## If not set, none of the keep-alive setting (including those below) will be applied.
-  # keepalive_time = "10s"
+  ## If set and set below 10 seconds, the gRPC library will apply a minimum value of 10s will be used instead.
+  # keepalive_time = ""
 
   ## Timeout for seeing any activity after the keep-alive probe was
   ## sent. If no activity is seen the connection is closed.
-  ## keepalive_timeout = "20s"
+  # keepalive_timeout = ""
 
   ## gRPC Maximum Message Size
   # max_msg_size = "4MB"

--- a/plugins/inputs/gnmi/README.md
+++ b/plugins/inputs/gnmi/README.md
@@ -64,12 +64,6 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## sent. If no activity is seen the connection is closed.
   ## keepalive_timeout = "20s"
 
-  ## If true, client sends keepalive pings even with no active RPCs. If false,
-  ## when there are no active RPCs, Time and Timeout will be ignored and no
-  ## keepalive pings will be sent.
-  ## false by default in GRPC
-  # keepalive_permit_without_stream = false
-
   ## gRPC Maximum Message Size
   # max_msg_size = "4MB"
 

--- a/plugins/inputs/gnmi/README.md
+++ b/plugins/inputs/gnmi/README.md
@@ -54,16 +54,14 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
   ## gRPC Keepalive settings
   ## See https://pkg.go.dev/google.golang.org/grpc/keepalive
-  ## After a duration of this time if the client doesn't see any activity it
-  ## pings the server to see if the transport is still alive.
-  ## If set and set below 10s, a minimum value of 10s will be used instead.
-  ## If not set, none of the other keepalive values will be configured.
+  ## The client will ping the server to see if the transport is still alive if it has
+  ## not see any activity for the given time.
+  ## If set below 10 seconds, a minimum value of 10s will be used instead.
+  ## If not set, none of the keep-alive setting (including those below) will be applied.
   # keepalive_time = "10s"
 
-  ## After having pinged for keepalive check, the client waits for a duration
-  ## of Timeout and if no activity is seen even after that the connection is
-  ## closed.
-  ## The current default value in GRPC is 20 seconds.
+  ## Timeout for seeing any activity after the keep-alive probe was
+  ## sent. If no activity is seen the connection is closed.
   ## keepalive_timeout = "20s"
 
   ## If true, client sends keepalive pings even with no active RPCs. If false,

--- a/plugins/inputs/gnmi/gnmi.go
+++ b/plugins/inputs/gnmi/gnmi.go
@@ -38,30 +38,29 @@ var supportedExtensions = []string{"juniper_header"}
 
 // gNMI plugin instance
 type GNMI struct {
-	Addresses                    []string          `toml:"addresses"`
-	Subscriptions                []Subscription    `toml:"subscription"`
-	TagSubscriptions             []TagSubscription `toml:"tag_subscription"`
-	Aliases                      map[string]string `toml:"aliases"`
-	Encoding                     string            `toml:"encoding"`
-	Origin                       string            `toml:"origin"`
-	Prefix                       string            `toml:"prefix"`
-	Target                       string            `toml:"target"`
-	UpdatesOnly                  bool              `toml:"updates_only"`
-	VendorSpecific               []string          `toml:"vendor_specific"`
-	Username                     string            `toml:"username"`
-	Password                     string            `toml:"password"`
-	Redial                       config.Duration   `toml:"redial"`
-	MaxMsgSize                   config.Size       `toml:"max_msg_size"`
-	Trace                        bool              `toml:"dump_responses"`
-	CanonicalFieldNames          bool              `toml:"canonical_field_names"`
-	TrimFieldNames               bool              `toml:"trim_field_names"`
-	GuessPathTag                 bool              `toml:"guess_path_tag" deprecated:"1.30.0;use 'path_guessing_strategy' instead"`
-	GuessPathStrategy            string            `toml:"path_guessing_strategy"`
-	EnableTLS                    bool              `toml:"enable_tls" deprecated:"1.27.0;use 'tls_enable' instead"`
-	KeepaliveTime                config.Duration   `toml:"keepalive_time"`
-	KeepaliveTimeout             config.Duration   `toml:"keepalive_timeout"`
-	KeepalivePermitWithoutStream bool              `toml:"keepalive_permit_without_stream"`
-	Log                          telegraf.Logger   `toml:"-"`
+	Addresses           []string          `toml:"addresses"`
+	Subscriptions       []Subscription    `toml:"subscription"`
+	TagSubscriptions    []TagSubscription `toml:"tag_subscription"`
+	Aliases             map[string]string `toml:"aliases"`
+	Encoding            string            `toml:"encoding"`
+	Origin              string            `toml:"origin"`
+	Prefix              string            `toml:"prefix"`
+	Target              string            `toml:"target"`
+	UpdatesOnly         bool              `toml:"updates_only"`
+	VendorSpecific      []string          `toml:"vendor_specific"`
+	Username            string            `toml:"username"`
+	Password            string            `toml:"password"`
+	Redial              config.Duration   `toml:"redial"`
+	MaxMsgSize          config.Size       `toml:"max_msg_size"`
+	Trace               bool              `toml:"dump_responses"`
+	CanonicalFieldNames bool              `toml:"canonical_field_names"`
+	TrimFieldNames      bool              `toml:"trim_field_names"`
+	GuessPathTag        bool              `toml:"guess_path_tag" deprecated:"1.30.0;use 'path_guessing_strategy' instead"`
+	GuessPathStrategy   string            `toml:"path_guessing_strategy"`
+	EnableTLS           bool              `toml:"enable_tls" deprecated:"1.27.0;use 'tls_enable' instead"`
+	KeepaliveTime       config.Duration   `toml:"keepalive_time"`
+	KeepaliveTimeout    config.Duration   `toml:"keepalive_timeout"`
+	Log                 telegraf.Logger   `toml:"-"`
 	internaltls.ClientConfig
 
 	// Internal state
@@ -240,7 +239,7 @@ func (c *GNMI) Start(acc telegraf.Accumulator) error {
 				ClientParameters: keepalive.ClientParameters{
 					Time:                time.Duration(c.KeepaliveTime),
 					Timeout:             time.Duration(c.KeepaliveTimeout),
-					PermitWithoutStream: c.KeepalivePermitWithoutStream,
+					PermitWithoutStream: false,
 				},
 			}
 			for ctx.Err() == nil {

--- a/plugins/inputs/gnmi/gnmi.go
+++ b/plugins/inputs/gnmi/gnmi.go
@@ -6,13 +6,13 @@ import (
 	_ "embed"
 	"errors"
 	"fmt"
-	"google.golang.org/grpc/keepalive"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/google/gnxi/utils/xpath"
 	gnmiLib "github.com/openconfig/gnmi/proto/gnmi"
+	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/metadata"
 
 	"github.com/influxdata/telegraf"

--- a/plugins/inputs/gnmi/gnmi.go
+++ b/plugins/inputs/gnmi/gnmi.go
@@ -58,10 +58,10 @@ type GNMI struct {
 	GuessPathTag                 bool              `toml:"guess_path_tag" deprecated:"1.30.0;use 'path_guessing_strategy' instead"`
 	GuessPathStrategy            string            `toml:"path_guessing_strategy"`
 	EnableTLS                    bool              `toml:"enable_tls" deprecated:"1.27.0;use 'tls_enable' instead"`
-	Log                          telegraf.Logger   `toml:"-"`
 	KeepaliveTime                config.Duration   `toml:"keepalive_time"`
 	KeepaliveTimeout             config.Duration   `toml:"keepalive_timeout"`
 	KeepalivePermitWithoutStream bool              `toml:"keepalive_permit_without_stream"`
+	Log                          telegraf.Logger   `toml:"-"`
 	internaltls.ClientConfig
 
 	// Internal state

--- a/plugins/inputs/gnmi/handler.go
+++ b/plugins/inputs/gnmi/handler.go
@@ -17,6 +17,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/keepalive"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 
@@ -42,6 +43,7 @@ type handler struct {
 	trimSlash           bool
 	guessPathStrategy   string
 	log                 telegraf.Logger
+	keepalive.ClientParameters
 }
 
 // SubscribeGNMI and extract telemetry data
@@ -60,6 +62,10 @@ func (h *handler) subscribeGNMI(ctx context.Context, acc telegraf.Accumulator, t
 		opts = append(opts, grpc.WithDefaultCallOptions(
 			grpc.MaxCallRecvMsgSize(h.maxMsgSize),
 		))
+	}
+
+	if h.ClientParameters.Time > 0 {
+		opts = append(opts, grpc.WithKeepaliveParams(h.ClientParameters))
 	}
 
 	client, err := grpc.DialContext(ctx, h.address, opts...)

--- a/plugins/inputs/gnmi/sample.conf
+++ b/plugins/inputs/gnmi/sample.conf
@@ -15,16 +15,14 @@
 
   ## gRPC Keepalive settings
   ## See https://pkg.go.dev/google.golang.org/grpc/keepalive
-  ## After a duration of this time if the client doesn't see any activity it
-  ## pings the server to see if the transport is still alive.
-  ## If set and set below 10s, a minimum value of 10s will be used instead.
-  ## If not set, none of the other keepalive values will be configured.
+  ## The client will ping the server to see if the transport is still alive if it has
+  ## not see any activity for the given time.
+  ## If set below 10 seconds, a minimum value of 10s will be used instead.
+  ## If not set, none of the keep-alive setting (including those below) will be applied.
   # keepalive_time = "10s"
 
-  ## After having pinged for keepalive check, the client waits for a duration
-  ## of Timeout and if no activity is seen even after that the connection is
-  ## closed.
-  ## The current default value in GRPC is 20 seconds.
+  ## Timeout for seeing any activity after the keep-alive probe was
+  ## sent. If no activity is seen the connection is closed.
   ## keepalive_timeout = "20s"
 
   ## If true, client sends keepalive pings even with no active RPCs. If false,

--- a/plugins/inputs/gnmi/sample.conf
+++ b/plugins/inputs/gnmi/sample.conf
@@ -25,12 +25,6 @@
   ## sent. If no activity is seen the connection is closed.
   ## keepalive_timeout = "20s"
 
-  ## If true, client sends keepalive pings even with no active RPCs. If false,
-  ## when there are no active RPCs, Time and Timeout will be ignored and no
-  ## keepalive pings will be sent.
-  ## false by default in GRPC
-  # keepalive_permit_without_stream = false
-
   ## gRPC Maximum Message Size
   # max_msg_size = "4MB"
 

--- a/plugins/inputs/gnmi/sample.conf
+++ b/plugins/inputs/gnmi/sample.conf
@@ -17,13 +17,13 @@
   ## See https://pkg.go.dev/google.golang.org/grpc/keepalive
   ## The client will ping the server to see if the transport is still alive if it has
   ## not see any activity for the given time.
-  ## If set below 10 seconds, a minimum value of 10s will be used instead.
   ## If not set, none of the keep-alive setting (including those below) will be applied.
-  # keepalive_time = "10s"
+  ## If set and set below 10 seconds, the gRPC library will apply a minimum value of 10s will be used instead.
+  # keepalive_time = ""
 
   ## Timeout for seeing any activity after the keep-alive probe was
   ## sent. If no activity is seen the connection is closed.
-  ## keepalive_timeout = "20s"
+  # keepalive_timeout = ""
 
   ## gRPC Maximum Message Size
   # max_msg_size = "4MB"

--- a/plugins/inputs/gnmi/sample.conf
+++ b/plugins/inputs/gnmi/sample.conf
@@ -13,6 +13,26 @@
   ## redial in case of failures after
   # redial = "10s"
 
+  ## gRPC Keepalive settings
+  ## See https://pkg.go.dev/google.golang.org/grpc/keepalive
+  ## After a duration of this time if the client doesn't see any activity it
+  ## pings the server to see if the transport is still alive.
+  ## If set and set below 10s, a minimum value of 10s will be used instead.
+  ## If not set, none of the other keepalive values will be configured.
+  # keepalive_time = "10s"
+
+  ## After having pinged for keepalive check, the client waits for a duration
+  ## of Timeout and if no activity is seen even after that the connection is
+  ## closed.
+  ## The current default value in GRPC is 20 seconds.
+  ## keepalive_timeout = "20s"
+
+  ## If true, client sends keepalive pings even with no active RPCs. If false,
+  ## when there are no active RPCs, Time and Timeout will be ignored and no
+  ## keepalive pings will be sent.
+  ## false by default in GRPC
+  # keepalive_permit_without_stream = false
+
   ## gRPC Maximum Message Size
   # max_msg_size = "4MB"
 


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

This is a simple PR to plumb through the keep alive settings for the gRPC connections used by the gnmi input plugin, see the related issue for more details.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #15148
