### PR TITLE
feat(outputs.datadog): Add support for submitting alongside dd-agent

### DIFF
--- a/plugins/outputs/datadog/README.md
+++ b/plugins/outputs/datadog/README.md
@@ -36,6 +36,14 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## Override the default (none) compression used to send data.
   ## Supports: "zlib", "none"
   # compression = "none"
+
+  ## Convert counts to rates
+  ## Use this to be able to submit metrics from telegraf alongside Datadog agent
+  # should_rate_counts = true
+
+  ## When should_rate_counts is enabled, this overrides the
+  ## default (10s) rate interval used to divide count metrics by
+  # rate_interval = 20
 ```
 
 ## Metrics
@@ -46,11 +54,9 @@ field key with a `.` character.
 Field values are converted to floating point numbers.  Strings and floats that
 cannot be sent over JSON, namely NaN and Inf, are ignored.
 
-We do not send `Rate` types. Counts are sent as `count`, with an
-interval hard-coded to 1. Note that this behavior does *not* play
-super-well if running simultaneously with current Datadog agents; they
-will attempt to change to `Rate` with `interval=10`. We prefer this
-method, however, as it reflects the raw data more accurately.
+Enabling the `should_rate_counts` will convert `count` metrics to `rate`
+and divide it by the `rate_interval`. This will allow telegraf to run
+alongside current Datadog agents.
 
 [metrics]: https://docs.datadoghq.com/api/v1/metrics/#submit-metrics
 [apikey]: https://app.datadoghq.com/account/settings#api

--- a/plugins/outputs/datadog/README.md
+++ b/plugins/outputs/datadog/README.md
@@ -37,13 +37,12 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## Supports: "zlib", "none"
   # compression = "none"
 
-  ## Convert counts to rates
-  ## Use this to be able to submit metrics from telegraf alongside Datadog agent
-  # should_rate_counts = false
-
-  ## Overrides the default rate interval used to divide count metrics by
-  ## when should_rate_counts is enabled
-  # rate_interval = 10
+  ## When non-zero, converts count metrics submitted by inputs.statsd
+  ## into rate, while dividing the metric value by this number.
+  ## Note that in order for metrics to be submitted simultaenously alongside
+  ## a Datadog agent, rate_interval has to match the interval used by the
+  ## agent - which defaults to 10s
+  # rate_interval = 0s
 ```
 
 ## Metrics
@@ -54,9 +53,10 @@ field key with a `.` character.
 Field values are converted to floating point numbers.  Strings and floats that
 cannot be sent over JSON, namely NaN and Inf, are ignored.
 
-Enabling the `should_rate_counts` will convert `count` metrics to `rate`
-and divide it by the `rate_interval` before submitting to Datadog.
-This allows telegraf to submit metrics alongside Datadog agents.
+Setting `rate_interval` to non-zero will convert `count` metrics to `rate`
+and divide its value by this interval before submitting to Datadog.
+This allows Telegraf to submit metrics alongside Datadog agents when their rate
+intervals are the same (Datadog defaults to `10s`).
 Note that this only supports metrics ingested via `inputs.statsd` given
 the dependency on the `metric_type` tag it creates. There is only support for
 `counter` metrics, and `count` values from `timing` and `histogram` metrics.

--- a/plugins/outputs/datadog/README.md
+++ b/plugins/outputs/datadog/README.md
@@ -39,11 +39,11 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
   ## Convert counts to rates
   ## Use this to be able to submit metrics from telegraf alongside Datadog agent
-  # should_rate_counts = true
+  # should_rate_counts = false
 
