### PR TITLE
chore: Print debug message when no messages generated from parse

### DIFF
--- a/internal/internal.go
+++ b/internal/internal.go
@@ -24,6 +24,7 @@ import (
 )
 
 const alphanum string = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+const NoMetricsCreatedMsg = "No metrics were created from a message. Verify your parser settings. This message is only printed once."
 
 var once sync.Once
 

--- a/plugins/inputs/amqp_consumer/amqp_consumer.go
+++ b/plugins/inputs/amqp_consumer/amqp_consumer.go
@@ -23,6 +23,8 @@ import (
 //go:embed sample.conf
 var sampleConfig string
 
+var once sync.Once
+
 type empty struct{}
 type semaphore chan empty
 
@@ -440,6 +442,11 @@ func (a *AMQPConsumer) onMessage(acc telegraf.TrackingAccumulator, d amqp.Delive
 	if err != nil {
 		onError()
 		return err
+	}
+	if len(metrics) == 0 {
+		once.Do(func() {
+			a.Log.Debug(internal.NoMetricsCreatedMsg)
+		})
 	}
 
 	id := acc.AddTrackingMetricGroup(metrics)

--- a/plugins/inputs/cloud_pubsub/cloud_pubsub.go
+++ b/plugins/inputs/cloud_pubsub/cloud_pubsub.go
@@ -23,6 +23,8 @@ import (
 //go:embed sample.conf
 var sampleConfig string
 
+var once sync.Once
+
 type empty struct{}
 type semaphore chan empty
 
@@ -190,6 +192,11 @@ func (ps *PubSub) onMessage(ctx context.Context, msg message) error {
 
 	if len(metrics) == 0 {
 		msg.Ack()
+
+		once.Do(func() {
+			ps.Log.Debug(internal.NoMetricsCreatedMsg)
+		})
+
 		return nil
 	}
 

--- a/plugins/inputs/cloud_pubsub_push/cloud_pubsub_push.go
+++ b/plugins/inputs/cloud_pubsub_push/cloud_pubsub_push.go
@@ -14,12 +14,15 @@ import (
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
+	"github.com/influxdata/telegraf/internal"
 	tlsint "github.com/influxdata/telegraf/plugins/common/tls"
 	"github.com/influxdata/telegraf/plugins/inputs"
 )
 
 //go:embed sample.conf
 var sampleConfig string
+
+var once sync.Once
 
 // defaultMaxBodySize is the default maximum request body size, in bytes.
 // if the request body is over this size, we will return an HTTP 413 error.
@@ -196,6 +199,12 @@ func (p *PubSubPush) serveWrite(res http.ResponseWriter, req *http.Request) {
 		p.Log.Debug(err.Error())
 		res.WriteHeader(http.StatusBadRequest)
 		return
+	}
+
+	if len(metrics) == 0 {
+		once.Do(func() {
+			p.Log.Debug(internal.NoMetricsCreatedMsg)
+		})
 	}
 
 	if p.AddMeta {

--- a/plugins/inputs/directory_monitor/directory_monitor.go
+++ b/plugins/inputs/directory_monitor/directory_monitor.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
+	"github.com/influxdata/telegraf/internal"
 	"github.com/influxdata/telegraf/internal/choice"
 	"github.com/influxdata/telegraf/plugins/inputs"
 	"github.com/influxdata/telegraf/plugins/parsers"
@@ -29,6 +30,8 @@ import (
 
 //go:embed sample.conf
 var sampleConfig string
+
+var once sync.Once
 
 var (
 	defaultFilesToMonitor             = []string{}
@@ -304,6 +307,12 @@ func (monitor *DirectoryMonitor) parseMetrics(parser telegraf.Parser, line []byt
 			return nil, nil
 		}
 		return nil, err
+	}
+
+	if len(metrics) == 0 {
+		once.Do(func() {
+			monitor.Log.Debug(internal.NoMetricsCreatedMsg)
+		})
 	}
 
 	if monitor.FileTag != "" {

--- a/plugins/inputs/eventhub_consumer/eventhub_consumer.go
+++ b/plugins/inputs/eventhub_consumer/eventhub_consumer.go
@@ -20,6 +20,8 @@ import (
 //go:embed sample.conf
 var sampleConfig string
 
+var once sync.Once
+
 const (
 	defaultMaxUndeliveredMessages = 1000
 )
@@ -266,6 +268,12 @@ func (e *EventHub) createMetrics(event *eventhubClient.Event) ([]telegraf.Metric
 	metrics, err := e.parser.Parse(event.Data)
 	if err != nil {
 		return nil, err
+	}
+
+	if len(metrics) == 0 {
+		once.Do(func() {
+			e.Log.Debug(internal.NoMetricsCreatedMsg)
+		})
 	}
 
 	for i := range metrics {

--- a/plugins/inputs/exec/exec.go
+++ b/plugins/inputs/exec/exec.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
+	"github.com/influxdata/telegraf/internal"
 	"github.com/influxdata/telegraf/models"
 	"github.com/influxdata/telegraf/plugins/inputs"
 	"github.com/influxdata/telegraf/plugins/parsers/nagios"
@@ -22,6 +23,8 @@ import (
 
 //go:embed sample.conf
 var sampleConfig string
+
+var once sync.Once
 
 const MaxStderrBytes int = 512
 
@@ -116,6 +119,12 @@ func (e *Exec) ProcessCommand(command string, acc telegraf.Accumulator, wg *sync
 	if err != nil {
 		acc.AddError(err)
 		return
+	}
+
+	if len(metrics) == 0 {
+		once.Do(func() {
+			e.Log.Debug(internal.NoMetricsCreatedMsg)
+		})
 	}
 
 	if e.exitcodeHandler != nil {

--- a/plugins/inputs/file/file_test.go
+++ b/plugins/inputs/file/file_test.go
@@ -28,6 +28,7 @@ func TestRefreshFilePaths(t *testing.T) {
 
 	r := File{
 		Files: []string{filepath.Join(wd, "dev", "testfiles", "**.log")},
+		Log:   testutil.Logger{},
 	}
 	err = r.Init()
 	require.NoError(t, err)
@@ -45,6 +46,7 @@ func TestFileTag(t *testing.T) {
 		Files:       []string{filepath.Join(wd, "dev", "testfiles", "json_a.log")},
 		FileTag:     "filename",
 		FilePathTag: "filepath",
+		Log:         testutil.Logger{},
 	}
 	require.NoError(t, r.Init())
 
@@ -70,6 +72,7 @@ func TestJSONParserCompile(t *testing.T) {
 	wd, _ := os.Getwd()
 	r := File{
 		Files: []string{filepath.Join(wd, "dev", "testfiles", "json_a.log")},
+		Log:   testutil.Logger{},
 	}
 	require.NoError(t, r.Init())
 
@@ -89,6 +92,7 @@ func TestGrokParser(t *testing.T) {
 	var acc testutil.Accumulator
 	r := File{
 		Files: []string{filepath.Join(wd, "dev", "testfiles", "grok_a.log")},
+		Log:   testutil.Logger{},
 	}
 	err := r.Init()
 	require.NoError(t, err)
@@ -191,6 +195,7 @@ func TestCharacterEncoding(t *testing.T) {
 			plugin: &File{
 				Files:             []string{"testdata/mtr-utf-8.csv"},
 				CharacterEncoding: "",
+				Log:               testutil.Logger{},
 			},
 			csv: csv.Parser{
 				MetricName:  "file",
@@ -204,6 +209,7 @@ func TestCharacterEncoding(t *testing.T) {
 			plugin: &File{
 				Files:             []string{"testdata/mtr-utf-8.csv"},
 				CharacterEncoding: "utf-8",
+				Log:               testutil.Logger{},
 			},
 			csv: csv.Parser{
 				MetricName:  "file",
@@ -217,6 +223,7 @@ func TestCharacterEncoding(t *testing.T) {
 			plugin: &File{
 				Files:             []string{"testdata/mtr-utf-16le.csv"},
 				CharacterEncoding: "utf-16le",
+				Log:               testutil.Logger{},
 			},
 			csv: csv.Parser{
 				MetricName:  "file",
@@ -230,6 +237,7 @@ func TestCharacterEncoding(t *testing.T) {
 			plugin: &File{
 				Files:             []string{"testdata/mtr-utf-16be.csv"},
 				CharacterEncoding: "utf-16be",
+				Log:               testutil.Logger{},
 			},
 			csv: csv.Parser{
 				MetricName:  "file",
@@ -343,6 +351,7 @@ func TestStatefulParsers(t *testing.T) {
 			plugin: &File{
 				Files:             []string{"testdata/mtr-utf-8.csv"},
 				CharacterEncoding: "",
+				Log:               testutil.Logger{},
 			},
 			csv: csv.Parser{
 				MetricName:  "file",
@@ -390,6 +399,7 @@ func TestCSVBehavior(t *testing.T) {
 	// Setup the plugin
 	plugin := &File{
 		Files: []string{filepath.Join("testdata", "csv_behavior_input.csv")},
+		Log:   testutil.Logger{},
 	}
 	plugin.SetParserFunc(parserFunc)
 	require.NoError(t, plugin.Init())

--- a/plugins/inputs/http/http.go
+++ b/plugins/inputs/http/http.go
@@ -23,6 +23,8 @@ import (
 //go:embed sample.conf
 var sampleConfig string
 
+var once sync.Once
+
 type HTTP struct {
 	URLs            []string `toml:"urls"`
 	Method          string   `toml:"method"`
@@ -205,6 +207,12 @@ func (h *HTTP) gatherURL(acc telegraf.Accumulator, url string) error {
 	metrics, err := parser.Parse(b)
 	if err != nil {
 		return fmt.Errorf("parsing metrics failed: %w", err)
+	}
+
+	if len(metrics) == 0 {
+		once.Do(func() {
+			h.Log.Debug(internal.NoMetricsCreatedMsg)
+		})
 	}
 
 	for _, metric := range metrics {

--- a/plugins/inputs/http_listener_v2/http_listener_v2.go
+++ b/plugins/inputs/http_listener_v2/http_listener_v2.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
+	"github.com/influxdata/telegraf/internal"
 	"github.com/influxdata/telegraf/internal/choice"
 	tlsint "github.com/influxdata/telegraf/plugins/common/tls"
 	"github.com/influxdata/telegraf/plugins/inputs"
@@ -26,6 +27,8 @@ import (
 
 //go:embed sample.conf
 var sampleConfig string
+
+var once sync.Once
 
 // defaultMaxBodySize is the default maximum request body size, in bytes.
 // if the request body is over this size, we will return an HTTP 413 error.
@@ -234,6 +237,12 @@ func (h *HTTPListenerV2) serveWrite(res http.ResponseWriter, req *http.Request) 
 			h.Log.Debugf("error in bad-request: %v", err)
 		}
 		return
+	}
+
+	if len(metrics) == 0 {
+		once.Do(func() {
+			h.Log.Debug(internal.NoMetricsCreatedMsg)
+		})
 	}
 
 	for _, m := range metrics {

--- a/plugins/inputs/kafka_consumer/kafka_consumer.go
+++ b/plugins/inputs/kafka_consumer/kafka_consumer.go
@@ -23,6 +23,8 @@ import (
 //go:embed sample.conf
 var sampleConfig string
 
+var once sync.Once
+
 const (
 	defaultMaxUndeliveredMessages = 1000
 	defaultMaxProcessingTime      = config.Duration(100 * time.Millisecond)
@@ -488,6 +490,12 @@ func (h *ConsumerGroupHandler) Handle(session sarama.ConsumerGroupSession, msg *
 		session.MarkMessage(msg, "")
 		h.release()
 		return err
+	}
+
+	if len(metrics) == 0 {
+		once.Do(func() {
+			h.log.Debug(internal.NoMetricsCreatedMsg)
+		})
 	}
 
 	headerKey := ""

--- a/plugins/inputs/mqtt_consumer/mqtt_consumer.go
+++ b/plugins/inputs/mqtt_consumer/mqtt_consumer.go
@@ -275,8 +275,7 @@ func (m *MQTTConsumer) onMessage(_ mqtt.Client, msg mqtt.Message) {
 	if err != nil || len(metrics) == 0 {
 		if len(metrics) == 0 {
 			once.Do(func() {
-				const msg = "No metrics were created from a message. Verify your parser settings. This message is only printed once."
-				m.Log.Debug(msg)
+				m.Log.Debug(internal.NoMetricsCreatedMsg)
 			})
 		}
 


### PR DESCRIPTION
## Summary
To aid debugging and users, this now will print, once, that no messages were generated after parsing a message. This already existed with the MQTT plugin. This has proven useful and helpful to guide users to their parser settings.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR
