### PR TITLE
chore(outputs.amqp): Remove deprecated options from sample config

### DIFF
--- a/plugins/outputs/amqp/README.md
+++ b/plugins/outputs/amqp/README.md
@@ -33,10 +33,6 @@ to use them.
 ```toml @sample.conf
 # Publishes metrics to an AMQP broker
 [[outputs.amqp]]
-  ## Broker to publish to.
-  ##   deprecated in 1.7; use the brokers option
-  # url = "amqp://localhost:5672/influxdb"
-
   ## Brokers to publish to.  If multiple brokers are specified a random broker
   ## will be selected anytime a connection is established.  This can be
   ## helpful for load balancing when not using a dedicated load balancer.
@@ -84,14 +80,6 @@ to use them.
   ## Delivery Mode controls if a published message is persistent.
   ##   One of "transient" or "persistent".
   # delivery_mode = "transient"
-
-  ## InfluxDB database added as a message header.
-  ##   deprecated in 1.7; use the headers option
-  # database = "telegraf"
-
-  ## InfluxDB retention policy added as a message header
-  ##   deprecated in 1.7; use the headers option
-  # retention_policy = "default"
 
   ## Static headers added to each published message.
   # headers = { }

--- a/plugins/outputs/amqp/sample.conf
+++ b/plugins/outputs/amqp/sample.conf
@@ -1,9 +1,5 @@
 # Publishes metrics to an AMQP broker
 [[outputs.amqp]]
-  ## Broker to publish to.
-  ##   deprecated in 1.7; use the brokers option
-  # url = "amqp://localhost:5672/influxdb"
-
   ## Brokers to publish to.  If multiple brokers are specified a random broker
   ## will be selected anytime a connection is established.  This can be
   ## helpful for load balancing when not using a dedicated load balancer.
@@ -51,14 +47,6 @@
   ## Delivery Mode controls if a published message is persistent.
   ##   One of "transient" or "persistent".
   # delivery_mode = "transient"
-
-  ## InfluxDB database added as a message header.
-  ##   deprecated in 1.7; use the headers option
-  # database = "telegraf"
-
-  ## InfluxDB retention policy added as a message header
-  ##   deprecated in 1.7; use the headers option
-  # retention_policy = "default"
 
   ## Static headers added to each published message.
   # headers = { }


### PR DESCRIPTION
## Summary

- Remove deprecated options from the sample config as they might be confusing.
- Cleanup code to not use deprecated options.
- Move config checking to the Init method.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

