### PR TITLE
fix(agent): Ignore startup-errors in test mode

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -436,7 +436,7 @@ func (a *Agent) runInputs(
 }
 
 // testStartInputs is a variation of startInputs for use in --test and --once
-// mode.  It differs by logging Start errors and returning only plugins
+// mode. It differs by logging Start errors and returning only plugins
 // successfully started.
 func (a *Agent) testStartInputs(
 	dst chan<- telegraf.Metric,
@@ -458,6 +458,7 @@ func (a *Agent) testStartInputs(
 
 		if err := input.Start(acc); err != nil {
 			log.Printf("E! [agent] Starting input %s: %v", input.LogName(), err)
+			continue
 		}
 
 		unit.inputs = append(unit.inputs, input)


### PR DESCRIPTION
## Summary

When running Telegraf with `--test` startup errors of plugins are supposed to be logged and the plugin to be ignored. However, currently the plugin is added to the processing units despite reporting errors on startup. Therefore, the `Gather()` method of those erroneous plugins is called leading to problems due to partial startup (or no startup at all). As an example the following configuration

```toml
[[inputs.openstack]]
  username = "admin"
  password = "password"
```
will cause Telegraf to panic because parts of the internal plugin structure are not initialized but `Gather()` is called.

The PR ignores plugins reporting startup errors and makes Telegraf to behave as expected in testing mode.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues
