### PR TITLE
feat(outputs.dynatrace): add support for metric to be treated and reported as a delta counter using regular expression

### DIFF
--- a/plugins/outputs/dynatrace/README.md
+++ b/plugins/outputs/dynatrace/README.md
@@ -8,7 +8,7 @@ plugin can be found in the [Dynatrace documentation][docs].  All metrics are
 reported as gauges, unless they are specified to be delta counters using the
 `additional_counters` or `additional_counters_patterns` config option
 (see below).
-See the [Dynatrace Metrics ingestion protocol documentation][proto-docs] 
+See the [Dynatrace Metrics ingestion protocol documentation][proto-docs]
 for details on the types defined there.
 
 [api-v2]: https://docs.dynatrace.com/docs/shortlink/api-metrics-v2
@@ -225,8 +225,8 @@ additional_counters = [ ]
 
 *required*: `false`
 
-In addition or as an alternative to additional_counters, if you want a metric 
-to be treated and reported as a delta counter using regular expression, 
+In addition or as an alternative to additional_counters, if you want a metric
+to be treated and reported as a delta counter using regular expression,
 add its pattern to this list.
 
 ```toml

--- a/plugins/outputs/dynatrace/README.md
+++ b/plugins/outputs/dynatrace/README.md
@@ -144,8 +144,8 @@ to use them.
   ## If you want metrics to be treated and reported as delta counters, add the metric names here
   additional_counters = [ ]
 
-  ## In addition or as an alternative to additional_counters, if you want metrics to be treated and reported as
-  ## delta counters using regular expression pattern matching
+  ## In addition or as an alternative to additional_counters, if you want metrics to be treated and
+  ## reported as delta counters using regular expression pattern matching
   additional_counters_patterns = [ ]
 
   ## NOTE: Due to the way TOML is parsed, tables must be at the END of the

--- a/plugins/outputs/dynatrace/README.md
+++ b/plugins/outputs/dynatrace/README.md
@@ -6,9 +6,10 @@ OneAgent for automatic authentication or it may be run standalone on a host
 without a OneAgent by specifying a URL and API Token.  More information on the
 plugin can be found in the [Dynatrace documentation][docs].  All metrics are
 reported as gauges, unless they are specified to be delta counters using the
-`additional_counters` or `additional_counters_patterns` config option (see below).
-See the [Dynatrace Metrics ingestion protocol documentation][proto-docs] for details on the types defined
-there.
+`additional_counters` or `additional_counters_patterns` config option
+(see below).
+See the [Dynatrace Metrics ingestion protocol documentation][proto-docs] for details
+on the types defined there.
 
 [api-v2]: https://docs.dynatrace.com/docs/shortlink/api-metrics-v2
 
@@ -224,8 +225,9 @@ additional_counters = [ ]
 
 *required*: `false`
 
-In addition or as an alternative to additional_counters, if you want a metric to be treated and
-reported as a delta counter using regular expression, add its pattern to this list.
+In addition or as an alternative to additional_counters, if you want a metric to be
+treated and reported as a delta counter using regular expression, add its pattern
+to this list.
 
 ```toml
 additional_counters_patterns = [ ]

--- a/plugins/outputs/dynatrace/README.md
+++ b/plugins/outputs/dynatrace/README.md
@@ -6,8 +6,8 @@ OneAgent for automatic authentication or it may be run standalone on a host
 without a OneAgent by specifying a URL and API Token.  More information on the
 plugin can be found in the [Dynatrace documentation][docs].  All metrics are
 reported as gauges, unless they are specified to be delta counters using the
-`additional_counters` config option (see below).  See the [Dynatrace Metrics
-ingestion protocol documentation][proto-docs] for details on the types defined
+`additional_counters` or `additional_counters_patterns` config option (see below).
+See the [Dynatrace Metrics ingestion protocol documentation][proto-docs] for details on the types defined
 there.
 
 [api-v2]: https://docs.dynatrace.com/docs/shortlink/api-metrics-v2
