### PR TITLE
fix(inputs.opcua): Reconnect if closed connection

### DIFF
--- a/plugins/inputs/opcua/read_client.go
+++ b/plugins/inputs/opcua/read_client.go
@@ -91,7 +91,7 @@ func (o *ReadClient) Connect() error {
 }
 
 func (o *ReadClient) ensureConnected() error {
-	if o.State() == opcua.Disconnected {
+	if o.State() == opcua.Disconnected || o.State() == opcua.Closed {
 		return o.Connect()
 	}
 	return nil


### PR DESCRIPTION




## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Rather than checking if we are only disconnected, we should also check if the connection is closed to try to reconnect.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

fixes: #15693