### PR TITLE
feat: Enable PIE hardening for certain architechtures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ GOARCH ?= $(shell go env GOARCH)
 GOBUILDMODE := default
 HOSTGO := env -u GOOS -u GOARCH -u GOARM -- go
 INTERNAL_PKG=github.com/influxdata/telegraf/internal
-LDFLAGS := $(LDFLAGS) -X $(INTERNAL_PKG).Commit=$(commit) -X $(INTERNAL_PKG).Branch=$(branch)
+LDFLAGS := $(LDFLAGS) -linkmode=internal -X $(INTERNAL_PKG).Commit=$(commit) -X $(INTERNAL_PKG).Branch=$(branch)
 ifneq ($(tag),)
 	LDFLAGS += -X $(INTERNAL_PKG).Version=$(version)
 else
@@ -58,15 +58,11 @@ endif
 ifneq ($(GOARCH), 386)
 	race_detector := -race
 endif
+
+# Enable PIE only on select architectures
 ifeq ($(GOARCH),amd64)
 	GOBUILDMODE := pie
 else ifeq ($(GOARCH),arm64)
-	GOBUILDMODE := pie
-else ifeq ($(GOARCH),ppc64el)
-	GOBUILDMODE := pie
-else ifeq ($(GOARCH),riscv64)
-	GOBUILDMODE := pie
-else ifeq ($(GOARCH),s390x)
 	GOBUILDMODE := pie
 endif
 


### PR DESCRIPTION


## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Enables PIE hardening during builds for amd64, arm64, ppc64el, riscv64, and s390x.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

fixes: #15187
