### PR TITLE
chore(deps): Bump golangci-lint from v1.57.2 to v1.58.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,7 +101,7 @@ jobs:
       - run: 'make check-deps'
       - run:
           name: "Install golangci-lint"
-          command: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.57.2
+          command: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.58.0
       - run:
           name: "golangci-lint/Linux"
           command: GOGC=80 GOMEMLIMIT=6656MiB /go/bin/golangci-lint run --verbose
@@ -112,7 +112,7 @@ jobs:
       - check-changed-files-or-halt
       - run:
           name: "Install golangci-lint"
-          command: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.57.2
+          command: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.58.0
       - run:
           name: "golangci-lint/macOS"
           command: GOGC=80 GOMEMLIMIT=6656MiB GOOS=darwin /go/bin/golangci-lint run --verbose --timeout=30m
@@ -124,7 +124,7 @@ jobs:
       - check-changed-files-or-halt
       - run:
           name: "Install golangci-lint"
-          command: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.57.2
+          command: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.58.0
       - run:
           name: "golangci-lint/Windows"
           command: GOGC=80 GOMEMLIMIT=6656MiB GOOS=windows /go/bin/golangci-lint run --verbose --timeout=30m

--- a/Makefile
+++ b/Makefile
@@ -174,7 +174,7 @@ vet:
 .PHONY: lint-install
 lint-install:
 	@echo "Installing golangci-lint"
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.57.2
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.58.0
 
 	@echo "Installing markdownlint"
 	npm install -g markdownlint-cli

--- a/models/buffer.go
+++ b/models/buffer.go
@@ -251,10 +251,3 @@ func (b *Buffer) resetBatch() {
 	b.batchFirst = 0
 	b.batchSize = 0
 }
-
-func min(a, b int) int {
-	if b < a {
-		return b
-	}
-	return a
-}

--- a/plugins/outputs/dynatrace/dynatrace.go
+++ b/plugins/outputs/dynatrace/dynatrace.go
@@ -261,10 +261,3 @@ func (d *Dynatrace) getTypeOption(metric telegraf.Metric, field *telegraf.Field)
 
 	return nil
 }
-
-func min(a, b int) int {
-	if a <= b {
-		return a
-	}
-	return b
-}

--- a/plugins/processors/topk/topk.go
+++ b/plugins/processors/topk/topk.go
@@ -190,13 +190,6 @@ func (t *TopK) Apply(in ...telegraf.Metric) []telegraf.Metric {
 	return []telegraf.Metric{}
 }
 
-func min(a, b int) int {
-	if a > b {
-		return b
-	}
-	return a
-}
-
 func convert(in interface{}) (float64, bool) {
 	switch v := in.(type) {
 	case float64:


### PR DESCRIPTION
## Summary
Update golangci-lint and remove our min functions, in favor or using the builtin min function.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR
