### PR TITLE
fix(secretstores.oauth2): Ensure endpoint params is not nil

### DIFF
--- a/plugins/secretstores/oauth2/oauth2.go
+++ b/plugins/secretstores/oauth2/oauth2.go
@@ -6,6 +6,7 @@ import (
 	_ "embed"
 	"errors"
 	"fmt"
+	"net/url"
 	"strings"
 	"time"
 
@@ -126,11 +127,12 @@ func (o *OAuth2) Init() error {
 
 		// Setup the configuration
 		cfg := &clientcredentials.Config{
-			ClientID:     cid.String(),
-			ClientSecret: csecret.String(),
-			TokenURL:     endpoint.TokenURL,
-			Scopes:       c.Scopes,
-			AuthStyle:    endpoint.AuthStyle,
+			ClientID:       cid.String(),
+			ClientSecret:   csecret.String(),
+			TokenURL:       endpoint.TokenURL,
+			Scopes:         c.Scopes,
+			AuthStyle:      endpoint.AuthStyle,
+			EndpointParams: url.Values{},
 		}
 		cid.Destroy()
 		csecret.Destroy()

--- a/plugins/secretstores/oauth2/oauth2_test.go
+++ b/plugins/secretstores/oauth2/oauth2_test.go
@@ -12,11 +12,32 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/influxdata/telegraf/config"
+	"github.com/influxdata/telegraf/testutil"
 )
 
 func TestSampleConfig(t *testing.T) {
 	plugin := &OAuth2{}
 	require.NotEmpty(t, plugin.SampleConfig())
+}
+
+func TestEndpointParams(t *testing.T) {
+	plugin := &OAuth2{
+		Endpoint: "http://localhost:8080/token",
+		Tenant:   "tenantID",
+		TokenConfigs: []TokenConfig{
+			{
+				ClientID:     config.NewSecret([]byte("clientID")),
+				ClientSecret: config.NewSecret([]byte("clientSecret")),
+				Key:          "test",
+				Params: map[string]string{
+					"foo": "bar",
+				},
+			},
+		},
+		Log: testutil.Logger{},
+	}
+
+	require.NoError(t, plugin.Init())
 }
 
 func TestInitFail(t *testing.T) {


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

fixes: #15530
