### PR TITLE
feat(inputs.execd): Allow to provide logging prefixes on stderr

### DIFF
--- a/plugins/inputs/execd/README.md
+++ b/plugins/inputs/execd/README.md
@@ -11,7 +11,12 @@ collection interval. This is used for when you want to have Telegraf notify the
 plugin when it's time to run collection. STDIN is recommended, which writes a
 new line to the process's STDIN.
 
-STDERR from the process will be relayed to Telegraf as errors in the logs.
+STDERR from the process will be relayed to Telegraf's logging facilities. By
+default all messages on `stderr` will be logged as errors. However, you can
+log to other levels by prefixing your message with `E!` for error, `W!` for
+warning, `I!` for info, `D!` for debugging and `T!` for trace levels followed by
+a space and the actual message. For example outputting `I! A log message` will
+create a `info` log line in your Telegraf logging output.
 
 [Input Data Formats]: ../../../docs/DATA_FORMATS_INPUT.md
 [inputs.exec]: ../exec/README.md

--- a/plugins/inputs/execd/execd.go
+++ b/plugins/inputs/execd/execd.go
@@ -157,7 +157,6 @@ func (e *Execd) cmdReadErr(out io.Reader) {
 		case strings.HasPrefix(msg, "D! "):
 			e.Log.Debug(msg[3:])
 		case strings.HasPrefix(msg, "T! "):
-			fmt.Println("received trace message:", msg[3:])
 			e.Log.Trace(msg[3:])
 		default:
 			e.Log.Errorf("stderr: %q", msg)

--- a/plugins/inputs/execd/execd.go
+++ b/plugins/inputs/execd/execd.go
@@ -146,7 +146,22 @@ func (e *Execd) cmdReadErr(out io.Reader) {
 	scanner := bufio.NewScanner(out)
 
 	for scanner.Scan() {
-		e.Log.Errorf("stderr: %q", scanner.Text())
+		msg := scanner.Text()
+		switch {
+		case strings.HasPrefix(msg, "E! "):
+			e.Log.Error(msg[3:])
+		case strings.HasPrefix(msg, "W! "):
+			e.Log.Warn(msg[3:])
+		case strings.HasPrefix(msg, "I! "):
+			e.Log.Info(msg[3:])
+		case strings.HasPrefix(msg, "D! "):
+			e.Log.Debug(msg[3:])
+		case strings.HasPrefix(msg, "T! "):
+			fmt.Println("received trace message:", msg[3:])
+			e.Log.Trace(msg[3:])
+		default:
+			e.Log.Errorf("stderr: %q", scanner.Text())
+		}
 	}
 
 	if err := scanner.Err(); err != nil {

--- a/plugins/inputs/execd/execd.go
+++ b/plugins/inputs/execd/execd.go
@@ -160,7 +160,7 @@ func (e *Execd) cmdReadErr(out io.Reader) {
 			fmt.Println("received trace message:", msg[3:])
 			e.Log.Trace(msg[3:])
 		default:
-			e.Log.Errorf("stderr: %q", scanner.Text())
+			e.Log.Errorf("stderr: %q", msg)
 		}
 	}
 

--- a/testutil/capturelog.go
+++ b/testutil/capturelog.go
@@ -50,9 +50,8 @@ func (l *CaptureLogger) loga(level byte, args ...any) {
 	l.print(Entry{level, l.Name, fmt.Sprint(args...)})
 }
 
-// We always want to output at debug level during testing to find issues easier
-func (*CaptureLogger) Level() telegraf.LogLevel {
-	return telegraf.Debug
+func (l *CaptureLogger) Level() telegraf.LogLevel {
+	return telegraf.Trace
 }
 
 // Adding attributes is not supported by the test-logger


### PR DESCRIPTION
## Summary

Enable more differentiated logging in external plugins by allowing to provide logging indicators and reflecting those levels in the actual logging on Telegraf side. The PR is backward compatible if no indicator is provided.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #9487 
