### PR TITLE
chore(outputs.mqtt): Remove dead code

### DIFF
--- a/plugins/outputs/mqtt/mqtt.go
+++ b/plugins/outputs/mqtt/mqtt.go
@@ -269,11 +269,6 @@ func (m *MQTT) collectHomieV4(hostname string, metrics []telegraf.Metric) []mess
 		collection = append(collection, msgs...)
 
 		for _, tag := range metric.TagList() {
-			if err != nil {
-				m.Log.Warnf("Could not serialize metric for topic %q tag %q: %v", topic, tag.Key, err)
-				m.Log.Debugf("metric was: %v", metric)
-				continue
-			}
 			propID := normalizeID(tag.Key)
 			collection = append(collection,
 				message{path + "/" + propID, []byte(tag.Value)},


### PR DESCRIPTION
## Summary

The removed comparison can never be true as the error is not set in the for loop and checked before to be `nil`. This the code in the branch is dead and should be removed.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues
