### PR TITLE
docs(inputs.swap): Remove linux only comment

### DIFF
--- a/plugins/inputs/swap/README.md
+++ b/plugins/inputs/swap/README.md
@@ -18,7 +18,6 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 ```toml @sample.conf
 # Read metrics about swap memory usage
-# This plugin ONLY supports Linux
 [[inputs.swap]]
   # no configuration
 ```

--- a/plugins/inputs/swap/sample.conf
+++ b/plugins/inputs/swap/sample.conf
@@ -1,4 +1,3 @@
 # Read metrics about swap memory usage
-# This plugin ONLY supports Linux
 [[inputs.swap]]
   # no configuration


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
gopsutil does have support for swap information for linux, windows, *bsd, and others.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

fixes: #15449
