### PR TITLE
feat(inputs.mqtt_consumer): Implement startup error behaviors

### DIFF
--- a/plugins/inputs/mqtt_consumer/README.md
+++ b/plugins/inputs/mqtt_consumer/README.md
@@ -85,7 +85,7 @@ to use them.
   ## The sum of those options defines when a connection loss is detected.
   ## Note: The keep-alive interval needs to be in second granularity e.g. 1m
   ##       but not 100ms.
-  # keep_alive = "60s"
+  # keepalive = "60s"
   # ping_timeout = "10s"
 
   ## Max undelivered messages

--- a/plugins/inputs/mqtt_consumer/README.md
+++ b/plugins/inputs/mqtt_consumer/README.md
@@ -83,8 +83,8 @@ to use them.
 
   ## Interval and ping timeout for keep-alive messages
   ## The sum of those options defines when a connection loss is detected.
-  ## Note: The keep-alive interval needs to be in second granularity e.g. 1m
-  ##       but not 100ms.
+  ## Note: The keep-alive interval needs to be greater or equal one second and
+  ## fractions of a second are not supported.
   # keepalive = "60s"
   # ping_timeout = "10s"
 

--- a/plugins/inputs/mqtt_consumer/README.md
+++ b/plugins/inputs/mqtt_consumer/README.md
@@ -81,6 +81,13 @@ to use them.
   ## Connection timeout for initial connection in seconds
   # connection_timeout = "30s"
 
+  ## Interval and ping timeout for keep-alive messages
+  ## The sum of those options defines when a connection loss is detected.
+  ## Note: The keep-alive interval needs to be in second granularity e.g. 1m
+  ##       but not 100ms.
+  # keep_alive = "60s"
+  # ping_timeout = "10s"
+
   ## Max undelivered messages
   ## This plugin uses tracking metrics, which ensure messages are read to
   ## outputs before acknowledging them to the original broker to ensure data

--- a/plugins/inputs/mqtt_consumer/README.md
+++ b/plugins/inputs/mqtt_consumer/README.md
@@ -23,6 +23,20 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 [CONFIGURATION.md]: ../../../docs/CONFIGURATION.md#plugins
 
+## Startup error behavior options <!-- @/docs/includes/startup_error_behavior.md -->
+
+In addition to the plugin-specific and global configuration settings the plugin
+supports options for specifying the behavior when experiencing startup errors
+using the `startup_error_behavior` setting. Available values are:
+
+- `error`:  Telegraf with stop and exit in case of startup errors. This is the
+            default behavior.
+- `ignore`: Telegraf will ignore startup errors for this plugin and disables it
+            but continues processing for all other plugins.
+- `retry`:  Telegraf will try to startup the plugin in every gather or write
+            cycle in case of startup errors. The plugin is disabled until
+            the startup succeeds.
+
 ## Secret-store support
 
 This plugin supports secrets from secret-stores for the `username` and

