### PR TITLE
feat(inputs.snmp): Convert octet string with invalid data to hex

### DIFF
--- a/internal/snmp/field_test.go
+++ b/internal/snmp/field_test.go
@@ -161,6 +161,24 @@ func TestConvertHextoint(t *testing.T) {
 			expected: uint64(0x84c807fffd3854c1),
 		},
 		{
+			name:       "big endian uint32",
+			conversion: "hextoint:BigEndian:uint32",
+			ent: gosnmp.SnmpPDU{
+				Type:  gosnmp.OctetString,
+				Value: []byte{0x84, 0xc8, 0x7, 0xff},
+			},
+			expected: uint32(0x84c807ff),
+		},
+		{
+			name:       "big endian uint16",
+			conversion: "hextoint:BigEndian:uint16",
+			ent: gosnmp.SnmpPDU{
+				Type:  gosnmp.OctetString,
+				Value: []byte{0x84, 0xc8},
+			},
+			expected: uint16(0x84c8),
+		},
+		{
 			name:       "big endian invalid",
 			conversion: "hextoint:BigEndian:invalid",
 			ent:        gosnmp.SnmpPDU{Type: gosnmp.OctetString, Value: []uint8{}},
@@ -174,6 +192,24 @@ func TestConvertHextoint(t *testing.T) {
 				Value: []byte{0x84, 0xc8, 0x7, 0xff, 0xfd, 0x38, 0x54, 0xc1},
 			},
 			expected: uint64(0xc15438fdff07c884),
+		},
+		{
+			name:       "little endian uint32",
+			conversion: "hextoint:LittleEndian:uint32",
+			ent: gosnmp.SnmpPDU{
+				Type:  gosnmp.OctetString,
+				Value: []byte{0x84, 0xc8, 0x7, 0xff},
+			},
+			expected: uint32(0xff07c884),
+		},
+		{
+			name:       "little endian uint16",
+			conversion: "hextoint:LittleEndian:uint16",
+			ent: gosnmp.SnmpPDU{
+				Type:  gosnmp.OctetString,
+				Value: []byte{0x84, 0xc8},
+			},
+			expected: uint16(0xc884),
 		},
 		{
 			name:       "little endian invalid",

--- a/internal/snmp/field_test.go
+++ b/internal/snmp/field_test.go
@@ -1,0 +1,85 @@
+package snmp
+
+import (
+	"testing"
+
+	"github.com/gosnmp/gosnmp"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConvert(t *testing.T) {
+	tests := []struct {
+		name       string
+		conversion string
+		ent        gosnmp.SnmpPDU
+		expected   interface{}
+		errmsg     string
+	}{
+		{
+			name: "integer",
+			ent: gosnmp.SnmpPDU{
+				Type:  gosnmp.Integer,
+				Value: 2,
+			},
+			expected: 2,
+		},
+		{
+			name: "gauge",
+			ent: gosnmp.SnmpPDU{
+				Type:  gosnmp.Gauge32,
+				Value: 0x2,
+			},
+			expected: 2,
+		},
+		{
+			name: "octet string with valid bytes",
+			ent: gosnmp.SnmpPDU{
+				Type:  gosnmp.OctetString,
+				Value: []uint8{0x48, 0x65, 0x6C, 0x6C, 0x6F, 0x20, 0x77, 0x6F, 0x72, 0x6C, 0x64},
+			},
+			expected: "Hello world",
+		},
+		{
+			name: "octet string with invalid bytes",
+			ent: gosnmp.SnmpPDU{
+				Type:  gosnmp.OctetString,
+				Value: []uint8{0x84, 0xc8, 0x7, 0xff, 0xfd, 0x38, 0x54, 0xc1},
+			},
+			expected: "84c807fffd3854c1",
+		},
+		{
+			name:       "hextoint big endian uint64",
+			conversion: "hextoint:BigEndian:uint64",
+			ent: gosnmp.SnmpPDU{
+				Type:  gosnmp.OctetString,
+				Value: []uint8{0x84, 0xc8, 0x7, 0xff, 0xfd, 0x38, 0x54, 0xc1},
+			},
+			expected: uint64(0x84c807fffd3854c1),
+		},
+		{
+			name:       "hextoint little endian uint64",
+			conversion: "hextoint:LittleEndian:uint64",
+			ent: gosnmp.SnmpPDU{
+				Type:  gosnmp.OctetString,
+				Value: []uint8{0x84, 0xc8, 0x7, 0xff, 0xfd, 0x38, 0x54, 0xc1},
+			},
+			expected: uint64(0xc15438fdff07c884),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := Field{Conversion: tt.conversion}
+
+			actual, err := f.Convert(tt.ent)
+
+			if tt.errmsg != "" {
+				require.ErrorContains(t, err, tt.errmsg)
+			} else {
+				require.NoError(t, err)
+			}
+
+			require.Equal(t, tt.expected, actual)
+		})
+	}
+}

--- a/internal/snmp/field_test.go
+++ b/internal/snmp/field_test.go
@@ -19,7 +19,7 @@ func TestConvert(t *testing.T) {
 			name: "integer",
 			ent: gosnmp.SnmpPDU{
 				Type:  gosnmp.Integer,
-				Value: 2,
+				Value: int(2),
 			},
 			expected: 2,
 		},
@@ -27,7 +27,7 @@ func TestConvert(t *testing.T) {
 			name: "gauge",
 			ent: gosnmp.SnmpPDU{
 				Type:  gosnmp.Gauge32,
-				Value: 0x2,
+				Value: uint(2),
 			},
 			expected: 2,
 		},
@@ -48,6 +48,11 @@ func TestConvert(t *testing.T) {
 			expected: "84c807fffd3854c1",
 		},
 		{
+			name:       "hextoint empty",
+			conversion: "hextoint:BigEndian:uint64",
+			ent:        gosnmp.SnmpPDU{},
+		},
+		{
 			name:       "hextoint big endian uint64",
 			conversion: "hextoint:BigEndian:uint64",
 			ent: gosnmp.SnmpPDU{
@@ -57,6 +62,12 @@ func TestConvert(t *testing.T) {
 			expected: uint64(0x84c807fffd3854c1),
 		},
 		{
+			name:       "hextoint big endian invalid",
+			conversion: "hextoint:BigEndian:invalid",
+			ent:        gosnmp.SnmpPDU{Type: gosnmp.OctetString, Value: []uint8{}},
+			errmsg:     "invalid bit value",
+		},
+		{
 			name:       "hextoint little endian uint64",
 			conversion: "hextoint:LittleEndian:uint64",
 			ent: gosnmp.SnmpPDU{
@@ -64,6 +75,24 @@ func TestConvert(t *testing.T) {
 				Value: []uint8{0x84, 0xc8, 0x7, 0xff, 0xfd, 0x38, 0x54, 0xc1},
 			},
 			expected: uint64(0xc15438fdff07c884),
+		},
+		{
+			name:       "hextoint little endian invalid",
+			conversion: "hextoint:LittleEndian:invalid",
+			ent:        gosnmp.SnmpPDU{Type: gosnmp.OctetString, Value: []uint8{}},
+			errmsg:     "invalid bit value",
+		},
+		{
+			name:       "hextoint invalid",
+			conversion: "hextoint:invalid:uint64",
+			ent:        gosnmp.SnmpPDU{Type: gosnmp.OctetString, Value: []uint8{}},
+			errmsg:     "invalid Endian value",
+		},
+		{
+			name:       "invalid",
+			conversion: "invalid",
+			ent:        gosnmp.SnmpPDU{},
+			errmsg:     "invalid conversion type",
 		},
 	}
 

--- a/internal/snmp/translator_gosmi_test.go
+++ b/internal/snmp/translator_gosmi_test.go
@@ -294,7 +294,6 @@ func TestFieldConvertGosmi(t *testing.T) {
 		conv     string
 		expected interface{}
 	}{
-		{[]byte("foo"), "", "foo"},
 		{"0.123", "float", float64(0.123)},
 		{[]byte("0.123"), "float", float64(0.123)},
 		{float32(0.123), "float", float64(float32(0.123))},

--- a/internal/snmp/translator_gosmi_test.go
+++ b/internal/snmp/translator_gosmi_test.go
@@ -333,12 +333,6 @@ func TestFieldConvertGosmi(t *testing.T) {
 		{[]byte("abcd"), "ipaddr", "97.98.99.100"},
 		{"abcd", "ipaddr", "97.98.99.100"},
 		{[]byte("abcdefghijklmnop"), "ipaddr", "6162:6364:6566:6768:696a:6b6c:6d6e:6f70"},
-		{[]byte{0x00, 0x09, 0x3E, 0xE3, 0xF6, 0xD5, 0x3B, 0x60}, "hextoint:BigEndian:uint64", uint64(2602423610063712)},
-		{[]byte{0x00, 0x09, 0x3E, 0xE3}, "hextoint:BigEndian:uint32", uint32(605923)},
-		{[]byte{0x00, 0x09}, "hextoint:BigEndian:uint16", uint16(9)},
-		{[]byte{0x00, 0x09, 0x3E, 0xE3, 0xF6, 0xD5, 0x3B, 0x60}, "hextoint:LittleEndian:uint64", uint64(6934371307618175232)},
-		{[]byte{0x00, 0x09, 0x3E, 0xE3}, "hextoint:LittleEndian:uint32", uint32(3812493568)},
-		{[]byte{0x00, 0x09}, "hextoint:LittleEndian:uint16", uint16(2304)},
 		{3, "enum", "testing"},
 		{3, "enum(1)", "testing(3)"},
 	}

--- a/internal/snmp/translator_netsnmp_test.go
+++ b/internal/snmp/translator_netsnmp_test.go
@@ -4,7 +4,6 @@ package snmp
 import (
 	"testing"
 
-	"github.com/gosnmp/gosnmp"
 	"github.com/stretchr/testify/require"
 
 	"github.com/influxdata/telegraf/testutil"
@@ -220,72 +219,6 @@ func TestTableBuild_noWalk(t *testing.T) {
 	}
 	require.Len(t, tb.Rows, 1)
 	require.Contains(t, tb.Rows, rtr)
-}
-
-func TestFieldConvert(t *testing.T) {
-	testTable := []struct {
-		input    interface{}
-		conv     string
-		expected interface{}
-	}{
-		{[]byte("foo"), "", "foo"},
-		{"0.123", "float", float64(0.123)},
-		{[]byte("0.123"), "float", float64(0.123)},
-		{float32(0.123), "float", float64(float32(0.123))},
-		{float64(0.123), "float", float64(0.123)},
-		{float64(0.123123123123), "float", float64(0.123123123123)},
-		{123, "float", float64(123)},
-		{123, "float(0)", float64(123)},
-		{123, "float(4)", float64(0.0123)},
-		{int8(123), "float(3)", float64(0.123)},
-		{int16(123), "float(3)", float64(0.123)},
-		{int32(123), "float(3)", float64(0.123)},
-		{int64(123), "float(3)", float64(0.123)},
-		{uint(123), "float(3)", float64(0.123)},
-		{uint8(123), "float(3)", float64(0.123)},
-		{uint16(123), "float(3)", float64(0.123)},
-		{uint32(123), "float(3)", float64(0.123)},
-		{uint64(123), "float(3)", float64(0.123)},
-		{"123", "int", int64(123)},
-		{[]byte("123"), "int", int64(123)},
-		{"123123123123", "int", int64(123123123123)},
-		{[]byte("123123123123"), "int", int64(123123123123)},
-		{float32(12.3), "int", int64(12)},
-		{float64(12.3), "int", int64(12)},
-		{int(123), "int", int64(123)},
-		{int8(123), "int", int64(123)},
-		{int16(123), "int", int64(123)},
-		{int32(123), "int", int64(123)},
-		{int64(123), "int", int64(123)},
-		{uint(123), "int", int64(123)},
-		{uint8(123), "int", int64(123)},
-		{uint16(123), "int", int64(123)},
-		{uint32(123), "int", int64(123)},
-		{uint64(123), "int", int64(123)},
-		{[]byte("abcdef"), "hwaddr", "61:62:63:64:65:66"},
-		{"abcdef", "hwaddr", "61:62:63:64:65:66"},
-		{[]byte("abcd"), "ipaddr", "97.98.99.100"},
-		{"abcd", "ipaddr", "97.98.99.100"},
-		{[]byte("abcdefghijklmnop"), "ipaddr", "6162:6364:6566:6768:696a:6b6c:6d6e:6f70"},
-		{[]byte{0x00, 0x09, 0x3E, 0xE3, 0xF6, 0xD5, 0x3B, 0x60}, "hextoint:BigEndian:uint64", uint64(2602423610063712)},
-		{[]byte{0x00, 0x09, 0x3E, 0xE3}, "hextoint:BigEndian:uint32", uint32(605923)},
-		{[]byte{0x00, 0x09}, "hextoint:BigEndian:uint16", uint16(9)},
-		{[]byte{0x00, 0x09, 0x3E, 0xE3, 0xF6, 0xD5, 0x3B, 0x60}, "hextoint:LittleEndian:uint64", uint64(6934371307618175232)},
-		{[]byte{0x00, 0x09, 0x3E, 0xE3}, "hextoint:LittleEndian:uint32", uint32(3812493568)},
-		{[]byte{0x00, 0x09}, "hextoint:LittleEndian:uint16", uint16(2304)},
-	}
-
-	for _, tc := range testTable {
-		f := Field{
-			Name:       "test",
-			Conversion: tc.conv,
-		}
-		require.NoError(t, f.Init(NewNetsnmpTranslator(testutil.Logger{})))
-
-		act, err := f.Convert(gosnmp.SnmpPDU{Value: tc.input})
-		require.NoError(t, err, "input=%T(%v) conv=%s expected=%T(%v)", tc.input, tc.input, tc.conv, tc.expected, tc.expected)
-		require.EqualValues(t, tc.expected, act, "input=%T(%v) conv=%s expected=%T(%v)", tc.input, tc.input, tc.conv, tc.expected, tc.expected)
-	}
 }
 
 func TestSnmpTranslateCache_miss(t *testing.T) {

--- a/plugins/inputs/snmp/README.md
+++ b/plugins/inputs/snmp/README.md
@@ -171,11 +171,12 @@ option operate similar to the `snmpget` utility.
     ##   int:         Convert the value into an integer.
     ##   hwaddr:      Convert the value to a MAC address.
     ##   ipaddr:      Convert the value to an IP address.
-    ##   hextoint:X:Y Convert a hex string value to integer. Where X is the Endian
-    ##                and Y the bit size. For example: hextoint:LittleEndian:uint64
-    ##                or hextoint:BigEndian:uint32. Valid options for the Endian are:
-    ##                BigEndian and LittleEndian. For the bit size: uint16, uint32
-    ##                and uint64.
+    ##   hex:         Convert bytes to a hex string.
+    ##   hextoint:X:Y Convert bytes to integer, where X is the endian and Y the
+    ##                bit size. For example: hextoint:LittleEndian:uint64 or
+    ##                hextoint:BigEndian:uint32. Valid options for the endian
+    ##                are: BigEndian and LittleEndian. For the bit size: 
+    ##                uint16, uint32 and uint64.
     ##   enum(1):     Convert the value according to its syntax in the MIB (full).
     ##                (Only supported with gosmi translator)
     ##   enum:        Convert the value according to its syntax in the MIB.


### PR DESCRIPTION
## Summary
Some snmp data is binary encoded and displayed as HEX string with net-snmp tools (`Hex-STRING: 84 C8 07 FF FD 38 54 C1`). Currently Telegraf tries to interpret these bytes as string and thus resulting in non-printable characters: `raw="����8T�"`.

This PR changes this so that they will be converted to HEX in the case of OctetString and containing not valid UTF8 characters, resulting in `raw="84c807fffd3854c1"`. Similar fix has been done for `inputs.snmp_trap`: #14619.

Meanwhile I also added a new field `conversion` option so you can force to always convert the value to HEX string.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

related to #14619
resolves #12456
resolves #3716
resolves #3478
