### PR TITLE
fix(inputs.cloudwatch): Add accounts when enabled

### DIFF
--- a/plugins/inputs/cloudwatch/cloudwatch.go
+++ b/plugins/inputs/cloudwatch/cloudwatch.go
@@ -262,6 +262,10 @@ func getFilteredMetrics(c *CloudWatch) ([]filteredMetric, error) {
 						})
 					}
 				}
+				if c.IncludeLinkedAccounts {
+					_, allAccounts := c.fetchNamespaceMetrics()
+					accounts = append(accounts, allAccounts...)
+				}
 			} else {
 				allMetrics, allAccounts := c.fetchNamespaceMetrics()
 


### PR DESCRIPTION




## Summary
There was one case, where a user defined a metric, but no dimensions. In this case, the accounts were never added when IncludeLinkedAccounts was set to true.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->
fixes: #15422
