### PR TITLE
fix(systemd): Remove 5 second timeout, use default (90)

### DIFF
--- a/scripts/telegraf.service
+++ b/scripts/telegraf.service
@@ -15,7 +15,6 @@ ExecReload=/bin/kill -HUP $MAINPID
 Restart=on-failure
 RestartForceExitStatus=SIGPIPE
 KillMode=mixed
-TimeoutStopSec=5
 LimitMEMLOCK=8M:8M
 PrivateMounts=true
 


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
The 5 second timeout was a little aggressive as a default value for users. Instead use the systemd default and/or let a user to set this to what they want.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

fixes: #15167
