### PR TITLE
docs(inputs.prometheus): Remove invalid deprecation statement

### DIFF
--- a/plugins/inputs/prometheus/README.md
+++ b/plugins/inputs/prometheus/README.md
@@ -140,7 +140,6 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## Specify timeout duration for slower prometheus clients (default is 5s)
   # timeout = "5s"
 
-  ## deprecated in 1.26; use the timeout option
   ## This option is now used by the HTTP client to set the header response
   ## timeout, not the overall HTTP timeout.
   # response_timeout = "5s"

--- a/plugins/inputs/prometheus/sample.conf
+++ b/plugins/inputs/prometheus/sample.conf
@@ -123,7 +123,6 @@
   ## Specify timeout duration for slower prometheus clients (default is 5s)
   # timeout = "5s"
 
-  ## deprecated in 1.26; use the timeout option
   ## This option is now used by the HTTP client to set the header response
   ## timeout, not the overall HTTP timeout.
   # response_timeout = "5s"


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Description
- The change updates the documentation of the Prometheus Input plugin. The `response_timeout` parameter is generally no longer obsolete and is [reused](https://github.com/influxdata/telegraf/pull/15078) by the HTTP header timeout.