### PR TITLE
feat(outputs.influxdb_v2): Add rate limit implementation

### DIFF
--- a/plugins/common/ratelimiter/config.go
+++ b/plugins/common/ratelimiter/config.go
@@ -1,6 +1,7 @@
 package ratelimiter
 
 import (
+	"errors"
 	"time"
 
 	"github.com/influxdata/telegraf/config"
@@ -11,9 +12,12 @@ type RateLimitConfig struct {
 	Period config.Duration `toml:"rate_limit_period"`
 }
 
-func (cfg *RateLimitConfig) CreateRateLimiter() *RateLimiter {
+func (cfg *RateLimitConfig) CreateRateLimiter() (*RateLimiter, error) {
+	if cfg.Limit > 0 && cfg.Period <= 0 {
+		return nil, errors.New("invalid period for rate-limit")
+	}
 	return &RateLimiter{
 		limit:  int64(cfg.Limit),
 		period: time.Duration(cfg.Period),
-	}
+	}, nil
 }

--- a/plugins/common/ratelimiter/limiters_test.go
+++ b/plugins/common/ratelimiter/limiters_test.go
@@ -9,9 +9,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestInvalidPeriod(t *testing.T) {
+	cfg := &RateLimitConfig{Limit: config.Size(1024)}
+	_, err := cfg.CreateRateLimiter()
+	require.ErrorContains(t, err, "invalid period for rate-limit")
+}
+
 func TestUnlimited(t *testing.T) {
 	cfg := &RateLimitConfig{}
-	limiter := cfg.CreateRateLimiter()
+	limiter, err := cfg.CreateRateLimiter()
+	require.NoError(t, err)
 
 	start := time.Now()
 	end := start.Add(30 * time.Minute)
@@ -24,7 +31,8 @@ func TestUnlimitedWithPeriod(t *testing.T) {
 	cfg := &RateLimitConfig{
 		Period: config.Duration(5 * time.Minute),
 	}
-	limiter := cfg.CreateRateLimiter()
+	limiter, err := cfg.CreateRateLimiter()
+	require.NoError(t, err)
 
 	start := time.Now()
 	end := start.Add(30 * time.Minute)
@@ -67,7 +75,8 @@ func TestLimited(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name+" at period", func(t *testing.T) {
 			// Setup the limiter
-			limiter := tt.cfg.CreateRateLimiter()
+			limiter, err := tt.cfg.CreateRateLimiter()
+			require.NoError(t, err)
 
 			// Compute the actual values
 			start := time.Now().Truncate(tt.step)
@@ -85,7 +94,8 @@ func TestLimited(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Setup the limiter
-			limiter := tt.cfg.CreateRateLimiter()
+			limiter, err := tt.cfg.CreateRateLimiter()
+			require.NoError(t, err)
 
 			// Compute the actual values
 			start := time.Now().Truncate(tt.step).Add(1 * time.Second)
@@ -134,7 +144,8 @@ func TestUndo(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name+" at period", func(t *testing.T) {
 			// Setup the limiter
-			limiter := tt.cfg.CreateRateLimiter()
+			limiter, err := tt.cfg.CreateRateLimiter()
+			require.NoError(t, err)
 
 			// Compute the actual values
 			start := time.Now().Truncate(tt.step)
@@ -156,7 +167,8 @@ func TestUndo(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Setup the limiter
-			limiter := tt.cfg.CreateRateLimiter()
+			limiter, err := tt.cfg.CreateRateLimiter()
+			require.NoError(t, err)
 
 			// Compute the actual values
 			start := time.Now().Truncate(tt.step).Add(1 * time.Second)

--- a/plugins/outputs/influxdb_v2/README.md
+++ b/plugins/outputs/influxdb_v2/README.md
@@ -101,6 +101,12 @@ to use them.
   # tls_key = "/etc/telegraf/key.pem"
   ## Use TLS but skip chain & host verification
   # insecure_skip_verify = false
+
+  ## Rate limits for sending data (disabled by default)
+  ## Available, uncompressed payload size e.g. "5Mb"
+  # rate_limit = "unlimited"
+  ## Fixed time-window for the available payload size e.g. "5m"
+  # rate_limit_period = "0s"
 ```
 
 ## Metrics

--- a/plugins/outputs/influxdb_v2/sample.conf
+++ b/plugins/outputs/influxdb_v2/sample.conf
@@ -71,3 +71,9 @@
   # tls_key = "/etc/telegraf/key.pem"
   ## Use TLS but skip chain & host verification
   # insecure_skip_verify = false
+
+  ## Rate limits for sending data (disabled by default)
+  ## Available, uncompressed payload size e.g. "5Mb"
+  # rate_limit = "unlimited"
+  ## Fixed time-window for the available payload size e.g. "5m"
+  # rate_limit_period = "0s"


### PR DESCRIPTION
## Summary

This PR adds the ability to limit the output rate to InfluxDBv2 instances. Currently only a _fixed_ window rate-limit for the amount of _uncompressed_ data is supported.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #14802
