### PR TITLE
fix(inputs.gnmi): Ensure path contains elements to avoid panic

### DIFF
--- a/plugins/inputs/gnmi/handler.go
+++ b/plugins/inputs/gnmi/handler.go
@@ -212,6 +212,10 @@ func (h *handler) handleSubscribeResponseUpdate(acc telegraf.Accumulator, respon
 
 	// Parse individual update message and create measurements
 	for _, field := range valueFields {
+		if field.path.empty() {
+			continue
+		}
+
 		// Prepare tags from prefix
 		fieldTags := field.path.Tags()
 		tags := make(map[string]string, len(headerTags)+len(fieldTags))


### PR DESCRIPTION


## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
In the event of an empty message, ensure the path actually contains segments to avoid a panic.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

fixes: #15257
