### PR TITLE
feat(inputs.knx_listener): Add support for string data type

### DIFF
--- a/plugins/inputs/knx_listener/knx_listener.go
+++ b/plugins/inputs/knx_listener/knx_listener.go
@@ -187,6 +187,8 @@ func (kl *KNXListener) listen(acc telegraf.Accumulator) {
 				value = vi.Uint()
 			case reflect.Float32, reflect.Float64:
 				value = vi.Float()
+			case reflect.String:
+				value = vi.String()
 			default:
 				kl.Log.Errorf("Type conversion %v failed for address %q", vi.Kind(), ga)
 				continue

--- a/plugins/inputs/knx_listener/knx_listener_test.go
+++ b/plugins/inputs/knx_listener/knx_listener_test.go
@@ -30,6 +30,8 @@ func setValue(data dpt.DatapointValue, value interface{}) error {
 		d.SetInt(v)
 	case uint64:
 		d.SetUint(v)
+	case string:
+		d.SetString(v)
 	default:
 		return fmt.Errorf("unknown type '%T' when setting value for DPT", value)
 	}
@@ -104,6 +106,7 @@ func TestRegularReceives_DPT(t *testing.T) {
 		{"14/0/4", "14.004", false, 1.00794, 1.00794},
 		{"14/1/0", "14.010", false, 5963.78, 5963.78},
 		{"14/1/1", "14.011", false, 150.95, 150.95},
+		{"16/0/0", "16.000", false, "hello world", "hello world"},
 	}
 	acc := &testutil.Accumulator{}
 


### PR DESCRIPTION
## Summary
KNX has string data types like DPT 16.000 (ASCII text) which can transfer up to 14 bytes of ASCII text. knx_listener didn't support these yet and therefore couldn't log telegrams of this type; this PR adds the required support.

Please review this carefully; I've never written Go before.

## Checklist
- [x] No AI generated code was used in this PR

## Related issues
resolves #15158
