### PR TITLE
feat(inputs.exec): Add option to ignore return code

### DIFF
--- a/plugins/inputs/exec/README.md
+++ b/plugins/inputs/exec/README.md
@@ -21,11 +21,7 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 # Read metrics from one or more commands that can output to stdout
 [[inputs.exec]]
   ## Commands array
-  commands = [
-    "/tmp/test.sh",
-    "/usr/bin/mycollector --foo=bar",
-    "/tmp/collect_*.sh"
-  ]
+  commands = []
 
   ## Environment variables
   ## Array of "key=value" pairs to pass as environment variables
@@ -34,16 +30,24 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   # environment = []
 
   ## Timeout for each command to complete.
-  timeout = "5s"
+  # timeout = "5s"
 
-  ## measurement name suffix (for separating different commands)
-  name_suffix = "_mycollector"
+  ## Measurement name suffix
+  ## Used for separating different commands
+  # name_suffix = ""
 
-  ## Data format to consume.
-  ## Each data format has its own unique set of configuration options, read
-  ## more about them here:
+  ## Ignore Error Code
+  ## If set to true, a non-zero error code in not considered an error and the
+  ## plugin will continue to parse the output.
+  # ignore_error = false
+
+  ## Data format
+  ## By default, exec expects JSON. This was done for historical reasons and is
+  ## different than other inputs that use the influx line protocol. Each data
+  ## format has its own unique set of configuration options, read more about
+  ## them here:
   ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_INPUT.md
-  data_format = "influx"
+  # data_format = "json"
 ```
 
 Glob patterns in the `command` option are matched on every run, so adding new

--- a/plugins/inputs/exec/exec.go
+++ b/plugins/inputs/exec/exec.go
@@ -31,6 +31,7 @@ type Exec struct {
 	Commands    []string        `toml:"commands"`
 	Command     string          `toml:"command"`
 	Environment []string        `toml:"environment"`
+	IgnoreError bool            `toml:"ignore_error"`
 	Timeout     config.Duration `toml:"timeout"`
 	Log         telegraf.Logger `toml:"-"`
 
@@ -105,7 +106,7 @@ func (e *Exec) ProcessCommand(command string, acc telegraf.Accumulator, wg *sync
 	defer wg.Done()
 
 	out, errBuf, runErr := e.runner.Run(command, e.Environment, time.Duration(e.Timeout))
-	if !e.parseDespiteError && runErr != nil {
+	if !e.IgnoreError && !e.parseDespiteError && runErr != nil {
 		err := fmt.Errorf("exec: %w for command %q: %s", runErr, command, string(errBuf))
 		acc.AddError(err)
 		return

--- a/plugins/inputs/exec/sample.conf
+++ b/plugins/inputs/exec/sample.conf
@@ -1,11 +1,7 @@
 # Read metrics from one or more commands that can output to stdout
 [[inputs.exec]]
   ## Commands array
-  commands = [
-    "/tmp/test.sh",
-    "/usr/bin/mycollector --foo=bar",
-    "/tmp/collect_*.sh"
-  ]
+  commands = []
 
   ## Environment variables
   ## Array of "key=value" pairs to pass as environment variables
@@ -14,13 +10,21 @@
   # environment = []
 
   ## Timeout for each command to complete.
-  timeout = "5s"
+  # timeout = "5s"
 
-  ## measurement name suffix (for separating different commands)
-  name_suffix = "_mycollector"
+  ## Measurement name suffix
+  ## Used for separating different commands
+  # name_suffix = ""
 
-  ## Data format to consume.
-  ## Each data format has its own unique set of configuration options, read
-  ## more about them here:
+  ## Ignore Error Code
+  ## If set to true, a non-zero error code in not considered an error and the
+  ## plugin will continue to parse the output.
+  # ignore_error = false
+
+  ## Data format
+  ## By default, exec expects JSON. This was done for historical reasons and is
+  ## different than other inputs that use the influx line protocol. Each data
+  ## format has its own unique set of configuration options, read more about
+  ## them here:
   ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_INPUT.md
-  data_format = "influx"
+  # data_format = "json"


### PR DESCRIPTION



## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

This allows the exec plugin to ignore any errors returned and continue to parse the output.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

fixes: #9483
