### PR TITLE
feat(inputs.influxdb_v2_listener): Add support for rate limiting

### DIFF
--- a/plugins/inputs/influxdb_v2_listener/README.md
+++ b/plugins/inputs/influxdb_v2_listener/README.md
@@ -40,6 +40,11 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## (Double check the port. Could be 9999 if using OSS Beta)
   service_address = ":8086"
 
+  ## Maximum undelivered metrics before rate limit kicks in.
+  ## When the rate limit kicks in, HTTP status 429 will be returned.
+  ## 0 disables rate limiting
+  # max_undelivered_metrics = 0
+
   ## Maximum duration before timing out read of the request
   # read_timeout = "10s"
   ## Maximum duration before timing out write of the response

--- a/plugins/inputs/influxdb_v2_listener/influxdb_v2_listener.go
+++ b/plugins/inputs/influxdb_v2_listener/influxdb_v2_listener.go
@@ -13,6 +13,8 @@ import (
 	"net"
 	"net/http"
 	"strconv"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/influxdata/telegraf"
@@ -52,19 +54,27 @@ type InfluxDBV2Listener struct {
 	port           int
 	tlsint.ServerConfig
 
-	ReadTimeout  config.Duration `toml:"read_timeout"`
-	WriteTimeout config.Duration `toml:"write_timeout"`
-	MaxBodySize  config.Size     `toml:"max_body_size"`
-	Token        string          `toml:"token"`
-	BucketTag    string          `toml:"bucket_tag"`
-	ParserType   string          `toml:"parser_type"`
+	MaxUndeliveredMetrics int             `toml:"max_undelivered_metrics"`
+	ReadTimeout           config.Duration `toml:"read_timeout"`
+	WriteTimeout          config.Duration `toml:"write_timeout"`
+	MaxBodySize           config.Size     `toml:"max_body_size"`
+	Token                 string          `toml:"token"`
+	BucketTag             string          `toml:"bucket_tag"`
+	ParserType            string          `toml:"parser_type"`
+
+	ctx                     context.Context
+	cancel                  context.CancelFunc
+	trackingMetricCount     map[telegraf.TrackingID]int64
+	countLock               sync.Mutex
+	totalUndeliveredMetrics atomic.Int64
 
 	timeFunc influx.TimeFunc
 
 	listener net.Listener
 	server   http.Server
 
-	acc telegraf.Accumulator
+	acc         telegraf.Accumulator
+	trackingAcc telegraf.TrackingAccumulator
 
 	bytesRecv       selfstat.Stat
 	requestsServed  selfstat.Stat
@@ -135,6 +145,26 @@ func (h *InfluxDBV2Listener) Init() error {
 // Start starts the InfluxDB listener service.
 func (h *InfluxDBV2Listener) Start(acc telegraf.Accumulator) error {
 	h.acc = acc
+	h.ctx, h.cancel = context.WithCancel(context.Background())
+	if h.MaxUndeliveredMetrics > 0 {
+		h.trackingAcc = h.acc.WithTracking(h.MaxUndeliveredMetrics)
+		h.trackingMetricCount = make(map[telegraf.TrackingID]int64, h.MaxUndeliveredMetrics)
+		go func() {
+			for {
+				select {
+				case <-h.ctx.Done():
+					return
+				case info := <-h.trackingAcc.Delivered():
+					if count, ok := h.trackingMetricCount[info.ID()]; ok {
+						h.countLock.Lock()
+						h.totalUndeliveredMetrics.Add(-count)
+						delete(h.trackingMetricCount, info.ID())
+						h.countLock.Unlock()
+					}
+				}
+			}
+		}()
+	}
 
 	tlsConf, err := h.ServerConfig.TLSConfig()
 	if err != nil {
@@ -180,6 +210,7 @@ func (h *InfluxDBV2Listener) Start(acc telegraf.Accumulator) error {
 
 // Stop cleans up all resources
 func (h *InfluxDBV2Listener) Stop() {
+	h.cancel()
 	err := h.server.Shutdown(context.Background())
 	if err != nil {
 		h.Log.Infof("Error shutting down HTTP server: %v", err.Error())
@@ -219,6 +250,7 @@ func (h *InfluxDBV2Listener) handleDefault() http.HandlerFunc {
 func (h *InfluxDBV2Listener) handleWrite() http.HandlerFunc {
 	return func(res http.ResponseWriter, req *http.Request) {
 		defer h.writesServed.Incr(1)
+
 		// Check that the content length is not too large for us to handle.
 		if req.ContentLength > int64(h.MaxBodySize) {
 			if err := tooLarge(res, int64(h.MaxBodySize)); err != nil {
@@ -308,13 +340,35 @@ func (h *InfluxDBV2Listener) handleWrite() http.HandlerFunc {
 			if h.BucketTag != "" && bucket != "" {
 				m.AddTag(h.BucketTag, bucket)
 			}
-
-			h.acc.AddMetric(m)
 		}
 
-		// http request success
-		res.WriteHeader(http.StatusNoContent)
+		if h.MaxUndeliveredMetrics > 0 {
+			h.writeTracking(res, metrics)
+		} else {
+			for _, m := range metrics {
+				h.acc.AddMetric(m)
+			}
+
+			res.WriteHeader(http.StatusNoContent)
+			return
+		}
 	}
+}
+
+func (h *InfluxDBV2Listener) writeTracking(res http.ResponseWriter, metrics []telegraf.Metric) {
+	pending := h.totalUndeliveredMetrics.Load()
+	if pending+int64(len(metrics)) > int64(h.MaxUndeliveredMetrics) {
+		res.WriteHeader(http.StatusTooManyRequests)
+		return
+	}
+
+	h.countLock.Lock()
+	trackingId := h.trackingAcc.AddTrackingMetricGroup(metrics)
+	h.trackingMetricCount[trackingId] = int64(len(metrics))
+	h.totalUndeliveredMetrics.Add(int64(len(metrics)))
+	h.countLock.Unlock()
+
+	res.WriteHeader(http.StatusNoContent)
 }
 
 func tooLarge(res http.ResponseWriter, maxLength int64) error {

--- a/plugins/inputs/influxdb_v2_listener/sample.conf
+++ b/plugins/inputs/influxdb_v2_listener/sample.conf
@@ -4,6 +4,11 @@
   ## (Double check the port. Could be 9999 if using OSS Beta)
   service_address = ":8086"
 
+  ## Maximum undelivered metrics before rate limit kicks in.
+  ## When the rate limit kicks in, HTTP status 429 will be returned.
+  ## 0 disables rate limiting
+  # max_undelivered_metrics = 0
+
   ## Maximum duration before timing out read of the request
   # read_timeout = "10s"
   ## Maximum duration before timing out write of the response


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
As discussed in #15340 it can be beneficial for the Influx listener to rate limit any client pushing data. This change is compatible with the API spec described here: https://docs.influxdata.com/influxdb/v2/api/#operation/PostWrite

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #15340 