@@ -144,6 +144,10 @@ to use them.
   ## If you want metrics to be treated and reported as delta counters, add the metric names here
   additional_counters = [ ]
 
+  ## In addition or as an alternative to additional_counters, if you want metrics to be treated and reported as
+  ## delta counters using regular expression pattern matching
+  additional_counters_patterns = [ ]
+
   ## NOTE: Due to the way TOML is parsed, tables must be at the END of the
   ## plugin definition, otherwise additional config options are read as part of
   ## the table
@@ -214,6 +218,17 @@ to this list.
 
 ```toml
 additional_counters = [ ]
+```
+
+### `additional_counters_patterns`
+
+*required*: `false`
+
+In addition or as an alternative to additional_counters, if you want a metric to be treated and
+reported as a delta counter using regular expression, add its pattern to this list.
+
+```toml
+additional_counters_patterns = [ ]
 ```
 
 ### `default_dimensions`

--- a/plugins/outputs/dynatrace/README.md
+++ b/plugins/outputs/dynatrace/README.md
@@ -8,8 +8,8 @@ plugin can be found in the [Dynatrace documentation][docs].  All metrics are
 reported as gauges, unless they are specified to be delta counters using the
 `additional_counters` or `additional_counters_patterns` config option
 (see below).
-See the [Dynatrace Metrics ingestion protocol documentation][proto-docs] for details
-on the types defined there.
+See the [Dynatrace Metrics ingestion protocol documentation][proto-docs] 
+for details on the types defined there.
 
 [api-v2]: https://docs.dynatrace.com/docs/shortlink/api-metrics-v2
 
@@ -225,9 +225,9 @@ additional_counters = [ ]
 
 *required*: `false`
 
