### PR TITLE
feat(inputs.file): Add tag with absolute path of file

### DIFF
--- a/plugins/inputs/file/README.md
+++ b/plugins/inputs/file/README.md
@@ -39,12 +39,17 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_INPUT.md
   data_format = "influx"
 
-
-  ## Name a tag containing the name of the file the data was parsed from.  Leave empty
-  ## to disable. Cautious when file name variation is high, this can increase the cardinality
-  ## significantly. Read more about cardinality here:
+  ## Please use caution when using the following options: when file name
+  ## variation is high, this can increase the cardinality significantly. Read
+  ## more about cardinality here:
   ## https://docs.influxdata.com/influxdb/cloud/reference/glossary/#series-cardinality
+
+  ## Name of tag to store the name of the file. Disabled if not set.
   # file_tag = ""
+
+  ## Name of tag to store the absolute path and name of the file. Disabled if
+  ## not set.
+  # file_path_tag = ""
 ```
 
 ## Metrics

--- a/plugins/inputs/file/file.go
+++ b/plugins/inputs/file/file.go
@@ -22,6 +22,7 @@ var sampleConfig string
 type File struct {
 	Files             []string `toml:"files"`
 	FileTag           string   `toml:"file_tag"`
+	FilePathTag       string   `toml:"file_path_tag"`
 	CharacterEncoding string   `toml:"character_encoding"`
 
 	parserFunc telegraf.ParserFunc
@@ -53,6 +54,11 @@ func (f *File) Gather(acc telegraf.Accumulator) error {
 		for _, m := range metrics {
 			if f.FileTag != "" {
 				m.AddTag(f.FileTag, filepath.Base(k))
+			}
+			if f.FilePathTag != "" {
+				if absPath, err := filepath.Abs(k); err == nil {
+					m.AddTag(f.FilePathTag, absPath)
+				}
 			}
 			acc.AddMetric(m)
 		}

--- a/plugins/inputs/file/file_test.go
+++ b/plugins/inputs/file/file_test.go
@@ -42,8 +42,9 @@ func TestFileTag(t *testing.T) {
 	wd, err := os.Getwd()
 	require.NoError(t, err)
 	r := File{
-		Files:   []string{filepath.Join(wd, "dev", "testfiles", "json_a.log")},
-		FileTag: "filename",
+		Files:       []string{filepath.Join(wd, "dev", "testfiles", "json_a.log")},
+		FileTag:     "filename",
+		FilePathTag: "filepath",
 	}
 	require.NoError(t, r.Init())
 
@@ -56,10 +57,11 @@ func TestFileTag(t *testing.T) {
 	require.NoError(t, r.Gather(&acc))
 
 	for _, m := range acc.Metrics {
-		for key, value := range m.Tags {
-			require.Equal(t, r.FileTag, key)
-			require.Equal(t, filepath.Base(r.Files[0]), value)
-		}
+		require.Contains(t, m.Tags, "filename")
+		require.Equal(t, filepath.Base(r.Files[0]), m.Tags["filename"])
+
+		require.Contains(t, m.Tags, "filepath")
+		require.True(t, filepath.IsAbs(m.Tags["filepath"]))
 	}
 }
 

--- a/plugins/inputs/file/sample.conf
+++ b/plugins/inputs/file/sample.conf
@@ -19,9 +19,14 @@
   ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_INPUT.md
   data_format = "influx"
 
-
-  ## Name a tag containing the name of the file the data was parsed from.  Leave empty
-  ## to disable. Cautious when file name variation is high, this can increase the cardinality
-  ## significantly. Read more about cardinality here:
+  ## Please use caution when using the following options: when file name
+  ## variation is high, this can increase the cardinality significantly. Read
+  ## more about cardinality here:
   ## https://docs.influxdata.com/influxdb/cloud/reference/glossary/#series-cardinality
+
+  ## Name of tag to store the name of the file. Disabled if not set.
   # file_tag = ""
+
+  ## Name of tag to store the absolute path and name of the file. Disabled if
+  ## not set.
+  # file_path_tag = ""


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Add option to add a tag with the absolute path to the file (e.g. `/tmp/myfile.toml`)

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

fixes: #15133