### PR TITLE
chore: Update removal dates to either v1.35.0 or v1.40.0

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -212,12 +212,12 @@ type AgentConfig struct {
 	// FlushBufferWhenFull tells Telegraf to flush the metric buffer whenever
 	// it fills up, regardless of FlushInterval. Setting this option to true
 	// does _not_ deactivate FlushInterval.
-	FlushBufferWhenFull bool `toml:"flush_buffer_when_full" deprecated:"0.13.0;1.30.0;option is ignored"`
+	FlushBufferWhenFull bool `toml:"flush_buffer_when_full" deprecated:"0.13.0;1.35.0;option is ignored"`
 
 	// TODO(cam): Remove UTC and parameter, they are no longer
 	// valid for the agent config. Leaving them here for now for backwards-
 	// compatibility
-	UTC bool `toml:"utc" deprecated:"1.0.0;option is ignored"`
+	UTC bool `toml:"utc" deprecated:"1.0.0;1.35.0;option is ignored"`
 
 	// Debug is the option for running in debug mode
 	Debug bool `toml:"debug"`
@@ -552,7 +552,7 @@ func (c *Config) LoadConfigData(data []byte) error {
 	if c.Agent.SnmpTranslator == "netsnmp" {
 		PrintOptionValueDeprecationNotice("agent", "snmp_translator", "netsnmp", telegraf.DeprecationInfo{
 			Since:     "1.25.0",
-			RemovalIn: "2.0.0",
+			RemovalIn: "1.40.0",
 			Notice:    "Use 'gosmi' instead",
 		})
 	}
@@ -1394,7 +1394,7 @@ func (c *Config) buildFilter(plugin string, tbl *ast.Table) (models.Filter, erro
 	if len(oldPass) > 0 {
 		PrintOptionDeprecationNotice(plugin, "pass", telegraf.DeprecationInfo{
 			Since:     "0.10.4",
-			RemovalIn: "2.0.0",
+			RemovalIn: "1.35.0",
 			Notice:    "use 'fieldinclude' instead",
 		})
 		f.FieldInclude = append(f.FieldInclude, oldPass...)
@@ -1404,7 +1404,7 @@ func (c *Config) buildFilter(plugin string, tbl *ast.Table) (models.Filter, erro
 	if len(oldFieldPass) > 0 {
 		PrintOptionDeprecationNotice(plugin, "fieldpass", telegraf.DeprecationInfo{
 			Since:     "1.29.0",
-			RemovalIn: "2.0.0",
+			RemovalIn: "1.40.0",
 			Notice:    "use 'fieldinclude' instead",
 		})
 		f.FieldInclude = append(f.FieldInclude, oldFieldPass...)
@@ -1416,7 +1416,7 @@ func (c *Config) buildFilter(plugin string, tbl *ast.Table) (models.Filter, erro
 	if len(oldDrop) > 0 {
 		PrintOptionDeprecationNotice(plugin, "drop", telegraf.DeprecationInfo{
 			Since:     "0.10.4",
-			RemovalIn: "2.0.0",
+			RemovalIn: "1.35.0",
 			Notice:    "use 'fieldexclude' instead",
 		})
 		f.FieldExclude = append(f.FieldExclude, oldDrop...)
@@ -1426,7 +1426,7 @@ func (c *Config) buildFilter(plugin string, tbl *ast.Table) (models.Filter, erro
 	if len(oldFieldDrop) > 0 {
 		PrintOptionDeprecationNotice(plugin, "fielddrop", telegraf.DeprecationInfo{
 			Since:     "1.29.0",
-			RemovalIn: "2.0.0",
+			RemovalIn: "1.40.0",
 			Notice:    "use 'fieldexclude' instead",
 		})
 		f.FieldExclude = append(f.FieldExclude, oldFieldDrop...)

--- a/plugins/common/opcua/input/input_client.go
+++ b/plugins/common/opcua/input/input_client.go
@@ -52,9 +52,9 @@ type NodeSettings struct {
 	Namespace        string               `toml:"namespace"`
 	IdentifierType   string               `toml:"identifier_type"`
 	Identifier       string               `toml:"identifier"`
-	DataType         string               `toml:"data_type" deprecated:"1.17.0;option is ignored"`
-	Description      string               `toml:"description" deprecated:"1.17.0;option is ignored"`
-	TagsSlice        [][]string           `toml:"tags" deprecated:"1.25.0;use 'default_tags' instead"`
+	DataType         string               `toml:"data_type" deprecated:"1.17.0;1.35.0;option is ignored"`
+	Description      string               `toml:"description" deprecated:"1.17.0;1.35.0;option is ignored"`
+	TagsSlice        [][]string           `toml:"tags" deprecated:"1.25.0;1.35.0;use 'default_tags' instead"`
 	DefaultTags      map[string]string    `toml:"default_tags"`
 	MonitoringParams MonitoringParameters `toml:"monitoring_params"`
 }
@@ -70,7 +70,7 @@ type NodeGroupSettings struct {
 	Namespace        string            `toml:"namespace"`       // Can be overridden by node setting
 	IdentifierType   string            `toml:"identifier_type"` // Can be overridden by node setting
 	Nodes            []NodeSettings    `toml:"nodes"`
-	TagsSlice        [][]string        `toml:"tags" deprecated:"1.26.0;use default_tags"`
+	TagsSlice        [][]string        `toml:"tags" deprecated:"1.26.0;1.35.0;use default_tags"`
 	DefaultTags      map[string]string `toml:"default_tags"`
 	SamplingInterval config.Duration   `toml:"sampling_interval"` // Can be overridden by monitoring parameters
 }

--- a/plugins/common/tls/config.go
+++ b/plugins/common/tls/config.go
@@ -29,9 +29,9 @@ type ClientConfig struct {
 	RenegotiationMethod string   `toml:"tls_renegotiation_method"`
 	Enable              *bool    `toml:"tls_enable"`
 
-	SSLCA   string `toml:"ssl_ca" deprecated:"1.7.0;use 'tls_ca' instead"`
-	SSLCert string `toml:"ssl_cert" deprecated:"1.7.0;use 'tls_cert' instead"`
-	SSLKey  string `toml:"ssl_key" deprecated:"1.7.0;use 'tls_key' instead"`
+	SSLCA   string `toml:"ssl_ca" deprecated:"1.7.0;1.35.0;use 'tls_ca' instead"`
+	SSLCert string `toml:"ssl_cert" deprecated:"1.7.0;1.35.0;use 'tls_cert' instead"`
+	SSLKey  string `toml:"ssl_key" deprecated:"1.7.0;1.35.0;use 'tls_key' instead"`
 }
 
 // ServerConfig represents the standard server TLS config.

--- a/plugins/inputs/aerospike/aerospike.go
+++ b/plugins/inputs/aerospike/aerospike.go
@@ -28,7 +28,7 @@ type Aerospike struct {
 	Password string `toml:"password"`
 
 	EnableTLS bool   `toml:"enable_tls"`
-	EnableSSL bool   `toml:"enable_ssl" deprecated:"1.7.0;use 'enable_tls' instead"`
+	EnableSSL bool   `toml:"enable_ssl" deprecated:"1.7.0;1.35.0;use 'enable_tls' instead"`
 	TLSName   string `toml:"tls_name"`
 	tlsint.ClientConfig
 

--- a/plugins/inputs/amqp_consumer/amqp_consumer.go
+++ b/plugins/inputs/amqp_consumer/amqp_consumer.go
@@ -28,7 +28,7 @@ type semaphore chan empty
 
 // AMQPConsumer is the top level struct for this plugin
 type AMQPConsumer struct {
-	URL                    string            `toml:"url" deprecated:"1.7.0;use 'brokers' instead"`
+	URL                    string            `toml:"url" deprecated:"1.7.0;1.35.0;use 'brokers' instead"`
 	Brokers                []string          `toml:"brokers"`
 	Username               config.Secret     `toml:"username"`
 	Password               config.Secret     `toml:"password"`

--- a/plugins/inputs/cloudwatch/cloudwatch.go
+++ b/plugins/inputs/cloudwatch/cloudwatch.go
@@ -41,7 +41,7 @@ type CloudWatch struct {
 
 	Period                config.Duration `toml:"period"`
 	Delay                 config.Duration `toml:"delay"`
-	Namespace             string          `toml:"namespace" deprecated:"1.25.0;use 'namespaces' instead"`
+	Namespace             string          `toml:"namespace" deprecated:"1.25.0;1.35.0;use 'namespaces' instead"`
 	Namespaces            []string        `toml:"namespaces"`
 	Metrics               []*Metric       `toml:"metrics"`
 	CacheTTL              config.Duration `toml:"cache_ttl"`

--- a/plugins/inputs/consul/consul.go
+++ b/plugins/inputs/consul/consul.go
@@ -22,7 +22,7 @@ type Consul struct {
 	Token      string
 	Username   string
 	Password   string
-	Datacentre string `toml:"datacentre" deprecated:"1.10.0;use 'datacenter' instead"`
+	Datacentre string `toml:"datacentre" deprecated:"1.10.0;1.35.0;use 'datacenter' instead"`
 	Datacenter string
 	tls.ClientConfig
 	TagDelimiter  string

--- a/plugins/inputs/deprecations.go
+++ b/plugins/inputs/deprecations.go
@@ -5,8 +5,9 @@ import "github.com/influxdata/telegraf"
 // Deprecations lists the deprecated plugins
 var Deprecations = map[string]telegraf.DeprecationInfo{
 	"aerospike": {
-		Since:  "1.30.0",
-		Notice: "use 'inputs.prometheus' with the Aerospike Prometheus Exporter instead",
+		Since:     "1.30.0",
+		RemovalIn: "1.40.0",
+		Notice:    "use 'inputs.prometheus' with the Aerospike Prometheus Exporter instead",
 	},
 	"cassandra": {
 		Since:     "1.7.0",
@@ -46,12 +47,14 @@ var Deprecations = map[string]telegraf.DeprecationInfo{
 		Notice: "has been renamed to 'knx_listener'",
 	},
 	"logparser": {
-		Since:  "1.15.0",
-		Notice: "use 'inputs.tail' with 'grok' data format instead",
+		Since:     "1.15.0",
+		RemovalIn: "1.35.0",
+		Notice:    "use 'inputs.tail' with 'grok' data format instead",
 	},
 	"sflow": {
-		Since:  "1.31.0",
-		Notice: "use 'inputs.netflow' instead",
+		Since:     "1.31.0",
+		RemovalIn: "1.40.0",
+		Notice:    "use 'inputs.netflow' instead",
 	},
 	"snmp_legacy": {
 		Since:     "1.0.0",

--- a/plugins/inputs/docker/docker.go
+++ b/plugins/inputs/docker/docker.go
@@ -36,14 +36,14 @@ var sampleConfig string
 // Docker object
 type Docker struct {
 	Endpoint       string
-	ContainerNames []string `toml:"container_names" deprecated:"1.4.0;use 'container_name_include' instead"`
+	ContainerNames []string `toml:"container_names" deprecated:"1.4.0;1.35.0;use 'container_name_include' instead"`
 
 	GatherServices bool `toml:"gather_services"`
 
 	Timeout          config.Duration
-	PerDevice        bool     `toml:"perdevice" deprecated:"1.18.0;use 'perdevice_include' instead"`
+	PerDevice        bool     `toml:"perdevice" deprecated:"1.18.0;1.35.0;use 'perdevice_include' instead"`
 	PerDeviceInclude []string `toml:"perdevice_include"`
-	Total            bool     `toml:"total" deprecated:"1.18.0;use 'total_include' instead"`
+	Total            bool     `toml:"total" deprecated:"1.18.0;1.35.0;use 'total_include' instead"`
 	TotalInclude     []string `toml:"total_include"`
 	TagEnvironment   []string `toml:"tag_env"`
 	LabelInclude     []string `toml:"docker_label_include"`

--- a/plugins/inputs/elasticsearch/elasticsearch.go
+++ b/plugins/inputs/elasticsearch/elasticsearch.go
@@ -98,7 +98,7 @@ type indexStat struct {
 type Elasticsearch struct {
 	Local                      bool            `toml:"local"`
 	Servers                    []string        `toml:"servers"`
-	HTTPTimeout                config.Duration `toml:"http_timeout" deprecated:"1.29.0;use 'timeout' instead"`
+	HTTPTimeout                config.Duration `toml:"http_timeout" deprecated:"1.29.0;1.35.0;use 'timeout' instead"`
 	ClusterHealth              bool            `toml:"cluster_health"`
 	ClusterHealthLevel         string          `toml:"cluster_health_level"`
 	ClusterStats               bool            `toml:"cluster_stats"`

--- a/plugins/inputs/filecount/filecount.go
+++ b/plugins/inputs/filecount/filecount.go
@@ -21,7 +21,7 @@ import (
 var sampleConfig string
 
 type FileCount struct {
-	Directory      string `toml:"directory" deprecated:"1.9.0;use 'directories' instead"`
+	Directory      string `toml:"directory" deprecated:"1.9.0;1.35.0;use 'directories' instead"`
 	Directories    []string
 	Name           string
 	Recursive      bool

--- a/plugins/inputs/gnmi/gnmi.go
+++ b/plugins/inputs/gnmi/gnmi.go
@@ -58,9 +58,9 @@ type GNMI struct {
 	CanonicalFieldNames  bool              `toml:"canonical_field_names"`
 	TrimFieldNames       bool              `toml:"trim_field_names"`
 	PrefixTagKeyWithPath bool              `toml:"prefix_tag_key_with_path"`
-	GuessPathTag         bool              `toml:"guess_path_tag" deprecated:"1.30.0;use 'path_guessing_strategy' instead"`
+	GuessPathTag         bool              `toml:"guess_path_tag" deprecated:"1.30.0;1.35.0;use 'path_guessing_strategy' instead"`
 	GuessPathStrategy    string            `toml:"path_guessing_strategy"`
-	EnableTLS            bool              `toml:"enable_tls" deprecated:"1.27.0;use 'tls_enable' instead"`
+	EnableTLS            bool              `toml:"enable_tls" deprecated:"1.27.0;1.35.0;use 'tls_enable' instead"`
 	KeepaliveTime        config.Duration   `toml:"keepalive_time"`
 	KeepaliveTimeout     config.Duration   `toml:"keepalive_timeout"`
 	YangModelPaths       []string          `toml:"yang_model_paths"`
@@ -83,7 +83,7 @@ type Subscription struct {
 	SampleInterval    config.Duration `toml:"sample_interval"`
 	SuppressRedundant bool            `toml:"suppress_redundant"`
 	HeartbeatInterval config.Duration `toml:"heartbeat_interval"`
-	TagOnly           bool            `toml:"tag_only" deprecated:"1.25.0;2.0.0;please use 'tag_subscription's instead"`
+	TagOnly           bool            `toml:"tag_only" deprecated:"1.25.0;1.35.0;please use 'tag_subscription's instead"`
 
 	fullPath *gnmiLib.Path
 }

--- a/plugins/inputs/http/http.go
+++ b/plugins/inputs/http/http.go
@@ -34,7 +34,7 @@ type HTTP struct {
 	Password config.Secret `toml:"password"`
 
 	// Bearer authentication
-	BearerToken string        `toml:"bearer_token" deprecated:"1.28.0;use 'token_file' instead"`
+	BearerToken string        `toml:"bearer_token" deprecated:"1.28.0;1.35.0;use 'token_file' instead"`
 	Token       config.Secret `toml:"token"`
 	TokenFile   string        `toml:"token_file"`
 

--- a/plugins/inputs/http_listener_v2/http_listener_v2.go
+++ b/plugins/inputs/http_listener_v2/http_listener_v2.go
@@ -44,7 +44,7 @@ type TimeFunc func() time.Time
 // HTTPListenerV2 is an input plugin that collects external metrics sent via HTTP
 type HTTPListenerV2 struct {
 	ServiceAddress string            `toml:"service_address"`
-	Path           string            `toml:"path" deprecated:"1.20.0;use 'paths' instead"`
+	Path           string            `toml:"path" deprecated:"1.20.0;1.35.0;use 'paths' instead"`
 	Paths          []string          `toml:"paths"`
 	PathTag        bool              `toml:"path_tag"`
 	Methods        []string          `toml:"methods"`

--- a/plugins/inputs/http_response/http_response.go
+++ b/plugins/inputs/http_response/http_response.go
@@ -36,7 +36,7 @@ const (
 
 // HTTPResponse struct
 type HTTPResponse struct {
-	Address         string   `toml:"address" deprecated:"1.12.0;use 'urls' instead"`
+	Address         string   `toml:"address" deprecated:"1.12.0;1.35.0;use 'urls' instead"`
 	URLs            []string `toml:"urls"`
 	HTTPProxy       string   `toml:"http_proxy"`
 	Body            string

--- a/plugins/inputs/icinga2/icinga2.go
+++ b/plugins/inputs/icinga2/icinga2.go
@@ -25,7 +25,7 @@ type Icinga2 struct {
 	Server          string
 	Objects         []string
 	Status          []string
-	ObjectType      string `toml:"object_type" deprecated:"1.26.0;2.0.0;use 'objects' instead"`
+	ObjectType      string `toml:"object_type" deprecated:"1.26.0;1.35.0;use 'objects' instead"`
 	Username        string
 	Password        string
 	ResponseTimeout config.Duration

--- a/plugins/inputs/influxdb_listener/influxdb_listener.go
+++ b/plugins/inputs/influxdb_listener/influxdb_listener.go
@@ -40,7 +40,7 @@ type InfluxDBListener struct {
 	ReadTimeout        config.Duration `toml:"read_timeout"`
 	WriteTimeout       config.Duration `toml:"write_timeout"`
 	MaxBodySize        config.Size     `toml:"max_body_size"`
-	MaxLineSize        config.Size     `toml:"max_line_size" deprecated:"1.14.0;parser now handles lines of unlimited length and option is ignored"`
+	MaxLineSize        config.Size     `toml:"max_line_size" deprecated:"1.14.0;1.35.0;parser now handles lines of unlimited length and option is ignored"`
 	BasicUsername      string          `toml:"basic_username"`
 	BasicPassword      string          `toml:"basic_password"`
 	TokenSharedSecret  string          `toml:"token_shared_secret"`

--- a/plugins/inputs/intel_powerstat/intel_powerstat.go
+++ b/plugins/inputs/intel_powerstat/intel_powerstat.go
@@ -240,7 +240,7 @@ func (p *PowerStat) parseCPUMetrics() error {
 	if slices.Contains(p.CPUMetrics, cpuBusyCycles) {
 		config.PrintOptionValueDeprecationNotice("inputs.intel_powerstat", "cpu_metrics", cpuBusyCycles, telegraf.DeprecationInfo{
 			Since:     "1.23.0",
-			RemovalIn: "2.0.0",
+			RemovalIn: "1.35.0;",
 			Notice:    "'cpu_c0_state_residency' metric name should be used instead.",
 		})
 	}

--- a/plugins/inputs/internet_speed/internet_speed.go
+++ b/plugins/inputs/internet_speed/internet_speed.go
@@ -26,7 +26,7 @@ var sampleConfig string
 type InternetSpeed struct {
 	ServerIDInclude    []string `toml:"server_id_include"`
 	ServerIDExclude    []string `toml:"server_id_exclude"`
-	EnableFileDownload bool     `toml:"enable_file_download" deprecated:"1.25.0;use 'memory_saving_mode' instead"`
+	EnableFileDownload bool     `toml:"enable_file_download" deprecated:"1.25.0;1.35.0;use 'memory_saving_mode' instead"`
 	MemorySavingMode   bool     `toml:"memory_saving_mode"`
 	Cache              bool     `toml:"cache"`
 	Connections        int      `toml:"connections"`

--- a/plugins/inputs/kube_inventory/kube_inventory.go
+++ b/plugins/inputs/kube_inventory/kube_inventory.go
@@ -32,7 +32,7 @@ type KubernetesInventory struct {
 	URL               string          `toml:"url"`
 	KubeletURL        string          `toml:"url_kubelet"`
 	BearerToken       string          `toml:"bearer_token"`
-	BearerTokenString string          `toml:"bearer_token_string" deprecated:"1.24.0;use 'BearerToken' with a file instead"`
+	BearerTokenString string          `toml:"bearer_token_string" deprecated:"1.24.0;1.35.0;use 'BearerToken' with a file instead"`
 	Namespace         string          `toml:"namespace"`
 	ResponseTimeout   config.Duration `toml:"response_timeout"` // Timeout specified as a string - 3s, 1m, 1h
 	ResourceExclude   []string        `toml:"resource_exclude"`

--- a/plugins/inputs/kubernetes/kubernetes.go
+++ b/plugins/inputs/kubernetes/kubernetes.go
@@ -31,7 +31,7 @@ var sampleConfig string
 type Kubernetes struct {
 	URL               string          `toml:"url"`
 	BearerToken       string          `toml:"bearer_token"`
-	BearerTokenString string          `toml:"bearer_token_string" deprecated:"1.24.0;use 'BearerToken' with a file instead"`
+	BearerTokenString string          `toml:"bearer_token_string" deprecated:"1.24.0;1.35.0;use 'BearerToken' with a file instead"`
 	NodeMetricName    string          `toml:"node_metric_name"`
 	LabelInclude      []string        `toml:"label_include"`
 	LabelExclude      []string        `toml:"label_exclude"`

--- a/plugins/inputs/mock/mock.go
+++ b/plugins/inputs/mock/mock.go
@@ -53,8 +53,8 @@ type step struct {
 	Start float64 `toml:"start"`
 	Step  float64 `toml:"step"`
 
-	Min float64 `toml:"min" deprecated:"1.28.2;use 'start' instead"`
-	Max float64 `toml:"max" deprecated:"1.28.2;use 'step' instead"`
+	Min float64 `toml:"min" deprecated:"1.28.2;1.35.0;use 'start' instead"`
+	Max float64 `toml:"max" deprecated:"1.28.2;1.35.0;use 'step' instead"`
 }
 
 type stock struct {

--- a/plugins/inputs/modbus/configuration_register.go
+++ b/plugins/inputs/modbus/configuration_register.go
@@ -271,7 +271,7 @@ func (c *ConfigurationOriginal) normalizeInputDatatype(dataType string, words in
 	if dataType == "FLOAT32" {
 		config.PrintOptionValueDeprecationNotice("input.modbus", "data_type", "FLOAT32", telegraf.DeprecationInfo{
 			Since:     "v1.16.0",
-			RemovalIn: "v2.0.0",
+			RemovalIn: "v1.35.0",
 			Notice:    "Use 'UFIXED' instead",
 		})
 	}

--- a/plugins/inputs/mongodb/mongodb.go
+++ b/plugins/inputs/mongodb/mongodb.go
@@ -46,8 +46,8 @@ type MongoDB struct {
 }
 
 type Ssl struct {
-	Enabled bool     `toml:"ssl_enabled" deprecated:"1.3.0;use 'tls_*' options instead"`
-	CaCerts []string `toml:"cacerts" deprecated:"1.3.0;use 'tls_ca' instead"`
+	Enabled bool     `toml:"ssl_enabled" deprecated:"1.3.0;1.35.0;use 'tls_*' options instead"`
+	CaCerts []string `toml:"cacerts" deprecated:"1.3.0;1.35.0;use 'tls_ca' instead"`
 }
 
 func (*MongoDB) SampleConfig() string {

--- a/plugins/inputs/nsq_consumer/nsq_consumer.go
+++ b/plugins/inputs/nsq_consumer/nsq_consumer.go
@@ -34,7 +34,7 @@ func (l *logger) Output(_ int, s string) error {
 
 // NSQConsumer represents the configuration of the plugin
 type NSQConsumer struct {
-	Server      string   `toml:"server" deprecated:"1.5.0;use 'nsqd' instead"`
+	Server      string   `toml:"server" deprecated:"1.5.0;1.35.0;use 'nsqd' instead"`
 	Nsqd        []string `toml:"nsqd"`
 	Nsqlookupd  []string `toml:"nsqlookupd"`
 	Topic       string   `toml:"topic"`

--- a/plugins/inputs/ntpq/ntpq.go
+++ b/plugins/inputs/ntpq/ntpq.go
@@ -64,7 +64,7 @@ var fieldElements = map[string]elementType{
 }
 
 type NTPQ struct {
-	DNSLookup   bool     `toml:"dns_lookup" deprecated:"1.24.0;add '-n' to 'options' instead to skip DNS lookup"`
+	DNSLookup   bool     `toml:"dns_lookup" deprecated:"1.24.0;1.35.0;add '-n' to 'options' instead to skip DNS lookup"`
 	Options     string   `toml:"options"`
 	Servers     []string `toml:"servers"`
 	ReachFormat string   `toml:"reach_format"`

--- a/plugins/inputs/openldap/openldap.go
+++ b/plugins/inputs/openldap/openldap.go
@@ -20,10 +20,10 @@ var sampleConfig string
 type Openldap struct {
 	Host               string
 	Port               int
-	SSL                string `toml:"ssl" deprecated:"1.7.0;use 'tls' instead"`
+	SSL                string `toml:"ssl" deprecated:"1.7.0;1.35.0;use 'tls' instead"`
 	TLS                string `toml:"tls"`
 	InsecureSkipVerify bool
-	SSLCA              string `toml:"ssl_ca" deprecated:"1.7.0;use 'tls_ca' instead"`
+	SSLCA              string `toml:"ssl_ca" deprecated:"1.7.0;1.35.0;use 'tls_ca' instead"`
 	TLSCA              string `toml:"tls_ca"`
 	BindDn             string
 	BindPassword       string

--- a/plugins/inputs/procstat/procstat.go
+++ b/plugins/inputs/procstat/procstat.go
@@ -41,15 +41,15 @@ type Procstat struct {
 	Exe                    string          `toml:"exe"`
 	Pattern                string          `toml:"pattern"`
 	Prefix                 string          `toml:"prefix"`
-	CmdLineTag             bool            `toml:"cmdline_tag" deprecated:"1.29.0;use 'tag_with' instead"`
+	CmdLineTag             bool            `toml:"cmdline_tag" deprecated:"1.29.0;1.40.0;use 'tag_with' instead"`
 	ProcessName            string          `toml:"process_name"`
 	User                   string          `toml:"user"`
 	SystemdUnit            string          `toml:"systemd_unit"`
-	SupervisorUnit         []string        `toml:"supervisor_unit" deprecated:"1.29.0;use 'supervisor_units' instead"`
+	SupervisorUnit         []string        `toml:"supervisor_unit" deprecated:"1.29.0;1.40.0;use 'supervisor_units' instead"`
 	SupervisorUnits        []string        `toml:"supervisor_units"`
 	IncludeSystemdChildren bool            `toml:"include_systemd_children"`
 	CGroup                 string          `toml:"cgroup"`
-	PidTag                 bool            `toml:"pid_tag" deprecated:"1.29.0;use 'tag_with' instead"`
+	PidTag                 bool            `toml:"pid_tag" deprecated:"1.29.0;1.40.0;use 'tag_with' instead"`
 	WinService             string          `toml:"win_service"`
 	Mode                   string          `toml:"mode"`
 	Properties             []string        `toml:"properties"`

--- a/plugins/inputs/rabbitmq/rabbitmq.go
+++ b/plugins/inputs/rabbitmq/rabbitmq.go
@@ -42,7 +42,7 @@ const DefaultClientTimeout = 4
 // see the sample config for further details
 type RabbitMQ struct {
 	URL      string        `toml:"url"`
-	Name     string        `toml:"name" deprecated:"1.3.0;use 'tags' instead"`
+	Name     string        `toml:"name" deprecated:"1.3.0;1.35.0;use 'tags' instead"`
 	Username config.Secret `toml:"username"`
 	Password config.Secret `toml:"password"`
 	tls.ClientConfig
@@ -51,7 +51,7 @@ type RabbitMQ struct {
 	ClientTimeout         config.Duration `toml:"client_timeout"`
 
 	Nodes     []string `toml:"nodes"`
-	Queues    []string `toml:"queues" deprecated:"1.6.0;use 'queue_name_include' instead"`
+	Queues    []string `toml:"queues" deprecated:"1.6.0;1.35.0;use 'queue_name_include' instead"`
 	Exchanges []string `toml:"exchanges"`
 
 	MetricInclude             []string `toml:"metric_include"`

--- a/plugins/inputs/smart/smart.go
+++ b/plugins/inputs/smart/smart.go
@@ -358,7 +358,7 @@ var (
 
 // Smart plugin reads metrics from storage devices supporting S.M.A.R.T.
 type Smart struct {
-	Path              string          `toml:"path" deprecated:"1.16.0;use 'path_smartctl' instead"`
+	Path              string          `toml:"path" deprecated:"1.16.0;1.35.0;use 'path_smartctl' instead"`
 	PathSmartctl      string          `toml:"path_smartctl"`
 	PathNVMe          string          `toml:"path_nvme"`
 	Nocheck           string          `toml:"nocheck"`

--- a/plugins/inputs/snmp_trap/snmp_trap.go
+++ b/plugins/inputs/snmp_trap/snmp_trap.go
@@ -43,7 +43,7 @@ func (l wrapLog) Print(args ...interface{}) {
 
 type SnmpTrap struct {
 	ServiceAddress string          `toml:"service_address"`
-	Timeout        config.Duration `toml:"timeout" deprecated:"1.20.0;unused option"`
+	Timeout        config.Duration `toml:"timeout" deprecated:"1.20.0;1.35.0;unused option"`
 	Version        string          `toml:"version"`
 	Translator     string          `toml:"-"`
 	Path           []string        `toml:"path"`

--- a/plugins/inputs/sqlserver/sqlserver.go
+++ b/plugins/inputs/sqlserver/sqlserver.go
@@ -28,8 +28,8 @@ type SQLServer struct {
 	Servers      []*config.Secret `toml:"servers"`
 	QueryTimeout config.Duration  `toml:"query_timeout"`
 	AuthMethod   string           `toml:"auth_method"`
-	QueryVersion int              `toml:"query_version" deprecated:"1.16.0;use 'database_type' instead"`
-	AzureDB      bool             `toml:"azuredb" deprecated:"1.16.0;use 'database_type' instead"`
+	QueryVersion int              `toml:"query_version" deprecated:"1.16.0;1.35.0;use 'database_type' instead"`
+	AzureDB      bool             `toml:"azuredb" deprecated:"1.16.0;1.35.0;use 'database_type' instead"`
 	DatabaseType string           `toml:"database_type"`
 	IncludeQuery []string         `toml:"include_query"`
 	ExcludeQuery []string         `toml:"exclude_query"`

--- a/plugins/inputs/statsd/statsd.go
+++ b/plugins/inputs/statsd/statsd.go
@@ -84,7 +84,7 @@ type Statsd struct {
 	MetricSeparator string `toml:"metric_separator"`
 	// This flag enables parsing of tags in the dogstatsd extension to the
 	// statsd protocol (http://docs.datadoghq.com/guides/dogstatsd/)
-	ParseDataDogTags bool `toml:"parse_data_dog_tags" deprecated:"1.10.0;use 'datadog_extensions' instead"`
+	ParseDataDogTags bool `toml:"parse_data_dog_tags" deprecated:"1.10.0;1.35.0;use 'datadog_extensions' instead"`
 
 	// Parses extensions to statsd in the datadog statsd format
 	// currently supports metrics and datadog tags.
@@ -105,7 +105,7 @@ type Statsd struct {
 	// we now always create 1 max size buffer and then copy only what we need
 	// into the in channel
 	// see https://github.com/influxdata/telegraf/pull/992
-	UDPPacketSize int `toml:"udp_packet_size" deprecated:"0.12.1;2.0.0;option is ignored"`
+	UDPPacketSize int `toml:"udp_packet_size" deprecated:"0.12.1;1.35.0;option is ignored"`
 
 	ReadBufferSize      int              `toml:"read_buffer_size"`
 	SanitizeNamesMethod string           `toml:"sanitize_name_method"`

--- a/plugins/inputs/vsphere/vsphere.go
+++ b/plugins/inputs/vsphere/vsphere.go
@@ -72,7 +72,7 @@ type VSphere struct {
 	MaxQueryMetrics             int             `toml:"max_query_metrics"`
 	CollectConcurrency          int             `toml:"collect_concurrency"`
 	DiscoverConcurrency         int             `toml:"discover_concurrency"`
-	ForceDiscoverOnInit         bool            `toml:"force_discover_on_init" deprecated:"1.14.0;option is ignored"`
+	ForceDiscoverOnInit         bool            `toml:"force_discover_on_init" deprecated:"1.14.0;1.35.0;option is ignored"`
 	ObjectDiscoveryInterval     config.Duration `toml:"object_discovery_interval"`
 	Timeout                     config.Duration `toml:"timeout"`
 	HistoricalInterval          config.Duration `toml:"historical_interval"`

--- a/plugins/inputs/win_perf_counters/win_perf_counters.go
+++ b/plugins/inputs/win_perf_counters/win_perf_counters.go
@@ -25,7 +25,7 @@ var defaultMaxBufferSize = config.Size(100 * 1024 * 1024)
 
 type WinPerfCounters struct {
 	PrintValid                 bool `toml:"PrintValid"`
-	PreVistaSupport            bool `toml:"PreVistaSupport" deprecated:"1.7.0;determined dynamically"`
+	PreVistaSupport            bool `toml:"PreVistaSupport" deprecated:"1.7.0;1.35.0;determined dynamically"`
 	UsePerfCounterTime         bool
 	Object                     []perfObject
 	CountersRefreshInterval    config.Duration

--- a/plugins/inputs/zookeeper/zookeeper.go
+++ b/plugins/inputs/zookeeper/zookeeper.go
@@ -31,7 +31,7 @@ type Zookeeper struct {
 	ParseFloats string          `toml:"parse_floats"`
 
 	EnableTLS bool `toml:"enable_tls"`
-	EnableSSL bool `toml:"enable_ssl" deprecated:"1.7.0;use 'enable_tls' instead"`
+	EnableSSL bool `toml:"enable_ssl" deprecated:"1.7.0;1.35.0;use 'enable_tls' instead"`
 	tlsint.ClientConfig
 
 	initialized bool

--- a/plugins/outputs/amqp/amqp.go
+++ b/plugins/outputs/amqp/amqp.go
@@ -42,7 +42,7 @@ func (a *externalAuth) Response() string {
 }
 
 type AMQP struct {
-	URL                string            `toml:"url" deprecated:"1.7.0;use 'brokers' instead"`
+	URL                string            `toml:"url" deprecated:"1.7.0;1.35.0;use 'brokers' instead"`
 	Brokers            []string          `toml:"brokers"`
 	Exchange           string            `toml:"exchange"`
 	ExchangeType       string            `toml:"exchange_type"`
@@ -56,9 +56,9 @@ type AMQP struct {
 	RoutingTag         string            `toml:"routing_tag"`
 	RoutingKey         string            `toml:"routing_key"`
 	DeliveryMode       string            `toml:"delivery_mode"`
-	Database           string            `toml:"database" deprecated:"1.7.0;use 'headers' instead"`
-	RetentionPolicy    string            `toml:"retention_policy" deprecated:"1.7.0;use 'headers' instead"`
-	Precision          string            `toml:"precision" deprecated:"1.2.0;option is ignored"`
+	Database           string            `toml:"database" deprecated:"1.7.0;1.35.0;use 'headers' instead"`
+	RetentionPolicy    string            `toml:"retention_policy" deprecated:"1.7.0;1.35.0;use 'headers' instead"`
+	Precision          string            `toml:"precision" deprecated:"1.2.0;1.35.0;option is ignored"`
 	Headers            map[string]string `toml:"headers"`
 	Timeout            config.Duration   `toml:"timeout"`
 	UseBatchFormat     bool              `toml:"use_batch_format"`

--- a/plugins/outputs/influxdb/influxdb.go
+++ b/plugins/outputs/influxdb/influxdb.go
@@ -59,7 +59,7 @@ type InfluxDB struct {
 	SkipDatabaseCreation      bool              `toml:"skip_database_creation"`
 	InfluxUintSupport         bool              `toml:"influx_uint_support"`
 	OmitTimestamp             bool              `toml:"influx_omit_timestamp"`
-	Precision                 string            `toml:"precision" deprecated:"1.0.0;option is ignored"`
+	Precision                 string            `toml:"precision" deprecated:"1.0.0;1.35.0;option is ignored"`
 	Log                       telegraf.Logger   `toml:"-"`
 	tls.ClientConfig
 

--- a/plugins/outputs/kinesis/kinesis.go
+++ b/plugins/outputs/kinesis/kinesis.go
@@ -26,8 +26,8 @@ const maxRecordsPerRequest uint32 = 500
 type (
 	KinesisOutput struct {
 		StreamName         string     `toml:"streamname"`
-		PartitionKey       string     `toml:"partitionkey" deprecated:"1.5.0;use 'partition.key' instead"`
-		RandomPartitionKey bool       `toml:"use_random_partitionkey" deprecated:"1.5.0;use 'partition.method' instead"`
+		PartitionKey       string     `toml:"partitionkey" deprecated:"1.5.0;1.35.0;use 'partition.key' instead"`
+		RandomPartitionKey bool       `toml:"use_random_partitionkey" deprecated:"1.5.0;1.35.0;use 'partition.method' instead"`
 		Partition          *Partition `toml:"partition"`
 		Debug              bool       `toml:"debug"`
 

--- a/plugins/outputs/librato/librato.go
+++ b/plugins/outputs/librato/librato.go
@@ -26,7 +26,7 @@ type Librato struct {
 	APIUser   config.Secret   `toml:"api_user"`
 	APIToken  config.Secret   `toml:"api_token"`
 	Debug     bool            `toml:"debug"`
-	SourceTag string          `toml:"source_tag" deprecated:"1.0.0;use 'template' instead"`
+	SourceTag string          `toml:"source_tag" deprecated:"1.0.0;1.35.0;use 'template' instead"`
 	Timeout   config.Duration `toml:"timeout"`
 	Template  string          `toml:"template"`
 	Log       telegraf.Logger `toml:"-"`

--- a/plugins/outputs/mqtt/mqtt.go
+++ b/plugins/outputs/mqtt/mqtt.go
@@ -26,9 +26,9 @@ type message struct {
 }
 
 type MQTT struct {
-	TopicPrefix     string          `toml:"topic_prefix" deprecated:"1.25.0;use 'topic' instead"`
+	TopicPrefix     string          `toml:"topic_prefix" deprecated:"1.25.0;1.35.0;use 'topic' instead"`
 	Topic           string          `toml:"topic"`
-	BatchMessage    bool            `toml:"batch" deprecated:"1.25.2;use 'layout = \"batch\"' instead"`
+	BatchMessage    bool            `toml:"batch" deprecated:"1.25.2;1.35.0;use 'layout = \"batch\"' instead"`
 	Layout          string          `toml:"layout"`
 	HomieDeviceName string          `toml:"homie_device_name"`
 	HomieNodeID     string          `toml:"homie_node_id"`

--- a/plugins/outputs/wavefront/wavefront.go
+++ b/plugins/outputs/wavefront/wavefront.go
@@ -37,8 +37,8 @@ type Wavefront struct {
 	CSPBaseURL               string                          `toml:"auth_csp_base_url"`
 	AuthCSPAPIToken          config.Secret                   `toml:"auth_csp_api_token"`
 	AuthCSPClientCredentials *authCSPClientCredentials       `toml:"auth_csp_client_credentials"`
-	Host                     string                          `toml:"host" deprecated:"2.4.0;use url instead"`
-	Port                     int                             `toml:"port" deprecated:"2.4.0;use url instead"`
+	Host                     string                          `toml:"host" deprecated:"1.28.0;1.35.0;use url instead"`
+	Port                     int                             `toml:"port" deprecated:"1.28.0;1.35.0;use url instead"`
 	Prefix                   string                          `toml:"prefix"`
 	SimpleFields             bool                            `toml:"simple_fields"`
 	MetricSeparator          string                          `toml:"metric_separator"`
@@ -51,7 +51,7 @@ type Wavefront struct {
 	ImmediateFlush           bool                            `toml:"immediate_flush"`
 	SendInternalMetrics      bool                            `toml:"send_internal_metrics"`
 	SourceOverride           []string                        `toml:"source_override"`
-	StringToNumber           map[string][]map[string]float64 `toml:"string_to_number" deprecated:"1.9.0;use the enum processor instead"`
+	StringToNumber           map[string][]map[string]float64 `toml:"string_to_number" deprecated:"1.9.0;1.35.0;use the enum processor instead"`
 
 	httpconfig.HTTPClientConfig
 

--- a/plugins/parsers/binary/parser.go
+++ b/plugins/parsers/binary/parser.go
@@ -16,10 +16,10 @@ import (
 
 type Parser struct {
 	AllowNoMatch bool            `toml:"allow_no_match"`
-	Endianess    string          `toml:"endianess" deprecated:"1.27.4;use 'endianness' instead"`
+	Endianess    string          `toml:"endianess" deprecated:"1.27.4;1.35.0;use 'endianness' instead"`
 	Endianness   string          `toml:"endianness"`
 	Configs      []Config        `toml:"binary"`
-	HexEncoding  bool            `toml:"hex_encoding" deprecated:"1.30.0;use 'binary_encoding' instead"`
+	HexEncoding  bool            `toml:"hex_encoding" deprecated:"1.30.0;1.35.0;use 'binary_encoding' instead"`
 	Encoding     string          `toml:"binary_encoding"`
 	Log          telegraf.Logger `toml:"-"`
 

--- a/plugins/parsers/xpath/parser.go
+++ b/plugins/parsers/xpath/parser.go
@@ -50,10 +50,10 @@ type Parser struct {
 	Log                 telegraf.Logger   `toml:"-"`
 
 	// Required for backward compatibility
-	ConfigsXML     []Config `toml:"xml" deprecated:"1.23.1;use 'xpath' instead"`
-	ConfigsJSON    []Config `toml:"xpath_json" deprecated:"1.23.1;use 'xpath' instead"`
-	ConfigsMsgPack []Config `toml:"xpath_msgpack" deprecated:"1.23.1;use 'xpath' instead"`
-	ConfigsProto   []Config `toml:"xpath_protobuf" deprecated:"1.23.1;use 'xpath' instead"`
+	ConfigsXML     []Config `toml:"xml" deprecated:"1.23.1;1.35.0;use 'xpath' instead"`
+	ConfigsJSON    []Config `toml:"xpath_json" deprecated:"1.23.1;1.35.0;use 'xpath' instead"`
+	ConfigsMsgPack []Config `toml:"xpath_msgpack" deprecated:"1.23.1;1.35.0;use 'xpath' instead"`
+	ConfigsProto   []Config `toml:"xpath_protobuf" deprecated:"1.23.1;1.35.0;use 'xpath' instead"`
 
 	document dataDocument
 }
@@ -95,7 +95,7 @@ func (p *Parser) Init() error {
 			p.Configs = append(p.Configs, p.ConfigsXML...)
 			config.PrintOptionDeprecationNotice("parsers.xpath", "xml", telegraf.DeprecationInfo{
 				Since:     "1.23.1",
-				RemovalIn: "2.0.0",
+				RemovalIn: "1.35.0",
 				Notice:    "use 'xpath' instead",
 			})
 		}
@@ -109,7 +109,7 @@ func (p *Parser) Init() error {
 			p.Configs = append(p.Configs, p.ConfigsJSON...)
 			config.PrintOptionDeprecationNotice("parsers.xpath", "xpath_json", telegraf.DeprecationInfo{
 				Since:     "1.23.1",
-				RemovalIn: "2.0.0",
+				RemovalIn: "1.35.0",
 				Notice:    "use 'xpath' instead",
 			})
 		}
@@ -121,7 +121,7 @@ func (p *Parser) Init() error {
 			p.Configs = append(p.Configs, p.ConfigsMsgPack...)
 			config.PrintOptionDeprecationNotice("parsers.xpath", "xpath_msgpack", telegraf.DeprecationInfo{
 				Since:     "1.23.1",
-				RemovalIn: "2.0.0",
+				RemovalIn: "1.35.0",
 				Notice:    "use 'xpath' instead",
 			})
 		}
@@ -143,7 +143,7 @@ func (p *Parser) Init() error {
 			p.Configs = append(p.Configs, p.ConfigsProto...)
 			config.PrintOptionDeprecationNotice("parsers.xpath", "xpath_proto", telegraf.DeprecationInfo{
 				Since:     "1.23.1",
-				RemovalIn: "2.0.0",
+				RemovalIn: "1.35.0",
 				Notice:    "use 'xpath' instead",
 			})
 		}


### PR DESCRIPTION
## Summary
Updates all deprecated removal messages to set them for June 2025 as a part of v1.35.0 or September 2026 with v1.40.0.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR
