### PR TITLE
feat(inputs.gnmi): Add keepalive settings

### DIFF
--- a/plugins/inputs/gnmi/README.md
+++ b/plugins/inputs/gnmi/README.md
@@ -52,6 +52,18 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## redial in case of failures after
   # redial = "10s"
 
+  ## gRPC Keepalive settings
+  ## See https://pkg.go.dev/google.golang.org/grpc/keepalive
+  ## The client will ping the server to see if the transport is still alive if it has
+  ## not see any activity for the given time.
+  ## If not set, none of the keep-alive setting (including those below) will be applied.
+  ## If set and set below 10 seconds, the gRPC library will apply a minimum value of 10s will be used instead.
+  # keepalive_time = ""
+
+  ## Timeout for seeing any activity after the keep-alive probe was
+  ## sent. If no activity is seen the connection is closed.
+  # keepalive_timeout = ""
+
   ## gRPC Maximum Message Size
   # max_msg_size = "4MB"
 

--- a/plugins/inputs/gnmi/handler.go
+++ b/plugins/inputs/gnmi/handler.go
@@ -17,6 +17,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/keepalive"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 
@@ -42,6 +43,7 @@ type handler struct {
 	trimSlash           bool
 	guessPathStrategy   string
 	log                 telegraf.Logger
+	keepalive.ClientParameters
 }
 
 // SubscribeGNMI and extract telemetry data
@@ -60,6 +62,10 @@ func (h *handler) subscribeGNMI(ctx context.Context, acc telegraf.Accumulator, t
 		opts = append(opts, grpc.WithDefaultCallOptions(
 			grpc.MaxCallRecvMsgSize(h.maxMsgSize),
 		))
+	}
+
+	if h.ClientParameters.Time > 0 {
+		opts = append(opts, grpc.WithKeepaliveParams(h.ClientParameters))
 	}
 
 	client, err := grpc.DialContext(ctx, h.address, opts...)

--- a/plugins/inputs/gnmi/sample.conf
+++ b/plugins/inputs/gnmi/sample.conf
@@ -13,6 +13,18 @@
   ## redial in case of failures after
   # redial = "10s"
 
+  ## gRPC Keepalive settings
+  ## See https://pkg.go.dev/google.golang.org/grpc/keepalive
+  ## The client will ping the server to see if the transport is still alive if it has
+  ## not see any activity for the given time.
+  ## If not set, none of the keep-alive setting (including those below) will be applied.
+  ## If set and set below 10 seconds, the gRPC library will apply a minimum value of 10s will be used instead.
+  # keepalive_time = ""
+
+  ## Timeout for seeing any activity after the keep-alive probe was
+  ## sent. If no activity is seen the connection is closed.
+  # keepalive_timeout = ""
+
   ## gRPC Maximum Message Size
   # max_msg_size = "4MB"
 


### PR DESCRIPTION
## Summary
This is a simple PR to plumb through the keep alive settings for the gRPC connections used by the gnmi input plugin, see the related issue for more details.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves: #15148

Co-authored-by: Hunter Kelly <retnuh@gmail.com>