### PR TITLE
chore(circleci): Build Windows package after linux testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -557,7 +557,7 @@ workflows:
               only: /.*/
       - 'windows-package':
           requires:
-            - 'test-go-windows'
+            - 'test-go-linux'
           filters:
             tags:
               only: /.*/


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
The project does not build in Windows or macOS packages for those OSes. Instead, all packages are cross-built in a linux container. As such, there is little reason to wait to build the Windows package till after the Windows tests pass. This can help reduce our total CI time down by around 10mins, or 1/3 of the total time.

Yes, if a test fails it could mean issues, but our CI would still report failed. This is more concerned with speeding up CI.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

