### PR TITLE
feat(agent): Add uint support in cli test output

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -974,7 +974,7 @@ func (a *Agent) Test(ctx context.Context, wait time.Duration) error {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		s := &influx.Serializer{SortFields: true}
+		s := &influx.Serializer{SortFields: true, UintSupport: true}
 		for metric := range src {
 			octets, err := s.Serialize(metric)
 			if err == nil {


### PR DESCRIPTION
## Summary
I had a long time figuring out why the `inputs.snmp.field` conversion option of `hextoint` didn't work as expected. It turned out the value I tested with appears to be larger than `MaxInt64` and thus only that value was returned.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

