### PR TITLE
fix: use --scan-open instead of --scan of smartctl to provide correct…

### DIFF
--- a/plugins/inputs/smartctl/README.md
+++ b/plugins/inputs/smartctl/README.md
@@ -48,8 +48,9 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
     ## Devices to include or exclude
     ## By default, the plugin will use all devices found in the output of
-    ## `smartctl --scan`. Only one option is allowed at a time. If set, include
-    ## sets the specific devices to scan, while exclude omits specific devices.
+    ## `smartctl --scan-open`. Only one option is allowed at a time. If set, 
+    ## include sets the specific devices to scan, while exclude omits specific 
+    ## devices.
     # devices_include = []
     # devices_exclude = []
 
@@ -96,7 +97,7 @@ Defaults!SMARTCTL !logfile, !syslog, !pam_session
 This plugin uses the following commands to determine devices and collect
 metrics:
 
-* `smartctl --json --scan`
+* `smartctl --json --scan-open`
 * `smartctl --json --all $DEVICE --device $TYPE --nocheck=$NOCHECK`
 
 Please include the output of the above two commands for all devices that are

--- a/plugins/inputs/smartctl/README.md
+++ b/plugins/inputs/smartctl/README.md
@@ -48,9 +48,8 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
     ## Devices to include or exclude
     ## By default, the plugin will use all devices found in the output of
-    ## `smartctl --scan-open`. Only one option is allowed at a time. If set, 
-    ## include sets the specific devices to scan, while exclude omits specific 
-    ## devices.
+    ## `smartctl --scan-open`. Only one option is allowed at a time. If set, include
+    ## sets the specific devices to scan, while exclude omits specific devices.
     # devices_include = []
     # devices_exclude = []
 

--- a/plugins/inputs/smartctl/sample.conf
+++ b/plugins/inputs/smartctl/sample.conf
@@ -11,7 +11,7 @@
 
     ## Devices to include or exclude
     ## By default, the plugin will use all devices found in the output of
-    ## `smartctl --scan`. Only one option is allowed at a time. If set, include
+    ## `smartctl --scan-open`. Only one option is allowed at a time. If set, include
     ## sets the specific devices to scan, while exclude omits specific devices.
     # devices_include = []
     # devices_exclude = []

--- a/plugins/inputs/smartctl/smartctl_scan.go
+++ b/plugins/inputs/smartctl/smartctl_scan.go
@@ -9,7 +9,7 @@ import (
 )
 
 // This is here so we can override it during testing
-var scanArgs = []string{"--json", "--scan"}
+var scanArgs = []string{"--json", "--scan-open"}
 
 type scanDevice struct {
 	Name string


### PR DESCRIPTION
… device type info

## Summary
see #15723 , address incorrect device type information by smartctl --scan

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #15723 
