### PR TITLE
chore: Fix linter findings for `revive:enforce-repeated-arg-type-style` in `plugins/inputs/[a-g]*`

### DIFF
--- a/plugins/inputs/aerospike/aerospike.go
+++ b/plugins/inputs/aerospike/aerospike.go
@@ -198,7 +198,7 @@ func (a *Aerospike) getNodeInfo(n *as.Node, infoPolicy *as.InfoPolicy) (map[stri
 	return stats, nil
 }
 
-func (a *Aerospike) parseNodeInfo(acc telegraf.Accumulator, stats map[string]string, hostPort string, nodeName string) {
+func (a *Aerospike) parseNodeInfo(acc telegraf.Accumulator, stats map[string]string, hostPort, nodeName string) {
 	nTags := map[string]string{
 		"aerospike_host": hostPort,
 		"node_name":      nodeName,
@@ -239,7 +239,7 @@ func (a *Aerospike) getNamespaceInfo(namespace string, n *as.Node, infoPolicy *a
 
 	return stats, err
 }
-func (a *Aerospike) parseNamespaceInfo(acc telegraf.Accumulator, stats map[string]string, hostPort string, namespace string, nodeName string) {
+func (a *Aerospike) parseNamespaceInfo(acc telegraf.Accumulator, stats map[string]string, hostPort, namespace, nodeName string) {
 	nTags := map[string]string{
 		"aerospike_host": hostPort,
 		"node_name":      nodeName,
@@ -304,7 +304,7 @@ func (a *Aerospike) getSetInfo(namespaceSet string, n *as.Node, infoPolicy *as.I
 	return stats, nil
 }
 
-func (a *Aerospike) parseSetInfo(acc telegraf.Accumulator, stats map[string]string, hostPort string, namespaceSet string, nodeName string) {
+func (a *Aerospike) parseSetInfo(acc telegraf.Accumulator, stats map[string]string, hostPort, namespaceSet, nodeName string) {
 	stat := strings.Split(
 		strings.TrimSuffix(
 			stats["sets/"+namespaceSet], ";"), ":")
@@ -326,7 +326,7 @@ func (a *Aerospike) parseSetInfo(acc telegraf.Accumulator, stats map[string]stri
 	acc.AddFields("aerospike_set", nFields, nTags, time.Now())
 }
 
-func (a *Aerospike) getTTLHistogram(acc telegraf.Accumulator, hostPort string, namespace string, set string, n *as.Node, infoPolicy *as.InfoPolicy) error {
+func (a *Aerospike) getTTLHistogram(acc telegraf.Accumulator, hostPort, namespace, set string, n *as.Node, infoPolicy *as.InfoPolicy) error {
 	stats, err := a.getHistogram(namespace, set, "ttl", n, infoPolicy)
 	if err != nil {
 		return err
@@ -338,14 +338,7 @@ func (a *Aerospike) getTTLHistogram(acc telegraf.Accumulator, hostPort string, n
 	return nil
 }
 
-func (a *Aerospike) getObjectSizeLinearHistogram(
-	acc telegraf.Accumulator,
-	hostPort string,
-	namespace string,
-	set string,
-	n *as.Node,
-	infoPolicy *as.InfoPolicy,
-) error {
+func (a *Aerospike) getObjectSizeLinearHistogram(acc telegraf.Accumulator, hostPort, namespace, set string, n *as.Node, infoPolicy *as.InfoPolicy) error {
 	stats, err := a.getHistogram(namespace, set, "object-size-linear", n, infoPolicy)
 	if err != nil {
 		return err
@@ -357,7 +350,7 @@ func (a *Aerospike) getObjectSizeLinearHistogram(
 	return nil
 }
 
-func (a *Aerospike) getHistogram(namespace string, set string, histogramType string, n *as.Node, infoPolicy *as.InfoPolicy) (map[string]string, error) {
+func (a *Aerospike) getHistogram(namespace, set, histogramType string, n *as.Node, infoPolicy *as.InfoPolicy) (map[string]string, error) {
 	var queryArg string
 	if len(set) > 0 {
 		queryArg = fmt.Sprintf("histogram:type=%s;namespace=%v;set=%v", histogramType, namespace, set)
@@ -372,7 +365,7 @@ func (a *Aerospike) getHistogram(namespace string, set string, histogramType str
 	return stats, nil
 }
 
-func (a *Aerospike) parseHistogram(acc telegraf.Accumulator, stats map[string]string, nTags map[string]string, histogramType string) {
+func (a *Aerospike) parseHistogram(acc telegraf.Accumulator, stats, nTags map[string]string, histogramType string) {
 	nFields := make(map[string]interface{})
 
 	for _, stat := range stats {
@@ -422,12 +415,12 @@ func (a *Aerospike) parseHistogram(acc telegraf.Accumulator, stats map[string]st
 	acc.AddFields(fmt.Sprintf("aerospike_histogram_%v", strings.ReplaceAll(histogramType, "-", "_")), nFields, nTags, time.Now())
 }
 
-func splitNamespaceSet(namespaceSet string) (namespace string, set string) {
+func splitNamespaceSet(namespaceSet string) (namespace, set string) {
 	split := strings.Split(namespaceSet, "/")
 	return split[0], split[1]
 }
 
-func parseAerospikeValue(key string, v string) interface{} {
+func parseAerospikeValue(key, v string) interface{} {
 	if protectedHexFields[key] {
 		return v
 	} else if parsed, err := strconv.ParseInt(v, 10, 64); err == nil {
@@ -443,7 +436,7 @@ func parseAerospikeValue(key string, v string) interface{} {
 	return v
 }
 
-func createTags(hostPort string, nodeName string, namespace string, set string) map[string]string {
+func createTags(hostPort, nodeName, namespace, set string) map[string]string {
 	nTags := map[string]string{
 		"aerospike_host": hostPort,
 		"node_name":      nodeName,

--- a/plugins/inputs/aerospike/aerospike_test.go
+++ b/plugins/inputs/aerospike/aerospike_test.go
@@ -473,7 +473,7 @@ func TestAerospikeParseValue(t *testing.T) {
 	require.Equal(t, `1992929191`, val, "must be left as a string")
 }
 
-func FindTagValue(acc *testutil.Accumulator, measurement string, key string, value string) bool {
+func FindTagValue(acc *testutil.Accumulator, measurement, key, value string) bool {
 	for _, p := range acc.Metrics {
 		if p.Measurement == measurement {
 			v, ok := p.Tags[key]

--- a/plugins/inputs/aliyuncms/aliyuncms.go
+++ b/plugins/inputs/aliyuncms/aliyuncms.go
@@ -342,7 +342,7 @@ func (s *AliyunCMS) gatherMetric(acc telegraf.Accumulator, metricName string, me
 }
 
 // tag helper
-func parseTag(tagSpec string, data interface{}) (tagKey string, tagValue string, err error) {
+func parseTag(tagSpec string, data interface{}) (tagKey, tagValue string, err error) {
 	var (
 		ok        bool
 		queryPath = tagSpec
@@ -474,7 +474,7 @@ L:
 }
 
 // Formatting helpers
-func formatField(metricName string, statistic string) string {
+func formatField(metricName, statistic string) string {
 	if metricName == statistic {
 		statistic = "value"
 	}

--- a/plugins/inputs/azure_monitor/azure_monitor.go
+++ b/plugins/inputs/azure_monitor/azure_monitor.go
@@ -171,10 +171,7 @@ func (am *AzureMonitor) setReceiver() error {
 }
 
 func (acm *azureClientsManager) createAzureClients(
-	subscriptionID string,
-	clientID string,
-	clientSecret string,
-	tenantID string,
+	subscriptionID, clientID, clientSecret, tenantID string,
 	clientOptions azcore.ClientOptions,
 ) (*receiver.AzureClients, error) {
 	if clientSecret != "" {

--- a/plugins/inputs/azure_monitor/azure_monitor_test.go
+++ b/plugins/inputs/azure_monitor/azure_monitor_test.go
@@ -27,7 +27,7 @@ type mockAzureMetricDefinitionsClient struct{}
 
 type mockAzureMetricsClient struct{}
 
-func (mam *mockAzureClientsManager) createAzureClients(_ string, _ string, _ string, _ string, _ azcore.ClientOptions) (*receiver.AzureClients, error) {
+func (mam *mockAzureClientsManager) createAzureClients(_, _, _, _ string, _ azcore.ClientOptions) (*receiver.AzureClients, error) {
 	return &receiver.AzureClients{
 		Ctx:                     context.Background(),
 		ResourcesClient:         &mockAzureResourcesClient{},

--- a/plugins/inputs/beanstalkd/beanstalkd_test.go
+++ b/plugins/inputs/beanstalkd/beanstalkd_test.go
@@ -345,7 +345,7 @@ func getOverviewTags(server string) map[string]string {
 	}
 }
 
-func getTubeTags(server string, tube string) map[string]string {
+func getTubeTags(server, tube string) map[string]string {
 	return map[string]string{
 		"name":   tube,
 		"server": server,

--- a/plugins/inputs/bond/bond.go
+++ b/plugins/inputs/bond/bond.go
@@ -79,7 +79,7 @@ func (bond *Bond) Gather(acc telegraf.Accumulator) error {
 	return nil
 }
 
-func (bond *Bond) gatherBondInterface(bondName string, rawFile string, acc telegraf.Accumulator) error {
+func (bond *Bond) gatherBondInterface(bondName, rawFile string, acc telegraf.Accumulator) error {
 	splitIndex := strings.Index(rawFile, "Slave Interface:")
 	if splitIndex == -1 {
 		splitIndex = len(rawFile)
@@ -98,7 +98,7 @@ func (bond *Bond) gatherBondInterface(bondName string, rawFile string, acc teleg
 	return nil
 }
 
-func (bond *Bond) gatherBondPart(bondName string, rawFile string, acc telegraf.Accumulator) error {
+func (bond *Bond) gatherBondPart(bondName, rawFile string, acc telegraf.Accumulator) error {
 	fields := make(map[string]interface{})
 	tags := map[string]string{
 		"bond": bondName,
@@ -210,7 +210,7 @@ func (bond *Bond) gatherSysDetails(bondName string, files sysFiles, acc telegraf
 	acc.AddFields("bond_sys", fields, tags)
 }
 
-func (bond *Bond) gatherSlavePart(bondName string, rawFile string, acc telegraf.Accumulator) error {
+func (bond *Bond) gatherSlavePart(bondName, rawFile string, acc telegraf.Accumulator) error {
 	var slaveCount int
 	tags := map[string]string{
 		"bond": bondName,

--- a/plugins/inputs/cisco_telemetry_mdt/cisco_telemetry_mdt.go
+++ b/plugins/inputs/cisco_telemetry_mdt/cisco_telemetry_mdt.go
@@ -649,8 +649,13 @@ func (c *CiscoTelemetryMDT) getMeasurementName(encodingPath string) string {
 	return measurement
 }
 
-func (c *CiscoTelemetryMDT) parseContentField(grouper *metric.SeriesGrouper, field *telemetry.TelemetryField, prefix string,
-	encodingPath string, tags map[string]string, timestamp time.Time) {
+func (c *CiscoTelemetryMDT) parseContentField(
+	grouper *metric.SeriesGrouper,
+	field *telemetry.TelemetryField,
+	prefix, encodingPath string,
+	tags map[string]string,
+	timestamp time.Time,
+) {
 	name := strings.ReplaceAll(field.Name, "-", "_")
 
 	if (name == "modTs" || name == "createTs") && decodeValue(field) == "never" {

--- a/plugins/inputs/cloudwatch_metric_streams/cloudwatch_metric_streams_test.go
+++ b/plugins/inputs/cloudwatch_metric_streams/cloudwatch_metric_streams_test.go
@@ -69,7 +69,7 @@ func getHTTPSClient() *http.Client {
 	}
 }
 
-func createURL(scheme string, path string) string {
+func createURL(scheme, path string) string {
 	u := url.URL{
 		Scheme:   scheme,
 		Host:     "localhost:8080",

--- a/plugins/inputs/couchbase/couchbase.go
+++ b/plugins/inputs/couchbase/couchbase.go
@@ -180,7 +180,7 @@ func (cb *Couchbase) basicBucketStats(basicStats map[string]interface{}) map[str
 	return fields
 }
 
-func (cb *Couchbase) gatherDetailedBucketStats(server, bucket string, nodeHostname string, fields map[string]interface{}) error {
+func (cb *Couchbase) gatherDetailedBucketStats(server, bucket, nodeHostname string, fields map[string]interface{}) error {
 	extendedBucketStats := &BucketStats{}
 	err := cb.queryDetailedBucketStats(server, bucket, nodeHostname, extendedBucketStats)
 	if err != nil {
@@ -421,7 +421,7 @@ func (cb *Couchbase) addBucketFieldChecked(fields map[string]interface{}, fieldK
 	cb.addBucketField(fields, fieldKey, values[len(values)-1])
 }
 
-func (cb *Couchbase) queryDetailedBucketStats(server, bucket string, nodeHostname string, bucketStats *BucketStats) error {
+func (cb *Couchbase) queryDetailedBucketStats(server, bucket, nodeHostname string, bucketStats *BucketStats) error {
 	url := server + "/pools/default/buckets/" + bucket
 	if nodeHostname != "" {
 		url += "/nodes/" + nodeHostname

--- a/plugins/inputs/cpu/cpu_test.go
+++ b/plugins/inputs/cpu/cpu_test.go
@@ -124,8 +124,7 @@ func assertContainsTaggedFloat(
 	t *testing.T,
 	acc *testutil.Accumulator,
 	field string,
-	expectedValue float64,
-	delta float64,
+	expectedValue, delta float64,
 ) {
 	var actualValue float64
 	measurement := "cpu" // always cpu

--- a/plugins/inputs/dcos/client.go
+++ b/plugins/inputs/dcos/client.go
@@ -259,7 +259,7 @@ func (c *ClusterClient) GetAppMetrics(ctx context.Context, node, container strin
 	return c.getMetrics(ctx, c.toURL(path))
 }
 
-func createGetRequest(address string, token string) (*http.Request, error) {
+func createGetRequest(address, token string) (*http.Request, error) {
 	req, err := http.NewRequest("GET", address, nil)
 	if err != nil {
 		return nil, err

--- a/plugins/inputs/directory_monitor/directory_monitor.go
+++ b/plugins/inputs/directory_monitor/directory_monitor.go
@@ -336,7 +336,7 @@ func (monitor *DirectoryMonitor) sendMetrics(metrics []telegraf.Metric) error {
 	return nil
 }
 
-func (monitor *DirectoryMonitor) moveFile(srcPath string, dstBaseDir string) {
+func (monitor *DirectoryMonitor) moveFile(srcPath, dstBaseDir string) {
 	// Appends any subdirectories in the srcPath to the dstBaseDir and
 	// creates those subdirectories.
 	basePath := strings.Replace(srcPath, monitor.Directory, "", 1)

--- a/plugins/inputs/dns_query/dns_query.go
+++ b/plugins/inputs/dns_query/dns_query.go
@@ -107,7 +107,7 @@ func (d *DNSQuery) Gather(acc telegraf.Accumulator) error {
 	return nil
 }
 
-func (d *DNSQuery) query(domain string, server string) (map[string]interface{}, map[string]string, error) {
+func (d *DNSQuery) query(domain, server string) (map[string]interface{}, map[string]string, error) {
 	tags := map[string]string{
 		"server":      server,
 		"domain":      domain,

--- a/plugins/inputs/docker/docker.go
+++ b/plugins/inputs/docker/docker.go
@@ -608,8 +608,7 @@ func (d *Docker) parseContainerStats(
 	stat *typeContainer.StatsResponse,
 	acc telegraf.Accumulator,
 	tags map[string]string,
-	id string,
-	daemonOSType string,
+	id, daemonOSType string,
 ) {
 	tm := stat.Read
 

--- a/plugins/inputs/docker/stats_helpers.go
+++ b/plugins/inputs/docker/stats_helpers.go
@@ -66,7 +66,7 @@ func CalculateMemUsageUnixNoCache(mem container.MemoryStats) float64 {
 	return float64(mem.Usage)
 }
 
-func CalculateMemPercentUnixNoCache(limit float64, usedNoCache float64) float64 {
+func CalculateMemPercentUnixNoCache(limit, usedNoCache float64) float64 {
 	// MemoryStats.Limit will never be 0 unless the container is not running and we haven't
 	// got any data from cgroup
 	if limit != 0 {

--- a/plugins/inputs/dovecot/dovecot.go
+++ b/plugins/inputs/dovecot/dovecot.go
@@ -65,7 +65,7 @@ func (d *Dovecot) Gather(acc telegraf.Accumulator) error {
 	return nil
 }
 
-func (d *Dovecot) gatherServer(addr string, acc telegraf.Accumulator, qtype string, filter string) error {
+func (d *Dovecot) gatherServer(addr string, acc telegraf.Accumulator, qtype, filter string) error {
 	var proto string
 
 	if strings.HasPrefix(addr, "/") {
@@ -124,7 +124,7 @@ func (d *Dovecot) gatherServer(addr string, acc telegraf.Accumulator, qtype stri
 	return nil
 }
 
-func gatherStats(buf *bytes.Buffer, acc telegraf.Accumulator, host string, qtype string) {
+func gatherStats(buf *bytes.Buffer, acc telegraf.Accumulator, host, qtype string) {
 	lines := strings.Split(buf.String(), "\n")
 	head := strings.Split(lines[0], "\t")
 	vals := lines[1:]
@@ -160,7 +160,7 @@ func gatherStats(buf *bytes.Buffer, acc telegraf.Accumulator, host string, qtype
 	}
 }
 
-func splitSec(tm string) (sec int64, msec int64) {
+func splitSec(tm string) (sec, msec int64) {
 	var err error
 	ss := strings.Split(tm, ".")
 

--- a/plugins/inputs/dpdk/dpdk_utils.go
+++ b/plugins/inputs/dpdk/dpdk_utils.go
@@ -14,7 +14,7 @@ import (
 	"github.com/influxdata/telegraf/filter"
 )
 
-func commandWithParams(command string, params string) string {
+func commandWithParams(command, params string) string {
 	if params != "" {
 		return command + "," + params
 	}

--- a/plugins/inputs/ecs/ecs.go
+++ b/plugins/inputs/ecs/ecs.go
@@ -193,7 +193,7 @@ func copyTags(in map[string]string) map[string]string {
 }
 
 // returns a new map with the merged content values of the two input maps
-func mergeTags(a map[string]string, b map[string]string) map[string]string {
+func mergeTags(a, b map[string]string) map[string]string {
 	c := copyTags(a)
 	for k, v := range b {
 		c[k] = v

--- a/plugins/inputs/elasticsearch_query/aggregation_parser.go
+++ b/plugins/inputs/elasticsearch_query/aggregation_parser.go
@@ -124,7 +124,7 @@ func recurseResponse(acc telegraf.Accumulator, aggNameFunction map[string]string
 	return m, nil
 }
 
-func getResponseAggregation(function string, aggName string, aggs elastic5.Aggregations) (agg interface{}) {
+func getResponseAggregation(function, aggName string, aggs elastic5.Aggregations) (agg interface{}) {
 	switch function {
 	case "avg":
 		agg, _ = aggs.Avg(aggName)

--- a/plugins/inputs/elasticsearch_query/aggregation_query.go
+++ b/plugins/inputs/elasticsearch_query/aggregation_query.go
@@ -197,7 +197,7 @@ func (aggregation *esAggregation) buildAggregationQuery() error {
 	return nil
 }
 
-func getFunctionAggregation(function string, aggfield string) (elastic5.Aggregation, error) {
+func getFunctionAggregation(function, aggfield string) (elastic5.Aggregation, error) {
 	var agg elastic5.Aggregation
 
 	switch function {

--- a/plugins/inputs/exec/exec_test.go
+++ b/plugins/inputs/exec/exec_test.go
@@ -73,7 +73,7 @@ type runnerMock struct {
 	err    error
 }
 
-func newRunnerMock(out []byte, errout []byte, err error) Runner {
+func newRunnerMock(out, errout []byte, err error) Runner {
 	return &runnerMock{
 		out:    out,
 		errout: errout,

--- a/plugins/inputs/execd/shim/shim_test.go
+++ b/plugins/inputs/execd/shim/shim_test.go
@@ -53,7 +53,7 @@ func TestShimStdinSignalingWorks(t *testing.T) {
 	<-exited
 }
 
-func runInputPlugin(t *testing.T, interval time.Duration, stdin io.Reader, stdout, stderr io.Writer) (metricProcessed chan bool, exited chan bool) {
+func runInputPlugin(t *testing.T, interval time.Duration, stdin io.Reader, stdout, stderr io.Writer) (metricProcessed, exited chan bool) {
 	metricProcessed = make(chan bool)
 	exited = make(chan bool)
 	inp := &testInput{

--- a/plugins/inputs/fibaro/hc2/parser.go
+++ b/plugins/inputs/fibaro/hc2/parser.go
@@ -7,7 +7,7 @@ import (
 	"github.com/influxdata/telegraf"
 )
 
-func Parse(acc telegraf.Accumulator, sectionBytes []byte, roomBytes []byte, deviecsBytes []byte) error {
+func Parse(acc telegraf.Accumulator, sectionBytes, roomBytes, deviecsBytes []byte) error {
 	var tmpSections []Sections
 	if err := json.Unmarshal(sectionBytes, &tmpSections); err != nil {
 		return err

--- a/plugins/inputs/fibaro/hc3/parser.go
+++ b/plugins/inputs/fibaro/hc3/parser.go
@@ -9,7 +9,7 @@ import (
 	"github.com/influxdata/telegraf/internal"
 )
 
-func Parse(acc telegraf.Accumulator, sectionBytes []byte, roomBytes []byte, deviecsBytes []byte) error {
+func Parse(acc telegraf.Accumulator, sectionBytes, roomBytes, deviecsBytes []byte) error {
 	var tmpSections []Sections
 	if err := json.Unmarshal(sectionBytes, &tmpSections); err != nil {
 		return err

--- a/plugins/inputs/filecount/filecount_test.go
+++ b/plugins/inputs/filecount/filecount_test.go
@@ -239,7 +239,7 @@ func getFakeFileSystem(basePath string) fakeFileSystem {
 	return fakeFileSystem{files: fileList}
 }
 
-func fileCountEquals(t *testing.T, fc FileCount, expectedCount int, expectedSize int) {
+func fileCountEquals(t *testing.T, fc FileCount, expectedCount, expectedSize int) {
 	tags := map[string]string{"directory": getTestdataDir()}
 	acc := testutil.Accumulator{}
 	require.NoError(t, acc.GatherError(fc.Gather))

--- a/plugins/inputs/github/github.go
+++ b/plugins/inputs/github/github.go
@@ -158,7 +158,7 @@ func (g *GitHub) handleRateLimit(response *githubLib.Response, err error) {
 	}
 }
 
-func splitRepositoryName(repositoryName string) (owner string, repository string, err error) {
+func splitRepositoryName(repositoryName string) (owner, repository string, err error) {
 	splits := strings.SplitN(repositoryName, "/", 2)
 
 	if len(splits) != 2 {

--- a/plugins/inputs/gnmi/gnmi.go
+++ b/plugins/inputs/gnmi/gnmi.go
@@ -377,7 +377,7 @@ func (c *GNMI) newSubscribeRequest() (*gnmiLib.SubscribeRequest, error) {
 }
 
 // ParsePath from XPath-like string to gNMI path structure
-func parsePath(origin string, pathToParse string, target string) (*gnmiLib.Path, error) {
+func parsePath(origin, pathToParse, target string) (*gnmiLib.Path, error) {
 	gnmiPath, err := xpath.ToGNMIPath(pathToParse)
 	if err != nil {
 		return nil, err

--- a/plugins/inputs/google_cloud_storage/google_cloud_storage_test.go
+++ b/plugins/inputs/google_cloud_storage/google_cloud_storage_test.go
@@ -333,7 +333,7 @@ func stateFullGCSServer(t *testing.T) *httptest.Server {
 	return srv
 }
 
-func serveBlobs(t *testing.T, w http.ResponseWriter, urlPath string, offsetKey string) {
+func serveBlobs(t *testing.T, w http.ResponseWriter, urlPath, offsetKey string) {
 	singleObjectNotFound := readJSON(t, "testdata/single_object_not_found.json")
 	firstFile := readJSON(t, "testdata/first_file.json")
 	secondFile := readJSON(t, "testdata/second_file.json")

--- a/plugins/inputs/graylog/graylog.go
+++ b/plugins/inputs/graylog/graylog.go
@@ -173,7 +173,7 @@ func (h *GrayLog) gatherServer(
 // Returns:
 //
 //	void
-func (h *GrayLog) flatten(item map[string]interface{}, fields map[string]interface{}, id string) {
+func (h *GrayLog) flatten(item, fields map[string]interface{}, id string) {
 	if id != "" {
 		id = id + "_"
 	}


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

Address findings for [revive:enforce-repeated-arg-type-style](https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#enforce-repeated-arg-type-style) in `plugins/inputs/[a-g]*`

As we agreed here https://github.com/influxdata/telegraf/issues/15811, we will fix the errors found by the following configuration:
```
      - name: enforce-repeated-arg-type-style
        arguments: ["short"]
```

It is only part of the bigger job.
After all findings of this type in whole project are handled, we can enable `revive:enforce-repeated-arg-type-style` rule in `golangci-lint`.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR


