### PR TITLE
feat(common.tls): Allow group aliases for ciphersuites

### DIFF
--- a/plugins/common/tls/client.conf
+++ b/plugins/common/tls/client.conf
@@ -14,7 +14,9 @@
   ## Minimal TLS version to accept by the client
   # tls_min_version = "TLS12"
   ## List of ciphers to accept, by default all secure ciphers will be accepted
-  ## See https://pkg.go.dev/crypto/tls#pkg-constants for supported values
+  ## See https://pkg.go.dev/crypto/tls#pkg-constants for supported values.
+  ## Use "all", "secure" and "insecure" to add all support ciphers, secure
+  ## suites or insecure suites respectively.
   # tls_cipher_suites = []
   ## Renegotiation method, "never", "once" or "freely"
   # tls_renegotiation_method = "never"

--- a/plugins/common/tls/client.conf
+++ b/plugins/common/tls/client.conf
@@ -17,7 +17,7 @@
   ## See https://pkg.go.dev/crypto/tls#pkg-constants for supported values.
   ## Use "all", "secure" and "insecure" to add all support ciphers, secure
   ## suites or insecure suites respectively.
-  # tls_cipher_suites = []
+  # tls_cipher_suites = ["secure"]
   ## Renegotiation method, "never", "once" or "freely"
   # tls_renegotiation_method = "never"
   ## Use TLS but skip chain & host verification

--- a/plugins/inputs/gnmi/README.md
+++ b/plugins/inputs/gnmi/README.md
@@ -111,7 +111,7 @@ details on how to use them.
   ## See https://pkg.go.dev/crypto/tls#pkg-constants for supported values.
   ## Use "all", "secure" and "insecure" to add all support ciphers, secure
   ## suites or insecure suites respectively.
-  # tls_cipher_suites = []
+  # tls_cipher_suites = ["secure"]
   ## Renegotiation method, "never", "once" or "freely"
   # tls_renegotiation_method = "never"
   ## Use TLS but skip chain & host verification

--- a/plugins/inputs/gnmi/README.md
+++ b/plugins/inputs/gnmi/README.md
@@ -108,7 +108,9 @@ details on how to use them.
   ## Minimal TLS version to accept by the client
   # tls_min_version = "TLS12"
   ## List of ciphers to accept, by default all secure ciphers will be accepted
-  ## See https://pkg.go.dev/crypto/tls#pkg-constants for supported values
+  ## See https://pkg.go.dev/crypto/tls#pkg-constants for supported values.
+  ## Use "all", "secure" and "insecure" to add all support ciphers, secure
+  ## suites or insecure suites respectively.
   # tls_cipher_suites = []
   ## Renegotiation method, "never", "once" or "freely"
   # tls_renegotiation_method = "never"

--- a/plugins/inputs/gnmi/sample.conf
+++ b/plugins/inputs/gnmi/sample.conf
@@ -61,7 +61,9 @@
   ## Minimal TLS version to accept by the client
   # tls_min_version = "TLS12"
   ## List of ciphers to accept, by default all secure ciphers will be accepted
-  ## See https://pkg.go.dev/crypto/tls#pkg-constants for supported values
+  ## See https://pkg.go.dev/crypto/tls#pkg-constants for supported values.
+  ## Use "all", "secure" and "insecure" to add all support ciphers, secure
+  ## suites or insecure suites respectively.
   # tls_cipher_suites = []
   ## Renegotiation method, "never", "once" or "freely"
   # tls_renegotiation_method = "never"

--- a/plugins/inputs/gnmi/sample.conf
+++ b/plugins/inputs/gnmi/sample.conf
@@ -64,7 +64,7 @@
   ## See https://pkg.go.dev/crypto/tls#pkg-constants for supported values.
   ## Use "all", "secure" and "insecure" to add all support ciphers, secure
   ## suites or insecure suites respectively.
-  # tls_cipher_suites = []
+  # tls_cipher_suites = ["secure"]
   ## Renegotiation method, "never", "once" or "freely"
   # tls_renegotiation_method = "never"
   ## Use TLS but skip chain & host verification

--- a/plugins/inputs/http/README.md
+++ b/plugins/inputs/http/README.md
@@ -84,7 +84,9 @@ to use them.
   ## Minimal TLS version to accept by the client
   # tls_min_version = "TLS12"
   ## List of ciphers to accept, by default all secure ciphers will be accepted
-  ## See https://pkg.go.dev/crypto/tls#pkg-constants for supported values
+  ## See https://pkg.go.dev/crypto/tls#pkg-constants for supported values.
+  ## Use "all", "secure" and "insecure" to add all support ciphers, secure
+  ## suites or insecure suites respectively.
   # tls_cipher_suites = []
   ## Renegotiation method, "never", "once" or "freely"
   # tls_renegotiation_method = "never"

