### PR TITLE
fix(logging): Add back constants for backward compatibility

### DIFF
--- a/logger/default_logger.go
+++ b/logger/default_logger.go
@@ -15,6 +15,11 @@ import (
 
 var prefixRegex = regexp.MustCompile("^[DIWE]!")
 
+const (
+	LogTargetFile   = "file"
+	LogTargetStderr = "stderr"
+)
+
 type defaultLogger struct {
 	writer         io.Writer
 	internalWriter io.Writer
@@ -90,6 +95,6 @@ func createFileLogger(cfg Config) (io.WriteCloser, error) {
 }
 
 func init() {
-	registerLogger("stderr", createStderrLogger)
-	registerLogger("file", createFileLogger)
+	registerLogger(LogTargetStderr, createStderrLogger)
+	registerLogger(LogTargetFile, createFileLogger)
 }

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -25,7 +25,7 @@ func SetupLogging(cfg Config) error {
 	}
 
 	if cfg.LogTarget == "" {
-		cfg.LogTarget = "stderr"
+		cfg.LogTarget = LogTargetStderr
 	}
 
 	// Get the logging factory


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
 Before v1.31.0, Telegraf had some public constants inside logging package: https://github.com/influxdata/telegraf/blob/release-1.30/logger/logger.go#L20~#L23. Starting from v1.31.0, these constants are removed and hard-coded strings are used instead in the code. This seems to be a breaking change for some projects referring to these constants. This change is not announced in the release announcement of v1.31.0 as well. It would be great if we can add back those constants to Telegraf source code to have a consistent behavior as the historical code and avoid hard-coded string in the source code.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [X] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #15513
