### PR TITLE
fix(inputs.snmp): Avoid sending a nil to gosmi's GetEnumBitsFormatted

### DIFF
--- a/internal/snmp/translator_gosmi.go
+++ b/internal/snmp/translator_gosmi.go
@@ -54,9 +54,12 @@ func (g *gosmiTranslator) SnmpTable(oid string) (
 }
 
 func (g *gosmiTranslator) SnmpFormatEnum(oid string, value interface{}, full bool) (string, error) {
+	if value == nil {
+		return "", nil
+	}
+
 	//nolint:dogsled // only need to get the node
 	_, _, _, _, node, err := snmpTranslateCall(oid)
-
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION

## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
There is an upstream PR to resolve an issue when a nil value is passed. However that PR has not been looked at or merged. As such, this attempts to catch that scenario in Telegraf first.

See: https://github.com/sleepinggenius2/gosmi/pull/45

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

fixes: #15200