### PR TITLE
fix(inputs.snmp): Field translate didn't work on when not in table

### DIFF
--- a/internal/snmp/table.go
+++ b/internal/snmp/table.go
@@ -172,6 +172,18 @@ func (t Table) Build(gs Connection, walk bool) (*RTable, error) {
 				return nil, fmt.Errorf("performing get on field %s: %w", f.Name, err)
 			} else if pkt != nil && len(pkt.Variables) > 0 && pkt.Variables[0].Type != gosnmp.NoSuchObject && pkt.Variables[0].Type != gosnmp.NoSuchInstance {
 				ent := pkt.Variables[0]
+
+				// snmptranslate table field value here
+				if f.Translate {
+					if entOid, ok := ent.Value.(string); ok {
+						_, _, oidText, _, err := t.translator.SnmpTranslate(entOid)
+						if err == nil {
+							// If no error translating, the original value for ent.Value should be replaced
+							ent.Value = oidText
+						}
+					}
+				}
+
 				fv, err := f.Convert(ent)
 				if err != nil {
 					return nil, fmt.Errorf("converting %q (OID %s) for field %s: %w", ent.Value, ent.Name, f.Name, err)

--- a/internal/snmp/translator_gosmi_test.go
+++ b/internal/snmp/translator_gosmi_test.go
@@ -274,15 +274,21 @@ func TestTableBuild_noWalkGosmi(t *testing.T) {
 				Name: "noexist",
 				Oid:  ".1.2.3.4.5",
 			},
+			{
+				Name:      "myfield4",
+				Oid:       ".1.3.6.1.2.1.3.1.1.3.0",
+				Translate: true,
+			},
 		},
 	}
 
+	require.NoError(t, tbl.Init(getGosmiTr(t)))
 	tb, err := tbl.Build(tsc, false)
 	require.NoError(t, err)
 
 	rtr := RTableRow{
 		Tags:   map[string]string{"myfield1": "baz", "myfield3": "234"},
-		Fields: map[string]interface{}{"myfield2": 234},
+		Fields: map[string]interface{}{"myfield2": 234, "myfield4": "atNetAddress"},
 	}
 	require.Len(t, tb.Rows, 1)
 	require.Contains(t, tb.Rows, rtr)

--- a/internal/snmp/translator_netsnmp_test.go
+++ b/internal/snmp/translator_netsnmp_test.go
@@ -207,15 +207,21 @@ func TestTableBuild_noWalk(t *testing.T) {
 				Name: "noexist",
 				Oid:  ".1.2.3.4.5",
 			},
+			{
+				Name:      "myfield4",
+				Oid:       ".1.0.0.0.1.6.0",
+				Translate: true,
+			},
 		},
 	}
 
+	require.NoError(t, tbl.Init(NewNetsnmpTranslator(testutil.Logger{})))
 	tb, err := tbl.Build(tsc, false)
 	require.NoError(t, err)
 
 	rtr := RTableRow{
 		Tags:   map[string]string{"myfield1": "baz", "myfield3": "234"},
-		Fields: map[string]interface{}{"myfield2": 234},
+		Fields: map[string]interface{}{"myfield2": 234, "myfield4": "testTableEntry.7"},
 	}
 	require.Len(t, tb.Rows, 1)
 	require.Contains(t, tb.Rows, rtr)


### PR DESCRIPTION
## Summary
Apparently, the `translate` option for a `field` in the SNMP input only worked in a `inputs.snmp.table.field` and not in a `inputs.snmp.field`.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

Fixes #15617
