### PR TITLE
chore(common.starlark): Print nonconvertible data

### DIFF
--- a/plugins/common/starlark/field_dict.go
+++ b/plugins/common/starlark/field_dict.go
@@ -2,6 +2,7 @@ package starlark
 
 import (
 	"errors"
+	"fmt"
 	"reflect"
 	"strings"
 
@@ -259,7 +260,7 @@ func asStarlarkValue(value interface{}) (starlark.Value, error) {
 		return starlark.Bool(v.Bool()), nil
 	}
 
-	return starlark.None, errors.New("invalid type")
+	return nil, fmt.Errorf("invalid type %T", value)
 }
 
 // AsGoValue converts a starlark.Value to a field value.
@@ -270,7 +271,7 @@ func asGoValue(value interface{}) (interface{}, error) {
 	case starlark.Int:
 		n, ok := v.Int64()
 		if !ok {
-			return nil, errors.New("cannot represent integer as int64")
+			return nil, fmt.Errorf("cannot represent integer %v as int64", v)
 		}
 		return n, nil
 	case starlark.String:
@@ -279,7 +280,7 @@ func asGoValue(value interface{}) (interface{}, error) {
 		return bool(v), nil
 	}
 
-	return nil, errors.New("invalid starlark type")
+	return nil, fmt.Errorf("invalid starlark type %T", value)
 }
 
 // ToFields converts a starlark.Value to a map of values.

--- a/plugins/processors/starlark/README.md
+++ b/plugins/processors/starlark/README.md
@@ -243,6 +243,20 @@ def apply(metric):
     return metric
 ```
 
+**What does `cannot represent integer ...` mean?**
+
+The error occurs if an integer value in starlark exceeds the signed 64 bit
+integer limit. This can occur if you are summing up large values in a starlark
+integer value or convert an unsigned 64 bit integer to starlark and then create
+a new metric field from it.
+
+This is due to the fact that integer values in starlark are *always* signed and
+can grow beyond the 64-bit size. Therefore converting the value back fails in
+the cases mentioned above.
+
+As a workaround you can either clip the field value at the signed 64-bit limit
+or return the value as a floating-point number.
+
 ### Examples
 
 - [drop string fields](testdata/drop_string_fields.star) - Drop fields containing string values.

--- a/plugins/processors/starlark/starlark_test.go
+++ b/plugins/processors/starlark/starlark_test.go
@@ -2572,7 +2572,7 @@ def apply(metric):
 			for _, m := range tt.input {
 				err = plugin.Add(m, &acc)
 				if tt.expectedErrorStr != "" {
-					require.EqualError(t, err, tt.expectedErrorStr)
+					require.ErrorContains(t, err, tt.expectedErrorStr)
 				} else {
 					require.NoError(t, err)
 				}


### PR DESCRIPTION
## Summary

Print nonconvertible data when being unable to convert a Starlark integer to `int64`. Furthermore, document the limitation in the README of the processor.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #15499
