### PR TITLE
docs(aggregators.final): Swap useful statements

### DIFF
--- a/plugins/aggregators/final/README.md
+++ b/plugins/aggregators/final/README.md
@@ -27,18 +27,18 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 [[aggregators.final]]
   ## The period on which to flush & clear the aggregator.
   period = "30s"
+
   ## If true, the original metric will be dropped by the
   ## aggregator and will not get sent to the output plugins.
   # drop_original = false
 
-  ## The time that a series is not updated until considering it final.
+  ## The time that a series is not updated until considering it final. Ignored
+  ## when output_strategy is "periodic".
   # series_timeout = "5m"
 
   ## Output strategy, supported values:
-  ##   timeout  -- output a metric if no new input arrived for `series_timeout`;
-  ##               useful for filling gaps in input data
-  ##   periodic -- output the last received metric every `period`; useful to
-  ##               downsample the input data
+  ##   timeout  -- output a metric if no new input arrived for `series_timeout`
+  ##   periodic -- output the last received metric every `period`
   # output_strategy = "timeout"
 ```
 
@@ -50,13 +50,10 @@ will not guarantee a regular output of a `final` metric e.g. if the
 series-timeout is a multiple of the gathering interval for an input. In this
 case metric sporadically arrive in the timeout phase of the period and emitting
 the `final` metric is suppressed.
-This can be helpful to fill in gaps in the data if no input arrived in time.
 
 Contrary to this, `output_strategy = "periodic"` will always output a `final`
 metric at the end of the period irrespectively of when the last metric arrived,
 the `series_timeout` is ignored.
-This is helpful if you for example want to downsample input data arriving at a
-high rate and require a periodic output of the `final` metric.
 
 ## Metrics
 

--- a/plugins/aggregators/final/sample.conf
+++ b/plugins/aggregators/final/sample.conf
@@ -2,16 +2,16 @@
 [[aggregators.final]]
   ## The period on which to flush & clear the aggregator.
   period = "30s"
+
   ## If true, the original metric will be dropped by the
   ## aggregator and will not get sent to the output plugins.
   # drop_original = false
 
-  ## The time that a series is not updated until considering it final.
+  ## The time that a series is not updated until considering it final. Ignored
+  ## when output_strategy is "periodic".
   # series_timeout = "5m"
 
   ## Output strategy, supported values:
-  ##   timeout  -- output a metric if no new input arrived for `series_timeout`;
-  ##               useful for filling gaps in input data
-  ##   periodic -- output the last received metric every `period`; useful to
-  ##               downsample the input data
+  ##   timeout  -- output a metric if no new input arrived for `series_timeout`
+  ##   periodic -- output the last received metric every `period`
   # output_strategy = "timeout"


### PR DESCRIPTION
## Summary
The statements seem switched around currently and are causing confusion for users. Periodic is used to avoid gaps in the data, while timeout is used to only show the last value when a whole bunch come in, i.e. downsample.

https://community.influxdata.com/t/get-at-least-every-5-min-datapoint-by-mqtt-consumer/33911/8

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR
