### PR TITLE
fix(inputs.chrony): Handle ServerStats4 response

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -74,7 +74,7 @@ require (
 	github.com/dynatrace-oss/dynatrace-metric-utils-go v0.5.0
 	github.com/eclipse/paho.golang v0.21.0
 	github.com/eclipse/paho.mqtt.golang v1.4.3
-	github.com/facebook/time v0.0.0-20240125155343-557f84f4ad3e
+	github.com/facebook/time v0.0.0-20240626113945-18207c5d8ddc
 	github.com/fatih/color v1.17.0
 	github.com/go-ldap/ldap/v3 v3.4.8
 	github.com/go-logfmt/logfmt v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -1132,8 +1132,8 @@ github.com/envoyproxy/protoc-gen-validate v0.9.1/go.mod h1:OKNgG7TCp5pF4d6XftA0+
 github.com/envoyproxy/protoc-gen-validate v0.10.1/go.mod h1:DRjgyB0I43LtJapqN6NiRwroiAU2PaFuvk/vjgh61ss=
 github.com/envoyproxy/protoc-gen-validate v1.0.4 h1:gVPz/FMfvh57HdSJQyvBtF00j8JU4zdyUgIUNhlgg0A=
 github.com/envoyproxy/protoc-gen-validate v1.0.4/go.mod h1:qys6tmnRsYrQqIhm2bvKZH4Blx/1gTIZ2UKVY1M+Yew=
-github.com/facebook/time v0.0.0-20240125155343-557f84f4ad3e h1:PaVm1gMon1pkJdbzoyw2VUCn07cA6RDbGdTbsppjcY8=
-github.com/facebook/time v0.0.0-20240125155343-557f84f4ad3e/go.mod h1:NBW7VY75BPCsOPrSsARAengTlgOICicHey4Bv70lCUI=
+github.com/facebook/time v0.0.0-20240626113945-18207c5d8ddc h1:0VQsg5ZXW9MPUxzemUHW7UBK8gfIO8K+YJGbdv4kBIM=
+github.com/facebook/time v0.0.0-20240626113945-18207c5d8ddc/go.mod h1:2UFAomOuD2vAK1x68czUtCVjAqmyWCEnAXOlmGqf+G0=
 github.com/facebookgo/stack v0.0.0-20160209184415-751773369052 h1:JWuenKqqX8nojtoVVWjGfOF9635RETekkoH6Cc9SX0A=
 github.com/facebookgo/stack v0.0.0-20160209184415-751773369052/go.mod h1:UbMTZqLaRiH3MsBH8va0n7s1pQYcu3uTb8G4tygF4Zg=
 github.com/facebookgo/stackerr v0.0.0-20150612192056-c2fcf88613f4 h1:fP04zlkPjAGpsduG7xN3rRkxjAqkJaIQnnkNYYw/pAk=

--- a/plugins/inputs/chrony/chrony.go
+++ b/plugins/inputs/chrony/chrony.go
@@ -283,6 +283,26 @@ func (c *Chrony) gatherServerStats(acc telegraf.Accumulator) error {
 			"nke_hits":             resp.NKEHits,
 			"nke_drops":            resp.NKEDrops,
 		}
+	case *fbchrony.ReplyServerStats4:
+		fields = map[string]interface{}{
+			"ntp_hits":                   resp.NTPHits,
+			"ntp_drops":                  resp.NTPDrops,
+			"ntp_auth_hits":              resp.NTPAuthHits,
+			"ntp_interleaved_hits":       resp.NTPInterleavedHits,
+			"ntp_timestamps":             resp.NTPTimestamps,
+			"ntp_span_seconds":           resp.NTPSpanSeconds,
+			"cmd_hits":                   resp.CMDHits,
+			"cmd_drops":                  resp.CMDDrops,
+			"log_drops":                  resp.LogDrops,
+			"nke_hits":                   resp.NKEHits,
+			"nke_drops":                  resp.NKEDrops,
+			"ntp_daemon_rx_timestamps":   resp.NTPDaemonRxtimestamps,
+			"ntp_daemon_tx_timestamps":   resp.NTPDaemonTxtimestamps,
+			"ntp_kernel_rx_timestamps":   resp.NTPKernelRxtimestamps,
+			"ntp_kernel_tx_timestamps":   resp.NTPKernelTxtimestamps,
+			"ntp_hardware_rx_timestamps": resp.NTPHwRxTimestamps,
+			"ntp_hardware_tx_timestamps": resp.NTPHwTxTimestamps,
+		}
 	default:
 		return fmt.Errorf("got unexpected response type %T while waiting for server statistics", r)
 	}


### PR DESCRIPTION
Chrony ≥ 4.4 introduces a new ServerStats response with u64 numbers and more fields.

Fixes #15553

NB: The plugin still doesn't work due to #15549. To test this commit, please make sure you use #15552.

## Summary
Support chrony versions ≥ 4.4

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #15553 
