### PR TITLE
feat(outputs.elasticsearch): Allow custom template index settings

### DIFF
--- a/plugins/outputs/elasticsearch/README.md
+++ b/plugins/outputs/elasticsearch/README.md
@@ -328,6 +328,16 @@ to use them.
   # To pass custom HTTP headers please define it in a given below section
   # [outputs.elasticsearch.headers]
   #    "X-Custom-Header" = "custom-value"
+
+  ## Template Index Settings
+  ## Overrides the template settings.index section with any provided options.
+  ## Defaults provided here in the config
+  # template_index_settings = {
+  #   refresh_interval = "10s",
+  #   mapping.total_fields.limit = 5000,
+  #   auto_expand_replicas = "0-1",
+  #   codec = "best_compression"
+  # }
 ```
 
 ### Permissions

--- a/plugins/outputs/elasticsearch/elasticsearch.go
+++ b/plugins/outputs/elasticsearch/elasticsearch.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"crypto/sha256"
 	_ "embed"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math"
@@ -28,27 +29,28 @@ import (
 var sampleConfig string
 
 type Elasticsearch struct {
-	AuthBearerToken     config.Secret     `toml:"auth_bearer_token"`
-	DefaultPipeline     string            `toml:"default_pipeline"`
-	DefaultTagValue     string            `toml:"default_tag_value"`
-	EnableGzip          bool              `toml:"enable_gzip"`
-	EnableSniffer       bool              `toml:"enable_sniffer"`
-	FloatHandling       string            `toml:"float_handling"`
-	FloatReplacement    float64           `toml:"float_replacement_value"`
-	ForceDocumentID     bool              `toml:"force_document_id"`
-	HealthCheckInterval config.Duration   `toml:"health_check_interval"`
-	HealthCheckTimeout  config.Duration   `toml:"health_check_timeout"`
-	IndexName           string            `toml:"index_name"`
-	ManageTemplate      bool              `toml:"manage_template"`
-	OverwriteTemplate   bool              `toml:"overwrite_template"`
-	Username            config.Secret     `toml:"username"`
-	Password            config.Secret     `toml:"password"`
-	TemplateName        string            `toml:"template_name"`
-	Timeout             config.Duration   `toml:"timeout"`
-	URLs                []string          `toml:"urls"`
-	UsePipeline         string            `toml:"use_pipeline"`
-	Headers             map[string]string `toml:"headers"`
-	Log                 telegraf.Logger   `toml:"-"`
+	AuthBearerToken     config.Secret          `toml:"auth_bearer_token"`
+	DefaultPipeline     string                 `toml:"default_pipeline"`
+	DefaultTagValue     string                 `toml:"default_tag_value"`
+	EnableGzip          bool                   `toml:"enable_gzip"`
+	EnableSniffer       bool                   `toml:"enable_sniffer"`
+	FloatHandling       string                 `toml:"float_handling"`
+	FloatReplacement    float64                `toml:"float_replacement_value"`
+	ForceDocumentID     bool                   `toml:"force_document_id"`
+	HealthCheckInterval config.Duration        `toml:"health_check_interval"`
+	HealthCheckTimeout  config.Duration        `toml:"health_check_timeout"`
+	IndexName           string                 `toml:"index_name"`
+	IndexTemplate       map[string]interface{} `toml:"template_index_settings"`
+	ManageTemplate      bool                   `toml:"manage_template"`
+	OverwriteTemplate   bool                   `toml:"overwrite_template"`
+	Username            config.Secret          `toml:"username"`
+	Password            config.Secret          `toml:"password"`
+	TemplateName        string                 `toml:"template_name"`
+	Timeout             config.Duration        `toml:"timeout"`
+	URLs                []string               `toml:"urls"`
+	UsePipeline         string                 `toml:"use_pipeline"`
+	Headers             map[string]string      `toml:"headers"`
+	Log                 telegraf.Logger        `toml:"-"`
 	majorReleaseNumber  int
 	pipelineName        string
 	pipelineTagKeys     []string
@@ -66,12 +68,7 @@ const telegrafTemplate = `
 	"index_patterns" : [ "{{.TemplatePattern}}" ],
 	{{ end }}
 	"settings": {
-		"index": {
-			"refresh_interval": "10s",
-			"mapping.total_fields.limit": 5000,
-			"auto_expand_replicas" : "0-1",
-			"codec" : "best_compression"
-		}
+		"index": {{.IndexTemplate}}
 	},
 	"mappings" : {
 		{{ if (lt .Version 7) }}
@@ -128,9 +125,18 @@ const telegrafTemplate = `
 	}
 }`
 
+const defaultTemplateIndexSettings = `
+{
+	"refresh_interval": "10s",
+	"mapping.total_fields.limit": 5000,
+	"auto_expand_replicas": "0-1",
+	"codec": "best_compression"
+}`
+
 type templatePart struct {
 	TemplatePattern string
 	Version         int
+	IndexTemplate   string
 }
 
 func (*Elasticsearch) SampleConfig() string {
@@ -369,19 +375,12 @@ func (a *Elasticsearch) manageTemplate(ctx context.Context) error {
 	}
 
 	if (a.OverwriteTemplate) || (!templateExists) || (templatePattern != "") {
-		tp := templatePart{
-			TemplatePattern: templatePattern + "*",
-			Version:         a.majorReleaseNumber,
-		}
-
-		t := template.Must(template.New("template").Parse(telegrafTemplate))
-		var tmpl bytes.Buffer
-
-		if err := t.Execute(&tmpl, tp); err != nil {
+		data, err := a.createNewTemplate(templatePattern)
+		if err != nil {
 			return err
 		}
-		_, errCreateTemplate := a.Client.IndexPutTemplate(a.TemplateName).BodyString(tmpl.String()).Do(ctx)
 
+		_, errCreateTemplate := a.Client.IndexPutTemplate(a.TemplateName).BodyString(data.String()).Do(ctx)
 		if errCreateTemplate != nil {
 			return fmt.Errorf("elasticsearch failed to create index template %s: %w", a.TemplateName, errCreateTemplate)
 		}
@@ -391,6 +390,33 @@ func (a *Elasticsearch) manageTemplate(ctx context.Context) error {
 		a.Log.Debug("Found existing Elasticsearch template. Skipping template management")
 	}
 	return nil
+}
+
+func (a *Elasticsearch) createNewTemplate(templatePattern string) (*bytes.Buffer, error) {
+	var indexTemplate string
+	if a.IndexTemplate != nil {
+		data, err := json.Marshal(&a.IndexTemplate)
+		if err != nil {
+			return nil, fmt.Errorf("elasticsearch failed to create index settings for template %s: %w", a.TemplateName, err)
+		}
+		indexTemplate = string(data)
+	} else {
+		indexTemplate = defaultTemplateIndexSettings
+	}
+
+	tp := templatePart{
+		TemplatePattern: templatePattern + "*",
+		Version:         a.majorReleaseNumber,
+		IndexTemplate:   indexTemplate,
+	}
+
+	t := template.Must(template.New("template").Parse(telegrafTemplate))
+	var tmpl bytes.Buffer
+
+	if err := t.Execute(&tmpl, tp); err != nil {
+		return nil, err
+	}
+	return &tmpl, nil
 }
 
 func (a *Elasticsearch) GetTagKeys(indexName string) (string, []string) {

--- a/plugins/outputs/elasticsearch/sample.conf
+++ b/plugins/outputs/elasticsearch/sample.conf
@@ -82,3 +82,13 @@
   # To pass custom HTTP headers please define it in a given below section
   # [outputs.elasticsearch.headers]
   #    "X-Custom-Header" = "custom-value"
+
+  ## Template Index Settings
+  ## Overrides the template settings.index section with any provided options.
+  ## Defaults provided here in the config
+  # template_index_settings = {
+  #   refresh_interval = "10s",
+  #   mapping.total_fields.limit = 5000,
+  #   auto_expand_replicas = "0-1",
+  #   codec = "best_compression"
+  # }


### PR DESCRIPTION
## Summary
Allows users to provide custom template index settings for the Elasticsearch output plugin. Fully flexible for any allowed setting rather than only allowing specific ones.

## Checklist
- [X] No AI generated code was used in this PR

## Related issues
resolves #13053
