### PR TITLE
test(linters): Enable `testifylint`: `formatter`, `suite-broken-parallel` and `suite-subtest-run`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -304,12 +304,15 @@ linters-settings:
       - error-nil
       - expected-actual
       - float-compare
+      - formatter
       - len
       - negative-positive
       - nil-compare
       - require-error
+      - suite-broken-parallel
       - suite-dont-use-pkg
       - suite-extra-assert-call
+      - suite-subtest-run
       - suite-thelper
       - useless-assert
 

--- a/plugins/inputs/kube_inventory/client_test.go
+++ b/plugins/inputs/kube_inventory/client_test.go
@@ -26,8 +26,8 @@ func toBoolPtr(b bool) *bool {
 
 func TestNewClient(t *testing.T) {
 	_, err := newClient("https://127.0.0.1:443/", "default", "", "abc123", time.Second, tls.ClientConfig{})
-	require.NoErrorf(t, err, "Failed to create new client - %v", err)
+	require.NoErrorf(t, err, "Failed to create new client: %v", err)
 
 	_, err = newClient("https://127.0.0.1:443/", "default", "nonexistantFile", "", time.Second, tls.ClientConfig{})
-	require.Errorf(t, err, "failed to read token file \"file\": open file: no such file or directory", err)
+	require.Errorf(t, err, "Failed to read token file \"file\": open file: no such file or directory: %v", err)
 }

--- a/plugins/secretstores/docker/docker_test.go
+++ b/plugins/secretstores/docker/docker_test.go
@@ -22,7 +22,7 @@ func TestPathNonExistent(t *testing.T) {
 		ID:   "non_existent_path_test",
 		Path: "non/existent/path",
 	}
-	require.ErrorContainsf(t, plugin.Init(), "accessing directory", "accessing directory %q failed: %w", plugin.Path, plugin.Init())
+	require.ErrorContainsf(t, plugin.Init(), "accessing directory", "accessing directory %q failed: %v", plugin.Path, plugin.Init())
 }
 
 func TestSetNotAvailable(t *testing.T) {


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

Fixes following findings:
```
plugins/inputs/kube_inventory/client_test.go:32:2  testifylint  formatter: require.Errorf call has arguments but no formatting directives
plugins/secretstores/docker/docker_test.go:25:2    testifylint  formatter: require.ErrorContainsf does not support error-wrapping directive %w
```

Enables following checkers:
![image](https://github.com/user-attachments/assets/32e8d8e3-ca4e-4b80-9a84-883ed4c7b910)
![image](https://github.com/user-attachments/assets/c41d3872-1e43-4f1e-b43b-8cb05e9c1539)
![image](https://github.com/user-attachments/assets/8a118968-4ff6-4053-8c91-fbfab9be1f9a)