--- a/plugins/inputs/http/README.md
+++ b/plugins/inputs/http/README.md
@@ -87,7 +87,7 @@ to use them.
   ## See https://pkg.go.dev/crypto/tls#pkg-constants for supported values.
   ## Use "all", "secure" and "insecure" to add all support ciphers, secure
   ## suites or insecure suites respectively.
-  # tls_cipher_suites = []
+  # tls_cipher_suites = ["secure"]
   ## Renegotiation method, "never", "once" or "freely"
   # tls_renegotiation_method = "never"
   ## Use TLS but skip chain & host verification

--- a/plugins/inputs/http/sample.conf
+++ b/plugins/inputs/http/sample.conf
@@ -58,7 +58,7 @@
   ## See https://pkg.go.dev/crypto/tls#pkg-constants for supported values.
   ## Use "all", "secure" and "insecure" to add all support ciphers, secure
   ## suites or insecure suites respectively.
-  # tls_cipher_suites = []
+  # tls_cipher_suites = ["secure"]
   ## Renegotiation method, "never", "once" or "freely"
   # tls_renegotiation_method = "never"
   ## Use TLS but skip chain & host verification

--- a/plugins/inputs/http/sample.conf
+++ b/plugins/inputs/http/sample.conf
@@ -55,7 +55,9 @@
   ## Minimal TLS version to accept by the client
   # tls_min_version = "TLS12"
   ## List of ciphers to accept, by default all secure ciphers will be accepted
-  ## See https://pkg.go.dev/crypto/tls#pkg-constants for supported values
+  ## See https://pkg.go.dev/crypto/tls#pkg-constants for supported values.
+  ## Use "all", "secure" and "insecure" to add all support ciphers, secure
+  ## suites or insecure suites respectively.
   # tls_cipher_suites = []
   ## Renegotiation method, "never", "once" or "freely"
   # tls_renegotiation_method = "never"

--- a/plugins/inputs/ldap/README.md
+++ b/plugins/inputs/ldap/README.md
@@ -58,7 +58,7 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## See https://pkg.go.dev/crypto/tls#pkg-constants for supported values.
   ## Use "all", "secure" and "insecure" to add all support ciphers, secure
   ## suites or insecure suites respectively.
-  # tls_cipher_suites = []
+  # tls_cipher_suites = ["secure"]
   ## Renegotiation method, "never", "once" or "freely"
   # tls_renegotiation_method = "never"
   ## Use TLS but skip chain & host verification

--- a/plugins/inputs/ldap/README.md
+++ b/plugins/inputs/ldap/README.md
@@ -55,7 +55,9 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## Minimal TLS version to accept by the client
   # tls_min_version = "TLS12"
   ## List of ciphers to accept, by default all secure ciphers will be accepted
-  ## See https://pkg.go.dev/crypto/tls#pkg-constants for supported values
+  ## See https://pkg.go.dev/crypto/tls#pkg-constants for supported values.
+  ## Use "all", "secure" and "insecure" to add all support ciphers, secure
+  ## suites or insecure suites respectively.
   # tls_cipher_suites = []
   ## Renegotiation method, "never", "once" or "freely"
   # tls_renegotiation_method = "never"

--- a/plugins/inputs/ldap/sample.conf
+++ b/plugins/inputs/ldap/sample.conf
@@ -40,7 +40,7 @@
   ## See https://pkg.go.dev/crypto/tls#pkg-constants for supported values.
   ## Use "all", "secure" and "insecure" to add all support ciphers, secure
   ## suites or insecure suites respectively.
-  # tls_cipher_suites = []
+  # tls_cipher_suites = ["secure"]
   ## Renegotiation method, "never", "once" or "freely"
   # tls_renegotiation_method = "never"
   ## Use TLS but skip chain & host verification

--- a/plugins/inputs/ldap/sample.conf
+++ b/plugins/inputs/ldap/sample.conf
@@ -37,7 +37,9 @@
   ## Minimal TLS version to accept by the client
   # tls_min_version = "TLS12"
   ## List of ciphers to accept, by default all secure ciphers will be accepted
-  ## See https://pkg.go.dev/crypto/tls#pkg-constants for supported values
+  ## See https://pkg.go.dev/crypto/tls#pkg-constants for supported values.
+  ## Use "all", "secure" and "insecure" to add all support ciphers, secure
+  ## suites or insecure suites respectively.
   # tls_cipher_suites = []
   ## Renegotiation method, "never", "once" or "freely"
   # tls_renegotiation_method = "never"


### PR DESCRIPTION
## Summary

Allow to specify `all`, `secure` and `insecure` for the `tls_cipher_suites` setting to be able to select whole suites of ciphers instead of specifying them one-by-one. This can be combined with individual ciphers e.g.
```toml
  tls_cipher_suites = ["secure", "TLS_RSA_WITH_AES_256_GCM_SHA384"]
```
to e.g. allow specific insecure ciphers.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

related to #15436 
