### PR TITLE
docs(parsers): update readme for json_v2 parser

### DIFF
--- a/plugins/parsers/json_v2/README.md
+++ b/plugins/parsers/json_v2/README.md
@@ -7,7 +7,7 @@ this playground to test out your GJSON path here:
 [gjson.dev/](https://gjson.dev). You can find multiple examples under the
 [`testdata`][] folder.
 
-**NOTE:** If you don't have any configuration fields or tags this parser 
+**NOTE:** If you don't have any configuration fields or tags this parser
 will not produce any metric.
 
 ## Configuration

--- a/plugins/parsers/json_v2/README.md
+++ b/plugins/parsers/json_v2/README.md
@@ -8,7 +8,6 @@ this playground to test out your GJSON path here:
 [`testdata`][] folder.
 
 **NOTE:** This parser has a different semantics comparing to regular JSON Parser - if you don't have any configuration fields or tags it will not produce any metric on contrary to JSON Parser.
-Also it cannot be used as an output format.
 
 ## Configuration
 

--- a/plugins/parsers/json_v2/README.md
+++ b/plugins/parsers/json_v2/README.md
@@ -7,9 +7,8 @@ this playground to test out your GJSON path here:
 [gjson.dev/](https://gjson.dev). You can find multiple examples under the
 [`testdata`][] folder.
 
-**NOTE:** This parser has a different semantics comparing to regular JSON 
-Parser - if you don't have any configuration fields or tags it will not 
-produce any metric on contrary to JSON Parser.
+**NOTE:** If you don't have any configuration fields or tags this parser 
+will not produce any metric.
 
 ## Configuration
 

--- a/plugins/parsers/json_v2/README.md
+++ b/plugins/parsers/json_v2/README.md
@@ -7,6 +7,9 @@ this playground to test out your GJSON path here:
 [gjson.dev/](https://gjson.dev). You can find multiple examples under the
 [`testdata`][] folder.
 
+**NOTE:** This parser has a different semantics comparing to regular JSON Parser - if you don't have any configuration fields or tags it will not produce any metric on contrary to JSON Parser.
+Also it cannot be used as an output format.
+
 ## Configuration
 
 ```toml

--- a/plugins/parsers/json_v2/README.md
+++ b/plugins/parsers/json_v2/README.md
@@ -7,7 +7,8 @@ this playground to test out your GJSON path here:
 [gjson.dev/](https://gjson.dev). You can find multiple examples under the
 [`testdata`][] folder.
 
-**NOTE:** This parser has a different semantics comparing to regular JSON Parser - if you don't have any configuration fields or tags it will not produce any metric on contrary to JSON Parser.
+**NOTE:** This parser has a different semantics comparing to regular JSON Parser - 
+if you don't have any configuration fields or tags it will not produce any metric on contrary to JSON Parser.
 
 ## Configuration
 

--- a/plugins/parsers/json_v2/README.md
+++ b/plugins/parsers/json_v2/README.md
@@ -7,8 +7,9 @@ this playground to test out your GJSON path here:
 [gjson.dev/](https://gjson.dev). You can find multiple examples under the
 [`testdata`][] folder.
 
-**NOTE:** This parser has a different semantics comparing to regular JSON Parser - 
-if you don't have any configuration fields or tags it will not produce any metric on contrary to JSON Parser.
+**NOTE:** This parser has a different semantics comparing to regular JSON 
+Parser - if you don't have any configuration fields or tags it will not 
+produce any metric on contrary to JSON Parser.
 
 ## Configuration
 


### PR DESCRIPTION
## Summary
related to https://github.com/influxdata/telegraf/pull/15837

switching parser from "json" to "json_v2" is not equivalent.
Not sure if this is expected behavior or not.
In my config I have only

data_format = "json"

If I switch it to

data_format = "json_v2"

then Telegraf just stops working and not printing any output.
It is very confusing, even though it may be expected.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
