### PR TITLE
chore: Update golangci-lint from v1.58.0 to v1.59.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,7 +106,7 @@ jobs:
       - run: 'make check-deps'
       - run:
           name: "Install golangci-lint"
-          command: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.58.0
+          command: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.59.0
       - run:
           name: "golangci-lint/Linux"
           command: GOGC=80 GOMEMLIMIT=6656MiB /go/bin/golangci-lint run --verbose
@@ -117,7 +117,7 @@ jobs:
       - check-changed-files-or-halt
       - run:
           name: "Install golangci-lint"
-          command: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.58.0
+          command: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.59.0
       - run:
           name: "golangci-lint/macOS"
           command: GOGC=80 GOMEMLIMIT=6656MiB GOOS=darwin /go/bin/golangci-lint run --verbose --timeout=30m
@@ -129,7 +129,7 @@ jobs:
       - check-changed-files-or-halt
       - run:
           name: "Install golangci-lint"
-          command: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.58.0
+          command: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.59.0
       - run:
           name: "golangci-lint/Windows"
           command: GOGC=80 GOMEMLIMIT=6656MiB GOOS=windows /go/bin/golangci-lint run --verbose --timeout=30m

--- a/Makefile
+++ b/Makefile
@@ -180,7 +180,7 @@ vet:
 .PHONY: lint-install
 lint-install:
 	@echo "Installing golangci-lint"
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.58.0
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.59.0
 
 	@echo "Installing markdownlint"
 	npm install -g markdownlint-cli

