### PR TITLE
fix(inputs.mqtt_consumer): Restore trace logging option

### DIFF
--- a/plugins/inputs/mqtt_consumer/mqtt_consumer.go
+++ b/plugins/inputs/mqtt_consumer/mqtt_consumer.go
@@ -58,6 +58,7 @@ type MQTTConsumer struct {
 	PingTimeout            config.Duration      `toml:"ping_timeout"`
 	MaxUndeliveredMessages int                  `toml:"max_undelivered_messages"`
 	PersistentSession      bool                 `toml:"persistent_session"`
+	ClientTrace            bool                 `toml:"client_trace"`
 	ClientID               string               `toml:"client_id"`
 	Log                    telegraf.Logger      `toml:"-"`
 	tls.ClientConfig
@@ -87,6 +88,14 @@ func (m *MQTTConsumer) SetParser(parser telegraf.Parser) {
 	m.parser = parser
 }
 func (m *MQTTConsumer) Init() error {
+	if m.ClientTrace {
+		log := &mqttLogger{m.Log}
+		mqtt.ERROR = log
+		mqtt.CRITICAL = log
+		mqtt.WARN = log
+		mqtt.DEBUG = log
+	}
+
 	if m.PersistentSession && m.ClientID == "" {
 		return errors.New("persistent_session requires client_id")
 	}

--- a/plugins/inputs/mqtt_consumer/mqtt_logger.go
+++ b/plugins/inputs/mqtt_consumer/mqtt_logger.go
@@ -1,0 +1,16 @@
+package mqtt_consumer
+
+import (
+	"github.com/influxdata/telegraf"
+)
+
+type mqttLogger struct {
+	telegraf.Logger
+}
+
+func (l mqttLogger) Printf(fmt string, args ...interface{}) {
+	l.Logger.Debugf(fmt, args...)
+}
+func (l mqttLogger) Println(args ...interface{}) {
+	l.Logger.Debug(args...)
+}


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
In #15429, I added trace logging to the mqtt outputs for v3 and v5. I removed trace logging settings from the input, moving it to the common code. However, the input does not even use the common code *facepalm*. This restores the trace option for the input. I discovered this while testing out the new logging mechanisms.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

