### PR TITLE
fix(outputs.graphite): Handle local address without port correctly

### DIFF
--- a/plugins/outputs/graphite/graphite.go
+++ b/plugins/outputs/graphite/graphite.go
@@ -109,8 +109,11 @@ func (g *Graphite) Connect() error {
 		if g.LocalAddr != "" {
 			// Resolve the local address into IP address and the given port if any
 			addr, sPort, err := net.SplitHostPort(g.LocalAddr)
-			if err != nil && !strings.Contains(err.Error(), "missing port") {
-				return fmt.Errorf("invalid local address: %w", err)
+			if err != nil {
+				if !strings.Contains(err.Error(), "missing port") {
+					return fmt.Errorf("invalid local address: %w", err)
+				}
+				addr = g.LocalAddr
 			}
 			local, err := net.ResolveIPAddr("ip", addr)
 			if err != nil {


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
The original PR #14628 which resolved #14614 mishandled the case in which no port is given together with the local address. The integrated code expected `net.SplitHostPort` to return the address even when no port is given, however, `net.SplitHostPort` instead returns an emptry string. (https://github.com/golang/go/blob/master/src/net/ipsock.go)

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #14614 further
