### PR TITLE
chore(linters): Bump golangci-lint to v1.59.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,7 +106,7 @@ jobs:
       - run: 'make check-deps'
       - run:
           name: "Install golangci-lint"
-          command: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.59.0
+          command: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.59.1
       - run:
           name: "golangci-lint/Linux"
           command: GOGC=80 GOMEMLIMIT=6656MiB /go/bin/golangci-lint run --verbose
@@ -117,7 +117,7 @@ jobs:
       - check-changed-files-or-halt
       - run:
           name: "Install golangci-lint"
-          command: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.59.0
+          command: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.59.1
       - run:
           name: "golangci-lint/macOS"
           command: GOGC=80 GOMEMLIMIT=6656MiB GOOS=darwin /go/bin/golangci-lint run --verbose --timeout=30m
@@ -129,7 +129,7 @@ jobs:
       - check-changed-files-or-halt
       - run:
           name: "Install golangci-lint"
-          command: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.59.0
+          command: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.59.1
       - run:
           name: "golangci-lint/Windows"
           command: GOGC=80 GOMEMLIMIT=6656MiB GOOS=windows /go/bin/golangci-lint run --verbose --timeout=30m

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -289,7 +289,7 @@ linters-settings:
     # Enable checkers by name
     # (in addition to default
     #   blank-import, bool-compare, compares, empty, error-is-as, error-nil, expected-actual, go-require, float-compare,
-    #   len, nil-compare, require-error, suite-dont-use-pkg, suite-extra-assert-call, useless-assert
+    #   len, negative-positive, nil-compare, require-error, suite-dont-use-pkg, suite-extra-assert-call, useless-assert
     # ).
     enable:
       - bool-compare
@@ -388,7 +388,19 @@ issues:
 # output configuration options
 output:
   # The formats used to render issues.
-  # Format: `colored-line-number`, `line-number`, `json`, `colored-tab`, `tab`, `checkstyle`, `code-climate`, `junit-xml`, `github-actions`, `teamcity`
+  # Formats:
+  # - `colored-line-number`
+  # - `line-number`
+  # - `json`
+  # - `colored-tab`
+  # - `tab`
+  # - `html`
+  # - `checkstyle`
+  # - `code-climate`
+  # - `junit-xml`
+  # - `github-actions`
+  # - `teamcity`
+  # - `sarif`
   # Output path can be either `stdout`, `stderr` or path to the file to write to.
   #
   # For the CLI flag (`--out-format`), multiple formats can be specified by separating them by comma.

--- a/Makefile
+++ b/Makefile
@@ -180,7 +180,7 @@ vet:
 .PHONY: lint-install
 lint-install:
 	@echo "Installing golangci-lint"
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.59.0
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.59.1
 
 	@echo "Installing markdownlint"
 	npm install -g markdownlint-cli

--- a/plugins/inputs/cloudwatch/cloudwatch.go
+++ b/plugins/inputs/cloudwatch/cloudwatch.go
@@ -173,7 +173,8 @@ func (c *CloudWatch) Gather(acc telegraf.Accumulator) error {
 	}
 
 	wg.Wait()
