### PR TITLE
fix(toolkit): more specific toolkit version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/influxdata/telegraf
 
-go 1.22
+go 1.22.0
 
 require (
 	cloud.google.com/go/bigquery v1.61.0


### PR DESCRIPTION
## Summary
On trying to build using `make build` an error occurred during build 
```
go: downloading go1.22 (darwin/arm64)
go: download go1.22 for darwin/arm64: toolchain not available
```

According to go docs specified in this [thread](https://github.com/golang/go/issues/62278#issuecomment-1693538776) the build was able to do successfully

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #15398 
