### PR TITLE
feat(inputs.elasticsearch): Add support for custom headers

### DIFF
--- a/plugins/inputs/elasticsearch/README.md
+++ b/plugins/inputs/elasticsearch/README.md
@@ -46,6 +46,9 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## servers = ["http://user:pass@localhost:9200"]
   servers = ["http://localhost:9200"]
 
+  ## HTTP headers to send with each request
+  http_headers = { "X-Custom-Header" = "Custom" }
+
   ## Timeout for HTTP requests to the elastic search server(s)
   ## deprecated in 1.29.0; use 'timeout' instead
   http_timeout = "5s"

--- a/plugins/inputs/elasticsearch/README.md
+++ b/plugins/inputs/elasticsearch/README.md
@@ -47,7 +47,7 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   servers = ["http://localhost:9200"]
 
   ## HTTP headers to send with each request
-  http_headers = { "X-Custom-Header" = "Custom" }
+  headers = { "X-Custom-Header" = "Custom" }
 
   ## Timeout for HTTP requests to the elastic search server(s)
   ## deprecated in 1.29.0; use 'timeout' instead

--- a/plugins/inputs/elasticsearch/README.md
+++ b/plugins/inputs/elasticsearch/README.md
@@ -47,7 +47,7 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   servers = ["http://localhost:9200"]
 
   ## HTTP headers to send with each request
-  headers = { "X-Custom-Header" = "Custom" }
+  # headers = { "X-Custom-Header" = "Custom" }
 
   ## Timeout for HTTP requests to the elastic search server(s)
   ## deprecated in 1.29.0; use 'timeout' instead

--- a/plugins/inputs/elasticsearch/elasticsearch.go
+++ b/plugins/inputs/elasticsearch/elasticsearch.go
@@ -98,7 +98,7 @@ type indexStat struct {
 type Elasticsearch struct {
 	Local                      bool              `toml:"local"`
 	Servers                    []string          `toml:"servers"`
-	HTTPHeaders                map[string]string `toml:"http_headers"`
+	HTTPHeaders                map[string]string `toml:"headers"`
 	HTTPTimeout                config.Duration   `toml:"http_timeout" deprecated:"1.29.0;1.35.0;use 'timeout' instead"`
 	ClusterHealth              bool              `toml:"cluster_health"`
 	ClusterHealthLevel         string            `toml:"cluster_health_level"`

--- a/plugins/inputs/elasticsearch/elasticsearch.go
+++ b/plugins/inputs/elasticsearch/elasticsearch.go
@@ -96,19 +96,20 @@ type indexStat struct {
 // Elasticsearch is a plugin to read stats from one or many Elasticsearch
 // servers.
 type Elasticsearch struct {
-	Local                      bool            `toml:"local"`
-	Servers                    []string        `toml:"servers"`
-	HTTPTimeout                config.Duration `toml:"http_timeout" deprecated:"1.29.0;1.35.0;use 'timeout' instead"`
-	ClusterHealth              bool            `toml:"cluster_health"`
-	ClusterHealthLevel         string          `toml:"cluster_health_level"`
-	ClusterStats               bool            `toml:"cluster_stats"`
-	ClusterStatsOnlyFromMaster bool            `toml:"cluster_stats_only_from_master"`
-	IndicesInclude             []string        `toml:"indices_include"`
-	IndicesLevel               string          `toml:"indices_level"`
-	NodeStats                  []string        `toml:"node_stats"`
-	Username                   string          `toml:"username"`
-	Password                   string          `toml:"password"`
-	NumMostRecentIndices       int             `toml:"num_most_recent_indices"`
+	Local                      bool              `toml:"local"`
+	Servers                    []string          `toml:"servers"`
+	HTTPHeaders                map[string]string `toml:"http_headers"`
+	HTTPTimeout                config.Duration   `toml:"http_timeout" deprecated:"1.29.0;1.35.0;use 'timeout' instead"`
+	ClusterHealth              bool              `toml:"cluster_health"`
+	ClusterHealthLevel         string            `toml:"cluster_health_level"`
+	ClusterStats               bool              `toml:"cluster_stats"`
+	ClusterStatsOnlyFromMaster bool              `toml:"cluster_stats_only_from_master"`
+	IndicesInclude             []string          `toml:"indices_include"`
+	IndicesLevel               string            `toml:"indices_level"`
+	NodeStats                  []string          `toml:"node_stats"`
+	Username                   string            `toml:"username"`
+	Password                   string            `toml:"password"`
+	NumMostRecentIndices       int               `toml:"num_most_recent_indices"`
 
 	Log telegraf.Logger `toml:"-"`
 
@@ -641,6 +642,10 @@ func (e *Elasticsearch) getCatMaster(url string) (string, error) {
 		req.SetBasicAuth(e.Username, e.Password)
 	}
 
+	for key, value := range e.HTTPHeaders {
+		req.Header.Add(key, value)
+	}
+
 	r, err := e.client.Do(req)
 	if err != nil {
 		return "", err
@@ -675,6 +680,10 @@ func (e *Elasticsearch) gatherJSONData(url string, v interface{}) error {
 
 	if e.Username != "" || e.Password != "" {
 		req.SetBasicAuth(e.Username, e.Password)
+	}
+
+	for key, value := range e.HTTPHeaders {
+		req.Header.Add(key, value)
 	}
 
 	r, err := e.client.Do(req)

--- a/plugins/inputs/elasticsearch/sample.conf
+++ b/plugins/inputs/elasticsearch/sample.conf
@@ -6,7 +6,7 @@
   servers = ["http://localhost:9200"]
 
   ## HTTP headers to send with each request
-  # http_headers = { "X-Custom-Header" = "Custom" }
+  # headers = { "X-Custom-Header" = "Custom" }
 
   ## Timeout for HTTP requests to the elastic search server(s)
   ## deprecated in 1.29.0; use 'timeout' instead

--- a/plugins/inputs/elasticsearch/sample.conf
+++ b/plugins/inputs/elasticsearch/sample.conf
@@ -5,6 +5,9 @@
   ## servers = ["http://user:pass@localhost:9200"]
   servers = ["http://localhost:9200"]
 
+  ## HTTP headers to send with each request
+  # http_headers = { "X-Custom-Header" = "Custom" }
+
   ## Timeout for HTTP requests to the elastic search server(s)
   ## deprecated in 1.29.0; use 'timeout' instead
   http_timeout = "5s"


### PR DESCRIPTION
## Summary

This PR adds support for custom HTTP headers to the Elasticsearch input plugin. We have some clusters that utilize a custom plugin which require a few particular HTTP headers to be present in order to interact with standard APIs.

## Checklist

- [X] No AI generated code was used in this PR

## Related issues

resolves #15543