--- a/plugins/inputs/mqtt_consumer/mqtt_consumer.go
+++ b/plugins/inputs/mqtt_consumer/mqtt_consumer.go
@@ -68,7 +68,7 @@ type MQTTConsumer struct {
 	Password               config.Secret        `toml:"password"`
 	QoS                    int                  `toml:"qos"`
 	ConnectionTimeout      config.Duration      `toml:"connection_timeout"`
-	KeepAliveInterval      config.Duration      `toml:"keep_alive"`
+	KeepAliveInterval      config.Duration      `toml:"keepalive"`
 	PingTimeout            config.Duration      `toml:"ping_timeout"`
 	MaxUndeliveredMessages int                  `toml:"max_undelivered_messages"`
 	PersistentSession      bool                 `toml:"persistent_session"`

--- a/plugins/inputs/mqtt_consumer/mqtt_consumer.go
+++ b/plugins/inputs/mqtt_consumer/mqtt_consumer.go
@@ -182,6 +182,7 @@ func (m *MQTTConsumer) connect() error {
 			// Network errors might be retryable, stop the metric-tracking
 			// goroutine and return a retryable error.
 			m.cancel()
+			m.cancel = nil
 			return &internal.StartupError{
 				Err:   token.Error(),
 				Retry: true,
@@ -327,6 +328,9 @@ func (m *MQTTConsumer) Stop() {
 }
 func (m *MQTTConsumer) Gather(_ telegraf.Accumulator) error {
 	if !m.client.IsConnected() {
+		if m.cancel == nil {
+			return internal.ErrNotConnected
+		}
 		m.Log.Debugf("Connecting %v", m.Servers)
 		return m.connect()
 	}

--- a/plugins/inputs/mqtt_consumer/mqtt_consumer.go
+++ b/plugins/inputs/mqtt_consumer/mqtt_consumer.go
@@ -183,8 +183,10 @@ func (m *MQTTConsumer) connect() error {
 		if ct, ok := token.(*mqtt.ConnectToken); ok && ct.ReturnCode() == packets.ErrNetworkError {
 			// Network errors might be retryable, stop the metric-tracking
 			// goroutine and return a retryable error.
-			m.cancel()
-			m.cancel = nil
+			if m.cancel != nil {
+				m.cancel()
+				m.cancel = nil
+			}
 			return &internal.StartupError{
 				Err:   token.Error(),
 				Retry: true,

--- a/plugins/inputs/mqtt_consumer/mqtt_consumer.go
+++ b/plugins/inputs/mqtt_consumer/mqtt_consumer.go
@@ -328,9 +328,6 @@ func (m *MQTTConsumer) Stop() {
 }
 func (m *MQTTConsumer) Gather(_ telegraf.Accumulator) error {
 	if !m.client.IsConnected() {
-		if m.cancel == nil {
-			return internal.ErrNotConnected
-		}
 		m.Log.Debugf("Connecting %v", m.Servers)
 		return m.connect()
 	}

--- a/plugins/inputs/mqtt_consumer/mqtt_consumer_test.go
+++ b/plugins/inputs/mqtt_consumer/mqtt_consumer_test.go
@@ -723,6 +723,7 @@ func TestStartupErrorBehaviorErrorIntegration(t *testing.T) {
 			Alias: "error-test", // required to get a unique error stats instance
 		},
 	)
+	model.StartupErrors.Set(0)
 	require.NoError(t, model.Init())
 
 	// Starting the plugin will fail with an error because the container is paused.
@@ -770,6 +771,7 @@ func TestStartupErrorBehaviorIgnoreIntegration(t *testing.T) {
 	parser := &influx.Parser{}
 	require.NoError(t, parser.Init())
 	plugin.SetParser(parser)
+
 	// Create a model to be able to use the startup retry strategy
 	model := models.NewRunningInput(
 		plugin,
@@ -779,6 +781,7 @@ func TestStartupErrorBehaviorIgnoreIntegration(t *testing.T) {
 			StartupErrorBehavior: "ignore",
 		},
 	)
+	model.StartupErrors.Set(0)
 	require.NoError(t, model.Init())
 
 	// Starting the plugin will fail because the container is paused.
@@ -841,7 +844,9 @@ func TestStartupErrorBehaviorRetryIntegration(t *testing.T) {
 			StartupErrorBehavior: "retry",
 		},
 	)
+	model.StartupErrors.Set(0)
 	require.NoError(t, model.Init())
+
 	var acc testutil.Accumulator
 	require.NoError(t, model.Start(&acc))
 

--- a/plugins/inputs/mqtt_consumer/mqtt_consumer_test.go
+++ b/plugins/inputs/mqtt_consumer/mqtt_consumer_test.go
@@ -719,7 +719,8 @@ func TestStartupErrorBehaviorErrorIntegration(t *testing.T) {
 	model := models.NewRunningInput(
 		plugin,
 		&models.InputConfig{
-			Name: "mqtt_consumer",
+			Name:  "mqtt_consumer",
+			Alias: "error-test", // required to get a unique error stats instance
 		},
 	)
 	require.NoError(t, model.Init())
@@ -774,6 +775,7 @@ func TestStartupErrorBehaviorIgnoreIntegration(t *testing.T) {
 		plugin,
 		&models.InputConfig{
 			Name:                 "mqtt_consumer",
+			Alias:                "ignore-test", // required to get a unique error stats instance
 			StartupErrorBehavior: "ignore",
 		},
 	)
@@ -835,6 +837,7 @@ func TestStartupErrorBehaviorRetryIntegration(t *testing.T) {
 		plugin,
 		&models.InputConfig{
 			Name:                 "mqtt_consumer",
+			Alias:                "retry-test", // required to get a unique error stats instance
 			StartupErrorBehavior: "retry",
 		},
 	)

--- a/plugins/inputs/mqtt_consumer/mqtt_consumer_test.go
+++ b/plugins/inputs/mqtt_consumer/mqtt_consumer_test.go
@@ -619,8 +619,10 @@ func TestIntegration(t *testing.T) {
 	plugin := &MQTTConsumer{
 		Servers:                []string{url},
 		Topics:                 []string{topic},
-		ConnectionTimeout:      config.Duration(5 * time.Second),
 		MaxUndeliveredMessages: defaultMaxUndeliveredMessages,
+		ConnectionTimeout:      config.Duration(5 * time.Second),
+		KeepAliveInterval:      config.Duration(1 * time.Second),
+		PingTimeout:            config.Duration(100 * time.Millisecond),
 		Log:                    testutil.Logger{Name: "mqtt-integration-test"},
 		clientFactory:          factory,
 	}
@@ -706,8 +708,10 @@ func TestStartupErrorBehaviorErrorIntegration(t *testing.T) {
 	plugin := &MQTTConsumer{
 		Servers:                []string{url},
 		Topics:                 []string{topic},
-		ConnectionTimeout:      config.Duration(5 * time.Second),
 		MaxUndeliveredMessages: defaultMaxUndeliveredMessages,
+		ConnectionTimeout:      config.Duration(5 * time.Second),
+		KeepAliveInterval:      config.Duration(1 * time.Second),
+		PingTimeout:            config.Duration(100 * time.Millisecond),
 		Log:                    testutil.Logger{Name: "mqtt-integration-test"},
 		clientFactory:          factory,
 	}
@@ -763,8 +767,10 @@ func TestStartupErrorBehaviorIgnoreIntegration(t *testing.T) {
 	plugin := &MQTTConsumer{
 		Servers:                []string{url},
 		Topics:                 []string{topic},
-		ConnectionTimeout:      config.Duration(5 * time.Second),
 		MaxUndeliveredMessages: defaultMaxUndeliveredMessages,
+		ConnectionTimeout:      config.Duration(5 * time.Second),
+		KeepAliveInterval:      config.Duration(1 * time.Second),
+		PingTimeout:            config.Duration(100 * time.Millisecond),
 		Log:                    testutil.Logger{Name: "mqtt-integration-test"},
 		clientFactory:          factory,
 	}
@@ -826,8 +832,10 @@ func TestStartupErrorBehaviorRetryIntegration(t *testing.T) {
 	plugin := &MQTTConsumer{
 		Servers:                []string{url},
 		Topics:                 []string{topic},
-		ConnectionTimeout:      config.Duration(5 * time.Second),
 		MaxUndeliveredMessages: defaultMaxUndeliveredMessages,
+		ConnectionTimeout:      config.Duration(5 * time.Second),
+		KeepAliveInterval:      config.Duration(1 * time.Second),
+		PingTimeout:            config.Duration(100 * time.Millisecond),
 		Log:                    testutil.Logger{Name: "mqtt-integration-test"},
 		clientFactory:          factory,
 	}

--- a/plugins/inputs/mqtt_consumer/sample.conf
+++ b/plugins/inputs/mqtt_consumer/sample.conf
@@ -32,8 +32,8 @@
 
   ## Interval and ping timeout for keep-alive messages
   ## The sum of those options defines when a connection loss is detected.
-  ## Note: The keep-alive interval needs to be in second granularity e.g. 1m
-  ##       but not 100ms.
+  ## Note: The keep-alive interval needs to be greater or equal one second and
+  ## fractions of a second are not supported.
   # keepalive = "60s"
   # ping_timeout = "10s"
 

--- a/plugins/inputs/mqtt_consumer/sample.conf
+++ b/plugins/inputs/mqtt_consumer/sample.conf
@@ -34,7 +34,7 @@
   ## The sum of those options defines when a connection loss is detected.
   ## Note: The keep-alive interval needs to be in second granularity e.g. 1m
   ##       but not 100ms.
-  # keep_alive = "60s"
+  # keepalive = "60s"
   # ping_timeout = "10s"
 
   ## Max undelivered messages

--- a/plugins/inputs/mqtt_consumer/sample.conf
+++ b/plugins/inputs/mqtt_consumer/sample.conf
@@ -30,6 +30,13 @@
   ## Connection timeout for initial connection in seconds
   # connection_timeout = "30s"
 
+  ## Interval and ping timeout for keep-alive messages
+  ## The sum of those options defines when a connection loss is detected.
+  ## Note: The keep-alive interval needs to be in second granularity e.g. 1m
+  ##       but not 100ms.
+  # keep_alive = "60s"
+  # ping_timeout = "10s"
+
   ## Max undelivered messages
   ## This plugin uses tracking metrics, which ensure messages are read to
   ## outputs before acknowledging them to the original broker to ensure data


### PR DESCRIPTION
## Summary

This PR allows to use the startup-error-behavior options `error`, `retry` and `ignore`. It furthermore provided integration test for the different options and one for a "normal" startup.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #10694
