### PR TITLE
feat(inputs.statsd): Allow counters to report as float

### DIFF
--- a/plugins/inputs/statsd/README.md
+++ b/plugins/inputs/statsd/README.md
@@ -117,6 +117,11 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## Replace dots (.) with underscore (_) and dashes (-) with
   ## double underscore (__) in metric names.
   # convert_names = false
+
+  ## Convert all numeric counters to float
+  ## Enabling this would ensure that both counters and guages are both emitted
+  ## as floats.
+  # float_counters = false
 ```
 
 ## Description

--- a/plugins/inputs/statsd/sample.conf
+++ b/plugins/inputs/statsd/sample.conf
@@ -90,3 +90,8 @@
   ## Replace dots (.) with underscore (_) and dashes (-) with
   ## double underscore (__) in metric names.
   # convert_names = false
+
+  ## Convert all numeric counters to float
+  ## Enabling this would ensure that both counters and guages are both emitted
+  ## as floats.
+  # float_counters = false

--- a/plugins/inputs/statsd/statsd.go
+++ b/plugins/inputs/statsd/statsd.go
@@ -76,6 +76,7 @@ type Statsd struct {
 	DeleteSets      bool     `toml:"delete_sets"`
 	DeleteTimings   bool     `toml:"delete_timings"`
 	ConvertNames    bool     `toml:"convert_names"`
+	FloatCounters   bool     `toml:"float_counters"`
 
 	EnableAggregationTemporality bool `toml:"enable_aggregation_temporality"`
 
@@ -285,6 +286,11 @@ func (s *Statsd) Gather(acc telegraf.Accumulator) error {
 			m.fields["start_time"] = s.lastGatherTime.Format(time.RFC3339)
 		}
 
+		if s.FloatCounters {
+			for key := range m.fields {
+				m.fields[key] = float64(m.fields[key].(int64))
+			}
+		}
 		acc.AddCounter(m.name, m.fields, m.tags, now)
 	}
 	if s.DeleteCounters {


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
By default counters are stored as ints. However, if a user is using a value as both a float or a int it can lead to type conflicts. This maintains the interal representation as an int to avoid messing with the caching code, but allows the counter to be reported as a float when a metric is reported.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

fixes: #1978
