### PR TITLE
docs(outputs.postgresql): Add example to create index for tag columns

### DIFF
--- a/plugins/outputs/postgresql/README.md
+++ b/plugins/outputs/postgresql/README.md
@@ -274,6 +274,17 @@ tag_table_add_column_templates = [
 ]
 ```
 
+#### Index
+
+Create an index on time and tag columns for faster querying of data.
+
+```toml
+create_templates = [
+    '''CREATE TABLE {{ .table }} ({{ .columns }})''',
+    '''CREATE INDEX ON {{ .table }} USING btree({{ .columns.Keys.Identifiers | join "," }})'''
+  ]
+```
+
 ## Error handling
 
 When the plugin encounters an error writing to the database, it attempts to


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

A user had a speed issue and requested help to create indexes for the auto generated table in PostgreSQL on [this Slack thread](https://influxcommunity.slack.com/archives/CH99HUH8V/p1715133186596159). We figured out  how to solve this, so returning the knowledge into an extra sample config in the documentation.


## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

N/A
