### PR TITLE
feat(inputs.redis): Add latency percentiles metric

### DIFF
--- a/plugins/inputs/redis/README.md
+++ b/plugins/inputs/redis/README.md
@@ -157,6 +157,12 @@ and the elapsed time since the last rdb save (rdb\_last\_save\_time\_elapsed).
   - usec(int, mircoseconds)
   - usec_per_call(float, microseconds)
 
+- redis_latency_percentiles_usec
+  - fields:
+    - p50(float, microseconds)
+    - p99(float, microseconds)
+    - p99.9(float, microseconds)
+
 - redis_replication
   - tags:
     - replication_role
@@ -184,7 +190,10 @@ and the elapsed time since the last rdb save (rdb\_last\_save\_time\_elapsed).
 - The redis_keyspace measurement has an additional database tag:
   - database
 
-- The redis_cmdstat measurement has an additional tag:
+- The redis_cmdstat measurement has an additional command tag:
+  - command
+
+- The redis_latency_percentiles_usec measurement has an additional command tag:
   - command
 
 ## Example Output
@@ -226,6 +235,12 @@ redis_command:
 
 ```text
 redis_cmdstat,command=publish,host=host,port=6379,replication_role=master,server=localhost calls=569514i,failed_calls=0i,rejected_calls=0i,usec=9916334i,usec_per_call=17.41 1559227136000000000
+```
+
+redis_latency_percentiles_usec:
+
+```text
+redis_latency_percentiles_usec,command=zadd,host=host,port=6379,replication_role=master,server=localhost p50=9.023,p99=28.031,p99.9=43.007 1559227136000000000
 ```
 
 redis_error:

--- a/plugins/inputs/redis/redis_test.go
+++ b/plugins/inputs/redis/redis_test.go
@@ -258,6 +258,22 @@ func TestRedis_ParseMetrics(t *testing.T) {
 	}
 	acc.AssertContainsTaggedFields(t, "redis_cmdstat", cmdstatPublishFields, cmdstatPublishTags)
 
+	latencyZaddTags := map[string]string{"host": "redis.net", "replication_role": "master", "command": "zadd"}
+	latencyZaddFields := map[string]interface{}{
+		"p50":   float64(9.023),
+		"p99":   float64(28.031),
+		"p99.9": float64(43.007),
+	}
+	acc.AssertContainsTaggedFields(t, "redis_latency_percentiles_usec", latencyZaddFields, latencyZaddTags)
+
+	latencyHgetallTags := map[string]string{"host": "redis.net", "replication_role": "master", "command": "hgetall"}
+	latencyHgetallFields := map[string]interface{}{
+		"p50":   float64(11.007),
+		"p99":   float64(34.047),
+		"p99.9": float64(66.047),
+	}
+	acc.AssertContainsTaggedFields(t, "redis_latency_percentiles_usec", latencyHgetallFields, latencyHgetallTags)
+
 	replicationTags := map[string]string{
 		"host":             "redis.net",
 		"replication_role": "slave",
@@ -540,6 +556,10 @@ errorstat_MOVED:count=3628
 errorstat_NOSCRIPT:count=4
 errorstat_WRONGPASS:count=2
 errorstat_WRONGTYPE:count=30
+
+# Latencystats
+latency_percentiles_usec_zadd:p50=9.023,p99=28.031,p99.9=43.007
+latency_percentiles_usec_hgetall:p50=11.007,p99=34.047,p99.9=66.047
 
 # Keyspace
 db0:keys=2,expires=0,avg_ttl=0


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

"ALL" info contains latency percentile statistics, and these were not parsed. This creates problems in e.g. the Prometheus output.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [X] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #15294
