### PR TITLE
chore: Fix linter findings for `revive:enforce-repeated-arg-type-style` in `plugins/inputs/[h-n]*`

### DIFF
--- a/plugins/inputs/http_listener_v2/http_listener_v2_test.go
+++ b/plugins/inputs/http_listener_v2/http_listener_v2_test.go
@@ -111,7 +111,7 @@ func getHTTPSClient() *http.Client {
 	}
 }
 
-func createURL(listener *HTTPListenerV2, scheme string, path string, rawquery string) string {
+func createURL(listener *HTTPListenerV2, scheme, path, rawquery string) string {
 	var port int
 	if strings.HasPrefix(listener.ServiceAddress, "tcp://") {
 		port = listener.listener.Addr().(*net.TCPAddr).Port

--- a/plugins/inputs/http_response/http_response_test.go
+++ b/plugins/inputs/http_response/http_response_test.go
@@ -149,14 +149,7 @@ func setUpTestMux() http.Handler {
 	return mux
 }
 
-func checkOutput(
-	t *testing.T,
-	acc *testutil.Accumulator,
-	presentFields map[string]interface{},
-	presentTags map[string]interface{},
-	absentFields []string,
-	absentTags []string,
-) {
+func checkOutput(t *testing.T, acc *testutil.Accumulator, presentFields, presentTags map[string]interface{}, absentFields, absentTags []string) {
 	t.Helper()
 	if presentFields != nil {
 		checkFields(t, presentFields, acc)

--- a/plugins/inputs/hugepages/hugepages.go
+++ b/plugins/inputs/hugepages/hugepages.go
@@ -152,12 +152,7 @@ func (h *Hugepages) gatherStatsPerNode(acc telegraf.Accumulator) error {
 	return nil
 }
 
-func (h *Hugepages) gatherFromHugepagePath(
-	acc telegraf.Accumulator,
-	measurement, path string,
-	fileFilter map[string]string,
-	defaultTags map[string]string,
-) error {
+func (h *Hugepages) gatherFromHugepagePath(acc telegraf.Accumulator, measurement, path string, fileFilter, defaultTags map[string]string) error {
 	// read metrics from: hugepages/hugepages-*/*
 	hugepagesDirs, err := os.ReadDir(path)
 	if err != nil {

--- a/plugins/inputs/infiniband/infiniband_linux.go
+++ b/plugins/inputs/infiniband/infiniband_linux.go
@@ -40,7 +40,7 @@ func (i *Infiniband) Gather(acc telegraf.Accumulator) error {
 }
 
 // Add the statistics to the accumulator
-func addStats(dev string, port string, stats []rdmamap.RdmaStatEntry, acc telegraf.Accumulator) {
+func addStats(dev, port string, stats []rdmamap.RdmaStatEntry, acc telegraf.Accumulator) {
 	// Allow users to filter by card and port
 	tags := map[string]string{"device": dev, "port": port}
 	fields := make(map[string]interface{})

--- a/plugins/inputs/influxdb_listener/influxdb_listener_test.go
+++ b/plugins/inputs/influxdb_listener/influxdb_listener_test.go
@@ -95,7 +95,7 @@ func getSecureClient() *http.Client {
 	}
 }
 
-func createURL(listener *InfluxDBListener, scheme string, path string, rawquery string) string {
+func createURL(listener *InfluxDBListener, scheme, path, rawquery string) string {
 	u := url.URL{
 		Scheme:   scheme,
 		Host:     "localhost:" + strconv.Itoa(listener.port),

--- a/plugins/inputs/influxdb_v2_listener/influxdb_v2_listener_test.go
+++ b/plugins/inputs/influxdb_v2_listener/influxdb_v2_listener_test.go
@@ -96,7 +96,7 @@ func getSecureClient() *http.Client {
 	}
 }
 
-func createURL(listener *InfluxDBV2Listener, scheme string, path string, rawquery string) string {
+func createURL(listener *InfluxDBV2Listener, scheme, path, rawquery string) string {
 	u := url.URL{
 		Scheme:   scheme,
 		Host:     "localhost:" + strconv.Itoa(listener.port),

--- a/plugins/inputs/intel_pmt/intel_pmt.go
+++ b/plugins/inputs/intel_pmt/intel_pmt.go
@@ -299,7 +299,7 @@ func getTelemSample(s sample, buf []byte, offset uint64) (uint64, error) {
 // Returns:
 //
 //	error - error if getting values has failed, if sample IDref is missing or if equation evaluation has failed.
-func (p *IntelPMT) aggregateSamples(acc telegraf.Accumulator, guid string, data []byte, numaNode string, pciBdf string) error {
+func (p *IntelPMT) aggregateSamples(acc telegraf.Accumulator, guid string, data []byte, numaNode, pciBdf string) error {
 	results, err := p.getSampleValues(guid, data)
 	if err != nil {
 		return err

--- a/plugins/inputs/intel_pmt/intel_pmt_test.go
+++ b/plugins/inputs/intel_pmt/intel_pmt_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func createTempFile(t *testing.T, dir string, pattern string, data []byte) (*os.File, os.FileInfo) {
+func createTempFile(t *testing.T, dir, pattern string, data []byte) (*os.File, os.FileInfo) {
 	tempFile, err := os.CreateTemp(dir, pattern)
 	if err != nil {
 		t.Fatalf("error creating a temporary file %v: %v", tempFile.Name(), err)

--- a/plugins/inputs/intel_pmt/xml_parser.go
+++ b/plugins/inputs/intel_pmt/xml_parser.go
@@ -199,7 +199,7 @@ func (p *IntelPMT) readXMLs() error {
 // Returns:
 //
 //	error - if reading XML has failed.
-func (p *IntelPMT) getAllXMLData(guid string, dtMetricsFound map[string]bool, smFound map[string]bool) error {
+func (p *IntelPMT) getAllXMLData(guid string, dtMetricsFound, smFound map[string]bool) error {
 	for _, mapping := range p.pmtMetadata.Mappings.Mapping {
 		if mapping.GUID == guid {
 			basedir := mapping.XMLSet.Basedir
@@ -246,7 +246,7 @@ func (a *aggregator) calculateMasks() {
 	}
 }
 
-func computeMask(msb uint64, lsb uint64) uint64 {
+func computeMask(msb, lsb uint64) uint64 {
 	msbMask := uint64(0xffffffffffffffff) & ((1 << (msb + 1)) - 1)
 	lsbMask := uint64(0xffffffffffffffff) & (1<<lsb - 1)
 	return msbMask & (^lsbMask)

--- a/plugins/inputs/intel_pmu/config.go
+++ b/plugins/inputs/intel_pmu/config.go
@@ -210,7 +210,7 @@ func parseIDs(allIDsStrings []string) ([]int, error) {
 	return result, nil
 }
 
-func removeDuplicateValues(intSlice []int) (result []int, duplicates []int) {
+func removeDuplicateValues(intSlice []int) (result, duplicates []int) {
 	keys := make(map[int]bool)
 
 	for _, entry := range intSlice {
@@ -224,7 +224,7 @@ func removeDuplicateValues(intSlice []int) (result []int, duplicates []int) {
 	return result, duplicates
 }
 
-func removeDuplicateStrings(strSlice []string) (result []string, duplicates []string) {
+func removeDuplicateStrings(strSlice []string) (result, duplicates []string) {
 	keys := make(map[string]bool)
 
 	for _, entry := range strSlice {

--- a/plugins/inputs/intel_pmu/intel_pmu.go
+++ b/plugins/inputs/intel_pmu/intel_pmu.go
@@ -326,7 +326,7 @@ func estimateUncoreFd(entities []*UncoreEventEntity) (uint64, error) {
 	return number, nil
 }
 
-func multiplyAndAdd(factorA uint64, factorB uint64, sum uint64) (uint64, error) {
+func multiplyAndAdd(factorA, factorB, sum uint64) (uint64, error) {
 	bigA := new(big.Int).SetUint64(factorA)
 	bigB := new(big.Int).SetUint64(factorB)
 	activeEvents := new(big.Int).Mul(bigA, bigB)

--- a/plugins/inputs/intel_pmu/intel_pmu_test.go
+++ b/plugins/inputs/intel_pmu/intel_pmu_test.go
@@ -399,7 +399,7 @@ func TestEstimateCoresFd(t *testing.T) {
 	}
 }
 
-func makeEvents(number int, pmusNumber int) []*eventWithQuals {
+func makeEvents(number, pmusNumber int) []*eventWithQuals {
 	a := make([]*eventWithQuals, number)
 	for i := range a {
 		b := make([]ia.NamedPMUType, pmusNumber)

--- a/plugins/inputs/intel_pmu/resolver.go
+++ b/plugins/inputs/intel_pmu/resolver.go
@@ -78,7 +78,7 @@ func (e *iaEntitiesResolver) resolveEntities(coreEntities []*CoreEventEntity, un
 	return nil
 }
 
-func (e *iaEntitiesResolver) resolveAllEvents() (coreEvents []*eventWithQuals, uncoreEvents []*eventWithQuals, err error) {
+func (e *iaEntitiesResolver) resolveAllEvents() (coreEvents, uncoreEvents []*eventWithQuals, err error) {
 	if e.transformer == nil {
 		return nil, nil, errors.New("transformer is nil")
 	}

--- a/plugins/inputs/intel_powerstat/intel_powerstat.go
+++ b/plugins/inputs/intel_powerstat/intel_powerstat.go
@@ -537,7 +537,7 @@ func (p *PowerStat) addPerCPUPerfMetrics(acc telegraf.Accumulator, cpuID, coreID
 }
 
 // getDataCPUID takes a topologyFetcher and CPU ID, and returns the core ID and package ID corresponding to the CPU ID.
-func getDataCPUID(t topologyFetcher, cpuID int) (coreID int, packageID int, err error) {
+func getDataCPUID(t topologyFetcher, cpuID int) (coreID, packageID int, err error) {
 	coreID, err = t.GetCPUCoreID(cpuID)
 	if err != nil {
 		return 0, 0, fmt.Errorf("failed to get core ID from CPU ID %v: %w", cpuID, err)
@@ -977,7 +977,7 @@ func (p *PowerStat) addUncoreFrequencyCurrentValues(acc telegraf.Accumulator, pa
 }
 
 // getUncoreFreqInitialLimits returns the initial uncore frequency limits of a given package ID and die ID.
-func getUncoreFreqInitialLimits(fetcher metricFetcher, packageID, dieID int) (initialMin float64, initialMax float64, err error) {
+func getUncoreFreqInitialLimits(fetcher metricFetcher, packageID, dieID int) (initialMin, initialMax float64, err error) {
 	initialMin, err = fetcher.GetInitialUncoreFrequencyMin(packageID, dieID)
 	if err != nil {
 		return 0.0, 0.0, fmt.Errorf("failed to get initial minimum uncore frequency limit: %w", err)

--- a/plugins/inputs/intel_rdt/intel_rdt.go
+++ b/plugins/inputs/intel_rdt/intel_rdt.go
@@ -526,7 +526,7 @@ func arrayToString(array []int) string {
 	return strings.TrimSuffix(result, ",")
 }
 
-func checkForDuplicates(values []int, valuesToCheck []int) bool {
+func checkForDuplicates(values, valuesToCheck []int) bool {
 	for _, value := range values {
 		for _, valueToCheck := range valuesToCheck {
 			if value == valueToCheck {

--- a/plugins/inputs/ipmi_sensor/ipmi_sensor.go
+++ b/plugins/inputs/ipmi_sensor/ipmi_sensor.go
@@ -113,7 +113,7 @@ func (m *Ipmi) Gather(acc telegraf.Accumulator) error {
 	return nil
 }
 
-func (m *Ipmi) parse(acc telegraf.Accumulator, server string, sensor string) error {
+func (m *Ipmi) parse(acc telegraf.Accumulator, server, sensor string) error {
 	var command []string
 	switch sensor {
 	case "sdr":

--- a/plugins/inputs/jenkins/client.go
+++ b/plugins/inputs/jenkins/client.go
@@ -113,7 +113,7 @@ func (e APIError) Error() string {
 	return fmt.Sprintf("[%s] %s", e.URL, e.Title)
 }
 
-func createGetRequest(url string, username, password string, sessionCookie *http.Cookie) (*http.Request, error) {
+func createGetRequest(url, username, password string, sessionCookie *http.Cookie) (*http.Request, error) {
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, err

--- a/plugins/inputs/knx_listener/knx_listener_test.go
+++ b/plugins/inputs/knx_listener/knx_listener_test.go
@@ -44,7 +44,7 @@ type message struct {
 	value   interface{}
 }
 
-func produceKnxEvent(t *testing.T, address string, datapoint string, value interface{}) *knx.GroupEvent {
+func produceKnxEvent(t *testing.T, address, datapoint string, value interface{}) *knx.GroupEvent {
 	addr, err := cemi.NewGroupAddrString(address)
 	require.NoError(t, err)
 

--- a/plugins/inputs/kube_inventory/client.go
+++ b/plugins/inputs/kube_inventory/client.go
@@ -23,7 +23,7 @@ type client struct {
 	*kubernetes.Clientset
 }
 
-func newClient(baseURL, namespace, bearerTokenFile string, bearerToken string, timeout time.Duration, tlsConfig tls.ClientConfig) (*client, error) {
+func newClient(baseURL, namespace, bearerTokenFile, bearerToken string, timeout time.Duration, tlsConfig tls.ClientConfig) (*client, error) {
 	var clientConfig *rest.Config
 	var err error
 

--- a/plugins/inputs/leofs/leofs_test.go
+++ b/plugins/inputs/leofs/leofs_test.go
@@ -123,7 +123,7 @@ func main() {
 }
 `
 
-func testMain(t *testing.T, code string, endpoint string, serverType ServerType) {
+func testMain(t *testing.T, code, endpoint string, serverType ServerType) {
 	executable := "snmpwalk"
 	if runtime.GOOS == "windows" {
 		executable = "snmpwalk.exe"

--- a/plugins/inputs/mcrouter/mcrouter.go
+++ b/plugins/inputs/mcrouter/mcrouter.go
@@ -137,7 +137,7 @@ func (m *Mcrouter) Gather(acc telegraf.Accumulator) error {
 }
 
 // ParseAddress parses an address string into 'host:port' and 'protocol' parts
-func (m *Mcrouter) ParseAddress(address string) (parsedAddress string, protocol string, err error) {
+func (m *Mcrouter) ParseAddress(address string) (parsedAddress, protocol string, err error) {
 	var host string
 	var port string
 

--- a/plugins/inputs/mongodb/mongodb_server.go
+++ b/plugins/inputs/mongodb/mongodb_server.go
@@ -53,7 +53,7 @@ func (s *Server) authLog(err error) {
 	}
 }
 
-func (s *Server) runCommand(database string, cmd interface{}, result interface{}) error {
+func (s *Server) runCommand(database string, cmd, result interface{}) error {
 	r := s.client.Database(database).RunCommand(context.Background(), cmd)
 	if r.Err() != nil {
 		return r.Err()
@@ -270,14 +270,7 @@ func (s *Server) gatherCollectionStats(colStatsDbs []string) (*ColStats, error) 
 	return results, nil
 }
 
-func (s *Server) gatherData(
-	acc telegraf.Accumulator,
-	gatherClusterStatus bool,
-	gatherDbStats bool,
-	gatherColStats bool,
-	gatherTopStat bool,
-	colStatsDbs []string,
-) error {
+func (s *Server) gatherData(acc telegraf.Accumulator, gatherClusterStatus, gatherDbStats, gatherColStats, gatherTopStat bool, colStatsDbs []string) error {
 	serverStatus, err := s.gatherServerStatus()
 	if err != nil {
 		return err

--- a/plugins/inputs/mongodb/mongostat.go
+++ b/plugins/inputs/mongodb/mongostat.go
@@ -928,7 +928,7 @@ func computeLockDiffs(prevLocks, curLocks map[string]LockUsage) []LockUsage {
 	return lockUsages
 }
 
-func diff(newVal, oldVal, sampleTime int64) (avg int64, newValue int64) {
+func diff(newVal, oldVal, sampleTime int64) (avg, newValue int64) {
 	d := newVal - oldVal
 	if d < 0 {
 		d = newVal

--- a/plugins/inputs/mqtt_consumer/topic_parser.go
+++ b/plugins/inputs/mqtt_consumer/topic_parser.go
@@ -200,7 +200,7 @@ func (p *TopicParser) Parse(metric telegraf.Metric, topic string) error {
 	return nil
 }
 
-func (p *TopicParser) convertToFieldType(value string, key string) (interface{}, error) {
+func (p *TopicParser) convertToFieldType(value, key string) (interface{}, error) {
 	// If the user configured inputs.mqtt_consumer.topic.types, check for the desired type
 	desiredType, ok := p.fieldTypes[key]
 	if !ok {

--- a/plugins/inputs/mysql/mysql.go
+++ b/plugins/inputs/mysql/mysql.go
@@ -1815,7 +1815,7 @@ func (m *Mysql) gatherTableSchema(db *sql.DB, servtag string, acc telegraf.Accum
 	return nil
 }
 
-func (m *Mysql) gatherSchemaForDB(db *sql.DB, database string, servtag string, acc telegraf.Accumulator) error {
+func (m *Mysql) gatherSchemaForDB(db *sql.DB, database, servtag string, acc telegraf.Accumulator) error {
 	rows, err := db.Query(fmt.Sprintf(tableSchemaQuery, database))
 	if err != nil {
 		return err

--- a/plugins/inputs/nfsclient/nfsclient.go
+++ b/plugins/inputs/nfsclient/nfsclient.go
@@ -63,7 +63,7 @@ func convertToUint64(line []string) ([]uint64, error) {
 	return nline, nil
 }
 
-func (n *NFSClient) parseStat(mountpoint string, export string, version string, line []string, acc telegraf.Accumulator) error {
+func (n *NFSClient) parseStat(mountpoint, export, version string, line []string, acc telegraf.Accumulator) error {
 	tags := map[string]string{"mountpoint": mountpoint, "serverexport": export}
 	nline, err := convertToUint64(line)
 	if err != nil {

--- a/plugins/inputs/nginx_plus_api/nginx_plus_api_metrics_test.go
+++ b/plugins/inputs/nginx_plus_api/nginx_plus_api_metrics_test.go
@@ -1552,7 +1552,7 @@ func prepareAddr(t *testing.T, ts *httptest.Server) (*url.URL, string, string) {
 	return addr, host, port
 }
 
-func prepareEndpoint(t *testing.T, path string, payload string) (*httptest.Server, *NginxPlusAPI) {
+func prepareEndpoint(t *testing.T, path, payload string) (*httptest.Server, *NginxPlusAPI) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, r.URL.Path, fmt.Sprintf("/api/%d/%s", defaultAPIVersion, path), "unknown request path")
 

--- a/plugins/inputs/nsd/nsd.go
+++ b/plugins/inputs/nsd/nsd.go
@@ -38,7 +38,7 @@ var defaultBinary = "/usr/sbin/nsd-control"
 var defaultTimeout = config.Duration(time.Second)
 
 // Shell out to nsd_stat and return the output
-func nsdRunner(cmdName string, timeout config.Duration, useSudo bool, server string, configFile string) (*bytes.Buffer, error) {
+func nsdRunner(cmdName string, timeout config.Duration, useSudo bool, server, configFile string) (*bytes.Buffer, error) {
 	cmdArgs := []string{"stats_noreset"}
 
 	if server != "" {


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

Address findings for [revive:enforce-repeated-arg-type-style](https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#enforce-repeated-arg-type-style) in `plugins/inputs/[h-n]*`

As we agreed here https://github.com/influxdata/telegraf/issues/15811, we will fix the errors found by the following configuration:
```
      - name: enforce-repeated-arg-type-style
        arguments: ["short"]
```

It is only part of the bigger job.
After all findings of this type in whole project are handled, we can enable `revive:enforce-repeated-arg-type-style` rule in `golangci-lint`.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR


