### PR TITLE
fix(inputs.diskio): Print warnings once, add details to messages

### DIFF
--- a/plugins/inputs/diskio/diskio_linux.go
+++ b/plugins/inputs/diskio/diskio_linux.go
@@ -25,7 +25,7 @@ func (d *DiskIO) diskInfo(devName string) (map[string]string, error) {
 	path := "/dev/" + devName
 	var stat unix.Stat_t
 	if err := unix.Stat(path, &stat); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error reading %s: %w", path, err)
 	}
 
 	// Check if we already got a cached and valid entry
@@ -49,7 +49,7 @@ func (d *DiskIO) diskInfo(devName string) (map[string]string, error) {
 			udevDataPath = "/dev/.udev/db/block:" + devName
 			if _, err := os.Stat(udevDataPath); err != nil {
 				// Giving up, cannot retrieve disk info
-				return nil, err
+				return nil, fmt.Errorf("error reading %s: %w", udevDataPath, err)
 			}
 		}
 	}


### PR DESCRIPTION



## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
These warnings are printed every time and probably should not be as it is very unlikely that something would change to make the behavior start working. Additionally, the warnings are void of actual information about what went wrong, what file was attempting to be read, etc.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

fixes: #15666 
