### PR TITLE
test(processors.parser): Sort test metrics

### DIFF
--- a/plugins/processors/parser/parser_test.go
+++ b/plugins/processors/parser/parser_test.go
@@ -828,9 +828,9 @@ func TestApply(t *testing.T) {
 
 			// check timestamp when using with-timestamp merge type
 			if tt.merge == "override-with-timestamp" {
-				testutil.RequireMetricsEqual(t, tt.expected, output)
+				testutil.RequireMetricsEqual(t, tt.expected, output, testutil.SortMetrics())
 			} else {
-				testutil.RequireMetricsEqual(t, tt.expected, output, testutil.IgnoreTime())
+				testutil.RequireMetricsEqual(t, tt.expected, output, testutil.SortMetrics(), testutil.IgnoreTime())
 			}
 		})
 	}


### PR DESCRIPTION


## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
CircleCI complained about test failures where results were not in the same order. Sort the metrics to ensure a consistent ordering. This was due to landing #15328 

https://app.circleci.com/pipelines/github/influxdata/telegraf/21557/workflows/481fee41-db19-44d7-a014-7bdc9ca83014/jobs/332868

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

