### PR TITLE
feat(input.azure_monitor): Use default azure credentials chain when no secret provided

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -131,7 +131,7 @@ require (
 	github.com/klauspost/pgzip v1.2.6
 	github.com/kolo/xmlrpc v0.0.0-20220921171641-a4b6fa1dd06b
 	github.com/linkedin/goavro/v2 v2.12.0
-	github.com/logzio/azure-monitor-metrics-receiver v1.0.1
+	github.com/logzio/azure-monitor-metrics-receiver v1.0.2
 	github.com/lxc/incus v0.4.0
 	github.com/mdlayher/apcupsd v0.0.0-20220319200143-473c7b5f3c6a
 	github.com/mdlayher/vsock v1.2.1
@@ -237,8 +237,8 @@ require (
 	github.com/Azure/azure-amqp-common-go/v4 v4.2.0 // indirect
 	github.com/Azure/azure-pipeline-go v0.2.3 // indirect
 	github.com/Azure/azure-sdk-for-go v68.0.0+incompatible // indirect
-	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.10.0 // indirect
-	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.5.1 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.10.0
+	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.5.1
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.5.2 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.1.0 // indirect
 	github.com/Azure/go-amqp v1.0.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -237,7 +237,7 @@ require (
 	github.com/Azure/azure-amqp-common-go/v4 v4.2.0 // indirect
 	github.com/Azure/azure-pipeline-go v0.2.3 // indirect
 	github.com/Azure/azure-sdk-for-go v68.0.0+incompatible // indirect
-	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.10.0
+	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.10.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.5.1
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.5.2 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1731,8 +1731,8 @@ github.com/linkedin/goavro/v2 v2.12.0 h1:rIQQSj8jdAUlKQh6DttK8wCRv4t4QO09g1C4aBW
 github.com/linkedin/goavro/v2 v2.12.0/go.mod h1:KXx+erlq+RPlGSPmLF7xGo6SAbh8sCQ53x064+ioxhk=
 github.com/linode/linodego v1.23.0 h1:s0ReCZtuN9Z1IoUN9w1RLeYO1dMZUGPwOQ/IBFsBHtU=
 github.com/linode/linodego v1.23.0/go.mod h1:0U7wj/UQOqBNbKv1FYTXiBUXueR8DY4HvIotwE0ENgg=
-github.com/logzio/azure-monitor-metrics-receiver v1.0.1 h1:FTwUtM0K3RB8XX4N4xfswzOUWoiLK9pJUMqPpTOJclc=
-github.com/logzio/azure-monitor-metrics-receiver v1.0.1/go.mod h1:yJGdECqN75b4r4SXLwNkeeZoN/rPVKcfJLfixQw1hZc=
+github.com/logzio/azure-monitor-metrics-receiver v1.0.2 h1:1vNuag1MwjTm02BJ9U7w3hCStJug2CgPMmzI8VmEbFA=
+github.com/logzio/azure-monitor-metrics-receiver v1.0.2/go.mod h1:yJGdECqN75b4r4SXLwNkeeZoN/rPVKcfJLfixQw1hZc=
 github.com/loov/hrtime v1.0.1/go.mod h1:yDY3Pwv2izeY4sq7YcPX/dtLwzg5NU1AxWuWxKwd0p0=
 github.com/loov/hrtime v1.0.3/go.mod h1:yDY3Pwv2izeY4sq7YcPX/dtLwzg5NU1AxWuWxKwd0p0=
 github.com/loov/hrtime/hrplot v1.0.2/go.mod h1:9t65xYn4d42ntjv40Wt5lbU72/VC5S0zGDgjC8kD5BU=

--- a/plugins/inputs/azure_monitor/README.md
+++ b/plugins/inputs/azure_monitor/README.md
@@ -67,7 +67,13 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   subscription_id = "<<SUBSCRIPTION_ID>>"
   # can be obtained by registering an application under Azure Active Directory
   client_id = "<<CLIENT_ID>>"
-  # can be obtained by registering an application under Azure Active Directory
+  # can be obtained by registering an application under Azure Active Directory.
+  # If not specified Default Azure Credentials chain will be attempted:
+  # - Environment credentials (AZURE_*)
+  # - Workload Identity in Kubernetes cluster
+  # - Managed Identity
+  # - Azure CLI auth
+  # - Developer Azure CLI auth
   client_secret = "<<CLIENT_SECRET>>"
   # can be found under Azure Active Directory->Properties
   tenant_id = "<<TENANT_ID>>"

--- a/plugins/inputs/azure_monitor/azure_monitor.go
+++ b/plugins/inputs/azure_monitor/azure_monitor.go
@@ -4,6 +4,8 @@ package azure_monitor
 import (
 	_ "embed"
 	"fmt"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"sync"
 
 	"github.com/influxdata/telegraf"
@@ -158,8 +160,17 @@ func (acm *azureClientsManager) createAzureClients(
 	clientID string,
 	clientSecret string,
 	tenantID string,
-) (*receiver.AzureClients, error) {
-	azureClients, err := receiver.CreateAzureClients(subscriptionID, clientID, clientSecret, tenantID)
+) (azureClients *receiver.AzureClients, err error) {
+	var token azcore.TokenCredential
+	if clientSecret != "" {
+		azureClients, err = receiver.CreateAzureClients(subscriptionID, clientID, clientSecret, tenantID)
+	} else {
+		if token, err = azidentity.NewDefaultAzureCredential(&azidentity.DefaultAzureCredentialOptions{
+			TenantID: tenantID,
+		}); err == nil {
+			azureClients, err = receiver.CreateAzureClientsWithCreds(subscriptionID, token)
+		}
+	}
 	if err != nil {
 		return nil, fmt.Errorf("error creating Azure clients: %w", err)
 	}

--- a/plugins/inputs/azure_monitor/sample.conf
+++ b/plugins/inputs/azure_monitor/sample.conf
@@ -4,7 +4,13 @@
   subscription_id = "<<SUBSCRIPTION_ID>>"
   # can be obtained by registering an application under Azure Active Directory
   client_id = "<<CLIENT_ID>>"
-  # can be obtained by registering an application under Azure Active Directory
+  # can be obtained by registering an application under Azure Active Directory.
+  # If not specified Default Azure Credentials chain will be attempted:
+  # - Environment credentials (AZURE_*)
+  # - Workload Identity in Kubernetes cluster
+  # - Managed Identity
+  # - Azure CLI auth
+  # - Developer Azure CLI auth
   client_secret = "<<CLIENT_SECRET>>"
   # can be found under Azure Active Directory->Properties
   tenant_id = "<<TENANT_ID>>"


### PR DESCRIPTION
## Summary

This allows Telegraf authenticating with Workload Identity on K8S or with
VM identity when running directly on a virtual machine.

## Checklist
- [x] No AI generated code was used in this PR

