### PR TITLE
feat(common.shim): Enable metric tracking within external plugins

### DIFF
--- a/docs/INPUTS.md
+++ b/docs/INPUTS.md
@@ -87,7 +87,7 @@ Metric Tracking provides a system to be notified when metrics have been
 successfully written to their outputs or otherwise discarded.  This allows
 inputs to be created that function as reliable queue consumers.
 
-Please note that this process applies only to internal plugins. For external 
+Please note that this process applies only to internal plugins. For external
 plugins, the metrics are acknowledged regardless of the actual output.
 
 To get started with metric tracking begin by calling `WithTracking` on the

--- a/docs/INPUTS.md
+++ b/docs/INPUTS.md
@@ -87,6 +87,9 @@ Metric Tracking provides a system to be notified when metrics have been
 successfully written to their outputs or otherwise discarded.  This allows
 inputs to be created that function as reliable queue consumers.
 
+Please note that this process applies only to internal plugins. For external 
+plugins, the metrics are acknowledged regardless of the actual output.
+
 To get started with metric tracking begin by calling `WithTracking` on the
 [telegraf.Accumulator][].  Add metrics using the `AddTrackingMetricGroup`
 function on the returned [telegraf.TrackingAccumulator][] and store the

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -34,7 +34,7 @@ before telling the metric source that the message was read. If Telegraf were to
 stop or the system running Telegraf to crash, this allows the messages that
 were not completely delivered to an output to get re-read at a later date.
 
-Please note that this process applies only to internal plugins. For external 
+Please note that this process applies only to internal plugins. For external
 plugins, the metrics are acknowledged regardless of the actual output.
 
 ### Undelivered Messages

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -34,6 +34,9 @@ before telling the metric source that the message was read. If Telegraf were to
 stop or the system running Telegraf to crash, this allows the messages that
 were not completely delivered to an output to get re-read at a later date.
 
+Please note that this process applies only to internal plugins. For external 
+plugins, the metrics are acknowledged regardless of the actual output.
+
 ### Undelivered Messages
 
 When an input uses tracking metrics, an additional setting,

--- a/plugins/common/shim/goshim.go
+++ b/plugins/common/shim/goshim.go
@@ -115,13 +115,16 @@ func (s *Shim) writeProcessedMetrics() error {
 			}
 			b, err := serializer.Serialize(m)
 			if err != nil {
+				m.Reject()
 				return fmt.Errorf("failed to serialize metric: %w", err)
 			}
 			// Write this to stdout
 			_, err = fmt.Fprint(s.stdout, string(b))
 			if err != nil {
+				m.Drop()
 				return fmt.Errorf("failed to write metric: %w", err)
 			}
+			m.Accept()
 		}
 	}
 }


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

 - This PR enables external plugins to use metric tracking within their isolated environment

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #15572
