### PR TITLE
feat: enhance explanation in opc ua listener sample.conf regarding subscription_interval

### DIFF
--- a/plugins/inputs/opcua_listener/sample.conf
+++ b/plugins/inputs/opcua_listener/sample.conf
@@ -21,7 +21,9 @@
   # Maximum time that a session shall remain open without activity.
   # session_timeout = "20m"
   #
-  ## The interval at which the server should at least update its monitored items
+  ## The interval at which the server should at least update its monitored items. 
+  ## Please note that the OPC UA server might reject the specified interval if it cannot meet the required update rate. 
+  ## Therefore, always refer to the hardware/software documentation of your server to ensure the specified interval is supported.
   # subscription_interval = "100ms"
   #
   ## Security policy, one of "None", "Basic128Rsa15", "Basic256",


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
The rationale behind this change is to clarify that setting the subscription_interval does not guarantee the server will update at this rate. The server might reject the interval if it cannot meet the required update rate due to hardware or software limitations. These notes aim to prevent misunderstandings and guide users to refer to their server's documentation, ensuring correct  system configuration.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [ x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
