### PR TITLE
fix(common.socket): Switch to context to simplify closing

### DIFF
--- a/plugins/common/socket/socket.go
+++ b/plugins/common/socket/socket.go
@@ -27,7 +27,7 @@ type listener interface {
 }
 
 type Config struct {
-	MaxConnections       int              `toml:"max_connections"`
+	MaxConnections       uint64           `toml:"max_connections"`
 	ReadBufferSize       config.Size      `toml:"read_buffer_size"`
 	ReadTimeout          config.Duration  `toml:"read_timeout"`
 	KeepAlivePeriod      *config.Duration `toml:"keep_alive_period"`

--- a/plugins/common/socket/socket_test.go
+++ b/plugins/common/socket/socket_test.go
@@ -499,6 +499,10 @@ func TestClosingConnections(t *testing.T) {
 	require.Empty(t, logger.Warnings())
 }
 func TestMaxConnections(t *testing.T) {
+	if runtime.GOOS == "darwin" {
+		t.Skip("Skipping on darwin due to missing socket options")
+	}
+
 	// Setup the configuration
 	period := config.Duration(10 * time.Millisecond)
 	cfg := &Config{

--- a/plugins/common/socket/stream.go
+++ b/plugins/common/socket/stream.go
@@ -286,6 +286,7 @@ func (l *streamListener) listenConnection(onConnection CallbackConnection, onErr
 				continue
 			}
 
+			l.wg.Add(1)
 			go func(c net.Conn) {
 				if err := l.handleConnection(ctx, c, onConnection); err != nil {
 					if !errors.Is(err, io.EOF) && !errors.Is(err, syscall.ECONNRESET) {
@@ -380,7 +381,6 @@ func (l *streamListener) readAll(conn net.Conn, onData CallbackData) error {
 }
 
 func (l *streamListener) handleConnection(ctx context.Context, conn net.Conn, onConnection CallbackConnection) error {
-	l.wg.Add(1)
 	defer l.wg.Done()
 
 	localCtx, cancel := context.WithCancel(ctx)


### PR DESCRIPTION
## Summary

Switching the socket-close implementation to context cancellation avoids the complexity to keep track of all open connection. As side effects, this PR avoids the memory leak described in #15509 and avoids race conditions when closing the socket while new connections arrive.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #15509 
