### PR TITLE
feat(processors.parser): Add base64 decode for fields

### DIFF
--- a/plugins/processors/parser/README.md
+++ b/plugins/processors/parser/README.md
@@ -41,6 +41,11 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## more about them here:
   ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_INPUT.md
   data_format = "influx"
+
+  ## Fields to base64 decode
+  ## This list of fields must be a subset of parse_fields. Fields specified
+  ## here will have base64 decode applied to them.
+  # base64_fields = []
 ```
 
 ## Example

--- a/plugins/processors/parser/README.md
+++ b/plugins/processors/parser/README.md
@@ -20,6 +20,11 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## The name of the fields whose value will be parsed.
   parse_fields = ["message"]
 
+  ## Fields to base64 decode.
+  ## These fields do not need to be specified in parse_fields.
+  ## Fields specified here will have base64 decode applied to them.
+  # parse_fields_base64 = []
+
   ## The name of the tags whose value will be parsed.
   # parse_tags = []
 
@@ -41,11 +46,6 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## more about them here:
   ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_INPUT.md
   data_format = "influx"
-
-  ## Fields to base64 decode
-  ## This list of fields must be a subset of parse_fields. Fields specified
-  ## here will have base64 decode applied to them.
-  # base64_fields = []
 ```
 
 ## Example

