### PR TITLE
test(inputs.syslog): Add timeout to closed socket test

### DIFF
--- a/plugins/inputs/syslog/syslog_test.go
+++ b/plugins/inputs/syslog/syslog_test.go
@@ -287,15 +287,13 @@ func TestCases(t *testing.T) {
 }
 
 func TestSocketClosed(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("Skipping test as very flaky on Windows")
-	}
-
 	// Setup the plugin
 	plugin := &Syslog{
 		Address: "tcp://127.0.0.1:0",
-		Config:  socket.Config{},
-		Log:     testutil.Logger{},
+		Config: socket.Config{
+			ReadTimeout: config.Duration(10 * time.Millisecond),
+		},
+		Log: testutil.Logger{},
 	}
 	require.NoError(t, plugin.Init())
 


### PR DESCRIPTION

## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
This is the most flaky test we currently have. It was omitted from Windows testing because it was failing consistently and then started happening on Linux as well.

The Test fails after waiting 9mins waiting to read from the socket. With no timeout set in the config the connection is expected to stay open indefinitely as described in #10121.

This re-enables the Windows tests as well to ensure it is actually fixed.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR
