### PR TITLE
fix(inputs.sqlserver): Honor timezone on backup metrics 

### DIFF
--- a/plugins/inputs/sqlserver/sqlserverqueries.go
+++ b/plugins/inputs/sqlserver/sqlserverqueries.go
@@ -1400,6 +1400,7 @@ EXEC sp_executesql @SqlStatement
 `
 
 const sqlServerRecentBackups string = `
+DECLARE @TimeZoneOffset INT = (SELECT DATEPART(TZOFFSET, SYSDATETIMEOFFSET()));
 SET DEADLOCK_PRIORITY -10;
 IF SERVERPROPERTY('EngineEdition') NOT IN (2,3,4) BEGIN /*NOT IN Standard,Enterpris,Express*/
 	DECLARE @ErrorMessage AS nvarchar(500) = 'Telegraf - Connection string Server:'+ @@ServerName + ',Database:' + DB_NAME() +' is not a SQL Server Standard,Enterprise or Express. Check the database_type parameter in the telegraf configuration.';
@@ -1434,12 +1435,12 @@ SELECT
 	d.database_id as [database_id],
 	d.state_desc AS [state],
 	d.recovery_model_desc AS [recovery_model],
-	DATEDIFF(SECOND,{d '1970-01-01'}, bf.LastBackupTime) AS [last_full_backup_time],
-	bf.backup_size AS [full_backup_size_bytes],
-	DATEDIFF(SECOND,{d '1970-01-01'}, bd.LastBackupTime) AS [last_differential_backup_time],
-	bd.backup_size AS [differential_backup_size_bytes],
-	DATEDIFF(SECOND,{d '1970-01-01'}, bt.LastBackupTime) AS [last_transaction_log_backup_time],
-	bt.backup_size AS [transaction_log_backup_size_bytes]
+	DATEDIFF(SECOND, {d '1970-01-01'}, DATEADD(MINUTE, -@TimeZoneOffset, bf.LastBackupTime)) AS [last_full_backup_time],
+    	bf.backup_size AS [full_backup_size_bytes],
+    	DATEDIFF(SECOND, {d '1970-01-01'}, DATEADD(MINUTE, -@TimeZoneOffset, bd.LastBackupTime)) AS [last_differential_backup_time],
+    	bd.backup_size AS [differential_backup_size_bytes],
+    	DATEDIFF(SECOND, {d '1970-01-01'}, DATEADD(MINUTE, -@TimeZoneOffset, bt.LastBackupTime)) AS [last_transaction_log_backup_time],
+    	bt.backup_size AS [transaction_log_backup_size_bytes]
 FROM sys.databases d
 LEFT JOIN BackupsWithSize bf ON (d.name = bf.[Database] AND (bf.Type = 'Full' OR bf.Type IS NULL))
 LEFT JOIN BackupsWithSize bd ON (d.name = bd.[Database] AND (bd.Type = 'Differential' OR bd.Type IS NULL))


### PR DESCRIPTION

We have been testing the sql server input in monitoring our production server and for the last_full_backup/last_differential_backup/last_log_backup we can see that if the timezone is different than UTC on the server, the time is not displayed properly. By adding the timezone offset in the query, we have removed the issue.

## Summary
If it provided in the issue.



## Checklist

- [X ] No AI generated code was used in this PR

## Related issues
Timezone Not Inlcuded in Backup in SQL Server input #15153

resolves #
![2](https://github.com/influxdata/telegraf/assets/80029951/df1b8e74-f5ee-4838-ab51-16b06241f776)
![Untitled](https://github.com/influxdata/telegraf/assets/80029951/027bc0f8-c9d3-4dbf-be49-eeaaeb53fcfc)
![poza1](https://github.com/influxdata/telegraf/assets/80029951/0add6d96-b451-4f67-8806-6a8ef6b5e82b)
