### PR TITLE
fix(inputs.http_listener_v2): Wrap timestamp parsing error messages

### DIFF
--- a/plugins/parsers/json_v2/parser.go
+++ b/plugins/parsers/json_v2/parser.go
@@ -176,9 +176,8 @@ func (p *Parser) parseCriticalPath(input []byte) ([]telegraf.Metric, error) {
 
 				var err error
 				timestamp, err = internal.ParseTimestamp(c.TimestampFormat, result.String(), c.Location)
-
 				if err != nil {
-					return nil, err
+					return nil, fmt.Errorf("unable to parse timestamp %q: %w", result.String(), err)
 				}
 			}
 		}


### PR DESCRIPTION


## Summary
When a timestamp fails to parse it produces a very vauge message:

```s
2024-04-26T12:45:22Z E! [inputs.file] Error in plugin: could not parse "data": invalid number
```

This does not tell you what the data is, or even that it is the timestamp that failed to parse. Instead this PR changes to this:

```s
2024-04-26T12:47:34Z E! [inputs.file] Error in plugin: could not parse "data": unable to parse timestamp "12a34567890": invalid number
```

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

fixes: #15237
