### PR TITLE
feat(processors.aws_ec2): Allow to use instance metadata

### DIFF
--- a/plugins/processors/aws_ec2/README.md
+++ b/plugins/processors/aws_ec2/README.md
@@ -39,11 +39,6 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## * version
   # imds_tags = []
 
-  ## Instance metadata tags to attach to the metrics.
-  ## For more information see:
-  ## https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html
-  # metadata_tags = []
-
   ## EC2 instance tags retrieved with DescribeTags action.
   ## In case tag is empty upon retrieval it's omitted when tagging metrics.
   ## Note that in order for this to work, role attached to EC2 instance or AWS
@@ -53,6 +48,18 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## For more information see:
   ## https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeTags.html
   # ec2_tags = []
+
+  ## Paths to instance metadata information to attach to the metrics.
+  ## Specify the full path without the base-path e.g. `tags/instance/Name`.
+  ##
+  ## For more information see:
+  ## https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html
+  # metadata_paths = []
+
+  ## Allows to convert metadata tag-names to canonical names representing the
+  ## full path with slashes ('/') being replaces with underscores. By default,
+  ## only the last path element is used to name the tag.
+  # canonical_metadata_tags = false
 
   ## Timeout for http requests made by against aws ec2 metadata endpoint.
   # timeout = "10s"

--- a/plugins/processors/aws_ec2/README.md
+++ b/plugins/processors/aws_ec2/README.md
@@ -37,7 +37,12 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## * ramdiskId
   ## * region
   ## * version
-  imds_tags = []
+  # imds_tags = []
+
+  ## Instance metadata tags to attach to the metrics.
+  ## For more information see:
+  ## https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html
+  # metadata_tags = []
 
   ## EC2 instance tags retrieved with DescribeTags action.
   ## In case tag is empty upon retrieval it's omitted when tagging metrics.
@@ -47,10 +52,10 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ##
   ## For more information see:
   ## https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeTags.html
-  ec2_tags = []
+  # ec2_tags = []
 
   ## Timeout for http requests made by against aws ec2 metadata endpoint.
-  timeout = "10s"
+  # timeout = "10s"
 
   ## ordered controls whether or not the metrics need to stay in the same order
   ## this plugin received them in. If false, this plugin will change the order
@@ -58,12 +63,12 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## waiting on slower lookups. This may cause issues for you if you are
   ## depending on the order of metrics staying the same. If so, set this to true.
   ## Keeping the metrics ordered may be slightly slower.
-  ordered = false
+  # ordered = false
 
   ## max_parallel_calls is the maximum number of AWS API calls to be in flight
   ## at the same time.
   ## It's probably best to keep this number fairly low.
-  max_parallel_calls = 10
+  # max_parallel_calls = 10
 
   ## cache_ttl determines how long each cached item will remain in the cache before
   ## it is removed and subsequently needs to be queried for from the AWS API. By

--- a/plugins/processors/aws_ec2/ec2.go
+++ b/plugins/processors/aws_ec2/ec2.go
@@ -280,6 +280,7 @@ func (r *AwsEc2Processor) lookupMetadataTags(metric telegraf.Metric) telegraf.Me
 		r.Log.Errorf("Error when getting metadata: %v", err)
 		return metric
 	}
+	r.Log.Tracef("received metadata: %+v", metadata.ResultMetadata)
 
 	for _, tag := range tagsNotFound {
 		v, err := internal.ToString(metadata.ResultMetadata.Get(tag))

--- a/plugins/processors/aws_ec2/ec2.go
+++ b/plugins/processors/aws_ec2/ec2.go
@@ -277,7 +277,7 @@ func (r *AwsEc2Processor) lookupMetadataTags(metric telegraf.Metric) telegraf.Me
 
 	metadata, err := r.imdsClient.GetMetadata(ctx, &imds.GetMetadataInput{})
 	if err != nil {
-		r.Log.Errorf("Error when calling GetInstanceIdentityDocument: %v", err)
+		r.Log.Errorf("Error when getting metadata: %v", err)
 		return metric
 	}
 

--- a/plugins/processors/aws_ec2/ec2.go
+++ b/plugins/processors/aws_ec2/ec2.go
@@ -275,7 +275,7 @@ func (r *AwsEc2Processor) lookupMetadataTags(metric telegraf.Metric) telegraf.Me
 		return metric
 	}
 
