### PR TITLE
fix(processors.snmp_lookup): Return empty tag-map on error to avoid panic

### DIFF
--- a/plugins/processors/snmp_lookup/lookup.go
+++ b/plugins/processors/snmp_lookup/lookup.go
@@ -126,25 +126,25 @@ func (l *Lookup) Add(m telegraf.Metric, acc telegraf.Accumulator) error {
 
 // Default update function
 func (l *Lookup) updateAgent(agent string) *tagMap {
+	tm := &tagMap{created: time.Now()}
+
 	// Initialize connection to agent
 	conn, err := l.getConnectionFunc(agent)
 	if err != nil {
 		l.Log.Errorf("Getting connection for %q failed: %v", agent, err)
-		return nil
+		return tm
 	}
 
 	// Query table including translation
 	table, err := l.table.Build(conn, true)
 	if err != nil {
 		l.Log.Errorf("Building table for %q failed: %v", agent, err)
-		return nil
+		return tm
 	}
 
 	// Copy tags for all rows
-	tm := &tagMap{
-		created: table.Time,
-		rows:    make(tagMapRows, len(table.Rows)),
-	}
+	tm.created = table.Time
+	tm.rows = make(tagMapRows, len(table.Rows))
 	for _, row := range table.Rows {
 		index := row.Tags["index"]
 		delete(row.Tags, "index")

--- a/plugins/processors/snmp_lookup/lookup_test.go
+++ b/plugins/processors/snmp_lookup/lookup_test.go
@@ -231,7 +231,12 @@ func TestUpdateAgent(t *testing.T) {
 	t.Run("table build fail", func(t *testing.T) {
 		tsc = &testSNMPConnection{}
 
-		require.Nil(t, p.updateAgent("127.0.0.1"))
+		start := time.Now()
+		tm := p.updateAgent("127.0.0.1")
+		end := time.Now()
+
+		require.Nil(t, tm.rows)
+		require.WithinRange(t, tm.created, start, end)
 		require.EqualValues(t, 1, tsc.calls.Load())
 	})
 
@@ -240,7 +245,12 @@ func TestUpdateAgent(t *testing.T) {
 			return nil, errors.New("Random connection error")
 		}
 
-		require.Nil(t, p.updateAgent("127.0.0.1"))
+		start := time.Now()
+		tm := p.updateAgent("127.0.0.1")
+		end := time.Now()
+
+		require.Nil(t, tm.rows)
+		require.WithinRange(t, tm.created, start, end)
 	})
 }
 


### PR DESCRIPTION
## Summary

Returning a `tagMap` with empty `rows` but `created` set, makes sure the rebuild of the table will only happen after `min_time_between_updates`.

### Before

Telegraf crashes:
```log
2024-06-05T08:32:43Z E! [processors.snmp_lookup] Building table for "172.16.43.2" failed: performing bulk walk for field ifName: request timeout (after 3 retries)
Worker exits from a panic: runtime error: invalid memory address or nil pointer dereference
Stack trace: goroutine 160 [running]:
runtime/debug.Stack()
/usr/local/go/src/runtime/debug/stack.go:24 +0x5e
github.com/alitto/pond.defaultPanicHandler({0x70a8180, 0xdc68f90})
/go/pkg/mod/github.com/alitto/pond@v1.8.3/pond.go:26 +0x25
github.com/alitto/pond.(*WorkerPool).executeTask.func1()
/go/pkg/mod/github.com/alitto/pond@v1.8.3/pond.go:437 +0x4a
panic({0x70a8180?, 0xdc68f90?})
/usr/local/go/src/runtime/panic.go:770 +0x132
github.com/influxdata/telegraf/plugins/processors/snmp_lookup.(*backlog).resolve(0xc03b210180, {0xc0256de590, 0xb}, 0x0)
/go/src/github.com/influxdata/telegraf/plugins/processors/snmp_lookup/backlog.go:79 +0x26e
github.com/influxdata/telegraf/plugins/processors/snmp_lookup.(*store).enqueue.func1()
/go/src/github.com/influxdata/telegraf/plugins/processors/snmp_lookup/store.go:80 +0x96
github.com/alitto/pond.(*WorkerPool).executeTask(0xc03b220000, 0x0?, 0x0?)
/go/pkg/mod/github.com/alitto/pond@v1.8.3/pond.go:454 +0x6c
github.com/alitto/pond.worker({0x8cdbd10, 0xc03aee5400}, 0x0?, 0x0?, 0xc02f837980, 0xc03aee1ee0)
/go/pkg/mod/github.com/alitto/pond@v1.8.3/worker.go:32 +0xc2
created by github.com/alitto/pond.(*WorkerPool).maybeStartWorker in goroutine 1
/go/pkg/mod/github.com/alitto/pond@v1.8.3/pond.go:423 +0x133
```

### After

Processor returns the metrics unmodified:
```
2024-06-06T07:46:20Z E! [processors.snmp_lookup] Building table for "172.16.43.2" failed: performing bulk walk for field ifName: request timeout (after 3 retries)
2024-06-06T07:46:20Z W! [processors.snmp_lookup] Cannot resolve metrics because index "123" not found for agent "172.16.43.2"!
```

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #15465 
