### PR TITLE
chore: Fix linter findings for `revive:enforce-repeated-arg-type-style` in `plugins/inputs/[o-z]*`

### DIFF
--- a/plugins/inputs/openweathermap/openweathermap.go
+++ b/plugins/inputs/openweathermap/openweathermap.go
@@ -312,7 +312,7 @@ func (n *OpenWeatherMap) gatherForecast(acc telegraf.Accumulator, city string) e
 	return nil
 }
 
-func (n *OpenWeatherMap) formatURL(path string, city string) string {
+func (n *OpenWeatherMap) formatURL(path, city string) string {
 	v := url.Values{
 		"id":    []string{city},
 		"APPID": []string{n.AppID},

--- a/plugins/inputs/phpfpm/fcgi.go
+++ b/plugins/inputs/phpfpm/fcgi.go
@@ -152,7 +152,7 @@ func (c *conn) writeRecord(recType recType, reqID uint16, b []byte) error {
 	return err
 }
 
-func (c *conn) writeBeginRequest(reqID uint16, role uint16, flags uint8) error {
+func (c *conn) writeBeginRequest(reqID, role uint16, flags uint8) error {
 	b := [8]byte{byte(role >> 8), byte(role), flags}
 	return c.writeRecord(typeBeginRequest, reqID, b[:])
 }

--- a/plugins/inputs/phpfpm/fcgi_client.go
+++ b/plugins/inputs/phpfpm/fcgi_client.go
@@ -44,7 +44,7 @@ func newFcgiClient(timeout time.Duration, h string, args ...interface{}) (*conn,
 	return &conn{rwc: con}, nil
 }
 
-func (c *conn) Request(env map[string]string, requestData string) (retout []byte, reterr []byte, err error) {
+func (c *conn) Request(env map[string]string, requestData string) (retout, reterr []byte, err error) {
 	defer c.rwc.Close()
 	var reqID uint16 = 1
 

--- a/plugins/inputs/phpfpm/phpfpm.go
+++ b/plugins/inputs/phpfpm/phpfpm.go
@@ -383,7 +383,7 @@ func globUnixSocket(address string) ([]string, error) {
 	return addresses, nil
 }
 
-func unixSocketPaths(addr string) (socketPath string, statusPath string) {
+func unixSocketPaths(addr string) (socketPath, statusPath string) {
 	socketAddr := strings.Split(addr, ":")
 	if len(socketAddr) >= 2 {
 		socketPath = socketAddr[0]

--- a/plugins/inputs/ping/ping_notwindows.go
+++ b/plugins/inputs/ping/ping_notwindows.go
@@ -105,7 +105,7 @@ func (p *Ping) pingToURL(u string, acc telegraf.Accumulator) {
 }
 
 // args returns the arguments for the 'ping' executable
-func (p *Ping) args(url string, system string) []string {
+func (p *Ping) args(url, system string) []string {
 	if len(p.Arguments) > 0 {
 		return append(p.Arguments, url)
 	}
@@ -214,7 +214,7 @@ func processPingOutput(out string) (statistics, error) {
 	return stats, err
 }
 
-func getPacketStats(line string) (trans int, recv int, err error) {
+func getPacketStats(line string) (trans, recv int, err error) {
 	recv = 0
 
 	stats := strings.Split(line, ", ")

--- a/plugins/inputs/proxmox/proxmox.go
+++ b/plugins/inputs/proxmox/proxmox.go
@@ -86,7 +86,7 @@ func getNodeSearchDomain(px *Proxmox) error {
 	return nil
 }
 
-func performRequest(px *Proxmox, apiURL string, method string, data url.Values) ([]byte, error) {
+func performRequest(px *Proxmox, apiURL, method string, data url.Values) ([]byte, error) {
 	request, err := http.NewRequest(method, px.BaseURL+apiURL, strings.NewReader(data.Encode()))
 	if err != nil {
 		return nil, err
@@ -220,7 +220,7 @@ func getFields(vmStat VMStat) map[string]interface{} {
 	}
 }
 
-func getByteMetrics(total json.Number, used json.Number) metrics {
+func getByteMetrics(total, used json.Number) metrics {
 	int64Total := jsonNumberToInt64(total)
 	int64Used := jsonNumberToInt64(used)
 	int64Free := int64Total - int64Used

--- a/plugins/inputs/proxmox/proxmox_test.go
+++ b/plugins/inputs/proxmox/proxmox_test.go
@@ -24,7 +24,7 @@ var lxcCurrentStatusTestData = `{"data":{"vmid":"111","type":"lxc","uptime":2078
 var qemuCurrentStatusTestData = `{"data":{"name":"qemu1","status":"running","maxdisk":10737418240,"cpu":0.029336643550795,"vmid":"113",` +
 	`"uptime":2159739,"disk":0,"maxmem":2147483648,"mem":1722451796}}`
 
-func performTestRequest(_ *Proxmox, apiURL string, _ string, _ url.Values) ([]byte, error) {
+func performTestRequest(_ *Proxmox, apiURL, _ string, _ url.Values) ([]byte, error) {
 	var bytedata = []byte("")
 
 	if strings.HasSuffix(apiURL, "dns") {

--- a/plugins/inputs/redis/redis.go
+++ b/plugins/inputs/redis/redis.go
@@ -490,12 +490,7 @@ func gatherInfoOutput(
 //	db0:keys=2,expires=0,avg_ttl=0
 //
 // And there is one for each db on the redis instance
-func gatherKeyspaceLine(
-	name string,
-	line string,
-	acc telegraf.Accumulator,
-	globalTags map[string]string,
-) {
+func gatherKeyspaceLine(name, line string, acc telegraf.Accumulator, globalTags map[string]string) {
 	if strings.Contains(line, "keys=") {
 		fields := make(map[string]interface{})
 		tags := make(map[string]string)
@@ -521,12 +516,7 @@ func gatherKeyspaceLine(
 //	cmdstat_publish:calls=33791,usec=208789,usec_per_call=6.18
 //
 // Tag: command=publish; Fields: calls=33791i,usec=208789i,usec_per_call=6.18
-func gatherCommandstateLine(
-	name string,
-	line string,
-	acc telegraf.Accumulator,
-	globalTags map[string]string,
-) {
+func gatherCommandstateLine(name, line string, acc telegraf.Accumulator, globalTags map[string]string) {
 	if !strings.HasPrefix(name, "cmdstat") {
 		return
 	}
@@ -568,12 +558,7 @@ func gatherCommandstateLine(
 //	latency_percentiles_usec_zadd:p50=9.023,p99=28.031,p99.9=43.007
 //
 // Tag: command=zadd; Fields: p50=9.023,p99=28.031,p99.9=43.007
-func gatherLatencystatsLine(
-	name string,
-	line string,
-	acc telegraf.Accumulator,
-	globalTags map[string]string,
-) {
+func gatherLatencystatsLine(name, line string, acc telegraf.Accumulator, globalTags map[string]string) {
 	if !strings.HasPrefix(name, "latency_percentiles_usec") {
 		return
 	}
@@ -608,12 +593,7 @@ func gatherLatencystatsLine(
 //	slave0:ip=127.0.0.1,port=7379,state=online,offset=4556468,lag=0
 //
 // This line will only be visible when a node has a replica attached.
-func gatherReplicationLine(
-	name string,
-	line string,
-	acc telegraf.Accumulator,
-	globalTags map[string]string,
-) {
+func gatherReplicationLine(name, line string, acc telegraf.Accumulator, globalTags map[string]string) {
 	fields := make(map[string]interface{})
 	tags := make(map[string]string)
 	for k, v := range globalTags {
@@ -653,12 +633,7 @@ func gatherReplicationLine(
 //
 // errorstat_ERR:count=37
 // errorstat_MOVED:count=3626
-func gatherErrorstatsLine(
-	name string,
-	line string,
-	acc telegraf.Accumulator,
-	globalTags map[string]string,
-) {
+func gatherErrorstatsLine(name, line string, acc telegraf.Accumulator, globalTags map[string]string) {
 	tags := make(map[string]string, len(globalTags)+1)
 	for k, v := range globalTags {
 		tags[k] = v

--- a/plugins/inputs/redis_sentinel/redis_sentinel.go
+++ b/plugins/inputs/redis_sentinel/redis_sentinel.go
@@ -328,11 +328,7 @@ func (client *RedisSentinelClient) gatherSentinelStats(acc telegraf.Accumulator,
 }
 
 // converts `sentinel masters <name>` output to tags and fields
-func convertSentinelMastersOutput(
-	globalTags map[string]string,
-	master map[string]string,
-	quorumErr error,
-) (map[string]string, map[string]interface{}, error) {
+func convertSentinelMastersOutput(globalTags, master map[string]string, quorumErr error) (map[string]string, map[string]interface{}, error) {
 	tags := globalTags
 
 	tags["master"] = master["name"]

--- a/plugins/inputs/redis_sentinel/redis_sentinel_test.go
+++ b/plugins/inputs/redis_sentinel/redis_sentinel_test.go
@@ -362,7 +362,7 @@ func createRedisContainer(networkName string) testutil.Container {
 	}
 }
 
-func createSentinelContainer(redisAddress string, networkName string, waitingFor wait.Strategy) testutil.Container {
+func createSentinelContainer(redisAddress, networkName string, waitingFor wait.Strategy) testutil.Container {
 	return testutil.Container{
 		Image:        "bitnami/redis-sentinel:7.0",
 		ExposedPorts: []string{sentinelServicePort},

--- a/plugins/inputs/sflow/sflow.go
+++ b/plugins/inputs/sflow/sflow.go
@@ -119,7 +119,7 @@ func (s *SFlow) process(acc telegraf.Accumulator, buf []byte) {
 	}
 }
 
-func listenUDP(network string, address string) (*net.UDPConn, error) {
+func listenUDP(network, address string) (*net.UDPConn, error) {
 	switch network {
 	case "udp", "udp4", "udp6":
 		addr, err := net.ResolveUDPAddr(network, address)

--- a/plugins/inputs/smart/smart.go
+++ b/plugins/inputs/smart/smart.go
@@ -493,7 +493,7 @@ func (m *Smart) scanAllDevices(ignoreExcludes bool) ([]string, []string, error) 
 	return nvmeDevices, nonNVMeDevices, nil
 }
 
-func distinguishNVMeDevices(userDevices []string, availableNVMeDevices []string) []string {
+func distinguishNVMeDevices(userDevices, availableNVMeDevices []string) []string {
 	var nvmeDevices []string
 
 	for _, userDevice := range userDevices {

--- a/plugins/inputs/smartctl/smartctl_device.go
+++ b/plugins/inputs/smartctl/smartctl_device.go
@@ -9,7 +9,7 @@ import (
 	"github.com/influxdata/telegraf/internal"
 )
 
-func (s *Smartctl) scanDevice(acc telegraf.Accumulator, deviceName string, deviceType string) error {
+func (s *Smartctl) scanDevice(acc telegraf.Accumulator, deviceName, deviceType string) error {
 	args := []string{"--json", "--all", deviceName, "--device", deviceType, "--nocheck=" + s.NoCheck}
 	cmd := execCommand(s.Path, args...)
 	if s.UseSudo {

--- a/plugins/inputs/snmp_trap/snmp_trap_test.go
+++ b/plugins/inputs/snmp_trap/snmp_trap_test.go
@@ -54,7 +54,7 @@ func newMsgFlagsV3(secLevel string) gosnmp.SnmpV3MsgFlags {
 	return msgFlags
 }
 
-func newUsmSecurityParametersForV3(authProto string, privProto string, username string, privPass string, authPass string) *gosnmp.UsmSecurityParameters {
+func newUsmSecurityParametersForV3(authProto, privProto, username, privPass, authPass string) *gosnmp.UsmSecurityParameters {
 	var authenticationProtocol gosnmp.SnmpV3AuthProtocol
 	switch strings.ToLower(authProto) {
 	case "md5":
@@ -107,7 +107,7 @@ func newUsmSecurityParametersForV3(authProto string, privProto string, username 
 	}
 }
 
-func newGoSNMPV3(port uint16, contextName string, engineID string, msgFlags gosnmp.SnmpV3MsgFlags, sp *gosnmp.UsmSecurityParameters) gosnmp.GoSNMP {
+func newGoSNMPV3(port uint16, contextName, engineID string, msgFlags gosnmp.SnmpV3MsgFlags, sp *gosnmp.UsmSecurityParameters) gosnmp.GoSNMP {
 	return gosnmp.GoSNMP{
 		Port:               port,
 		Version:            gosnmp.Version3,

--- a/plugins/inputs/socketstat/socketstat.go
+++ b/plugins/inputs/socketstat/socketstat.go
@@ -60,7 +60,7 @@ func (ss *Socketstat) Gather(acc telegraf.Accumulator) error {
 	return nil
 }
 
-func socketList(cmdName string, proto string, timeout config.Duration) (*bytes.Buffer, error) {
+func socketList(cmdName, proto string, timeout config.Duration) (*bytes.Buffer, error) {
 	// Run ss for the given protocol, return the output as bytes.Buffer
 	args := []string{"-in", "--" + proto}
 	cmd := exec.Command(cmdName, args...)

--- a/plugins/inputs/sqlserver/connectionstring.go
+++ b/plugins/inputs/sqlserver/connectionstring.go
@@ -13,7 +13,7 @@ const (
 // getConnectionIdentifiers returns the sqlInstance and databaseName from the given connection string.
 // The name of the SQL instance is returned as-is in the connection string
 // If the connection string could not be parsed or sqlInstance/databaseName were not present, a placeholder value is returned
-func getConnectionIdentifiers(connectionString string) (sqlInstance string, databaseName string) {
+func getConnectionIdentifiers(connectionString string) (sqlInstance, databaseName string) {
 	if len(connectionString) == 0 {
 		return emptySQLInstance, emptyDatabaseName
 	}
@@ -31,7 +31,7 @@ func getConnectionIdentifiers(connectionString string) (sqlInstance string, data
 }
 
 // parseConnectionStringKeyValue parses a "key=value;" connection string and returns the SQL instance and database name
-func parseConnectionStringKeyValue(connectionString string) (sqlInstance string, databaseName string) {
+func parseConnectionStringKeyValue(connectionString string) (sqlInstance, databaseName string) {
 	sqlInstance = ""
 	databaseName = ""
 
@@ -71,7 +71,7 @@ func parseConnectionStringKeyValue(connectionString string) (sqlInstance string,
 }
 
 // parseConnectionStringURL parses a URL-formatted connection string and returns the SQL instance and database name
-func parseConnectionStringURL(connectionString string) (sqlInstance string, databaseName string) {
+func parseConnectionStringURL(connectionString string) (sqlInstance, databaseName string) {
 	databaseName = emptyDatabaseName
 
 	u, err := url.Parse(connectionString)

--- a/plugins/inputs/stackdriver/stackdriver.go
+++ b/plugins/inputs/stackdriver/stackdriver.go
@@ -430,7 +430,7 @@ func (s *Stackdriver) initializeStackdriverClient(ctx context.Context) error {
 	return nil
 }
 
-func includeExcludeHelper(key string, includes []string, excludes []string) bool {
+func includeExcludeHelper(key string, includes, excludes []string) bool {
 	if len(includes) > 0 {
 		for _, includeStr := range includes {
 			if strings.HasPrefix(key, includeStr) {

--- a/plugins/inputs/statsd/datadog.go
+++ b/plugins/inputs/statsd/datadog.go
@@ -23,7 +23,7 @@ const (
 
 var uncommenter = strings.NewReplacer("\\n", "\n")
 
-func (s *Statsd) parseEventMessage(now time.Time, message string, defaultHostname string) error {
+func (s *Statsd) parseEventMessage(now time.Time, message, defaultHostname string) error {
 	// _e{title.length,text.length}:title|text
 	//  [
 	//   |d:date_happened

--- a/plugins/inputs/statsd/statsd.go
+++ b/plugins/inputs/statsd/statsd.go
@@ -730,7 +730,7 @@ func (s *Statsd) parseStatsdLine(line string) error {
 // config file. If there is a match, it will parse the name of the metric and
 // map of tags.
 // Return values are (<name>, <field>, <tags>)
-func (s *Statsd) parseName(bucket string) (name string, field string, tags map[string]string) {
+func (s *Statsd) parseName(bucket string) (name, field string, tags map[string]string) {
 	s.Lock()
 	defer s.Unlock()
 	tags = make(map[string]string)
@@ -786,7 +786,7 @@ func (s *Statsd) parseName(bucket string) (name string, field string, tags map[s
 }
 
 // Parse the key,value out of a string that looks like "key=value"
-func parseKeyValue(keyValue string) (key string, val string) {
+func parseKeyValue(keyValue string) (key, val string) {
 	split := strings.Split(keyValue, "=")
 	// Must be exactly 2 to get anything meaningful out of them
 	if len(split) == 2 {

--- a/plugins/inputs/sysstat/sysstat.go
+++ b/plugins/inputs/sysstat/sysstat.go
@@ -198,7 +198,7 @@ func withCLocale(cmd *exec.Cmd) *exec.Cmd {
 //	Sadf -p -- -p <option> tmpFile
 //
 // and parses the output to add it to the telegraf.Accumulator acc.
-func (s *Sysstat) parse(acc telegraf.Accumulator, option string, tmpfile string, ts time.Time) error {
+func (s *Sysstat) parse(acc telegraf.Accumulator, option, tmpfile string, ts time.Time) error {
 	cmd := execCommand(s.Sadf, s.sadfOptions(option, tmpfile)...)
 	cmd = withCLocale(cmd)
 	stdout, err := cmd.StdoutPipe()
@@ -282,7 +282,7 @@ func (s *Sysstat) parse(acc telegraf.Accumulator, option string, tmpfile string,
 }
 
 // sadfOptions creates the correct options for the sadf utility.
-func (s *Sysstat) sadfOptions(activityOption string, tmpfile string) []string {
+func (s *Sysstat) sadfOptions(activityOption, tmpfile string) []string {
 	options := []string{
 		"-p",
 		"--",

--- a/plugins/inputs/system/mock_PS.go
+++ b/plugins/inputs/system/mock_PS.go
@@ -46,7 +46,7 @@ func (m *MockPS) CPUTimes(_, _ bool) ([]cpu.TimesStat, error) {
 	return r0, r1
 }
 
-func (m *MockPS) DiskUsage(mountPointFilter []string, mountOptsExclude []string, fstypeExclude []string) ([]*disk.UsageStat, []*disk.PartitionStat, error) {
+func (m *MockPS) DiskUsage(mountPointFilter, mountOptsExclude, fstypeExclude []string) ([]*disk.UsageStat, []*disk.PartitionStat, error) {
 	ret := m.Called(mountPointFilter, mountOptsExclude, fstypeExclude)
 
 	r0 := ret.Get(0).([]*disk.UsageStat)

--- a/plugins/inputs/system/ps.go
+++ b/plugins/inputs/system/ps.go
@@ -89,11 +89,7 @@ func newSet() *set {
 	return s
 }
 
-func (s *SystemPS) DiskUsage(
-	mountPointFilter []string,
-	mountOptsExclude []string,
-	fstypeExclude []string,
-) ([]*disk.UsageStat, []*disk.PartitionStat, error) {
+func (s *SystemPS) DiskUsage(mountPointFilter, mountOptsExclude, fstypeExclude []string) ([]*disk.UsageStat, []*disk.PartitionStat, error) {
 	parts, err := s.Partitions(true)
 	if err != nil {
 		return nil, nil, err

--- a/plugins/inputs/vsphere/client.go
+++ b/plugins/inputs/vsphere/client.go
@@ -346,7 +346,7 @@ func (c *Client) CounterInfoByKey(ctx context.Context) (map[int32]*types.PerfCou
 }
 
 // ListResources wraps property.Collector.Retrieve to give it proper timeouts
-func (c *Client) ListResources(ctx context.Context, root *view.ContainerView, kind []string, ps []string, dst interface{}) error {
+func (c *Client) ListResources(ctx context.Context, root *view.ContainerView, kind, ps []string, dst interface{}) error {
 	ctx1, cancel1 := context.WithTimeout(ctx, c.Timeout)
 	defer cancel1()
 	return root.Retrieve(ctx1, kind, ps, dst)

--- a/plugins/inputs/vsphere/endpoint.go
+++ b/plugins/inputs/vsphere/endpoint.go
@@ -272,7 +272,7 @@ func anythingEnabled(ex []string) bool {
 	return true
 }
 
-func newFilterOrPanic(include []string, exclude []string) filter.Filter {
+func newFilterOrPanic(include, exclude []string) filter.Filter {
 	f, err := filter.NewIncludeExcludeFilter(include, exclude)
 	if err != nil {
 		panic(fmt.Sprintf("Include/exclude filters are invalid: %v", err))
@@ -280,7 +280,7 @@ func newFilterOrPanic(include []string, exclude []string) filter.Filter {
 	return f
 }
 
-func isSimple(include []string, exclude []string) bool {
+func isSimple(include, exclude []string) bool {
 	if len(exclude) > 0 || len(include) == 0 {
 		return false
 	}
@@ -998,7 +998,7 @@ func submitChunkJob(ctx context.Context, te *ThrottledExecutor, job queryJob, pq
 	})
 }
 
-func (e *Endpoint) chunkify(ctx context.Context, res *resourceKind, now time.Time, latest time.Time, job queryJob) {
+func (e *Endpoint) chunkify(ctx context.Context, res *resourceKind, now, latest time.Time, job queryJob) {
 	te := NewThrottledExecutor(e.Parent.CollectConcurrency)
 	maxMetrics := e.Parent.MaxQueryMetrics
 	if maxMetrics < 1 {
@@ -1414,7 +1414,7 @@ func (e *Endpoint) populateTags(objectRef *objectRef, resourceType string, resou
 	}
 }
 
-func (e *Endpoint) makeMetricIdentifier(prefix, metric string) (metricName string, fieldName string) {
+func (e *Endpoint) makeMetricIdentifier(prefix, metric string) (metricName, fieldName string) {
 	parts := strings.Split(metric, ".")
 	if len(parts) == 1 {
 		return prefix, parts[0]

--- a/plugins/inputs/vsphere/tscache.go
+++ b/plugins/inputs/vsphere/tscache.go
@@ -40,7 +40,7 @@ func (t *TSCache) Purge() {
 
 // IsNew returns true if the supplied timestamp for the supplied key is more recent than the
 // timestamp we have on record.
-func (t *TSCache) IsNew(key string, metricName string, tm time.Time) bool {
+func (t *TSCache) IsNew(key, metricName string, tm time.Time) bool {
 	t.mux.RLock()
 	defer t.mux.RUnlock()
 	v, ok := t.table[makeKey(key, metricName)]
@@ -51,7 +51,7 @@ func (t *TSCache) IsNew(key string, metricName string, tm time.Time) bool {
 }
 
 // Get returns a timestamp (if present)
-func (t *TSCache) Get(key string, metricName string) (time.Time, bool) {
+func (t *TSCache) Get(key, metricName string) (time.Time, bool) {
 	t.mux.RLock()
 	defer t.mux.RUnlock()
 	ts, ok := t.table[makeKey(key, metricName)]
@@ -59,7 +59,7 @@ func (t *TSCache) Get(key string, metricName string) (time.Time, bool) {
 }
 
 // Put updates the latest timestamp for the supplied key.
-func (t *TSCache) Put(key string, metricName string, timestamp time.Time) {
+func (t *TSCache) Put(key, metricName string, timestamp time.Time) {
 	t.mux.Lock()
 	defer t.mux.Unlock()
 	k := makeKey(key, metricName)
@@ -68,6 +68,6 @@ func (t *TSCache) Put(key string, metricName string, timestamp time.Time) {
 	}
 }
 
-func makeKey(resource string, metric string) string {
+func makeKey(resource, metric string) string {
 	return resource + "|" + metric
 }

--- a/plugins/inputs/vsphere/vsan.go
+++ b/plugins/inputs/vsphere/vsan.go
@@ -421,7 +421,7 @@ func populateClusterTags(tags map[string]string, clusterRef *objectRef, vcenter 
 }
 
 // populateCMMDSTags takes in a tag map, makes a copy, adds more tags using a cmmds map and returns the copy.
-func populateCMMDSTags(tags map[string]string, entityName string, uuid string, cmmds map[string]CmmdsEntity) map[string]string {
+func populateCMMDSTags(tags map[string]string, entityName, uuid string, cmmds map[string]CmmdsEntity) map[string]string {
 	newTags := make(map[string]string)
 	// deep copy
 	for k, v := range tags {
@@ -494,7 +494,7 @@ func populateCMMDSTags(tags map[string]string, entityName string, uuid string, c
 }
 
 // versionLowerThan returns true is the current version < a base version
-func versionLowerThan(current string, major int, minor int) bool {
+func versionLowerThan(current string, major, minor int) bool {
 	version := strings.Split(current, ".")
 	currentMajor, err := strconv.Atoi(version[0])
 	if err != nil {

--- a/plugins/inputs/webhooks/artifactory/artifactory_webhook.go
+++ b/plugins/inputs/webhooks/artifactory/artifactory_webhook.go
@@ -70,7 +70,7 @@ func (e *newEventError) Error() string {
 	return e.s
 }
 
-func (awh *ArtifactoryWebhook) NewEvent(data []byte, et string, ed string) (Event, error) {
+func (awh *ArtifactoryWebhook) NewEvent(data []byte, et, ed string) (Event, error) {
 	awh.log.Debugf("New %v domain %v event received", ed, et)
 	switch ed {
 	case "artifact":

--- a/plugins/inputs/webhooks/artifactory/artifactory_webhook_test.go
+++ b/plugins/inputs/webhooks/artifactory/artifactory_webhook_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/influxdata/telegraf/testutil"
 )
 
-func ArtifactoryWebhookRequest(t *testing.T, domain string, event string, jsonString string) {
+func ArtifactoryWebhookRequest(t *testing.T, domain, event, jsonString string) {
 	var acc testutil.Accumulator
 	awh := &ArtifactoryWebhook{Path: "/artifactory", acc: &acc, log: testutil.Logger{}}
 	req, err := http.NewRequest("POST", "/artifactory", strings.NewReader(jsonString))
@@ -23,7 +23,7 @@ func ArtifactoryWebhookRequest(t *testing.T, domain string, event string, jsonSt
 	}
 }
 
-func ArtifactoryWebhookRequestWithSignature(event string, jsonString string, t *testing.T, signature string, expectedStatus int) {
+func ArtifactoryWebhookRequestWithSignature(t *testing.T, event, jsonString, signature string, expectedStatus int) {
 	var acc testutil.Accumulator
 	awh := &ArtifactoryWebhook{Path: "/artifactory", acc: &acc, log: testutil.Logger{}}
 	req, err := http.NewRequest("POST", "/artifactory", strings.NewReader(jsonString))
@@ -142,9 +142,9 @@ func TestDestinationDeleteFailedEvent(t *testing.T) {
 
 func TestEventWithSignatureSuccess(t *testing.T) {
 	ArtifactoryWebhookRequestWithSignature(
+		t,
 		"watch",
 		ArtifactDeployedEventJSON(),
-		t,
 		generateSignature("signature", []byte(ArtifactDeployedEventJSON())),
 		http.StatusOK,
 	)

--- a/plugins/inputs/webhooks/github/github_webhooks_test.go
+++ b/plugins/inputs/webhooks/github/github_webhooks_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/influxdata/telegraf/testutil"
 )
 
-func GithubWebhookRequest(t *testing.T, event string, jsonString string) {
+func GithubWebhookRequest(t *testing.T, event, jsonString string) {
 	var acc testutil.Accumulator
 	gh := &GithubWebhook{Path: "/github", acc: &acc, log: testutil.Logger{}}
 	req, err := http.NewRequest("POST", "/github", strings.NewReader(jsonString))
@@ -24,7 +24,7 @@ func GithubWebhookRequest(t *testing.T, event string, jsonString string) {
 	}
 }
 
-func GithubWebhookRequestWithSignature(event string, jsonString string, t *testing.T, signature string, expectedStatus int) {
+func GithubWebhookRequestWithSignature(t *testing.T, event, jsonString, signature string, expectedStatus int) {
 	var acc testutil.Accumulator
 	gh := &GithubWebhook{Path: "/github", Secret: "signature", acc: &acc, log: testutil.Logger{}}
 	req, err := http.NewRequest("POST", "/github", strings.NewReader(jsonString))
@@ -119,11 +119,11 @@ func TestWatchEvent(t *testing.T) {
 }
 
 func TestEventWithSignatureFail(t *testing.T) {
-	GithubWebhookRequestWithSignature("watch", WatchEventJSON(), t, "signature", http.StatusBadRequest)
+	GithubWebhookRequestWithSignature(t, "watch", WatchEventJSON(), "signature", http.StatusBadRequest)
 }
 
 func TestEventWithSignatureSuccess(t *testing.T) {
-	GithubWebhookRequestWithSignature("watch", WatchEventJSON(), t, generateSignature("signature", []byte(WatchEventJSON())), http.StatusOK)
+	GithubWebhookRequestWithSignature(t, "watch", WatchEventJSON(), generateSignature("signature", []byte(WatchEventJSON())), http.StatusOK)
 }
 
 func TestCheckSignatureSuccess(t *testing.T) {

--- a/plugins/inputs/webhooks/papertrail/papertrail_test.go
+++ b/plugins/inputs/webhooks/papertrail/papertrail_test.go
@@ -15,7 +15,7 @@ const (
 	contentType = "application/x-www-form-urlencoded"
 )
 
-func post(t *testing.T, pt *PapertrailWebhook, contentType string, body string) *httptest.ResponseRecorder {
+func post(t *testing.T, pt *PapertrailWebhook, contentType, body string) *httptest.ResponseRecorder {
 	req, err := http.NewRequest("POST", "/", strings.NewReader(body))
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", contentType)


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

Address findings for [revive:enforce-repeated-arg-type-style](https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#enforce-repeated-arg-type-style) in `plugins/inputs/[o-z]*`

As we agreed here https://github.com/influxdata/telegraf/issues/15811, we will fix the errors found by the following configuration:
```
      - name: enforce-repeated-arg-type-style
        arguments: ["short"]
```

It is only part of the bigger job.
After all findings of this type in whole project are handled, we can enable `revive:enforce-repeated-arg-type-style` rule in `golangci-lint`.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR