### PR TITLE
chore(inputs.net): Clarify option deprecation notice

### DIFF
--- a/plugins/inputs/net/net.go
+++ b/plugins/inputs/net/net.go
@@ -39,7 +39,7 @@ func (n *NetIOStats) Init() error {
 			telegraf.DeprecationInfo{
 				Since:     "1.27.3",
 				RemovalIn: "1.36.0",
-				Notice:    "use the 'inputs.nstat' plugin instead",
+				Notice:    "use the 'inputs.nstat' plugin instead for protocol stats",
 			},
 		)
 	}


### PR DESCRIPTION
## Summary
Clarifies the deprecation notice for the `ignore_protocol_stats` option to be more clear about only the option being deprecated, not the plugin

## Checklist

- [X] No AI generated code was used in this PR
