### PR TITLE
chore: Update to Xcode 15 in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,11 @@ commands:
             equal: [ "386", << parameters.arch >> ]
           steps:
             - run: echo 'export RACE="-race"' >> $BASH_ENV
+            - unless:
+                condition:
+                  equal: [ "darwin", << parameters.os >> ]
+                steps:
+                  - run: echo 'export RACE="-race -ldflags=-extldflags=-Wl,-ld_classic"' >> $BASH_ENV
       - when:
           condition:
             equal: [ windows, << parameters.os >> ]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,16 +42,16 @@ commands:
             equal: [ "386", << parameters.arch >> ]
           steps:
             - run: echo 'export RACE="-race"' >> $BASH_ENV
-            - unless:
-                condition:
-                  equal: [ "darwin", << parameters.os >> ]
-                steps:
-                  - run: echo 'export RACE="-race -ldflags=-extldflags=-Wl,-ld_classic"' >> $BASH_ENV
       - when:
           condition:
             equal: [ windows, << parameters.os >> ]
           steps:
             - run: echo 'export CGO_ENABLED=1' >> $BASH_ENV
+      - when:
+          condition:
+            equal: [ darwin, << parameters.os >> ]
+          steps:
+            - run: echo 'export RACE="$RACE -ldflags=-extldflags=-Wl,-ld_classic"' >> $BASH_ENV
       - run: |
           GOARCH=<< parameters.arch >> ./<< parameters.gotestsum >> -- ${RACE} -short ./...
   package-build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ executors:
     working_directory: '~/go/src/github.com/influxdata/telegraf'
     resource_class: macos.m1.medium.gen1
     macos:
-      xcode: 14.2.0
+      xcode: 15.2.0
     environment:
       HOMEBREW_NO_AUTO_UPDATE: 1
       GOFLAGS: -p=4

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ executors:
     working_directory: '~/go/src/github.com/influxdata/telegraf'
     resource_class: macos.m1.medium.gen1
     macos:
-      xcode: 15.2.0
+      xcode: 15.4.0
     environment:
       HOMEBREW_NO_AUTO_UPDATE: 1
       GOFLAGS: -p=4

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,13 @@ endif
 
 # Go built-in race detector works only for 64 bits architectures.
 ifneq ($(GOARCH), 386)
-	race_detector := -race
+	# Resolve macOS issue with Xcode 15 when running in race detector mode
+	# https://github.com/golang/go/issues/61229
+	ifeq ($(GOOS), darwin)
+		race_detector := -race -ldflags=-extldflags=-Wl,-ld_classic
+	else
+		race_detector := -race
+	endif
 endif
 
 


### PR DESCRIPTION
## Summary
Updates the CircleCI config and Makefile for Xcode 15. For the CircleCI testing container this should be inconsequential. For the Makefile, these new options are (currently) necessary for macOS 13.5+, but will not work on macOS 13.4 and below. 

## Checklist
- [X] No AI generated code was used in this PR
