### PR TITLE
chore(deps): Bump golangci-lint from v1.60.3 to v1.61.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,7 +106,7 @@ jobs:
       - run: 'make check-deps'
       - run:
           name: "Install golangci-lint"
-          command: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.60.3
+          command: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.61.0
       - run:
           name: "golangci-lint/Linux"
           # There are only 4 vCPUs available for this executor, so use only 4 instead of the default number
@@ -120,7 +120,7 @@ jobs:
       - check-changed-files-or-halt
       - run:
           name: "Install golangci-lint"
-          command: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.60.3
+          command: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.61.0
       - run:
           name: "golangci-lint/macOS"
           # There are only 4 vCPUs available for this executor, so use only 4 instead of the default number
@@ -134,7 +134,7 @@ jobs:
       - check-changed-files-or-halt
       - run:
           name: "Install golangci-lint"
-          command: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.60.3
+          command: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.61.0
       - run:
           name: "golangci-lint/Windows"
           # There are only 4 vCPUs available for this executor, so use only 4 instead of the default number

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -66,6 +66,11 @@ linters-settings:
           - "!**/tools/**"
           - "!**/*_test.go"
   errcheck:
+    # report about assignment of errors to blank identifier: `num, _ := strconv.Atoi(numStr)`.
+    # Such cases aren't reported by default.
+    # Default: false
+    check-blank: true
+
     # List of functions to exclude from checking, where each entry is a single function to exclude.
     # See https://github.com/kisielk/errcheck#excluding-functions for details.
     exclude-functions:
@@ -73,7 +78,7 @@ linters-settings:
       - "(*hash/maphash.Hash).WriteByte"
       - "(*hash/maphash.Hash).WriteString"
       - "(*github.com/influxdata/telegraf/plugins/outputs/postgresql/sqltemplate.Template).UnmarshalText"
-    check-blank: true
+
   gocritic:
     # Disable all checks.
     # Default: false
@@ -187,6 +192,7 @@ linters-settings:
       - G601
       - G602
       # G104, G105, G113, G204, G304, G307, G402, G504 were not enabled intentionally
+      # TODO: review G115 when reporting false positives is fixed (https://github.com/securego/gosec/issues/1212)
     # To specify the configuration of rules.
     config:
       # Maximum allowed permissions mode for os.OpenFile and os.Chmod
@@ -297,10 +303,6 @@ linters-settings:
     # Default: false
     disable-all: true
     # Enable checkers by name
-    # (in addition to default
-    #   blank-import, bool-compare, compares, empty, error-is-as, error-nil, expected-actual, go-require, float-compare,
-    #   len, negative-positive, nil-compare, require-error, suite-dont-use-pkg, suite-extra-assert-call, useless-assert
-    # ).
     enable:
       - blank-import
       - bool-compare
@@ -413,6 +415,7 @@ output:
   # - `checkstyle`
   # - `code-climate`
   # - `junit-xml`
+  # - `junit-xml-extended`
   # - `github-actions`
   # - `teamcity`
   # - `sarif`

--- a/Makefile
+++ b/Makefile
@@ -180,7 +180,7 @@ vet:
 .PHONY: lint-install
 lint-install:
 	@echo "Installing golangci-lint"
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.60.3
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.61.0
 
 	@echo "Installing markdownlint"
 	npm install -g markdownlint-cli


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

- `golangci-lint` bumped to `v1.61.0`
- Matching the configuration file to the example from https://github.com/golangci/golangci-lint/blob/master/.golangci.reference.yml.



## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR
