### PR TITLE
chore: Fix errcheck CI warnings outside of plugins directory

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -71,6 +71,7 @@ linters-settings:
       - "(*hash/maphash.Hash).Write"
       - "(*hash/maphash.Hash).WriteByte"
       - "(*hash/maphash.Hash).WriteString"
+    check-blank: true
   gocritic:
     # Disable all checks.
     # Default: false
@@ -325,6 +326,9 @@ issues:
     - package comment should be of the form "(.+)...
     # EXC0015 revive: Annoying issue about not having a comment. The rare codebase has such comments
     - should have a package comment
+    # nolintlint: directive `//nolint:errcheck` is unused for linter "errcheck"
+    # temporary while these are being fixed
+    - directive `//nolint:errcheck //.*` is unused for linter "errcheck"
 
   # Excluding configuration per-path, per-linter, per-text and per-source
   exclude-rules:
@@ -334,6 +338,10 @@ issues:
 
     - path: cmd/telegraf/(main|printer|cmd_plugins).go
       text: "Error return value of `outputBuffer.Write` is not checked" #errcheck
+
+    - path: plugins/*
+      linters:
+        - errcheck # temporary as this linter is gradually being applied across the codebase
 
     - path: _test\.go
       text: "Potential hardcoded credentials" #gosec:G101

--- a/cmd/telegraf/telegraf.go
+++ b/cmd/telegraf/telegraf.go
@@ -351,6 +351,7 @@ func (t *Telegraf) runAgent(ctx context.Context, c *config.Config, reloadConfig 
 	// SdNotify() only tries to notify if the NOTIFY_SOCKET environment is set, so it's safe to call when systemd isn't present.
 	// Ignore the return values here because they're not valid for platforms that don't use systemd.
 	// For platforms that use systemd, telegraf doesn't log if the notification failed.
+	//nolint:errcheck // see above
 	_, _ = daemon.SdNotify(false, daemon.SdNotifyReady)
 
 	if t.once {

--- a/cmd/telegraf/telegraf.go
+++ b/cmd/telegraf/telegraf.go
@@ -352,7 +352,7 @@ func (t *Telegraf) runAgent(ctx context.Context, c *config.Config, reloadConfig 
 	// Ignore the return values here because they're not valid for platforms that don't use systemd.
 	// For platforms that use systemd, telegraf doesn't log if the notification failed.
 	//nolint:errcheck // see above
-	_, _ = daemon.SdNotify(false, daemon.SdNotifyReady)
+	daemon.SdNotify(false, daemon.SdNotifyReady)
 
 	if t.once {
 		wait := time.Duration(t.testWait) * time.Second

--- a/config/config.go
+++ b/config/config.go
@@ -948,7 +948,7 @@ func (c *Config) probeParser(parentcategory string, parentname string, table *as
 	// Try to parse the options to detect if any of them is misspelled
 	parser := creator("")
 	//nolint:errcheck // We don't actually use the parser, so no need to check the error.
-	_ = c.toml.UnmarshalTable(table, parser)
+	c.toml.UnmarshalTable(table, parser)
 
 	return true
 }

--- a/config/config.go
+++ b/config/config.go
@@ -946,8 +946,8 @@ func (c *Config) probeParser(parentcategory string, parentname string, table *as
 	}
 
 	// Try to parse the options to detect if any of them is misspelled
-	// We don't actually use the parser, so no need to check the error.
 	parser := creator("")
+	//nolint:errcheck // We don't actually use the parser, so no need to check the error.
 	_ = c.toml.UnmarshalTable(table, parser)
 
 	return true

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -519,7 +519,8 @@ func TestConfig_AzureMonitorNamespacePrefix(t *testing.T) {
 func TestGetDefaultConfigPathFromEnvURL(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte("[agent]\ndebug = true"))
+		_, err := w.Write([]byte("[agent]\ndebug = true"))
+		require.NoError(t, err)
 	}))
 	defer ts.Close()
 
@@ -1193,7 +1194,8 @@ func TestPersisterInputStoreLoad(t *testing.T) {
 		p.state.Version++
 		p.state.Offset += uint64(i + 1)
 		p.state.Bits = append(p.state.Bits, len(p.state.Bits))
-		p.state.Modified, _ = time.Parse(time.RFC3339, "2022-11-03T16:49:00+02:00")
+		p.state.Modified, err = time.Parse(time.RFC3339, "2022-11-03T16:49:00+02:00")
+		require.NoError(t, err)
 
 		// Store the state for later comparison
 		expected[plugin.ID()] = p.GetState()
@@ -1542,7 +1544,10 @@ type MockupStatePlugin struct {
 }
 
 func (m *MockupStatePlugin) Init() error {
-	t0, _ := time.Parse(time.RFC3339, "2021-04-24T23:42:00+02:00")
+	t0, err := time.Parse(time.RFC3339, "2021-04-24T23:42:00+02:00")
+	if err != nil {
+		return err
+	}
 	m.state = MockupState{
 		Name:     "mockup",
 		Bits:     []int{},

--- a/filter/filter_test.go
+++ b/filter/filter_test.go
@@ -70,7 +70,8 @@ func TestIncludeExclude(t *testing.T) {
 var benchbool bool
 
 func BenchmarkFilterSingleNoGlobFalse(b *testing.B) {
-	f, _ := Compile([]string{"cpu"})
+	f, err := Compile([]string{"cpu"})
+	require.NoError(b, err)
 	var tmp bool
 	for n := 0; n < b.N; n++ {
 		tmp = f.Match("network")
@@ -79,7 +80,8 @@ func BenchmarkFilterSingleNoGlobFalse(b *testing.B) {
 }
 
 func BenchmarkFilterSingleNoGlobTrue(b *testing.B) {
-	f, _ := Compile([]string{"cpu"})
+	f, err := Compile([]string{"cpu"})
+	require.NoError(b, err)
 	var tmp bool
 	for n := 0; n < b.N; n++ {
 		tmp = f.Match("cpu")
@@ -88,7 +90,8 @@ func BenchmarkFilterSingleNoGlobTrue(b *testing.B) {
 }
 
 func BenchmarkFilter(b *testing.B) {
-	f, _ := Compile([]string{"cpu", "mem", "net*"})
+	f, err := Compile([]string{"cpu", "mem", "net*"})
+	require.NoError(b, err)
 	var tmp bool
 	for n := 0; n < b.N; n++ {
 		tmp = f.Match("network")
@@ -97,7 +100,8 @@ func BenchmarkFilter(b *testing.B) {
 }
 
 func BenchmarkFilterNoGlob(b *testing.B) {
-	f, _ := Compile([]string{"cpu", "mem", "net"})
+	f, err := Compile([]string{"cpu", "mem", "net"})
+	require.NoError(b, err)
 	var tmp bool
 	for n := 0; n < b.N; n++ {
 		tmp = f.Match("net")
@@ -106,8 +110,9 @@ func BenchmarkFilterNoGlob(b *testing.B) {
 }
 
 func BenchmarkFilter2(b *testing.B) {
-	f, _ := Compile([]string{"aa", "bb", "c", "ad", "ar", "at", "aq",
+	f, err := Compile([]string{"aa", "bb", "c", "ad", "ar", "at", "aq",
 		"aw", "az", "axxx", "ab", "cpu", "mem", "net*"})
+	require.NoError(b, err)
 	var tmp bool
 	for n := 0; n < b.N; n++ {
 		tmp = f.Match("network")
@@ -116,8 +121,9 @@ func BenchmarkFilter2(b *testing.B) {
 }
 
 func BenchmarkFilter2NoGlob(b *testing.B) {
-	f, _ := Compile([]string{"aa", "bb", "c", "ad", "ar", "at", "aq",
+	f, err := Compile([]string{"aa", "bb", "c", "ad", "ar", "at", "aq",
 		"aw", "az", "axxx", "ab", "cpu", "mem", "net"})
+	require.NoError(b, err)
 	var tmp bool
 	for n := 0; n < b.N; n++ {
 		tmp = f.Match("net")

--- a/internal/globpath/globpath.go
+++ b/internal/globpath/globpath.go
@@ -50,6 +50,7 @@ func (g *GlobPath) Match() []string {
 	g.path = strings.ReplaceAll(g.path, "**/**", "**")
 	g.path = strings.ReplaceAll(g.path, "**", "**/**")
 
+	//nolint:errcheck // pattern is known
 	files, _ := doublestar.Glob(g.path)
 	return files
 }
@@ -58,6 +59,7 @@ func (g *GlobPath) Match() []string {
 // the host platform separator.
 func (g *GlobPath) MatchString(path string) bool {
 	if !g.HasSuperMeta {
+		//nolint:errcheck // pattern is known
 		res, _ := filepath.Match(g.path, path)
 		return res
 	}
@@ -75,9 +77,11 @@ func (g *GlobPath) GetRoots() []string {
 		return []string{g.path}
 	}
 	if !g.HasSuperMeta {
+		//nolint:errcheck // pattern is known
 		matches, _ := filepath.Glob(g.path)
 		return matches
 	}
+	//nolint:errcheck // pattern is known
 	roots, _ := filepath.Glob(g.rootGlob)
 	return roots
 }

--- a/internal/globpath/globpath_test.go
+++ b/internal/globpath/globpath_test.go
@@ -69,7 +69,8 @@ func TestRootGlob(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		actual, _ := Compile(test.input)
+		actual, err := Compile(test.input)
+		require.NoError(t, err)
 		require.Equal(t, actual.rootGlob, test.output)
 	}
 }

--- a/internal/internal_test.go
+++ b/internal/internal_test.go
@@ -44,21 +44,17 @@ func TestSnakeCase(t *testing.T) {
 	}
 }
 
-var (
-	sleepbin, _ = exec.LookPath("sleep")
-	echobin, _  = exec.LookPath("echo")
-	shell, _    = exec.LookPath("sh")
-)
-
 func TestRunTimeout(t *testing.T) {
 	t.Skip("Skipping test due to random failures & a data race when running test-all.")
 
-	if sleepbin == "" {
+	sleepbin, err := exec.LookPath("sleep")
+	if err != nil || sleepbin == "" {
 		t.Skip("'sleep' binary not available on OS, skipping.")
 	}
+
 	cmd := exec.Command(sleepbin, "10")
 	start := time.Now()
-	err := RunTimeout(cmd, time.Millisecond*20)
+	err = RunTimeout(cmd, time.Millisecond*20)
 	elapsed := time.Since(start)
 
 	require.Equal(t, ErrTimeout, err)
@@ -71,12 +67,13 @@ func TestRunTimeoutFastExit(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping test due to random failures.")
 	}
-	if echobin == "" {
+	echobin, err := exec.LookPath("echo")
+	if err != nil || echobin == "" {
 		t.Skip("'echo' binary not available on OS, skipping.")
 	}
 	cmd := exec.Command(echobin)
 	start := time.Now()
-	err := RunTimeout(cmd, time.Millisecond*20)
+	err = RunTimeout(cmd, time.Millisecond*20)
 	buf := &bytes.Buffer{}
 	log.SetOutput(buf)
 	elapsed := time.Since(start)
@@ -93,12 +90,13 @@ func TestRunTimeoutFastExit(t *testing.T) {
 func TestCombinedOutputTimeout(t *testing.T) {
 	// TODO: Fix this test
 	t.Skip("Test failing too often, skip for now and revisit later.")
-	if sleepbin == "" {
+	sleepbin, err := exec.LookPath("sleep")
+	if err != nil || sleepbin == "" {
 		t.Skip("'sleep' binary not available on OS, skipping.")
 	}
 	cmd := exec.Command(sleepbin, "10")
 	start := time.Now()
-	_, err := CombinedOutputTimeout(cmd, time.Millisecond*20)
+	_, err = CombinedOutputTimeout(cmd, time.Millisecond*20)
 	elapsed := time.Since(start)
 
 	require.Equal(t, ErrTimeout, err)
@@ -107,7 +105,8 @@ func TestCombinedOutputTimeout(t *testing.T) {
 }
 
 func TestCombinedOutput(t *testing.T) {
-	if echobin == "" {
+	echobin, err := exec.LookPath("echo")
+	if err != nil || echobin == "" {
 		t.Skip("'echo' binary not available on OS, skipping.")
 	}
 	cmd := exec.Command(echobin, "foo")
@@ -120,7 +119,8 @@ func TestCombinedOutput(t *testing.T) {
 // test that CombinedOutputTimeout and exec.Cmd.CombinedOutput return
 // the same output from a failed command.
 func TestCombinedOutputError(t *testing.T) {
-	if shell == "" {
+	shell, err := exec.LookPath("sh")
+	if err != nil || shell == "" {
 		t.Skip("'sh' binary not available on OS, skipping.")
 	}
 	cmd := exec.Command(shell, "-c", "false")
@@ -135,11 +135,12 @@ func TestCombinedOutputError(t *testing.T) {
 }
 
 func TestRunError(t *testing.T) {
-	if shell == "" {
+	shell, err := exec.LookPath("sh")
+	if err != nil || shell == "" {
 		t.Skip("'sh' binary not available on OS, skipping.")
 	}
 	cmd := exec.Command(shell, "-c", "false")
-	err := RunTimeout(cmd, time.Second)
+	err = RunTimeout(cmd, time.Second)
 
 	require.Error(t, err)
 }
@@ -306,8 +307,9 @@ func TestAlignDuration(t *testing.T) {
 
 func TestAlignTime(t *testing.T) {
 	rfc3339 := func(value string) time.Time {
-		t, _ := time.Parse(time.RFC3339, value)
-		return t
+		tt, err := time.Parse(time.RFC3339, value)
+		require.NoError(t, err)
+		return tt
 	}
 
 	tests := []struct {

--- a/internal/process/process.go
+++ b/internal/process/process.go
@@ -210,5 +210,6 @@ func isQuitting(ctx context.Context) bool {
 }
 
 func defaultReadPipe(r io.Reader) {
+	//nolint:errcheck // Discarding the data, no need to handle an error
 	_, _ = io.Copy(io.Discard, r)
 }

--- a/internal/process/process.go
+++ b/internal/process/process.go
@@ -211,5 +211,5 @@ func isQuitting(ctx context.Context) bool {
 
 func defaultReadPipe(r io.Reader) {
 	//nolint:errcheck // Discarding the data, no need to handle an error
-	_, _ = io.Copy(io.Discard, r)
+	io.Copy(io.Discard, r)
 }

--- a/internal/rotate/file_writer_test.go
+++ b/internal/rotate/file_writer_test.go
@@ -19,13 +19,15 @@ func TestFileWriter_NoRotation(t *testing.T) {
 	require.NoError(t, err)
 	_, err = writer.Write([]byte("Hello World 2"))
 	require.NoError(t, err)
-	files, _ := os.ReadDir(tempDir)
+	files, err := os.ReadDir(tempDir)
+	require.NoError(t, err)
 	require.Len(t, files, 1)
 }
 
 func TestFileWriter_TimeRotation(t *testing.T) {
 	tempDir := t.TempDir()
-	interval, _ := time.ParseDuration("10ms")
+	interval, err := time.ParseDuration("10ms")
+	require.NoError(t, err)
 	writer, err := NewFileWriter(filepath.Join(tempDir, "test"), interval, 0, -1)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, writer.Close()) })
@@ -35,22 +37,25 @@ func TestFileWriter_TimeRotation(t *testing.T) {
 	time.Sleep(interval)
 	_, err = writer.Write([]byte("Hello World 2"))
 	require.NoError(t, err)
-	files, _ := os.ReadDir(tempDir)
+	files, err := os.ReadDir(tempDir)
+	require.NoError(t, err)
 	require.Len(t, files, 2)
 }
 
 func TestFileWriter_ReopenTimeRotation(t *testing.T) {
 	tempDir := t.TempDir()
-	interval, _ := time.ParseDuration("10ms")
+	interval, err := time.ParseDuration("10ms")
+	require.NoError(t, err)
 	filePath := filepath.Join(tempDir, "test.log")
-	err := os.WriteFile(filePath, []byte("Hello World"), 0640)
+	err = os.WriteFile(filePath, []byte("Hello World"), 0640)
 	time.Sleep(interval)
 	require.NoError(t, err)
 	writer, err := NewFileWriter(filepath.Join(tempDir, "test.log"), interval, 0, -1)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, writer.Close()) })
 
-	files, _ := os.ReadDir(tempDir)
+	files, err := os.ReadDir(tempDir)
+	require.NoError(t, err)
 	require.Len(t, files, 2)
 }
 
@@ -65,7 +70,8 @@ func TestFileWriter_SizeRotation(t *testing.T) {
 	require.NoError(t, err)
 	_, err = writer.Write([]byte("World 2"))
 	require.NoError(t, err)
-	files, _ := os.ReadDir(tempDir)
+	files, err := os.ReadDir(tempDir)
+	require.NoError(t, err)
 	require.Len(t, files, 2)
 }
 
@@ -81,7 +87,8 @@ func TestFileWriter_ReopenSizeRotation(t *testing.T) {
 
 	_, err = writer.Write([]byte("Hello World Again"))
 	require.NoError(t, err)
-	files, _ := os.ReadDir(tempDir)
+	files, err := os.ReadDir(tempDir)
+	require.NoError(t, err)
 	require.Len(t, files, 2)
 }
 
@@ -108,7 +115,8 @@ func TestFileWriter_DeleteArchives(t *testing.T) {
 	_, err = writer.Write([]byte("Third file"))
 	require.NoError(t, err)
 
-	files, _ := os.ReadDir(tempDir)
+	files, err := os.ReadDir(tempDir)
+	require.NoError(t, err)
 	require.Len(t, files, 3)
 
 	for _, tempFile := range files {
@@ -135,7 +143,8 @@ func TestFileWriter_CloseDoesNotRotate(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, writer.Close())
 
-	files, _ := os.ReadDir(tempDir)
+	files, err := os.ReadDir(tempDir)
+	require.NoError(t, err)
 	require.Len(t, files, 1)
 	require.Regexp(t, "^test.log$", files[0].Name())
 }

--- a/internal/snmp/field.go
+++ b/internal/snmp/field.go
@@ -129,10 +129,16 @@ func (f *Field) Convert(ent gosnmp.SnmpPDU) (v interface{}, err error) {
 		case uint64:
 			v = float64(vt) / math.Pow10(d)
 		case []byte:
-			vf, _ := strconv.ParseFloat(string(vt), 64)
+			vf, err := strconv.ParseFloat(string(vt), 64)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert field to float with value %s: %w", vt, err)
+			}
 			v = vf / math.Pow10(d)
 		case string:
-			vf, _ := strconv.ParseFloat(vt, 64)
+			vf, err := strconv.ParseFloat(vt, 64)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert field to float with value %s: %w", vt, err)
+			}
 			v = vf / math.Pow10(d)
 		}
 		return v, nil

--- a/internal/snmp/field.go
+++ b/internal/snmp/field.go
@@ -146,7 +146,6 @@ func (f *Field) Convert(ent gosnmp.SnmpPDU) (v interface{}, err error) {
 
 	if f.Conversion == "int" {
 		v = ent.Value
-		err = nil
 		switch vt := v.(type) {
 		case float32:
 			v = int64(vt)

--- a/internal/snmp/field.go
+++ b/internal/snmp/field.go
@@ -146,6 +146,7 @@ func (f *Field) Convert(ent gosnmp.SnmpPDU) (v interface{}, err error) {
 
 	if f.Conversion == "int" {
 		v = ent.Value
+		err = nil
 		switch vt := v.(type) {
 		case float32:
 			v = int64(vt)
@@ -172,11 +173,11 @@ func (f *Field) Convert(ent gosnmp.SnmpPDU) (v interface{}, err error) {
 		case uint64:
 			v = int64(vt)
 		case []byte:
-			v, _ = strconv.ParseInt(string(vt), 10, 64)
+			v, err = strconv.ParseInt(string(vt), 10, 64)
 		case string:
-			v, _ = strconv.ParseInt(vt, 10, 64)
+			v, err = strconv.ParseInt(vt, 10, 64)
 		}
-		return v, nil
+		return v, err
 	}
 
 	if f.Conversion == "hwaddr" {

--- a/internal/snmp/field.go
+++ b/internal/snmp/field.go
@@ -92,7 +92,7 @@ func (f *Field) Init(tr Translator) error {
 }
 
 // fieldConvert converts from any type according to the conv specification
-func (f *Field) Convert(ent gosnmp.SnmpPDU) (v interface{}, err error) {
+func (f *Field) Convert(ent gosnmp.SnmpPDU) (interface{}, error) {
 	if f.Conversion == "" {
 		if bs, ok := ent.Value.([]byte); ok {
 			return string(bs), nil
@@ -100,6 +100,7 @@ func (f *Field) Convert(ent gosnmp.SnmpPDU) (v interface{}, err error) {
 		return ent.Value, nil
 	}
 
+	var v interface{}
 	var d int
 	if _, err := fmt.Sscanf(f.Conversion, "float(%d)", &d); err == nil || f.Conversion == "float" {
 		v = ent.Value
@@ -146,6 +147,7 @@ func (f *Field) Convert(ent gosnmp.SnmpPDU) (v interface{}, err error) {
 
 	if f.Conversion == "int" {
 		v = ent.Value
+		var err error
 		switch vt := v.(type) {
 		case float32:
 			v = int64(vt)

--- a/internal/snmp/translator_gosmi.go
+++ b/internal/snmp/translator_gosmi.go
@@ -136,7 +136,10 @@ func snmpTranslateCall(oid string) (mibName string, oidNum string, oidText strin
 			}
 		}
 		oidNum = strings.Join(s, ".")
-		out, _ = gosmi.GetNodeByOID(types.OidMustFromString(oidNum))
+		out, err = gosmi.GetNodeByOID(types.OidMustFromString(oidNum))
+		if err != nil {
+			return oid, oid, oid, "", out, err
+		}
 	} else {
 		out, err = gosmi.GetNodeByOID(types.OidMustFromString(oid))
 		oidNum = oid

--- a/internal/templating/engine_test.go
+++ b/internal/templating/engine_test.go
@@ -7,7 +7,8 @@ import (
 )
 
 func TestEngineAlternateSeparator(t *testing.T) {
-	defaultTemplate, _ := NewDefaultTemplateWithPattern("topic*")
+	defaultTemplate, err := NewDefaultTemplateWithPattern("topic*")
+	require.NoError(t, err)
 	engine, err := NewEngine("_", defaultTemplate, []string{
 		"/ /*/*/* /measurement/origin/measurement*",
 	})

--- a/internal/templating/engine_test.go
+++ b/internal/templating/engine_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestEngineAlternateSeparator(t *testing.T) {
-	defaultTemplate, err := NewDefaultTemplateWithPattern("topic*")
+	defaultTemplate, err := NewDefaultTemplateWithPattern("measurement*")
 	require.NoError(t, err)
 	engine, err := NewEngine("_", defaultTemplate, []string{
 		"/ /*/*/* /measurement/origin/measurement*",

--- a/logger/default_logger_test.go
+++ b/logger/default_logger_test.go
@@ -111,7 +111,8 @@ func TestWriteToFileInRotation(t *testing.T) {
 
 	log.Printf("I! TEST 1") // Writes 31 bytes, will rotate
 	log.Printf("I! TEST")   // Writes 29 byes, no rotation expected
-	files, _ := os.ReadDir(tempDir)
+	files, err := os.ReadDir(tempDir)
+	require.NoError(t, err)
 	require.Len(t, files, 2)
 }
 

--- a/migrations/inputs_httpjson/migration_test.go
+++ b/migrations/inputs_httpjson/migration_test.go
@@ -112,7 +112,8 @@ func TestParsing(t *testing.T) {
 			// Start the test-server
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if r.URL.Path == "/stats" {
-					_, _ = w.Write(input)
+					_, err = w.Write(input)
+					require.NoError(t, err)
 				} else {
 					w.WriteHeader(http.StatusNotFound)
 				}

--- a/testutil/accumulator.go
+++ b/testutil/accumulator.go
@@ -1,7 +1,6 @@
 package testutil
 
 import (
-	"encoding/json"
 	"fmt"
 	"reflect"
 	"sync"
@@ -128,14 +127,6 @@ func (a *Accumulator) addMeasurement(
 		} else {
 			t = a.TimeFunc()
 		}
-	}
-
-	if a.debug {
-		pretty, _ := json.MarshalIndent(fields, "", "  ")
-		prettyTags, _ := json.MarshalIndent(tags, "", "  ")
-		msg := fmt.Sprintf("Adding Measurement [%s]\nFields:%s\nTags:%s\n",
-			measurement, string(pretty), string(prettyTags))
-		fmt.Print(msg)
 	}
 
 	m := &Metric{

--- a/tools/package_incus_test/container.go
+++ b/tools/package_incus_test/container.go
@@ -68,8 +68,10 @@ func (c *Container) Create(image string) error {
 
 // delete the container
 func (c *Container) Delete() {
-	_ = c.client.Stop(c.Name)
-	_ = c.client.Delete(c.Name)
+	//nolint:errcheck // cleaning up state so no need to check for error
+	c.client.Stop(c.Name)
+	//nolint:errcheck // cleaning up state so no need to check for error
+	c.client.Delete(c.Name)
 }
 
 // installs the package from configured repos
@@ -121,14 +123,17 @@ func (c *Container) CheckStatus(serviceName string) error {
 
 	err = c.client.Exec(c.Name, "systemctl", "start", serviceName)
 	if err != nil {
-		_ = c.client.Exec(c.Name, "systemctl", "status", serviceName)
-		_ = c.client.Exec(c.Name, "journalctl", "--no-pager", "--unit", serviceName)
+		//nolint:errcheck // cleaning up state so no need to check for error
+		c.client.Exec(c.Name, "systemctl", "status", serviceName)
+		//nolint:errcheck // cleaning up state so no need to check for error
+		c.client.Exec(c.Name, "journalctl", "--no-pager", "--unit", serviceName)
 		return err
 	}
 
 	err = c.client.Exec(c.Name, "systemctl", "status", serviceName)
 	if err != nil {
-		_ = c.client.Exec(c.Name, "journalctl", "--no-pager", "--unit", serviceName)
+		//nolint:errcheck // cleaning up state so no need to check for error
+		c.client.Exec(c.Name, "journalctl", "--no-pager", "--unit", serviceName)
 		return err
 	}
 
@@ -188,11 +193,14 @@ func (c *Container) configureApt() error {
 		return err
 	}
 
-	_ = c.client.Exec(
+	err = c.client.Exec(
 		c.Name,
 		"bash", "-c", "--",
 		"cat /etc/apt/sources.list.d/influxdata.list",
 	)
+	if err != nil {
+		return err
+	}
 
 	err = c.client.Exec(c.Name, "apt-get", "update")
 	if err != nil {
@@ -213,11 +221,14 @@ func (c *Container) configureYum() error {
 		return err
 	}
 
-	_ = c.client.Exec(
+	err = c.client.Exec(
 		c.Name,
 		"bash", "-c", "--",
 		"cat /etc/yum.repos.d/influxdata.repo",
 	)
+	if err != nil {
+		return err
+	}
 
 	// will return a non-zero return code if there are packages to update
 	return c.client.Exec(c.Name, "bash", "-c", "yum check-update || true")
@@ -234,11 +245,14 @@ func (c *Container) configureDnf() error {
 		return err
 	}
 
-	_ = c.client.Exec(
+	err = c.client.Exec(
 		c.Name,
 		"bash", "-c", "--",
 		"cat /etc/yum.repos.d/influxdata.repo",
 	)
+	if err != nil {
+		return err
+	}
 
 	// will return a non-zero return code if there are packages to update
 	return c.client.Exec(c.Name, "bash", "-c", "dnf check-update || true")
@@ -255,11 +269,14 @@ func (c *Container) configureZypper() error {
 		return err
 	}
 
-	_ = c.client.Exec(
+	err = c.client.Exec(
 		c.Name,
 		"bash", "-c", "--",
 		"cat /etc/zypp/repos.d/influxdata.repo",
 	)
+	if err != nil {
+		return err
+	}
 
 	return c.client.Exec(c.Name, "zypper", "--no-gpg-checks", "refresh")
 }


### PR DESCRIPTION
## Summary
Resolves all of the warnings returned by the `errcheck` linter in files outside of the `plugins/` directory and enables the errcheck `check-blank` option. This excludes errcheck from running in the plugins/ directory, as well as `nolintlint` checking for `nolint:errcheck` lines in that directory temporarily until a follow-up PR which will resolve the remaining errcheck warnings.

## Checklist
- [X] No AI generated code was used in this PR

## Related issues
Part of #13013
