### PR TITLE
fix(tools.custom_builder): Handle multiple instance of the same plugin correctly

### DIFF
--- a/tools/custom_builder/main_test.go
+++ b/tools/custom_builder/main_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"bufio"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCases(t *testing.T) {
+	// Silence the output
+	log.SetOutput(io.Discard)
+
+	// Get all directories in testdata
+	folders, err := os.ReadDir("testcases")
+	require.NoError(t, err)
+
+	for _, f := range folders {
+		// Only handle folders
+		if !f.IsDir() {
+			continue
+		}
+		configFilename := filepath.Join("testcases", f.Name(), "telegraf.conf")
+		expecedFilename := filepath.Join("testcases", f.Name(), "expected.tags")
+
+		t.Run(f.Name(), func(t *testing.T) {
+			// Read the expected output
+			file, err := os.Open(expecedFilename)
+			require.NoError(t, err)
+			defer file.Close()
+
+			var expected []string
+			scanner := bufio.NewScanner(file)
+			for scanner.Scan() {
+				expected = append(expected, scanner.Text())
+			}
+			require.NoError(t, scanner.Err())
+
+			// Configure the command
+			cfg := &cmdConfig{
+				dryrun:      true,
+				quiet:       true,
+				configFiles: []string{configFilename},
+				root:        "../..",
+			}
+
+			actual, err := process(cfg)
+			require.NoError(t, err)
+			require.EqualValues(t, expected, actual)
+		})
+	}
+}

--- a/tools/custom_builder/packages.go
+++ b/tools/custom_builder/packages.go
@@ -36,6 +36,7 @@ type packageInfo struct {
 }
 
 type packageCollection struct {
+	root     string
 	packages map[string][]packageInfo
 }
 
@@ -53,7 +54,7 @@ var exceptions = map[string][]packageInfo{
 
 func (p *packageCollection) collectPackagesForCategory(category string) error {
 	var entries []packageInfo
-	pluginDir := filepath.Join("plugins", category)
+	pluginDir := filepath.Join(p.root, "plugins", category)
 
 	// Add exceptional packages if any
 	if pkgs, found := exceptions[category]; found {

--- a/tools/custom_builder/testcases/issue_13592/expected.tags
+++ b/tools/custom_builder/testcases/issue_13592/expected.tags
@@ -1,0 +1,5 @@
+inputs.disk
+inputs.mem
+inputs.swap
+inputs.system
+outputs.datadog

--- a/tools/custom_builder/testcases/issue_13592/telegraf.conf
+++ b/tools/custom_builder/testcases/issue_13592/telegraf.conf
@@ -1,0 +1,65 @@
+## Telegraf Configuration for ThinClients
+## /etc/telegraf/telegraf.conf
+
+[global_tags]
+  service_name = "thinclient"
+  env = "prod"
+  team = "planetexpress"
+
+## Configuration for telegraf agent
+[agent]
+  ## Data input and output settings
+  interval = "10s"
+  round_interval = true
+  metric_batch_size = 1000
+  metric_buffer_limit = 10000
+  collection_jitter = "0s"
+  flush_interval = "10s"
+  flush_jitter = "5s"
+
+  ## Logging configuration
+  debug = false
+  quiet = false
+  # emtpy string means log to stderr
+  logfile = ""
+
+  ## host configuration
+  # if emtpty use os.hostname()
+  hostname = ""
+
+  omit_hostname = false
+
+# Configuration for sending metrics to Datadog
+[[outputs.datadog]]
+  ## Datadog API key
+  apikey = "${datadog_secret}"
+
+  ## Connection timeout.
+  timeout = "5s"
+
+
+  ## Write URL override; useful for debugging.
+  url = "${datadog_url}"
+
+## Metrics to log
+
+[[inputs.system]]
+  name_prefix = "dg.systemengineering.thinclient."
+  # default configuration; getting uptime values.
+
+[[inputs.mem]]
+  name_prefix = "dg.systemengineering.thinclient."
+  # no configuration
+
+[[inputs.disk]]
+  name_prefix = "dg.systemengineering.thinclient."
+  ## By default stats will be gathered for all mount points.
+  ## Set mount_points will restrict the stats to only the specified mount points.
+  mount_points = ["/"]
+
+[[inputs.swap]]
+  name_prefix = "dg.systemengineering.thinclient."
+  ## Monitoring SWAP (zswap) usage
+
+  ## Ignore mount points by filesystem type.
+  #ignore_fs = ["tmpfs", "devtmpfs", "devfs", "iso9660", "overlay", "aufs", "squashfs"]

--- a/tools/custom_builder/testcases/issue_15627/expected.tags
+++ b/tools/custom_builder/testcases/issue_15627/expected.tags
@@ -1,0 +1,4 @@
+inputs.mqtt_consumer
+outputs.influxdb_v2
+parsers.json_v2
+parsers.value

--- a/tools/custom_builder/testcases/issue_15627/telegraf.conf
+++ b/tools/custom_builder/testcases/issue_15627/telegraf.conf
@@ -1,0 +1,39 @@
+[[inputs.mqtt_consumer]]
+  name_override = "qr_mqtt_message"
+  servers = ["tcp://mosquitto:1883"]
+  topics = [
+    "<REDACTED>"
+  ]
+
+  qos = 2
+  persistent_session = false
+  client_id = "telegraf_qr_code"
+
+  data_format = "json_v2"
+
+  [[inputs.mqtt_consumer.json_v2]]
+    [[inputs.mqtt_consumer.json_v2.object]]
+      path = "message.data"
+      tags = ["data"]
+
+[[inputs.mqtt_consumer]]
+  name_override = "raw_mqtt_message"
+  servers = ["tcp://mosquitto:1883"]
+
+  # Capture the content as a string since we do not know the format of it...
+  data_format = "value"
+  data_type = "string"
+
+  # Capture all topics and store the topic as a tag with name "topic"...
+  topics = ["#"]
+  topic_tag = "topic"
+
+  qos = 2
+  persistent_session = false
+  client_id = "telegraf_generic"
+
+[[outputs.influxdb_v2]]
+  urls = ["http://influxdb:8086"]
+  token = "${INFLUX_TOKEN}"
+  organization = "test"
+  bucket = "test_bucket"


### PR DESCRIPTION
## Summary

The existing code only handles the data-format field correctly for single instances of the same plugin as we overwrite the parsers/serializers for each instance.

This PR fixes the issue and additionally restructures the code to be able to add test-cases and do so for previous issues.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #15627 
