### PR TITLE
fix(outputs.kinesis): Honor the configured endpoint

### DIFF
--- a/plugins/outputs/kinesis/kinesis.go
+++ b/plugins/outputs/kinesis/kinesis.go
@@ -69,6 +69,10 @@ func (k *KinesisOutput) Connect() error {
 		return err
 	}
 
+	if k.EndpointURL != "" {
+		cfg.BaseEndpoint = &k.EndpointURL
+	}
+
 	svc := kinesis.NewFromConfig(cfg)
 
 	_, err = svc.DescribeStreamSummary(context.Background(), &kinesis.DescribeStreamSummaryInput{


### PR DESCRIPTION
## Summary
When trying to run telegraf locally in docker-compose and trying to connect to localstack kinesis, it tries to call public aws url instead of one in the config

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues

resolves #