-  ## When should_rate_counts is enabled, this overrides the
-  ## default (10s) rate interval used to divide count metrics by
-  # rate_interval = 20
+  ## Overrides the default rate interval used to divide count metrics by
+  ## when should_rate_counts is enabled
+  # rate_interval = 10
 ```
 
 ## Metrics
@@ -55,8 +55,11 @@ Field values are converted to floating point numbers.  Strings and floats that
 cannot be sent over JSON, namely NaN and Inf, are ignored.
 
 Enabling the `should_rate_counts` will convert `count` metrics to `rate`
-and divide it by the `rate_interval`. This will allow telegraf to run
-alongside current Datadog agents.
+and divide it by the `rate_interval` before submitting to Datadog.
+This allows telegraf to submit metrics alongside Datadog agents.
+Note that this only supports metrics ingested via `inputs.statsd` given
+the dependency on the `metric_type` tag it creates. There is only support for
+`counter` metrics, and `count` values from `timing` and `histogram` metrics.
 
 [metrics]: https://docs.datadoghq.com/api/v1/metrics/#submit-metrics
 [apikey]: https://app.datadoghq.com/account/settings#api

--- a/plugins/outputs/datadog/datadog.go
+++ b/plugins/outputs/datadog/datadog.go
@@ -76,7 +76,7 @@ func (d *Datadog) Connect() error {
 	return nil
 }
 
-func (d *Datadog) convertToDatadogMetric(metrics []telegraf.Metric) ([]*Metric) {
+func (d *Datadog) convertToDatadogMetric(metrics []telegraf.Metric) []*Metric {
 	tempSeries := []*Metric{}
 
 	for _, m := range metrics {

--- a/plugins/outputs/datadog/datadog.go
+++ b/plugins/outputs/datadog/datadog.go
@@ -25,12 +25,12 @@ import (
 var sampleConfig string
 
 type Datadog struct {
-	Apikey           string          `toml:"apikey"`
-	Timeout          config.Duration `toml:"timeout"`
-	URL              string          `toml:"url"`
-	Compression      string          `toml:"compression"`
-	RateInterval     int64           `toml:"rate_interval"`
-	Log              telegraf.Logger `toml:"-"`
+	Apikey       string          `toml:"apikey"`
+	Timeout      config.Duration `toml:"timeout"`
+	URL          string          `toml:"url"`
+	Compression  string          `toml:"compression"`
+	RateInterval config.Duration `toml:"rate_interval"`
+	Log          telegraf.Logger `toml:"-"`
 
 	client *http.Client
 	proxy.HTTPProxy
@@ -106,7 +106,8 @@ func (d *Datadog) convertToDatadogMetric(metrics []telegraf.Metric) ([]*Metric, 
 				switch m.Type() {
 				case telegraf.Counter, telegraf.Untyped:
 					if d.RateInterval > 0 && isRateable(statsDMetricType, fieldName) {
-						interval = d.RateInterval
+						// interval is expected to be in seconds
+						interval = int64(d.RateInterval / 1000000000)
 						dogM[1] = dogM[1] / float64(interval)
 						tname = "rate"
 					} else if m.Type() == telegraf.Counter {
@@ -278,8 +279,8 @@ func (d *Datadog) Close() error {
 func init() {
 	outputs.Add("datadog", func() telegraf.Output {
 		return &Datadog{
-			URL:          datadogAPI,
-			Compression:  "none",
+			URL:         datadogAPI,
+			Compression: "none",
 		}
 	})
 }

--- a/plugins/outputs/datadog/datadog.go
+++ b/plugins/outputs/datadog/datadog.go
@@ -108,7 +108,7 @@ func (d *Datadog) convertToDatadogMetric(metrics []telegraf.Metric) []*Metric {
 						// interval is expected to be in seconds
 						rateIntervalSeconds := time.Duration(d.RateInterval).Seconds()
 						interval = int64(rateIntervalSeconds)
-						dogM[1] = dogM[1] / float64(rateIntervalSeconds)
+						dogM[1] = dogM[1] / rateIntervalSeconds
 						tname = "rate"
 					} else if m.Type() == telegraf.Counter {
 						tname = "count"

--- a/plugins/outputs/datadog/datadog.go
+++ b/plugins/outputs/datadog/datadog.go
@@ -106,8 +106,9 @@ func (d *Datadog) convertToDatadogMetric(metrics []telegraf.Metric) []*Metric {
 				case telegraf.Counter, telegraf.Untyped:
 					if d.RateInterval > 0 && isRateable(statsDMetricType, fieldName) {
 						// interval is expected to be in seconds
-						interval = int64(d.RateInterval / 1000000000)
-						dogM[1] = dogM[1] / float64(interval)
+						rateIntervalSeconds := time.Duration(d.RateInterval).Seconds()
+						interval = int64(rateIntervalSeconds)
+						dogM[1] = dogM[1] / float64(rateIntervalSeconds)
 						tname = "rate"
 					} else if m.Type() == telegraf.Counter {
 						tname = "count"

--- a/plugins/outputs/datadog/datadog_test.go
+++ b/plugins/outputs/datadog/datadog_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/testutil"
 )
 
@@ -309,7 +310,7 @@ func TestInfIsSkipped(t *testing.T) {
 func TestNonZeroRateIntervalConvertsRatesToCount(t *testing.T) {
 	d := &Datadog{
 		Apikey:       "123456",
-		RateInterval: 10,
+		RateInterval: config.Duration(10 * time.Second),
 	}
 
 	var tests = []struct {
@@ -606,7 +607,7 @@ func TestNonZeroRateIntervalConvertsRatesToCount(t *testing.T) {
 
 func TestZeroRateIntervalConvertsRatesToCount(t *testing.T) {
 	d := &Datadog{
-		Apikey:       "123456",
+		Apikey: "123456",
 	}
 
 	var tests = []struct {

--- a/plugins/outputs/datadog/datadog_test.go
+++ b/plugins/outputs/datadog/datadog_test.go
@@ -314,10 +314,12 @@ func TestShouldRateCount(t *testing.T) {
 	}
 
 	var tests = []struct {
+		name       string
 		metricsIn  []telegraf.Metric
 		metricsOut []*Metric
 	}{
 		{
+			"convert counter metrics to rate",
 			[]telegraf.Metric{
 				testutil.MustMetric(
 					"count_metric_converted_to_rate",
@@ -349,6 +351,7 @@ func TestShouldRateCount(t *testing.T) {
 			},
 		},
 		{
+			"convert count value in timing metrics to rate",
 			[]telegraf.Metric{
 				testutil.MustMetric(
 					"timing_metric",
@@ -470,6 +473,7 @@ func TestShouldRateCount(t *testing.T) {
 			},
 		},
 		{
+			"convert count value in histogram metrics to rate",
 			[]telegraf.Metric{
 				testutil.MustMetric(
 					"histogram_metric",
@@ -593,21 +597,23 @@ func TestShouldRateCount(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		actualMetricsOut, _ := d.convertToDatadogMetric(tt.metricsIn)
-		if len(actualMetricsOut) != len(tt.metricsOut) {
-			t.Errorf("\nexpected %+v\ngot %+v\n", len(tt.metricsOut), len(actualMetricsOut))
-		}
-
-		for i := range tt.metricsOut {
-			expectedMetric := *tt.metricsOut[i]
-			if !inSlice(expectedMetric, actualMetricsOut) {
-				s := ""
-				for _, m := range actualMetricsOut {
-					s = fmt.Sprintf("%s\n%v", s, m)
-				}
-				t.Errorf("\nmetric not found in slice %+v\nslice %+s\n", expectedMetric, s)
+		t.Run(tt.name, func(t *testing.T) {
+			actualMetricsOut, _ := d.convertToDatadogMetric(tt.metricsIn)
+			if len(actualMetricsOut) != len(tt.metricsOut) {
+				t.Errorf("\nexpected %+v\ngot %+v\n", len(tt.metricsOut), len(actualMetricsOut))
 			}
-		}
+
+			for i := range tt.metricsOut {
+				expectedMetric := *tt.metricsOut[i]
+				if !inSlice(expectedMetric, actualMetricsOut) {
+					s := ""
+					for _, m := range actualMetricsOut {
+						s = fmt.Sprintf("%s\n%v", s, m)
+					}
+					t.Errorf("\nmetric not found in slice %+v\nslice %+s\n", expectedMetric, s)
+				}
+			}
+		})
 	}
 }
 

--- a/plugins/outputs/datadog/datadog_test.go
+++ b/plugins/outputs/datadog/datadog_test.go
@@ -306,11 +306,10 @@ func TestInfIsSkipped(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestShouldRateCount(t *testing.T) {
+func TestNonZeroRateIntervalConvertsRatesToCount(t *testing.T) {
 	d := &Datadog{
-		Apikey:           "123456",
-		ShouldRateCounts: true,
-		RateInterval:     10,
+		Apikey:       "123456",
+		RateInterval: 10,
 	}
 
 	var tests = []struct {
@@ -322,7 +321,7 @@ func TestShouldRateCount(t *testing.T) {
 			"convert counter metrics to rate",
 			[]telegraf.Metric{
 				testutil.MustMetric(
-					"count_metric_converted_to_rate",
+					"count_metric",
 					map[string]string{
 						"metric_type": "counter",
 					},
@@ -335,7 +334,7 @@ func TestShouldRateCount(t *testing.T) {
 			},
 			[]*Metric{
 				{
-					Metric: "count_metric_converted_to_rate",
+					Metric: "count_metric",
 					Points: [1]Point{
 						{
 							float64(time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC).Unix()),
@@ -507,6 +506,303 @@ func TestShouldRateCount(t *testing.T) {
 						"metric_type:histogram",
 					},
 					Interval: 10,
+				},
+				{
+					Metric: "histogram_metric.lower",
+					Points: [1]Point{
+						{
+							float64(time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC).Unix()),
+							float64(10),
+						},
+					},
+					Type: "",
+					Tags: []string{
+						"metric_type:histogram",
+					},
+					Interval: 1,
+				},
+				{
+					Metric: "histogram_metric.mean",
+					Points: [1]Point{
+						{
+							float64(time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC).Unix()),
+							float64(10),
+						},
+					},
+					Type: "",
+					Tags: []string{
+						"metric_type:histogram",
+					},
+					Interval: 1,
+				},
+				{
+					Metric: "histogram_metric.median",
+					Points: [1]Point{
+						{
+							float64(time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC).Unix()),
+							float64(10),
+						},
+					},
+					Type: "",
+					Tags: []string{
+						"metric_type:histogram",
+					},
+					Interval: 1,
+				},
+				{
+					Metric: "histogram_metric.stddev",
+					Points: [1]Point{
+						{
+							float64(time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC).Unix()),
+							float64(0),
+						},
+					},
+					Type: "",
+					Tags: []string{
+						"metric_type:histogram",
+					},
+					Interval: 1,
+				},
+				{
+					Metric: "histogram_metric.sum",
+					Points: [1]Point{
+						{
+							float64(time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC).Unix()),
+							float64(10),
+						},
+					},
+					Type: "",
+					Tags: []string{
+						"metric_type:histogram",
+					},
+					Interval: 1,
+				},
+				{
+					Metric: "histogram_metric.upper",
+					Points: [1]Point{
+						{
+							float64(time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC).Unix()),
+							float64(10),
+						},
+					},
+					Type: "",
+					Tags: []string{
+						"metric_type:histogram",
+					},
+					Interval: 1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actualMetricsOut, actualLen := d.convertToDatadogMetric(tt.metricsIn)
+			require.Len(t, actualMetricsOut, actualLen)
+			require.ElementsMatch(t, tt.metricsOut, actualMetricsOut)
+		})
+	}
+}
+
+func TestZeroRateIntervalConvertsRatesToCount(t *testing.T) {
+	d := &Datadog{
+		Apikey:       "123456",
+	}
+
+	var tests = []struct {
+		name       string
+		metricsIn  []telegraf.Metric
+		metricsOut []*Metric
+	}{
+		{
+			"does not convert counter metrics to rate",
+			[]telegraf.Metric{
+				testutil.MustMetric(
+					"count_metric",
+					map[string]string{
+						"metric_type": "counter",
+					},
+					map[string]interface{}{
+						"value": 100,
+					},
+					time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC),
+					telegraf.Counter,
+				),
+			},
+			[]*Metric{
+				{
+					Metric: "count_metric",
+					Points: [1]Point{
+						{
+							float64(time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC).Unix()),
+							100,
+						},
+					},
+					Type: "count",
+					Tags: []string{
+						"metric_type:counter",
+					},
+					Interval: 1,
+				},
+			},
+		},
+		{
+			"does not convert count value in timing metrics to rate",
+			[]telegraf.Metric{
+				testutil.MustMetric(
+					"timing_metric",
+					map[string]string{
+						"metric_type": "timing",
+					},
+					map[string]interface{}{
+						"count":  1,
+						"lower":  float64(10),
+						"mean":   float64(10),
+						"median": float64(10),
+						"stddev": float64(0),
+						"sum":    float64(10),
+						"upper":  float64(10),
+					},
+					time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC),
+					telegraf.Untyped,
+				),
+			},
+			[]*Metric{
+				{
+					Metric: "timing_metric.count",
+					Points: [1]Point{
+						{
+							float64(time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC).Unix()),
+							1,
+						},
+					},
+					Type: "",
+					Tags: []string{
+						"metric_type:timing",
+					},
+					Interval: 1,
+				},
+				{
+					Metric: "timing_metric.lower",
+					Points: [1]Point{
+						{
+							float64(time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC).Unix()),
+							float64(10),
+						},
+					},
+					Type: "",
+					Tags: []string{
+						"metric_type:timing",
+					},
+					Interval: 1,
+				},
+				{
+					Metric: "timing_metric.mean",
+					Points: [1]Point{
+						{
+							float64(time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC).Unix()),
+							float64(10),
+						},
+					},
+					Type: "",
+					Tags: []string{
+						"metric_type:timing",
+					},
+					Interval: 1,
+				},
+				{
+					Metric: "timing_metric.median",
+					Points: [1]Point{
+						{
+							float64(time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC).Unix()),
+							float64(10),
+						},
+					},
+					Type: "",
+					Tags: []string{
+						"metric_type:timing",
+					},
+					Interval: 1,
+				},
+				{
+					Metric: "timing_metric.stddev",
+					Points: [1]Point{
+						{
+							float64(time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC).Unix()),
+							float64(0),
+						},
+					},
+					Type: "",
+					Tags: []string{
+						"metric_type:timing",
+					},
+					Interval: 1,
+				},
+				{
+					Metric: "timing_metric.sum",
+					Points: [1]Point{
+						{
+							float64(time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC).Unix()),
+							float64(10),
+						},
+					},
+					Type: "",
+					Tags: []string{
+						"metric_type:timing",
+					},
+					Interval: 1,
+				},
+				{
+					Metric: "timing_metric.upper",
+					Points: [1]Point{
+						{
+							float64(time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC).Unix()),
+							float64(10),
+						},
+					},
+					Type: "",
+					Tags: []string{
+						"metric_type:timing",
+					},
+					Interval: 1,
+				},
+			},
+		},
+		{
+			"does not convert count value in histogram metrics to rate",
+			[]telegraf.Metric{
+				testutil.MustMetric(
+					"histogram_metric",
+					map[string]string{
+						"metric_type": "histogram",
+					},
+					map[string]interface{}{
+						"count":  1,
+						"lower":  float64(10),
+						"mean":   float64(10),
+						"median": float64(10),
+						"stddev": float64(0),
+						"sum":    float64(10),
+						"upper":  float64(10),
+					},
+					time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC),
+					telegraf.Untyped,
+				),
+			},
+			[]*Metric{
+				{
+					Metric: "histogram_metric.count",
+					Points: [1]Point{
+						{
+							float64(time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC).Unix()),
+							1,
+						},
+					},
+					Type: "",
+					Tags: []string{
+						"metric_type:histogram",
+					},
+					Interval: 1,
 				},
 				{
 					Metric: "histogram_metric.lower",

--- a/plugins/outputs/datadog/datadog_test.go
+++ b/plugins/outputs/datadog/datadog_test.go
@@ -598,30 +598,9 @@ func TestShouldRateCount(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			actualMetricsOut, _ := d.convertToDatadogMetric(tt.metricsIn)
-			if len(actualMetricsOut) != len(tt.metricsOut) {
-				t.Errorf("\nexpected %+v\ngot %+v\n", len(tt.metricsOut), len(actualMetricsOut))
-			}
-
-			for i := range tt.metricsOut {
-				expectedMetric := *tt.metricsOut[i]
-				if !inSlice(expectedMetric, actualMetricsOut) {
-					s := ""
-					for _, m := range actualMetricsOut {
-						s = fmt.Sprintf("%s\n%v", s, m)
-					}
-					t.Errorf("\nmetric not found in slice %+v\nslice %+s\n", expectedMetric, s)
-				}
-			}
+			actualMetricsOut, actualLen := d.convertToDatadogMetric(tt.metricsIn)
+			require.Len(t, actualMetricsOut, actualLen)
+			require.ElementsMatch(t, tt.metricsOut, actualMetricsOut)
 		})
 	}
-}
-
-func inSlice(metric Metric, searchSlice []*Metric) bool {
-	for _, element := range searchSlice {
-		if reflect.DeepEqual(metric, *element) {
-			return true
-		}
-	}
-	return false
 }

--- a/plugins/outputs/datadog/datadog_test.go
+++ b/plugins/outputs/datadog/datadog_test.go
@@ -305,3 +305,317 @@ func TestInfIsSkipped(t *testing.T) {
 	})
 	require.NoError(t, err)
 }
+
+func TestShouldRateCount(t *testing.T) {
+	d := &Datadog{
+		Apikey:           "123456",
+		ShouldRateCounts: true,
+		RateInterval:     10,
+	}
+
+	var tests = []struct {
+		metricsIn  []telegraf.Metric
+		metricsOut []*Metric
+	}{
+		{
+			[]telegraf.Metric{
+				testutil.MustMetric(
+					"count_metric_converted_to_rate",
+					map[string]string{
+						"metric_type": "counter",
+					},
+					map[string]interface{}{
+						"value": 100,
+					},
+					time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC),
+					telegraf.Counter,
+				),
+			},
+			[]*Metric{
+				{
+					Metric: "count_metric_converted_to_rate",
+					Points: [1]Point{
+						{
+							float64(time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC).Unix()),
+							10,
+						},
+					},
+					Type: "rate",
+					Tags: []string{
+						"metric_type:counter",
+					},
+					Interval: 10,
+				},
+			},
+		},
+		{
+			[]telegraf.Metric{
+				testutil.MustMetric(
+					"timing_metric",
+					map[string]string{
+						"metric_type": "timing",
+					},
+					map[string]interface{}{
+						"count":  1,
+						"lower":  float64(10),
+						"mean":   float64(10),
+						"median": float64(10),
+						"stddev": float64(0),
+						"sum":    float64(10),
+						"upper":  float64(10),
+					},
+					time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC),
+					telegraf.Untyped,
+				),
+			},
+			[]*Metric{
+				{
+					Metric: "timing_metric.count",
+					Points: [1]Point{
+						{
+							float64(time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC).Unix()),
+							0.1,
+						},
+					},
+					Type: "rate",
+					Tags: []string{
+						"metric_type:timing",
+					},
+					Interval: 10,
+				},
+				{
+					Metric: "timing_metric.lower",
+					Points: [1]Point{
+						{
+							float64(time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC).Unix()),
+							float64(10),
+						},
+					},
+					Type: "",
+					Tags: []string{
+						"metric_type:timing",
+					},
+					Interval: 1,
+				},
+				{
+					Metric: "timing_metric.mean",
+					Points: [1]Point{
+						{
+							float64(time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC).Unix()),
+							float64(10),
+						},
+					},
+					Type: "",
+					Tags: []string{
+						"metric_type:timing",
+					},
+					Interval: 1,
+				},
+				{
+					Metric: "timing_metric.median",
+					Points: [1]Point{
+						{
+							float64(time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC).Unix()),
+							float64(10),
+						},
+					},
+					Type: "",
+					Tags: []string{
+						"metric_type:timing",
+					},
+					Interval: 1,
+				},
+				{
+					Metric: "timing_metric.stddev",
+					Points: [1]Point{
+						{
+							float64(time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC).Unix()),
+							float64(0),
+						},
+					},
+					Type: "",
+					Tags: []string{
+						"metric_type:timing",
+					},
+					Interval: 1,
+				},
+				{
+					Metric: "timing_metric.sum",
+					Points: [1]Point{
+						{
+							float64(time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC).Unix()),
+							float64(10),
+						},
+					},
+					Type: "",
+					Tags: []string{
+						"metric_type:timing",
+					},
+					Interval: 1,
+				},
+				{
+					Metric: "timing_metric.upper",
+					Points: [1]Point{
+						{
+							float64(time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC).Unix()),
+							float64(10),
+						},
+					},
+					Type: "",
+					Tags: []string{
+						"metric_type:timing",
+					},
+					Interval: 1,
+				},
+			},
+		},
+		{
+			[]telegraf.Metric{
+				testutil.MustMetric(
+					"histogram_metric",
+					map[string]string{
+						"metric_type": "histogram",
+					},
+					map[string]interface{}{
+						"count":  1,
+						"lower":  float64(10),
+						"mean":   float64(10),
+						"median": float64(10),
+						"stddev": float64(0),
+						"sum":    float64(10),
+						"upper":  float64(10),
+					},
+					time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC),
+					telegraf.Untyped,
+				),
+			},
+			[]*Metric{
+				{
+					Metric: "histogram_metric.count",
+					Points: [1]Point{
+						{
+							float64(time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC).Unix()),
+							0.1,
+						},
+					},
+					Type: "rate",
+					Tags: []string{
+						"metric_type:histogram",
+					},
+					Interval: 10,
+				},
+				{
+					Metric: "histogram_metric.lower",
+					Points: [1]Point{
+						{
+							float64(time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC).Unix()),
+							float64(10),
+						},
+					},
+					Type: "",
+					Tags: []string{
+						"metric_type:histogram",
+					},
+					Interval: 1,
+				},
+				{
+					Metric: "histogram_metric.mean",
+					Points: [1]Point{
+						{
+							float64(time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC).Unix()),
+							float64(10),
+						},
+					},
+					Type: "",
+					Tags: []string{
+						"metric_type:histogram",
+					},
+					Interval: 1,
+				},
+				{
+					Metric: "histogram_metric.median",
+					Points: [1]Point{
+						{
+							float64(time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC).Unix()),
+							float64(10),
+						},
+					},
+					Type: "",
+					Tags: []string{
+						"metric_type:histogram",
+					},
+					Interval: 1,
+				},
+				{
+					Metric: "histogram_metric.stddev",
+					Points: [1]Point{
+						{
+							float64(time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC).Unix()),
+							float64(0),
+						},
+					},
+					Type: "",
+					Tags: []string{
+						"metric_type:histogram",
+					},
+					Interval: 1,
+				},
+				{
+					Metric: "histogram_metric.sum",
+					Points: [1]Point{
+						{
+							float64(time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC).Unix()),
+							float64(10),
+						},
+					},
+					Type: "",
+					Tags: []string{
+						"metric_type:histogram",
+					},
+					Interval: 1,
+				},
+				{
+					Metric: "histogram_metric.upper",
+					Points: [1]Point{
+						{
+							float64(time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC).Unix()),
+							float64(10),
+						},
+					},
+					Type: "",
+					Tags: []string{
+						"metric_type:histogram",
+					},
+					Interval: 1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		actualMetricsOut, _ := d.convertToDatadogMetric(tt.metricsIn)
+		if len(actualMetricsOut) != len(tt.metricsOut) {
+			t.Errorf("\nexpected %+v\ngot %+v\n", len(tt.metricsOut), len(actualMetricsOut))
+		}
+
+		for i := range tt.metricsOut {
+			expectedMetric := *tt.metricsOut[i]
+			if !inSlice(expectedMetric, actualMetricsOut) {
+				s := ""
+				for _, m := range actualMetricsOut {
+					s = fmt.Sprintf("%s\n%v", s, m)
+				}
+				t.Errorf("\nmetric not found in slice %+v\nslice %+s\n", expectedMetric, s)
+			}
+		}
+	}
+}
+
+func inSlice(metric Metric, searchSlice []*Metric) bool {
+	for _, element := range searchSlice {
+		if reflect.DeepEqual(metric, *element) {
+			return true
+		}
+	}
+	return false
+}

--- a/plugins/outputs/datadog/datadog_test.go
+++ b/plugins/outputs/datadog/datadog_test.go
@@ -598,8 +598,7 @@ func TestNonZeroRateIntervalConvertsRatesToCount(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			actualMetricsOut, actualLen := d.convertToDatadogMetric(tt.metricsIn)
-			require.Len(t, actualMetricsOut, actualLen)
+			actualMetricsOut := d.convertToDatadogMetric(tt.metricsIn)
 			require.ElementsMatch(t, tt.metricsOut, actualMetricsOut)
 		})
 	}
@@ -895,8 +894,7 @@ func TestZeroRateIntervalConvertsRatesToCount(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			actualMetricsOut, actualLen := d.convertToDatadogMetric(tt.metricsIn)
-			require.Len(t, actualMetricsOut, actualLen)
+			actualMetricsOut := d.convertToDatadogMetric(tt.metricsIn)
 			require.ElementsMatch(t, tt.metricsOut, actualMetricsOut)
 		})
 	}

--- a/plugins/outputs/datadog/sample.conf
+++ b/plugins/outputs/datadog/sample.conf
@@ -19,10 +19,9 @@
   ## Supports: "zlib", "none"
   # compression = "none"
 
-  ## Convert counts to rates
-  ## Use this to be able to submit metrics from telegraf alongside Datadog agent
-  # should_rate_counts = true
-
-  ## When should_rate_counts is enabled, this overrides the
-  ## default (10s) rate interval used to divide count metrics by
-  # rate_interval = 20
+  ## When non-zero, converts count metrics submitted by inputs.statsd
+  ## into rate, while dividing the metric value by this number.
+  ## Note that in order for metrics to be submitted simultaenously alongside
+  ## a Datadog agent, rate_interval has to match the interval used by the
+  ## agent - which defaults to 10
+  # rate_interval = 0

--- a/plugins/outputs/datadog/sample.conf
+++ b/plugins/outputs/datadog/sample.conf
@@ -18,3 +18,11 @@
   ## Override the default (none) compression used to send data.
   ## Supports: "zlib", "none"
   # compression = "none"
+
+  ## Convert counts to rates
+  ## Use this to be able to submit metrics from telegraf alongside Datadog agent
+  # should_rate_counts = true
+
+  ## When should_rate_counts is enabled, this overrides the
+  ## default (10s) rate interval used to divide count metrics by
+  # rate_interval = 20

--- a/plugins/outputs/datadog/sample.conf
+++ b/plugins/outputs/datadog/sample.conf
@@ -23,5 +23,5 @@
   ## into rate, while dividing the metric value by this number.
   ## Note that in order for metrics to be submitted simultaenously alongside
   ## a Datadog agent, rate_interval has to match the interval used by the
-  ## agent - which defaults to 10
-  # rate_interval = 0
+  ## agent - which defaults to 10s
+  # rate_interval = 0s


### PR DESCRIPTION
## Summary
Telegraf's outputs.datadog plugin is incompatible with submitting statsd metrics alongside the Datadog agent, as the dd-agent submits counter metrics as rates instead. Telegraf does not do this in order to reflect raw data more accurately. See #10979 for that change.

This PR enables a new config `should_rate_counts` which will convert count metrics to rates via the defined `rate_interval` (defaults to 10s - the same default as the Datadog agent) if those metrics are eligible. See below for eligibility.

### What does the Datadog agent do?

- Counts
  - [Source](https://docs.datadoghq.com/metrics/types/?tab=count#definition)
  - [Logic](https://github.com/DataDog/datadog-agent/blob/main/pkg/metrics/counter.go#L42-L43)
  - rate
- Histogram
  - [Source](https://docs.datadoghq.com/metrics/types/?tab=histogram#definition)
  - [Logic]( https://github.com/DataDog/datadog-agent/blob/10392708cfed50ebd2017b35e4cef56e37b18372/pkg/metrics/histogram.go#L151-L153)
  - values
    - avg
      - gauge
    - count
      - rate
    - median
      - gauge
    - 95percentile
      - gauge
    - max
      - gauge

Histograms and Timings are synonymous.

### Testing

I fired some test StatsD UDP packets to all these endpoints:

- Datadog v7.48.1
- Telegraf 1.31.2
- Telegraf 1.32.0 (including this PR)

#### Count

```bash
# sent via datadog
while true; do
  echo "test.metric.datadog:1|c" | nc -w 1 -u localhost 8125
  sleep 1;
done

## sent via telegraf

while true; do
  echo "test.metric.telegraf:1|c" | nc -w 1 -u localhost 8125
  sleep 1;
done
```

**Submitted to datadog agent**

![image](https://github.com/user-attachments/assets/29104d78-717c-46db-b012-62751317af06)

**Submitted to telegraf 1.32.0 (including this PR)**

![image](https://github.com/user-attachments/assets/08d4a3f6-b32e-4a9c-82ab-fad4213754b9)

#### Timings

```bash
# sent via datadog
while true; do
  echo "test.timing.datadog:100|ms" | nc -w 1 -u localhost 8125
  sleep 1;
done

## sent via telegraf

while true; do
  echo "test.timing.telegraf:100|ms|#region:us-west-2" | nc -w 1 -u localhost 8125
  sleep 1;
done
```

**Submitted to Datadog agent**

```
test.timing.datadog.95percentile
  - type: Gauge, interval: 10
test.timing.datadog.avg
   - type: Gauge, interval: 10
test.timing.datadog.count
   - type: Rate, interval: 10
test.timing.datadog.max
   - type: Gauge, interval: 10
test.timing.datadog.median
   - type: Gauge, interval: 10
```

![image](https://github.com/user-attachments/assets/7acc9100-ea53-4041-a1be-1409bdb2ca28)

![image](https://github.com/user-attachments/assets/9c0404b4-4f04-46df-bc06-71f46ebe8313)

**Submitted to telegraf 1.32.0 (including this PR)**

```
test.timing.telegraf.95percentile
  - type: Not assigned
test.timing.telegraf.avg
   - type: Not assigned
test.timing.telegraf.count
   - type: Rate, interval: 10
test.timing.telegraf.max
    - type: Not assigned 
test.timing.telegraf.median
     - type: Not assigned
```

![image](https://github.com/user-attachments/assets/67ffac59-7a1c-4506-8a88-c8d6a9b2a397)

![image](https://github.com/user-attachments/assets/dfd49619-b222-4027-aaf0-7ce1c4e44650)

#### Histogram

```bash
# sent via datadog
while true; do
  echo "test.histogram.datadog:100|ms" | nc -w 1 -u localhost 8125
  sleep 1;
done

## sent via telegraf

while true; do
  echo "test.histogram.telegraf:100|ms|#region:us-west-2" | nc -w 1 -u localhost 8125
  sleep 1;
done
```

**Submitted to Datadog agent**

```
test.histogram.datadog.95percentile
  - type: Gauge, interval: 10
test.histogram.datadog.avg
   - type: Gauge, interval: 10
test.histogram.datadog.count
   - type: Rate, interval: 10
test.histogram.datadog.max
   - type: Gauge, interval: 10
test.histogram.datadog.median
   - type: Gauge, interval: 10
```

**Submitted to telegraf fork**

```
test.histogram.telegraf.95percentile
  - type: Not assigned
test.histogram.telegraf.avg
   - type: Not assigned
test.histogram.telegraf.count
   - type: Rate, interval: 10
test.histogram.telegraf.max
    - type: Not assigned 
test.histogram.telegraf.median
     - type: Not assigned
```

![image](https://github.com/user-attachments/assets/95d74751-f014-416b-a8db-ea811d1af19c)

![image](https://github.com/user-attachments/assets/7738194a-f23c-4f11-b86a-0b058c8712bd)

**Histogram status quo in 1.31.2**

```
test.histogram.telegraf.original.95percentile
  - type: Not assigned
test.histogram.telegraf.original.avg
   - type: Not assigned
test.histogram.telegraf.original.count
    - type: Not assigned
test.histogram.telegraf.original.max
    - type: Not assigned 
test.histogram.telegraf.original.median
     - type: Not assigned
```

## Questions

- Should timings/histograms also submit the same metric type and interval as Datadog (gauge, 10) when `should_rate_counts` is enabled?

## Other points

- I extracted most of `Write` into `convertToDatadogMetric` so that I have a way to add unit tests
- I wonder if I need a `rate_interval` config, and whether I can just use the interval defined at the root level
  - My thinking was to make it as configurable as possible so that the user can override it
- I have only tested `inputs.statsd`, since I assume this to be the most common approach for inputting metrics that supports datadog's dogstatsd library
  - inputs.statsd creates timing and histograms as `telegraf.Untyped`

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #13561
