### PR TITLE
docs(inputs.netflow): Clarify and document 'template not found' warnings

### DIFF
--- a/plugins/inputs/netflow/README.md
+++ b/plugins/inputs/netflow/README.md
@@ -100,6 +100,22 @@ Currently the following `data-type`s are supported:
 - `ip`     IPv4 or IPv6 address
 - `proto`  mapping of layer-4 protocol numbers to names
 
+## Troubleshooting
+
+### `Error template not found` warnings
+
+Those warnings usually occur in cases where Telegraf is restarted or reloaded
+while the flow-device is already streaming data.
+As background, the Netflow and IPFIX protocols rely on templates sent by the
+flow-device to decode fields. Without those templates, it is not clear what the
+data-type and size of the payload is and this makes it impossible to correctly
+interpret the data. However, templates are sent by the flow-device, usually at
+the start of streaming and in regular intervals (configurable in the device) and
+Telegraf has no means to trigger sending of the templates. Therefore, we need to
+skip the packets until the templates are resent by the device.
+
+### Template
+
 ## Metrics
 
 Metrics depend on the format used as well as on the information provided

--- a/plugins/inputs/netflow/netflow_decoder.go
+++ b/plugins/inputs/netflow/netflow_decoder.go
@@ -562,7 +562,8 @@ func (d *netflowDecoder) Decode(srcIP net.IP, payload []byte) ([]telegraf.Metric
 	buf := bytes.NewBuffer(payload)
 	if err := netflow.DecodeMessageVersion(buf, templates, &msg9, &msg10); err != nil {
 		if errors.Is(err, netflow.ErrorTemplateNotFound) {
-			d.Log.Warnf("%v; skipping packet", err)
+			msg := "Skipping packet until the device resends the required template..."
+			d.Log.Warnf("%v. %s", err, msg)
 			return nil, nil
 		}
 		return nil, fmt.Errorf("decoding message failed: %w", err)


### PR DESCRIPTION
## Summary

Clarifiy the warning about missing templates and add a troubleshooting section to the README.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #15089 
