### PR TITLE
feat(parsers.value): Add base64 datatype

### DIFF
--- a/plugins/parsers/value/README.md
+++ b/plugins/parsers/value/README.md
@@ -41,6 +41,7 @@ You **must** tell Telegraf what type of metric to collect by using the
              will treat integers as floating-point values and produces an error
              on data that cannot be converted (e.g. strings).
 - `string`:  outputs the data as a string.
+- `base64`:  outputs the data as a base64 encoded string.
 - `boolean`: converts the received data to a boolean value. This setting will
              produce an error on any data except for `true` and `false` strings.
 - `auto_integer`: converts the received data to an integer value if possible and

--- a/plugins/parsers/value/parser.go
+++ b/plugins/parsers/value/parser.go
@@ -2,6 +2,7 @@ package value
 
 import (
 	"bytes"
+	"encoding/base64"
 	"fmt"
 	"strconv"
 	"strings"
@@ -27,6 +28,8 @@ func (v *Parser) Init() error {
 		v.DataType = "float"
 	case "str", "string":
 		v.DataType = "string"
+	case "base64":
+		v.DataType = "base64"
 	case "bool", "boolean":
 		v.DataType = "bool"
 	case "auto_integer", "auto_float":
@@ -64,6 +67,8 @@ func (v *Parser) Parse(buf []byte) ([]telegraf.Metric, error) {
 		value, err = strconv.ParseFloat(vStr, 64)
 	case "string":
 		value = vStr
+	case "base64":
+		value = base64.StdEncoding.EncodeToString([]byte(vStr))
 	case "bool":
 		value, err = strconv.ParseBool(vStr)
 	case "auto_integer":

--- a/plugins/parsers/value/parser.go
+++ b/plugins/parsers/value/parser.go
@@ -68,7 +68,7 @@ func (v *Parser) Parse(buf []byte) ([]telegraf.Metric, error) {
 	case "string":
 		value = vStr
 	case "base64":
-		value = base64.StdEncoding.EncodeToString([]byte(vStr))
+		value = base64.StdEncoding.EncodeToString(buf)
 	case "bool":
 		value, err = strconv.ParseBool(vStr)
 	case "auto_integer":

--- a/plugins/parsers/value/parser_test.go
+++ b/plugins/parsers/value/parser_test.go
@@ -36,6 +36,12 @@ func TestParseValidValues(t *testing.T) {
 			expected: "foobar",
 		},
 		{
+			name:     "base64",
+			dtype:    "base64",
+			input:    []byte("foobar"),
+			expected: "Zm9vYmFy",
+		},
+		{
 			name:     "boolean",
 			dtype:    "boolean",
 			input:    []byte("true"),
@@ -131,6 +137,12 @@ func TestParseLineValidValues(t *testing.T) {
 			dtype:    "string",
 			input:    "foobar",
 			expected: "foobar",
+		},
+		{
+			name:     "base64",
+			dtype:    "base64",
+			input:    "foobar",
+			expected: "Zm9vYmFy",
 		},
 		{
 			name:     "boolean",


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Introduce data type to encode raw data as base64 to allow for further parsing down the line.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

fixes: #15694