-In addition or as an alternative to additional_counters, if you want a metric to be
-treated and reported as a delta counter using regular expression, add its pattern
-to this list.
+In addition or as an alternative to additional_counters, if you want a metric 
+to be treated and reported as a delta counter using regular expression, 
+add its pattern to this list.
 
 ```toml
 additional_counters_patterns = [ ]

--- a/plugins/outputs/dynatrace/dynatrace.go
+++ b/plugins/outputs/dynatrace/dynatrace.go
@@ -232,10 +232,8 @@ func init() {
 
 func (d *Dynatrace) getTypeOption(metric telegraf.Metric, field *telegraf.Field) dtMetric.MetricOption {
 	metricName := metric.Name() + "." + field.Key
-
 	if d.isCounterMetricsMatch(d.AddCounterMetrics, metricName) ||
 		d.isCounterMetricsPatternsMatch(d.AddCounterMetricsPatterns, metricName) {
-
 		switch v := field.Value.(type) {
 		case float64:
 			return dtMetric.WithFloatCounterValueDelta(v)
@@ -247,7 +245,6 @@ func (d *Dynatrace) getTypeOption(metric telegraf.Metric, field *telegraf.Field)
 			return nil
 		}
 	}
-
 	switch v := field.Value.(type) {
 	case float64:
 		return dtMetric.WithFloatGaugeValue(v)

--- a/plugins/outputs/dynatrace/dynatrace.go
+++ b/plugins/outputs/dynatrace/dynatrace.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"regexp"
 	"strings"
 	"time"
 
@@ -26,12 +27,14 @@ var sampleConfig string
 
 // Dynatrace Configuration for the Dynatrace output plugin
 type Dynatrace struct {
-	URL               string            `toml:"url"`
-	APIToken          config.Secret     `toml:"api_token"`
-	Prefix            string            `toml:"prefix"`
-	Log               telegraf.Logger   `toml:"-"`
-	Timeout           config.Duration   `toml:"timeout"`
-	AddCounterMetrics []string          `toml:"additional_counters"`
+	URL                       string          `toml:"url"`
+	APIToken                  config.Secret   `toml:"api_token"`
+	Prefix                    string          `toml:"prefix"`
+	Log                       telegraf.Logger `toml:"-"`
+	Timeout                   config.Duration `toml:"timeout"`
+	AddCounterMetrics         []string        `toml:"additional_counters"`
+	AddCounterMetricsPatterns []string        `toml:"additional_counters_patterns"`
+
 	DefaultDimensions map[string]string `toml:"default_dimensions"`
 
 	normalizedDefaultDimensions dimensions.NormalizedDimensionList
@@ -229,10 +232,10 @@ func init() {
 
 func (d *Dynatrace) getTypeOption(metric telegraf.Metric, field *telegraf.Field) dtMetric.MetricOption {
 	metricName := metric.Name() + "." + field.Key
-	for _, i := range d.AddCounterMetrics {
-		if metricName != i {
-			continue
-		}
+
+	if d.isCounterMetricsMatch(d.AddCounterMetrics, metricName) ||
+		d.isCounterMetricsPatternsMatch(d.AddCounterMetricsPatterns, metricName) {
+
 		switch v := field.Value.(type) {
 		case float64:
 			return dtMetric.WithFloatCounterValueDelta(v)
@@ -260,4 +263,23 @@ func (d *Dynatrace) getTypeOption(metric telegraf.Metric, field *telegraf.Field)
 	}
 
 	return nil
+}
+
+func (d *Dynatrace) isCounterMetricsMatch(counterMetrics []string, metricName string) bool {
+	for _, i := range counterMetrics {
+		if i == metricName {
+			return true
+		}
+	}
+	return false
+}
+
+func (d *Dynatrace) isCounterMetricsPatternsMatch(counterPatterns []string, metricName string) bool {
+	for _, pattern := range counterPatterns {
+		regex, err := regexp.Compile(pattern)
+		if err == nil && regex.MatchString(metricName) {
+			return true
+		}
+	}
+	return false
 }

--- a/plugins/outputs/dynatrace/dynatrace_test.go
+++ b/plugins/outputs/dynatrace/dynatrace_test.go
@@ -260,7 +260,9 @@ func TestSendMetricsWithPatterns(t *testing.T) {
 		"simple_xyz_metric.value,dt.metrics.source=telegraf gauge,3.14 1289430000000",
 		"simple_xyz_metric.counter,dt.metrics.source=telegraf count,delta=5 1289430000000",
 	)
+	// Add pattern to match all metrics that match simple_[a-z]+_metric.counter
 	d.AddCounterMetricsPatterns = append(d.AddCounterMetricsPatterns, "simple_[a-z]+_metric.counter")
+
 	m1 := metric.New(
 		"simple_abc_metric",
 		map[string]string{},

--- a/plugins/outputs/dynatrace/dynatrace_test.go
+++ b/plugins/outputs/dynatrace/dynatrace_test.go
@@ -257,8 +257,8 @@ func TestSendMetricsWithPatterns(t *testing.T) {
 	expected = append(expected,
 		"simple_abc_metric.value,dt.metrics.source=telegraf gauge,3.14 1289430000000",
 		"simple_abc_metric.counter,dt.metrics.source=telegraf count,delta=5 1289430000000",
-		"simple_xyz_metric.value,dt.metrics.source=telegraf gauge,3.14 1289516400000",
-		"simple_xyz_metric.counter,dt.metrics.source=telegraf count,delta=5 1289516400000",
+		"simple_xyz_metric.value,dt.metrics.source=telegraf gauge,3.14 1289430000000",
+		"simple_xyz_metric.counter,dt.metrics.source=telegraf count,delta=5 1289430000000",
 	)
 	d.AddCounterMetricsPatterns = append(d.AddCounterMetricsPatterns, "simple_[a-z]+_metric.counter")
 	m1 := metric.New(
@@ -272,15 +272,15 @@ func TestSendMetricsWithPatterns(t *testing.T) {
 		"simple_xyz_metric",
 		map[string]string{},
 		map[string]interface{}{"value": float64(3.14), "counter": 5},
-		time.Date(2010, time.November, 11, 23, 0, 0, 0, time.UTC),
+		time.Date(2010, time.November, 10, 23, 0, 0, 0, time.UTC),
 	)
 
 	// Even if Type() returns counter, all metrics are treated as a gauge unless pattern match with additional_counters_patterns
 	expected = append(expected,
 		"counter_fan01_type.value,dt.metrics.source=telegraf gauge,3.14 1289430000000",
 		"counter_fan01_type.counter,dt.metrics.source=telegraf count,delta=5 1289430000000",
-		"counter_fanNaN_type.counter,dt.metrics.source=telegraf gauge,5 1289516400000",
-		"counter_fanNaN_type.value,dt.metrics.source=telegraf gauge,3.14 1289516400000",
+		"counter_fanNaN_type.counter,dt.metrics.source=telegraf gauge,5 1289430000000",
+		"counter_fanNaN_type.value,dt.metrics.source=telegraf gauge,3.14 1289430000000",
 	)
 	d.AddCounterMetricsPatterns = append(d.AddCounterMetricsPatterns, "counter_fan[0-9]+_type.counter")
 	m3 := metric.New(
@@ -295,7 +295,7 @@ func TestSendMetricsWithPatterns(t *testing.T) {
 		"counter_fanNaN_type",
 		map[string]string{},
 		map[string]interface{}{"value": float64(3.14), "counter": 5},
-		time.Date(2010, time.November, 11, 23, 0, 0, 0, time.UTC),
+		time.Date(2010, time.November, 10, 23, 0, 0, 0, time.UTC),
 		telegraf.Counter,
 	)
 

--- a/plugins/outputs/dynatrace/dynatrace_test.go
+++ b/plugins/outputs/dynatrace/dynatrace_test.go
@@ -213,6 +213,114 @@ func TestSendMetrics(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestSendMetricsWithPatterns(t *testing.T) {
+	expected := []string{}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// check the encoded result
+		bodyBytes, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		bodyString := string(bodyBytes)
+
+		lines := strings.Split(bodyString, "\n")
+
+		sort.Strings(lines)
+		sort.Strings(expected)
+
+		expectedString := strings.Join(expected, "\n")
+		foundString := strings.Join(lines, "\n")
+		if foundString != expectedString {
+			t.Errorf("Metric encoding failed. expected: %#v but got: %#v", expectedString, foundString)
+		}
+		w.WriteHeader(http.StatusOK)
+		err = json.NewEncoder(w).Encode(fmt.Sprintf(`{"linesOk":%d,"linesInvalid":0,"error":null}`, len(lines)))
+		require.NoError(t, err)
+	}))
+	defer ts.Close()
+
+	d := &Dynatrace{
+		URL:                       ts.URL,
+		APIToken:                  config.NewSecret([]byte("123")),
+		Log:                       testutil.Logger{},
+		AddCounterMetrics:         []string{},
+		AddCounterMetricsPatterns: []string{},
+	}
+
+	err := d.Init()
+	require.NoError(t, err)
+	err = d.Connect()
+	require.NoError(t, err)
+
+	// Init metrics
+
+	// Simple metrics are exported as a gauge unless pattern match in additional_counters_patterns
+	expected = append(expected,
+		"simple_abc_metric.value,dt.metrics.source=telegraf gauge,3.14 1289430000000",
+		"simple_abc_metric.counter,dt.metrics.source=telegraf count,delta=5 1289430000000",
+		"simple_xyz_metric.value,dt.metrics.source=telegraf gauge,3.14 1289516400000",
+		"simple_xyz_metric.counter,dt.metrics.source=telegraf count,delta=5 1289516400000",
+	)
+	d.AddCounterMetricsPatterns = append(d.AddCounterMetricsPatterns, "simple_[a-z]+_metric.counter")
+	m1 := metric.New(
+		"simple_abc_metric",
+		map[string]string{},
+		map[string]interface{}{"value": float64(3.14), "counter": 5},
+		time.Date(2010, time.November, 10, 23, 0, 0, 0, time.UTC),
+	)
+
+	m2 := metric.New(
+		"simple_xyz_metric",
+		map[string]string{},
+		map[string]interface{}{"value": float64(3.14), "counter": 5},
+		time.Date(2010, time.November, 11, 23, 0, 0, 0, time.UTC),
+	)
+
+	// Even if Type() returns counter, all metrics are treated as a gauge unless pattern match with additional_counters_patterns
+	expected = append(expected,
+		"counter_fan01_type.value,dt.metrics.source=telegraf gauge,3.14 1289430000000",
+		"counter_fan01_type.counter,dt.metrics.source=telegraf count,delta=5 1289430000000",
+		"counter_fanNaN_type.counter,dt.metrics.source=telegraf gauge,5 1289516400000",
+		"counter_fanNaN_type.value,dt.metrics.source=telegraf gauge,3.14 1289516400000",
+	)
+	d.AddCounterMetricsPatterns = append(d.AddCounterMetricsPatterns, "counter_fan[0-9]+_type.counter")
+	m3 := metric.New(
+		"counter_fan01_type",
+		map[string]string{},
+		map[string]interface{}{"value": float64(3.14), "counter": 5},
+		time.Date(2010, time.November, 10, 23, 0, 0, 0, time.UTC),
+		telegraf.Counter,
+	)
+
+	m4 := metric.New(
+		"counter_fanNaN_type",
+		map[string]string{},
+		map[string]interface{}{"value": float64(3.14), "counter": 5},
+		time.Date(2010, time.November, 11, 23, 0, 0, 0, time.UTC),
+		telegraf.Counter,
+	)
+
+	expected = append(expected,
+		"complex_metric.int,dt.metrics.source=telegraf gauge,1 1289430000000",
+		"complex_metric.int64,dt.metrics.source=telegraf gauge,2 1289430000000",
+		"complex_metric.float,dt.metrics.source=telegraf gauge,3 1289430000000",
+		"complex_metric.float64,dt.metrics.source=telegraf gauge,4 1289430000000",
+		"complex_metric.true,dt.metrics.source=telegraf gauge,1 1289430000000",
+		"complex_metric.false,dt.metrics.source=telegraf gauge,0 1289430000000",
+	)
+
+	m5 := metric.New(
+		"complex_metric",
+		map[string]string{},
+		map[string]interface{}{"int": 1, "int64": int64(2), "float": 3.0, "float64": float64(4.0), "true": true, "false": false},
+		time.Date(2010, time.November, 10, 23, 0, 0, 0, time.UTC),
+	)
+
+	metrics := []telegraf.Metric{m1, m2, m3, m4, m5}
+
+	err = d.Write(metrics)
+	require.NoError(t, err)
+}
+
 func TestSendSingleMetricWithUnorderedTags(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// check the encoded result

--- a/plugins/outputs/dynatrace/sample.conf
+++ b/plugins/outputs/dynatrace/sample.conf
@@ -31,6 +31,10 @@
   ## If you want metrics to be treated and reported as delta counters, add the metric names here
   additional_counters = [ ]
 
+  ## In addition or as an alternative to additional_counters, if you want metrics to be treated and
+  ## reported as delta counters using regular expression pattern matching
+  additional_counters_patterns = [ ]
+
   ## NOTE: Due to the way TOML is parsed, tables must be at the END of the
   ## plugin definition, otherwise additional config options are read as part of
   ## the table


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Adding support for metric to be treated and reported as a delta counter using regular expression using a new configuration variable:

```
AddCounterMetricsPatterns []string        `toml:"additional_counters_patterns"`
```

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->
- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] README.md updated.
- [x] Has appropriate unit tests.
- [x] Resolves [Issue#15659](https://github.com/influxdata/telegraf/issues/15659)
- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #15659 
