### PR TITLE
fix(inputs.chrony): Use DGRAM for the unix socket

### DIFF
--- a/plugins/inputs/chrony/README.md
+++ b/plugins/inputs/chrony/README.md
@@ -42,6 +42,15 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   # metrics = ["tracking"]
 ```
 
+## Rights
+
+To use the unix socket, telegraf must be able to talk to it. Please ensure that
+the telegraf user is a member of the `chrony` group or telegraf won't be able to
+use the socket!
+
+The unix socket is needed in order to use the `serverstats` metrics. All other
+metrics can be gathered using the udp connection.
+
 ## Metrics
 
 - chrony

--- a/plugins/inputs/chrony/README.md
+++ b/plugins/inputs/chrony/README.md
@@ -48,7 +48,7 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   # socket_perms = "0660"
 ```
 
-## Rights
+## Local socket permissions
 
 To use the unix socket, telegraf must be able to talk to it. Please ensure that
 the telegraf user is a member of the `chrony` group or telegraf won't be able to

--- a/plugins/inputs/chrony/README.md
+++ b/plugins/inputs/chrony/README.md
@@ -40,6 +40,12 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ##   sources     -- extended information about peers
   ##   sourcestats -- statistics on peers
   # metrics = ["tracking"]
+
+  ## Socket group & permissions
+  ## If the user requests collecting metrics via unix socket, then it is created
+  ## with the following group and permissions.
+  # socket_group = "chrony"
+  # socket_perms = "0660"
 ```
 
 ## Rights

--- a/plugins/inputs/chrony/sample.conf
+++ b/plugins/inputs/chrony/sample.conf
@@ -21,3 +21,9 @@
   ##   sources     -- extended information about peers
   ##   sourcestats -- statistics on peers
   # metrics = ["tracking"]
+
+  ## Socket group & permissions
+  ## If the user requests collecting metrics via unix socket, then it is created
+  ## with the following group and permissions.
+  # socket_group = "chrony"
+  # socket_perms = "0660"


### PR DESCRIPTION

## Summary
We must use the DGRAM type when connecting to the chrony socket. On top of that, the socket must be duplicated in order to allow concurrent calls to it.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #15549

