### PR TITLE
feat(logging): Add 'trace' log-level

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -410,7 +410,7 @@ Parameters that can be used with any input plugin:
 - **name_suffix**: Specifies a suffix to attach to the measurement name.
 - **tags**: A map of tags to apply to a specific input's measurements.
 - **log_level**: Override the log-level for this plugin. Possible values are
-  `error`, `warn`, `info` and `debug`.
+  `error`, `warn`, `info`, `debug` and `trace`.
 
 The [metric filtering][] parameters can be used to limit what metrics are
 emitted from the input plugin.

--- a/logger.go
+++ b/logger.go
@@ -14,6 +14,8 @@ const (
 	Info
 	// Debug will log all of the above and debugging messages issued by plugins
 	Debug
+	// Trace will log all of the above and trace messages issued by plugins
+	Trace
 )
 
 func LogLevelFromString(name string) LogLevel {
@@ -26,6 +28,8 @@ func LogLevelFromString(name string) LogLevel {
 		return Info
 	case "DEBUG", "debug":
 		return Debug
+	case "TRACE", "trace":
+		return Trace
 	}
 	return None
 }
@@ -40,6 +44,8 @@ func (e LogLevel) String() string {
 		return "INFO"
 	case Debug:
 		return "DEBUG"
+	case Trace:
+		return "TRACE"
 	}
 	return "NONE"
 }
@@ -54,6 +60,8 @@ func (e LogLevel) Indicator() string {
 		return "I!"
 	case Debug:
 		return "D!"
+	case Trace:
+		return "T!"
 	}
 	return "U!"
 }
@@ -63,7 +71,7 @@ func (e LogLevel) Includes(level LogLevel) bool {
 }
 
 // Logger defines an plugin-related interface for logging.
