### PR TITLE
feat(processors.execd): All user configurable buffer size

### DIFF
--- a/plugins/processors/execd/README.md
+++ b/plugins/processors/execd/README.md
@@ -48,6 +48,10 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## Delay before the process is restarted after an unexpected termination
   # restart_delay = "10s"
 
+  ## Buffer size used to read from the command out and error streams
+  ## Optional parameter. Default is 64 Kib, minimum is 16 bytes
+  # buffer_size = "64Kib"
+
   ## Serialization format for communicating with the executed program
   ## Please note that the corresponding data-format must exist both in
   ## parsers and serializers

--- a/plugins/processors/execd/sample.conf
+++ b/plugins/processors/execd/sample.conf
@@ -14,6 +14,10 @@
   ## Delay before the process is restarted after an unexpected termination
   # restart_delay = "10s"
 
+  ## Buffer size used to read from the command out and error streams
+  ## Optional parameter. Default is 64 Kib, minimum is 16 bytes
+  # buffer_size = "64Kib"
+
   ## Serialization format for communicating with the executed program
   ## Please note that the corresponding data-format must exist both in
   ## parsers and serializers


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Allow the user to set the buffer size used to read the command out and error streams. This does make the default out stream a bit bigger than before (4096 -> 65536) to match the scanners default, but a user could always decrease this back if required.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

fixes: #15684
