### PR TITLE
feat(inputs.systemd_units): Support user scoped units (#12053)

### DIFF
--- a/plugins/inputs/systemd_units/README.md
+++ b/plugins/inputs/systemd_units/README.md
@@ -73,7 +73,7 @@ These metrics are available in both modes:
     - load (string, load state)
     - active (string, active state)
     - sub (string, sub state)
-    - user (string, username when `scope = "user"`, empty when `scope = "system"`)
+    - user (string, username only for user scope)
   - fields:
     - load_code (int, see below)
     - active_code (int, see below)

--- a/plugins/inputs/systemd_units/README.md
+++ b/plugins/inputs/systemd_units/README.md
@@ -31,6 +31,10 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## automount, swap, timer, path, slice and scope
   # unittype = "service"
 
+  ## Collect system or user scoped units
+  ##  ex: scope = "user"
+  # scope = "system"
+
   ## Collect also units not loaded by systemd, i.e. disabled or static units
   ## Enabling this feature might introduce significant load when used with
   ## unspecific patterns (such as '*') as systemd will need to load all

--- a/plugins/inputs/systemd_units/README.md
+++ b/plugins/inputs/systemd_units/README.md
@@ -69,6 +69,7 @@ These metrics are available in both modes:
     - load (string, load state)
     - active (string, active state)
     - sub (string, sub state)
+    - user (string, username when `scope = "user"`, empty when `scope = "system"`)
   - fields:
     - load_code (int, see below)
     - active_code (int, see below)
@@ -198,15 +199,15 @@ were removed, tables are hex aligned to keep some space for future values
 ### Output in non-detailed mode
 
 ```text
-systemd_units,host=host1.example.com,name=dbus.service,load=loaded,active=active,sub=running load_code=0i,active_code=0i,sub_code=0i 1533730725000000000
-systemd_units,host=host1.example.com,name=networking.service,load=loaded,active=failed,sub=failed load_code=0i,active_code=3i,sub_code=12i 1533730725000000000
-systemd_units,host=host1.example.com,name=ssh.service,load=loaded,active=active,sub=running load_code=0i,active_code=0i,sub_code=0i 1533730725000000000
+systemd_units,host=host1.example.com,name=dbus.service,load=loaded,active=active,sub=running,user=telegraf load_code=0i,active_code=0i,sub_code=0i 1533730725000000000
+systemd_units,host=host1.example.com,name=networking.service,load=loaded,active=failed,sub=failed,user=telegraf load_code=0i,active_code=3i,sub_code=12i 1533730725000000000
+systemd_units,host=host1.example.com,name=ssh.service,load=loaded,active=active,sub=running,user=telegraf load_code=0i,active_code=0i,sub_code=0i 1533730725000000000
 ```
 
 ### Output in detailed mode
 
 ```text
-systemd_units,active=active,host=host1.example.com,load=loaded,name=dbus.service,sub=running,preset=disabled,state=static active_code=0i,load_code=0i,mem_avail=6470856704i,mem_current=2691072i,mem_peak=3895296i,pid=481i,restarts=0i,status_errno=0i,sub_code=0i,swap_current=794624i,swap_peak=884736i 1533730725000000000
-systemd_units,active=inactive,host=host1.example.com,load=not-found,name=networking.service,sub=dead active_code=2i,load_code=2i,pid=0i,restarts=0i,status_errno=0i,sub_code=1i 1533730725000000000
-systemd_units,active=active,host=host1.example.com,load=loaded,name=pcscd.service,sub=running,preset=disabled,state=indirect active_code=0i,load_code=0i,mem_avail=6370541568i,mem_current=512000i,mem_peak=4399104i,pid=1673i,restarts=0i,status_errno=0i,sub_code=0i,swap_current=3149824i,swap_peak=3149824i 1533730725000000000
+systemd_units,active=active,host=host1.example.com,load=loaded,name=dbus.service,sub=running,preset=disabled,state=static,user=telegraf active_code=0i,load_code=0i,mem_avail=6470856704i,mem_current=2691072i,mem_peak=3895296i,pid=481i,restarts=0i,status_errno=0i,sub_code=0i,swap_current=794624i,swap_peak=884736i 1533730725000000000
+systemd_units,active=inactive,host=host1.example.com,load=not-found,name=networking.service,sub=dead,user=telegraf active_code=2i,load_code=2i,pid=0i,restarts=0i,status_errno=0i,sub_code=1i 1533730725000000000
+systemd_units,active=active,host=host1.example.com,load=loaded,name=pcscd.service,sub=running,preset=disabled,state=indirect,user=telegraf active_code=0i,load_code=0i,mem_avail=6370541568i,mem_current=512000i,mem_peak=4399104i,pid=1673i,restarts=0i,status_errno=0i,sub_code=0i,swap_current=3149824i,swap_peak=3149824i 1533730725000000000
 ```

--- a/plugins/inputs/systemd_units/sample.conf
+++ b/plugins/inputs/systemd_units/sample.conf
@@ -12,6 +12,10 @@
   ## automount, swap, timer, path, slice and scope
   # unittype = "service"
 
+  ## Collect system or user scoped units
+  ##  ex: scope = "user"
+  # scope = "system"
+
   ## Collect also units not loaded by systemd, i.e. disabled or static units
   ## Enabling this feature might introduce significant load when used with
   ## unspecific patterns (such as '*') as systemd will need to load all

--- a/plugins/inputs/systemd_units/systemd_units.go
+++ b/plugins/inputs/systemd_units/systemd_units.go
@@ -17,6 +17,7 @@ var sampleConfig string
 type SystemdUnits struct {
 	Pattern         string          `toml:"pattern"`
 	UnitType        string          `toml:"unittype"`
+	Scope           string          `toml:"scope"`
 	Details         bool            `toml:"details"`
 	CollectDisabled bool            `toml:"collect_disabled_units"`
 	Timeout         config.Duration `toml:"timeout"`

--- a/plugins/inputs/systemd_units/systemd_units_linux.go
+++ b/plugins/inputs/systemd_units/systemd_units_linux.go
@@ -164,7 +164,6 @@ func (s *SystemdUnits) Init() error {
 	switch s.Scope {
 	case "", "system":
 		s.scope = "system"
-		s.user = ""
 	case "user":
 		u, err := user.Current()
 		if err != nil {

--- a/plugins/inputs/systemd_units/systemd_units_linux.go
+++ b/plugins/inputs/systemd_units/systemd_units_linux.go
@@ -340,7 +340,6 @@ func (s *SystemdUnits) Gather(acc telegraf.Accumulator) error {
 			continue
 		}
 
-		var tags map[string]string
 		// Create the metric
 		if s.scope == "user" {
 			tags = map[string]string{

--- a/plugins/inputs/systemd_units/systemd_units_linux.go
+++ b/plugins/inputs/systemd_units/systemd_units_linux.go
@@ -348,7 +348,7 @@ func (s *SystemdUnits) Gather(acc telegraf.Accumulator) error {
 			"sub":    state.SubState,
 		}
 		if s.scope == "user" {
-			tags["user"] =  s.user
+			tags["user"] = s.user
 		}
 
 		fields := map[string]interface{}{

--- a/plugins/inputs/systemd_units/systemd_units_linux.go
+++ b/plugins/inputs/systemd_units/systemd_units_linux.go
@@ -166,13 +166,13 @@ func (s *SystemdUnits) Init() error {
 		s.scope = "system"
 		s.user = ""
 	case "user":
-		user, err := user.Current()
+		u, err := user.Current()
 		if err != nil {
 			return fmt.Errorf("unable to determine user: %w", err)
 		}
 
 		s.scope = "user"
-		s.user = user.Username
+		s.user = u.Username
 	default:
 		return fmt.Errorf("invalid 'scope' %q", s.Scope)
 	}

--- a/plugins/inputs/systemd_units/systemd_units_linux.go
+++ b/plugins/inputs/systemd_units/systemd_units_linux.go
@@ -341,21 +341,14 @@ func (s *SystemdUnits) Gather(acc telegraf.Accumulator) error {
 		}
 
 		// Create the metric
+		tags := map[string]string{
+			"name":   state.Name,
+			"load":   state.LoadState,
+			"active": state.ActiveState,
+			"sub":    state.SubState,
+		}
 		if s.scope == "user" {
-			tags = map[string]string{
-				"name":   state.Name,
-				"load":   state.LoadState,
-				"active": state.ActiveState,
-				"sub":    state.SubState,
-				"user":   s.user,
-			}
-		} else {
-			tags = map[string]string{
-				"name":   state.Name,
-				"load":   state.LoadState,
-				"active": state.ActiveState,
-				"sub":    state.SubState,
-			}
+			tags["user"] =  s.user
 		}
 
 		fields := map[string]interface{}{

--- a/plugins/inputs/systemd_units/systemd_units_test.go
+++ b/plugins/inputs/systemd_units/systemd_units_test.go
@@ -7,7 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"os"
+	"os/user"
 	"strings"
 	"testing"
 	"time"
@@ -40,31 +40,34 @@ func TestDefaultPattern(t *testing.T) {
 }
 
 func TestDefaultScope(t *testing.T) {
+	u, err := user.Current()
+	if err != nil {
+		return
+	}
+
 	tests := []struct {
-		name     string
-		scope    string
-		expected map[string]string
+		name          string
+		scope         string
+		expectedScope string
+		expectedUser  string
 	}{
 		{
-			scope: "",
-			expected: map[string]string{
-				"scope": "system",
-				"user":  "",
-			},
+			name:          "default scope",
+			scope:         "",
+			expectedScope: "system",
+			expectedUser:  "",
 		},
 		{
-			scope: "system",
-			expected: map[string]string{
-				"scope": "system",
-				"user":  "",
-			},
+			name:          "system scope",
+			scope:         "system",
+			expectedScope: "system",
+			expectedUser:  "",
 		},
 		{
-			scope: "user",
-			expected: map[string]string{
-				"scope": "user",
-				"user":  os.Getenv("USER"),
-			},
+			name:          "user scope",
+			scope:         "user",
+			expectedScope: "user",
+			expectedUser:  u.Username,
 		},
 	}
 
@@ -74,13 +77,8 @@ func TestDefaultScope(t *testing.T) {
 				Scope: tt.scope,
 			}
 			require.NoError(t, plugin.Init())
-			if tt.expected["scope"] != plugin.scope {
-				t.Fatalf("Incorrect scope set: %q", plugin.scope)
-			}
-
-			if tt.expected["user"] != plugin.user {
-				t.Fatalf("Wrong username established: %q", plugin.user)
-			}
+			require.Equal(t, tt.expectedScope, plugin.scope)
+			require.Equal(t, tt.expectedUser, plugin.user)
 		})
 	}
 }
@@ -115,7 +113,6 @@ func TestListFiles(t *testing.T) {
 						"load":   "loaded",
 						"active": "active",
 						"sub":    "running",
-						"user":   "",
 					},
 					map[string]interface{}{
 						"load_code":   0,
@@ -148,7 +145,6 @@ func TestListFiles(t *testing.T) {
 						"load":   "loaded",
 						"active": "active",
 						"sub":    "exited",
-						"user":   "",
 					},
 					map[string]interface{}{
 						"load_code":   0,
@@ -181,7 +177,6 @@ func TestListFiles(t *testing.T) {
 						"load":   "loaded",
 						"active": "failed",
 						"sub":    "failed",
-						"user":   "",
 					},
 					map[string]interface{}{
 						"load_code":   0,
@@ -214,7 +209,6 @@ func TestListFiles(t *testing.T) {
 						"load":   "not-found",
 						"active": "inactive",
 						"sub":    "dead",
-						"user":   "",
 					},
 					map[string]interface{}{
 						"load_code":   2,
@@ -332,7 +326,6 @@ func TestShow(t *testing.T) {
 						"sub":    "running",
 						"state":  "enabled",
 						"preset": "disabled",
-						"user":   "",
 					},
 					map[string]interface{}{
 						"load_code":    0,
@@ -381,7 +374,6 @@ func TestShow(t *testing.T) {
 						"sub":    "exited",
 						"state":  "enabled",
 						"preset": "disabled",
-						"user":   "",
 					},
 					map[string]interface{}{
 						"load_code":    0,
@@ -434,7 +426,6 @@ func TestShow(t *testing.T) {
 						"sub":    "failed",
 						"state":  "enabled",
 						"preset": "disabled",
-						"user":   "",
 					},
 					map[string]interface{}{
 						"load_code":    0,
@@ -480,7 +471,6 @@ func TestShow(t *testing.T) {
 						"sub":    "dead",
 						"state":  "enabled",
 						"preset": "disabled",
-						"user":   "",
 					},
 					map[string]interface{}{
 						"load_code":    2,
@@ -551,7 +541,6 @@ func TestShow(t *testing.T) {
 						"sub":    "dead",
 						"state":  "disabled",
 						"preset": "disabled",
-						"user":   "",
 					},
 					map[string]interface{}{
 						"load_code":    0,
@@ -625,7 +614,6 @@ func TestMultiInstance(t *testing.T) {
 						"load":   "loaded",
 						"active": "active",
 						"sub":    "running",
-						"user":   "",
 					},
 					map[string]interface{}{
 						"load_code":   0,
@@ -641,7 +629,6 @@ func TestMultiInstance(t *testing.T) {
 						"load":   "loaded",
 						"active": "active",
 						"sub":    "running",
-						"user":   "",
 					},
 					map[string]interface{}{
 						"load_code":   0,
@@ -657,7 +644,6 @@ func TestMultiInstance(t *testing.T) {
 						"load":   "loaded",
 						"active": "active",
 						"sub":    "exited",
-						"user":   "",
 					},
 					map[string]interface{}{
 						"load_code":   0,
@@ -679,7 +665,6 @@ func TestMultiInstance(t *testing.T) {
 						"load":   "loaded",
 						"active": "active",
 						"sub":    "running",
-						"user":   "",
 					},
 					map[string]interface{}{
 						"load_code":   0,
@@ -695,7 +680,6 @@ func TestMultiInstance(t *testing.T) {
 						"load":   "loaded",
 						"active": "active",
 						"sub":    "exited",
-						"user":   "",
 					},
 					map[string]interface{}{
 						"load_code":   0,
@@ -717,7 +701,6 @@ func TestMultiInstance(t *testing.T) {
 						"load":   "loaded",
 						"active": "active",
 						"sub":    "exited",
-						"user":   "",
 					},
 					map[string]interface{}{
 						"load_code":   0,
@@ -739,7 +722,6 @@ func TestMultiInstance(t *testing.T) {
 						"load":   "loaded",
 						"active": "inactive",
 						"sub":    "dead",
-						"user":   "",
 					},
 					map[string]interface{}{
 						"load_code":   0,
@@ -761,7 +743,6 @@ func TestMultiInstance(t *testing.T) {
 						"load":   "stub",
 						"active": "inactive",
 						"sub":    "dead",
-						"user":   "",
 					},
 					map[string]interface{}{
 						"load_code":   1,
@@ -1030,7 +1011,6 @@ func oldParseListUnits(line string) ([]telegraf.Metric, error) {
 		"load":   load,
 		"active": active,
 		"sub":    sub,
-		"user":   "",
 	}
 
 	var (

--- a/plugins/inputs/systemd_units/systemd_units_test.go
+++ b/plugins/inputs/systemd_units/systemd_units_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -36,6 +37,52 @@ func TestDefaultPattern(t *testing.T) {
 	plugin := &SystemdUnits{}
 	require.NoError(t, plugin.Init())
 	require.Equal(t, "*", plugin.Pattern)
+}
+
+func TestDefaultScope(t *testing.T) {
+	tests := []struct {
+		name     string
+		scope    string
+		expected map[string]string
+	}{
+		{
+			scope: "",
+			expected: map[string]string{
+				"scope": "system",
+				"user":  "",
+			},
+		},
+		{
+			scope: "system",
+			expected: map[string]string{
+				"scope": "system",
+				"user":  "",
+			},
+		},
+		{
+			scope: "user",
+			expected: map[string]string{
+				"scope": "user",
+				"user":  os.Getenv("USER"),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			plugin := &SystemdUnits{
+				Scope: tt.scope,
+			}
+			require.NoError(t, plugin.Init())
+			if tt.expected["scope"] != plugin.scope {
+				t.Fatalf("Incorrect scope set: %q", plugin.scope)
+			}
+
+			if tt.expected["user"] != plugin.user {
+				t.Fatalf("Wrong username established: %q", plugin.user)
+			}
+		})
+	}
 }
 
 func TestListFiles(t *testing.T) {
@@ -68,6 +115,7 @@ func TestListFiles(t *testing.T) {
 						"load":   "loaded",
 						"active": "active",
 						"sub":    "running",
+						"user":   "",
 					},
 					map[string]interface{}{
 						"load_code":   0,
@@ -100,6 +148,7 @@ func TestListFiles(t *testing.T) {
 						"load":   "loaded",
 						"active": "active",
 						"sub":    "exited",
+						"user":   "",
 					},
 					map[string]interface{}{
 						"load_code":   0,
@@ -132,6 +181,7 @@ func TestListFiles(t *testing.T) {
 						"load":   "loaded",
 						"active": "failed",
 						"sub":    "failed",
+						"user":   "",
 					},
 					map[string]interface{}{
 						"load_code":   0,
@@ -164,6 +214,7 @@ func TestListFiles(t *testing.T) {
 						"load":   "not-found",
 						"active": "inactive",
 						"sub":    "dead",
+						"user":   "",
 					},
 					map[string]interface{}{
 						"load_code":   2,
@@ -281,6 +332,7 @@ func TestShow(t *testing.T) {
 						"sub":    "running",
 						"state":  "enabled",
 						"preset": "disabled",
+						"user":   "",
 					},
 					map[string]interface{}{
 						"load_code":    0,
@@ -329,6 +381,7 @@ func TestShow(t *testing.T) {
 						"sub":    "exited",
 						"state":  "enabled",
 						"preset": "disabled",
+						"user":   "",
 					},
 					map[string]interface{}{
 						"load_code":    0,
@@ -381,6 +434,7 @@ func TestShow(t *testing.T) {
 						"sub":    "failed",
 						"state":  "enabled",
 						"preset": "disabled",
+						"user":   "",
 					},
 					map[string]interface{}{
 						"load_code":    0,
@@ -426,6 +480,7 @@ func TestShow(t *testing.T) {
 						"sub":    "dead",
 						"state":  "enabled",
 						"preset": "disabled",
+						"user":   "",
 					},
 					map[string]interface{}{
 						"load_code":    2,
@@ -496,6 +551,7 @@ func TestShow(t *testing.T) {
 						"sub":    "dead",
 						"state":  "disabled",
 						"preset": "disabled",
+						"user":   "",
 					},
 					map[string]interface{}{
 						"load_code":    0,
@@ -569,6 +625,7 @@ func TestMultiInstance(t *testing.T) {
 						"load":   "loaded",
 						"active": "active",
 						"sub":    "running",
+						"user":   "",
 					},
 					map[string]interface{}{
 						"load_code":   0,
@@ -584,6 +641,7 @@ func TestMultiInstance(t *testing.T) {
 						"load":   "loaded",
 						"active": "active",
 						"sub":    "running",
+						"user":   "",
 					},
 					map[string]interface{}{
 						"load_code":   0,
@@ -599,6 +657,7 @@ func TestMultiInstance(t *testing.T) {
 						"load":   "loaded",
 						"active": "active",
 						"sub":    "exited",
+						"user":   "",
 					},
 					map[string]interface{}{
 						"load_code":   0,
@@ -620,6 +679,7 @@ func TestMultiInstance(t *testing.T) {
 						"load":   "loaded",
 						"active": "active",
 						"sub":    "running",
+						"user":   "",
 					},
 					map[string]interface{}{
 						"load_code":   0,
@@ -635,6 +695,7 @@ func TestMultiInstance(t *testing.T) {
 						"load":   "loaded",
 						"active": "active",
 						"sub":    "exited",
+						"user":   "",
 					},
 					map[string]interface{}{
 						"load_code":   0,
@@ -656,6 +717,7 @@ func TestMultiInstance(t *testing.T) {
 						"load":   "loaded",
 						"active": "active",
 						"sub":    "exited",
+						"user":   "",
 					},
 					map[string]interface{}{
 						"load_code":   0,
@@ -677,6 +739,7 @@ func TestMultiInstance(t *testing.T) {
 						"load":   "loaded",
 						"active": "inactive",
 						"sub":    "dead",
+						"user":   "",
 					},
 					map[string]interface{}{
 						"load_code":   0,
@@ -698,6 +761,7 @@ func TestMultiInstance(t *testing.T) {
 						"load":   "stub",
 						"active": "inactive",
 						"sub":    "dead",
+						"user":   "",
 					},
 					map[string]interface{}{
 						"load_code":   1,
@@ -966,6 +1030,7 @@ func oldParseListUnits(line string) ([]telegraf.Metric, error) {
 		"load":   load,
 		"active": active,
 		"sub":    sub,
+		"user":   "",
 	}
 
 	var (


### PR DESCRIPTION
## Summary
Systemctl allows to monitor both system- and user-scoped units while `systemd_units` plugin currently supports only system units. PR aims to solve this limitation.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #12053 
