### PR TITLE
fix(inputs.netflow): Log unknown fields only once

### DIFF
--- a/plugins/inputs/netflow/netflow_decoder.go
+++ b/plugins/inputs/netflow/netflow_decoder.go
@@ -756,6 +756,7 @@ func (d *netflowDecoder) decodeValueV9(field netflow.DataField) ([]telegraf.Fiel
 	key := fmt.Sprintf("type_%d", elementID)
 	if !d.logged[key] {
 		d.Log.Debugf("unknown Netflow v9 data field %v", field)
+		d.logged[key] = true
 	}
 	v, err := decodeHex(raw)
 	if err != nil {
@@ -789,6 +790,7 @@ func (d *netflowDecoder) decodeValueIPFIX(field netflow.DataField) ([]telegraf.F
 		}
 		if !d.logged[key] {
 			d.Log.Debugf("unknown IPFIX PEN data field %v", field)
+			d.logged[key] = true
 		}
 		name := fmt.Sprintf("type_%d_%s%d", field.Pen, prefix, elementID)
 		v, err := decodeHex(raw)
@@ -837,6 +839,7 @@ func (d *netflowDecoder) decodeValueIPFIX(field netflow.DataField) ([]telegraf.F
 	key := fmt.Sprintf("type_%d", elementID)
 	if !d.logged[key] {
 		d.Log.Debugf("unknown IPFIX data field %v", field)
+		d.logged[key] = true
 	}
 	v, err := decodeHex(raw)
 	if err != nil {


### PR DESCRIPTION
## Summary

When logging unknown fields, we forgot to mark the field as "already logged". This PR fixes the issue.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues
