### PR TITLE
chore(inputs.amd_rocm_smi): Consolidate startup_retry_behavior to model implementation

### DIFF
--- a/models/running_input.go
+++ b/models/running_input.go
@@ -132,7 +132,7 @@ func (r *RunningInput) Start(acc telegraf.Accumulator) error {
 
 	// Check if the plugin reports a retry-able error, otherwise we exit.
 	var serr *internal.StartupError
-	if !errors.As(err, &serr) || !serr.Retry {
+	if !errors.As(err, &serr) {
 		return err
 	}
 
@@ -140,6 +140,9 @@ func (r *RunningInput) Start(acc telegraf.Accumulator) error {
 	switch r.Config.StartupErrorBehavior {
 	case "", "error": // fall-trough to return the actual error
 	case "retry":
+		if !serr.Retry {
+			return err
+		}
 		r.log.Infof("Startup failed: %v; retrying...", err)
 		return nil
 	case "ignore":

--- a/plugins/inputs/amd_rocm_smi/README.md
+++ b/plugins/inputs/amd_rocm_smi/README.md
@@ -14,6 +14,18 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 [CONFIGURATION.md]: ../../../docs/CONFIGURATION.md#plugins
 
+## Startup error behavior options
+
+In addition to the plugin-specific and global configuration settings the plugin
+supports options for specifying the behavior when experiencing startup errors
+using the `startup_error_behavior` setting. Available values are:
+
+- `error`:  Telegraf with stop and exit in case of startup errors. This is the
+            default behavior.
+- `ignore`: Telegraf will ignore startup errors for this plugin and disables it
+            but continues processing for all other plugins.
+- `retry`:  NOT AVAILABLE
+
 ## Configuration
 
 ```toml @sample.conf
@@ -21,12 +33,6 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 [[inputs.amd_rocm_smi]]
   ## Optional: path to rocm-smi binary, defaults to $PATH via exec.LookPath
   # bin_path = "/opt/rocm/bin/rocm-smi"
-
-  ## Optional: specifies plugin behavior regarding missing rocm-smi binary
-  ## Available choices:
-  ##   - error: telegraf will return an error on startup
-  ##   - ignore: telegraf will ignore this plugin
-  # startup_error_behavior = "error"
 
   ## Optional: timeout for GPU polling
   # timeout = "5s"

--- a/plugins/inputs/amd_rocm_smi/sample.conf
+++ b/plugins/inputs/amd_rocm_smi/sample.conf
@@ -3,11 +3,5 @@
   ## Optional: path to rocm-smi binary, defaults to $PATH via exec.LookPath
   # bin_path = "/opt/rocm/bin/rocm-smi"
 
-  ## Optional: specifies plugin behavior regarding missing rocm-smi binary
-  ## Available choices:
-  ##   - error: telegraf will return an error on startup
-  ##   - ignore: telegraf will ignore this plugin
-  # startup_error_behavior = "error"
-
   ## Optional: timeout for GPU polling
   # timeout = "5s"


### PR DESCRIPTION
## Summary

Use the common implementation of startup-retry-behavior implementation.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues
