### PR TITLE
fix(Makefile): Use go's dependency checker for 'per platform' builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -273,6 +273,7 @@ install: $(buildbin)
 # Telegraf build per platform.  This improves package performance by sharing
 # the bin between deb/rpm/tar packages over building directly into the package
 # directory.
+.PHONY: $(buildbin)
 $(buildbin):
 	echo $(GOOS)
 	@mkdir -pv $(dir $@)


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

In the telegraf building process `make` doesn't do any dependency checking as the process relies on the automatic dependency checking of `go build`. The `package` target previously used non-phony targets `$(buildbin)`, whose recipe, due to the absence of prerequites, is not reexecuted if the `$(buildbin)` files exist. This PR fixes this issue by defining the `$(buildbin)` target as phony.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->
Resolves #15222 
