### PR TITLE
feat(common.cookie): Allow usage of secrets for header

### DIFF
--- a/plugins/common/cookie/cookie_test.go
+++ b/plugins/common/cookie/cookie_test.go
@@ -37,6 +37,8 @@ var fakeCookie = &http.Cookie{
 	Value: "this is an auth cookie",
 }
 
+var reqHeaderValSecret = config.NewSecret([]byte(reqHeaderVal))
+
 type fakeServer struct {
 	*httptest.Server
 	*int32
@@ -123,7 +125,7 @@ func TestAuthConfig_Start(t *testing.T) {
 		Username string
 		Password string
 		Body     string
-		Headers  map[string]string
+		Headers  map[string]*config.Secret
 	}
 	type args struct {
 		renewal  time.Duration
@@ -157,7 +159,7 @@ func TestAuthConfig_Start(t *testing.T) {
 				endpoint: authEndpointWithHeader,
 			},
 			fields: fields{
-				Headers: map[string]string{reqHeaderKey: reqHeaderVal},
+				Headers: map[string]*config.Secret{reqHeaderKey: &reqHeaderValSecret},
 			},
 			firstAuthCount:    1,
 			lastAuthCount:     3,

--- a/plugins/inputs/http/README.md
+++ b/plugins/inputs/http/README.md
@@ -18,7 +18,7 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 ## Secret-store support
 
 This plugin supports secrets from secret-stores for the `username`, `password`,
-`token` and `headers` option.
+`token`, `headers`, and `cookie_auth_headers` option.
 See the [secret-store documentation][SECRETSTORE] for more details on how
 to use them.
 

--- a/plugins/outputs/http/README.md
+++ b/plugins/outputs/http/README.md
@@ -16,7 +16,7 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 ## Secret-store support
 
 This plugin supports secrets from secret-stores for the `username`, `password`
-and `headers` option.
+`headers`, and `cookie_auth_headers` option.
 See the [secret-store documentation][SECRETSTORE] for more details on how
 to use them.
 


### PR DESCRIPTION
## Summary
common.cookie does not support secretstores, it may be required to send header values based on secretstores

## Checklist
- [x] No AI generated code was used in this PR

## Related issues
resolves https://github.com/influxdata/telegraf/issues/15639
