### PR TITLE
chore: Fix linter issues

### DIFF
--- a/cmd/telegraf/telegraf.go
+++ b/cmd/telegraf/telegraf.go
@@ -419,7 +419,7 @@ func (t *Telegraf) runAgent(ctx context.Context, reloadConfig bool) error {
 			log.Printf("I! Found %d secrets...", c.NumberSecrets)
 			msg := fmt.Sprintf("Insufficient lockable memory %dkb when %dkb is required.", available, required)
 			msg += " Please increase the limit for Telegraf in your Operating System!"
-			log.Printf("W! " + color.RedString(msg))
+			log.Print("W! " + color.RedString(msg))
 		}
 	}
 	ag := agent.NewAgent(c)

--- a/internal/globpath/globpath_test.go
+++ b/internal/globpath/globpath_test.go
@@ -8,7 +8,6 @@ package globpath
 import (
 	"os"
 	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -85,10 +84,6 @@ func TestFindNestedTextFile(t *testing.T) {
 }
 
 func TestMatch_ErrPermission(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("Skipping Unix only test")
-	}
-
 	tests := []struct {
 		input    string
 		expected []string
@@ -106,10 +101,6 @@ func TestMatch_ErrPermission(t *testing.T) {
 }
 
 func TestWindowsSeparator(t *testing.T) {
-	if runtime.GOOS != "windows" {
-		t.Skip("Skipping Windows only test")
-	}
-
 	glob, err := Compile("testdata/nested1")
 	require.NoError(t, err)
 	ok := glob.MatchString("testdata\\nested1")

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -123,8 +123,8 @@ func SnakeCase(in string) string {
 
 // RandomSleep will sleep for a random amount of time up to max.
 // If the shutdown channel is closed, it will return before it has finished sleeping.
-func RandomSleep(max time.Duration, shutdown chan struct{}) {
-	sleepDuration := RandomDuration(max)
+func RandomSleep(limit time.Duration, shutdown chan struct{}) {
+	sleepDuration := RandomDuration(limit)
 	if sleepDuration == 0 {
 		return
 	}
@@ -140,12 +140,12 @@ func RandomSleep(max time.Duration, shutdown chan struct{}) {
 }
 
 // RandomDuration returns a random duration between 0 and max.
-func RandomDuration(max time.Duration) time.Duration {
-	if max == 0 {
+func RandomDuration(limit time.Duration) time.Duration {
+	if limit == 0 {
 		return 0
 	}
 
-	return time.Duration(rand.Int63n(max.Nanoseconds())) //nolint:gosec // G404: not security critical
+	return time.Duration(rand.Int63n(limit.Nanoseconds())) //nolint:gosec // G404: not security critical
 }
 
 // SleepContext sleeps until the context is closed or the duration is reached.

--- a/internal/internal_test.go
+++ b/internal/internal_test.go
@@ -234,7 +234,7 @@ func TestCompressWithGzipErrorPropagationCopy(t *testing.T) {
 
 		rc := CompressWithGzip(r)
 		n, err := io.Copy(io.Discard, rc)
-		require.Greater(t, n, int64(0))
+		require.Positive(t, n)
 		require.ErrorIs(t, err, expected)
 		require.NoError(t, rc.Close())
 	}

--- a/plugins/common/kafka/config_test.go
+++ b/plugins/common/kafka/config_test.go
@@ -9,13 +9,13 @@ import (
 
 func TestBackoffFunc(t *testing.T) {
 	b := 250 * time.Millisecond
-	max := 1100 * time.Millisecond
+	limit := 1100 * time.Millisecond
 
-	f := makeBackoffFunc(b, max)
+	f := makeBackoffFunc(b, limit)
 	require.Equal(t, b, f(0, 0))
 	require.Equal(t, b*2, f(1, 0))
 	require.Equal(t, b*4, f(2, 0))
-	require.Equal(t, max, f(3, 0)) // would be 2000 but that's greater than max
+	require.Equal(t, limit, f(3, 0)) // would be 2000 but that's greater than max
 
 	f = makeBackoffFunc(b, 0)      // max = 0 means no max
 	require.Equal(t, b*8, f(3, 0)) // with no max, it's 2000

--- a/plugins/inputs/activemq/activemq_test.go
+++ b/plugins/inputs/activemq/activemq_test.go
@@ -161,7 +161,7 @@ func TestURLs(t *testing.T) {
 			require.NoError(t, err)
 		default:
 			w.WriteHeader(http.StatusNotFound)
-			t.Fatalf("unexpected path: " + r.URL.Path)
+			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
 	})
 

--- a/plugins/inputs/cloudwatch_metric_streams/cloudwatch_metric_streams.go
+++ b/plugins/inputs/cloudwatch_metric_streams/cloudwatch_metric_streams.go
@@ -314,21 +314,18 @@ func (cms *CloudWatchMetricStreams) composeMetrics(data Data) {
 
 	// Rename Statistics to match the CloudWatch API if in API Compatability mode
 	if cms.APICompatability {
-		max, ok := fields["max"]
-		if ok {
-			fields["maximum"] = max
+		if v, ok := fields["max"]; ok {
+			fields["maximum"] = v
 			delete(fields, "max")
 		}
 
-		min, ok := fields["min"]
-		if ok {
-			fields["minimum"] = min
+		if v, ok := fields["min"]; ok {
+			fields["minimum"] = v
 			delete(fields, "min")
 		}
 
-		count, ok := fields["count"]
-		if ok {
-			fields["samplecount"] = count
+		if v, ok := fields["count"]; ok {
+			fields["samplecount"] = v
 			delete(fields, "count")
 		}
 	}

--- a/plugins/inputs/conntrack/conntrack_test.go
+++ b/plugins/inputs/conntrack/conntrack_test.go
@@ -78,9 +78,9 @@ func TestConfigsUsed(t *testing.T) {
 	dfltFiles = []string{cntFname, maxFname}
 
 	count := 1234321
-	max := 9999999
+	limit := 9999999
 	require.NoError(t, os.WriteFile(cntFile.Name(), []byte(strconv.Itoa(count)), 0640))
-	require.NoError(t, os.WriteFile(maxFile.Name(), []byte(strconv.Itoa(max)), 0640))
+	require.NoError(t, os.WriteFile(maxFile.Name(), []byte(strconv.Itoa(limit)), 0640))
 	c := &Conntrack{}
 	require.NoError(t, c.Init())
 	acc := &testutil.Accumulator{}
@@ -94,7 +94,7 @@ func TestConfigsUsed(t *testing.T) {
 	acc.AssertContainsFields(t, inputName,
 		map[string]interface{}{
 			fix(cntFname): float64(count),
-			fix(maxFname): float64(max),
+			fix(maxFname): float64(limit),
 		})
 }
 

--- a/plugins/inputs/directory_monitor/directory_monitor.go
+++ b/plugins/inputs/directory_monitor/directory_monitor.go
@@ -215,7 +215,7 @@ func (monitor *DirectoryMonitor) read(filePath string) {
 
 	// Handle a file read error. We don't halt execution but do document, log, and move the problematic file.
 	if err != nil {
-		monitor.Log.Errorf("Error while reading file: '" + filePath + "'. " + err.Error())
+		monitor.Log.Errorf("Error while reading file: %q: %v", filePath, err)
 		monitor.filesDropped.Incr(1)
 		monitor.filesDroppedDir.Incr(1)
 		if monitor.ErrorDirectory != "" {
@@ -343,7 +343,7 @@ func (monitor *DirectoryMonitor) moveFile(srcPath string, dstBaseDir string) {
 	dstPath := filepath.Join(dstBaseDir, basePath)
 	err := os.MkdirAll(filepath.Dir(dstPath), 0750)
 	if err != nil {
-		monitor.Log.Errorf("Error creating directory hierarchy for " + srcPath + ". Error: " + err.Error())
+		monitor.Log.Errorf("Error creating directory hierarchy for %q: %v", srcPath, err)
 	}
 
 	inputFile, err := os.Open(srcPath)

--- a/plugins/inputs/google_cloud_storage/google_cloud_storage_test.go
+++ b/plugins/inputs/google_cloud_storage/google_cloud_storage_test.go
@@ -269,7 +269,7 @@ func startMultipleItemGCSServer(t *testing.T) *httptest.Server {
 				require.NoError(t, err)
 			} else {
 				w.WriteHeader(http.StatusNotFound)
-				t.Fatalf("unexpected path: " + r.URL.Path)
+				t.Fatalf("unexpected path: %s", r.URL.Path)
 			}
 
 		default:
@@ -399,7 +399,7 @@ func serveJSONText(w http.ResponseWriter, jsonText []byte) {
 
 func failPath(path string, t *testing.T, w http.ResponseWriter) {
 	w.WriteHeader(http.StatusNotFound)
-	t.Fatalf("unexpected path: " + path)
+	t.Fatalf("unexpected path: %s", path)
 }
 
 func parseJSONFromFile(t *testing.T, jsonFilePath string) map[string]interface{} {

--- a/plugins/inputs/http_response/http_response.go
+++ b/plugins/inputs/http_response/http_response.go
@@ -376,7 +376,7 @@ func (h *HTTPResponse) httpGather(cl client) (map[string]interface{}, map[string
 
 // Set result in case of a body read error
 func (h *HTTPResponse) setBodyReadError(errorMsg string, bodyBytes []byte, fields map[string]interface{}, tags map[string]string) {
-	h.Log.Debugf(errorMsg)
+	h.Log.Debug(errorMsg)
 	setResult("body_read_error", fields, tags)
 	fields["content_length"] = len(bodyBytes)
 	if h.ResponseStringMatch != "" {

--- a/plugins/inputs/intel_pmu/intel_pmu.go
+++ b/plugins/inputs/intel_pmu/intel_pmu.go
@@ -348,11 +348,11 @@ func readMaxFD(reader fileInfoProvider) (uint64, error) {
 	if err != nil {
 		return 0, fmt.Errorf("cannot open file %q: %w", fileMaxPath, err)
 	}
-	max, err := strconv.ParseUint(strings.Trim(string(buf), "\n "), 10, 64)
+	limit, err := strconv.ParseUint(strings.Trim(string(buf), "\n "), 10, 64)
 	if err != nil {
 		return 0, fmt.Errorf("cannot parse file content of %q: %w", fileMaxPath, err)
 	}
-	return max, nil
+	return limit, nil
 }
 
 func checkFiles(paths []string, fileInfo fileInfoProvider) error {

--- a/plugins/inputs/intel_pmu/resolver_test.go
+++ b/plugins/inputs/intel_pmu/resolver_test.go
@@ -145,43 +145,38 @@ func TestResolveEntities(t *testing.T) {
 
 	t.Run("uncore event found in core entity", func(t *testing.T) {
 		mQuals := []string{"config1=0x23h"}
-		mOptions, err := ia.NewOptions().SetAttrModifiers(mQuals).Build()
-		require.NoError(t, err)
 		eventName := "uncore event 1"
 
-		testCase := test{event: &eventWithQuals{name: eventName, qualifiers: mQuals},
-			options:   mOptions,
-			perfEvent: &ia.PerfEvent{Name: eventName, Uncore: true}}
+		testCase := test{
+			event:     &eventWithQuals{name: eventName, qualifiers: mQuals},
+			perfEvent: &ia.PerfEvent{Name: eventName, Uncore: true},
+		}
 
 		matcher := ia.NewNameMatcher(eventName)
 		mTransformer.On("Transform", nil, matcher).Return([]*ia.PerfEvent{testCase.perfEvent}, nil).Once()
 
 		mCoreEntity := &CoreEventEntity{parsedEvents: []*eventWithQuals{testCase.event}, allEvents: false}
-		err = mResolver.resolveEntities([]*CoreEventEntity{mCoreEntity}, nil)
-
-		require.Error(t, err)
-		require.Contains(t, err.Error(), fmt.Sprintf("uncore event %q found in core entity", eventName))
+		err := mResolver.resolveEntities([]*CoreEventEntity{mCoreEntity}, nil)
+		require.ErrorContains(t, err, fmt.Sprintf("uncore event %q found in core entity", eventName))
 		mTransformer.AssertExpectations(t)
 	})
 
 	t.Run("core event found in uncore entity", func(t *testing.T) {
 		mQuals := []string{"config1=0x23h"}
-		mOptions, err := ia.NewOptions().SetAttrModifiers(mQuals).Build()
-		require.NoError(t, err)
 		eventName := "core event 1"
 
-		testCase := test{event: &eventWithQuals{name: eventName, qualifiers: mQuals},
-			options:   mOptions,
-			perfEvent: &ia.PerfEvent{Name: eventName, Uncore: false}}
+		testCase := test{
+			event:     &eventWithQuals{name: eventName, qualifiers: mQuals},
+			perfEvent: &ia.PerfEvent{Name: eventName, Uncore: false},
+		}
 
 		matcher := ia.NewNameMatcher(eventName)
 		mTransformer.On("Transform", nil, matcher).Return([]*ia.PerfEvent{testCase.perfEvent}, nil).Once()
 
 		mUncoreEntity := &UncoreEventEntity{parsedEvents: []*eventWithQuals{testCase.event}, allEvents: false}
-		err = mResolver.resolveEntities(nil, []*UncoreEventEntity{mUncoreEntity})
+		err := mResolver.resolveEntities(nil, []*UncoreEventEntity{mUncoreEntity})
 
-		require.Error(t, err)
-		require.Contains(t, err.Error(), fmt.Sprintf("core event %q found in uncore entity", eventName))
+		require.ErrorContains(t, err, fmt.Sprintf("core event %q found in uncore entity", eventName))
 		mTransformer.AssertExpectations(t)
 	})
 

--- a/plugins/inputs/intel_powerstat/metrics.go
+++ b/plugins/inputs/intel_powerstat/metrics.go
@@ -294,7 +294,6 @@ type packageMetric[T numeric] struct {
 	fetchFn   func(packageID int) (T, error)
 }
 
-//nolint:revive // Confusing-naming caused by a generic type that implements this interface method.
 func (m *packageMetric[T]) fields() (map[string]interface{}, error) {
 	val, err := m.fetchFn(m.packageID)
 	if err != nil {
@@ -306,7 +305,6 @@ func (m *packageMetric[T]) fields() (map[string]interface{}, error) {
 	}, nil
 }
 
-//nolint:revive // Confusing-naming caused by a generic type that implements this interface method.
 func (m *packageMetric[T]) tags() map[string]string {
 	return map[string]string{
 		"package_id": strconv.Itoa(m.packageID),

--- a/plugins/inputs/intel_powerstat/metrics.go
+++ b/plugins/inputs/intel_powerstat/metrics.go
@@ -294,6 +294,7 @@ type packageMetric[T numeric] struct {
 	fetchFn   func(packageID int) (T, error)
 }
 
+//nolint:revive // Confusing-naming caused by a generic type that implements this interface method.
 func (m *packageMetric[T]) fields() (map[string]interface{}, error) {
 	val, err := m.fetchFn(m.packageID)
 	if err != nil {
@@ -305,6 +306,7 @@ func (m *packageMetric[T]) fields() (map[string]interface{}, error) {
 	}, nil
 }
 
+//nolint:revive // Confusing-naming caused by a generic type that implements this interface method.
 func (m *packageMetric[T]) tags() map[string]string {
 	return map[string]string{
 		"package_id": strconv.Itoa(m.packageID),

--- a/plugins/inputs/intel_rdt/intel_rdt.go
+++ b/plugins/inputs/intel_rdt/intel_rdt.go
@@ -537,10 +537,10 @@ func checkForDuplicates(values []int, valuesToCheck []int) bool {
 	return false
 }
 
-func makeRange(min, max int) []int {
-	a := make([]int, max-min+1)
+func makeRange(low, high int) []int {
+	a := make([]int, high-low+1)
 	for i := range a {
-		a[i] = min + i
+		a[i] = low + i
 	}
 	return a
 }

--- a/plugins/inputs/jolokia2_agent/jolokia2_agent_test.go
+++ b/plugins/inputs/jolokia2_agent/jolokia2_agent_test.go
@@ -650,7 +650,7 @@ func TestJolokia2_ClientAuthRequest(t *testing.T) {
 
 	require.EqualValuesf(t, "sally", username, "Expected to post with username %s, but was %s", "sally", username)
 	require.EqualValuesf(t, "seashore", password, "Expected to post with password %s, but was %s", "seashore", password)
-	require.NotZero(t, len(requests), "Expected to post a request body, but was empty.")
+	require.NotEmpty(t, requests, "Expected to post a request body, but was empty.")
 
 	request := requests[0]["mbean"]
 	require.EqualValuesf(t, "hello:foo=bar", request, "Expected to query mbean %s, but was %s", "hello:foo=bar", request)

--- a/plugins/inputs/jolokia2_proxy/jolokia2_proxy_test.go
+++ b/plugins/inputs/jolokia2_proxy/jolokia2_proxy_test.go
@@ -113,7 +113,7 @@ func TestJolokia2_ClientProxyAuthRequest(t *testing.T) {
 	require.NoError(t, plugin.Gather(&acc))
 	require.EqualValuesf(t, "sally", username, "Expected to post with username %s, but was %s", "sally", username)
 	require.EqualValuesf(t, "seashore", password, "Expected to post with password %s, but was %s", "seashore", password)
-	require.NotZero(t, len(requests), "Expected to post a request body, but was empty.")
+	require.NotEmpty(t, requests, "Expected to post a request body, but was empty.")
 
 	request := requests[0]
 	expected := "hello:foo=bar"

--- a/plugins/inputs/kafka_consumer/kafka_consumer_test.go
+++ b/plugins/inputs/kafka_consumer/kafka_consumer_test.go
@@ -553,7 +553,7 @@ func TestExponentialBackoff(t *testing.T) {
 	var err error
 
 	backoff := 10 * time.Millisecond
-	max := 3
+	limit := 3
 
 	// get an unused port by listening on next available port, then closing it
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
@@ -574,7 +574,7 @@ func TestExponentialBackoff(t *testing.T) {
 
 		ReadConfig: kafka.ReadConfig{
 			Config: kafka.Config{
-				MetadataRetryMax:     max,
+				MetadataRetryMax:     limit,
 				MetadataRetryBackoff: config.Duration(backoff),
 				MetadataRetryType:    "exponential",
 			},
@@ -594,7 +594,7 @@ func TestExponentialBackoff(t *testing.T) {
 	t.Logf("elapsed %d", elapsed)
 
 	var expectedRetryDuration time.Duration
-	for i := 0; i < max; i++ {
+	for i := 0; i < limit; i++ {
 		expectedRetryDuration += backoff * time.Duration(math.Pow(2, float64(i)))
 	}
 	t.Logf("expected > %d", expectedRetryDuration)

--- a/plugins/inputs/smart/smart.go
+++ b/plugins/inputs/smart/smart.go
@@ -995,12 +995,12 @@ func parseThermalThrottle(acc telegraf.Accumulator, fields map[string]interface{
 }
 
 func parseWearLeveling(acc telegraf.Accumulator, fields map[string]interface{}, tags map[string]string, str string) error {
-	var min, max, avg int64
+	var vmin, vmax, avg int64
 
-	if _, err := fmt.Sscanf(str, "min: %d, max: %d, avg: %d", &min, &max, &avg); err != nil {
+	if _, err := fmt.Sscanf(str, "min: %d, max: %d, avg: %d", &vmin, &vmax, &avg); err != nil {
 		return err
 	}
-	values := []int64{min, max, avg}
+	values := []int64{vmin, vmax, avg}
 	for i, submetricName := range []string{"Min", "Max", "Avg"} {
 		fields["raw_value"] = values[i]
 		tags["name"] = "Wear_Leveling_" + submetricName

--- a/plugins/inputs/statsd/running_stats.go
+++ b/plugins/inputs/statsd/running_stats.go
@@ -146,15 +146,5 @@ func (rs *RunningStats) Percentile(n float64) float64 {
 	}
 
 	i := float64(len(rs.perc)) * n / float64(100)
-	return rs.perc[clamp(i, 0, len(rs.perc)-1)]
-}
-
-func clamp(i float64, min int, max int) int {
-	if i < float64(min) {
-		return min
-	}
-	if i > float64(max) {
-		return max
-	}
-	return int(i)
+	return rs.perc[max(0, min(int(i), len(rs.perc)-1))]
 }

--- a/plugins/inputs/temp/temp_test.go
+++ b/plugins/inputs/temp/temp_test.go
@@ -38,7 +38,8 @@ func TestInvalidMetricFormat(t *testing.T) {
 }
 
 func TestNameCollisions(t *testing.T) {
-	require.NoError(t, os.Setenv("HOST_SYS", filepath.Join("testcases", "with_name", "sys")))
+	t.Setenv("HOST_SYS", filepath.Join("testcases", "with_name", "sys"))
+
 	plugin := &Temperature{Log: &testutil.Logger{}}
 	require.NoError(t, plugin.Init())
 
@@ -87,7 +88,7 @@ func TestCases(t *testing.T) {
 			}
 
 			// Prepare the environment
-			require.NoError(t, os.Setenv("HOST_SYS", filepath.Join(testcasePath, "sys")))
+			t.Setenv("HOST_SYS", filepath.Join(testcasePath, "sys"))
 
 			// Configure the plugin
 			cfg := config.NewConfig()
@@ -120,7 +121,7 @@ func TestCases(t *testing.T) {
 			}
 
 			// Prepare the environment
-			require.NoError(t, os.Setenv("HOST_SYS", filepath.Join(testcasePath, "sys")))
+			t.Setenv("HOST_SYS", filepath.Join(testcasePath, "sys"))
 
 			// Configure the plugin
 			cfg := config.NewConfig()
@@ -221,7 +222,7 @@ func TestRegression(t *testing.T) {
 			}
 
 			// Prepare the environment
-			require.NoError(t, os.Setenv("HOST_SYS", filepath.Join(testcasePath, "sys")))
+			t.Setenv("HOST_SYS", filepath.Join(testcasePath, "sys"))
 
 			// Use the v1.28.x code to compare against
 			var acc testutil.Accumulator

--- a/plugins/inputs/zipkin/codec/codec.go
+++ b/plugins/inputs/zipkin/codec/codec.go
@@ -134,21 +134,21 @@ func NewBinaryAnnotations(annotations []BinaryAnnotation, endpoint Endpoint) []t
 }
 
 func minMax(span Span) (time.Time, time.Time) {
-	min := now().UTC()
-	max := time.Time{}.UTC()
+	low := now().UTC()
+	high := time.Time{}.UTC()
 	for _, annotation := range span.Annotations() {
 		ts := annotation.Timestamp()
-		if !ts.IsZero() && ts.Before(min) {
-			min = ts
+		if !ts.IsZero() && ts.Before(low) {
+			low = ts
 		}
-		if !ts.IsZero() && ts.After(max) {
-			max = ts
+		if !ts.IsZero() && ts.After(high) {
+			high = ts
 		}
 	}
-	if max.IsZero() {
-		max = min
+	if high.IsZero() {
+		high = low
 	}
-	return min, max
+	return low, high
 }
 
 func guessTimestamp(span Span) time.Time {
@@ -157,8 +157,8 @@ func guessTimestamp(span Span) time.Time {
 		return ts
 	}
 
-	min, _ := minMax(span)
-	return min
+	low, _ := minMax(span)
+	return low
 }
 
 func convertDuration(span Span) time.Duration {
@@ -166,8 +166,8 @@ func convertDuration(span Span) time.Duration {
 	if duration != 0 {
 		return duration
 	}
-	min, max := minMax(span)
-	return max.Sub(min)
+	low, high := minMax(span)
+	return high.Sub(low)
 }
 
 func parentID(span Span) (string, error) {

--- a/plugins/outputs/azure_monitor/azure_monitor.go
+++ b/plugins/outputs/azure_monitor/azure_monitor.go
@@ -380,19 +380,19 @@ func translate(m telegraf.Metric, prefix string) (*azureMonitorMetric, error) {
 		dimensionValues = append(dimensionValues, tag.Value)
 	}
 
-	min, err := getFloatField(m, "min")
+	vmin, err := getFloatField(m, "min")
 	if err != nil {
 		return nil, err
 	}
-	max, err := getFloatField(m, "max")
+	vmax, err := getFloatField(m, "max")
 	if err != nil {
 		return nil, err
 	}
-	sum, err := getFloatField(m, "sum")
+	vsum, err := getFloatField(m, "sum")
 	if err != nil {
 		return nil, err
 	}
-	count, err := getIntField(m, "count")
+	vcount, err := getIntField(m, "count")
 	if err != nil {
 		return nil, err
 	}
@@ -417,10 +417,10 @@ func translate(m telegraf.Metric, prefix string) (*azureMonitorMetric, error) {
 				Series: []*azureMonitorSeries{
 					{
 						DimensionValues: dimensionValues,
-						Min:             min,
-						Max:             max,
-						Sum:             sum,
-						Count:           count,
+						Min:             vmin,
+						Max:             vmax,
+						Sum:             vsum,
+						Count:           vcount,
 					},
 				},
 			},

--- a/plugins/outputs/cloudwatch/cloudwatch.go
+++ b/plugins/outputs/cloudwatch/cloudwatch.go
@@ -69,20 +69,20 @@ func (f *statisticField) buildDatum() []types.MetricDatum {
 
 	if f.hasAllFields() {
 		// If we have all required fields, we build datum with StatisticValues
-		min := f.values[statisticTypeMin]
-		max := f.values[statisticTypeMax]
-		sum := f.values[statisticTypeSum]
-		count := f.values[statisticTypeCount]
+		vmin := f.values[statisticTypeMin]
+		vmax := f.values[statisticTypeMax]
+		vsum := f.values[statisticTypeSum]
+		vcount := f.values[statisticTypeCount]
 
 		datum := types.MetricDatum{
 			MetricName: aws.String(strings.Join([]string{f.metricName, f.fieldName}, "_")),
 			Dimensions: BuildDimensions(f.tags),
 			Timestamp:  aws.Time(f.timestamp),
 			StatisticValues: &types.StatisticSet{
-				Minimum:     aws.Float64(min),
-				Maximum:     aws.Float64(max),
-				Sum:         aws.Float64(sum),
-				SampleCount: aws.Float64(count),
+				Minimum:     aws.Float64(vmin),
+				Maximum:     aws.Float64(vmax),
+				Sum:         aws.Float64(vsum),
+				SampleCount: aws.Float64(vcount),
 			},
 			StorageResolution: aws.Int32(int32(f.storageResolution)),
 		}

--- a/plugins/parsers/nagios/parser.go
+++ b/plugins/parsers/nagios/parser.go
@@ -278,30 +278,30 @@ const (
 var ErrBadThresholdFormat = errors.New("bad threshold format")
 
 // Handles all cases from https://nagios-plugins.org/doc/guidelines.html#THRESHOLDFORMAT
-func parseThreshold(threshold string) (min float64, max float64, err error) {
+func parseThreshold(threshold string) (vmin, vmax float64, err error) {
 	thresh := strings.Split(threshold, ":")
 	switch len(thresh) {
 	case 1:
-		max, err = strconv.ParseFloat(thresh[0], 64)
+		vmax, err = strconv.ParseFloat(thresh[0], 64)
 		if err != nil {
 			return 0, 0, ErrBadThresholdFormat
 		}
 
-		return 0, max, nil
+		return 0, vmax, nil
 	case 2:
 		if thresh[0] == "~" {
-			min = MinFloat64
+			vmin = MinFloat64
 		} else {
-			min, err = strconv.ParseFloat(thresh[0], 64)
+			vmin, err = strconv.ParseFloat(thresh[0], 64)
 			if err != nil {
-				min = 0
+				vmin = 0
 			}
 		}
 
 		if thresh[1] == "" {
-			max = MaxFloat64
+			vmax = MaxFloat64
 		} else {
-			max, err = strconv.ParseFloat(thresh[1], 64)
+			vmax, err = strconv.ParseFloat(thresh[1], 64)
 			if err != nil {
 				return 0, 0, ErrBadThresholdFormat
 			}
@@ -310,7 +310,7 @@ func parseThreshold(threshold string) (min float64, max float64, err error) {
 		return 0, 0, ErrBadThresholdFormat
 	}
 
-	return min, max, err
+	return vmin, vmax, err
 }
 
 func init() {

--- a/plugins/parsers/nagios/parser_test.go
+++ b/plugins/parsers/nagios/parser_test.go
@@ -518,9 +518,9 @@ func TestParseThreshold(t *testing.T) {
 	}
 
 	for i := range tests {
-		min, max, err := parseThreshold(tests[i].input)
-		require.InDelta(t, tests[i].eMin, min, testutil.DefaultDelta)
-		require.InDelta(t, tests[i].eMax, max, testutil.DefaultDelta)
+		vmin, vmax, err := parseThreshold(tests[i].input)
+		require.InDelta(t, tests[i].eMin, vmin, testutil.DefaultDelta)
+		require.InDelta(t, tests[i].eMax, vmax, testutil.DefaultDelta)
 		require.Equal(t, tests[i].eErr, err)
 	}
 }

--- a/plugins/processors/port_name/port_name_test.go
+++ b/plugins/processors/port_name/port_name_test.go
@@ -19,7 +19,7 @@ tftp		69/udp`
 
 func TestReadServicesFile(t *testing.T) {
 	readServicesFile()
-	require.NotZero(t, len(services))
+	require.NotEmpty(t, services)
 }
 
 func TestFakeServices(t *testing.T) {

--- a/plugins/processors/starlark/starlark_test.go
+++ b/plugins/processors/starlark/starlark_test.go
@@ -3755,7 +3755,7 @@ func parseMetricsFrom(t *testing.T, lines []string, header string) (metrics []te
 	parser := &influx.Parser{}
 	require.NoError(t, parser.Init())
 
-	require.NotZero(t, len(lines), "Expected some lines to parse from .star file, found none")
+	require.NotEmpty(t, lines, "Expected some lines to parse from .star file, found none")
 	startIdx := -1
 	endIdx := len(lines)
 	for i := range lines {
@@ -3782,7 +3782,7 @@ func parseMetricsFrom(t *testing.T, lines []string, header string) (metrics []te
 
 // parses error message out of line protocol following a header
 func parseErrorMessage(t *testing.T, lines []string, header string) string {
-	require.NotZero(t, len(lines), "Expected some lines to parse from .star file, found none")
+	require.NotEmpty(t, lines, "Expected some lines to parse from .star file, found none")
 	startIdx := -1
 	for i := range lines {
 		if strings.TrimLeft(lines[i], "# ") == header {

--- a/plugins/processors/topk/topk.go
+++ b/plugins/processors/topk/topk.go
@@ -299,7 +299,7 @@ func (t *TopK) getAggregationFunction(aggOperation string) (func([]telegraf.Metr
 
 	case "min":
 		return func(ms []telegraf.Metric, fields []string) map[string]float64 {
-			min := func(agg map[string]float64, val float64, field string) {
+			vmin := func(agg map[string]float64, val float64, field string) {
 				// If this field has not been set, set it to the maximum float64
 				_, ok := agg[field]
 				if !ok {
@@ -311,12 +311,12 @@ func (t *TopK) getAggregationFunction(aggOperation string) (func([]telegraf.Metr
 					agg[field] = val
 				}
 			}
-			return aggregator(ms, fields, min)
+			return aggregator(ms, fields, vmin)
 		}, nil
 
 	case "max":
 		return func(ms []telegraf.Metric, fields []string) map[string]float64 {
-			max := func(agg map[string]float64, val float64, field string) {
+			vmax := func(agg map[string]float64, val float64, field string) {
 				// If this field has not been set, set it to the minimum float64
 				_, ok := agg[field]
 				if !ok {
@@ -328,7 +328,7 @@ func (t *TopK) getAggregationFunction(aggOperation string) (func([]telegraf.Metr
 					agg[field] = val
 				}
 			}
-			return aggregator(ms, fields, max)
+			return aggregator(ms, fields, vmax)
 		}, nil
 
 	case "mean":

--- a/tools/readme_linter/rules.go
+++ b/tools/readme_linter/rules.go
@@ -32,9 +32,8 @@ func firstSection(t *T, root ast.Node) error {
 	n = n.NextSibling()
 	t.assertKind(ast.KindParagraph, n)
 	length := len(n.Text(t.markdown))
-	min := 30
-	if length < min {
-		t.assertNodef(n, "short first section. Please add short description of plugin. length %d, minimum %d", length, min)
+	if length < 30 {
+		t.assertNodef(n, "short first section. Please add short description of plugin. length %d, minimum 30", length)
 	}
 
 	return nil


### PR DESCRIPTION
## Summary

With golangci-lint version v1.60.1 we do see the following new linter issues:

```text
cmd/telegraf/telegraf.go:422:15                                              govet        printf: non-constant format string in call to log.Printf
internal/globpath/globpath_test.go:88:5                                      staticcheck  SA4032: due to the file's build constraints, runtime.GOOS will never equal "windows"
internal/globpath/globpath_test.go:109:5                                     staticcheck  SA4032: due to the file's build constraints, runtime.GOOS will never equal "windows"
internal/internal.go:126:18                                                  predeclared  param max has same name as predeclared identifier
internal/internal.go:143:21                                                  predeclared  param max has same name as predeclared identifier
internal/internal_test.go:237:3                                              testifylint  negative-positive: use require.Positive
plugins/common/kafka/config_test.go:12:2                                     predeclared  variable max has same name as predeclared identifier
plugins/inputs/activemq/activemq_test.go:164:13                              govet        printf: non-constant format string in call to (*testing.common).Fatalf
plugins/inputs/beanstalkd/beanstalkd.go:168:35                               govet        printf: non-constant format string in call to (*net/textproto.Conn).Cmd
plugins/inputs/cloudwatch_metric_streams/cloudwatch_metric_streams.go:317:3  predeclared  variable max has same name as predeclared identifier
plugins/inputs/cloudwatch_metric_streams/cloudwatch_metric_streams.go:323:3  predeclared  variable min has same name as predeclared identifier
plugins/inputs/conntrack/conntrack_test.go:81:2                              predeclared  variable max has same name as predeclared identifier
plugins/inputs/directory_monitor/directory_monitor.go:218:22                 govet        printf: non-constant format string in call to (github.com/influxdata/telegraf.Logger).Errorf
plugins/inputs/directory_monitor/directory_monitor.go:346:22                 govet        printf: non-constant format string in call to (github.com/influxdata/telegraf.Logger).Errorf
plugins/inputs/exec/exec_test.go:315:5                                       staticcheck  SA4032: due to the file's build constraints, runtime.GOOS will never equal "windows"
plugins/inputs/filecount/filecount_test.go:201:5                             staticcheck  SA4032: due to the file's build constraints, runtime.GOOS will never equal "windows"
plugins/inputs/google_cloud_storage/google_cloud_storage_test.go:272:14      govet        printf: non-constant format string in call to (*testing.common).Fatalf
plugins/inputs/google_cloud_storage/google_cloud_storage_test.go:402:11      govet        printf: non-constant format string in call to (*testing.common).Fatalf
plugins/inputs/http_response/http_response.go:379:15                         govet        printf: non-constant format string in call to (github.com/influxdata/telegraf.Logger).Debugf
plugins/inputs/intel_pmu/intel_pmu.go:351:2                                  predeclared  variable max has same name as predeclared identifier
plugins/inputs/intel_powerstat/metrics.go:297:1                              nolintlint   directive `//nolint:revive // Confusing-naming caused by a generic type that implements this interface method.` is unused for linter "revive"
plugins/inputs/intel_powerstat/metrics.go:309:1                              nolintlint   directive `//nolint:revive // Confusing-naming caused by a generic type that implements this interface method.` is unused for linter "revive"
plugins/inputs/intel_rdt/intel_rdt.go:540:16                                 predeclared  param min has same name as predeclared identifier
plugins/inputs/intel_rdt/intel_rdt.go:540:21                                 predeclared  param max has same name as predeclared identifier
plugins/inputs/jolokia2_agent/jolokia2_agent_test.go:653:2                   testifylint  empty: use require.NotEmpty
plugins/inputs/jolokia2_proxy/jolokia2_proxy_test.go:116:2                   testifylint  empty: use require.NotEmpty
plugins/inputs/kafka_consumer/kafka_consumer_test.go:556:2                   predeclared  variable max has same name as predeclared identifier
plugins/inputs/net/net_test.go:45:21                                         tenv         os.Setenv() can be replaced by `t.Setenv()` in TestNetIOStats
plugins/inputs/net/net_test.go:108:21                                        tenv         os.Setenv() can be replaced by `t.Setenv()` in TestNetIOStatsSpeedUnsupported
plugins/inputs/net/net_test.go:171:21                                        tenv         os.Setenv() can be replaced by `t.Setenv()` in TestNetIOStatsNoSpeedFile
plugins/inputs/processes/processes_test.go:38:2                              testifylint  negative-positive: use require.Positive
plugins/inputs/smart/smart.go:998:6                                          predeclared  variable min has same name as predeclared identifier
plugins/inputs/smart/smart.go:998:11                                         predeclared  variable max has same name as predeclared identifier
plugins/inputs/statsd/running_stats.go:152:23                                predeclared  param min has same name as predeclared identifier
plugins/inputs/statsd/running_stats.go:152:32                                predeclared  param max has same name as predeclared identifier
plugins/inputs/temp/temp_test.go:41:21                                       tenv         os.Setenv() can be replaced by `t.Setenv()` in TestNameCollisions
plugins/inputs/temp/temp_test.go:90:23                                       tenv         os.Setenv() can be replaced by `t.Setenv()` in anonymous function
plugins/inputs/temp/temp_test.go:123:23                                      tenv         os.Setenv() can be replaced by `t.Setenv()` in anonymous function
plugins/inputs/temp/temp_test.go:224:23                                      tenv         os.Setenv() can be replaced by `t.Setenv()` in anonymous function
plugins/inputs/zipkin/codec/codec.go:137:2                                   predeclared  variable min has same name as predeclared identifier
plugins/inputs/zipkin/codec/codec.go:138:2                                   predeclared  variable max has same name as predeclared identifier
plugins/inputs/zipkin/codec/codec.go:160:2                                   predeclared  variable min has same name as predeclared identifier
plugins/inputs/zipkin/codec/codec.go:169:2                                   predeclared  variable min has same name as predeclared identifier
plugins/inputs/zipkin/codec/codec.go:169:7                                   predeclared  variable max has same name as predeclared identifier
plugins/outputs/azure_monitor/azure_monitor.go:383:2                         predeclared  variable min has same name as predeclared identifier
plugins/outputs/azure_monitor/azure_monitor.go:387:2                         predeclared  variable max has same name as predeclared identifier
plugins/outputs/cloudwatch/cloudwatch.go:72:3                                predeclared  variable min has same name as predeclared identifier
plugins/outputs/cloudwatch/cloudwatch.go:73:3                                predeclared  variable max has same name as predeclared identifier
plugins/parsers/nagios/parser.go:281:40                                      predeclared  named return min has same name as predeclared identifier
plugins/parsers/nagios/parser.go:281:53                                      predeclared  named return max has same name as predeclared identifier
plugins/parsers/nagios/parser_test.go:521:3                                  predeclared  variable min has same name as predeclared identifier
plugins/parsers/nagios/parser_test.go:521:8                                  predeclared  variable max has same name as predeclared identifier
plugins/processors/port_name/port_name_test.go:22:2                          testifylint  empty: use require.NotEmpty
plugins/processors/starlark/starlark_test.go:3758:2                          testifylint  empty: use require.NotEmpty
plugins/processors/starlark/starlark_test.go:3785:2                          testifylint  empty: use require.NotEmpty
plugins/processors/topk/topk.go:302:4                                        predeclared  variable min has same name as predeclared identifier
plugins/processors/topk/topk.go:319:4                                        predeclared  variable max has same name as predeclared identifier
tools/readme_linter/rules.go:35:2                                            predeclared  variable min has same name as predeclared identifier
```

This PR reduces the list to

```text
plugins/inputs/beanstalkd/beanstalkd.go:168:35    govet        printf: non-constant format string in call to (*net/textproto.Conn).Cmd
plugins/inputs/exec/exec_test.go:315:5            staticcheck  SA4032: due to the file's build constraints, runtime.GOOS will never equal "windows"
plugins/inputs/filecount/filecount_test.go:201:5  staticcheck  SA4032: due to the file's build constraints, runtime.GOOS will never equal "windows"
plugins/inputs/intel_powerstat/metrics.go:297:1   nolintlint   directive `//nolint:revive // Confusing-naming caused by a generic type that implements this interface method.` is unused for linter "revive"
plugins/inputs/intel_powerstat/metrics.go:309:1   nolintlint   directive `//nolint:revive // Confusing-naming caused by a generic type that implements this interface method.` is unused for linter "revive"
```

For the first remaining issue it is unclear if we should simply ignore it or rework the code. Any idea @p-zak? The two other ones say that the tests should also be reenabled on Windows so I left them unchanged.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

