### PR TITLE
feat: add session_timeout configuration option for OPCUA input plugins

### DIFF
--- a/plugins/common/opcua/client.go
+++ b/plugins/common/opcua/client.go
@@ -51,6 +51,7 @@ type OpcUAClientConfig struct {
 
 	OptionalFields []string         `toml:"optional_fields"`
 	Workarounds    OpcUAWorkarounds `toml:"workarounds"`
+	SessionTimeout config.Duration  `toml:"session_timeout"`
 }
 
 func (o *OpcUAClientConfig) Validate() error {

--- a/plugins/common/opcua/opcua_util.go
+++ b/plugins/common/opcua/opcua_util.go
@@ -157,6 +157,7 @@ func (o *OpcUAClient) generateClientOpts(endpoints []*ua.EndpointDescription) ([
 		opcua.ApplicationURI(appuri),
 		opcua.ApplicationName(appname),
 		opcua.RequestTimeout(time.Duration(o.Config.RequestTimeout)),
+		opcua.SessionTimeout(time.Duration(o.Config.SessionTimeout)),
 	)
 
 	certFile := o.Config.Certificate

--- a/plugins/inputs/opcua/README.md
+++ b/plugins/inputs/opcua/README.md
@@ -40,6 +40,10 @@ to use them.
   ## Maximum time allowed for a request over the established connection.
   # request_timeout = "5s"
   #
+  # Maximum time that a session shall remain open without activity.
+  # Default is 20 minutes.
+  # session_timeout = "60s"
+  #
   ## Security policy, one of "None", "Basic128Rsa15", "Basic256",
   ## "Basic256Sha256", or "auto"
   # security_policy = "auto"

--- a/plugins/inputs/opcua/opcua_test.go
+++ b/plugins/inputs/opcua/opcua_test.go
@@ -129,6 +129,7 @@ func TestReadClientIntegration(t *testing.T) {
 				AuthMethod:     "Anonymous",
 				ConnectTimeout: config.Duration(10 * time.Second),
 				RequestTimeout: config.Duration(1 * time.Second),
+				SessionTimeout: config.Duration(1 * time.Minute),
 				Workarounds:    opcua.OpcUAWorkarounds{},
 			},
 			MetricName: "testing",

--- a/plugins/inputs/opcua/sample.conf
+++ b/plugins/inputs/opcua/sample.conf
@@ -11,6 +11,10 @@
   #
   ## Maximum time allowed for a request over the established connection.
   # request_timeout = "5s"
+
+  # Maximum time that a session shall remain open without activity.
+  # Default is 20 minutes.
+  # session_timeout = "60s"
   #
   ## Security policy, one of "None", "Basic128Rsa15", "Basic256",
   ## "Basic256Sha256", or "auto"

--- a/plugins/inputs/opcua_listener/README.md
+++ b/plugins/inputs/opcua_listener/README.md
@@ -57,6 +57,10 @@ to use them.
   ## Maximum time allowed for a request over the established connection.
   # request_timeout = "5s"
   #
+  # Maximum time that a session shall remain open without activity.
+  # Default is 20 minutes.
+  # session_timeout = "60s"
+  #
   ## The interval at which the server should at least update its monitored items
   # subscription_interval = "100ms"
   #

--- a/plugins/inputs/opcua_listener/sample.conf
+++ b/plugins/inputs/opcua_listener/sample.conf
@@ -18,6 +18,10 @@
   ## Maximum time allowed for a request over the established connection.
   # request_timeout = "5s"
   #
+  # Maximum time that a session shall remain open without activity.
+  # Default is 20 minutes.
+  # session_timeout = "60s"
+  #
   ## The interval at which the server should at least update its monitored items
   # subscription_interval = "100ms"
   #


### PR DESCRIPTION
## Summary
Adding the parameter "session_timeout" to OPCUA plugins configuration.

## Checklist
- [x] No AI generated code was used in this PR

## Related issues
Resolves https://github.com/influxdata/telegraf/issues/15258
