### PR TITLE
feat(outputs.influxdb_v2): Add option to set local address

### DIFF
--- a/plugins/outputs/influxdb_v2/README.md
+++ b/plugins/outputs/influxdb_v2/README.md
@@ -31,6 +31,10 @@ to use them.
   ##   ex: urls = ["https://us-west-2-1.aws.cloud2.influxdata.com"]
   urls = ["http://127.0.0.1:8086"]
 
+  ## Local address to bind when connecting to the server
+  ## If empty or not set, the local address is automatically chosen.
+  # local_address = ""
+
   ## Token for authentication.
   token = ""
 

--- a/plugins/outputs/influxdb_v2/influxdb_v2.go
+++ b/plugins/outputs/influxdb_v2/influxdb_v2.go
@@ -7,7 +7,10 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
+	"net"
 	"net/url"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/influxdata/telegraf"
@@ -35,6 +38,7 @@ type Client interface {
 
 type InfluxDB struct {
 	URLs             []string          `toml:"urls"`
+	LocalAddr        string            `toml:"local_address"`
 	Token            config.Secret     `toml:"token"`
 	Organization     string            `toml:"organization"`
 	Bucket           string            `toml:"bucket"`
@@ -78,9 +82,36 @@ func (i *InfluxDB) Connect() error {
 			}
 		}
 
+		var localAddr *net.TCPAddr
+		if i.LocalAddr != "" {
+			// Resolve the local address into IP address and the given port if any
+			addr, sPort, err := net.SplitHostPort(i.LocalAddr)
+			if err != nil {
+				if !strings.Contains(err.Error(), "missing port") {
+					return fmt.Errorf("invalid local address: %w", err)
+				}
+				addr = i.LocalAddr
+			}
+			local, err := net.ResolveIPAddr("ip", addr)
+			if err != nil {
+				return fmt.Errorf("cannot resolve local address: %w", err)
+			}
+
+			var port int
+			if sPort != "" {
+				p, err := strconv.ParseUint(sPort, 10, 16)
+				if err != nil {
+					return fmt.Errorf("invalid port: %w", err)
+				}
+				port = int(p)
+			}
+
+			localAddr = &net.TCPAddr{IP: local.IP, Port: port, Zone: local.Zone}
+		}
+
 		switch parts.Scheme {
 		case "http", "https", "unix":
-			c, err := i.getHTTPClient(parts, proxy)
+			c, err := i.getHTTPClient(parts, localAddr, proxy)
 			if err != nil {
 				return err
 			}
@@ -121,7 +152,7 @@ func (i *InfluxDB) Write(metrics []telegraf.Metric) error {
 	return errors.New("failed to send metrics to any configured server(s)")
 }
 
-func (i *InfluxDB) getHTTPClient(address *url.URL, proxy *url.URL) (Client, error) {
+func (i *InfluxDB) getHTTPClient(address *url.URL, localAddr *net.TCPAddr, proxy *url.URL) (Client, error) {
 	tlsConfig, err := i.ClientConfig.TLSConfig()
 	if err != nil {
 		return nil, err
@@ -134,6 +165,7 @@ func (i *InfluxDB) getHTTPClient(address *url.URL, proxy *url.URL) (Client, erro
 
 	httpConfig := &HTTPConfig{
 		URL:              address,
+		LocalAddr:        localAddr,
 		Token:            i.Token,
 		Organization:     i.Organization,
 		Bucket:           i.Bucket,

--- a/plugins/outputs/influxdb_v2/influxdb_v2_test.go
+++ b/plugins/outputs/influxdb_v2/influxdb_v2_test.go
@@ -1,6 +1,7 @@
 package influxdb_v2_test
 
 import (
+	"net"
 	"testing"
 
 	"github.com/influxdata/telegraf/plugins/common/tls"
@@ -99,4 +100,15 @@ func TestUnused(_ *testing.T) {
 	thing.Close()
 	thing.SampleConfig()
 	outputs.Outputs["influxdb_v2"]()
+}
+
+func TestInfluxDBLocalAddress(t *testing.T) {
+	t.Log("Starting server")
+	server, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer server.Close()
+
+	output := influxdb.InfluxDB{LocalAddr: "localhost"}
+	require.NoError(t, output.Connect())
+	require.NoError(t, output.Close())
 }

--- a/plugins/outputs/influxdb_v2/sample.conf
+++ b/plugins/outputs/influxdb_v2/sample.conf
@@ -7,6 +7,10 @@
   ##   ex: urls = ["https://us-west-2-1.aws.cloud2.influxdata.com"]
   urls = ["http://127.0.0.1:8086"]
 
+  ## Local address to bind when connecting to the server
+  ## If empty or not set, the local address is automatically chosen.
+  # local_address = ""
+
   ## Token for authentication.
   token = ""
 


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes. Based on #14628.
-->
Add option to set local ip (and port) which allows to select the interface over which the influxdb v2 server is contacted. Based on #14628.


## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->


- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #4287 (which was closed but never really resolved)
