### PR TITLE
feat(inputs.kafka_consumer): Allow to select the metric time source

### DIFF
--- a/plugins/inputs/kafka_consumer/README.md
+++ b/plugins/inputs/kafka_consumer/README.md
@@ -70,6 +70,13 @@ to use them.
   ## option, it will be excluded from the msg_headers_as_tags list.
   # msg_header_as_metric_name = ""
 
+  ## Set metric(s) timestamp using the given source.
+  ## Available options are:
+  ##   metric -- do not modify the metric timestamp
+  ##   inner  -- use the inner message timestamp (Kafka v0.10+)
+  ##   outer  -- use the outer (compressed) block timestamp (Kafka v0.10+)
+  # timestamp_source = "metric"
+
   ## Optional Client id
   # client_id = "Telegraf"
 

--- a/plugins/inputs/kafka_consumer/sample.conf
+++ b/plugins/inputs/kafka_consumer/sample.conf
@@ -33,6 +33,13 @@
   ## option, it will be excluded from the msg_headers_as_tags list.
   # msg_header_as_metric_name = ""
 
+  ## Set metric(s) timestamp using the given source.
+  ## Available options are:
+  ##   metric -- do not modify the metric timestamp
+  ##   inner  -- use the inner message timestamp (Kafka v0.10+)
+  ##   outer  -- use the outer (compressed) block timestamp (Kafka v0.10+)
+  # timestamp_source = "metric"
+
   ## Optional Client id
   # client_id = "Telegraf"
 


### PR DESCRIPTION
## Summary

This PR adds a new `timestamp_source` setting allowing to use the "inner" or "outer" timestamp of the Kafka message as metric timestamp.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #15783 
