### PR TITLE
feat(processors.printer): Embed Influx serializer options

### DIFF
--- a/plugins/processors/printer/README.md
+++ b/plugins/processors/printer/README.md
@@ -16,6 +16,25 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 ```toml @sample.conf
 # Print all metrics that pass through this filter.
 [[processors.printer]]
+  ## Maximum line length in bytes.  Useful only for debugging.
+  # influx_max_line_bytes = 0
+
+  ## When true, fields will be output in ascending lexical order.  Enabling
+  ## this option will result in decreased performance and is only recommended
+  ## when you need predictable ordering while debugging.
+  # influx_sort_fields = false
+
+  ## When true, Telegraf will output unsigned integers as unsigned values,
+  ## i.e.: `42u`.  You will need a version of InfluxDB supporting unsigned
+  ## integer values.  Enabling this option will result in field type errors if
+  ## existing data has been written.
+  # influx_uint_support = false
+
+  ## When true, Telegraf will omit the timestamp on data to allow InfluxDB
+  ## to set the timestamp of the data during ingestion. This is generally NOT
+  ## what you want as it can lead to data points captured at different times
+  ## getting omitted due to similar data.
+  # influx_omit_timestamp = false
 ```
 
 ## Tags

--- a/plugins/processors/printer/printer.go
+++ b/plugins/processors/printer/printer.go
@@ -14,21 +14,16 @@ import (
 var sampleConfig string
 
 type Printer struct {
-	serializer *influx.Serializer
+	influx.Serializer
 }
 
 func (*Printer) SampleConfig() string {
 	return sampleConfig
 }
 
-func (p *Printer) Init() error {
-	p.serializer = &influx.Serializer{}
-	return p.serializer.Init()
-}
-
 func (p *Printer) Apply(in ...telegraf.Metric) []telegraf.Metric {
 	for _, metric := range in {
-		octets, err := p.serializer.Serialize(metric)
+		octets, err := p.Serialize(metric)
 		if err != nil {
 			continue
 		}

--- a/plugins/processors/printer/sample.conf
+++ b/plugins/processors/printer/sample.conf
@@ -1,2 +1,21 @@
 # Print all metrics that pass through this filter.
 [[processors.printer]]
+  ## Maximum line length in bytes.  Useful only for debugging.
+  # influx_max_line_bytes = 0
+
+  ## When true, fields will be output in ascending lexical order.  Enabling
+  ## this option will result in decreased performance and is only recommended
+  ## when you need predictable ordering while debugging.
+  # influx_sort_fields = false
+
+  ## When true, Telegraf will output unsigned integers as unsigned values,
+  ## i.e.: `42u`.  You will need a version of InfluxDB supporting unsigned
+  ## integer values.  Enabling this option will result in field type errors if
+  ## existing data has been written.
+  # influx_uint_support = false
+
+  ## When true, Telegraf will omit the timestamp on data to allow InfluxDB
+  ## to set the timestamp of the data during ingestion. This is generally NOT
+  ## what you want as it can lead to data points captured at different times
+  ## getting omitted due to similar data.
+  # influx_omit_timestamp = false


### PR DESCRIPTION
## Summary
Add all options of the Influx serialised also to the Printer processor.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

related #15433 