### PR TITLE
feat(inputs.mqtt_consumer): Add variable length topic parsing

### DIFF
--- a/plugins/inputs/mqtt_consumer/README.md
+++ b/plugins/inputs/mqtt_consumer/README.md
@@ -136,7 +136,8 @@ to use them.
   data_format = "influx"
 
   ## Enable extracting tag values from MQTT topics
-  ## _ denotes an ignored entry in the topic path
+  ## _ denotes an ignored entry in the topic path,
+  ## # denotes a variable length path element (can only be used once per setting)
   # [[inputs.mqtt_consumer.topic_parsing]]
   #   topic = ""
   #   measurement = ""

--- a/plugins/inputs/mqtt_consumer/mqtt_consumer_test.go
+++ b/plugins/inputs/mqtt_consumer/mqtt_consumer_test.go
@@ -1,7 +1,6 @@
 package mqtt_consumer
 
 import (
-	"errors"
 	"fmt"
 	"path/filepath"
 	"testing"
@@ -200,7 +199,7 @@ func TestTopicTag(t *testing.T) {
 		name          string
 		topic         string
 		topicTag      func() *string
-		expectedError error
+		expectedError string
 		topicParsing  []TopicParsingConfig
 		expected      []telegraf.Metric
 	}{
@@ -333,7 +332,7 @@ func TestTopicTag(t *testing.T) {
 				tag := ""
 				return &tag
 			},
-			expectedError: errors.New("config error topic parsing: fields length does not equal topic length"),
+			expectedError: "fields length does not equal topic length",
 			topicParsing: []TopicParsingConfig{
 				{
 					Topic:       "telegraf/+/test/hello",
@@ -485,10 +484,12 @@ func TestTopicTag(t *testing.T) {
 			require.NoError(t, parser.Init())
 			plugin.SetParser(parser)
 
-			require.Equal(t, tt.expectedError, plugin.Init())
-			if tt.expectedError != nil {
+			err := plugin.Init()
+			if tt.expectedError != "" {
+				require.ErrorContains(t, err, tt.expectedError)
 				return
 			}
+			require.NoError(t, err)
 
 			var acc testutil.Accumulator
 			require.NoError(t, plugin.Start(&acc))

--- a/plugins/inputs/mqtt_consumer/mqtt_consumer_test.go
+++ b/plugins/inputs/mqtt_consumer/mqtt_consumer_test.go
@@ -332,7 +332,7 @@ func TestTopicTag(t *testing.T) {
 				tag := ""
 				return &tag
 			},
-			expectedError: "fields length does not equal topic length",
+			expectedError: "config error topic parsing: fields length does not equal topic length",
 			topicParsing: []TopicParsingConfig{
 				{
 					Topic:       "telegraf/+/test/hello",
@@ -478,7 +478,7 @@ func TestTopicTag(t *testing.T) {
 			plugin.Log = testutil.Logger{}
 			plugin.Topics = []string{tt.topic}
 			plugin.TopicTag = tt.topicTag()
-			plugin.TopicParsing = tt.topicParsing
+			plugin.TopicParserConfig = tt.topicParsing
 
 			parser := &influx.Parser{}
 			require.NoError(t, parser.Init())

--- a/plugins/inputs/mqtt_consumer/sample.conf
+++ b/plugins/inputs/mqtt_consumer/sample.conf
@@ -85,7 +85,8 @@
   data_format = "influx"
 
   ## Enable extracting tag values from MQTT topics
-  ## _ denotes an ignored entry in the topic path
+  ## _ denotes an ignored entry in the topic path,
+  ## # denotes a variable length path element (can only be used once per setting)
   # [[inputs.mqtt_consumer.topic_parsing]]
   #   topic = ""
   #   measurement = ""

--- a/plugins/inputs/mqtt_consumer/topic_parser.go
+++ b/plugins/inputs/mqtt_consumer/topic_parser.go
@@ -2,8 +2,12 @@ package mqtt_consumer
 
 import (
 	"errors"
+	"fmt"
+	"strconv"
 	"strings"
 )
+
+var ErrNoMatch = errors.New("not matching")
 
 type TopicParsingConfig struct {
 	Topic       string            `toml:"topic"`
@@ -11,36 +15,113 @@ type TopicParsingConfig struct {
 	Tags        string            `toml:"tags"`
 	Fields      string            `toml:"fields"`
 	FieldTypes  map[string]string `toml:"types"`
-	// cached split of user given information
-	MeasurementIndex int
-	SplitTags        []string
-	SplitFields      []string
-	SplitTopic       []string
 }
 
-func (cfg *TopicParsingConfig) Init() error {
+type TopicParser struct {
+	splitTopic []string
+
+	extractMeasurement bool
+	measurementIndex   int
+	splitTags          []string
+	splitFields        []string
+	fieldTypes         map[string]string
+}
+
+func (cfg *TopicParsingConfig) NewParser() (*TopicParser, error) {
+	p := &TopicParser{
+		extractMeasurement: cfg.Measurement != "",
+		fieldTypes:         cfg.FieldTypes,
+	}
+
 	splitMeasurement := strings.Split(cfg.Measurement, "/")
 	for j := range splitMeasurement {
 		if splitMeasurement[j] != "_" && splitMeasurement[j] != "" {
-			cfg.MeasurementIndex = j
+			p.measurementIndex = j
 			break
 		}
 	}
-	cfg.SplitTags = strings.Split(cfg.Tags, "/")
-	cfg.SplitFields = strings.Split(cfg.Fields, "/")
-	cfg.SplitTopic = strings.Split(cfg.Topic, "/")
+	p.splitTags = strings.Split(cfg.Tags, "/")
+	p.splitFields = strings.Split(cfg.Fields, "/")
+	p.splitTopic = strings.Split(cfg.Topic, "/")
 
-	if len(splitMeasurement) != len(cfg.SplitTopic) && len(splitMeasurement) != 1 {
-		return errors.New("measurement length does not equal topic length")
+	if len(splitMeasurement) != len(p.splitTopic) && len(splitMeasurement) != 1 {
+		return nil, errors.New("measurement length does not equal topic length")
 	}
 
-	if len(cfg.SplitFields) != len(cfg.SplitTopic) && cfg.Fields != "" {
-		return errors.New("fields length does not equal topic length")
+	if len(p.splitFields) != len(p.splitTopic) && cfg.Fields != "" {
+		return nil, errors.New("fields length does not equal topic length")
 	}
 
-	if len(cfg.SplitTags) != len(cfg.SplitTopic) && cfg.Tags != "" {
-		return errors.New("tags length does not equal topic length")
+	if len(p.splitTags) != len(p.splitTopic) && cfg.Tags != "" {
+		return nil, errors.New("tags length does not equal topic length")
 	}
 
-	return nil
+	return p, nil
+}
+
+func (p *TopicParser) Parse(topic string) (string, map[string]string, map[string]interface{}, error) {
+	// Split the actual topic into its elements
+	values := strings.Split(topic, "/")
+	if !compareTopics(p.splitTopic, values) {
+		return "", nil, nil, ErrNoMatch
+	}
+
+	// Extract the measurement name
+	var measurement string
+	if p.extractMeasurement {
+		measurement = values[p.measurementIndex]
+	}
+
+	// Extract the tags
+	tags := make(map[string]string, len(p.splitTags))
+	for i, k := range p.splitTags {
+		if k == "_" || k == "" {
+			continue
+		}
+		tags[k] = values[i]
+	}
+
+	// Extract the fields
+	fields := make(map[string]interface{}, len(p.splitFields))
+	for i, k := range p.splitFields {
+		if k == "_" || k == "" {
+			continue
+		}
+		v, err := p.convertToFieldType(values[i], k)
+		if err != nil {
+			return "", nil, nil, err
+		}
+		fields[k] = v
+	}
+
+	return measurement, tags, fields, nil
+}
+
+func (p *TopicParser) convertToFieldType(value string, key string) (interface{}, error) {
+	// If the user configured inputs.mqtt_consumer.topic.types, check for the desired type
+	desiredType, ok := p.fieldTypes[key]
+	if !ok {
+		return value, nil
+	}
+
+	var v interface{}
+	var err error
+	switch desiredType {
+	case "uint":
+		if v, err = strconv.ParseUint(value, 10, 64); err != nil {
+			return nil, fmt.Errorf("unable to convert field %q to type uint: %w", value, err)
+		}
+	case "int":
+		if v, err = strconv.ParseInt(value, 10, 64); err != nil {
+			return nil, fmt.Errorf("unable to convert field %q to type int: %w", value, err)
+		}
+	case "float":
+		if v, err = strconv.ParseFloat(value, 64); err != nil {
+			return nil, fmt.Errorf("unable to convert field %q to type float: %w", value, err)
+		}
+	default:
+		return nil, fmt.Errorf("converting to the type %s is not supported: use int, uint, or float", desiredType)
+	}
+
+	return v, nil
 }

--- a/plugins/inputs/mqtt_consumer/topic_parser.go
+++ b/plugins/inputs/mqtt_consumer/topic_parser.go
@@ -77,28 +77,33 @@ func (cfg *TopicParsingConfig) NewParser() (*TopicParser, error) {
 }
 
 func (p *TopicParser) Parse(topic string) (string, map[string]string, map[string]interface{}, error) {
-	// Split the actual topic into its elements
-	values := strings.Split(topic, "/")
-	if !compareTopics(p.topic, values) {
+	// Split the actual topic into its elements and check for a match
+	topicParts := strings.Split(topic, "/")
+	if len(p.topic) != len(topicParts) {
 		return "", nil, nil, ErrNoMatch
+	}
+	for i, expected := range p.topic {
+		if topicParts[i] != expected && expected != "+" {
+			return "", nil, nil, ErrNoMatch
+		}
 	}
 
 	// Extract the measurement name
 	var measurement string
 	if p.extractMeasurement {
-		measurement = values[p.measurementIndex]
+		measurement = topicParts[p.measurementIndex]
 	}
 
 	// Extract the tags
 	tags := make(map[string]string, len(p.tagIndices))
 	for k, i := range p.tagIndices {
-		tags[k] = values[i]
+		tags[k] = topicParts[i]
 	}
 
 	// Extract the fields
 	fields := make(map[string]interface{}, len(p.fieldIndices))
 	for k, i := range p.fieldIndices {
-		v, err := p.convertToFieldType(values[i], k)
+		v, err := p.convertToFieldType(topicParts[i], k)
 		if err != nil {
 			return "", nil, nil, err
 		}

--- a/plugins/inputs/mqtt_consumer/topic_parser.go
+++ b/plugins/inputs/mqtt_consumer/topic_parser.go
@@ -1,0 +1,46 @@
+package mqtt_consumer
+
+import (
+	"errors"
+	"strings"
+)
+
+type TopicParsingConfig struct {
+	Topic       string            `toml:"topic"`
+	Measurement string            `toml:"measurement"`
+	Tags        string            `toml:"tags"`
+	Fields      string            `toml:"fields"`
+	FieldTypes  map[string]string `toml:"types"`
+	// cached split of user given information
+	MeasurementIndex int
+	SplitTags        []string
+	SplitFields      []string
+	SplitTopic       []string
+}
+
+func (cfg *TopicParsingConfig) Init() error {
+	splitMeasurement := strings.Split(cfg.Measurement, "/")
+	for j := range splitMeasurement {
+		if splitMeasurement[j] != "_" && splitMeasurement[j] != "" {
+			cfg.MeasurementIndex = j
+			break
+		}
+	}
+	cfg.SplitTags = strings.Split(cfg.Tags, "/")
+	cfg.SplitFields = strings.Split(cfg.Fields, "/")
+	cfg.SplitTopic = strings.Split(cfg.Topic, "/")
+
+	if len(splitMeasurement) != len(cfg.SplitTopic) && len(splitMeasurement) != 1 {
+		return errors.New("measurement length does not equal topic length")
+	}
+
+	if len(cfg.SplitFields) != len(cfg.SplitTopic) && cfg.Fields != "" {
+		return errors.New("fields length does not equal topic length")
+	}
+
+	if len(cfg.SplitTags) != len(cfg.SplitTopic) && cfg.Tags != "" {
+		return errors.New("tags length does not equal topic length")
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Summary

This PR allows to use a variable length indicator for topic parsing. The hash (`#`) sign indicates zero to `N` arbitrary path elements that are ignored during parsing.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #10716
