### PR TITLE
feat(inputs.prometheus): Allow to use secrets for credentials

### DIFF
--- a/plugins/inputs/prometheus/README.md
+++ b/plugins/inputs/prometheus/README.md
@@ -12,6 +12,14 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 [CONFIGURATION.md]: ../../../docs/CONFIGURATION.md#plugins
 
+## Secret-store support
+
+This plugin supports secrets from secret-stores for the `username`, `password`
+and `bearer_token_string` option. See the
+[secret-store documentation][SECRETSTORE] for more details on how to use them.
+
+[SECRETSTORE]: ../../../docs/CONFIGURATION.md#secret-store-secrets
+
 ## Configuration
 
 ```toml @sample.conf


### PR DESCRIPTION
## Summary

This PR allows to use secret-store secrets for the `username`, `password` and `bearer_token_string` settings.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #15855 
