### PR TITLE
fix(inputs.mysql): Replace "tls=custom" by "tls=tlsid" in the DSN before parsing it

### DIFF
--- a/plugins/inputs/mysql/mysql.go
+++ b/plugins/inputs/mysql/mysql.go
@@ -115,6 +115,19 @@ func (m *Mysql) Init() error {
 		}
 		dsn := dsnSecret.String()
 		dsnSecret.Destroy()
+		// We need to replace "tls=custom" in the DSN to use the tlsid generated instead.
+		// If not replaced, mysql.ParseDSN would look for a TLS Config named "custom" and
+		// would crash as the TLS Config needs to be present before parsing the DSN.
+		lastSlashIndex := strings.LastIndex(dsn, "/")
+		if lastSlashIndex != -1 {
+			// Split DSN by the last "/"
+			dsnBase := dsn[:lastSlashIndex]   
+			dsnQuery := dsn[lastSlashIndex:]  
+			// Replace "tls=custom" with "tls={tlsid}" in the query part
+			dsnQuery = strings.Replace(dsnQuery, "tls=custom", "tls="+tlsid, 1)
+			// Join the parts back together
+			dsn = dsnBase + dsnQuery
+		}
 		conf, err := mysql.ParseDSN(dsn)
 		if err != nil {
 			return fmt.Errorf("parsing %q failed: %w", dsn, err)


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
With the current implementation of inputs.mysql it is not possible to use a custom TLS configuration to authenticate as mysql.parseDSN() looks for a TLSConfig named "custom", that internally we are converting to "custom-{some random value}", so mysql.parseDSN() fails with the error: 
`tls: invalid value / unknown config name: custom`  
This fix avoids that error by replacing "custom" by the actual name of the TLSConfig that was created before parsing the DSN string.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #15490 
