### PR TITLE
feat(inputs.mock): Add baseline option to sine

### DIFF
--- a/plugins/inputs/mock/README.md
+++ b/plugins/inputs/mock/README.md
@@ -40,6 +40,7 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   #   name = "wave"
   #   amplitude = 1.0
   #   period = 0.5
+  #   base_line = 0.0
   # [[inputs.mock.step]]
   #   name = "plus_one"
   #   start = 0.0
@@ -62,7 +63,7 @@ The available algorithms for generating mock data include:
 * Constant - generate a field with the given value of type string, float, int
   or bool
 * Random Float - generate a random float, inclusive of min and max
-* Sine Wave - produce a sine wave with a certain amplitude and period
+* Sine Wave - produce a sine wave with a certain amplitude, period and baseline
 * Step - always add the step value, negative values accepted
 * Stock - generate fake, stock-like price values based on a volatility variable
 

--- a/plugins/inputs/mock/mock.go
+++ b/plugins/inputs/mock/mock.go
@@ -43,6 +43,7 @@ type sineWave struct {
 	Name      string  `toml:"name"`
 	Amplitude float64 `toml:"amplitude"`
 	Period    float64 `toml:"period"`
+	BaseLine  float64 `toml:"base_line"`
 }
 
 type step struct {
@@ -117,7 +118,7 @@ func (m *Mock) generateRandomFloat64(fields map[string]interface{}) {
 // Create sine waves
 func (m *Mock) generateSineWave(fields map[string]interface{}) {
 	for _, field := range m.SineWave {
-		fields[field.Name] = math.Sin(float64(m.counter)*field.Period*math.Pi) * field.Amplitude
+		fields[field.Name] = math.Sin(float64(m.counter)*field.Period*math.Pi)*field.Amplitude + field.BaseLine
 	}
 }
 

--- a/plugins/inputs/mock/mock_test.go
+++ b/plugins/inputs/mock/mock_test.go
@@ -34,6 +34,7 @@ func TestGather(t *testing.T) {
 		Name:      "sine",
 		Amplitude: 1.0,
 		Period:    0.5,
+		BaseLine:  2.0,
 	}
 	testStep := &step{
 		Name:  "step",
@@ -87,7 +88,7 @@ func TestGather(t *testing.T) {
 			require.GreaterOrEqual(t, 6.0, v)
 			require.LessOrEqual(t, 1.0, v)
 		case "sine":
-			require.Equal(t, 0.0, v)
+			require.Equal(t, 2.0, v)
 		case "step":
 			require.Equal(t, 0.0, v)
 		default:

--- a/plugins/inputs/mock/sample.conf
+++ b/plugins/inputs/mock/sample.conf
@@ -19,6 +19,7 @@
   #   name = "wave"
   #   amplitude = 1.0
   #   period = 0.5
+  #   base_line = 0.0
   # [[inputs.mock.step]]
   #   name = "plus_one"
   #   start = 0.0


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
We would like to simulate a sine wave that does not rotate around 0.0

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #15269