--- a/models/running_output_test.go
+++ b/models/running_output_test.go
@@ -592,7 +592,7 @@ func TestRetryableStartupBehaviorRetry(t *testing.T) {
 
 	// For retry, Connect() should succeed even though there is an error but
 	// should return an error on Write() until we successfully connect.
-	require.NoError(t, ro.Connect(), serr)
+	require.NotErrorIs(t, ro.Connect(), serr)
 	require.False(t, ro.started)
 
 	ro.AddMetric(testutil.TestMetric(1))
@@ -724,7 +724,7 @@ func TestPartiallyStarted(t *testing.T) {
 
 	// For retry, Connect() should succeed even though there is an error but
 	// should return an error on Write() until we successfully connect.
-	require.NoError(t, ro.Connect(), serr)
+	require.NotErrorIs(t, ro.Connect(), serr)
 	require.False(t, ro.started)
 
 	ro.AddMetric(testutil.TestMetric(1))

--- a/plugins/inputs/directory_monitor/directory_monitor.go
+++ b/plugins/inputs/directory_monitor/directory_monitor.go
@@ -341,7 +341,7 @@ func (monitor *DirectoryMonitor) moveFile(srcPath string, dstBaseDir string) {
 	// creates those subdirectories.
 	basePath := strings.Replace(srcPath, monitor.Directory, "", 1)
 	dstPath := filepath.Join(dstBaseDir, basePath)
-	err := os.MkdirAll(filepath.Dir(dstPath), os.ModePerm)
+	err := os.MkdirAll(filepath.Dir(dstPath), 0750)
 	if err != nil {
 		monitor.Log.Errorf("Error creating directory hierarchy for " + srcPath + ". Error: " + err.Error())
 	}

--- a/plugins/inputs/directory_monitor/directory_monitor_test.go
+++ b/plugins/inputs/directory_monitor/directory_monitor_test.go
@@ -578,7 +578,7 @@ func TestParseSubdirectories(t *testing.T) {
 	require.NoError(t, err)
 
 	// Write json file to process into a subdirectory in the 'process' directory.
-	err = os.Mkdir(filepath.Join(processDirectory, "sub"), os.ModePerm)
+	err = os.Mkdir(filepath.Join(processDirectory, "sub"), 0750)
 	require.NoError(t, err)
 	f, err = os.Create(filepath.Join(processDirectory, "sub", testJSONFile))
 	require.NoError(t, err)
@@ -656,7 +656,7 @@ func TestParseSubdirectoriesFilesIgnore(t *testing.T) {
 	require.NoError(t, err)
 
 	// Write json file to process into a subdirectory in the 'process' directory.
-	err = os.Mkdir(filepath.Join(processDirectory, "sub"), os.ModePerm)
+	err = os.Mkdir(filepath.Join(processDirectory, "sub"), 0750)
 	require.NoError(t, err)
 	f, err = os.Create(filepath.Join(processDirectory, "sub", testJSONFile))
 	require.NoError(t, err)

--- a/plugins/inputs/linux_cpu/linux_cpu_test.go
+++ b/plugins/inputs/linux_cpu/linux_cpu_test.go
@@ -30,7 +30,7 @@ func TestNoCPUs(t *testing.T) {
 func TestNoCPUMetrics(t *testing.T) {
 	td := t.TempDir()
 
-	require.NoError(t, os.MkdirAll(td+"/devices/system/cpu/cpu0/cpufreq", os.ModePerm))
+	require.NoError(t, os.MkdirAll(td+"/devices/system/cpu/cpu0/cpufreq", 0750))
 
 	plugin := &LinuxCPU{
 		Log:       testutil.Logger{Name: "LinuxCPUPluginTest"},
@@ -43,12 +43,12 @@ func TestNoCPUMetrics(t *testing.T) {
 func TestGatherCPUFreq(t *testing.T) {
 	td := t.TempDir()
 
-	require.NoError(t, os.MkdirAll(td+"/devices/system/cpu/cpu0/cpufreq", os.ModePerm))
+	require.NoError(t, os.MkdirAll(td+"/devices/system/cpu/cpu0/cpufreq", 0750))
 	require.NoError(t, os.WriteFile(td+"/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq", []byte("250\n"), 0640))
 	require.NoError(t, os.WriteFile(td+"/devices/system/cpu/cpu0/cpufreq/scaling_min_freq", []byte("100\n"), 0640))
 	require.NoError(t, os.WriteFile(td+"/devices/system/cpu/cpu0/cpufreq/scaling_max_freq", []byte("255\n"), 0640))
 
-	require.NoError(t, os.MkdirAll(td+"/devices/system/cpu/cpu1/cpufreq", os.ModePerm))
+	require.NoError(t, os.MkdirAll(td+"/devices/system/cpu/cpu1/cpufreq", 0750))
 	require.NoError(t, os.WriteFile(td+"/devices/system/cpu/cpu1/cpufreq/scaling_cur_freq", []byte("123\n"), 0640))
 	require.NoError(t, os.WriteFile(td+"/devices/system/cpu/cpu1/cpufreq/scaling_min_freq", []byte("80\n"), 0640))
 	require.NoError(t, os.WriteFile(td+"/devices/system/cpu/cpu1/cpufreq/scaling_max_freq", []byte("230\n"), 0640))
@@ -91,7 +91,7 @@ func TestGatherCPUFreq(t *testing.T) {
 func TestGatherThermal(t *testing.T) {
 	td := t.TempDir()
 
-	require.NoError(t, os.MkdirAll(td+"/devices/system/cpu/cpu0/thermal_throttle", os.ModePerm))
+	require.NoError(t, os.MkdirAll(td+"/devices/system/cpu/cpu0/thermal_throttle", 0750))
 	require.NoError(t, os.WriteFile(td+"/devices/system/cpu/cpu0/thermal_throttle/core_throttle_count", []byte("250\n"), 0640))
 	require.NoError(t, os.WriteFile(td+"/devices/system/cpu/cpu0/thermal_throttle/core_throttle_max_time_ms", []byte("100\n"), 0640))
 	require.NoError(t, os.WriteFile(td+"/devices/system/cpu/cpu0/thermal_throttle/core_throttle_total_time_ms", []byte("255\n"), 0640))
@@ -117,7 +117,7 @@ func TestGatherThermal(t *testing.T) {
 func TestGatherPropertyRemoved(t *testing.T) {
 	td := t.TempDir()
 
-	require.NoError(t, os.MkdirAll(td+"/devices/system/cpu/cpu0/cpufreq", os.ModePerm))
+	require.NoError(t, os.MkdirAll(td+"/devices/system/cpu/cpu0/cpufreq", 0750))
 	require.NoError(t, os.WriteFile(td+"/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq", []byte("250\n"), 0640))
 	require.NoError(t, os.WriteFile(td+"/devices/system/cpu/cpu0/cpufreq/scaling_min_freq", []byte("100\n"), 0640))
 	require.NoError(t, os.WriteFile(td+"/devices/system/cpu/cpu0/cpufreq/scaling_max_freq", []byte("255\n"), 0640))
@@ -153,7 +153,7 @@ func TestGatherPropertyRemoved(t *testing.T) {
 func TestGatherPropertyInvalid(t *testing.T) {
 	td := t.TempDir()
 
-	require.NoError(t, os.MkdirAll(td+"/devices/system/cpu/cpu0/cpufreq", os.ModePerm))
+	require.NoError(t, os.MkdirAll(td+"/devices/system/cpu/cpu0/cpufreq", 0750))
 	require.NoError(t, os.WriteFile(td+"/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq", []byte("ABC\n"), 0640))
 	require.NoError(t, os.WriteFile(td+"/devices/system/cpu/cpu0/cpufreq/scaling_min_freq", []byte("100\n"), 0640))
 	require.NoError(t, os.WriteFile(td+"/devices/system/cpu/cpu0/cpufreq/scaling_max_freq", []byte("255\n"), 0640))


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
We certainly should not be using 777 permissions anywhere, the directory monitor change is the only possible regression here. The others are all in tests.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR
