### PR TITLE
chore(cmd): Align plugin deprecation messages

### DIFF
--- a/cmd/telegraf/printer.go
+++ b/cmd/telegraf/printer.go
@@ -267,7 +267,7 @@ func printFilteredInputs(inputFilters []string, commented bool, outputBuffer io.
 	for _, pname := range pnames {
 		// Skip inputs that are registered twice for backward compatibility
 		switch pname {
-		case "cisco_telemetry_gnmi", "io", "KNXListener":
+		case "cisco_telemetry_gnmi", "http_listener", "io", "KNXListener":
 			continue
 		}
 		creator := inputs.Inputs[pname]

--- a/cmd/telegraf/printer.go
+++ b/cmd/telegraf/printer.go
@@ -364,7 +364,7 @@ func printConfig(name string, p telegraf.PluginDescriber, op string, commented b
 		if di.RemovalIn != "" {
 			removalNote = " and will be removed in " + di.RemovalIn
 		}
-		fmt.Fprintf(outputBuffer, "\n%s ## DEPRECATED: The %q plugin is deprecated in version %s%s, %s.",
+		fmt.Fprintf(outputBuffer, "\n%s## DEPRECATED: The %q plugin is deprecated in version %s%s, %s.",
 			comment, name, di.Since, removalNote, di.Notice)
 	}
 


### PR DESCRIPTION
## Summary

- Aligns the plugin deprecation messages with the plugin description.
- Skips the printing of `http_listener` input as that would result in having sample config printed for `inputs.influxdb_listener` twice, once with a very confusing deprecation message.

```diff
-#  ## DEPRECATED: The "aerospike" plugin is deprecated in version 1.30.0 and will be removed in 1.40.0, use 'inputs.prometheus' with the Aerospike Prometheus Exporter instead.
+# ## DEPRECATED: The "aerospike" plugin is deprecated in version 1.30.0 and will be removed in 1.40.0, use 'inputs.prometheus' with the Aerospike Prometheus Exporter instead.
 # # Read stats from aerospike server(s)
 # [[inputs.aerospike]]
```

## Checklist

- [x] No AI generated code was used in this PR

## Related issues
