### PR TITLE
fix(inputs.kinesis_consumer): Honor the configured endpoint

### DIFF
--- a/plugins/inputs/kinesis_consumer/kinesis_consumer.go
+++ b/plugins/inputs/kinesis_consumer/kinesis_consumer.go
@@ -94,6 +94,10 @@ func (k *KinesisConsumer) connect(ac telegraf.Accumulator) error {
 	if err != nil {
 		return err
 	}
+
+	if k.EndpointURL != "" {
+		cfg.BaseEndpoint = &k.EndpointURL
+	}
 	client := kinesis.NewFromConfig(cfg)
 
 	k.checkpoint = &noopStore{}


### PR DESCRIPTION
## Summary
Passing endpoint from config to input kinesis plugin

Otherwise running locally in docker-compose it cannot connect to kinesis

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
