### PR TITLE
fix(inputs.tail): Prevent deadlock when closing and max undelivered lines hit

### DIFF
--- a/plugins/inputs/tail/tail.go
+++ b/plugins/inputs/tail/tail.go
@@ -370,6 +370,11 @@ func (t *Tail) receiver(parser telegraf.Parser, tailer *tail.Tail) {
 		select {
 		case <-t.ctx.Done():
 			return
+		// Tail is trying to close so drain the sem to allow the receiver
+		// to exit. This condition is hit when the tailer may have hit the
+		// maximum undelivered lines and is trying to close.
+		case <-tailer.Dying():
+			<-t.sem
 		case t.sem <- empty{}:
 			t.acc.AddTrackingMetricGroup(metrics)
 		}


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
When we try to close the tailer, tail will block until the goroutine is in a dead state. When a tailer had read more than the max undelivered this condition was never hit and we deadlocked. This ensures that when the tailer is trying to die we clear out the channel to close successfully.

This was not an issue when the max undelivered was not hit.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

fixes: #15641
