### PR TITLE
docs(parsers.binary): Fix wording in README

### DIFF
--- a/plugins/parsers/binary/README.md
+++ b/plugins/parsers/binary/README.md
@@ -72,7 +72,7 @@ user-specified configurations.
     #   ## Filter message by the exact length in bytes (default: N/A).
     #   # length = 0
     #   ## Filter the message by a minimum length in bytes.
-    #   ## Messages longer of of equal length will pass.
+    #   ## Messages longer of equal length will pass.
     #   # length_min = 0
     #   ## List of data parts to match.
     #   ## Only if all selected parts match, the configuration will be


### PR DESCRIPTION


## Summary
minor fix
## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
