### PR TITLE
fix(windows): Make sure to log the final error message

### DIFF
--- a/cmd/telegraf/main.go
+++ b/cmd/telegraf/main.go
@@ -374,7 +374,11 @@ func runApp(args []string, outputBuffer io.Writer, pprof Server, c TelegrafConfi
 	defer memguard.Purge()
 	defer logger.CloseLogging()
 
-	return app.Run(args)
+	if err := app.Run(args); err != nil {
+		log.Printf("E! %s", err)
+		return err
+	}
+	return nil
 }
 
 func main() {
@@ -385,6 +389,6 @@ func main() {
 	pprof := NewPprofServer()
 	c := config.NewConfig()
 	if err := runApp(os.Args, os.Stdout, pprof, c, &agent); err != nil {
-		log.Fatalf("E! %s", err)
+		os.Exit(1)
 	}
 }


### PR DESCRIPTION
## Summary

When exiting a program with `log.Fatal`, the program does not execute any deferred calls and will also exit immediately. For logging with the Windows event-logger interface, this means that the connection to the logger is not shut down gracefully and thus the final  (and most important) log message is lost.

This PR does not use `log.Fatal` to log the message but rather rely on `log.Print` which allows for a graceful exit. Furthermore, we move the logging into the `runApp` function which really is the core processing loop.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #14144 
