### PR TITLE
fix(agent): Warn on multple agent configuration tables seen

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -94,6 +94,9 @@ type Config struct {
 	Persister *persister.Persister
 
 	NumberSecrets uint64
+
+	seenAgentTable     bool
+	seenAgentTableOnce sync.Once
 }
 
 // Ordered plugins used to keep the order in which they appear in a file
@@ -516,6 +519,13 @@ func (c *Config) LoadConfigData(data []byte) error {
 
 	// Parse agent table:
 	if val, ok := tbl.Fields["agent"]; ok {
+		if c.seenAgentTable {
+			c.seenAgentTableOnce.Do(func() {
+				log.Printf("W! Multiple agent tables are not supported: undefined behavior when multiple are present")
+			})
+		}
+		c.seenAgentTable = true
+
 		subTable, ok := val.(*ast.Table)
 		if !ok {
 			return errors.New("invalid configuration, error parsing agent table")

--- a/config/config.go
+++ b/config/config.go
@@ -521,7 +521,7 @@ func (c *Config) LoadConfigData(data []byte) error {
 	if val, ok := tbl.Fields["agent"]; ok {
 		if c.seenAgentTable {
 			c.seenAgentTableOnce.Do(func() {
-				log.Printf("W! Multiple agent tables are not supported: undefined behavior when multiple are present")
+				log.Printf("W! Overlapping settings in multiple agent tables are not supported: may cause undefined behavior")
 			})
 		}
 		c.seenAgentTable = true


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Users sometimes try to use multiple agent sections, but this leads to undefined behavior. We should start to warn and eventually error on these types of issues.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR
