### PR TITLE
fix(http): Stop plugins from leaking file descriptors on telegraf reload

### DIFF
--- a/plugins/inputs/ctrlx_datalayer/ctrlx_datalayer.go
+++ b/plugins/inputs/ctrlx_datalayer/ctrlx_datalayer.go
@@ -353,6 +353,9 @@ func (c *CtrlXDataLayer) gatherLoop(ctx context.Context) {
 func (c *CtrlXDataLayer) Stop() {
 	c.cancel()
 	c.wg.Wait()
+	if c.connection != nil {
+		c.connection.CloseIdleConnections()
+	}
 }
 
 // Gather is called by telegraf to collect the metrics.

--- a/plugins/inputs/elasticsearch/elasticsearch.go
+++ b/plugins/inputs/elasticsearch/elasticsearch.go
@@ -185,6 +185,10 @@ func (e *Elasticsearch) Init() error {
 	return nil
 }
 
+func (e *Elasticsearch) Start(_ telegraf.Accumulator) error {
+	return nil
+}
+
 // Gather reads the stats from Elasticsearch and writes it to the
 // Accumulator.
 func (e *Elasticsearch) Gather(acc telegraf.Accumulator) error {
@@ -280,6 +284,12 @@ func (e *Elasticsearch) Gather(acc telegraf.Accumulator) error {
 
 	wg.Wait()
 	return nil
+}
+
+func (e *Elasticsearch) Stop() {
+	if e.client != nil {
+		e.client.CloseIdleConnections()
+	}
 }
 
 func (e *Elasticsearch) createHTTPClient() (*http.Client, error) {

--- a/plugins/inputs/elasticsearch_query/elasticsearch_query.go
+++ b/plugins/inputs/elasticsearch_query/elasticsearch_query.go
@@ -173,6 +173,10 @@ func (e *ElasticsearchQuery) connectToES() error {
 	return nil
 }
 
+func (e *ElasticsearchQuery) Start(_ telegraf.Accumulator) error {
+	return nil
+}
+
 // Gather writes the results of the queries from Elasticsearch to the Accumulator.
 func (e *ElasticsearchQuery) Gather(acc telegraf.Accumulator) error {
 	var wg sync.WaitGroup
@@ -195,6 +199,12 @@ func (e *ElasticsearchQuery) Gather(acc telegraf.Accumulator) error {
 
 	wg.Wait()
 	return nil
+}
+
+func (e *ElasticsearchQuery) Stop() {
+	if e.httpclient != nil {
+		e.httpclient.CloseIdleConnections()
+	}
 }
 
 func (e *ElasticsearchQuery) createHTTPClient() (*http.Client, error) {

--- a/plugins/inputs/http/http.go
+++ b/plugins/inputs/http/http.go
@@ -80,6 +80,10 @@ func (h *HTTP) Init() error {
 	return nil
 }
 
+func (h *HTTP) Start(_ telegraf.Accumulator) error {
+	return nil
+}
+
 // Gather takes in an accumulator and adds the metrics that the Input
 // gathers. This is called every "interval"
 func (h *HTTP) Gather(acc telegraf.Accumulator) error {
@@ -97,6 +101,12 @@ func (h *HTTP) Gather(acc telegraf.Accumulator) error {
 	wg.Wait()
 
 	return nil
+}
+
+func (h *HTTP) Stop() {
+	if h.client != nil {
+		h.client.CloseIdleConnections()
+	}
 }
 
 // SetParserFunc takes the data_format from the config and finds the right parser for that format

--- a/plugins/inputs/kibana/kibana.go
+++ b/plugins/inputs/kibana/kibana.go
@@ -123,6 +123,10 @@ func (*Kibana) SampleConfig() string {
 	return sampleConfig
 }
 
+func (k *Kibana) Start(_ telegraf.Accumulator) error {
+	return nil
+}
+
 func (k *Kibana) Gather(acc telegraf.Accumulator) error {
 	if k.client == nil {
 		client, err := k.createHTTPClient()
@@ -148,6 +152,12 @@ func (k *Kibana) Gather(acc telegraf.Accumulator) error {
 
 	wg.Wait()
 	return nil
+}
+
+func (k *Kibana) Stop() {
+	if k.client != nil {
+		k.client.CloseIdleConnections()
+	}
 }
 
 func (k *Kibana) createHTTPClient() (*http.Client, error) {

--- a/plugins/inputs/logstash/logstash.go
+++ b/plugins/inputs/logstash/logstash.go
@@ -454,6 +454,10 @@ func (logstash *Logstash) gatherPipelinesStats(address string, accumulator teleg
 	return nil
 }
 
+func (logstash *Logstash) Start(_ telegraf.Accumulator) error {
+	return nil
+}
+
 // Gather ask this plugin to start gathering metrics
 func (logstash *Logstash) Gather(accumulator telegraf.Accumulator) error {
 	if logstash.client == nil {
@@ -506,6 +510,12 @@ func (logstash *Logstash) Gather(accumulator telegraf.Accumulator) error {
 	}
 
 	return nil
+}
+
+func (logstash *Logstash) Stop() {
+	if logstash.client != nil {
+		logstash.client.CloseIdleConnections()
+	}
 }
 
 // init registers this plugin instance

--- a/plugins/inputs/prometheus/prometheus.go
+++ b/plugins/inputs/prometheus/prometheus.go
@@ -588,6 +588,10 @@ func (p *Prometheus) Start(_ telegraf.Accumulator) error {
 func (p *Prometheus) Stop() {
 	p.cancel()
 	p.wg.Wait()
+
+	if p.client != nil {
+		p.client.CloseIdleConnections()
+	}
 }
 
 func init() {

--- a/plugins/inputs/vault/vault.go
+++ b/plugins/inputs/vault/vault.go
@@ -70,6 +70,10 @@ func (n *Vault) Init() error {
 	return nil
 }
 
+func (n *Vault) Start(_ telegraf.Accumulator) error {
+	return nil
+}
+
 // Gather, collects metrics from Vault endpoint
 func (n *Vault) Gather(acc telegraf.Accumulator) error {
 	sysMetrics, err := n.loadJSON(n.URL + "/v1/sys/metrics")
@@ -78,6 +82,12 @@ func (n *Vault) Gather(acc telegraf.Accumulator) error {
 	}
 
 	return buildVaultMetrics(acc, sysMetrics)
+}
+
+func (n *Vault) Stop() {
+	if n.client != nil {
+		n.client.CloseIdleConnections()
+	}
 }
 
 func (n *Vault) loadJSON(url string) (*SysMetrics, error) {

--- a/plugins/outputs/cloudwatch/cloudwatch.go
+++ b/plugins/outputs/cloudwatch/cloudwatch.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	_ "embed"
 	"math"
+	"net/http"
 	"sort"
 	"strings"
 	"time"
@@ -30,6 +31,7 @@ type CloudWatch struct {
 	Log                   telegraf.Logger `toml:"-"`
 	internalaws.CredentialConfig
 	httpconfig.HTTPClientConfig
+	client *http.Client
 }
 
 type statisticType int
@@ -170,14 +172,20 @@ func (c *CloudWatch) Connect() error {
 		return err
 	}
 
+	c.client = client
+
 	c.svc = cloudwatch.NewFromConfig(cfg, func(options *cloudwatch.Options) {
-		options.HTTPClient = client
+		options.HTTPClient = c.client
 	})
 
 	return nil
 }
 
 func (c *CloudWatch) Close() error {
+	if c.client != nil {
+		c.client.CloseIdleConnections()
+	}
+
 	return nil
 }
 

--- a/plugins/outputs/http/http.go
+++ b/plugins/outputs/http/http.go
@@ -102,6 +102,10 @@ func (h *HTTP) Connect() error {
 }
 
 func (h *HTTP) Close() error {
+	if h.client != nil {
+		h.client.CloseIdleConnections()
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
## Summary

On reload, telegraf rebuilds its plugins, which means creating a new `*http.Client` (and `*http.Transport`) in each of the files touched in this PR. In general, transports should be long-lived; they carry state and possibly idle HTTP connections.

Without explicitly calling `CloseIdleConnections()`, in cases where no `idle_conn_timeout` is set, we leave it up to the go runtime to decide when to drop the connections - and it can easily decide "never", leading to open connections accumulating over time, especially with repeated reloads of the telegraf config in a single process, and eventually telegraf failing with `EMFILE` problems.

Fix this by telling the Go runtime (by calling `CloseIdleConnections()`) when we're done with a given transport.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves https://github.com/influxdata/telegraf/issues/15177
