### PR TITLE
feat(inputs.procstat): Report consistent I/O  on Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 <!-- markdownlint-disable MD024 -->
 # Changelog
 
+## Unreleased
+
+### Important Changes
+
+- [PR #15186](https://github.com/influxdata/telegraf/pull/15186) changes the
+  meaning of `inputs.procstat` fields `read_bytes` and `write_bytes` on Linux
+  to now contain _all_ I/O operations for consistency with other
+  operating-systems. The previous values are output as `disk_read_bytes` and
+  `disk_write_bytes` measuring _only_ the I/O on the storage layer.
+
 ## v1.30.2 [2024-04-22]
 
 ### Important Changes

--- a/plugins/inputs/procstat/README.md
+++ b/plugins/inputs/procstat/README.md
@@ -159,6 +159,8 @@ Below are an example set of tags and fields:
     - cpu_time_system (float)
     - cpu_time_user (float)
     - cpu_usage (float)
+    - disk_read_bytes (int, Linux only, *telegraf* may need to be ran as **root**)
+    - disk_write_bytes (int, Linux only, *telegraf* may need to be ran as **root**)
     - involuntary_context_switches (int)
     - major_faults (int)
     - memory_anonymous (int)

--- a/plugins/inputs/procstat/os_linux.go
+++ b/plugins/inputs/procstat/os_linux.go
@@ -6,6 +6,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+
+	"github.com/prometheus/procfs"
 
 	"github.com/coreos/go-systemd/v22/dbus"
 	"github.com/shirou/gopsutil/v3/process"
@@ -75,4 +78,28 @@ func findBySystemdUnits(units []string) ([]processGroup, error) {
 
 func findByWindowsServices(_ []string) ([]processGroup, error) {
 	return nil, nil
+}
+
+func collectCachedReadWrite(proc Process) (r, w uint64, err error) {
+	path := procfs.DefaultMountPoint
+	if hp := os.Getenv("HOST_PROC"); hp != "" {
+		path = hp
+	}
+
+	fs, err := procfs.NewFS(path)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	p, err := fs.Proc(int(proc.PID()))
+	if err != nil {
+		return 0, 0, err
+	}
+
+	stat, err := p.IO()
+	if err != nil {
+		return 0, 0, err
+	}
+
+	return stat.RChar, stat.WChar, nil
 }

--- a/plugins/inputs/procstat/os_linux.go
+++ b/plugins/inputs/procstat/os_linux.go
@@ -80,7 +80,7 @@ func findByWindowsServices(_ []string) ([]processGroup, error) {
 	return nil, nil
 }
 
-func collectCachedReadWrite(proc Process) (r, w uint64, err error) {
+func collectTotalReadWrite(proc Process) (r, w uint64, err error) {
 	path := procfs.DefaultMountPoint
 	if hp := os.Getenv("HOST_PROC"); hp != "" {
 		path = hp

--- a/plugins/inputs/procstat/os_others.go
+++ b/plugins/inputs/procstat/os_others.go
@@ -25,3 +25,7 @@ func findBySystemdUnits(_ []string) ([]processGroup, error) {
 func findByWindowsServices(_ []string) ([]processGroup, error) {
 	return nil, nil
 }
+
+func collectCachedReadWrite(_ Process) (r, w uint64, err error) {
+	return 0, 0, errors.ErrUnsupported
+}

--- a/plugins/inputs/procstat/os_others.go
+++ b/plugins/inputs/procstat/os_others.go
@@ -26,6 +26,6 @@ func findByWindowsServices(_ []string) ([]processGroup, error) {
 	return nil, nil
 }
 
-func collectCachedReadWrite(_ Process) (r, w uint64, err error) {
+func collectTotalReadWrite(_ Process) (r, w uint64, err error) {
 	return 0, 0, errors.ErrUnsupported
 }

--- a/plugins/inputs/procstat/os_windows.go
+++ b/plugins/inputs/procstat/os_windows.go
@@ -83,6 +83,6 @@ func findByWindowsServices(services []string) ([]processGroup, error) {
 	return groups, nil
 }
 
-func collectCachedReadWrite(_ Process) (r, w uint64, err error) {
+func collectTotalReadWrite(_ Process) (r, w uint64, err error) {
 	return 0, 0, errors.ErrUnsupported
 }

--- a/plugins/inputs/procstat/os_windows.go
+++ b/plugins/inputs/procstat/os_windows.go
@@ -82,3 +82,7 @@ func findByWindowsServices(services []string) ([]processGroup, error) {
 
 	return groups, nil
 }
+
+func collectCachedReadWrite(_ Process) (r, w uint64, err error) {
+	return 0, 0, errors.ErrUnsupported
+}

--- a/plugins/inputs/procstat/process.go
+++ b/plugins/inputs/procstat/process.go
@@ -104,9 +104,13 @@ func (p *Proc) Metric(prefix string, tagging map[string]bool, solarisMode bool) 
 		fields[prefix+"write_bytes"] = io.WriteBytes
 	}
 
-	if rc, wc, err := collectCachedReadWrite(p); err == nil {
-		fields[prefix+"cached_read_bytes"] = rc
-		fields[prefix+"cached_write_bytes"] = wc
+	// Linux fixup for gopsutils exposing the disk-only-IO instead of the total
+	// I/O as for example on Windows
+	if rc, wc, err := collectTotalReadWrite(p); err == nil {
+		fields[prefix+"read_bytes"] = rc
+		fields[prefix+"write_bytes"] = wc
+		fields[prefix+"disk_read_bytes"] = io.ReadBytes
+		fields[prefix+"disk_write_bytes"] = io.WriteBytes
 	}
 
 	createdAt, err := p.CreateTime() // returns epoch in ms

--- a/plugins/inputs/procstat/process.go
+++ b/plugins/inputs/procstat/process.go
@@ -104,6 +104,11 @@ func (p *Proc) Metric(prefix string, tagging map[string]bool, solarisMode bool) 
 		fields[prefix+"write_bytes"] = io.WriteBytes
 	}
 
+	if rc, wc, err := collectCachedReadWrite(p); err == nil {
+		fields[prefix+"cached_read_bytes"] = rc
+		fields[prefix+"cached_write_bytes"] = wc
+	}
+
 	createdAt, err := p.CreateTime() // returns epoch in ms
 	if err == nil {
 		fields[prefix+"created_at"] = createdAt * 1000000 // ms to ns

--- a/plugins/inputs/procstat/procstat_test.go
+++ b/plugins/inputs/procstat/procstat_test.go
@@ -347,8 +347,6 @@ func TestGather_ProcessName(t *testing.T) {
 
 	var acc testutil.Accumulator
 	require.NoError(t, p.Gather(&acc))
-
-	testutil.PrintMetrics(acc.GetTelegrafMetrics())
 	require.Equal(t, "custom_name", acc.TagValue("procstat", "process_name"))
 	testutil.RequireMetricsEqual(t, expected, acc.GetTelegrafMetrics(), testutil.IgnoreTime())
 }


### PR DESCRIPTION
## Summary

The fields `read_bytes` and `write_bytes` do report the **overall** I/O including network etc on operating systems such as Windows. However on Linux, those two fields are filled by the I/O to the **storage layer** which causes inconsistent metrics across operating-systems.

This PR changes the behavior on Linux and is now consistently reporting the overall I/O in `read_bytes` and `write_bytes` (using the `rchar` and `wchar` information). It furthermore reports the previous (storage-only I/O) via the new `disk_read_bytes` and `disk_write_bytes` fields.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #9189 
