### PR TITLE
fix(inputs.gnmi): Handle YANG namespaces in paths correctly

### DIFF
--- a/plugins/inputs/gnmi/gnmi.go
+++ b/plugins/inputs/gnmi/gnmi.go
@@ -442,7 +442,7 @@ func (s *Subscription) buildAlias(aliases map[*pathInfo]string) error {
 	// If the user didn't provide a measurement name, use last path element
 	name := s.Name
 	if name == "" && len(info.segments) > 0 {
-		name = info.segments[len(info.segments)-1]
+		name = info.segments[len(info.segments)-1].id
 	}
 	if name != "" {
 		aliases[info] = name

--- a/plugins/inputs/gnmi/tag_store.go
+++ b/plugins/inputs/gnmi/tag_store.go
@@ -44,7 +44,7 @@ func (s *tagStore) insert(subscription TagSubscription, path *pathInfo, values [
 		for _, f := range values {
 			tagName := subscription.Name
 			if len(f.path.segments) > 0 {
-				key := f.path.segments[len(f.path.segments)-1]
+				key := f.path.Base()
 				key = strings.ReplaceAll(key, "-", "_")
 				tagName += "/" + key
 			}
@@ -74,7 +74,7 @@ func (s *tagStore) insert(subscription TagSubscription, path *pathInfo, values [
 		for _, f := range values {
 			tagName := subscription.Name
 			if len(f.path.segments) > 0 {
-				key := f.path.segments[len(f.path.segments)-1]
+				key := f.path.Base()
 				key = strings.ReplaceAll(key, "-", "_")
 				tagName += "/" + key
 			}
@@ -103,7 +103,7 @@ func (s *tagStore) insert(subscription TagSubscription, path *pathInfo, values [
 		for _, f := range values {
 			tagName := subscription.Name
 			if len(f.path.segments) > 0 {
-				key := f.path.segments[len(f.path.segments)-1]
+				key := f.path.Base()
 				key = strings.ReplaceAll(key, "-", "_")
 				tagName += "/" + key
 			}

--- a/plugins/inputs/gnmi/testcases/issue_15546/expected.out
+++ b/plugins/inputs/gnmi/testcases/issue_15546/expected.out
@@ -1,0 +1,1 @@
+event-stats,path=openconfig-system:/system/openconfig-events:event-stats/state,source=127.0.0.1 state/acked=0u,state/cleared=0u,state/events=4u,state/raised=0u 1718942414831832038

--- a/plugins/inputs/gnmi/testcases/issue_15546/responses.json
+++ b/plugins/inputs/gnmi/testcases/issue_15546/responses.json
@@ -1,0 +1,70 @@
+[
+    {
+        "update": {
+            "timestamp": "1718942414831832038",
+            "prefix": {
+                "elem": [
+                    {
+                        "name": "openconfig-system:system"
+                    },
+                    {
+                        "name": "openconfig-events:event-stats"
+                    },
+                    {
+                        "name": "state"
+                    }
+                ]
+            },
+            "update": [
+                {
+                    "path": {
+                        "elem": [
+                            {
+                                "name": "acked"
+                            }
+                        ]
+                    },
+                    "val": {
+                        "uintVal": "0"
+                    }
+                },
+                {
+                    "path": {
+                        "elem": [
+                            {
+                                "name": "cleared"
+                            }
+                        ]
+                    },
+                    "val": {
+                        "uintVal": "0"
+                    }
+                },
+                {
+                    "path": {
+                        "elem": [
+                            {
+                                "name": "events"
+                            }
+                        ]
+                    },
+                    "val": {
+                        "uintVal": "4"
+                    }
+                },
+                {
+                    "path": {
+                        "elem": [
+                            {
+                                "name": "raised"
+                            }
+                        ]
+                    },
+                    "val": {
+                        "uintVal": "0"
+                    }
+                }
+            ]
+        }
+    }
+]

--- a/plugins/inputs/gnmi/testcases/issue_15546/telegraf.conf
+++ b/plugins/inputs/gnmi/testcases/issue_15546/telegraf.conf
@@ -1,0 +1,10 @@
+[[inputs.gnmi]]
+  addresses = ["dummy"]
+  prefix_tag_key_with_path = true
+
+  [[inputs.gnmi.subscription]]
+    name = "event-stats"
+    origin = "openconfig-system"
+    path = "/system/event-stats"
+    subscription_mode = "sample"
+    sample_interval = "10s"


### PR DESCRIPTION
## Summary

The current code fails to resolve aliases for cases where the subscription update contains YANG-model namespaces in path elements. This PR explicitly handles the namespace elements the right way.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #15546 
