### PR TITLE
chore(parsers.grok): Improve non-matching debug message

### DIFF
--- a/plugins/parsers/grok/parser.go
+++ b/plugins/parsers/grok/parser.go
@@ -214,7 +214,7 @@ func (p *Parser) ParseLine(line string) (telegraf.Metric, error) {
 	}
 
 	if len(values) == 0 {
-		p.Log.Debugf("Grok no match found for: %q", line)
+		p.Log.Debugf("Grok no match found for or no data extracted from: %q", line)
 		return nil, nil
 	}
 


### PR DESCRIPTION
## Summary

When providing Grok patterns without a named field (or tag) Telegraf will currently report that no match was found for the pattern(s). This PR extends the message to also cover that case.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #15315 