-	metadata, err := r.imdsClient.GetMetadata(ctx, &imds.GetMetadataInput{})
+	metadata, err := r.imdsClient.GetMetadata(ctx, &imds.GetMetadataInput{Path: "tags/instance"})
 	if err != nil {
 		r.Log.Errorf("Error when getting metadata: %v", err)
 		return metric

--- a/plugins/processors/aws_ec2/ec2_test.go
+++ b/plugins/processors/aws_ec2/ec2_test.go
@@ -145,7 +145,6 @@ func TestTracking(t *testing.T) {
 		CacheTTL:         config.Duration(DefaultCacheTTL),
 		ImdsTags:         []string{"accountId", "instanceId"},
 		Log:              &testutil.Logger{},
-		imdsTagsMap:      make(map[string]struct{}),
 	}
 	require.NoError(t, plugin.Init())
 

--- a/plugins/processors/aws_ec2/sample.conf
+++ b/plugins/processors/aws_ec2/sample.conf
@@ -18,7 +18,12 @@
   ## * ramdiskId
   ## * region
   ## * version
-  imds_tags = []
+  # imds_tags = []
+
+  ## Instance metadata tags to attach to the metrics.
+  ## For more information see:
+  ## https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html
+  # metadata_tags = []
 
   ## EC2 instance tags retrieved with DescribeTags action.
   ## In case tag is empty upon retrieval it's omitted when tagging metrics.
@@ -28,10 +33,10 @@
   ##
   ## For more information see:
   ## https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeTags.html
-  ec2_tags = []
+  # ec2_tags = []
 
   ## Timeout for http requests made by against aws ec2 metadata endpoint.
-  timeout = "10s"
+  # timeout = "10s"
 
   ## ordered controls whether or not the metrics need to stay in the same order
   ## this plugin received them in. If false, this plugin will change the order
@@ -39,12 +44,12 @@
   ## waiting on slower lookups. This may cause issues for you if you are
   ## depending on the order of metrics staying the same. If so, set this to true.
   ## Keeping the metrics ordered may be slightly slower.
-  ordered = false
+  # ordered = false
 
   ## max_parallel_calls is the maximum number of AWS API calls to be in flight
   ## at the same time.
   ## It's probably best to keep this number fairly low.
-  max_parallel_calls = 10
+  # max_parallel_calls = 10
 
   ## cache_ttl determines how long each cached item will remain in the cache before
   ## it is removed and subsequently needs to be queried for from the AWS API. By

--- a/plugins/processors/aws_ec2/sample.conf
+++ b/plugins/processors/aws_ec2/sample.conf
@@ -20,11 +20,6 @@
   ## * version
   # imds_tags = []
 
-  ## Instance metadata tags to attach to the metrics.
-  ## For more information see:
-  ## https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html
-  # metadata_tags = []
-
   ## EC2 instance tags retrieved with DescribeTags action.
   ## In case tag is empty upon retrieval it's omitted when tagging metrics.
   ## Note that in order for this to work, role attached to EC2 instance or AWS
@@ -34,6 +29,18 @@
   ## For more information see:
   ## https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeTags.html
   # ec2_tags = []
+
+  ## Paths to instance metadata information to attach to the metrics.
+  ## Specify the full path without the base-path e.g. `tags/instance/Name`.
+  ##
+  ## For more information see:
+  ## https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html
+  # metadata_paths = []
+
+  ## Allows to convert metadata tag-names to canonical names representing the
+  ## full path with slashes ('/') being replaces with underscores. By default,
+  ## only the last path element is used to name the tag.
+  # canonical_metadata_tags = false
 
   ## Timeout for http requests made by against aws ec2 metadata endpoint.
   # timeout = "10s"


### PR DESCRIPTION
## Summary

Allow to use instance metadata to annotate metrics according to https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #15789 