--- a/plugins/processors/parser/parser.go
+++ b/plugins/processors/parser/parser.go
@@ -7,6 +7,7 @@ import (
 	"encoding/base64"
 	gobin "encoding/binary"
 	"fmt"
+	"slices"
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/internal"
@@ -55,13 +56,57 @@ func (p *Parser) Apply(metrics ...telegraf.Metric) []telegraf.Metric {
 		}
 
 		// parse fields
-		for _, key := range p.ParseFields {
-			newMetrics = append(newMetrics, p.parseField(key, metric, false)...)
-		}
+		for _, field := range metric.FieldList() {
+			plain := slices.Contains(p.ParseFields, field.Key)
+			b64 := slices.Contains(p.Base64Fields, field.Key)
 
-		// parse base64 fields
-		for _, key := range p.Base64Fields {
-			newMetrics = append(newMetrics, p.parseField(key, metric, true)...)
+			if !plain && !b64 {
+				continue
+			}
+
+			if plain && b64 {
+				p.Log.Errorf("field %s is listed in both parse fields and base64 fields; skipping", field.Key)
+				continue
+			}
+
+			value, err := p.toBytes(field.Value)
+			if err != nil {
+				p.Log.Errorf("could not convert field %s: %v; skipping", field.Key, err)
+				continue
+			}
+
+			if b64 {
+				decoded := make([]byte, base64.StdEncoding.DecodedLen(len(value)))
+				n, err := base64.StdEncoding.Decode(decoded, value)
+				if err != nil {
+					p.Log.Errorf("could not decode base64 field %s: %v; skipping", field.Key, err)
+					continue
+				}
+				value = decoded[:n]
+			}
+
+			fromFieldMetric, err := p.parser.Parse(value)
+			if err != nil {
+				p.Log.Errorf("could not parse field %s: %v", field.Key, err)
+				continue
+			}
+
+			for _, m := range fromFieldMetric {
+				// The parser get the parent plugin's name as
+				// default measurement name. Thus, in case the
+				// parsed metric does not provide a name itself,
+				// the parser  will return 'parser' as we are in
+				// processors.parser. In those cases we want to
+				// keep the original metric name.
+				if m.Name() == "" || m.Name() == "parser" {
+					m.SetName(metric.Name())
+				}
+			}
+
+			// multiple parsed fields shouldn't create multiple
+			// metrics so we'll merge tags/fields down into one
+			// prior to returning.
+			newMetrics = append(newMetrics, fromFieldMetric...)
 		}
 
 		// parse tags
@@ -103,43 +148,6 @@ func (p *Parser) Apply(metrics ...telegraf.Metric) []telegraf.Metric {
 	return results
 }
 
-func (p *Parser) parseField(key string, metric telegraf.Metric, b64 bool) []telegraf.Metric {
-	newMetrics := []telegraf.Metric{}
-	for _, field := range metric.FieldList() {
-		if field.Key != key {
-			continue
-		}
-		value, err := p.toBytes(field.Value, b64)
-		if err != nil {
-			p.Log.Errorf("could not convert field %s: %v; skipping", key, err)
-			continue
-		}
-		fromFieldMetric, err := p.parser.Parse(value)
-		if err != nil {
-			p.Log.Errorf("could not parse field %s: %v", key, err)
-			continue
-		}
-
-		for _, m := range fromFieldMetric {
-			// The parser get the parent plugin's name as
-			// default measurement name. Thus, in case the
-			// parsed metric does not provide a name itself,
-			// the parser  will return 'parser' as we are in
-			// processors.parser. In those cases we want to
-			// keep the original metric name.
-			if m.Name() == "" || m.Name() == "parser" {
-				m.SetName(metric.Name())
-			}
-		}
-
-		// multiple parsed fields shouldn't create multiple
-		// metrics so we'll merge tags/fields down into one
-		// prior to returning.
-		newMetrics = append(newMetrics, fromFieldMetric...)
-	}
-	return newMetrics
-}
-
 func merge(base telegraf.Metric, metrics []telegraf.Metric) telegraf.Metric {
 	for _, metric := range metrics {
 		for _, field := range metric.FieldList() {
@@ -173,27 +181,17 @@ func (p *Parser) parseValue(value string) ([]telegraf.Metric, error) {
 	return p.parser.Parse([]byte(value))
 }
 
-func (p *Parser) toBytes(value interface{}, b64 bool) ([]byte, error) {
-	var raw []byte
+func (p *Parser) toBytes(value interface{}) ([]byte, error) {
 	if v, ok := value.(string); ok {
-		raw = []byte(v)
-	} else {
-		var buf bytes.Buffer
-		if err := gobin.Write(&buf, internal.HostEndianness, value); err != nil {
-			return nil, err
-		}
-		raw = buf.Bytes()
+		return []byte(v), nil
 	}
 
-	if b64 {
-		decoded := make([]byte, base64.StdEncoding.DecodedLen(len(raw)))
-		n, err := base64.StdEncoding.Decode(decoded, raw)
-		if err != nil {
-			return nil, err
-		}
-		return decoded[:n], nil
+	var buf bytes.Buffer
+	if err := gobin.Write(&buf, internal.HostEndianness, value); err != nil {
+		return nil, err
 	}
-	return raw, nil
+
+	return buf.Bytes(), nil
 }
 
 func init() {

--- a/plugins/processors/parser/parser_test.go
+++ b/plugins/processors/parser/parser_test.go
@@ -24,6 +24,7 @@ func TestApply(t *testing.T) {
 		name         string
 		parseFields  []string
 		parseTags    []string
+		parseBase64  []string
 		parser       telegraf.Parser
 		dropOriginal bool
 		merge        string
@@ -708,6 +709,105 @@ func TestApply(t *testing.T) {
 					time.Unix(1593287020, 0)),
 			},
 		},
+		{
+			name:         "test base 64 field single",
+			parseFields:  []string{"sample"},
+			parseBase64:  []string{"sample"},
+			dropOriginal: true,
+			parser: &json.Parser{
+				TagKeys: []string{
+					"text",
+				},
+			},
+			input: metric.New(
+				"singleField",
+				map[string]string{
+					"some": "tag",
+				},
+				map[string]interface{}{
+					"sample": `eyJ0ZXh0IjogInRlc3QgYmFzZTY0In0=`,
+				},
+				time.Unix(0, 0)),
+			expected: []telegraf.Metric{
+				metric.New(
+					"singleField",
+					map[string]string{
+						"text": "test base64",
+					},
+					map[string]interface{}{},
+					time.Unix(0, 0)),
+			},
+		},
+		{
+			name:         "parse two base64 fields",
+			parseFields:  []string{"field_1", "field_2"},
+			parseBase64:  []string{"field_1", "field_2"},
+			dropOriginal: true,
+			parser: &json.Parser{
+				TagKeys: []string{"lvl", "msg", "err", "fatal"},
+			},
+			input: metric.New(
+				"bigMeasure",
+				map[string]string{},
+				map[string]interface{}{
+					"field_1": `eyJsdmwiOiJpbmZvIiwibXNnIjoiaHR0cCByZXF1ZXN0In0=`,
+					"field_2": `eyJlcnIiOiJmYXRhbCIsImZhdGFsIjoic2VjdXJpdHkgdGhyZWF0In0=`,
+				},
+				time.Unix(0, 0)),
+			expected: []telegraf.Metric{
+				metric.New(
+					"bigMeasure",
+					map[string]string{
+						"lvl": "info",
+						"msg": "http request",
+					},
+					map[string]interface{}{},
+					time.Unix(0, 0)),
+				metric.New(
+					"bigMeasure",
+					map[string]string{
+						"err":   "fatal",
+						"fatal": "security threat",
+					},
+					map[string]interface{}{},
+					time.Unix(0, 0)),
+			},
+		},
+		{
+			name:         "parse two fields, one base64",
+			parseFields:  []string{"field_1", "field_2"},
+			parseBase64:  []string{"field_1"},
+			dropOriginal: true,
+			parser: &json.Parser{
+				TagKeys: []string{"lvl", "msg", "err", "fatal"},
+			},
+			input: metric.New(
+				"bigMeasure",
+				map[string]string{},
+				map[string]interface{}{
+					"field_1": `eyJsdmwiOiJpbmZvIiwibXNnIjoiaHR0cCByZXF1ZXN0In0=`,
+					"field_2": `{"err":"fatal","fatal":"security threat"}`,
+				},
+				time.Unix(0, 0)),
+			expected: []telegraf.Metric{
+				metric.New(
+					"bigMeasure",
+					map[string]string{
+						"lvl": "info",
+						"msg": "http request",
+					},
+					map[string]interface{}{},
+					time.Unix(0, 0)),
+				metric.New(
+					"bigMeasure",
+					map[string]string{
+						"err":   "fatal",
+						"fatal": "security threat",
+					},
+					map[string]interface{}{},
+					time.Unix(0, 0)),
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -718,6 +818,7 @@ func TestApply(t *testing.T) {
 			plugin := Parser{
 				ParseFields:  tt.parseFields,
 				ParseTags:    tt.parseTags,
+				Base64Fields: tt.parseBase64,
 				DropOriginal: tt.dropOriginal,
 				Merge:        tt.merge,
 				Log:          testutil.Logger{Name: "processor.parser"},
@@ -810,6 +911,22 @@ func TestBadApply(t *testing.T) {
 			testutil.RequireMetricsEqual(t, tt.expected, output, testutil.IgnoreTime())
 		})
 	}
+}
+
+func TestBase64FieldValidation(t *testing.T) {
+	plugin := &Parser{
+		ParseFields:  []string{"a"},
+		Base64Fields: []string{"b"},
+	}
+	plugin.SetParser(&json.Parser{})
+	require.Error(t, plugin.Init())
+
+	plugin = &Parser{
+		ParseFields:  []string{"a"},
+		Base64Fields: []string{"a"},
+	}
+	plugin.SetParser(&json.Parser{})
+	require.NoError(t, plugin.Init())
 }
 
 func TestTracking(t *testing.T) {

--- a/plugins/processors/parser/sample.conf
+++ b/plugins/processors/parser/sample.conf
@@ -24,3 +24,8 @@
   ## more about them here:
   ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_INPUT.md
   data_format = "influx"
+
+  ## Fields to base64 decode
+  ## This list of fields must be a subset of parse_fields. Fields specified
+  ## here will have base64 decode applied to them.
+  # base64_fields = []

--- a/plugins/processors/parser/sample.conf
+++ b/plugins/processors/parser/sample.conf
@@ -3,6 +3,11 @@
   ## The name of the fields whose value will be parsed.
   parse_fields = ["message"]
 
+  ## Fields to base64 decode.
+  ## These fields do not need to be specified in parse_fields.
+  ## Fields specified here will have base64 decode applied to them.
+  # parse_fields_base64 = []
+
   ## The name of the tags whose value will be parsed.
   # parse_tags = []
 
@@ -24,8 +29,3 @@
   ## more about them here:
   ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_INPUT.md
   data_format = "influx"
-
-  ## Fields to base64 decode
-  ## This list of fields must be a subset of parse_fields. Fields specified
-  ## here will have base64 decode applied to them.
-  # base64_fields = []


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Adds a base64 decode option for any field specified in the `parse_fields` config option.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [X] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #15130
