### PR TITLE
feat(outputs.elasticsearch): Allow settings extra headers for elasticsearch output

### DIFF
--- a/plugins/outputs/elasticsearch/README.md
+++ b/plugins/outputs/elasticsearch/README.md
@@ -323,6 +323,11 @@ to use them.
   ## no pipeline is used for the metric.
   # use_pipeline = "{{es_pipeline}}"
   # default_pipeline = "my_pipeline"
+  #
+  # Custom HTTP headers
+  # To pass custom HTTP headers please define it in a given below section
+  # [outputs.elasticsearch.headers]
+  #    "X-Custom-Header" = "custom-value"
 ```
 
 ### Permissions
@@ -389,6 +394,8 @@ the `default_tag_value` will be used instead.
   instead.
 * `default_pipeline`: If dynamic pipeline names the tag does not exist in a
   particular metric, this value will be used instead.
+* `headers`: Custom HTTP headers, which are passed to Elasticsearch header
+  before each request.
 
 ## Known issues
 

--- a/plugins/outputs/elasticsearch/elasticsearch.go
+++ b/plugins/outputs/elasticsearch/elasticsearch.go
@@ -28,26 +28,27 @@ import (
 var sampleConfig string
 
 type Elasticsearch struct {
-	AuthBearerToken     config.Secret   `toml:"auth_bearer_token"`
-	DefaultPipeline     string          `toml:"default_pipeline"`
-	DefaultTagValue     string          `toml:"default_tag_value"`
-	EnableGzip          bool            `toml:"enable_gzip"`
-	EnableSniffer       bool            `toml:"enable_sniffer"`
-	FloatHandling       string          `toml:"float_handling"`
-	FloatReplacement    float64         `toml:"float_replacement_value"`
-	ForceDocumentID     bool            `toml:"force_document_id"`
-	HealthCheckInterval config.Duration `toml:"health_check_interval"`
-	HealthCheckTimeout  config.Duration `toml:"health_check_timeout"`
-	IndexName           string          `toml:"index_name"`
-	ManageTemplate      bool            `toml:"manage_template"`
-	OverwriteTemplate   bool            `toml:"overwrite_template"`
-	Username            config.Secret   `toml:"username"`
-	Password            config.Secret   `toml:"password"`
-	TemplateName        string          `toml:"template_name"`
-	Timeout             config.Duration `toml:"timeout"`
-	URLs                []string        `toml:"urls"`
-	UsePipeline         string          `toml:"use_pipeline"`
-	Log                 telegraf.Logger `toml:"-"`
+	AuthBearerToken     config.Secret     `toml:"auth_bearer_token"`
+	DefaultPipeline     string            `toml:"default_pipeline"`
+	DefaultTagValue     string            `toml:"default_tag_value"`
+	EnableGzip          bool              `toml:"enable_gzip"`
+	EnableSniffer       bool              `toml:"enable_sniffer"`
+	FloatHandling       string            `toml:"float_handling"`
+	FloatReplacement    float64           `toml:"float_replacement_value"`
+	ForceDocumentID     bool              `toml:"force_document_id"`
+	HealthCheckInterval config.Duration   `toml:"health_check_interval"`
+	HealthCheckTimeout  config.Duration   `toml:"health_check_timeout"`
+	IndexName           string            `toml:"index_name"`
+	ManageTemplate      bool              `toml:"manage_template"`
+	OverwriteTemplate   bool              `toml:"overwrite_template"`
+	Username            config.Secret     `toml:"username"`
+	Password            config.Secret     `toml:"password"`
+	TemplateName        string            `toml:"template_name"`
+	Timeout             config.Duration   `toml:"timeout"`
+	URLs                []string          `toml:"urls"`
+	UsePipeline         string            `toml:"use_pipeline"`
+	Headers             map[string]string `toml:"headers"`
+	Log                 telegraf.Logger   `toml:"-"`
 	majorReleaseNumber  int
 	pipelineName        string
 	pipelineTagKeys     []string
@@ -182,6 +183,16 @@ func (a *Elasticsearch) Connect() error {
 		elastic.SetHealthcheckTimeout(time.Duration(a.HealthCheckTimeout)),
 		elastic.SetGzip(a.EnableGzip),
 	)
+
+	if len(a.Headers) > 0 {
+		headers := http.Header{}
+		for k, vals := range a.Headers {
+			for _, v := range strings.Split(vals, ",") {
+				headers.Add(k, v)
+			}
+		}
+		clientOptions = append(clientOptions, elastic.SetHeaders(headers))
+	}
 
 	authOptions, err := a.getAuthOptions()
 	if err != nil {

--- a/plugins/outputs/elasticsearch/sample.conf
+++ b/plugins/outputs/elasticsearch/sample.conf
@@ -77,3 +77,8 @@
   ## no pipeline is used for the metric.
   # use_pipeline = "{{es_pipeline}}"
   # default_pipeline = "my_pipeline"
+  #
+  # Custom HTTP headers
+  # To pass custom HTTP headers please define it in a given below section
+  # [outputs.elasticsearch.headers]
+  #    "X-Custom-Header" = "custom-value"


### PR DESCRIPTION
## Summary
Allow settings extra headers for elasticsearch output's client

## Checklist
- [x] No AI generated code was used in this PR

## Related issues
resolves #15476
