### PR TITLE
feat(agent): Add config check sub-command

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -120,7 +120,7 @@ func (a *Agent) Run(ctx context.Context) error {
 	}
 
 	log.Printf("D! [agent] Initializing plugins")
-	if err := a.initPlugins(); err != nil {
+	if err := a.InitPlugins(); err != nil {
 		return err
 	}
 
@@ -207,8 +207,8 @@ func (a *Agent) Run(ctx context.Context) error {
 	return err
 }
 
-// initPlugins runs the Init function on plugins.
-func (a *Agent) initPlugins() error {
+// InitPlugins runs the Init function on plugins.
+func (a *Agent) InitPlugins() error {
 	for _, input := range a.Config.Inputs {
 		// Share the snmp translator setting with plugins that need it.
 		if tp, ok := input.Input.(snmp.TranslatorPlugin); ok {
@@ -1003,8 +1003,7 @@ func (a *Agent) Test(ctx context.Context, wait time.Duration) error {
 // inputs to run.
 func (a *Agent) runTest(ctx context.Context, wait time.Duration, outputC chan<- telegraf.Metric) error {
 	log.Printf("D! [agent] Initializing plugins")
-	err := a.initPlugins()
-	if err != nil {
+	if err := a.InitPlugins(); err != nil {
 		return err
 	}
 
@@ -1017,6 +1016,7 @@ func (a *Agent) runTest(ctx context.Context, wait time.Duration, outputC chan<- 
 	if len(a.Config.Aggregators) != 0 {
 		procC := next
 		if len(a.Config.AggProcessors) != 0 && !a.Config.Agent.SkipProcessorsAfterAggregators {
+			var err error
 			procC, apu, err = a.startProcessors(next, a.Config.AggProcessors)
 			if err != nil {
 				return err
@@ -1028,6 +1028,7 @@ func (a *Agent) runTest(ctx context.Context, wait time.Duration, outputC chan<- 
 
 	var pu []*processorUnit
 	if len(a.Config.Processors) != 0 {
+		var err error
 		next, pu, err = a.startProcessors(next, a.Config.Processors)
 		if err != nil {
 			return err
@@ -1098,8 +1099,7 @@ func (a *Agent) Once(ctx context.Context, wait time.Duration) error {
 // inputs to run.
 func (a *Agent) runOnce(ctx context.Context, wait time.Duration) error {
 	log.Printf("D! [agent] Initializing plugins")
-	err := a.initPlugins()
-	if err != nil {
+	if err := a.InitPlugins(); err != nil {
 		return err
 	}
 

--- a/cmd/telegraf/cmd_config.go
+++ b/cmd/telegraf/cmd_config.go
@@ -18,12 +18,12 @@ import (
 	"github.com/influxdata/telegraf/migrations"
 )
 
-func getConfigCommands(pluginFilterFlags []cli.Flag, outputBuffer io.Writer) []*cli.Command {
+func getConfigCommands(configHandlingFlags []cli.Flag, outputBuffer io.Writer) []*cli.Command {
 	return []*cli.Command{
 		{
 			Name:  "config",
 			Usage: "commands for generating and migrating configurations",
-			Flags: pluginFilterFlags,
+			Flags: configHandlingFlags,
 			Action: func(cCtx *cli.Context) error {
 				// The sub_Filters are populated when the filter flags are set after the subcommand config
 				// e.g. telegraf config --section-filter inputs
@@ -46,8 +46,9 @@ func getConfigCommands(pluginFilterFlags []cli.Flag, outputBuffer io.Writer) []*
 
 		To check the file 'mysettings.conf' use
 
-		> telegraf --config mysettings.conf config check
+		> telegraf config check --config mysettings.conf
 		`,
+					Flags: configHandlingFlags,
 					Action: func(cCtx *cli.Context) error {
 						// Setup logging
 						logConfig := &logger.Config{Debug: cCtx.Bool("debug")}
@@ -104,7 +105,7 @@ InfluxDB v2 output plugin use
 
 > telegraf config create --section-filter "inputs:outputs" --input-filter "modbus" --output-filter "influxdb_v2"
 `,
-					Flags: pluginFilterFlags,
+					Flags: configHandlingFlags,
 					Action: func(cCtx *cli.Context) error {
 						filters := processFilterFlags(cCtx)
 
@@ -129,7 +130,7 @@ those files unattended!
 
 To migrate the file 'mysettings.conf' use
 
-> telegraf --config mysettings.conf config migrate
+> telegraf config migrate --config mysettings.conf
 `,
 					Flags: []cli.Flag{
 						&cli.BoolFlag{

--- a/cmd/telegraf/main.go
+++ b/cmd/telegraf/main.go
@@ -99,7 +99,15 @@ func deleteEmpty(s []string) []string {
 // runApp defines all the subcommands and flags for Telegraf
 // this abstraction is used for testing, so outputBuffer and args can be changed
 func runApp(args []string, outputBuffer io.Writer, pprof Server, c TelegrafConfig, m App) error {
-	pluginFilterFlags := []cli.Flag{
+	configHandlingFlags := []cli.Flag{
+		&cli.StringSliceFlag{
+			Name:  "config",
+			Usage: "configuration file to load",
+		},
+		&cli.StringSliceFlag{
+			Name:  "config-directory",
+			Usage: "directory containing additional *.conf files",
+		},
 		&cli.StringFlag{
 			Name: "section-filter",
 			Usage: "filter the sections to print, separator is ':'. " +
@@ -127,7 +135,7 @@ func runApp(args []string, outputBuffer io.Writer, pprof Server, c TelegrafConfi
 		},
 	}
 
-	extraFlags := append(pluginFilterFlags, cliFlags()...)
+	mainFlags := append(configHandlingFlags, cliFlags()...)
 
 	// This function is used when Telegraf is run with only flags
 	action := func(cCtx *cli.Context) error {
@@ -247,7 +255,7 @@ func runApp(args []string, outputBuffer io.Writer, pprof Server, c TelegrafConfi
 	}
 
 	commands := append(
-		getConfigCommands(pluginFilterFlags, outputBuffer),
+		getConfigCommands(configHandlingFlags, outputBuffer),
 		getSecretStoreCommands(m)...,
 	)
 	commands = append(commands, getPluginCommands(outputBuffer)...)
@@ -259,15 +267,6 @@ func runApp(args []string, outputBuffer io.Writer, pprof Server, c TelegrafConfi
 		Writer: outputBuffer,
 		Flags: append(
 			[]cli.Flag{
-				// String slice flags
-				&cli.StringSliceFlag{
-					Name:  "config",
-					Usage: "configuration file to load",
-				},
-				&cli.StringSliceFlag{
-					Name:  "config-directory",
-					Usage: "directory containing additional *.conf files",
-				},
 				// Int flags
 				&cli.IntFlag{
 					Name:  "test-wait",
@@ -368,7 +367,7 @@ func runApp(args []string, outputBuffer io.Writer, pprof Server, c TelegrafConfi
 					Usage: "DEPRECATED: path to directory containing external plugins",
 				},
 				// !!!
-			}, extraFlags...),
+			}, mainFlags...),
 		Action: action,
 		Commands: append([]*cli.Command{
 			{


### PR DESCRIPTION
## Summary

This PR adds a `telegraf config check` sub-command to check if the configuration is valid and can be successfully parsed. All plugins are initialized to validate options but are **NOT** started or executed. The sub-command will exit with a non-zero error code if an error occurs and with a zero error-code otherwise.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #15726 
