### PR TITLE
docs(inputs.ldap): Document all TLS options

### DIFF
--- a/plugins/inputs/ldap/README.md
+++ b/plugins/inputs/ldap/README.md
@@ -39,14 +39,26 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   # reverse_field_names = false
 
   ## Optional TLS Config
+  ## Set to true/false to enforce TLS being enabled/disabled. If not set,
+  ## enable TLS only if any of the other options are specified.
+  # tls_enable =
   ## Trusted root certificates for server
   # tls_ca = "/path/to/cafile"
   ## Used for TLS client certificate authentication
   # tls_cert = "/path/to/certfile"
   ## Used for TLS client certificate authentication
   # tls_key = "/path/to/keyfile"
+  ## Password for the key file if it is encrypted
+  # tls_key_pwd = ""
   ## Send the specified TLS server name via SNI
   # tls_server_name = "kubernetes.example.com"
+  ## Minimal TLS version to accept by the client
+  # tls_min_version = "TLS12"
+  ## List of ciphers to accept, by default all secure ciphers will be accepted
+  ## See https://pkg.go.dev/crypto/tls#pkg-constants for supported values
+  # tls_cipher_suites = []
+  ## Renegotiation method, "never", "once" or "freely"
+  # tls_renegotiation_method = "never"
   ## Use TLS but skip chain & host verification
   # insecure_skip_verify = false
 ```

--- a/plugins/inputs/ldap/ldap.go
+++ b/plugins/inputs/ldap/ldap.go
@@ -1,3 +1,4 @@
+//go:generate ../../../tools/config_includer/generator
 //go:generate ../../../tools/readme_config_includer/generator
 package ldap
 

--- a/plugins/inputs/ldap/sample.conf
+++ b/plugins/inputs/ldap/sample.conf
@@ -21,13 +21,25 @@
   # reverse_field_names = false
 
   ## Optional TLS Config
+  ## Set to true/false to enforce TLS being enabled/disabled. If not set,
+  ## enable TLS only if any of the other options are specified.
+  # tls_enable =
   ## Trusted root certificates for server
   # tls_ca = "/path/to/cafile"
   ## Used for TLS client certificate authentication
   # tls_cert = "/path/to/certfile"
   ## Used for TLS client certificate authentication
   # tls_key = "/path/to/keyfile"
+  ## Password for the key file if it is encrypted
+  # tls_key_pwd = ""
   ## Send the specified TLS server name via SNI
   # tls_server_name = "kubernetes.example.com"
+  ## Minimal TLS version to accept by the client
+  # tls_min_version = "TLS12"
+  ## List of ciphers to accept, by default all secure ciphers will be accepted
+  ## See https://pkg.go.dev/crypto/tls#pkg-constants for supported values
+  # tls_cipher_suites = []
+  ## Renegotiation method, "never", "once" or "freely"
+  # tls_renegotiation_method = "never"
   ## Use TLS but skip chain & host verification
   # insecure_skip_verify = false

--- a/plugins/inputs/ldap/sample.conf.in
+++ b/plugins/inputs/ldap/sample.conf.in
@@ -1,0 +1,24 @@
+# LDAP monitoring plugin
+[[inputs.ldap]]
+  ## Server to monitor
+  ## The scheme determines the mode to use for connection with
+  ##    ldap://...      -- unencrypted (non-TLS) connection
+  ##    ldaps://...     -- TLS connection
+  ##    starttls://...  --  StartTLS connection
+  ## If no port is given, the default ports, 389 for ldap and starttls and
+  ## 636 for ldaps, are used.
+  server = "ldap://localhost"
+
+  ## Server dialect, can be "openldap" or "389ds"
+  # dialect = "openldap"
+
+  # DN and password to bind with
+  ## If bind_dn is empty an anonymous bind is performed.
+  bind_dn = ""
+  bind_password = ""
+
+  ## Reverse the field names constructed from the monitoring DN
+  # reverse_field_names = false
+
+  ## Optional TLS Config
+{{template "/plugins/common/tls/client.conf"}}


### PR DESCRIPTION
## Summary

Document all TLS client options in the plugin's `sample.conf`.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

related to #15436 
