### PR TITLE
test(outputs.sql): Update wait for log message

### DIFF
--- a/plugins/outputs/sql/sql_test.go
+++ b/plugins/outputs/sql/sql_test.go
@@ -174,7 +174,7 @@ func TestMysqlIntegration(t *testing.T) {
 
 	servicePort := "3306"
 	container := testutil.Container{
-		Image: "mariadb",
+		Image: "mariadb:11.4",
 		Env: map[string]string{
 			"MARIADB_ROOT_PASSWORD": password,
 		},

--- a/plugins/outputs/sql/sql_test.go
+++ b/plugins/outputs/sql/sql_test.go
@@ -174,7 +174,7 @@ func TestMysqlIntegration(t *testing.T) {
 
 	servicePort := "3306"
 	container := testutil.Container{
-		Image: "mariadb:11.4",
+		Image: "mariadb",
 		Env: map[string]string{
 			"MARIADB_ROOT_PASSWORD": password,
 		},
@@ -185,7 +185,7 @@ func TestMysqlIntegration(t *testing.T) {
 		ExposedPorts: []string{servicePort},
 		WaitingFor: wait.ForAll(
 			wait.ForListeningPort(nat.Port(servicePort)),
-			wait.ForLog("Buffer pool(s) load completed at"),
+			wait.ForLog("mariadbd: ready for connections.").WithOccurrence(2),
 		),
 	}
 	err = container.Start()


### PR DESCRIPTION

## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
It turns out there are additional messages and set up that occur after the message we were currently waiting for. This means that there were a few seconds were the DB was not ready for a connection. hence the error message was correct and the DB was not ready.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR
