### PR TITLE
chore(deps): Bump go from v1.22.2 to v1.22.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
     working_directory: '/go/src/github.com/influxdata/telegraf'
     resource_class: large
     docker:
-      - image: 'quay.io/influxdb/telegraf-ci:1.22.2'
+      - image: 'quay.io/influxdb/telegraf-ci:1.22.3'
     environment:
       GOFLAGS: -p=4
   mac:

--- a/.github/workflows/readme-linter.yml
+++ b/.github/workflows/readme-linter.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.22.2'
+          go-version: '1.22.3'
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0

--- a/Makefile
+++ b/Makefile
@@ -251,8 +251,8 @@ plugins/parsers/influx/machine.go: plugins/parsers/influx/machine.go.rl
 
 .PHONY: ci
 ci:
-	docker build -t quay.io/influxdb/telegraf-ci:1.22.2 - < scripts/ci.docker
-	docker push quay.io/influxdb/telegraf-ci:1.22.2
+	docker build -t quay.io/influxdb/telegraf-ci:1.22.3 - < scripts/ci.docker
+	docker push quay.io/influxdb/telegraf-ci:1.22.3
 
 .PHONY: install
 install: $(buildbin)

--- a/scripts/ci.docker
+++ b/scripts/ci.docker
@@ -1,4 +1,4 @@
-FROM golang:1.22.2
+FROM golang:1.22.3
 
 RUN chmod -R 755 "$GOPATH"
 

--- a/scripts/installgo_linux.sh
+++ b/scripts/installgo_linux.sh
@@ -2,10 +2,10 @@
 
 set -eux
 
-GO_VERSION="1.22.2"
+GO_VERSION="1.22.3"
 GO_ARCH="linux-amd64"
 # from https://golang.org/dl
-GO_VERSION_SHA="5901c52b7a78002aeff14a21f93e0f064f74ce1360fce51c6ee68cd471216a17"
+GO_VERSION_SHA="8920ea521bad8f6b7bc377b4824982e011c19af27df88a815e3586ea895f1b36"
 
 # Download Go and verify Go tarball
 setup_go () {

--- a/scripts/installgo_mac.sh
+++ b/scripts/installgo_mac.sh
@@ -3,9 +3,9 @@
 set -eux
 
 ARCH=$(uname -m)
-GO_VERSION="1.22.2"
-GO_VERSION_SHA_arm64="660298be38648723e783ba0398e90431de1cb288c637880cdb124f39bd977f0d" # from https://golang.org/dl
-GO_VERSION_SHA_amd64="33e7f63077b1c5bce4f1ecadd4d990cf229667c40bfb00686990c950911b7ab7" # from https://golang.org/dl
+GO_VERSION="1.22.3"
+GO_VERSION_SHA_arm64="02abeab3f4b8981232237ebd88f0a9bad933bc9621791cd7720a9ca29eacbe9d" # from https://golang.org/dl
+GO_VERSION_SHA_amd64="610e48c1df4d2f852de8bc2e7fd2dc1521aac216f0c0026625db12f67f192024" # from https://golang.org/dl
 
 if [ "$ARCH" = 'arm64' ]; then
     GO_ARCH="darwin-arm64"

--- a/scripts/installgo_windows.sh
+++ b/scripts/installgo_windows.sh
@@ -2,7 +2,7 @@
 
 set -eux
 
-GO_VERSION="1.22.2"
+GO_VERSION="1.22.3"
 
 setup_go () {
     choco upgrade golang --allow-downgrade --version=${GO_VERSION}


### PR DESCRIPTION
## Summary
Update go version.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

fixes: #15331