### PR TITLE
feat(aggregators.final): Add tags to new metrics

### DIFF
--- a/plugins/aggregators/final/README.md
+++ b/plugins/aggregators/final/README.md
@@ -43,6 +43,9 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ##   timeout  -- output a metric if no new input arrived for `series_timeout`
   ##   periodic -- output the last received metric every `period`
   # output_strategy = "timeout"
+
+  ## Tags that should be added to the downsampled metrics
+  # tags = { "t1" = "v1" }
 ```
 
 ### Output strategy

--- a/plugins/aggregators/final/final_test.go
+++ b/plugins/aggregators/final/final_test.go
@@ -307,12 +307,10 @@ func TestKeepOriginalFieldNames(t *testing.T) {
 }
 
 func TestAddTags(t *testing.T) {
-
 	final := &Final{
-		OutputStrategy:         "periodic",
-		SeriesTimeout:          config.Duration(30 * time.Second),
-		KeepOriginalFieldNames: true,
-		Tags:                   map[string]string{"k1": "v1"},
+		OutputStrategy: "periodic",
+		SeriesTimeout:  config.Duration(30 * time.Second),
+		Tags:           map[string]string{"k1": "v1"},
 	}
 
 	require.NoError(t, final.Init())
@@ -331,7 +329,7 @@ func TestAddTags(t *testing.T) {
 		metric.New(
 			"m",
 			map[string]string{"foo": "bar", "k1": "v1"},
-			map[string]any{"a": 3},
+			map[string]any{"a_final": 3},
 			now.Add(time.Second*-90),
 		),
 	}

--- a/plugins/aggregators/final/sample.conf
+++ b/plugins/aggregators/final/sample.conf
@@ -18,3 +18,6 @@
   ##   timeout  -- output a metric if no new input arrived for `series_timeout`
   ##   periodic -- output the last received metric every `period`
   # output_strategy = "timeout"
+
+  ## Tags that should be added to the downsampled metrics
+  # tags = { "t1" = "v1" }


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
It is useful to be able to distinguish between final and original fields using tags.

However, ideally this would be added as a global options for all processors and aggregators. I don't know if you're open to that.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #15283
