### PR TITLE
chore(linters): Fix non-input/output plugin errcheck warnings 

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -346,9 +346,6 @@ issues:
     - path: plugins/outputs/*
       linters:
         - errcheck
-    - path: plugins/processors/*
-      linters:
-        - errcheck
     - path: plugins/secretstores/*
       linters:
         - errcheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -340,9 +340,6 @@ issues:
       text: "Error return value of `outputBuffer.Write` is not checked" #errcheck
 
     # temporary disabling of errcheck as this linter is gradually being applied across the codebase
-    - path: plugins/common/*
-      linters:
-        - errcheck
     - path: plugins/inputs/*
       linters:
         - errcheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -346,9 +346,6 @@ issues:
     - path: plugins/outputs/*
       linters:
         - errcheck
-    - path: plugins/secretstores/*
-      linters:
-        - errcheck
     - path: plugins/serializers/*
       linters:
         - errcheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -339,9 +339,31 @@ issues:
     - path: cmd/telegraf/(main|printer|cmd_plugins).go
       text: "Error return value of `outputBuffer.Write` is not checked" #errcheck
 
-    - path: plugins/*
+    # temporary disabling of errcheck as this linter is gradually being applied across the codebase
+    - path: plugins/aggregators/*
       linters:
-        - errcheck # temporary as this linter is gradually being applied across the codebase
+        - errcheck
+    - path: plugins/common/*
+      linters:
+        - errcheck
+    - path: plugins/inputs/*
+      linters:
+        - errcheck
+    - path: plugins/outputs/*
+      linters:
+        - errcheck
+    - path: plugins/parsers/*
+      linters:
+        - errcheck
+    - path: plugins/processors/*
+      linters:
+        - errcheck
+    - path: plugins/secretstores/*
+      linters:
+        - errcheck
+    - path: plugins/serializers/*
+      linters:
+        - errcheck
 
     - path: _test\.go
       text: "Potential hardcoded credentials" #gosec:G101

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -346,9 +346,6 @@ issues:
     - path: plugins/outputs/*
       linters:
         - errcheck
-    - path: plugins/parsers/*
-      linters:
-        - errcheck
     - path: plugins/processors/*
       linters:
         - errcheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -346,9 +346,6 @@ issues:
     - path: plugins/outputs/*
       linters:
         - errcheck
-    - path: plugins/serializers/*
-      linters:
-        - errcheck
 
     - path: _test\.go
       text: "Potential hardcoded credentials" #gosec:G101

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -340,9 +340,6 @@ issues:
       text: "Error return value of `outputBuffer.Write` is not checked" #errcheck
 
     # temporary disabling of errcheck as this linter is gradually being applied across the codebase
-    - path: plugins/aggregators/*
-      linters:
-        - errcheck
     - path: plugins/common/*
       linters:
         - errcheck

--- a/plugins/aggregators/derivative/derivative_test.go
+++ b/plugins/aggregators/derivative/derivative_test.go
@@ -96,7 +96,8 @@ func TestTwoFullEventsWithoutParameter(t *testing.T) {
 	require.NoError(t, err)
 
 	startTime := time.Now()
-	duration, _ := time.ParseDuration("2s")
+	duration, err := time.ParseDuration("2s")
+	require.NoError(t, err)
 	endTime := startTime.Add(duration)
 
 	first := metric.New("One Field",
@@ -273,7 +274,8 @@ func TestMergesDifferentMetricsWithSameHash(t *testing.T) {
 	require.NoError(t, err)
 
 	startTime := time.Now()
-	duration, _ := time.ParseDuration("2s")
+	duration, err := time.ParseDuration("2s")
+	require.NoError(t, err)
 	endTime := startTime.Add(duration)
 	part1 := metric.New("TestMetric",
 		map[string]string{"state": "full"},
@@ -365,10 +367,11 @@ func TestAddMetricsResetsRollOver(t *testing.T) {
 
 func TestCalculatesCorrectDerivativeOnTwoConsecutivePeriods(t *testing.T) {
 	acc := testutil.Accumulator{}
-	period, _ := time.ParseDuration("10s")
+	period, err := time.ParseDuration("10s")
+	require.NoError(t, err)
 	derivative := NewDerivative()
 	derivative.Log = testutil.Logger{}
-	err := derivative.Init()
+	err = derivative.Init()
 	require.NoError(t, err)
 
 	startTime := time.Now()

--- a/plugins/aggregators/derivative/derivative_test.go
+++ b/plugins/aggregators/derivative/derivative_test.go
@@ -371,8 +371,7 @@ func TestCalculatesCorrectDerivativeOnTwoConsecutivePeriods(t *testing.T) {
 	require.NoError(t, err)
 	derivative := NewDerivative()
 	derivative.Log = testutil.Logger{}
-	err = derivative.Init()
-	require.NoError(t, err)
+	require.NoError(t, derivative.Init())
 
 	startTime := time.Now()
 	first := metric.New("One Field",

--- a/plugins/aggregators/quantile/quantile.go
+++ b/plugins/aggregators/quantile/quantile.go
@@ -62,9 +62,11 @@ func (q *Quantile) Add(in telegraf.Metric) {
 	}
 	for k, field := range in.Fields() {
 		if v, isconvertible := convert(field); isconvertible {
-			//nolint:errcheck // This should never error out as we tested it in Init()
-			algo, _ := q.newAlgorithm(q.Compression)
-			err := algo.Add(v)
+			algo, err := q.newAlgorithm(q.Compression)
+			if err != nil {
+				q.Log.Errorf("generating algorithm %s: %v", k, err)
+			}
+			err = algo.Add(v)
 			if err != nil {
 				q.Log.Errorf("adding field %s: %v", k, err)
 			}

--- a/plugins/aggregators/quantile/quantile.go
+++ b/plugins/aggregators/quantile/quantile.go
@@ -62,7 +62,7 @@ func (q *Quantile) Add(in telegraf.Metric) {
 	}
 	for k, field := range in.Fields() {
 		if v, isconvertible := convert(field); isconvertible {
-			// This should never error out as we tested it in Init()
+			//nolint:errcheck // This should never error out as we tested it in Init()
 			algo, _ := q.newAlgorithm(q.Compression)
 			err := algo.Add(v)
 			if err != nil {

--- a/plugins/aggregators/starlark/starlark_test.go
+++ b/plugins/aggregators/starlark/starlark_test.go
@@ -49,7 +49,8 @@ var m2 = metric.New("m1",
 )
 
 func BenchmarkApply(b *testing.B) {
-	minmax, _ := newMinMax()
+	minmax, err := newMinMax()
+	require.NoError(b, err)
 
 	for n := 0; n < b.N; n++ {
 		minmax.Add(m1)

--- a/plugins/common/cookie/cookie_test.go
+++ b/plugins/common/cookie/cookie_test.go
@@ -87,7 +87,8 @@ func newFakeServer(t *testing.T) fakeServer {
 					w.WriteHeader(http.StatusForbidden)
 					return
 				}
-				_, _ = w.Write([]byte("good test response"))
+				_, err := w.Write([]byte("good test response"))
+				require.NoError(t, err)
 			}
 		})),
 		int32: &c,

--- a/plugins/common/opcua/input/input_client_test.go
+++ b/plugins/common/opcua/input/input_client_test.go
@@ -330,13 +330,14 @@ func TestValidateNodeToAdd(t *testing.T) {
 			name:     "valid",
 			existing: map[metricParts]struct{}{},
 			nmm: func() *NodeMetricMapping {
-				nmm, _ := NewNodeMetricMapping("testmetric", NodeSettings{
+				nmm, err := NewNodeMetricMapping("testmetric", NodeSettings{
 					FieldName:      "f",
 					Namespace:      "2",
 					IdentifierType: "s",
 					Identifier:     "hf",
 					TagsSlice:      [][]string{},
 				}, map[string]string{})
+				require.NoError(t, err)
 				return nmm
 			}(),
 			err: nil,
@@ -345,13 +346,14 @@ func TestValidateNodeToAdd(t *testing.T) {
 			name:     "empty field name not allowed",
 			existing: map[metricParts]struct{}{},
 			nmm: func() *NodeMetricMapping {
-				nmm, _ := NewNodeMetricMapping("testmetric", NodeSettings{
+				nmm, err := NewNodeMetricMapping("testmetric", NodeSettings{
 					FieldName:      "",
 					Namespace:      "2",
 					IdentifierType: "s",
 					Identifier:     "hf",
 					TagsSlice:      [][]string{},
 				}, map[string]string{})
+				require.NoError(t, err)
 				return nmm
 			}(),
 			err: errors.New(`empty name in ""`),
@@ -360,13 +362,14 @@ func TestValidateNodeToAdd(t *testing.T) {
 			name:     "empty namespace not allowed",
 			existing: map[metricParts]struct{}{},
 			nmm: func() *NodeMetricMapping {
-				nmm, _ := NewNodeMetricMapping("testmetric", NodeSettings{
+				nmm, err := NewNodeMetricMapping("testmetric", NodeSettings{
 					FieldName:      "f",
 					Namespace:      "",
 					IdentifierType: "s",
 					Identifier:     "hf",
 					TagsSlice:      [][]string{},
 				}, map[string]string{})
+				require.NoError(t, err)
 				return nmm
 			}(),
 			err: errors.New("empty node namespace not allowed"),
@@ -375,13 +378,14 @@ func TestValidateNodeToAdd(t *testing.T) {
 			name:     "empty identifier type not allowed",
 			existing: map[metricParts]struct{}{},
 			nmm: func() *NodeMetricMapping {
-				nmm, _ := NewNodeMetricMapping("testmetric", NodeSettings{
+				nmm, err := NewNodeMetricMapping("testmetric", NodeSettings{
 					FieldName:      "f",
 					Namespace:      "2",
 					IdentifierType: "",
 					Identifier:     "hf",
 					TagsSlice:      [][]string{},
 				}, map[string]string{})
+				require.NoError(t, err)
 				return nmm
 			}(),
 			err: errors.New(`invalid identifier type "" in "f"`),
@@ -390,13 +394,14 @@ func TestValidateNodeToAdd(t *testing.T) {
 			name:     "invalid identifier type not allowed",
 			existing: map[metricParts]struct{}{},
 			nmm: func() *NodeMetricMapping {
-				nmm, _ := NewNodeMetricMapping("testmetric", NodeSettings{
+				nmm, err := NewNodeMetricMapping("testmetric", NodeSettings{
 					FieldName:      "f",
 					Namespace:      "2",
 					IdentifierType: "j",
 					Identifier:     "hf",
 					TagsSlice:      [][]string{},
 				}, map[string]string{})
+				require.NoError(t, err)
 				return nmm
 			}(),
 			err: errors.New(`invalid identifier type "j" in "f"`),
@@ -407,13 +412,14 @@ func TestValidateNodeToAdd(t *testing.T) {
 				{metricName: "testmetric", fieldName: "f", tags: "t1=v1, t2=v2"}: {},
 			},
 			nmm: func() *NodeMetricMapping {
-				nmm, _ := NewNodeMetricMapping("testmetric", NodeSettings{
+				nmm, err := NewNodeMetricMapping("testmetric", NodeSettings{
 					FieldName:      "f",
 					Namespace:      "2",
 					IdentifierType: "s",
 					Identifier:     "hf",
 					TagsSlice:      [][]string{{"t1", "v1"}, {"t2", "v2"}},
 				}, map[string]string{})
+				require.NoError(t, err)
 				return nmm
 			}(),
 			err: errors.New(`name "f" is duplicated (metric name "testmetric", tags "t1=v1, t2=v2")`),
@@ -422,13 +428,14 @@ func TestValidateNodeToAdd(t *testing.T) {
 			name:     "identifier type mismatch",
 			existing: map[metricParts]struct{}{},
 			nmm: func() *NodeMetricMapping {
-				nmm, _ := NewNodeMetricMapping("testmetric", NodeSettings{
+				nmm, err := NewNodeMetricMapping("testmetric", NodeSettings{
 					FieldName:      "f",
 					Namespace:      "2",
 					IdentifierType: "i",
 					Identifier:     "hf",
 					TagsSlice:      [][]string{},
 				}, map[string]string{})
+				require.NoError(t, err)
 				return nmm
 			}(),
 			err: errors.New(`identifier type "i" does not match the type of identifier "hf"`),
@@ -449,13 +456,14 @@ func TestValidateNodeToAdd(t *testing.T) {
 			name:     "identifier type " + idT + " allowed",
 			existing: map[metricParts]struct{}{},
 			nmm: func() *NodeMetricMapping {
-				nmm, _ := NewNodeMetricMapping("testmetric", NodeSettings{
+				nmm, err := NewNodeMetricMapping("testmetric", NodeSettings{
 					FieldName:      "f",
 					Namespace:      "2",
 					IdentifierType: idT,
 					Identifier:     idV,
 					TagsSlice:      [][]string{},
 				}, map[string]string{})
+				require.NoError(t, err)
 				return nmm
 			}(),
 			err: nil,
@@ -771,7 +779,8 @@ func TestUpdateNodeValue(t *testing.T) {
 		t.Run(tt.testname, func(t *testing.T) {
 			o.LastReceivedData = make([]NodeValue, 2)
 			for i, step := range tt.steps {
-				v, _ := ua.NewVariant(step.value)
+				v, err := ua.NewVariant(step.value)
+				require.NoError(t, err)
 				o.UpdateNodeValue(0, &ua.DataValue{
 					Value:             v,
 					Status:            step.status,

--- a/plugins/common/opcua/opcua_util.go
+++ b/plugins/common/opcua/opcua_util.go
@@ -32,7 +32,10 @@ func newTempDir() (string, error) {
 }
 
 func generateCert(host string, rsaBits int, certFile, keyFile string, dur time.Duration) (cert string, key string, err error) {
-	dir, _ := newTempDir()
+	dir, err := newTempDir()
+	if err != nil {
+		return "", "", fmt.Errorf("failed to create certificate: %w", err)
+	}
 
 	if len(host) == 0 {
 		return "", "", errors.New("missing required host parameter")

--- a/plugins/common/shim/input_test.go
+++ b/plugins/common/shim/input_test.go
@@ -47,7 +47,8 @@ func TestInputShimStdinSignalingWorks(t *testing.T) {
 	err = stdinWriter.Close()
 	require.NoError(t, err)
 	go func() {
-		_, _ = io.ReadAll(r)
+		_, err = io.ReadAll(r)
+		require.NoError(t, err)
 	}()
 	// check that it exits cleanly
 	<-exited

--- a/plugins/common/shim/processor_test.go
+++ b/plugins/common/shim/processor_test.go
@@ -88,7 +88,8 @@ func testSendAndReceive(t *testing.T, fieldKey string, fieldValue string) {
 	require.True(t, ok)
 	require.Equal(t, fieldValue, val2)
 	go func() {
-		_, _ = io.ReadAll(r)
+		_, err = io.ReadAll(r)
+		require.NoError(t, err)
 	}()
 	wg.Wait()
 }

--- a/plugins/common/socket/socket_test.go
+++ b/plugins/common/socket/socket_test.go
@@ -488,8 +488,7 @@ func TestClosingConnections(t *testing.T) {
 	sock.Close()
 
 	// Verify that plugin.Stop() closed the client's connection
-	err = client.SetReadDeadline(time.Now().Add(time.Second))
-	require.NoError(t, err)
+	require.NoError(t, client.SetReadDeadline(time.Now().Add(time.Second)))
 	buf := []byte{1}
 	_, err = client.Read(buf)
 	require.Equal(t, err, io.EOF)

--- a/plugins/common/socket/socket_test.go
+++ b/plugins/common/socket/socket_test.go
@@ -488,7 +488,8 @@ func TestClosingConnections(t *testing.T) {
 	sock.Close()
 
 	// Verify that plugin.Stop() closed the client's connection
-	_ = client.SetReadDeadline(time.Now().Add(time.Second))
+	err = client.SetReadDeadline(time.Now().Add(time.Second))
+	require.NoError(t, err)
 	buf := []byte{1}
 	_, err = client.Read(buf)
 	require.Equal(t, err, io.EOF)

--- a/plugins/common/socket/stream.go
+++ b/plugins/common/socket/stream.go
@@ -102,11 +102,17 @@ func (l *streamListener) setupVsock(u *url.URL) error {
 	}
 	// Parse CID and port number from address string both being 32-bit
 	// source: https://man7.org/linux/man-pages/man7/vsock.7.html
-	cid, _ := strconv.ParseUint(addrTuple[0], 10, 32)
+	cid, err := strconv.ParseUint(addrTuple[0], 10, 32)
+	if err != nil {
+		return fmt.Errorf("failed to parse CID %s: %w", addrTuple[0], err)
+	}
 	if (cid >= uint64(math.Pow(2, 32))-1) && (cid <= 0) {
 		return fmt.Errorf("CID %d is out of range", cid)
 	}
-	port, _ := strconv.ParseUint(addrTuple[1], 10, 32)
+	port, err := strconv.ParseUint(addrTuple[1], 10, 32)
+	if err != nil {
+		return fmt.Errorf("failed to parse port number %s: %w", addrTuple[1], err)
+	}
 	if (port >= uint64(math.Pow(2, 32))-1) && (port <= 0) {
 		return fmt.Errorf("port number %d is out of range", port)
 	}

--- a/plugins/common/yangmodel/decoder.go
+++ b/plugins/common/yangmodel/decoder.go
@@ -248,8 +248,8 @@ func (d *Decoder) DecodePathElement(origin, path string, value interface{}) (int
 	}
 
 	for _, root := range rootNodes {
-		node, _ := yang.FindNode(root, path)
-		if node == nil {
+		node, err := yang.FindNode(root, path)
+		if node == nil || err != nil {
 			// The path does not exist in this root node
 			continue
 		}

--- a/plugins/parsers/avro/parser_test.go
+++ b/plugins/parsers/avro/parser_test.go
@@ -115,6 +115,7 @@ func BenchmarkParsing(b *testing.B) {
 
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
+		//nolint:errcheck // Benchmarking so skip the error check to avoid the unnecessary operations
 		_, _ = plugin.Parse(benchmarkData)
 	}
 }
@@ -176,6 +177,7 @@ func BenchmarkParsingBinary(b *testing.B) {
 	require.NoError(b, err)
 
 	for n := 0; n < b.N; n++ {
+		//nolint:errcheck // Benchmarking so skip the error check to avoid the unnecessary operations
 		_, _ = plugin.Parse(benchmarkData)
 	}
 }

--- a/plugins/parsers/avro/parser_test.go
+++ b/plugins/parsers/avro/parser_test.go
@@ -116,7 +116,7 @@ func BenchmarkParsing(b *testing.B) {
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
 		//nolint:errcheck // Benchmarking so skip the error check to avoid the unnecessary operations
-		_, _ = plugin.Parse(benchmarkData)
+		plugin.Parse(benchmarkData)
 	}
 }
 
@@ -178,6 +178,6 @@ func BenchmarkParsingBinary(b *testing.B) {
 
 	for n := 0; n < b.N; n++ {
 		//nolint:errcheck // Benchmarking so skip the error check to avoid the unnecessary operations
-		_, _ = plugin.Parse(benchmarkData)
+		plugin.Parse(benchmarkData)
 	}
 }

--- a/plugins/parsers/binary/parser_test.go
+++ b/plugins/parsers/binary/parser_test.go
@@ -1608,6 +1608,7 @@ func BenchmarkParsing(b *testing.B) {
 	require.NoError(b, plugin.Init())
 
 	for n := 0; n < b.N; n++ {
+		//nolint:errcheck // Benchmarking so skip the error check to avoid the unnecessary operations
 		_, _ = plugin.Parse(benchmarkData[n%2])
 	}
 }

--- a/plugins/parsers/binary/parser_test.go
+++ b/plugins/parsers/binary/parser_test.go
@@ -1609,6 +1609,6 @@ func BenchmarkParsing(b *testing.B) {
 
 	for n := 0; n < b.N; n++ {
 		//nolint:errcheck // Benchmarking so skip the error check to avoid the unnecessary operations
-		_, _ = plugin.Parse(benchmarkData[n%2])
+		plugin.Parse(benchmarkData[n%2])
 	}
 }

--- a/plugins/parsers/collectd/parser_test.go
+++ b/plugins/parsers/collectd/parser_test.go
@@ -405,6 +405,7 @@ func BenchmarkParsing(b *testing.B) {
 
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
+		//nolint:errcheck // Benchmarking so skip the error check to avoid the unnecessary operations
 		_, _ = parser.Parse(bytes)
 	}
 }

--- a/plugins/parsers/collectd/parser_test.go
+++ b/plugins/parsers/collectd/parser_test.go
@@ -406,6 +406,6 @@ func BenchmarkParsing(b *testing.B) {
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
 		//nolint:errcheck // Benchmarking so skip the error check to avoid the unnecessary operations
-		_, _ = parser.Parse(bytes)
+		parser.Parse(bytes)
 	}
 }

--- a/plugins/parsers/csv/parser_test.go
+++ b/plugins/parsers/csv/parser_test.go
@@ -1574,6 +1574,7 @@ func BenchmarkParsing(b *testing.B) {
 	require.NoError(b, plugin.Init())
 
 	for n := 0; n < b.N; n++ {
+		//nolint:errcheck // Benchmarking so skip the error check to avoid the unnecessary operations
 		_, _ = plugin.Parse([]byte(benchmarkData))
 	}
 }

--- a/plugins/parsers/csv/parser_test.go
+++ b/plugins/parsers/csv/parser_test.go
@@ -1575,6 +1575,6 @@ func BenchmarkParsing(b *testing.B) {
 
 	for n := 0; n < b.N; n++ {
 		//nolint:errcheck // Benchmarking so skip the error check to avoid the unnecessary operations
-		_, _ = plugin.Parse([]byte(benchmarkData))
+		plugin.Parse([]byte(benchmarkData))
 	}
 }

--- a/plugins/parsers/dropwizard/parser.go
+++ b/plugins/parsers/dropwizard/parser.go
@@ -182,7 +182,6 @@ func (p *Parser) readDWMetrics(metricType string, dwms interface{}, metrics []te
 			tags := make(map[string]string)
 			fieldPrefix := ""
 			if p.templateEngine != nil {
-				//nolint:errcheck // Potential error not worth propagating
 				var err error
 				measurementName, tags, fieldPrefix, err = p.templateEngine.Apply(dwmName)
 				if err != nil {

--- a/plugins/parsers/dropwizard/parser.go
+++ b/plugins/parsers/dropwizard/parser.go
@@ -167,6 +167,7 @@ func (p *Parser) readDWMetrics(metricType string, dwms interface{}, metrics []te
 			tags := make(map[string]string)
 			fieldPrefix := ""
 			if p.templateEngine != nil {
+				//nolint:errcheck // Potential error not worth propagating
 				measurementName, tags, fieldPrefix, _ = p.templateEngine.Apply(dwmName)
 				if len(fieldPrefix) > 0 {
 					fieldPrefix = fmt.Sprintf("%s%s", fieldPrefix, p.Separator)

--- a/plugins/parsers/dropwizard/parser_test.go
+++ b/plugins/parsers/dropwizard/parser_test.go
@@ -89,7 +89,8 @@ const validEmbeddedCounterJSON = `
 
 func TestParseValidEmbeddedCounterJSON(t *testing.T) {
 	timeFormat := "2006-01-02T15:04:05Z07:00"
-	metricTime, _ := time.Parse(timeFormat, "2017-02-22T15:33:03.662+03:00")
+	metricTime, err := time.Parse(timeFormat, "2017-02-22T15:33:03.662+03:00")
+	require.NoError(t, err)
 	parser := &Parser{
 		MetricRegistryPath: "metrics",
 		TagsPath:           "tags",
@@ -646,6 +647,7 @@ func BenchmarkParsing(b *testing.B) {
 	require.NoError(b, plugin.Init())
 
 	for n := 0; n < b.N; n++ {
+		//nolint:errcheck // Benchmarking so skip the error check to avoid the unnecessary operations
 		_, _ = plugin.Parse([]byte(benchmarkData))
 	}
 }

--- a/plugins/parsers/dropwizard/parser_test.go
+++ b/plugins/parsers/dropwizard/parser_test.go
@@ -648,6 +648,6 @@ func BenchmarkParsing(b *testing.B) {
 
 	for n := 0; n < b.N; n++ {
 		//nolint:errcheck // Benchmarking so skip the error check to avoid the unnecessary operations
-		_, _ = plugin.Parse([]byte(benchmarkData))
+		plugin.Parse([]byte(benchmarkData))
 	}
 }

--- a/plugins/parsers/form_urlencoded/parser_test.go
+++ b/plugins/parsers/form_urlencoded/parser_test.go
@@ -210,6 +210,7 @@ func BenchmarkParsing(b *testing.B) {
 	}
 
 	for n := 0; n < b.N; n++ {
+		//nolint:errcheck // Benchmarking so skip the error check to avoid the unnecessary operations
 		_, _ = plugin.Parse([]byte(benchmarkData))
 	}
 }

--- a/plugins/parsers/form_urlencoded/parser_test.go
+++ b/plugins/parsers/form_urlencoded/parser_test.go
@@ -211,6 +211,6 @@ func BenchmarkParsing(b *testing.B) {
 
 	for n := 0; n < b.N; n++ {
 		//nolint:errcheck // Benchmarking so skip the error check to avoid the unnecessary operations
-		_, _ = plugin.Parse([]byte(benchmarkData))
+		plugin.Parse([]byte(benchmarkData))
 	}
 }

--- a/plugins/parsers/graphite/parser_test.go
+++ b/plugins/parsers/graphite/parser_test.go
@@ -128,7 +128,8 @@ func TestTemplateApply(t *testing.T) {
 		}
 		require.NoError(t, err)
 
-		measurement, tags, _, _ := tmpl.Apply(test.input, DefaultSeparator)
+		measurement, tags, _, err := tmpl.Apply(test.input, DefaultSeparator)
+		require.NoError(t, err)
 		require.Equal(t, test.measurement, measurement)
 		require.Len(t, tags, len(test.tags))
 		for k, v := range test.tags {
@@ -759,7 +760,8 @@ func TestApplyTemplateSpecific(t *testing.T) {
 	}
 	require.NoError(t, p.Init())
 
-	measurement, tags, _, _ := p.ApplyTemplate("current.users.facebook")
+	measurement, tags, _, err := p.ApplyTemplate("current.users.facebook")
+	require.NoError(t, err)
 	require.Equal(t, "current_users", measurement)
 
 	service, ok := tags["service"]
@@ -776,7 +778,8 @@ func TestApplyTemplateTags(t *testing.T) {
 	}
 	require.NoError(t, p.Init())
 
-	measurement, tags, _, _ := p.ApplyTemplate("current.users")
+	measurement, tags, _, err := p.ApplyTemplate("current.users")
+	require.NoError(t, err)
 	require.Equal(t, "current_users", measurement)
 
 	region, ok := tags["region"]

--- a/plugins/parsers/grok/parser.go
+++ b/plugins/parsers/grok/parser.go
@@ -186,7 +186,10 @@ func (p *Parser) Compile() error {
 	p.loc, err = time.LoadLocation(p.Timezone)
 	if err != nil {
 		p.Log.Warnf("Improper timezone supplied (%s), setting loc to UTC", p.Timezone)
-		p.loc, _ = time.LoadLocation("UTC")
+		p.loc, err = time.LoadLocation("UTC")
+		if err != nil {
+			return err
+		}
 	}
 
 	if p.timeFunc == nil {

--- a/plugins/parsers/grok/parser.go
+++ b/plugins/parsers/grok/parser.go
@@ -186,10 +186,7 @@ func (p *Parser) Compile() error {
 	p.loc, err = time.LoadLocation(p.Timezone)
 	if err != nil {
 		p.Log.Warnf("Improper timezone supplied (%s), setting loc to UTC", p.Timezone)
-		p.loc, err = time.LoadLocation("UTC")
-		if err != nil {
-			return err
-		}
+		p.loc = time.UTC
 	}
 
 	if p.timeFunc == nil {

--- a/plugins/parsers/grok/parser_test.go
+++ b/plugins/parsers/grok/parser_test.go
@@ -269,7 +269,8 @@ func TestCompileErrorsOnInvalidPattern(t *testing.T) {
 	}
 	require.Error(t, p.Compile())
 
-	metricA, _ := p.ParseLine(`1.25 200 192.168.1.1 5.432µs`)
+	metricA, err := p.ParseLine(`1.25 200 192.168.1.1 5.432µs`)
+	require.Error(t, err)
 	require.Nil(t, metricA)
 }
 
@@ -1236,6 +1237,7 @@ func BenchmarkParsing(b *testing.B) {
 	require.NoError(b, plugin.Init())
 
 	for n := 0; n < b.N; n++ {
+		//nolint:errcheck // Benchmarking so skip the error check to avoid the unnecessary operations
 		_, _ = plugin.Parse([]byte(benchmarkData))
 	}
 }

--- a/plugins/parsers/grok/parser_test.go
+++ b/plugins/parsers/grok/parser_test.go
@@ -1238,6 +1238,6 @@ func BenchmarkParsing(b *testing.B) {
 
 	for n := 0; n < b.N; n++ {
 		//nolint:errcheck // Benchmarking so skip the error check to avoid the unnecessary operations
-		_, _ = plugin.Parse([]byte(benchmarkData))
+		plugin.Parse([]byte(benchmarkData))
 	}
 }

--- a/plugins/parsers/influx/influx_upstream/parser_test.go
+++ b/plugins/parsers/influx/influx_upstream/parser_test.go
@@ -1065,6 +1065,7 @@ func BenchmarkParsing(b *testing.B) {
 	require.NoError(b, plugin.Init())
 
 	for n := 0; n < b.N; n++ {
+		//nolint:errcheck // Benchmarking so skip the error check to avoid the unnecessary operations
 		_, _ = plugin.Parse([]byte(benchmarkData))
 	}
 }

--- a/plugins/parsers/influx/influx_upstream/parser_test.go
+++ b/plugins/parsers/influx/influx_upstream/parser_test.go
@@ -1066,6 +1066,6 @@ func BenchmarkParsing(b *testing.B) {
 
 	for n := 0; n < b.N; n++ {
 		//nolint:errcheck // Benchmarking so skip the error check to avoid the unnecessary operations
-		_, _ = plugin.Parse([]byte(benchmarkData))
+		plugin.Parse([]byte(benchmarkData))
 	}
 }

--- a/plugins/parsers/influx/parser_test.go
+++ b/plugins/parsers/influx/parser_test.go
@@ -1033,6 +1033,6 @@ func BenchmarkParsing(b *testing.B) {
 
 	for n := 0; n < b.N; n++ {
 		//nolint:errcheck // Benchmarking so skip the error check to avoid the unnecessary operations
-		_, _ = plugin.Parse([]byte(benchmarkData))
+		plugin.Parse([]byte(benchmarkData))
 	}
 }

--- a/plugins/parsers/influx/parser_test.go
+++ b/plugins/parsers/influx/parser_test.go
@@ -1032,6 +1032,7 @@ func BenchmarkParsing(b *testing.B) {
 	require.NoError(b, plugin.Init())
 
 	for n := 0; n < b.N; n++ {
+		//nolint:errcheck // Benchmarking so skip the error check to avoid the unnecessary operations
 		_, _ = plugin.Parse([]byte(benchmarkData))
 	}
 }

--- a/plugins/parsers/json/parser_test.go
+++ b/plugins/parsers/json/parser_test.go
@@ -1454,7 +1454,7 @@ func BenchmarkParsingSequential(b *testing.B) {
 	// Do the benchmarking
 	for n := 0; n < b.N; n++ {
 		//nolint:errcheck // Benchmarking so skip the error check to avoid the unnecessary operations
-		_, _ = plugin.Parse([]byte(benchmarkData))
+		plugin.Parse([]byte(benchmarkData))
 	}
 }
 
@@ -1470,7 +1470,7 @@ func BenchmarkParsingParallel(b *testing.B) {
 	b.RunParallel(func(p *testing.PB) {
 		for p.Next() {
 			//nolint:errcheck // Benchmarking so skip the error check to avoid the unnecessary operations
-			_, _ = plugin.Parse([]byte(benchmarkData))
+			plugin.Parse([]byte(benchmarkData))
 		}
 	})
 }

--- a/plugins/parsers/json/parser_test.go
+++ b/plugins/parsers/json/parser_test.go
@@ -1453,6 +1453,7 @@ func BenchmarkParsingSequential(b *testing.B) {
 
 	// Do the benchmarking
 	for n := 0; n < b.N; n++ {
+		//nolint:errcheck // Benchmarking so skip the error check to avoid the unnecessary operations
 		_, _ = plugin.Parse([]byte(benchmarkData))
 	}
 }
@@ -1468,6 +1469,7 @@ func BenchmarkParsingParallel(b *testing.B) {
 	// Do the benchmarking
 	b.RunParallel(func(p *testing.PB) {
 		for p.Next() {
+			//nolint:errcheck // Benchmarking so skip the error check to avoid the unnecessary operations
 			_, _ = plugin.Parse([]byte(benchmarkData))
 		}
 	})
@@ -1488,7 +1490,8 @@ func FuzzParserJSON(f *testing.F) {
 	parser := &Parser{MetricName: "testing"}
 	require.NoError(f, parser.Init())
 
-	f.Fuzz(func(_ *testing.T, input []byte) {
-		_, _ = parser.Parse(input)
+	f.Fuzz(func(t *testing.T, input []byte) {
+		_, err := parser.Parse(input)
+		require.NoError(t, err)
 	})
 }

--- a/plugins/parsers/json/parser_test.go
+++ b/plugins/parsers/json/parser_test.go
@@ -1491,7 +1491,7 @@ func FuzzParserJSON(f *testing.F) {
 	require.NoError(f, parser.Init())
 
 	f.Fuzz(func(t *testing.T, input []byte) {
-		_, err := parser.Parse(input)
-		require.NoError(t, err)
+		//nolint:errcheck // fuzz testing can give lots of errors, but we just want to test for crashes
+		parser.Parse(input)
 	})
 }

--- a/plugins/parsers/json/parser_test.go
+++ b/plugins/parsers/json/parser_test.go
@@ -1490,7 +1490,7 @@ func FuzzParserJSON(f *testing.F) {
 	parser := &Parser{MetricName: "testing"}
 	require.NoError(f, parser.Init())
 
-	f.Fuzz(func(t *testing.T, input []byte) {
+	f.Fuzz(func(_ *testing.T, input []byte) {
 		//nolint:errcheck // fuzz testing can give lots of errors, but we just want to test for crashes
 		parser.Parse(input)
 	})

--- a/plugins/parsers/json_v2/parser_test.go
+++ b/plugins/parsers/json_v2/parser_test.go
@@ -125,6 +125,7 @@ func BenchmarkParsingSequential(b *testing.B) {
 
 	// Do the benchmarking
 	for n := 0; n < b.N; n++ {
+		//nolint:errcheck // Benchmarking so skip the error check to avoid the unnecessary operations
 		_, _ = plugin.Parse(input)
 	}
 }
@@ -155,6 +156,7 @@ func BenchmarkParsingParallel(b *testing.B) {
 	// Do the benchmarking
 	b.RunParallel(func(p *testing.PB) {
 		for p.Next() {
+			//nolint:errcheck // Benchmarking so skip the error check to avoid the unnecessary operations
 			_, _ = plugin.Parse(input)
 		}
 	})

--- a/plugins/parsers/json_v2/parser_test.go
+++ b/plugins/parsers/json_v2/parser_test.go
@@ -126,7 +126,7 @@ func BenchmarkParsingSequential(b *testing.B) {
 	// Do the benchmarking
 	for n := 0; n < b.N; n++ {
 		//nolint:errcheck // Benchmarking so skip the error check to avoid the unnecessary operations
-		_, _ = plugin.Parse(input)
+		plugin.Parse(input)
 	}
 }
 
@@ -157,7 +157,7 @@ func BenchmarkParsingParallel(b *testing.B) {
 	b.RunParallel(func(p *testing.PB) {
 		for p.Next() {
 			//nolint:errcheck // Benchmarking so skip the error check to avoid the unnecessary operations
-			_, _ = plugin.Parse(input)
+			plugin.Parse(input)
 		}
 	})
 }

--- a/plugins/parsers/logfmt/parser_test.go
+++ b/plugins/parsers/logfmt/parser_test.go
@@ -333,6 +333,7 @@ func BenchmarkParsing(b *testing.B) {
 	require.NoError(b, plugin.Init())
 
 	for n := 0; n < b.N; n++ {
+		//nolint:errcheck // Benchmarking so skip the error check to avoid the unnecessary operations
 		_, _ = plugin.Parse([]byte(benchmarkData))
 	}
 }

--- a/plugins/parsers/logfmt/parser_test.go
+++ b/plugins/parsers/logfmt/parser_test.go
@@ -334,6 +334,6 @@ func BenchmarkParsing(b *testing.B) {
 
 	for n := 0; n < b.N; n++ {
 		//nolint:errcheck // Benchmarking so skip the error check to avoid the unnecessary operations
-		_, _ = plugin.Parse([]byte(benchmarkData))
+		plugin.Parse([]byte(benchmarkData))
 	}
 }

--- a/plugins/parsers/nagios/parser_test.go
+++ b/plugins/parsers/nagios/parser_test.go
@@ -571,6 +571,7 @@ func BenchmarkParsing(b *testing.B) {
 	plugin := &Parser{}
 
 	for n := 0; n < b.N; n++ {
+		//nolint:errcheck // Benchmarking so skip the error check to avoid the unnecessary operations
 		_, _ = plugin.Parse([]byte(benchmarkData))
 	}
 }

--- a/plugins/parsers/nagios/parser_test.go
+++ b/plugins/parsers/nagios/parser_test.go
@@ -572,6 +572,6 @@ func BenchmarkParsing(b *testing.B) {
 
 	for n := 0; n < b.N; n++ {
 		//nolint:errcheck // Benchmarking so skip the error check to avoid the unnecessary operations
-		_, _ = plugin.Parse([]byte(benchmarkData))
+		plugin.Parse([]byte(benchmarkData))
 	}
 }

--- a/plugins/parsers/openmetrics/parser_test.go
+++ b/plugins/parsers/openmetrics/parser_test.go
@@ -159,6 +159,7 @@ func BenchmarkParsingMetricVersion1(b *testing.B) {
 	require.NotEmpty(b, benchmarkData)
 
 	for n := 0; n < b.N; n++ {
+		//nolint:errcheck // Benchmarking so skip the error check to avoid the unnecessary operations
 		_, _ = plugin.Parse(benchmarkData)
 	}
 }
@@ -171,6 +172,7 @@ func BenchmarkParsingMetricVersion2(b *testing.B) {
 	require.NotEmpty(b, benchmarkData)
 
 	for n := 0; n < b.N; n++ {
+		//nolint:errcheck // Benchmarking so skip the error check to avoid the unnecessary operations
 		_, _ = plugin.Parse(benchmarkData)
 	}
 }

--- a/plugins/parsers/openmetrics/parser_test.go
+++ b/plugins/parsers/openmetrics/parser_test.go
@@ -160,7 +160,7 @@ func BenchmarkParsingMetricVersion1(b *testing.B) {
 
 	for n := 0; n < b.N; n++ {
 		//nolint:errcheck // Benchmarking so skip the error check to avoid the unnecessary operations
-		_, _ = plugin.Parse(benchmarkData)
+		plugin.Parse(benchmarkData)
 	}
 }
 
@@ -173,6 +173,6 @@ func BenchmarkParsingMetricVersion2(b *testing.B) {
 
 	for n := 0; n < b.N; n++ {
 		//nolint:errcheck // Benchmarking so skip the error check to avoid the unnecessary operations
-		_, _ = plugin.Parse(benchmarkData)
+		plugin.Parse(benchmarkData)
 	}
 }

--- a/plugins/parsers/opentsdb/parser_test.go
+++ b/plugins/parsers/opentsdb/parser_test.go
@@ -352,6 +352,6 @@ func BenchmarkParsing(b *testing.B) {
 
 	for n := 0; n < b.N; n++ {
 		//nolint:errcheck // Benchmarking so skip the error check to avoid the unnecessary operations
-		_, _ = plugin.Parse([]byte(benchmarkData))
+		plugin.Parse([]byte(benchmarkData))
 	}
 }

--- a/plugins/parsers/opentsdb/parser_test.go
+++ b/plugins/parsers/opentsdb/parser_test.go
@@ -351,6 +351,7 @@ func BenchmarkParsing(b *testing.B) {
 	plugin := &Parser{}
 
 	for n := 0; n < b.N; n++ {
+		//nolint:errcheck // Benchmarking so skip the error check to avoid the unnecessary operations
 		_, _ = plugin.Parse([]byte(benchmarkData))
 	}
 }

--- a/plugins/parsers/parquet/parser_test.go
+++ b/plugins/parsers/parquet/parser_test.go
@@ -69,6 +69,7 @@ func BenchmarkParsing(b *testing.B) {
 
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
+		//nolint:errcheck // Benchmarking so skip the error check to avoid the unnecessary operations
 		_, _ = plugin.Parse(benchmarkData)
 	}
 }

--- a/plugins/parsers/parquet/parser_test.go
+++ b/plugins/parsers/parquet/parser_test.go
@@ -70,6 +70,6 @@ func BenchmarkParsing(b *testing.B) {
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
 		//nolint:errcheck // Benchmarking so skip the error check to avoid the unnecessary operations
-		_, _ = plugin.Parse(benchmarkData)
+		plugin.Parse(benchmarkData)
 	}
 }

--- a/plugins/parsers/prometheus/parser_test.go
+++ b/plugins/parsers/prometheus/parser_test.go
@@ -159,6 +159,7 @@ func BenchmarkParsingMetricVersion1(b *testing.B) {
 	require.NotEmpty(b, benchmarkData)
 
 	for n := 0; n < b.N; n++ {
+		//nolint:errcheck // Benchmarking so skip the error check to avoid the unnecessary operations
 		_, _ = plugin.Parse(benchmarkData)
 	}
 }
@@ -171,6 +172,7 @@ func BenchmarkParsingMetricVersion2(b *testing.B) {
 	require.NotEmpty(b, benchmarkData)
 
 	for n := 0; n < b.N; n++ {
+		//nolint:errcheck // Benchmarking so skip the error check to avoid the unnecessary operations
 		_, _ = plugin.Parse(benchmarkData)
 	}
 }

--- a/plugins/parsers/prometheus/parser_test.go
+++ b/plugins/parsers/prometheus/parser_test.go
@@ -160,7 +160,7 @@ func BenchmarkParsingMetricVersion1(b *testing.B) {
 
 	for n := 0; n < b.N; n++ {
 		//nolint:errcheck // Benchmarking so skip the error check to avoid the unnecessary operations
-		_, _ = plugin.Parse(benchmarkData)
+		plugin.Parse(benchmarkData)
 	}
 }
 
@@ -173,6 +173,6 @@ func BenchmarkParsingMetricVersion2(b *testing.B) {
 
 	for n := 0; n < b.N; n++ {
 		//nolint:errcheck // Benchmarking so skip the error check to avoid the unnecessary operations
-		_, _ = plugin.Parse(benchmarkData)
+		plugin.Parse(benchmarkData)
 	}
 }

--- a/plugins/parsers/prometheusremotewrite/parser_test.go
+++ b/plugins/parsers/prometheusremotewrite/parser_test.go
@@ -342,6 +342,6 @@ func BenchmarkParsing(b *testing.B) {
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
 		//nolint:errcheck // Benchmarking so skip the error check to avoid the unnecessary operations
-		_, _ = plugin.Parse(benchmarkData)
+		plugin.Parse(benchmarkData)
 	}
 }

--- a/plugins/parsers/prometheusremotewrite/parser_test.go
+++ b/plugins/parsers/prometheusremotewrite/parser_test.go
@@ -341,6 +341,7 @@ func BenchmarkParsing(b *testing.B) {
 
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
+		//nolint:errcheck // Benchmarking so skip the error check to avoid the unnecessary operations
 		_, _ = plugin.Parse(benchmarkData)
 	}
 }

--- a/plugins/parsers/value/parser_test.go
+++ b/plugins/parsers/value/parser_test.go
@@ -327,6 +327,7 @@ func BenchmarkParsing(b *testing.B) {
 	require.NoError(b, plugin.Init())
 
 	for n := 0; n < b.N; n++ {
+		//nolint:errcheck // Benchmarking so skip the error check to avoid the unnecessary operations
 		_, _ = plugin.Parse([]byte(benchmarkData))
 	}
 }

--- a/plugins/parsers/value/parser_test.go
+++ b/plugins/parsers/value/parser_test.go
@@ -328,6 +328,6 @@ func BenchmarkParsing(b *testing.B) {
 
 	for n := 0; n < b.N; n++ {
 		//nolint:errcheck // Benchmarking so skip the error check to avoid the unnecessary operations
-		_, _ = plugin.Parse([]byte(benchmarkData))
+		plugin.Parse([]byte(benchmarkData))
 	}
 }

--- a/plugins/parsers/wavefront/parser_test.go
+++ b/plugins/parsers/wavefront/parser_test.go
@@ -336,6 +336,7 @@ func BenchmarkParsing(b *testing.B) {
 	require.NoError(b, plugin.Init())
 
 	for n := 0; n < b.N; n++ {
+		//nolint:errcheck // Benchmarking so skip the error check to avoid the unnecessary operations
 		_, _ = plugin.Parse([]byte(benchmarkData))
 	}
 }

--- a/plugins/parsers/wavefront/parser_test.go
+++ b/plugins/parsers/wavefront/parser_test.go
@@ -337,6 +337,6 @@ func BenchmarkParsing(b *testing.B) {
 
 	for n := 0; n < b.N; n++ {
 		//nolint:errcheck // Benchmarking so skip the error check to avoid the unnecessary operations
-		_, _ = plugin.Parse([]byte(benchmarkData))
+		plugin.Parse([]byte(benchmarkData))
 	}
 }

--- a/plugins/parsers/xpath/parser_test.go
+++ b/plugins/parsers/xpath/parser_test.go
@@ -1580,7 +1580,7 @@ func BenchmarkParsingXML(b *testing.B) {
 
 	for n := 0; n < b.N; n++ {
 		//nolint:errcheck // Benchmarking so skip the error check to avoid the unnecessary operations
-		_, _ = plugin.Parse([]byte(benchmarkDataXML))
+		plugin.Parse([]byte(benchmarkDataXML))
 	}
 }
 
@@ -1643,7 +1643,7 @@ func BenchmarkParsingJSON(b *testing.B) {
 
 	for n := 0; n < b.N; n++ {
 		//nolint:errcheck // Benchmarking so skip the error check to avoid the unnecessary operations
-		_, _ = plugin.Parse([]byte(benchmarkDataJSON))
+		plugin.Parse([]byte(benchmarkDataJSON))
 	}
 }
 
@@ -1679,7 +1679,7 @@ func BenchmarkParsingProtobuf(b *testing.B) {
 
 	for n := 0; n < b.N; n++ {
 		//nolint:errcheck // Benchmarking so skip the error check to avoid the unnecessary operations
-		_, _ = plugin.Parse(benchmarkData)
+		plugin.Parse(benchmarkData)
 	}
 }
 
@@ -1783,7 +1783,7 @@ func BenchmarkParsingMsgPack(b *testing.B) {
 
 	for n := 0; n < b.N; n++ {
 		//nolint:errcheck // Benchmarking so skip the error check to avoid the unnecessary operations
-		_, _ = plugin.Parse(benchmarkDataMsgPack[n%2])
+		plugin.Parse(benchmarkDataMsgPack[n%2])
 	}
 }
 
@@ -1816,6 +1816,6 @@ func BenchmarkParsingCBOR(b *testing.B) {
 
 	for n := 0; n < b.N; n++ {
 		//nolint:errcheck // Benchmarking so skip the error check to avoid the unnecessary operations
-		_, _ = plugin.Parse(benchmarkData)
+		plugin.Parse(benchmarkData)
 	}
 }

--- a/plugins/parsers/xpath/parser_test.go
+++ b/plugins/parsers/xpath/parser_test.go
@@ -1345,11 +1345,11 @@ func TestTestCases(t *testing.T) {
 			require.NoError(t, err)
 
 			// Get the expectations
-			expectedOutputs, err := testutil.ParseMetricsFrom(header, "Expected Output:", parser)
-			require.NoError(t, err)
+			//nolint:errcheck // these may not be set by the testcase, in which case it would error correctly
+			expectedOutputs, _ := testutil.ParseMetricsFrom(header, "Expected Output:", parser)
 
-			expectedErrors, err := testutil.ParseRawLinesFrom(header, "Expected Error:")
-			require.NoError(t, err)
+			//nolint:errcheck // these may not be set by the testcase, in which case it would error correctly
+			expectedErrors, _ := testutil.ParseRawLinesFrom(header, "Expected Error:")
 
 			// Setup the parser and run it.
 			metricName := "xml"

--- a/plugins/parsers/xpath/parser_test.go
+++ b/plugins/parsers/xpath/parser_test.go
@@ -1348,7 +1348,8 @@ func TestTestCases(t *testing.T) {
 			expectedOutputs, err := testutil.ParseMetricsFrom(header, "Expected Output:", parser)
 			require.NoError(t, err)
 
-			expectedErrors, _ := testutil.ParseRawLinesFrom(header, "Expected Error:")
+			expectedErrors, err := testutil.ParseRawLinesFrom(header, "Expected Error:")
+			require.NoError(t, err)
 
 			// Setup the parser and run it.
 			metricName := "xml"
@@ -1578,6 +1579,7 @@ func BenchmarkParsingXML(b *testing.B) {
 	require.NoError(b, plugin.Init())
 
 	for n := 0; n < b.N; n++ {
+		//nolint:errcheck // Benchmarking so skip the error check to avoid the unnecessary operations
 		_, _ = plugin.Parse([]byte(benchmarkDataXML))
 	}
 }
@@ -1640,6 +1642,7 @@ func BenchmarkParsingJSON(b *testing.B) {
 	require.NoError(b, plugin.Init())
 
 	for n := 0; n < b.N; n++ {
+		//nolint:errcheck // Benchmarking so skip the error check to avoid the unnecessary operations
 		_, _ = plugin.Parse([]byte(benchmarkDataJSON))
 	}
 }
@@ -1675,6 +1678,7 @@ func BenchmarkParsingProtobuf(b *testing.B) {
 	require.NoError(b, err)
 
 	for n := 0; n < b.N; n++ {
+		//nolint:errcheck // Benchmarking so skip the error check to avoid the unnecessary operations
 		_, _ = plugin.Parse(benchmarkData)
 	}
 }
@@ -1778,6 +1782,7 @@ func BenchmarkParsingMsgPack(b *testing.B) {
 	require.NoError(b, plugin.Init())
 
 	for n := 0; n < b.N; n++ {
+		//nolint:errcheck // Benchmarking so skip the error check to avoid the unnecessary operations
 		_, _ = plugin.Parse(benchmarkDataMsgPack[n%2])
 	}
 }
@@ -1810,6 +1815,7 @@ func BenchmarkParsingCBOR(b *testing.B) {
 	require.NoError(b, err)
 
 	for n := 0; n < b.N; n++ {
+		//nolint:errcheck // Benchmarking so skip the error check to avoid the unnecessary operations
 		_, _ = plugin.Parse(benchmarkData)
 	}
 }

--- a/plugins/processors/dedup/dedup.go
+++ b/plugins/processors/dedup/dedup.go
@@ -126,6 +126,7 @@ func (d *Dedup) GetState() interface{} {
 	for _, value := range d.Cache {
 		v = append(v, value)
 	}
+	//nolint:errcheck // no way to propagate the error
 	state, _ := s.SerializeBatch(v)
 	return state
 }

--- a/plugins/processors/dedup/dedup.go
+++ b/plugins/processors/dedup/dedup.go
@@ -20,6 +20,7 @@ type Dedup struct {
 	DedupInterval config.Duration `toml:"dedup_interval"`
 	FlushTime     time.Time
 	Cache         map[uint64]telegraf.Metric
+	Log           telegraf.Logger `toml:"-"`
 }
 
 // Remove expired items from cache
@@ -127,7 +128,10 @@ func (d *Dedup) GetState() interface{} {
 		v = append(v, value)
 	}
 	//nolint:errcheck // no way to propagate the error
-	state, _ := s.SerializeBatch(v)
+	state, err := s.SerializeBatch(v)
+	if err != nil {
+		d.Log.Errorf("dedup processor failed to serialize metric batch: %v", err)
+	}
 	return state
 }
 

--- a/plugins/processors/dedup/dedup.go
+++ b/plugins/processors/dedup/dedup.go
@@ -127,7 +127,6 @@ func (d *Dedup) GetState() interface{} {
 	for _, value := range d.Cache {
 		v = append(v, value)
 	}
-	//nolint:errcheck // no way to propagate the error
 	state, err := s.SerializeBatch(v)
 	if err != nil {
 		d.Log.Errorf("dedup processor failed to serialize metric batch: %v", err)

--- a/plugins/processors/execd/execd_test.go
+++ b/plugins/processors/execd/execd_test.go
@@ -167,7 +167,8 @@ func runCountMultiplierProgram() {
 	fieldName := os.Getenv("FIELD_NAME")
 	parser := influx.NewStreamParser(os.Stdin)
 	serializer := &influxSerializer.Serializer{}
-	_ = serializer.Init() // this should always succeed
+	//nolint:errcheck // this should always succeed
+	serializer.Init()
 
 	for {
 		m, err := parser.Next()

--- a/plugins/processors/filepath/filepath.go
+++ b/plugins/processors/filepath/filepath.go
@@ -20,6 +20,8 @@ type Options struct {
 	Clean    []BaseOpts
 	Rel      []RelOpts
 	ToSlash  []BaseOpts `toml:"toslash"`
+
+	Log telegraf.Logger `toml:"-"`
 }
 
 type ProcessorFunc func(s string) string
@@ -82,8 +84,11 @@ func (o *Options) processMetric(metric telegraf.Metric) {
 	// Rel
 	for _, v := range o.Rel {
 		o.applyFunc(v.BaseOpts, func(s string) string {
-			//nolint:errcheck // no way to propagate the error
-			relPath, _ := filepath.Rel(v.BasePath, s)
+			relPath, err := filepath.Rel(v.BasePath, s)
+			if err != nil {
+				o.Log.Errorf("filepath processor failed to process relative filepath %s: %v", s, err)
+				return v.BasePath
+			}
 			return relPath
 		}, metric)
 	}

--- a/plugins/processors/filepath/filepath.go
+++ b/plugins/processors/filepath/filepath.go
@@ -82,6 +82,7 @@ func (o *Options) processMetric(metric telegraf.Metric) {
 	// Rel
 	for _, v := range o.Rel {
 		o.applyFunc(v.BaseOpts, func(s string) string {
+			//nolint:errcheck // no way to propagate the error
 			relPath, _ := filepath.Rel(v.BasePath, s)
 			return relPath
 		}, metric)

--- a/plugins/secretstores/http/http_test.go
+++ b/plugins/secretstores/http/http_test.go
@@ -62,7 +62,8 @@ func TestCases(t *testing.T) {
 
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if r.URL.Path == "/secrets" {
-					_, _ = w.Write(input)
+					_, err = w.Write(input)
+					require.NoError(t, err)
 				} else {
 					w.WriteHeader(http.StatusNotFound)
 				}
@@ -155,7 +156,8 @@ func TestGetErrors(t *testing.T) {
 
 func TestResolver(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		_, _ = w.Write([]byte(`{"test": "aedMZXaLR246OHHjVtJKXQ=="}`))
+		_, err := w.Write([]byte(`{"test": "aedMZXaLR246OHHjVtJKXQ=="}`))
+		require.NoError(t, err)
 	}))
 	defer server.Close()
 
@@ -196,7 +198,8 @@ func TestGetResolverErrors(t *testing.T) {
 	dummy.Close()
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		_, _ = w.Write([]byte(`[{"test": "aedMZXaLR246OHHjVtJKXQ=="}]`))
+		_, err = w.Write([]byte(`[{"test": "aedMZXaLR246OHHjVtJKXQ=="}]`))
+		require.NoError(t, err)
 	}))
 	defer server.Close()
 
@@ -229,7 +232,8 @@ func TestInvalidServerResponse(t *testing.T) {
 	defer dummy.Close()
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		_, _ = w.Write([]byte(`[somerandomebytes`))
+		_, err = w.Write([]byte(`[somerandomebytes`))
+		require.NoError(t, err)
 	}))
 	defer server.Close()
 
@@ -263,7 +267,8 @@ func TestAdditionalHeaders(t *testing.T) {
 		if r.Host != "" {
 			actual.Add("host", r.Host)
 		}
-		_, _ = w.Write([]byte(`{"test": "aedMZXaLR246OHHjVtJKXQ=="}`))
+		_, err = w.Write([]byte(`{"test": "aedMZXaLR246OHHjVtJKXQ=="}`))
+		require.NoError(t, err)
 	}))
 	defer server.Close()
 
@@ -305,12 +310,14 @@ func TestServerReturnCodes(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/", "/200":
-			_, _ = w.Write([]byte(`{}`))
+			_, err = w.Write([]byte(`{}`))
+			require.NoError(t, err)
 		case "/201":
 			w.WriteHeader(201)
 		case "/300":
 			w.WriteHeader(300)
-			_, _ = w.Write([]byte(`{}`))
+			_, err = w.Write([]byte(`{}`))
+			require.NoError(t, err)
 		case "/401":
 			w.WriteHeader(401)
 		default:
@@ -350,7 +357,8 @@ func TestAuthenticationBasic(t *testing.T) {
 	var header http.Header
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		header = r.Header
-		_, _ = w.Write([]byte(`{}`))
+		_, err = w.Write([]byte(`{}`))
+		require.NoError(t, err)
 	}))
 	defer server.Close()
 
@@ -377,7 +385,8 @@ func TestAuthenticationToken(t *testing.T) {
 	var header http.Header
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		header = r.Header
-		_, _ = w.Write([]byte(`{}`))
+		_, err = w.Write([]byte(`{}`))
+		require.NoError(t, err)
 	}))
 	defer server.Close()
 

--- a/plugins/secretstores/oauth2/oauth2_test.go
+++ b/plugins/secretstores/oauth2/oauth2_test.go
@@ -158,7 +158,8 @@ func TestGet(t *testing.T) {
 		func(w http.ResponseWriter, r *http.Request) {
 			body, err := io.ReadAll(r.Body)
 			if err != nil {
-				_, _ = w.Write([]byte(err.Error()))
+				_, err := w.Write([]byte(err.Error()))
+				require.NoError(t, err)
 				w.WriteHeader(http.StatusInternalServerError)
 				return
 			}
@@ -198,7 +199,8 @@ func TestGetMultipleTimes(t *testing.T) {
 		func(w http.ResponseWriter, r *http.Request) {
 			body, err := io.ReadAll(r.Body)
 			if err != nil {
-				_, _ = w.Write([]byte(err.Error()))
+				_, err := w.Write([]byte(err.Error()))
+				require.NoError(t, err)
 				w.WriteHeader(http.StatusInternalServerError)
 				return
 			}
@@ -244,7 +246,8 @@ func TestGetExpired(t *testing.T) {
 		func(w http.ResponseWriter, r *http.Request) {
 			body, err := io.ReadAll(r.Body)
 			if err != nil {
-				_, _ = w.Write([]byte(err.Error()))
+				_, err := w.Write([]byte(err.Error()))
+				require.NoError(t, err)
 				w.WriteHeader(http.StatusInternalServerError)
 				return
 			}
@@ -285,7 +288,8 @@ func TestGetRefresh(t *testing.T) {
 		func(w http.ResponseWriter, r *http.Request) {
 			body, err := io.ReadAll(r.Body)
 			if err != nil {
-				_, _ = w.Write([]byte(err.Error()))
+				_, err := w.Write([]byte(err.Error()))
+				require.NoError(t, err)
 				w.WriteHeader(http.StatusInternalServerError)
 				return
 			}

--- a/plugins/serializers/graphite/graphite_test.go
+++ b/plugins/serializers/graphite/graphite_test.go
@@ -1052,7 +1052,8 @@ func TestCleanWithTagsSupport(t *testing.T) {
 			require.NoError(t, s.Init())
 
 			m := metric.New(tt.metricName, tt.tags, tt.fields, now)
-			actual, _ := s.Serialize(m)
+			actual, err := s.Serialize(m)
+			require.NoError(t, err)
 			require.Equal(t, tt.expected, string(actual))
 		})
 	}
@@ -1149,7 +1150,8 @@ func TestCleanWithTagsSupportCompatibleSanitize(t *testing.T) {
 			require.NoError(t, s.Init())
 
 			m := metric.New(tt.metricName, tt.tags, tt.fields, now)
-			actual, _ := s.Serialize(m)
+			actual, err := s.Serialize(m)
+			require.NoError(t, err)
 			require.Equal(t, tt.expected, string(actual))
 		})
 	}
@@ -1179,7 +1181,8 @@ func TestSerializeBatch(t *testing.T) {
 			require.NoError(t, s.Init())
 
 			m := metric.New(tt.metricName, tt.tags, tt.fields, now)
-			actual, _ := s.SerializeBatch([]telegraf.Metric{m, m})
+			actual, err := s.SerializeBatch([]telegraf.Metric{m, m})
+			require.NoError(t, err)
 			require.Equal(t, tt.expected, string(actual))
 		})
 	}
@@ -1212,7 +1215,8 @@ func TestSerializeBatchWithTagsSupport(t *testing.T) {
 			require.NoError(t, s.Init())
 
 			m := metric.New(tt.metricName, tt.tags, tt.fields, now)
-			actual, _ := s.SerializeBatch([]telegraf.Metric{m, m})
+			actual, err := s.SerializeBatch([]telegraf.Metric{m, m})
+			require.NoError(t, err)
 			require.Equal(t, tt.expected, string(actual))
 		})
 	}

--- a/plugins/serializers/msgpack/metric_test.go
+++ b/plugins/serializers/msgpack/metric_test.go
@@ -81,57 +81,71 @@ func TestMsgPackTimeEdgeCases(t *testing.T) {
 
 	// Unix epoch. Begin of 4bytes dates
 	// Nanoseconds: 0x00000000, Seconds: 0x0000000000000000
-	ts, _ := time.Parse(time.RFC3339, "1970-01-01T00:00:00Z")
-	bs, _ := hex.DecodeString("d6ff00000000")
+	ts, err := time.Parse(time.RFC3339, "1970-01-01T00:00:00Z")
+	require.NoError(t, err)
+	bs, err := hex.DecodeString("d6ff00000000")
+	require.NoError(t, err)
 	times = append(times, ts)
 	expected = append(expected, bs)
 
 	// End of 4bytes dates
 	// Nanoseconds: 0x00000000, Seconds: 0x00000000ffffffff
-	ts, _ = time.Parse(time.RFC3339, "2106-02-07T06:28:15Z")
-	bs, _ = hex.DecodeString("d6ffffffffff")
+	ts, err = time.Parse(time.RFC3339, "2106-02-07T06:28:15Z")
+	require.NoError(t, err)
+	bs, err = hex.DecodeString("d6ffffffffff")
+	require.NoError(t, err)
 	times = append(times, ts)
 	expected = append(expected, bs)
 
 	// Begin of 8bytes dates
 	// Nanoseconds: 0x00000000, Seconds: 0x0000000100000000
-	ts, _ = time.Parse(time.RFC3339, "2106-02-07T06:28:16Z")
-	bs, _ = hex.DecodeString("d7ff0000000100000000")
+	ts, err = time.Parse(time.RFC3339, "2106-02-07T06:28:16Z")
+	require.NoError(t, err)
+	bs, err = hex.DecodeString("d7ff0000000100000000")
+	require.NoError(t, err)
 	times = append(times, ts)
 	expected = append(expected, bs)
 
 	// Just after Unix epoch. Non zero nanoseconds
 	// Nanoseconds: 0x00000001, Seconds: 0x0000000000000000
-	ts, _ = time.Parse(time.RFC3339Nano, "1970-01-01T00:00:00.000000001Z")
-	bs, _ = hex.DecodeString("d7ff0000000400000000")
+	ts, err = time.Parse(time.RFC3339Nano, "1970-01-01T00:00:00.000000001Z")
+	require.NoError(t, err)
+	bs, err = hex.DecodeString("d7ff0000000400000000")
+	require.NoError(t, err)
 	times = append(times, ts)
 	expected = append(expected, bs)
 
 	// End of 8bytes dates
 	// Nanoseconds: 0x00000000, Seconds: 0x00000003ffffffff
-	ts, _ = time.Parse(time.RFC3339Nano, "2514-05-30T01:53:03.000000000Z")
-	bs, _ = hex.DecodeString("d7ff00000003ffffffff")
+	ts, err = time.Parse(time.RFC3339Nano, "2514-05-30T01:53:03.000000000Z")
+	require.NoError(t, err)
+	bs, err = hex.DecodeString("d7ff00000003ffffffff")
+	require.NoError(t, err)
 	times = append(times, ts)
 	expected = append(expected, bs)
 
 	// Begin of 12bytes date
 	// Nanoseconds: 0x00000000, Seconds: 0x0000000400000000
-	ts, _ = time.Parse(time.RFC3339Nano, "2514-05-30T01:53:04.000000000Z")
-	bs, _ = hex.DecodeString("c70cff000000000000000400000000")
+	ts, err = time.Parse(time.RFC3339Nano, "2514-05-30T01:53:04.000000000Z")
+	require.NoError(t, err)
+	bs, err = hex.DecodeString("c70cff000000000000000400000000")
+	require.NoError(t, err)
 	times = append(times, ts)
 	expected = append(expected, bs)
 
 	// Zero value, 0001-01-01T00:00:00Z
 	// Nanoseconds: 0x00000000, Seconds: 0xfffffff1886e0900
 	ts = time.Time{}
-	bs, _ = hex.DecodeString("c70cff00000000fffffff1886e0900")
+	bs, err = hex.DecodeString("c70cff00000000fffffff1886e0900")
+	require.NoError(t, err)
 	times = append(times, ts)
 	expected = append(expected, bs)
 
 	// Max value
 	// Nanoseconds: 0x3b9ac9ff, Seconds: 0x7fffffffffffffff
 	ts = time.Unix(math.MaxInt64, 999_999_999).UTC()
-	bs, _ = hex.DecodeString("c70cff3b9ac9ff7fffffffffffffff")
+	bs, err = hex.DecodeString("c70cff3b9ac9ff7fffffffffffffff")
+	require.NoError(t, err)
 	times = append(times, ts)
 	expected = append(expected, bs)
 
@@ -141,7 +155,8 @@ func TestMsgPackTimeEdgeCases(t *testing.T) {
 		m := Metric{Time: t1}
 
 		buf = buf[:0]
-		buf, _ = m.MarshalMsg(buf)
+		buf, err = m.MarshalMsg(buf)
+		require.NoError(t, err)
 		require.Equal(t, expected[i], buf[12:len(buf)-14])
 	}
 }

--- a/plugins/serializers/prometheusremotewrite/prometheusremotewrite_test.go
+++ b/plugins/serializers/prometheusremotewrite/prometheusremotewrite_test.go
@@ -35,6 +35,7 @@ func BenchmarkRemoteWrite(b *testing.B) {
 	}
 	s := &Serializer{}
 	for n := 0; n < b.N; n++ {
+		//nolint:errcheck // Benchmarking so skip the error check to avoid the unnecessary operations
 		_, _ = s.SerializeBatch(batch)
 	}
 }

--- a/plugins/serializers/prometheusremotewrite/prometheusremotewrite_test.go
+++ b/plugins/serializers/prometheusremotewrite/prometheusremotewrite_test.go
@@ -36,7 +36,7 @@ func BenchmarkRemoteWrite(b *testing.B) {
 	s := &Serializer{}
 	for n := 0; n < b.N; n++ {
 		//nolint:errcheck // Benchmarking so skip the error check to avoid the unnecessary operations
-		_, _ = s.SerializeBatch(batch)
+		s.SerializeBatch(batch)
 	}
 }
 

--- a/plugins/serializers/splunkmetric/splunkmetric.go
+++ b/plugins/serializers/splunkmetric/splunkmetric.go
@@ -151,7 +151,7 @@ func (s *Serializer) createSingle(metric telegraf.Metric, dataGroup HECTimeSerie
 	return metricGroup, nil
 }
 
-func (s *Serializer) createObject(metric telegraf.Metric) (metricGroup []byte, err error) {
+func (s *Serializer) createObject(metric telegraf.Metric) ([]byte, error) {
 	/*  Splunk supports one metric json object, and does _not_ support an array of JSON objects.
 	     ** Splunk has the following required names for the metric store:
 		 ** metric_name: The name of the metric
@@ -180,15 +180,10 @@ func (s *Serializer) createObject(metric telegraf.Metric) (metricGroup []byte, e
 		}
 	}
 	commonTags.Time = float64(metric.Time().UnixNano()) / float64(1000000000)
-	switch s.MultiMetric {
-	case true:
-		metricGroup, err = s.createMulti(metric, dataGroup, commonTags)
-	default:
-		metricGroup, err = s.createSingle(metric, dataGroup, commonTags)
+	if s.MultiMetric {
+		return s.createMulti(metric, dataGroup, commonTags)
 	}
-
-	// Return the metric group regardless of if it's multimetric or single metric.
-	return metricGroup, err
+	return s.createSingle(metric, dataGroup, commonTags)
 }
 
 func verifyValue(v interface{}) (value interface{}, valid bool) {

--- a/plugins/serializers/wavefront/wavefront_test.go
+++ b/plugins/serializers/wavefront/wavefront_test.go
@@ -181,7 +181,8 @@ func TestSerializeMetricFloat(t *testing.T) {
 	m := metric.New("cpu", tags, fields, now)
 
 	s := &Serializer{}
-	buf, _ := s.Serialize(m)
+	buf, err := s.Serialize(m)
+	require.NoError(t, err)
 	mS := strings.Split(strings.TrimSpace(string(buf)), "\n")
 
 	expS := []string{fmt.Sprintf("\"cpu.usage.idle\" 91.500000 %d source=\"realHost\" \"cpu\"=\"cpu0\"", now.UnixNano()/1000000000)}
@@ -200,7 +201,8 @@ func TestSerializeMetricInt(t *testing.T) {
 	m := metric.New("cpu", tags, fields, now)
 
 	s := &Serializer{}
-	buf, _ := s.Serialize(m)
+	buf, err := s.Serialize(m)
+	require.NoError(t, err)
 	mS := strings.Split(strings.TrimSpace(string(buf)), "\n")
 
 	expS := []string{fmt.Sprintf("\"cpu.usage.idle\" 91.000000 %d source=\"realHost\" \"cpu\"=\"cpu0\"", now.UnixNano()/1000000000)}
@@ -219,7 +221,8 @@ func TestSerializeMetricBoolTrue(t *testing.T) {
 	m := metric.New("cpu", tags, fields, now)
 
 	s := &Serializer{}
-	buf, _ := s.Serialize(m)
+	buf, err := s.Serialize(m)
+	require.NoError(t, err)
 	mS := strings.Split(strings.TrimSpace(string(buf)), "\n")
 
 	expS := []string{fmt.Sprintf("\"cpu.usage.idle\" 1.000000 %d source=\"realHost\" \"cpu\"=\"cpu0\"", now.UnixNano()/1000000000)}
@@ -238,7 +241,8 @@ func TestSerializeMetricBoolFalse(t *testing.T) {
 	m := metric.New("cpu", tags, fields, now)
 
 	s := &Serializer{}
-	buf, _ := s.Serialize(m)
+	buf, err := s.Serialize(m)
+	require.NoError(t, err)
 	mS := strings.Split(strings.TrimSpace(string(buf)), "\n")
 
 	expS := []string{fmt.Sprintf("\"cpu.usage.idle\" 0.000000 %d source=\"realHost\" \"cpu\"=\"cpu0\"", now.UnixNano()/1000000000)}


### PR DESCRIPTION
## Summary
Fixes errcheck warnings in all files/directories in the `plugins/` directory besides input and output plugins. Separated this way to split the PR size roughly in half for ease of reviewing

## Checklist
- [X] No AI generated code was used in this PR

## Related issues
part of #13013
