### PR TITLE
fix(inputs.ping): Check addr length to avoid crash

### DIFF
--- a/plugins/inputs/ping/ping.go
+++ b/plugins/inputs/ping/ping.go
@@ -305,6 +305,9 @@ func (p *Ping) Init() error {
 			if err != nil {
 				return fmt.Errorf("failed to get the address of interface: %w", err)
 			}
+			if len(addrs) == 0 {
+				return fmt.Errorf("no address found for interface %s", p.Interface)
+			}
 			p.sourceAddress = addrs[0].(*net.IPNet).IP.String()
 		}
 	}

--- a/plugins/inputs/ping/ping.go
+++ b/plugins/inputs/ping/ping.go
@@ -147,6 +147,26 @@ func (p *Ping) nativePing(destination string) (*pingStats, error) {
 		}
 	}
 
+	// Support either an IP address or interface name
+	if p.Interface != "" && p.sourceAddress == "" {
+		if addr := net.ParseIP(p.Interface); addr != nil {
+			p.sourceAddress = p.Interface
+		} else {
+			i, err := net.InterfaceByName(p.Interface)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get interface: %w", err)
+			}
+			addrs, err := i.Addrs()
+			if err != nil {
+				return nil, fmt.Errorf("failed to get the address of interface: %w", err)
+			}
+			if len(addrs) == 0 {
+				return nil, fmt.Errorf("no address found for interface %s", p.Interface)
+			}
+			p.sourceAddress = addrs[0].(*net.IPNet).IP.String()
+		}
+	}
+
 	pinger.Source = p.sourceAddress
 	pinger.Interval = p.calcInterval
 
@@ -290,26 +310,6 @@ func (p *Ping) Init() error {
 		p.calcTimeout = time.Duration(5) * time.Second
 	} else {
 		p.calcTimeout = time.Duration(p.Timeout) * time.Second
-	}
-
-	// Support either an IP address or interface name
-	if p.Interface != "" {
-		if addr := net.ParseIP(p.Interface); addr != nil {
-			p.sourceAddress = p.Interface
-		} else {
-			i, err := net.InterfaceByName(p.Interface)
-			if err != nil {
-				return fmt.Errorf("failed to get interface: %w", err)
-			}
-			addrs, err := i.Addrs()
-			if err != nil {
-				return fmt.Errorf("failed to get the address of interface: %w", err)
-			}
-			if len(addrs) == 0 {
-				return fmt.Errorf("no address found for interface %s", p.Interface)
-			}
-			p.sourceAddress = addrs[0].(*net.IPNet).IP.String()
-		}
 	}
 
 	return nil


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
This will check the length of the slice to avoid a crash and moves this set up to Gather and out of Init to allow continued operation.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

fixes: #15591
