### PR TITLE
feat(inputs.statsd): Expose allowed_pending_messages as internal stat

### DIFF
--- a/plugins/inputs/statsd/statsd.go
+++ b/plugins/inputs/statsd/statsd.go
@@ -164,6 +164,7 @@ type Statsd struct {
 	UDPBytesRecv       selfstat.Stat
 	ParseTimeNS        selfstat.Stat
 	PendingMessages    selfstat.Stat
+	MaxPendingMessages selfstat.Stat
 
 	lastGatherTime time.Time
 }
@@ -356,6 +357,8 @@ func (s *Statsd) Start(ac telegraf.Accumulator) error {
 	s.UDPBytesRecv = selfstat.Register("statsd", "udp_bytes_received", tags)
 	s.ParseTimeNS = selfstat.Register("statsd", "parse_time_ns", tags)
 	s.PendingMessages = selfstat.Register("statsd", "pending_messages", tags)
+	s.MaxPendingMessages = selfstat.Register("statsd", "max_pending_messages", tags)
+	s.MaxPendingMessages.Set(int64(s.AllowedPendingMessages))
 
 	s.in = make(chan input, s.AllowedPendingMessages)
 	s.done = make(chan struct{})


### PR DESCRIPTION
## Summary
`allowed_pending_messages` is a config described as:

```
  ## Number of UDP messages allowed to queue up, once filled,
  ## the statsd server will start dropping packets
```

Currently `statsd_pending_messages` is exported which allows you to see the number of pending messages. However exporting the config value for `allowed_pending_messages` is helpful to then set up alerting on when that limit has been reached.

I'm open to changing the name of the stat away from `max_pending_messages`. I don't mind setting it to `allowed_pending_messages` but then I think I would need code similar to below to avoid the conflict in names. MaxPendingMessages to me indicates that pending messages cannot go above this value.

```go
	s.AllowedPendingMessagesStat = selfstat.Register("statsd", "allowed_pending_messages", tags)
	s.AllowedPendingMessagesStat.Set(int64(s.AllowedPendingMessages))
```

<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #15686
