### PR TITLE
feat(inputs.win_eventlog): Add option to define event batch-size

### DIFF
--- a/plugins/inputs/win_eventlog/README.md
+++ b/plugins/inputs/win_eventlog/README.md
@@ -151,6 +151,15 @@ XML Query documentation:
 
 <https://docs.microsoft.com/en-us/windows/win32/wes/consuming-events>
 
+## Troubleshooting
+
+In case you see a `Collection took longer than expected` warning, there might
+be a burst of events logged and the API is not able to deliver them fast enough
+to complete processing within the specified interval. Tweaking the
+`event_batch_size` setting might help to mitigate the issue.
+The said warning does not indicate data-loss, but you should investige the
+amount of events you log.
+
 ## Metrics
 
 You can send any field, *System*, *Computed* or *XML* as tag field. List of

--- a/plugins/inputs/win_eventlog/README.md
+++ b/plugins/inputs/win_eventlog/README.md
@@ -69,6 +69,9 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## events will be logged.
   # from_beginning = false
 
+  ## Number of events to fetch in one batch
+  # event_batch_size = 5
+
   # Process UserData XML to fields, if this node exists in Event XML
   # process_userdata = true
 

--- a/plugins/inputs/win_eventlog/sample.conf
+++ b/plugins/inputs/win_eventlog/sample.conf
@@ -44,6 +44,9 @@
   ## events will be logged.
   # from_beginning = false
 
+  ## Number of events to fetch in one batch
+  # event_batch_size = 5
+
   # Process UserData XML to fields, if this node exists in Event XML
   # process_userdata = true
 


### PR DESCRIPTION
## Summary

Currently, we are fetching five events at a time and process them. The new option allows to tweak the number of events to fetch as one batch to potentially improve performance when larger volumes of events occur.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #15242 