-	return c.aggregateMetrics(acc, results)
+	c.aggregateMetrics(acc, results)
+	return nil
 }
 
 func (c *CloudWatch) initializeCloudWatch() error {
@@ -455,13 +456,8 @@ func (c *CloudWatch) gatherMetrics(
 	return results, nil
 }
 
-func (c *CloudWatch) aggregateMetrics(
-	acc telegraf.Accumulator,
-	metricDataResults map[string][]types.MetricDataResult,
-) error {
-	var (
-		grouper = internalMetric.NewSeriesGrouper()
-	)
+func (c *CloudWatch) aggregateMetrics(acc telegraf.Accumulator, metricDataResults map[string][]types.MetricDataResult) {
+	var grouper = internalMetric.NewSeriesGrouper()
 
 	for namespace, results := range metricDataResults {
 		namespace = sanitizeMeasurement(namespace)
@@ -497,8 +493,6 @@ func (c *CloudWatch) aggregateMetrics(
 	for _, metric := range grouper.Metrics() {
 		acc.AddMetric(metric)
 	}
-
-	return nil
 }
 
 func init() {

--- a/plugins/inputs/cloudwatch/cloudwatch.go
+++ b/plugins/inputs/cloudwatch/cloudwatch.go
@@ -457,8 +457,7 @@ func (c *CloudWatch) gatherMetrics(
 }
 
 func (c *CloudWatch) aggregateMetrics(acc telegraf.Accumulator, metricDataResults map[string][]types.MetricDataResult) {
-	var grouper = internalMetric.NewSeriesGrouper()
-
+	grouper := internalMetric.NewSeriesGrouper()
 	for namespace, results := range metricDataResults {
 		namespace = sanitizeMeasurement(namespace)
 

--- a/plugins/inputs/dovecot/dovecot.go
+++ b/plugins/inputs/dovecot/dovecot.go
@@ -117,10 +117,11 @@ func (d *Dovecot) gatherServer(addr string, acc telegraf.Accumulator, qtype stri
 		host, _, _ = net.SplitHostPort(addr)
 	}
 
-	return gatherStats(&buf, acc, host, qtype)
+	gatherStats(&buf, acc, host, qtype)
+	return nil
 }
 
-func gatherStats(buf *bytes.Buffer, acc telegraf.Accumulator, host string, qtype string) error {
+func gatherStats(buf *bytes.Buffer, acc telegraf.Accumulator, host string, qtype string) {
 	lines := strings.Split(buf.String(), "\n")
 	head := strings.Split(lines[0], "\t")
 	vals := lines[1:]
@@ -154,8 +155,6 @@ func gatherStats(buf *bytes.Buffer, acc telegraf.Accumulator, host string, qtype
 
 		acc.AddFields("dovecot", fields, tags)
 	}
-
-	return nil
 }
 
 func splitSec(tm string) (sec int64, msec int64) {

--- a/plugins/inputs/dovecot/dovecot_test.go
+++ b/plugins/inputs/dovecot/dovecot_test.go
@@ -94,27 +94,21 @@ func TestDovecotIntegration(t *testing.T) {
 	tags = map[string]string{"server": "dovecot.test", "type": "global"}
 	buf := bytes.NewBufferString(sampleGlobal)
 
-	err = gatherStats(buf, &acc, "dovecot.test", "global")
-	require.NoError(t, err)
-
+	gatherStats(buf, &acc, "dovecot.test", "global")
 	acc.AssertContainsTaggedFields(t, "dovecot", fields, tags)
 
 	// Test type=domain
 	tags = map[string]string{"server": "dovecot.test", "type": "domain", "domain": "domain.test"}
 	buf = bytes.NewBufferString(sampleDomain)
 
-	err = gatherStats(buf, &acc, "dovecot.test", "domain")
-	require.NoError(t, err)
-
+	gatherStats(buf, &acc, "dovecot.test", "domain")
 	acc.AssertContainsTaggedFields(t, "dovecot", fields, tags)
 
 	// Test type=ip
 	tags = map[string]string{"server": "dovecot.test", "type": "ip", "ip": "192.168.0.100"}
 	buf = bytes.NewBufferString(sampleIP)
 
-	err = gatherStats(buf, &acc, "dovecot.test", "ip")
-	require.NoError(t, err)
-
+	gatherStats(buf, &acc, "dovecot.test", "ip")
 	acc.AssertContainsTaggedFields(t, "dovecot", fields, tags)
 
 	// Test type=user
@@ -146,9 +140,7 @@ func TestDovecotIntegration(t *testing.T) {
 	tags = map[string]string{"server": "dovecot.test", "type": "user", "user": "user.1@domain.test"}
 	buf = bytes.NewBufferString(sampleUser)
 
-	err = gatherStats(buf, &acc, "dovecot.test", "user")
-	require.NoError(t, err)
-
+	gatherStats(buf, &acc, "dovecot.test", "user")
 	acc.AssertContainsTaggedFields(t, "dovecot", fields, tags)
 }
 

--- a/plugins/inputs/http_response/http_response.go
+++ b/plugins/inputs/http_response/http_response.go
@@ -293,7 +293,7 @@ func (h *HTTPResponse) httpGather(u string) (map[string]interface{}, map[string]
 		return fields, tags, nil
 	} else if err != nil {
 		h.setBodyReadError("Failed to read body of HTTP Response : "+err.Error(), bodyBytes, fields, tags)
-		return fields, tags, nil //nolint:nilerr // error is handled properly
+		return fields, tags, nil
 	}
 
 	// Add the body of the response if expected

--- a/plugins/inputs/logparser/logparser.go
+++ b/plugins/inputs/logparser/logparser.go
@@ -96,7 +96,9 @@ func (l *LogParserPlugin) Gather(_ telegraf.Accumulator) error {
 	defer l.Unlock()
 
 	// always start from the beginning of files that appear while we're running
-	return l.tailNewfiles(true)
+	l.tailNewFiles(true)
+
+	return nil
 }
 
 // Start kicks off collection of stats for the plugin
@@ -134,7 +136,7 @@ func (l *LogParserPlugin) Start(acc telegraf.Accumulator) error {
 	l.wg.Add(1)
 	go l.parser()
 
-	err = l.tailNewfiles(l.FromBeginning)
+	l.tailNewFiles(l.FromBeginning)
 
 	// clear offsets
 	l.offsets = make(map[string]int64)
@@ -143,12 +145,12 @@ func (l *LogParserPlugin) Start(acc telegraf.Accumulator) error {
 	offsets = make(map[string]int64)
 	offsetsMutex.Unlock()
 
-	return err
+	return nil
 }
 
 // check the globs against files on disk, and start tailing any new files.
 // Assumes l's lock is held!
-func (l *LogParserPlugin) tailNewfiles(fromBeginning bool) error {
+func (l *LogParserPlugin) tailNewFiles(fromBeginning bool) {
 	var poll bool
 	if l.WatchMethod == "poll" {
 		poll = true
@@ -207,8 +209,6 @@ func (l *LogParserPlugin) tailNewfiles(fromBeginning bool) error {
 			l.tailers[file] = tailer
 		}
 	}
-
-	return nil
 }
 
 // receiver is launched as a goroutine to continuously watch a tailed logfile

--- a/plugins/inputs/net_response/net_response.go
+++ b/plugins/inputs/net_response/net_response.go
@@ -122,14 +122,14 @@ func (n *NetResponse) UDPGather() (map[string]string, map[string]interface{}, er
 	// Handle error
 	if err != nil {
 		setResult(ConnectionFailed, fields, tags, n.Expect)
-		return tags, fields, nil //nolint:nilerr // error encoded in result
+		return tags, fields, nil
 	}
 	// Connecting
 	conn, err := net.DialUDP("udp", nil, udpAddr)
 	// Handle error
 	if err != nil {
 		setResult(ConnectionFailed, fields, tags, n.Expect)
-		return tags, fields, nil //nolint:nilerr // error encoded in result
+		return tags, fields, nil
 	}
 	defer conn.Close()
 	// Send string
@@ -150,7 +150,7 @@ func (n *NetResponse) UDPGather() (map[string]string, map[string]interface{}, er
 	// Handle error
 	if err != nil {
 		setResult(ReadFailed, fields, tags, n.Expect)
-		return tags, fields, nil //nolint:nilerr // error encoded in result
+		return tags, fields, nil
 	}
 
 	// Looking for string in answer

--- a/plugins/inputs/raindrops/raindrops.go
+++ b/plugins/inputs/raindrops/raindrops.go
@@ -149,7 +149,7 @@ func (r *Raindrops) gatherURL(addr *url.URL, acc telegraf.Accumulator) error {
 		}
 		acc.AddFields("raindrops_listen", lis, tags)
 	}
-	return nil //nolint:nilerr // nil returned on purpose
+	return nil
 }
 
 // Get tag(s) for the raindrops calling/writing plugin

--- a/plugins/inputs/sqlserver/sqlserver.go
+++ b/plugins/inputs/sqlserver/sqlserver.go
@@ -510,6 +510,7 @@ func (s *SQLServer) getTokenProvider() (func() (string, error), error) {
 	}
 
 	// return acquired token
+	//nolint:unparam // token provider function always returns nil error in this scenario
 	return func() (string, error) {
 		return tokenString, nil
 	}, nil

--- a/plugins/inputs/win_eventlog/win_eventlog.go
+++ b/plugins/inputs/win_eventlog/win_eventlog.go
@@ -432,7 +432,7 @@ func (w *WinEventLog) renderEvent(eventHandle EvtHandle) (Event, error) {
 func (w *WinEventLog) renderLocalMessage(event Event, eventHandle EvtHandle) (Event, error) {
 	publisherHandle, err := openPublisherMetadata(0, event.Source.Name, w.Locale)
 	if err != nil {
-		return event, nil //nolint:nilerr // We can return event without most values
+		return event, nil
 	}
 	defer _EvtClose(publisherHandle) //nolint:errcheck // Ignore error returned during Close
 


### PR DESCRIPTION
- `golangci-lint` bumped to `v1.59.1`
- Addressing numerous findings caused by updates in several linters:
```
plugins/inputs/cloudwatch/cloudwatch.go:461:3         unparam     (*CloudWatch).aggregateMetrics - result 0 (error) is always nil
plugins/inputs/dovecot/dovecot.go:123:90              unparam     gatherStats - result 0 (error) is always nil
plugins/inputs/http_response/http_response.go:296:28  nolintlint  directive `//nolint:nilerr // error is handled properly` is unused for linter "nilerr"
plugins/inputs/logparser/logparser.go:151:60          unparam     (*LogParserPlugin).tailNewfiles - result 0 (error) is always nil
plugins/inputs/net_response/net_response.go:125:28    nolintlint  directive `//nolint:nilerr // error encoded in result` is unused for linter "nilerr"
plugins/inputs/net_response/net_response.go:132:28    nolintlint  directive `//nolint:nilerr // error encoded in result` is unused for linter "nilerr"
plugins/inputs/net_response/net_response.go:153:28    nolintlint  directive `//nolint:nilerr // error encoded in result` is unused for linter "nilerr"
plugins/inputs/raindrops/raindrops.go:152:13          nolintlint  directive `//nolint:nilerr // nil returned on purpose` is unused for linter "nilerr"
plugins/inputs/sqlserver/sqlserver.go:513:25          unparam     (*SQLServer).getTokenProvider$1 - result 1 (error) is always nil
```
- Matching the configuration file to the example from https://github.com/golangci/golangci-lint/blob/master/.golangci.reference.yml.

