### PR TITLE
feat(processors.batch): Add batch processor

### DIFF
--- a/plugins/processors/all/batch.go
+++ b/plugins/processors/all/batch.go
@@ -1,0 +1,5 @@
+//go:build !custom || processors || processors.batch
+
+package all
+
+import _ "github.com/influxdata/telegraf/plugins/processors/batch" // register plugin

--- a/plugins/processors/batch/README.md
+++ b/plugins/processors/batch/README.md
@@ -1,8 +1,10 @@
 # Batch Processor Plugin
 
-This processor groups metrics into batches by adding a batch tag. This is 
-useful for parallel processing of metrics where downstream processors, 
+This processor groups metrics into batches by adding a batch tag. This is
+useful for parallel processing of metrics where downstream processors,
 aggregators or outputs can then select a batch using `tagpass` or `metricpass`.
+
+Metrics are distributed across batches using the round-robin scheme.
 
 ## Global configuration options <!-- @/docs/includes/plugin_config.md -->
 
@@ -17,9 +19,6 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 ```toml @sample.conf
 ## Batch metrics into separate batches by adding a tag indicating the batch index.
-## Can be used to route batches of metrics to different outputs
-## to parallelize writing of metrics to an output
-## Metrics are distributed across batches using the round-robin scheme.
 [[processors.batch]]
   ## The name of the tag to use for adding the batch index
   batch_tag = "my_batch"

--- a/plugins/processors/batch/README.md
+++ b/plugins/processors/batch/README.md
@@ -24,7 +24,7 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   batch_tag = "my_batch"
 
   ## The number of batches to create
-  num_batches = 16
+  batches = 16
 
   ## Do not assign metrics with an existing batch assignment to a
   ## different batch. 
@@ -41,7 +41,7 @@ The example below uses these settings:
   batch_tag = "batch"
   
   ## The number of batches to create
-  num_batches = 3
+  batches = 3
 ```
 
 ```diff

--- a/plugins/processors/batch/README.md
+++ b/plugins/processors/batch/README.md
@@ -1,7 +1,6 @@
 # Batch Processor Plugin
 
-The batch processor batches metrics into
-batches by adding a batch tag to the metrics.
+This processor groups metrics into batches by adding a batch tag. This is useful for parallel processing of metrics where downstream processors, aggregators or outputs can then select a batch using `tagpass`.
 
 ## Global configuration options <!-- @/docs/includes/plugin_config.md -->
 

--- a/plugins/processors/batch/README.md
+++ b/plugins/processors/batch/README.md
@@ -1,0 +1,56 @@
+# Batch Processor Plugin
+
+The batch processor batches metrics into
+batches by adding a batch tag to the metrics.
+
+## Global configuration options <!-- @/docs/includes/plugin_config.md -->
+
+In addition to the plugin-specific configuration settings, plugins support
+additional global and plugin configuration settings. These settings are used to
+modify metrics, tags, and field or create aliases and configure ordering, etc.
+See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
+
+[CONFIGURATION.md]: ../../../docs/CONFIGURATION.md#plugins
+
+## Configuration
+
+```toml @sample.conf
+## Batch metrics into separate batches by adding a tag indicating the batch index.
+## Can be used to route batches of metrics to different outputs
+## to parallelize writing of metrics to an output
+## Metrics are distributed across batches using the round-robin scheme.
+[[processors.batch]]
+  ## The name of the tag to use for adding the batch index
+  batch_tag = "my_batch"
+
+  ## The number of batches to create
+  num_batches = 16
+```
+
+## Example
+
+The example below uses these settings:
+
+```toml
+[[processors.batch]]
+  ## The tag key to use for batching
+  batch_tag = "batch"
+  
+  ## The number of batches to create
+  num_batches = 3
+```
+
+```diff
+- temperature cpu=25
+- temperature cpu=50
+- temperature cpu=75
+- temperature cpu=25
+- temperature cpu=50
+- temperature cpu=75
++ temperature,batch=0 cpu=25
++ temperature,batch=1 cpu=50
++ temperature,batch=2 cpu=75
++ temperature,batch=0 cpu=25
++ temperature,batch=1 cpu=50
++ temperature,batch=2 cpu=75
+```

--- a/plugins/processors/batch/README.md
+++ b/plugins/processors/batch/README.md
@@ -1,6 +1,8 @@
 # Batch Processor Plugin
 
-This processor groups metrics into batches by adding a batch tag. This is useful for parallel processing of metrics where downstream processors, aggregators or outputs can then select a batch using `tagpass`.
+This processor groups metrics into batches by adding a batch tag. This is 
+useful for parallel processing of metrics where downstream processors, 
+aggregators or outputs can then select a batch using `tagpass` or `metricpass`.
 
 ## Global configuration options <!-- @/docs/includes/plugin_config.md -->
 
@@ -24,6 +26,10 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
   ## The number of batches to create
   num_batches = 16
+
+  ## Do not assign metrics with an existing batch assignment to a
+  ## different batch. 
+  # skip_existing = false
 ```
 
 ## Example

--- a/plugins/processors/batch/batch.go
+++ b/plugins/processors/batch/batch.go
@@ -1,0 +1,41 @@
+package batch
+
+import (
+	_ "embed"
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/plugins/processors"
+	"strconv"
+)
+
+//go:embed sample.conf
+var sampleConfig string
+
+type Batch struct {
+	BatchTag   string `toml:"batch_tag"`
+	NumBatches uint64 `toml:"num_batches"`
+
+	// the number of metrics that have been processed so far
+	count uint64
+}
+
+func (*Batch) SampleConfig() string {
+	return sampleConfig
+}
+
+func (b *Batch) Apply(in ...telegraf.Metric) []telegraf.Metric {
+	out := make([]telegraf.Metric, 0, len(in))
+	for _, m := range in {
+		batchId := b.count % b.NumBatches
+		b.count++
+		m.AddTag(b.BatchTag, strconv.FormatUint(batchId, 10))
+		out = append(out, m)
+	}
+
+	return out
+}
+
+func init() {
+	processors.Add("batch", func() telegraf.Processor {
+		return &Batch{}
+	})
+}

--- a/plugins/processors/batch/batch.go
+++ b/plugins/processors/batch/batch.go
@@ -28,6 +28,7 @@ func (b *Batch) Apply(in ...telegraf.Metric) []telegraf.Metric {
 	out := make([]telegraf.Metric, 0, len(in))
 	for _, m := range in {
 		if b.SkipExisting && m.HasTag(b.BatchTag) {
+			out = append(out, m)
 			continue
 		}
 

--- a/plugins/processors/batch/batch.go
+++ b/plugins/processors/batch/batch.go
@@ -13,7 +13,7 @@ var sampleConfig string
 
 type Batch struct {
 	BatchTag     string `toml:"batch_tag"`
-	NumBatches   uint64 `toml:"num_batches"`
+	NumBatches   uint64 `toml:"batches"`
 	SkipExisting bool   `toml:"skip_existing"`
 
 	// the number of metrics that have been processed so far

--- a/plugins/processors/batch/batch.go
+++ b/plugins/processors/batch/batch.go
@@ -33,8 +33,8 @@ func (b *Batch) Apply(in ...telegraf.Metric) []telegraf.Metric {
 		}
 
 		oldCount := b.count.Add(1) - 1
-		batchId := oldCount % b.NumBatches
-		m.AddTag(b.BatchTag, strconv.FormatUint(batchId, 10))
+		batchID := oldCount % b.NumBatches
+		m.AddTag(b.BatchTag, strconv.FormatUint(batchID, 10))
 		out = append(out, m)
 	}
 

--- a/plugins/processors/batch/batch_test.go
+++ b/plugins/processors/batch/batch_test.go
@@ -1,0 +1,69 @@
+package batch
+
+import (
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/testutil"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+const batchTag = "?internal_batch_idx"
+
+func MakeBatching(batches uint64) *Batch {
+	return &Batch{
+		BatchTag:   batchTag,
+		NumBatches: batches,
+	}
+}
+
+func MakeXMetrics(count int) []telegraf.Metric {
+	ms := make([]telegraf.Metric, 0, count)
+	for range count {
+		ms = append(ms, testutil.MockMetrics()...)
+	}
+
+	return ms
+}
+
+func requireMetricInBatch(t *testing.T, m telegraf.Metric, batch string) {
+	batchTagValue, ok := m.GetTag(batchTag)
+	require.True(t, ok)
+	require.Equal(t, batch, batchTagValue)
+}
+
+func Test_SingleMetricPutInBatch0(t *testing.T) {
+	b := MakeBatching(1)
+	m := testutil.MockMetricsWithValue(1)
+	expectedM := testutil.MockMetricsWithValue(1)
+	expectedM[0].AddTag(batchTag, "0")
+
+	res := b.Apply(m...)
+	testutil.RequireMetricsEqual(t, expectedM, res)
+}
+
+func Test_MetricsSmallerThanBatchSizeAreInDifferentBatches(t *testing.T) {
+	b := MakeBatching(3)
+	ms := MakeXMetrics(2)
+	res := b.Apply(ms...)
+	requireMetricInBatch(t, res[0], "0")
+	requireMetricInBatch(t, res[1], "1")
+}
+
+func Test_MetricsEqualToBatchSizeInDifferentBatches(t *testing.T) {
+	b := MakeBatching(3)
+	ms := MakeXMetrics(3)
+	res := b.Apply(ms...)
+	requireMetricInBatch(t, res[0], "0")
+	requireMetricInBatch(t, res[1], "1")
+	requireMetricInBatch(t, res[2], "2")
+}
+
+func Test_MetricsMoreThanBatchSizeInSameBatch(t *testing.T) {
+	b := MakeBatching(2)
+	ms := MakeXMetrics(3)
+	res := b.Apply(ms...)
+
+	requireMetricInBatch(t, res[0], "0")
+	requireMetricInBatch(t, res[1], "1")
+	requireMetricInBatch(t, res[2], "0")
+}

--- a/plugins/processors/batch/sample.conf
+++ b/plugins/processors/batch/sample.conf
@@ -4,7 +4,7 @@
   batch_tag = "my_batch"
 
   ## The number of batches to create
-  num_batches = 16
+  batches = 16
 
   ## Do not assign metrics with an existing batch assignment to a
   ## different batch.

--- a/plugins/processors/batch/sample.conf
+++ b/plugins/processors/batch/sample.conf
@@ -1,7 +1,4 @@
 ## Batch metrics into separate batches by adding a tag indicating the batch index.
-## Can be used to route batches of metrics to different outputs
-## to parallelize writing of metrics to an output
-## Metrics are distributed across batches using the round-robin scheme.
 [[processors.batch]]
   ## The name of the tag to use for adding the batch index
   batch_tag = "my_batch"

--- a/plugins/processors/batch/sample.conf
+++ b/plugins/processors/batch/sample.conf
@@ -8,3 +8,7 @@
 
   ## The number of batches to create
   num_batches = 16
+
+  ## Do not assign metrics with an existing batch assignment to a
+  ## different batch.
+  # skip_existing = false

--- a/plugins/processors/batch/sample.conf
+++ b/plugins/processors/batch/sample.conf
@@ -1,0 +1,10 @@
+## Batch metrics into separate batches by adding a tag indicating the batch index.
+## Can be used to route batches of metrics to different outputs
+## to parallelize writing of metrics to an output
+## Metrics are distributed across batches using the round-robin scheme.
+[[processors.batch]]
+  ## The name of the tag to use for adding the batch index
+  batch_tag = "my_batch"
+
+  ## The number of batches to create
+  num_batches = 16


### PR DESCRIPTION
## Summary
<!-- Mandatory 
Explain here the why, the rationale and motivation, for the changes.
-->
This new processor can distribute metrics across batches by adding a tag indicating what batch number it is in. This makes it possible to distribute the load of a high number of metrics across multiple instances of the same output plugin.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #15621
resolves #11707 