-type Logger interface {
+type Logger interface { //nolint:interfacebloat // All functions are required
 	// Level returns the configured log-level of the logger
 	Level() LogLevel
 
@@ -71,10 +79,6 @@ type Logger interface {
 	Errorf(format string, args ...interface{})
 	// Error logs an error message, patterned after log.Print.
 	Error(args ...interface{})
-	// Debugf logs a debug message, patterned after log.Printf.
-	Debugf(format string, args ...interface{})
-	// Debug logs a debug message, patterned after log.Print.
-	Debug(args ...interface{})
 	// Warnf logs a warning message, patterned after log.Printf.
 	Warnf(format string, args ...interface{})
 	// Warn logs a warning message, patterned after log.Print.
@@ -83,4 +87,12 @@ type Logger interface {
 	Infof(format string, args ...interface{})
 	// Info logs an information message, patterned after log.Print.
 	Info(args ...interface{})
+	// Debugf logs a debug message, patterned after log.Printf.
+	Debugf(format string, args ...interface{})
+	// Debug logs a debug message, patterned after log.Print.
+	Debug(args ...interface{})
+	// Tracef logs a trace message, patterned after log.Printf.
+	Tracef(format string, args ...interface{})
+	// Trace logs a trace message, patterned after log.Print.
+	Trace(args ...interface{})
 }

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -55,19 +55,6 @@ func New(category, name, alias string) *logger {
 	return l
 }
 
-// SetLevel changes the log-level to the given one
-func (l *logger) SetLogLevel(name string) error {
-	if name == "" {
-		return nil
-	}
-	level := telegraf.LogLevelFromString(name)
-	if level == telegraf.None {
-		return fmt.Errorf("invalid log-level %q", name)
-	}
-	l.level = &level
-	return nil
-}
-
 // SubLogger creates a new logger with the given name added as suffix
 func (l *logger) SubLogger(name string) telegraf.Logger {
 	suffix := l.suffix
@@ -116,6 +103,24 @@ func (l *logger) Level() telegraf.LogLevel {
 		return *l.level
 	}
 	return instance.level
+}
+
+// SetLevel overrides the current log-level of the logger
+func (l *logger) SetLevel(level telegraf.LogLevel) {
+	l.level = &level
+}
+
+// SetLevel changes the log-level to the given one
+func (l *logger) SetLogLevel(name string) error {
+	if name == "" {
+		return nil
+	}
+	level := telegraf.LogLevelFromString(name)
+	if level == telegraf.None {
+		return fmt.Errorf("invalid log-level %q", name)
+	}
+	l.SetLevel(level)
+	return nil
 }
 
 // Register a callback triggered when errors are about to be written to the log

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -162,6 +162,15 @@ func (l *logger) Debug(args ...interface{}) {
 	l.Print(telegraf.Debug, time.Now(), args...)
 }
 
+// Trace logging, this is suppressed on console
+func (l *logger) Tracef(format string, args ...interface{}) {
+	l.Trace(fmt.Sprintf(format, args...))
+}
+
+func (l *logger) Trace(args ...interface{}) {
+	l.Print(telegraf.Trace, time.Now(), args...)
+}
+
 func (l *logger) Print(level telegraf.LogLevel, ts time.Time, args ...interface{}) {
 	// Check if we are in early logging state and store the message in this case
 	if instance.impl == nil {

--- a/logger/stdlog_redirector.go
+++ b/logger/stdlog_redirector.go
@@ -24,6 +24,8 @@ func (s *stdlogRedirector) Write(b []byte) (n int, err error) {
 
 	// Log with the given level
 	switch level {
+	case 'T':
+		s.log.Trace(string(msg))
 	case 'D':
 		s.log.Debug(string(msg))
 	case 'I':

--- a/plugins/inputs/kafka_consumer/kafka_consumer.go
+++ b/plugins/inputs/kafka_consumer/kafka_consumer.go
@@ -52,11 +52,8 @@ type KafkaConsumer struct {
 	ConsumerFetchDefault                 config.Size     `toml:"consumer_fetch_default"`
 	ConnectionStrategy                   string          `toml:"connection_strategy"`
 	ResolveCanonicalBootstrapServersOnly bool            `toml:"resolve_canonical_bootstrap_servers_only"`
-
+	Log                                  telegraf.Logger `toml:"-"`
 	kafka.ReadConfig
-	kafka.Logger
-
-	Log telegraf.Logger `toml:"-"`
 
 	ConsumerCreator ConsumerGroupCreator `toml:"-"`
 	consumer        ConsumerGroup
@@ -99,7 +96,7 @@ func (k *KafkaConsumer) SetParser(parser telegraf.Parser) {
 }
 
 func (k *KafkaConsumer) Init() error {
-	k.SetLogger()
+	kafka.SetLogger(k.Log.Level())
 
 	if k.MaxUndeliveredMessages == 0 {
 		k.MaxUndeliveredMessages = defaultMaxUndeliveredMessages

--- a/plugins/inputs/kafka_consumer/kafka_consumer_test.go
+++ b/plugins/inputs/kafka_consumer/kafka_consumer_test.go
@@ -67,7 +67,7 @@ func TestInit(t *testing.T) {
 	}{
 		{
 			name:   "default config",
-			plugin: &KafkaConsumer{},
+			plugin: &KafkaConsumer{Log: testutil.Logger{}},
 			check: func(t *testing.T, plugin *KafkaConsumer) {
 				require.Equal(t, defaultConsumerGroup, plugin.ConsumerGroup)
 				require.Equal(t, defaultMaxUndeliveredMessages, plugin.MaxUndeliveredMessages)

--- a/plugins/inputs/modbus/README.md
+++ b/plugins/inputs/modbus/README.md
@@ -60,9 +60,8 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## and "RTU" for serial connections.
   # transmission_mode = "auto"
 
-  ## Trace the connection to the modbus device as debug messages
-  ## Note: You have to enable telegraf's debug mode to see those messages!
-  # debug_connection = false
+  ## Trace the connection to the modbus device
+  # log_level = "trace"
 
   ## Define the configuration schema
   ##  |---register -- define fields per register type in the original style (only supports one slave ID)

--- a/plugins/inputs/modbus/sample_general_begin.conf
+++ b/plugins/inputs/modbus/sample_general_begin.conf
@@ -42,9 +42,8 @@
   ## and "RTU" for serial connections.
   # transmission_mode = "auto"
 
-  ## Trace the connection to the modbus device as debug messages
-  ## Note: You have to enable telegraf's debug mode to see those messages!
-  # debug_connection = false
+  ## Trace the connection to the modbus device
+  # log_level = "trace"
 
   ## Define the configuration schema
   ##  |---register -- define fields per register type in the original style (only supports one slave ID)

--- a/plugins/inputs/netflow/README.md
+++ b/plugins/inputs/netflow/README.md
@@ -64,10 +64,8 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## decoding.
   # private_enterprise_number_files = []
 
-  ## Dump incoming packets to the log
-  ## This can be helpful to debug parsing issues. Only active if
-  ## Telegraf is in debug mode.
-  # dump_packets = false
+  ## Log incoming packets for tracing issues
+  # log_level = "trace"
 ```
 
 ## Private Enterprise Number mapping

--- a/plugins/inputs/netflow/netflow.go
+++ b/plugins/inputs/netflow/netflow.go
@@ -28,7 +28,7 @@ type NetFlow struct {
 	ServiceAddress string          `toml:"service_address"`
 	ReadBufferSize config.Size     `toml:"read_buffer_size"`
 	Protocol       string          `toml:"protocol"`
-	DumpPackets    bool            `toml:"dump_packets"`
+	DumpPackets    bool            `toml:"dump_packets" deprecated:"1.35.0;use 'log_level' 'trace' instead"`
 	PENFiles       []string        `toml:"private_enterprise_number_files"`
 	Log            telegraf.Logger `toml:"-"`
 
@@ -135,8 +135,8 @@ func (n *NetFlow) read(acc telegraf.Accumulator) {
 		if count < 1 {
 			continue
 		}
-		if n.DumpPackets {
-			n.Log.Debugf("raw data: %s", hex.EncodeToString(buf[:count]))
+		if n.Log.Level().Includes(telegraf.Trace) || n.DumpPackets { // for backward compatibility
+			n.Log.Tracef("raw data: %s", hex.EncodeToString(buf[:count]))
 		}
 		metrics, err := n.decoder.Decode(src.IP, buf[:count])
 		if err != nil {

--- a/plugins/inputs/netflow/sample.conf
+++ b/plugins/inputs/netflow/sample.conf
@@ -24,7 +24,5 @@
   ## decoding.
   # private_enterprise_number_files = []
 
-  ## Dump incoming packets to the log
-  ## This can be helpful to debug parsing issues. Only active if
-  ## Telegraf is in debug mode.
-  # dump_packets = false
+  ## Log incoming packets for tracing issues
+  # log_level = "trace"

--- a/plugins/inputs/s7comm/README.md
+++ b/plugins/inputs/s7comm/README.md
@@ -47,9 +47,8 @@ using the `startup_error_behavior` setting. Available values are:
   ## Timeout for requests
   # timeout = "10s"
 
-  ## Log detailed connection messages for debugging
-  ## This option only has an effect when Telegraf runs in debug mode
-  # debug_connection = false
+  ## Log detailed connection messages for tracing issues
+  # log_level = "trace"
 
   ## Metric definition(s)
   [[inputs.s7comm.metric]]

--- a/plugins/inputs/s7comm/sample.conf
+++ b/plugins/inputs/s7comm/sample.conf
@@ -17,9 +17,8 @@
   ## Timeout for requests
   # timeout = "10s"
 
-  ## Log detailed connection messages for debugging
-  ## This option only has an effect when Telegraf runs in debug mode
-  # debug_connection = false
+  ## Log detailed connection messages for tracing issues
+  # log_level = "trace"
 
   ## Metric definition(s)
   [[inputs.s7comm.metric]]

--- a/plugins/inputs/upsd/README.md
+++ b/plugins/inputs/upsd/README.md
@@ -42,10 +42,9 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
   ## Dump information for debugging
   ## Allows to print the raw variables (and corresponding types) as received
-  ## from the NUT server ONCE for each UPS. The output is only available when
-  ## running Telegraf in debug-mode.
+  ## from the NUT server ONCE for each UPS.
   ## Please attach this information when reporting issues!
-  # dump_raw_variables = false
+  # log_level = "trace"
 ```
 
 ## Pitfalls

--- a/plugins/inputs/upsd/sample.conf
+++ b/plugins/inputs/upsd/sample.conf
@@ -21,7 +21,6 @@
 
   ## Dump information for debugging
   ## Allows to print the raw variables (and corresponding types) as received
-  ## from the NUT server ONCE for each UPS. The output is only available when
-  ## running Telegraf in debug-mode.
+  ## from the NUT server ONCE for each UPS.
   ## Please attach this information when reporting issues!
-  # dump_raw_variables = false
+  # log_level = "trace"

--- a/plugins/inputs/upsd/upsd.go
+++ b/plugins/inputs/upsd/upsd.go
@@ -60,7 +60,7 @@ type Upsd struct {
 	Password   string          `toml:"password"`
 	ForceFloat bool            `toml:"force_float"`
 	Additional []string        `toml:"additional_fields"`
-	DumpRaw    bool            `toml:"dump_raw_variables"`
+	DumpRaw    bool            `toml:"dump_raw_variables" deprecated:"1.35.0;use 'log_level' 'trace' instead"`
 	Log        telegraf.Logger `toml:"-"`
 
 	filter filter.Filter
@@ -89,7 +89,7 @@ func (u *Upsd) Gather(acc telegraf.Accumulator) error {
 	if err != nil {
 		return err
 	}
-	if u.DumpRaw {
+	if u.Log.Level().Includes(telegraf.Trace) || u.DumpRaw { // for backward compatibility
 		for name, variables := range upsList {
 			// Only dump the information once per UPS
 			if u.dumped[name] {
@@ -101,7 +101,7 @@ func (u *Upsd) Gather(acc telegraf.Accumulator) error {
 				values = append(values, fmt.Sprintf("%s: %v", v.Name, v.Value))
 				types = append(types, fmt.Sprintf("%s: %v", v.Name, v.OriginalType))
 			}
-			u.Log.Debugf("Variables dump for UPS %q:\n%s\n-----\n%s", name, strings.Join(values, "\n"), strings.Join(types, "\n"))
+			u.Log.Tracef("Variables dump for UPS %q:\n%s\n-----\n%s", name, strings.Join(values, "\n"), strings.Join(types, "\n"))
 		}
 	}
 	for name, variables := range upsList {

--- a/plugins/outputs/postgresql/postgresql_test.go
+++ b/plugins/outputs/postgresql/postgresql_test.go
@@ -182,16 +182,6 @@ func (la *LogAccumulator) Error(args ...interface{}) {
 	la.append(pgx.LogLevelError, "%v", args)
 }
 
-func (la *LogAccumulator) Debugf(format string, args ...interface{}) {
-	la.tb.Helper()
-	la.append(pgx.LogLevelDebug, format, args)
-}
-
-func (la *LogAccumulator) Debug(args ...interface{}) {
-	la.tb.Helper()
-	la.append(pgx.LogLevelDebug, "%v", args)
-}
-
 func (la *LogAccumulator) Warnf(format string, args ...interface{}) {
 	la.tb.Helper()
 	la.append(pgx.LogLevelWarn, format, args)
@@ -210,6 +200,26 @@ func (la *LogAccumulator) Infof(format string, args ...interface{}) {
 func (la *LogAccumulator) Info(args ...interface{}) {
 	la.tb.Helper()
 	la.append(pgx.LogLevelInfo, "%v", args)
+}
+
+func (la *LogAccumulator) Debugf(format string, args ...interface{}) {
+	la.tb.Helper()
+	la.append(pgx.LogLevelDebug, format, args)
+}
+
+func (la *LogAccumulator) Debug(args ...interface{}) {
+	la.tb.Helper()
+	la.append(pgx.LogLevelDebug, "%v", args)
+}
+
+func (la *LogAccumulator) Tracef(format string, args ...interface{}) {
+	la.tb.Helper()
+	la.append(pgx.LogLevelDebug, format, args)
+}
+
+func (la *LogAccumulator) Trace(args ...interface{}) {
+	la.tb.Helper()
+	la.append(pgx.LogLevelDebug, "%v", args)
 }
 
 var ctx = context.Background()

--- a/plugins/parsers/xpath/README.md
+++ b/plugins/parsers/xpath/README.md
@@ -136,8 +136,7 @@ XPath expressions.
   # xpath_native_types = false
 
   ## Trace empty node selections for debugging
-  ## This will only produce output in debugging mode.
-  # xpath_trace = false
+  # log_level = "trace"
 
   ## Multiple parsing sections are allowed
   [[inputs.file.xpath]]

--- a/testutil/capturelog.go
+++ b/testutil/capturelog.go
@@ -15,6 +15,7 @@ const (
 	LevelWarn  = 'W'
 	LevelInfo  = 'I'
 	LevelDebug = 'D'
+	LevelTrace = 'T'
 )
 
 type Entry struct {
@@ -65,16 +66,6 @@ func (l *CaptureLogger) Error(args ...interface{}) {
 	l.loga(LevelError, args...)
 }
 
-// Debugf logs a debug message, patterned after log.Printf.
-func (l *CaptureLogger) Debugf(format string, args ...interface{}) {
-	l.logf(LevelDebug, format, args...)
-}
-
-// Debug logs a debug message, patterned after log.Print.
-func (l *CaptureLogger) Debug(args ...interface{}) {
-	l.loga(LevelDebug, args...)
-}
-
 // Warnf logs a warning message, patterned after log.Printf.
 func (l *CaptureLogger) Warnf(format string, args ...interface{}) {
 	l.logf(LevelWarn, format, args...)
@@ -93,6 +84,26 @@ func (l *CaptureLogger) Infof(format string, args ...interface{}) {
 // Info logs an information message, patterned after log.Print.
 func (l *CaptureLogger) Info(args ...interface{}) {
 	l.loga(LevelInfo, args...)
+}
+
+// Debugf logs a debug message, patterned after log.Printf.
+func (l *CaptureLogger) Debugf(format string, args ...interface{}) {
+	l.logf(LevelDebug, format, args...)
+}
+
+// Debug logs a debug message, patterned after log.Print.
+func (l *CaptureLogger) Debug(args ...interface{}) {
+	l.loga(LevelDebug, args...)
+}
+
+// Tracef logs a trace message, patterned after log.Printf.
+func (l *CaptureLogger) Tracef(format string, args ...interface{}) {
+	l.logf(LevelTrace, format, args...)
+}
+
+// Trace logs a trace message, patterned after log.Print.
+func (l *CaptureLogger) Trace(args ...interface{}) {
+	l.loga(LevelTrace, args...)
 }
 
 func (l *CaptureLogger) NMessages() int {

--- a/testutil/log.go
+++ b/testutil/log.go
@@ -30,20 +30,6 @@ func (l Logger) Error(args ...interface{}) {
 	log.Print(append([]interface{}{"E! [" + l.Name + "] "}, args...)...)
 }
 
-// Debugf logs a debug message, patterned after log.Printf.
-func (l Logger) Debugf(format string, args ...interface{}) {
-	if !l.Quiet {
-		log.Printf("D! ["+l.Name+"] "+format, args...)
-	}
-}
-
-// Debug logs a debug message, patterned after log.Print.
-func (l Logger) Debug(args ...interface{}) {
-	if !l.Quiet {
-		log.Print(append([]interface{}{"D! [" + l.Name + "] "}, args...)...)
-	}
-}
-
 // Warnf logs a warning message, patterned after log.Printf.
 func (l Logger) Warnf(format string, args ...interface{}) {
 	log.Printf("W! ["+l.Name+"] "+format, args...)
@@ -65,5 +51,33 @@ func (l Logger) Infof(format string, args ...interface{}) {
 func (l Logger) Info(args ...interface{}) {
 	if !l.Quiet {
 		log.Print(append([]interface{}{"I! [" + l.Name + "] "}, args...)...)
+	}
+}
+
+// Debugf logs a debug message, patterned after log.Printf.
+func (l Logger) Debugf(format string, args ...interface{}) {
+	if !l.Quiet {
+		log.Printf("D! ["+l.Name+"] "+format, args...)
+	}
+}
+
+// Debug logs a debug message, patterned after log.Print.
+func (l Logger) Debug(args ...interface{}) {
+	if !l.Quiet {
+		log.Print(append([]interface{}{"D! [" + l.Name + "] "}, args...)...)
+	}
+}
+
+// Tracef logs a trace message, patterned after log.Printf.
+func (l Logger) Tracef(format string, args ...interface{}) {
+	if !l.Quiet {
+		log.Printf("T! ["+l.Name+"] "+format, args...)
+	}
+}
+
+// Trace logs a trace message, patterned after log.Print.
+func (l Logger) Trace(args ...interface{}) {
+	if !l.Quiet {
+		log.Print(append([]interface{}{"T! [" + l.Name + "] "}, args...)...)
 	}
 }


### PR DESCRIPTION
## Summary

Add a `trace` log-level below the existing `debug` one to be able to trace plugin internal messages such as connection debugging etc potentially producing large amounts of messages. Please note, currently there is no means to enable this on an agent-wide scale. This is intentionally!

The PR furthermore, converts several plugins to use the new log-level instead of home-brewed settings.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues
