### PR TITLE
chore(inputs): Remove deprecated options from sample config

### DIFF
--- a/plugins/inputs/activemq/README.md
+++ b/plugins/inputs/activemq/README.md
@@ -20,11 +20,6 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## ActiveMQ WebConsole URL
   url = "http://127.0.0.1:8161"
 
-  ## Required ActiveMQ Endpoint
-  ##   deprecated in 1.11; use the url option
-  # server = "192.168.50.10"
-  # port = 8161
-
   ## Credentials for basic HTTP authentication
   # username = "admin"
   # password = "admin"

--- a/plugins/inputs/activemq/sample.conf
+++ b/plugins/inputs/activemq/sample.conf
@@ -3,11 +3,6 @@
   ## ActiveMQ WebConsole URL
   url = "http://127.0.0.1:8161"
 
-  ## Required ActiveMQ Endpoint
-  ##   deprecated in 1.11; use the url option
-  # server = "192.168.50.10"
-  # port = 8161
-
   ## Credentials for basic HTTP authentication
   # username = "admin"
   # password = "admin"

--- a/plugins/inputs/consul/consul.go
+++ b/plugins/inputs/consul/consul.go
@@ -40,7 +40,7 @@ func (*Consul) SampleConfig() string {
 
 func (c *Consul) Init() error {
 	if c.MetricVersion != 2 {
-		telegrafConfig.PrintOptionValueDeprecationNotice("inputs.consul", "metric_version", 1,
+		telegraf_config.PrintOptionValueDeprecationNotice("inputs.consul", "metric_version", 1,
 			telegraf.DeprecationInfo{
 				Since:     "1.16.0",
 				RemovalIn: "1.40.0",

--- a/plugins/inputs/consul/consul.go
+++ b/plugins/inputs/consul/consul.go
@@ -49,12 +49,6 @@ func (c *Consul) Init() error {
 		)
 	}
 
-	newClient, err := c.createAPIClient()
-	if err != nil {
-		return err
-	}
-	c.client = newClient
-
 	return nil
 }
 
@@ -142,6 +136,16 @@ func (c *Consul) GatherHealthCheck(acc telegraf.Accumulator, checks []*api.Healt
 }
 
 func (c *Consul) Gather(acc telegraf.Accumulator) error {
+	if c.client == nil {
+		newClient, err := c.createAPIClient()
+
+		if err != nil {
+			return err
+		}
+
+		c.client = newClient
+	}
+
 	checks, _, err := c.client.Health().State("any", nil)
 
 	if err != nil {

--- a/plugins/inputs/consul/consul.go
+++ b/plugins/inputs/consul/consul.go
@@ -49,6 +49,12 @@ func (c *Consul) Init() error {
 		)
 	}
 
+	newClient, err := c.createAPIClient()
+	if err != nil {
+		return err
+	}
+	c.client = newClient
+
 	return nil
 }
 
@@ -136,16 +142,6 @@ func (c *Consul) GatherHealthCheck(acc telegraf.Accumulator, checks []*api.Healt
 }
 
 func (c *Consul) Gather(acc telegraf.Accumulator) error {
-	if c.client == nil {
-		newClient, err := c.createAPIClient()
-
-		if err != nil {
-			return err
-		}
-
-		c.client = newClient
-	}
-
 	checks, _, err := c.client.Health().State("any", nil)
 
 	if err != nil {

--- a/plugins/inputs/consul/consul.go
+++ b/plugins/inputs/consul/consul.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/consul/api"
 
 	"github.com/influxdata/telegraf"
-	telegrafConfig "github.com/influxdata/telegraf/config"
+	telegraf_config "github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/plugins/common/tls"
 	"github.com/influxdata/telegraf/plugins/inputs"
 )

--- a/plugins/inputs/consul/consul.go
+++ b/plugins/inputs/consul/consul.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/consul/api"
 
 	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/plugins/common/tls"
 	"github.com/influxdata/telegraf/plugins/inputs"
 )
@@ -39,7 +40,13 @@ func (*Consul) SampleConfig() string {
 
 func (c *Consul) Init() error {
 	if c.MetricVersion != 2 {
-		c.Log.Warnf("Use of deprecated configuration: 'metric_version = 1'; please update to 'metric_version = 2'")
+		config.PrintOptionValueDeprecationNotice("inputs.consul", "metric_version", 1,
+			telegraf.DeprecationInfo{
+				Since:     "1.16.0",
+				RemovalIn: "1.40.0",
+				Notice:    `please update to 'metric_version = 2'`,
+			},
+		)
 	}
 
 	return nil

--- a/plugins/inputs/consul/consul.go
+++ b/plugins/inputs/consul/consul.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/consul/api"
 
 	"github.com/influxdata/telegraf"
-	"github.com/influxdata/telegraf/config"
+	telegrafConfig "github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/plugins/common/tls"
 	"github.com/influxdata/telegraf/plugins/inputs"
 )
@@ -40,7 +40,7 @@ func (*Consul) SampleConfig() string {
 
 func (c *Consul) Init() error {
 	if c.MetricVersion != 2 {
-		config.PrintOptionValueDeprecationNotice("inputs.consul", "metric_version", 1,
+		telegrafConfig.PrintOptionValueDeprecationNotice("inputs.consul", "metric_version", 1,
 			telegraf.DeprecationInfo{
 				Since:     "1.16.0",
 				RemovalIn: "1.40.0",

--- a/plugins/inputs/consul/consul_test.go
+++ b/plugins/inputs/consul/consul_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/hashicorp/consul/api"
+	"github.com/stretchr/testify/require"
+
 	"github.com/influxdata/telegraf/testutil"
 )
 
@@ -43,6 +45,7 @@ func TestGatherHealthCheck(t *testing.T) {
 	var acc testutil.Accumulator
 
 	consul := &Consul{}
+	require.NoError(t, consul.Init())
 	consul.GatherHealthCheck(&acc, sampleChecks)
 
 	acc.AssertContainsTaggedFields(t, "consul_health_checks", expectedFields, expectedTags)
@@ -72,6 +75,7 @@ func TestGatherHealthCheckWithDelimitedTags(t *testing.T) {
 	consul := &Consul{
 		TagDelimiter: ":",
 	}
+	require.NoError(t, consul.Init())
 	consul.GatherHealthCheck(&acc, sampleChecks)
 
 	acc.AssertContainsTaggedFields(t, "consul_health_checks", expectedFields, expectedTags)
@@ -101,6 +105,7 @@ func TestGatherHealthCheckV2(t *testing.T) {
 	consul := &Consul{
 		MetricVersion: 2,
 	}
+	require.NoError(t, consul.Init())
 	consul.GatherHealthCheck(&acc, sampleChecks)
 
 	acc.AssertContainsTaggedFields(t, "consul_health_checks", expectedFields, expectedTags)
@@ -131,6 +136,7 @@ func TestGatherHealthCheckWithDelimitedTagsV2(t *testing.T) {
 		MetricVersion: 2,
 		TagDelimiter:  ":",
 	}
+	require.NoError(t, consul.Init())
 	consul.GatherHealthCheck(&acc, sampleChecks)
 
 	acc.AssertContainsTaggedFields(t, "consul_health_checks", expectedFields, expectedTags)

--- a/plugins/inputs/consul/consul_test.go
+++ b/plugins/inputs/consul/consul_test.go
@@ -4,8 +4,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/consul/api"
-	"github.com/stretchr/testify/require"
-
 	"github.com/influxdata/telegraf/testutil"
 )
 
@@ -45,7 +43,6 @@ func TestGatherHealthCheck(t *testing.T) {
 	var acc testutil.Accumulator
 
 	consul := &Consul{}
-	require.NoError(t, consul.Init())
 	consul.GatherHealthCheck(&acc, sampleChecks)
 
 	acc.AssertContainsTaggedFields(t, "consul_health_checks", expectedFields, expectedTags)
@@ -75,7 +72,6 @@ func TestGatherHealthCheckWithDelimitedTags(t *testing.T) {
 	consul := &Consul{
 		TagDelimiter: ":",
 	}
-	require.NoError(t, consul.Init())
 	consul.GatherHealthCheck(&acc, sampleChecks)
 
 	acc.AssertContainsTaggedFields(t, "consul_health_checks", expectedFields, expectedTags)
@@ -105,7 +101,6 @@ func TestGatherHealthCheckV2(t *testing.T) {
 	consul := &Consul{
 		MetricVersion: 2,
 	}
-	require.NoError(t, consul.Init())
 	consul.GatherHealthCheck(&acc, sampleChecks)
 
 	acc.AssertContainsTaggedFields(t, "consul_health_checks", expectedFields, expectedTags)
@@ -136,7 +131,6 @@ func TestGatherHealthCheckWithDelimitedTagsV2(t *testing.T) {
 		MetricVersion: 2,
 		TagDelimiter:  ":",
 	}
-	require.NoError(t, consul.Init())
 	consul.GatherHealthCheck(&acc, sampleChecks)
 
 	acc.AssertContainsTaggedFields(t, "consul_health_checks", expectedFields, expectedTags)

--- a/plugins/inputs/docker/README.md
+++ b/plugins/inputs/docker/README.md
@@ -61,23 +61,10 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## Timeout for docker list, info, and stats commands
   timeout = "5s"
 
-  ## Whether to report for each container per-device blkio (8:0, 8:1...),
-  ## network (eth0, eth1, ...) and cpu (cpu0, cpu1, ...) stats or not.
-  ## Usage of this setting is discouraged since it will be deprecated in favor of 'perdevice_include'.
-  ## Default value is 'true' for backwards compatibility, please set it to 'false' so that 'perdevice_include' setting
-  ## is honored.
-  perdevice = true
-
   ## Specifies for which classes a per-device metric should be issued
   ## Possible values are 'cpu' (cpu0, cpu1, ...), 'blkio' (8:0, 8:1, ...) and 'network' (eth0, eth1, ...)
   ## Please note that this setting has no effect if 'perdevice' is set to 'true'
   # perdevice_include = ["cpu"]
-
-  ## Whether to report for each container total blkio and network stats or not.
-  ## Usage of this setting is discouraged since it will be deprecated in favor of 'total_include'.
-  ## Default value is 'false' for backwards compatibility, please set it to 'true' so that 'total_include' setting
-  ## is honored.
-  total = false
 
   ## Specifies for which classes a total metric should be issued. Total is an aggregated of the 'perdevice' values.
   ## Possible values are 'cpu', 'blkio' and 'network'

--- a/plugins/inputs/docker/sample.conf
+++ b/plugins/inputs/docker/sample.conf
@@ -37,23 +37,10 @@
   ## Timeout for docker list, info, and stats commands
   timeout = "5s"
 
-  ## Whether to report for each container per-device blkio (8:0, 8:1...),
-  ## network (eth0, eth1, ...) and cpu (cpu0, cpu1, ...) stats or not.
-  ## Usage of this setting is discouraged since it will be deprecated in favor of 'perdevice_include'.
-  ## Default value is 'true' for backwards compatibility, please set it to 'false' so that 'perdevice_include' setting
-  ## is honored.
-  perdevice = true
-
   ## Specifies for which classes a per-device metric should be issued
   ## Possible values are 'cpu' (cpu0, cpu1, ...), 'blkio' (8:0, 8:1, ...) and 'network' (eth0, eth1, ...)
   ## Please note that this setting has no effect if 'perdevice' is set to 'true'
   # perdevice_include = ["cpu"]
-
-  ## Whether to report for each container total blkio and network stats or not.
-  ## Usage of this setting is discouraged since it will be deprecated in favor of 'total_include'.
-  ## Default value is 'false' for backwards compatibility, please set it to 'true' so that 'total_include' setting
-  ## is honored.
-  total = false
 
   ## Specifies for which classes a total metric should be issued. Total is an aggregated of the 'perdevice' values.
   ## Possible values are 'cpu', 'blkio' and 'network'

--- a/plugins/inputs/elasticsearch/README.md
+++ b/plugins/inputs/elasticsearch/README.md
@@ -49,10 +49,6 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## HTTP headers to send with each request
   # headers = { "X-Custom-Header" = "Custom" }
 
-  ## Timeout for HTTP requests to the elastic search server(s)
-  ## deprecated in 1.29.0; use 'timeout' instead
-  http_timeout = "5s"
-
   ## When local is true (the default), the node will read only its own stats.
   ## Set local to false when you want to read the node stats from all nodes
   ## of the cluster.

--- a/plugins/inputs/elasticsearch/sample.conf
+++ b/plugins/inputs/elasticsearch/sample.conf
@@ -8,10 +8,6 @@
   ## HTTP headers to send with each request
   # headers = { "X-Custom-Header" = "Custom" }
 
-  ## Timeout for HTTP requests to the elastic search server(s)
-  ## deprecated in 1.29.0; use 'timeout' instead
-  http_timeout = "5s"
-
   ## When local is true (the default), the node will read only its own stats.
   ## Set local to false when you want to read the node stats from all nodes
   ## of the cluster.

--- a/plugins/inputs/influxdb_listener/README.md
+++ b/plugins/inputs/influxdb_listener/README.md
@@ -55,10 +55,6 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## 0 means to use the default of 32MiB.
   max_body_size = 0
 
-  ## Maximum line size allowed to be sent in bytes.
-  ##   deprecated in 1.14; parser now handles lines of unlimited length and option is ignored
-  # max_line_size = 0
-
   ## Set one or more allowed client CA certificate file names to
   ## enable mutually authenticated TLS connections
   tls_allowed_cacerts = ["/etc/telegraf/clientca.pem"]

--- a/plugins/inputs/influxdb_listener/sample.conf
+++ b/plugins/inputs/influxdb_listener/sample.conf
@@ -12,10 +12,6 @@
   ## 0 means to use the default of 32MiB.
   max_body_size = 0
 
-  ## Maximum line size allowed to be sent in bytes.
-  ##   deprecated in 1.14; parser now handles lines of unlimited length and option is ignored
-  # max_line_size = 0
-
   ## Set one or more allowed client CA certificate file names to
   ## enable mutually authenticated TLS connections
   tls_allowed_cacerts = ["/etc/telegraf/clientca.pem"]

--- a/plugins/inputs/kube_inventory/README.md
+++ b/plugins/inputs/kube_inventory/README.md
@@ -61,19 +61,9 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## Node name to filter to. No filtering by default.
   # node_name = ""
 
-  ## Use bearer token for authorization. ('bearer_token' takes priority)
-  ##
+  ## Use bearer token for authorization.
   ## Ignored if url is empty and in-cluster config is used.
-  ##
-  ## If both of these are empty, we'll use the default serviceaccount:
-  ## at: /var/run/secrets/kubernetes.io/serviceaccount/token
-  ##
-  ## To auto-refresh the token, please use a file with the bearer_token option.
-  ## If given a string, Telegraf cannot refresh the token periodically.
   # bearer_token = "/var/run/secrets/kubernetes.io/serviceaccount/token"
-  ## OR
-  ## deprecated in 1.24.0; use bearer_token with a file
-  # bearer_token_string = "abc_123"
 
   ## Set response_timeout (default 5 seconds)
   # response_timeout = "5s"

--- a/plugins/inputs/kube_inventory/sample.conf
+++ b/plugins/inputs/kube_inventory/sample.conf
@@ -13,19 +13,9 @@
   ## Node name to filter to. No filtering by default.
   # node_name = ""
 
-  ## Use bearer token for authorization. ('bearer_token' takes priority)
-  ##
+  ## Use bearer token for authorization.
   ## Ignored if url is empty and in-cluster config is used.
-  ##
-  ## If both of these are empty, we'll use the default serviceaccount:
-  ## at: /var/run/secrets/kubernetes.io/serviceaccount/token
-  ##
-  ## To auto-refresh the token, please use a file with the bearer_token option.
-  ## If given a string, Telegraf cannot refresh the token periodically.
   # bearer_token = "/var/run/secrets/kubernetes.io/serviceaccount/token"
-  ## OR
-  ## deprecated in 1.24.0; use bearer_token with a file
-  # bearer_token_string = "abc_123"
 
   ## Set response_timeout (default 5 seconds)
   # response_timeout = "5s"

--- a/plugins/inputs/modbus/README.md
+++ b/plugins/inputs/modbus/README.md
@@ -105,7 +105,6 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ##               INT16, UINT16, INT32, UINT32, INT64, UINT64,
   ##               FLOAT16-IEEE, FLOAT32-IEEE, FLOAT64-IEEE (IEEE 754 binary representation)
   ##               FIXED, UFIXED (fixed-point representation on input)
-  ##               FLOAT32 is a deprecated alias for UFIXED for historic reasons, should be avoided
   ##               STRING (byte-sequence converted to string)
   ## bit         - (optional) bit of the register, ONLY valid for BIT type
   ## scale       - the final numeric variable representation
@@ -407,7 +406,7 @@ This is the original style used by this plugin. It allows a per-register
 configuration for a single slave-device.
 
 > [!NOTE]
-> _For legacy reasons this configuration style is not completely consistent with the other styles. Especially `FLOAT32` which suggests a floating point representation is actually a_ ___Fixed Point___ _data type and should be considered_ ___deprecated___
+> _For legacy reasons this configuration style is not completely consistent with the other styles.
 
 #### Usage of `data_type`
 
@@ -440,7 +439,7 @@ modbus data source. For _coil_ and _discrete_ registers only `UINT16` is valid.
 Use these types if your modbus registers contain a value that is encoded in this
 format. These types always include the sign, therefore no variant exists.
 
-##### Fixed Point: `FIXED`, `UFIXED`, (`FLOAT32` - _deprecated_)
+##### Fixed Point: `FIXED`, `UFIXED`
 
 These types are handled as an integer type on input, but are converted to
 floating point representation for further processing (e.g. scaling). Use one of
@@ -455,9 +454,6 @@ representation with N decimal places'.
 Select the type `FIXED` when the input type is declared to hold signed integer
 values. Your documentation of the modbus device should indicate this with a term
 like 'int32 containing fixed-point representation with N decimal places'.
-
-(`FLOAT32` is deprecated and should not be used. `UFIXED` provides the same
-conversion from unsigned values).
 
 ##### String: `STRING`
 

--- a/plugins/inputs/modbus/configuration_register.go
+++ b/plugins/inputs/modbus/configuration_register.go
@@ -279,8 +279,8 @@ func (c *ConfigurationOriginal) validateFieldDefinitions(fieldDefs []fieldDefini
 func (c *ConfigurationOriginal) normalizeInputDatatype(dataType string, words int) (string, error) {
 	if dataType == "FLOAT32" {
 		config.PrintOptionValueDeprecationNotice("input.modbus", "data_type", "FLOAT32", telegraf.DeprecationInfo{
-			Since:     "v1.16.0",
-			RemovalIn: "v1.35.0",
+			Since:     "1.16.0",
+			RemovalIn: "1.36.0",
 			Notice:    "Use 'UFIXED' instead",
 		})
 	}

--- a/plugins/inputs/modbus/configuration_register.go
+++ b/plugins/inputs/modbus/configuration_register.go
@@ -280,7 +280,7 @@ func (c *ConfigurationOriginal) normalizeInputDatatype(dataType string, words in
 	if dataType == "FLOAT32" {
 		config.PrintOptionValueDeprecationNotice("input.modbus", "data_type", "FLOAT32", telegraf.DeprecationInfo{
 			Since:     "1.16.0",
-			RemovalIn: "1.36.0",
+			RemovalIn: "1.35.0",
 			Notice:    "Use 'UFIXED' instead",
 		})
 	}

--- a/plugins/inputs/modbus/sample_register.conf
+++ b/plugins/inputs/modbus/sample_register.conf
@@ -34,7 +34,6 @@
   ##               INT16, UINT16, INT32, UINT32, INT64, UINT64,
   ##               FLOAT16-IEEE, FLOAT32-IEEE, FLOAT64-IEEE (IEEE 754 binary representation)
   ##               FIXED, UFIXED (fixed-point representation on input)
-  ##               FLOAT32 is a deprecated alias for UFIXED for historic reasons, should be avoided
   ##               STRING (byte-sequence converted to string)
   ## bit         - (optional) bit of the register, ONLY valid for BIT type
   ## scale       - the final numeric variable representation

--- a/plugins/inputs/net/README.md
+++ b/plugins/inputs/net/README.md
@@ -21,9 +21,8 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## Setting interfaces will tell it to gather these explicit interfaces,
   ## regardless of status. When specifying an interface, glob-style
   ## patterns are also supported.
-  ##
   # interfaces = ["eth*", "enp0s[0-1]", "lo"]
-  ##
+
   ## On linux systems telegraf also collects protocol stats.
   ## Setting ignore_protocol_stats to true will skip reporting of protocol metrics.
   ##

--- a/plugins/inputs/net/sample.conf
+++ b/plugins/inputs/net/sample.conf
@@ -4,9 +4,8 @@
   ## Setting interfaces will tell it to gather these explicit interfaces,
   ## regardless of status. When specifying an interface, glob-style
   ## patterns are also supported.
-  ##
   # interfaces = ["eth*", "enp0s[0-1]", "lo"]
-  ##
+
   ## On linux systems telegraf also collects protocol stats.
   ## Setting ignore_protocol_stats to true will skip reporting of protocol metrics.
   ##

--- a/plugins/inputs/nsq_consumer/README.md
+++ b/plugins/inputs/nsq_consumer/README.md
@@ -28,9 +28,6 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 ```toml @sample.conf
 # Read metrics from NSQD topic(s)
 [[inputs.nsq_consumer]]
-  ## Server option still works but is deprecated, we just prepend it to the nsqd array.
-  # server = "localhost:4150"
-
   ## An array representing the NSQD TCP HTTP Endpoints
   nsqd = ["localhost:4150"]
 

--- a/plugins/inputs/nsq_consumer/nsq_consumer.go
+++ b/plugins/inputs/nsq_consumer/nsq_consumer.go
@@ -58,6 +58,20 @@ func (*NSQConsumer) SampleConfig() string {
 	return sampleConfig
 }
 
+func (n *NSQConsumer) Init() error {
+	// For backward compatibility
+	if n.Server != "" {
+		n.Nsqd = append(n.Nsqd, n.Server)
+	}
+
+	// Check if we have anything to connect to
+	if len(n.Nsqlookupd) == 0 && len(n.Nsqd) == 0 {
+		return errors.New("either 'nsqd' or 'nsqlookupd' needs to be specified")
+	}
+
+	return nil
+}
+
 // SetParser takes the data_format from the config and finds the right parser for that format
 func (n *NSQConsumer) SetParser(parser telegraf.Parser) {
 	n.parser = parser
@@ -103,16 +117,6 @@ func (n *NSQConsumer) Start(ac telegraf.Accumulator) error {
 		message.DisableAutoResponse()
 		return nil
 	}))
-
-	// For backward compatibility
-	if n.Server != "" {
-		n.Nsqd = append(n.Nsqd, n.Server)
-	}
-
-	// Check if we have anything to connect to
-	if len(n.Nsqlookupd) == 0 && len(n.Nsqd) == 0 {
-		return errors.New("either 'nsqd' or 'nsqlookupd' needs to be specified")
-	}
 
 	if len(n.Nsqlookupd) > 0 {
 		err := n.consumer.ConnectToNSQLookupds(n.Nsqlookupd)

--- a/plugins/inputs/nsq_consumer/nsq_consumer_test.go
+++ b/plugins/inputs/nsq_consumer/nsq_consumer_test.go
@@ -42,13 +42,13 @@ func TestReadsMetricsFromNSQ(t *testing.T) {
 
 	consumer := &NSQConsumer{
 		Log:                    testutil.Logger{},
-		Server:                 "127.0.0.1:4155",
 		Topic:                  "telegraf",
 		Channel:                "consume",
 		MaxInFlight:            1,
 		MaxUndeliveredMessages: defaultMaxUndeliveredMessages,
 		Nsqd:                   []string{"127.0.0.1:4155"},
 	}
+	require.NoError(t, consumer.Init())
 
 	p := &influx.Parser{}
 	require.NoError(t, p.Init())

--- a/plugins/inputs/nsq_consumer/sample.conf
+++ b/plugins/inputs/nsq_consumer/sample.conf
@@ -1,8 +1,5 @@
 # Read metrics from NSQD topic(s)
 [[inputs.nsq_consumer]]
-  ## Server option still works but is deprecated, we just prepend it to the nsqd array.
-  # server = "localhost:4150"
-
   ## An array representing the NSQD TCP HTTP Endpoints
   nsqd = ["localhost:4150"]
 

--- a/plugins/inputs/opcua/README.md
+++ b/plugins/inputs/opcua/README.md
@@ -90,14 +90,12 @@ to use them.
   ## namespace         - OPC UA namespace of the node (integer value 0 thru 3)
   ## identifier_type   - OPC UA ID type (s=string, i=numeric, g=guid, b=opaque)
   ## identifier        - OPC UA ID (tag as shown in opcua browser)
-  ## tags              - extra tags to be added to the output metric (optional); deprecated in 1.25.0; use default_tags
   ## default_tags      - extra tags to be added to the output metric (optional)
   ##
   ## Use either the inline notation or the bracketed notation, not both.
   #
   ## Inline notation (default_tags not supported yet)
   # nodes = [
-  #   {name="", namespace="", identifier_type="", identifier="", tags=[["tag1", "value1"], ["tag2", "value2"]},
   #   {name="", namespace="", identifier_type="", identifier=""},
   # ]
   #

--- a/plugins/inputs/opcua/sample.conf
+++ b/plugins/inputs/opcua/sample.conf
@@ -62,14 +62,12 @@
   ## namespace         - OPC UA namespace of the node (integer value 0 thru 3)
   ## identifier_type   - OPC UA ID type (s=string, i=numeric, g=guid, b=opaque)
   ## identifier        - OPC UA ID (tag as shown in opcua browser)
-  ## tags              - extra tags to be added to the output metric (optional); deprecated in 1.25.0; use default_tags
   ## default_tags      - extra tags to be added to the output metric (optional)
   ##
   ## Use either the inline notation or the bracketed notation, not both.
   #
   ## Inline notation (default_tags not supported yet)
   # nodes = [
-  #   {name="", namespace="", identifier_type="", identifier="", tags=[["tag1", "value1"], ["tag2", "value2"]},
   #   {name="", namespace="", identifier_type="", identifier=""},
   # ]
   #

--- a/plugins/inputs/postgresql_extensible/README.md
+++ b/plugins/inputs/postgresql_extensible/README.md
@@ -46,10 +46,6 @@ to use them.
   #
   address = "host=localhost user=postgres sslmode=disable"
 
-  ## A list of databases to pull metrics about.
-  ## deprecated in 1.22.3; use the sqlquery option to specify database to use
-  # databases = ["app_production", "testing"]
-
   ## Whether to use prepared statements when connecting to the database.
   ## This should be set to false when connecting through a PgBouncer instance
   ## with pool_mode set to transaction.
@@ -93,7 +89,7 @@ to use them.
   #   timestamp string
   [[inputs.postgresql_extensible.query]]
     measurement="pg_stat_database"
-    sqlquery="SELECT * FROM pg_stat_database where datname"
+    sqlquery="SELECT * FROM pg_stat_database WHERE datname"
     min_version=901
     tagvalue=""
   [[inputs.postgresql_extensible.query]]

--- a/plugins/inputs/postgresql_extensible/sample.conf
+++ b/plugins/inputs/postgresql_extensible/sample.conf
@@ -13,10 +13,6 @@
   #
   address = "host=localhost user=postgres sslmode=disable"
 
-  ## A list of databases to pull metrics about.
-  ## deprecated in 1.22.3; use the sqlquery option to specify database to use
-  # databases = ["app_production", "testing"]
-
   ## Whether to use prepared statements when connecting to the database.
   ## This should be set to false when connecting through a PgBouncer instance
   ## with pool_mode set to transaction.
@@ -60,7 +56,7 @@
   #   timestamp string
   [[inputs.postgresql_extensible.query]]
     measurement="pg_stat_database"
-    sqlquery="SELECT * FROM pg_stat_database where datname"
+    sqlquery="SELECT * FROM pg_stat_database WHERE datname"
     min_version=901
     tagvalue=""
   [[inputs.postgresql_extensible.query]]

--- a/plugins/inputs/rabbitmq/README.md
+++ b/plugins/inputs/rabbitmq/README.md
@@ -33,8 +33,7 @@ to use them.
 [[inputs.rabbitmq]]
   ## Management Plugin url. (default: http://localhost:15672)
   # url = "http://localhost:15672"
-  ## Tag added to rabbitmq_overview series; deprecated: use tags
-  # name = "rmq-server-1"
+
   ## Credentials
   # username = "guest"
   # password = "guest"
@@ -59,11 +58,6 @@ to use them.
   ## A list of nodes to gather as the rabbitmq_node measurement. If not
   ## specified, metrics for all nodes are gathered.
   # nodes = ["rabbit@node1", "rabbit@node2"]
-
-  ## A list of queues to gather as the rabbitmq_queue measurement. If not
-  ## specified, metrics for all queues are gathered.
-  ## Deprecated in 1.6: Use queue_name_include instead.
-  # queues = ["telegraf"]
 
   ## A list of exchanges to gather as the rabbitmq_exchange measurement. If not
   ## specified, metrics for all exchanges are gathered.

--- a/plugins/inputs/rabbitmq/sample.conf
+++ b/plugins/inputs/rabbitmq/sample.conf
@@ -2,8 +2,7 @@
 [[inputs.rabbitmq]]
   ## Management Plugin url. (default: http://localhost:15672)
   # url = "http://localhost:15672"
-  ## Tag added to rabbitmq_overview series; deprecated: use tags
-  # name = "rmq-server-1"
+
   ## Credentials
   # username = "guest"
   # password = "guest"
@@ -28,11 +27,6 @@
   ## A list of nodes to gather as the rabbitmq_node measurement. If not
   ## specified, metrics for all nodes are gathered.
   # nodes = ["rabbit@node1", "rabbit@node2"]
-
-  ## A list of queues to gather as the rabbitmq_queue measurement. If not
-  ## specified, metrics for all queues are gathered.
-  ## Deprecated in 1.6: Use queue_name_include instead.
-  # queues = ["telegraf"]
 
   ## A list of exchanges to gather as the rabbitmq_exchange measurement. If not
   ## specified, metrics for all exchanges are gathered.

--- a/plugins/inputs/sqlserver/README.md
+++ b/plugins/inputs/sqlserver/README.md
@@ -256,31 +256,6 @@ to use them.
   ## and following as optional (if mentioned in the include_query list)
   ## - SQLServerAvailabilityReplicaStates
   ## - SQLServerDatabaseReplicaStates
-
-  ## Version 2 by default collects the following queries
-  ## Version 2 is being deprecated, please consider using database_type.
-  ## - PerformanceCounters
-  ## - WaitStatsCategorized
-  ## - DatabaseIO
-  ## - ServerProperties
-  ## - MemoryClerk
-  ## - Schedulers
-  ## - SqlRequests
-  ## - VolumeSpace
-  ## - Cpu
-
-  ## Version 1 by default collects the following queries
-  ## Version 1 is deprecated, please consider using database_type.
-  ## - PerformanceCounters
-  ## - WaitStatsCategorized
-  ## - CPUHistory
-  ## - DatabaseIO
-  ## - DatabaseSize
-  ## - DatabaseStats
-  ## - DatabaseProperties
-  ## - MemoryClerk
-  ## - VolumeSpace
-  ## - PerformanceMetrics
 ```
 
 ## Support for Azure Active Directory (AAD) authentication using [Managed Identity](https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview)
@@ -341,7 +316,7 @@ the new format. The version 2 queries only report raw metrics, no math has
 been done to calculate deltas. To graph this data you must calculate deltas
 in your dashboarding software.
 
-### Version 1 (query_version=1): This is Deprecated in 1.6, all future development will be under configuration option database_type
+### Version 1 (query_version=1): This is Deprecated in 1.16, all future development will be under configuration option database_type
 
 The original metrics queries provide:
 
@@ -361,7 +336,7 @@ If you are using the original queries all stats have the following tags:
 - `servername`:  hostname:instance
 - `type`: type of stats to easily filter measurements
 
-### Version 2 (query_version=2): Being deprecated, All future development will be under configuration option database_type
+### Version 2 (query_version=2): This is Deprecated in 1.16, all future development will be under configuration option database_type
 
 The new (version 2) metrics provide:
 

--- a/plugins/inputs/sqlserver/sample.conf
+++ b/plugins/inputs/sqlserver/sample.conf
@@ -124,28 +124,3 @@
   ## and following as optional (if mentioned in the include_query list)
   ## - SQLServerAvailabilityReplicaStates
   ## - SQLServerDatabaseReplicaStates
-
-  ## Version 2 by default collects the following queries
-  ## Version 2 is being deprecated, please consider using database_type.
-  ## - PerformanceCounters
-  ## - WaitStatsCategorized
-  ## - DatabaseIO
-  ## - ServerProperties
-  ## - MemoryClerk
-  ## - Schedulers
-  ## - SqlRequests
-  ## - VolumeSpace
-  ## - Cpu
-
-  ## Version 1 by default collects the following queries
-  ## Version 1 is deprecated, please consider using database_type.
-  ## - PerformanceCounters
-  ## - WaitStatsCategorized
-  ## - CPUHistory
-  ## - DatabaseIO
-  ## - DatabaseSize
-  ## - DatabaseStats
-  ## - DatabaseProperties
-  ## - MemoryClerk
-  ## - VolumeSpace
-  ## - PerformanceMetrics

--- a/plugins/inputs/statsd/README.md
+++ b/plugins/inputs/statsd/README.md
@@ -67,11 +67,6 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## separator to use between elements of a statsd metric
   metric_separator = "_"
 
-  ## Parses tags in the datadog statsd format
-  ## http://docs.datadoghq.com/guides/dogstatsd/
-  ## deprecated in 1.10; use datadog_extensions option instead
-  parse_data_dog_tags = false
-
   ## Parses extensions to statsd in the datadog statsd format
   ## currently supports metrics and datadog tags.
   ## http://docs.datadoghq.com/guides/dogstatsd/

--- a/plugins/inputs/statsd/sample.conf
+++ b/plugins/inputs/statsd/sample.conf
@@ -40,11 +40,6 @@
   ## separator to use between elements of a statsd metric
   metric_separator = "_"
 
-  ## Parses tags in the datadog statsd format
-  ## http://docs.datadoghq.com/guides/dogstatsd/
-  ## deprecated in 1.10; use datadog_extensions option instead
-  parse_data_dog_tags = false
-
   ## Parses extensions to statsd in the datadog statsd format
   ## currently supports metrics and datadog tags.
   ## http://docs.datadoghq.com/guides/dogstatsd/


### PR DESCRIPTION
## Summary

Remove deprecated options from the sample config as they might be confusing and also cleanup some code to not use these options.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues
