### PR TITLE
fix(serializers.template): Unwrap metrics if required

### DIFF
--- a/plugins/serializers/template/template.go
+++ b/plugins/serializers/template/template.go
@@ -39,9 +39,13 @@ func (s *Serializer) Init() error {
 }
 
 func (s *Serializer) Serialize(metric telegraf.Metric) ([]byte, error) {
-	m, ok := metric.(telegraf.TemplateMetric)
+	metricPlain := metric
+	if wm, ok := metric.(telegraf.UnwrappableMetric); ok {
+		metricPlain = wm.Unwrap()
+	}
+	m, ok := metricPlain.(telegraf.TemplateMetric)
 	if !ok {
-		s.Log.Errorf("metric of type %T is not a template metric", metric)
+		s.Log.Errorf("metric of type %T is not a template metric", metricPlain)
 		return nil, nil
 	}
 	var b bytes.Buffer


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

Allow serialization with a template even if a metric is a TrackingMetric - which can happen with many inputs (e.g. MQTT). The template *processor* already accounts for this, the template *serializer* does not yet have this check & handling. This PR just adds the same behavior for the serializer as well. As the change is local to the method, I would not expect side effects.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #15739
