### PR TITLE
feat(agent): Introduce CLI option to set config URL retry attempts

### DIFF
--- a/cmd/telegraf/main.go
+++ b/cmd/telegraf/main.go
@@ -221,19 +221,20 @@ func runApp(args []string, outputBuffer io.Writer, pprof Server, c TelegrafConfi
 		filters := processFilterFlags(cCtx)
 
 		g := GlobalFlags{
-			config:         cCtx.StringSlice("config"),
-			configDir:      cCtx.StringSlice("config-directory"),
-			testWait:       cCtx.Int("test-wait"),
-			watchConfig:    cCtx.String("watch-config"),
-			pidFile:        cCtx.String("pidfile"),
-			plugindDir:     cCtx.String("plugin-directory"),
-			password:       cCtx.String("password"),
-			oldEnvBehavior: cCtx.Bool("old-env-behavior"),
-			test:           cCtx.Bool("test"),
-			debug:          cCtx.Bool("debug"),
-			once:           cCtx.Bool("once"),
-			quiet:          cCtx.Bool("quiet"),
-			unprotected:    cCtx.Bool("unprotected"),
+			config:                 cCtx.StringSlice("config"),
+			configDir:              cCtx.StringSlice("config-directory"),
+			testWait:               cCtx.Int("test-wait"),
+			configURLRetryAttempts: cCtx.Int("config-url-retry-attempts"),
+			watchConfig:            cCtx.String("watch-config"),
+			pidFile:                cCtx.String("pidfile"),
+			plugindDir:             cCtx.String("plugin-directory"),
+			password:               cCtx.String("password"),
+			oldEnvBehavior:         cCtx.Bool("old-env-behavior"),
+			test:                   cCtx.Bool("test"),
+			debug:                  cCtx.Bool("debug"),
+			once:                   cCtx.Bool("once"),
+			quiet:                  cCtx.Bool("quiet"),
+			unprotected:            cCtx.Bool("unprotected"),
 		}
 
 		w := WindowFlags{
@@ -274,6 +275,11 @@ func runApp(args []string, outputBuffer io.Writer, pprof Server, c TelegrafConfi
 				&cli.IntFlag{
 					Name:  "test-wait",
 					Usage: "wait up to this many seconds for service inputs to complete in test mode",
+				},
+				&cli.IntFlag{
+					Name: "config-url-retry-attempts",
+					Usage: "Number of attempts to obtain a remote configuration via a URL during startup. " +
+						"Set to -1 for unlimited attempts. (default: 3)",
 				},
 				//
 				// String flags

--- a/cmd/telegraf/telegraf.go
+++ b/cmd/telegraf/telegraf.go
@@ -32,19 +32,20 @@ import (
 var stop chan struct{}
 
 type GlobalFlags struct {
-	config         []string
-	configDir      []string
-	testWait       int
-	watchConfig    string
-	pidFile        string
-	plugindDir     string
-	password       string
-	oldEnvBehavior bool
-	test           bool
-	debug          bool
-	once           bool
-	quiet          bool
-	unprotected    bool
+	config                 []string
+	configDir              []string
+	testWait               int
+	configURLRetryAttempts int
+	watchConfig            string
+	pidFile                string
+	plugindDir             string
+	password               string
+	oldEnvBehavior         bool
+	test                   bool
+	debug                  bool
+	once                   bool
+	quiet                  bool
+	unprotected            bool
 }
 
 type WindowFlags struct {
@@ -248,6 +249,7 @@ func (t *Telegraf) loadConfiguration() (*config.Config, error) {
 		configFiles = append(configFiles, defaultFiles...)
 	}
 
+	c.Agent.ConfigURLRetryAttempts = t.configURLRetryAttempts
 	t.configFiles = configFiles
 	if err := c.LoadAll(configFiles...); err != nil {
 		return c, err

--- a/config/internal_test.go
+++ b/config/internal_test.go
@@ -383,7 +383,7 @@ func TestURLRetries3Fails(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	expected := fmt.Sprintf("error loading config file %s: retry 3 of 3 failed to retrieve remote config: 404 Not Found", ts.URL)
+	expected := fmt.Sprintf("error loading config file %s: failed to fetch HTTP config: 404 Not Found", ts.URL)
 
 	c := NewConfig()
 	err := c.LoadConfig(ts.URL)


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
This introduces a new cli option to allow the user to set the number of retry attempts to something other than 3. It also allows the user to set the attempt count to -1 to infinitely retry.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

fixes: #8854
