### PR TITLE
chore: Fix linter findings for revive:max-public-structs in plugins/inputs/[t-z]* and rest

### DIFF
--- a/plugins/inputs/tomcat/tomcat.go
+++ b/plugins/inputs/tomcat/tomcat.go
@@ -19,23 +19,23 @@ import (
 //go:embed sample.conf
 var sampleConfig string
 
-type TomcatStatus struct {
-	TomcatJvm        TomcatJvm         `xml:"jvm"`
-	TomcatConnectors []TomcatConnector `xml:"connector"`
+type tomcatStatus struct {
+	TomcatJvm        tomcatJvm         `xml:"jvm"`
+	TomcatConnectors []tomcatConnector `xml:"connector"`
 }
 
-type TomcatJvm struct {
-	JvmMemory      JvmMemoryStat       `xml:"memory"`
-	JvmMemoryPools []JvmMemoryPoolStat `xml:"memorypool"`
+type tomcatJvm struct {
+	JvmMemory      jvmMemoryStat       `xml:"memory"`
+	JvmMemoryPools []jvmMemoryPoolStat `xml:"memorypool"`
 }
 
-type JvmMemoryStat struct {
+type jvmMemoryStat struct {
 	Free  int64 `xml:"free,attr"`
 	Total int64 `xml:"total,attr"`
 	Max   int64 `xml:"max,attr"`
 }
 
-type JvmMemoryPoolStat struct {
+type jvmMemoryPoolStat struct {
 	Name           string `xml:"name,attr"`
 	Type           string `xml:"type,attr"`
 	UsageInit      int64  `xml:"usageInit,attr"`
@@ -44,18 +44,18 @@ type JvmMemoryPoolStat struct {
 	UsageUsed      int64  `xml:"usageUsed,attr"`
 }
 
-type TomcatConnector struct {
+type tomcatConnector struct {
 	Name        string      `xml:"name,attr"`
-	ThreadInfo  ThreadInfo  `xml:"threadInfo"`
-	RequestInfo RequestInfo `xml:"requestInfo"`
+	ThreadInfo  threadInfo  `xml:"threadInfo"`
+	RequestInfo requestInfo `xml:"requestInfo"`
 }
 
-type ThreadInfo struct {
+type threadInfo struct {
 	MaxThreads         int64 `xml:"maxThreads,attr"`
 	CurrentThreadCount int64 `xml:"currentThreadCount,attr"`
 	CurrentThreadsBusy int64 `xml:"currentThreadsBusy,attr"`
 }
-type RequestInfo struct {
+type requestInfo struct {
 	MaxTime        int   `xml:"maxTime,attr"`
 	ProcessingTime int   `xml:"processingTime,attr"`
 	RequestCount   int   `xml:"requestCount,attr"`
@@ -112,7 +112,7 @@ func (s *Tomcat) Gather(acc telegraf.Accumulator) error {
 			resp.StatusCode, s.URL)
 	}
 
-	var status TomcatStatus
+	var status tomcatStatus
 	if err := xml.NewDecoder(resp.Body).Decode(&status); err != nil {
 		return err
 	}

--- a/plugins/inputs/webhooks/artifactory/artifactory_webhook.go
+++ b/plugins/inputs/webhooks/artifactory/artifactory_webhook.go
@@ -70,35 +70,35 @@ func (e *newEventError) Error() string {
 	return e.s
 }
 
-func (awh *ArtifactoryWebhook) NewEvent(data []byte, et, ed string) (Event, error) {
+func (awh *ArtifactoryWebhook) NewEvent(data []byte, et, ed string) (event, error) {
 	awh.log.Debugf("New %v domain %v event received", ed, et)
 	switch ed {
 	case "artifact":
 		if et == "deployed" || et == "deleted" {
-			return generateEvent(data, &ArtifactDeploymentOrDeletedEvent{})
+			return generateEvent(data, &artifactDeploymentOrDeletedEvent{})
 		} else if et == "moved" || et == "copied" {
-			return generateEvent(data, &ArtifactMovedOrCopiedEvent{})
+			return generateEvent(data, &artifactMovedOrCopiedEvent{})
 		} else {
 			return nil, &newEventError{"Not a recognized event type"}
 		}
 	case "artifact_property":
-		return generateEvent(data, &ArtifactPropertiesEvent{})
+		return generateEvent(data, &artifactPropertiesEvent{})
 	case "docker":
-		return generateEvent(data, &DockerEvent{})
+		return generateEvent(data, &dockerEvent{})
 	case "build":
-		return generateEvent(data, &BuildEvent{})
+		return generateEvent(data, &buildEvent{})
 	case "release_bundle":
-		return generateEvent(data, &ReleaseBundleEvent{})
+		return generateEvent(data, &releaseBundleEvent{})
 	case "distribution":
-		return generateEvent(data, &DistributionEvent{})
+		return generateEvent(data, &distributionEvent{})
 	case "destination":
-		return generateEvent(data, &DestinationEvent{})
+		return generateEvent(data, &destinationEvent{})
 	}
 
 	return nil, &newEventError{"Not a recognized event type"}
 }
 
-func generateEvent(data []byte, event Event) (Event, error) {
+func generateEvent(data []byte, event event) (event, error) {
 	err := json.Unmarshal(data, event)
 	if err != nil {
 		return nil, err

--- a/plugins/inputs/webhooks/artifactory/artifactory_webhook_models.go
+++ b/plugins/inputs/webhooks/artifactory/artifactory_webhook_models.go
@@ -10,16 +10,11 @@ import (
 
 const meas = "artifactory_webhooks"
 
-type CommonFields struct {
-	Domain string `json:"domain"`
-	Event  string `json:"event_type"`
-}
-
-type Event interface {
+type event interface {
 	NewMetric() telegraf.Metric
 }
 
-type ArtifactDeploymentOrDeletedEvent struct {
+type artifactDeploymentOrDeletedEvent struct {
 	Domain string `json:"domain"`
 	Event  string `json:"event_type"`
 	Data   struct {
@@ -31,7 +26,7 @@ type ArtifactDeploymentOrDeletedEvent struct {
 	} `json:"data"`
 }
 
-func (e ArtifactDeploymentOrDeletedEvent) NewMetric() telegraf.Metric {
+func (e artifactDeploymentOrDeletedEvent) NewMetric() telegraf.Metric {
 	t := map[string]string{
 		"domain":     e.Domain,
 		"event_type": e.Event,
@@ -47,7 +42,7 @@ func (e ArtifactDeploymentOrDeletedEvent) NewMetric() telegraf.Metric {
 	return metric.New(meas, t, f, time.Now())
 }
 
-type ArtifactMovedOrCopiedEvent struct {
+type artifactMovedOrCopiedEvent struct {
 	Domain string `json:"domain"`
 	Event  string `json:"event_type"`
 	Data   struct {
@@ -60,7 +55,7 @@ type ArtifactMovedOrCopiedEvent struct {
 	} `json:"data"`
 }
 
-func (e ArtifactMovedOrCopiedEvent) NewMetric() telegraf.Metric {
+func (e artifactMovedOrCopiedEvent) NewMetric() telegraf.Metric {
 	t := map[string]string{
 		"domain":     e.Domain,
 		"event_type": e.Event,
@@ -77,7 +72,7 @@ func (e ArtifactMovedOrCopiedEvent) NewMetric() telegraf.Metric {
 	return metric.New(meas, t, f, time.Now())
 }
 
-type ArtifactPropertiesEvent struct {
+type artifactPropertiesEvent struct {
 	Domain string `json:"domain"`
 	Event  string `json:"event_type"`
 	Data   struct {
@@ -90,7 +85,7 @@ type ArtifactPropertiesEvent struct {
 	}
 }
 
-func (e ArtifactPropertiesEvent) NewMetric() telegraf.Metric {
+func (e artifactPropertiesEvent) NewMetric() telegraf.Metric {
 	t := map[string]string{
 		"domain":     e.Domain,
 		"event_type": e.Event,
@@ -107,7 +102,7 @@ func (e ArtifactPropertiesEvent) NewMetric() telegraf.Metric {
 	return metric.New(meas, t, f, time.Now())
 }
 
-type DockerEvent struct {
+type dockerEvent struct {
 	Domain string `json:"domain"`
 	Event  string `json:"event_type"`
 	Data   struct {
@@ -125,7 +120,7 @@ type DockerEvent struct {
 	} `json:"data"`
 }
 
-func (e DockerEvent) NewMetric() telegraf.Metric {
+func (e dockerEvent) NewMetric() telegraf.Metric {
 	t := map[string]string{
 		"domain":     e.Domain,
 		"event_type": e.Event,
@@ -144,7 +139,7 @@ func (e DockerEvent) NewMetric() telegraf.Metric {
 	return metric.New(meas, t, f, time.Now())
 }
 
-type BuildEvent struct {
+type buildEvent struct {
 	Domain string `json:"domain"`
 	Event  string `json:"event_type"`
 	Data   struct {
@@ -154,7 +149,7 @@ type BuildEvent struct {
 	} `json:"data"`
 }
 
-func (e BuildEvent) NewMetric() telegraf.Metric {
+func (e buildEvent) NewMetric() telegraf.Metric {
 	t := map[string]string{
 		"domain":     e.Domain,
 		"event_type": e.Event,
@@ -168,7 +163,7 @@ func (e BuildEvent) NewMetric() telegraf.Metric {
 	return metric.New(meas, t, f, time.Now())
 }
 
-type ReleaseBundleEvent struct {
+type releaseBundleEvent struct {
 	Domain      string `json:"domain"`
 	Event       string `json:"event_type"`
 	Destination string `json:"destination"`
@@ -180,7 +175,7 @@ type ReleaseBundleEvent struct {
 	JpdOrigin string `json:"jpd_origin"`
 }
 
-func (e ReleaseBundleEvent) NewMetric() telegraf.Metric {
+func (e releaseBundleEvent) NewMetric() telegraf.Metric {
 	t := map[string]string{
 		"domain":              e.Domain,
 		"event_type":          e.Event,
@@ -196,7 +191,7 @@ func (e ReleaseBundleEvent) NewMetric() telegraf.Metric {
 	return metric.New(meas, t, f, time.Now())
 }
 
-type DistributionEvent struct {
+type distributionEvent struct {
 	Domain      string `json:"domain"`
 	Event       string `json:"event_type"`
 	Destination string `json:"destination"`
@@ -214,7 +209,7 @@ type DistributionEvent struct {
 	OriginURL string `json:"jpd_origin"`
 }
 
-func (e DistributionEvent) NewMetric() telegraf.Metric {
+func (e distributionEvent) NewMetric() telegraf.Metric {
 	t := map[string]string{
 		"domain":              e.Domain,
 		"event_type":          e.Event,
@@ -232,7 +227,7 @@ func (e DistributionEvent) NewMetric() telegraf.Metric {
 	return metric.New(meas, t, f, time.Now())
 }
 
-type DestinationEvent struct {
+type destinationEvent struct {
 	Domain      string `json:"domain"`
 	Event       string `json:"event_type"`
 	Destination string `json:"destination"`
@@ -244,7 +239,7 @@ type DestinationEvent struct {
 	OriginURL string `json:"jpd_origin"`
 }
 
-func (e DestinationEvent) NewMetric() telegraf.Metric {
+func (e destinationEvent) NewMetric() telegraf.Metric {
 	t := map[string]string{
 		"domain":              e.Domain,
 		"event_type":          e.Event,

--- a/plugins/inputs/webhooks/github/github_webhooks.go
+++ b/plugins/inputs/webhooks/github/github_webhooks.go
@@ -64,7 +64,7 @@ func (gh *GithubWebhook) eventHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
-func generateEvent(data []byte, event Event) (Event, error) {
+func generateEvent(data []byte, event event) (event, error) {
 	err := json.Unmarshal(data, event)
 	if err != nil {
 		return nil, err
@@ -80,53 +80,53 @@ func (e *newEventError) Error() string {
 	return e.s
 }
 
-func (gh *GithubWebhook) NewEvent(data []byte, name string) (Event, error) {
+func (gh *GithubWebhook) NewEvent(data []byte, name string) (event, error) {
 	gh.log.Debugf("New %v event received", name)
 	switch name {
 	case "commit_comment":
-		return generateEvent(data, &CommitCommentEvent{})
+		return generateEvent(data, &commitCommentEvent{})
 	case "create":
-		return generateEvent(data, &CreateEvent{})
+		return generateEvent(data, &createEvent{})
 	case "delete":
-		return generateEvent(data, &DeleteEvent{})
+		return generateEvent(data, &deleteEvent{})
 	case "deployment":
-		return generateEvent(data, &DeploymentEvent{})
+		return generateEvent(data, &deploymentEvent{})
 	case "deployment_status":
-		return generateEvent(data, &DeploymentStatusEvent{})
+		return generateEvent(data, &deploymentStatusEvent{})
 	case "fork":
-		return generateEvent(data, &ForkEvent{})
+		return generateEvent(data, &forkEvent{})
 	case "gollum":
-		return generateEvent(data, &GollumEvent{})
+		return generateEvent(data, &gollumEvent{})
 	case "issue_comment":
-		return generateEvent(data, &IssueCommentEvent{})
+		return generateEvent(data, &issueCommentEvent{})
 	case "issues":
-		return generateEvent(data, &IssuesEvent{})
+		return generateEvent(data, &issuesEvent{})
 	case "member":
-		return generateEvent(data, &MemberEvent{})
+		return generateEvent(data, &memberEvent{})
 	case "membership":
-		return generateEvent(data, &MembershipEvent{})
+		return generateEvent(data, &membershipEvent{})
 	case "page_build":
-		return generateEvent(data, &PageBuildEvent{})
+		return generateEvent(data, &pageBuildEvent{})
 	case "ping":
 		return nil, nil
 	case "public":
-		return generateEvent(data, &PublicEvent{})
+		return generateEvent(data, &publicEvent{})
 	case "pull_request":
-		return generateEvent(data, &PullRequestEvent{})
+		return generateEvent(data, &pullRequestEvent{})
 	case "pull_request_review_comment":
-		return generateEvent(data, &PullRequestReviewCommentEvent{})
+		return generateEvent(data, &pullRequestReviewCommentEvent{})
 	case "push":
-		return generateEvent(data, &PushEvent{})
+		return generateEvent(data, &pushEvent{})
 	case "release":
-		return generateEvent(data, &ReleaseEvent{})
+		return generateEvent(data, &releaseEvent{})
 	case "repository":
-		return generateEvent(data, &RepositoryEvent{})
+		return generateEvent(data, &repositoryEvent{})
 	case "status":
-		return generateEvent(data, &StatusEvent{})
+		return generateEvent(data, &statusEvent{})
 	case "team_add":
-		return generateEvent(data, &TeamAddEvent{})
+		return generateEvent(data, &teamAddEvent{})
 	case "watch":
-		return generateEvent(data, &WatchEvent{})
+		return generateEvent(data, &watchEvent{})
 	}
 	return nil, &newEventError{"Not a recognized event type"}
 }

--- a/plugins/inputs/webhooks/github/github_webhooks_models.go
+++ b/plugins/inputs/webhooks/github/github_webhooks_models.go
@@ -10,11 +10,11 @@ import (
 
 const meas = "github_webhooks"
 
-type Event interface {
+type event interface {
 	NewMetric() telegraf.Metric
 }
 
-type Repository struct {
+type repository struct {
 	Repository string `json:"full_name"`
 	Private    bool   `json:"private"`
 	Stars      int    `json:"stargazers_count"`
@@ -22,44 +22,44 @@ type Repository struct {
 	Issues     int    `json:"open_issues_count"`
 }
 
-type Sender struct {
+type sender struct {
 	User  string `json:"login"`
 	Admin bool   `json:"site_admin"`
 }
 
-type CommitComment struct {
+type commitComment struct {
 	Commit string `json:"commit_id"`
 	Body   string `json:"body"`
 }
 
-type Deployment struct {
+type deployment struct {
 	Commit      string `json:"sha"`
 	Task        string `json:"task"`
 	Environment string `json:"environment"`
 	Description string `json:"description"`
 }
 
-type Page struct {
+type page struct {
 	Name   string `json:"page_name"`
 	Title  string `json:"title"`
 	Action string `json:"action"`
 }
 
-type Issue struct {
+type issue struct {
 	Number   int    `json:"number"`
 	Title    string `json:"title"`
 	Comments int    `json:"comments"`
 }
 
-type IssueComment struct {
+type issueComment struct {
 	Body string `json:"body"`
 }
 
-type Team struct {
+type team struct {
 	Name string `json:"name"`
 }
 
-type PullRequest struct {
+type pullRequest struct {
 	Number       int    `json:"number"`
 	State        string `json:"state"`
 	Title        string `json:"title"`
@@ -70,27 +70,27 @@ type PullRequest struct {
 	ChangedFiles int    `json:"changed_files"`
 }
 
-type PullRequestReviewComment struct {
+type pullRequestReviewComment struct {
 	File    string `json:"path"`
 	Comment string `json:"body"`
 }
 
-type Release struct {
+type release struct {
 	TagName string `json:"tag_name"`
 }
 
-type DeploymentStatus struct {
+type deploymentStatus struct {
 	State       string `json:"state"`
 	Description string `json:"description"`
 }
 
-type CommitCommentEvent struct {
-	Comment    CommitComment `json:"comment"`
-	Repository Repository    `json:"repository"`
-	Sender     Sender        `json:"sender"`
+type commitCommentEvent struct {
+	Comment    commitComment `json:"comment"`
+	Repository repository    `json:"repository"`
+	Sender     sender        `json:"sender"`
 }
 
-func (s CommitCommentEvent) NewMetric() telegraf.Metric {
+func (s commitCommentEvent) NewMetric() telegraf.Metric {
 	event := "commit_comment"
 	t := map[string]string{
 		"event":      event,
@@ -110,14 +110,14 @@ func (s CommitCommentEvent) NewMetric() telegraf.Metric {
 	return m
 }
 
-type CreateEvent struct {
+type createEvent struct {
 	Ref        string     `json:"ref"`
 	RefType    string     `json:"ref_type"`
-	Repository Repository `json:"repository"`
-	Sender     Sender     `json:"sender"`
+	Repository repository `json:"repository"`
+	Sender     sender     `json:"sender"`
 }
 
-func (s CreateEvent) NewMetric() telegraf.Metric {
+func (s createEvent) NewMetric() telegraf.Metric {
 	event := "create"
 	t := map[string]string{
 		"event":      event,
@@ -137,14 +137,14 @@ func (s CreateEvent) NewMetric() telegraf.Metric {
 	return m
 }
 
-type DeleteEvent struct {
+type deleteEvent struct {
 	Ref        string     `json:"ref"`
 	RefType    string     `json:"ref_type"`
-	Repository Repository `json:"repository"`
-	Sender     Sender     `json:"sender"`
+	Repository repository `json:"repository"`
+	Sender     sender     `json:"sender"`
 }
 
-func (s DeleteEvent) NewMetric() telegraf.Metric {
+func (s deleteEvent) NewMetric() telegraf.Metric {
 	event := "delete"
 	t := map[string]string{
 		"event":      event,
@@ -164,13 +164,13 @@ func (s DeleteEvent) NewMetric() telegraf.Metric {
 	return m
 }
 
-type DeploymentEvent struct {
-	Deployment Deployment `json:"deployment"`
-	Repository Repository `json:"repository"`
-	Sender     Sender     `json:"sender"`
+type deploymentEvent struct {
+	Deployment deployment `json:"deployment"`
+	Repository repository `json:"repository"`
+	Sender     sender     `json:"sender"`
 }
 
-func (s DeploymentEvent) NewMetric() telegraf.Metric {
+func (s deploymentEvent) NewMetric() telegraf.Metric {
 	event := "deployment"
 	t := map[string]string{
 		"event":      event,
@@ -192,14 +192,14 @@ func (s DeploymentEvent) NewMetric() telegraf.Metric {
 	return m
 }
 
-type DeploymentStatusEvent struct {
-	Deployment       Deployment       `json:"deployment"`
-	DeploymentStatus DeploymentStatus `json:"deployment_status"`
-	Repository       Repository       `json:"repository"`
-	Sender           Sender           `json:"sender"`
+type deploymentStatusEvent struct {
+	Deployment       deployment       `json:"deployment"`
+	DeploymentStatus deploymentStatus `json:"deployment_status"`
+	Repository       repository       `json:"repository"`
+	Sender           sender           `json:"sender"`
 }
 
-func (s DeploymentStatusEvent) NewMetric() telegraf.Metric {
+func (s deploymentStatusEvent) NewMetric() telegraf.Metric {
 	event := "delete"
 	t := map[string]string{
 		"event":      event,
@@ -223,13 +223,13 @@ func (s DeploymentStatusEvent) NewMetric() telegraf.Metric {
 	return m
 }
 
-type ForkEvent struct {
-	Forkee     Repository `json:"forkee"`
-	Repository Repository `json:"repository"`
-	Sender     Sender     `json:"sender"`
+type forkEvent struct {
+	Forkee     repository `json:"forkee"`
+	Repository repository `json:"repository"`
+	Sender     sender     `json:"sender"`
 }
 
-func (s ForkEvent) NewMetric() telegraf.Metric {
+func (s forkEvent) NewMetric() telegraf.Metric {
 	event := "fork"
 	t := map[string]string{
 		"event":      event,
@@ -248,14 +248,14 @@ func (s ForkEvent) NewMetric() telegraf.Metric {
 	return m
 }
 
-type GollumEvent struct {
-	Pages      []Page     `json:"pages"`
-	Repository Repository `json:"repository"`
-	Sender     Sender     `json:"sender"`
+type gollumEvent struct {
+	Pages      []page     `json:"pages"`
+	Repository repository `json:"repository"`
+	Sender     sender     `json:"sender"`
 }
 
 // REVIEW: Going to be lazy and not deal with the pages.
-func (s GollumEvent) NewMetric() telegraf.Metric {
+func (s gollumEvent) NewMetric() telegraf.Metric {
 	event := "gollum"
 	t := map[string]string{
 		"event":      event,
@@ -273,14 +273,14 @@ func (s GollumEvent) NewMetric() telegraf.Metric {
 	return m
 }
 
-type IssueCommentEvent struct {
-	Issue      Issue        `json:"issue"`
-	Comment    IssueComment `json:"comment"`
-	Repository Repository   `json:"repository"`
-	Sender     Sender       `json:"sender"`
+type issueCommentEvent struct {
+	Issue      issue        `json:"issue"`
+	Comment    issueComment `json:"comment"`
+	Repository repository   `json:"repository"`
+	Sender     sender       `json:"sender"`
 }
 
-func (s IssueCommentEvent) NewMetric() telegraf.Metric {
+func (s issueCommentEvent) NewMetric() telegraf.Metric {
 	event := "issue_comment"
 	t := map[string]string{
 		"event":      event,
@@ -302,14 +302,14 @@ func (s IssueCommentEvent) NewMetric() telegraf.Metric {
 	return m
 }
 
-type IssuesEvent struct {
+type issuesEvent struct {
 	Action     string     `json:"action"`
-	Issue      Issue      `json:"issue"`
-	Repository Repository `json:"repository"`
-	Sender     Sender     `json:"sender"`
+	Issue      issue      `json:"issue"`
+	Repository repository `json:"repository"`
+	Sender     sender     `json:"sender"`
 }
 
-func (s IssuesEvent) NewMetric() telegraf.Metric {
+func (s issuesEvent) NewMetric() telegraf.Metric {
 	event := "issue"
 	t := map[string]string{
 		"event":      event,
@@ -331,13 +331,13 @@ func (s IssuesEvent) NewMetric() telegraf.Metric {
 	return m
 }
 
-type MemberEvent struct {
-	Member     Sender     `json:"member"`
-	Repository Repository `json:"repository"`
-	Sender     Sender     `json:"sender"`
+type memberEvent struct {
+	Member     sender     `json:"member"`
+	Repository repository `json:"repository"`
+	Sender     sender     `json:"sender"`
 }
 
-func (s MemberEvent) NewMetric() telegraf.Metric {
+func (s memberEvent) NewMetric() telegraf.Metric {
 	event := "member"
 	t := map[string]string{
 		"event":      event,
@@ -357,14 +357,14 @@ func (s MemberEvent) NewMetric() telegraf.Metric {
 	return m
 }
 
-type MembershipEvent struct {
+type membershipEvent struct {
 	Action string `json:"action"`
-	Member Sender `json:"member"`
-	Sender Sender `json:"sender"`
-	Team   Team   `json:"team"`
+	Member sender `json:"member"`
+	Sender sender `json:"sender"`
+	Team   team   `json:"team"`
 }
 
-func (s MembershipEvent) NewMetric() telegraf.Metric {
+func (s membershipEvent) NewMetric() telegraf.Metric {
 	event := "membership"
 	t := map[string]string{
 		"event":  event,
@@ -380,12 +380,12 @@ func (s MembershipEvent) NewMetric() telegraf.Metric {
 	return m
 }
 
-type PageBuildEvent struct {
-	Repository Repository `json:"repository"`
-	Sender     Sender     `json:"sender"`
+type pageBuildEvent struct {
+	Repository repository `json:"repository"`
+	Sender     sender     `json:"sender"`
 }
 
-func (s PageBuildEvent) NewMetric() telegraf.Metric {
+func (s pageBuildEvent) NewMetric() telegraf.Metric {
 	event := "page_build"
 	t := map[string]string{
 		"event":      event,
@@ -403,12 +403,12 @@ func (s PageBuildEvent) NewMetric() telegraf.Metric {
 	return m
 }
 
-type PublicEvent struct {
-	Repository Repository `json:"repository"`
-	Sender     Sender     `json:"sender"`
+type publicEvent struct {
+	Repository repository `json:"repository"`
+	Sender     sender     `json:"sender"`
 }
 
-func (s PublicEvent) NewMetric() telegraf.Metric {
+func (s publicEvent) NewMetric() telegraf.Metric {
 	event := "public"
 	t := map[string]string{
 		"event":      event,
@@ -426,14 +426,14 @@ func (s PublicEvent) NewMetric() telegraf.Metric {
 	return m
 }
 
-type PullRequestEvent struct {
+type pullRequestEvent struct {
 	Action      string      `json:"action"`
-	PullRequest PullRequest `json:"pull_request"`
-	Repository  Repository  `json:"repository"`
-	Sender      Sender      `json:"sender"`
+	PullRequest pullRequest `json:"pull_request"`
+	Repository  repository  `json:"repository"`
+	Sender      sender      `json:"sender"`
 }
 
-func (s PullRequestEvent) NewMetric() telegraf.Metric {
+func (s pullRequestEvent) NewMetric() telegraf.Metric {
 	event := "pull_request"
 	t := map[string]string{
 		"event":      event,
@@ -460,14 +460,14 @@ func (s PullRequestEvent) NewMetric() telegraf.Metric {
 	return m
 }
 
-type PullRequestReviewCommentEvent struct {
-	Comment     PullRequestReviewComment `json:"comment"`
-	PullRequest PullRequest              `json:"pull_request"`
-	Repository  Repository               `json:"repository"`
-	Sender      Sender                   `json:"sender"`
+type pullRequestReviewCommentEvent struct {
+	Comment     pullRequestReviewComment `json:"comment"`
+	PullRequest pullRequest              `json:"pull_request"`
+	Repository  repository               `json:"repository"`
+	Sender      sender                   `json:"sender"`
 }
 
-func (s PullRequestReviewCommentEvent) NewMetric() telegraf.Metric {
+func (s pullRequestReviewCommentEvent) NewMetric() telegraf.Metric {
 	event := "pull_request_review_comment"
 	t := map[string]string{
 		"event":      event,
@@ -495,15 +495,15 @@ func (s PullRequestReviewCommentEvent) NewMetric() telegraf.Metric {
 	return m
 }
 
-type PushEvent struct {
+type pushEvent struct {
 	Ref        string     `json:"ref"`
 	Before     string     `json:"before"`
 	After      string     `json:"after"`
-	Repository Repository `json:"repository"`
-	Sender     Sender     `json:"sender"`
+	Repository repository `json:"repository"`
+	Sender     sender     `json:"sender"`
 }
 
-func (s PushEvent) NewMetric() telegraf.Metric {
+func (s pushEvent) NewMetric() telegraf.Metric {
 	event := "push"
 	t := map[string]string{
 		"event":      event,
@@ -524,13 +524,13 @@ func (s PushEvent) NewMetric() telegraf.Metric {
 	return m
 }
 
-type ReleaseEvent struct {
-	Release    Release    `json:"release"`
-	Repository Repository `json:"repository"`
-	Sender     Sender     `json:"sender"`
+type releaseEvent struct {
+	Release    release    `json:"release"`
+	Repository repository `json:"repository"`
+	Sender     sender     `json:"sender"`
 }
 
-func (s ReleaseEvent) NewMetric() telegraf.Metric {
+func (s releaseEvent) NewMetric() telegraf.Metric {
 	event := "release"
 	t := map[string]string{
 		"event":      event,
@@ -549,12 +549,12 @@ func (s ReleaseEvent) NewMetric() telegraf.Metric {
 	return m
 }
 
-type RepositoryEvent struct {
-	Repository Repository `json:"repository"`
-	Sender     Sender     `json:"sender"`
+type repositoryEvent struct {
+	Repository repository `json:"repository"`
+	Sender     sender     `json:"sender"`
 }
 
-func (s RepositoryEvent) NewMetric() telegraf.Metric {
+func (s repositoryEvent) NewMetric() telegraf.Metric {
 	event := "repository"
 	t := map[string]string{
 		"event":      event,
@@ -572,14 +572,14 @@ func (s RepositoryEvent) NewMetric() telegraf.Metric {
 	return m
 }
 
-type StatusEvent struct {
+type statusEvent struct {
 	Commit     string     `json:"sha"`
 	State      string     `json:"state"`
-	Repository Repository `json:"repository"`
-	Sender     Sender     `json:"sender"`
+	Repository repository `json:"repository"`
+	Sender     sender     `json:"sender"`
 }
 
-func (s StatusEvent) NewMetric() telegraf.Metric {
+func (s statusEvent) NewMetric() telegraf.Metric {
 	event := "status"
 	t := map[string]string{
 		"event":      event,
@@ -599,13 +599,13 @@ func (s StatusEvent) NewMetric() telegraf.Metric {
 	return m
 }
 
-type TeamAddEvent struct {
-	Team       Team       `json:"team"`
-	Repository Repository `json:"repository"`
-	Sender     Sender     `json:"sender"`
+type teamAddEvent struct {
+	Team       team       `json:"team"`
+	Repository repository `json:"repository"`
+	Sender     sender     `json:"sender"`
 }
 
-func (s TeamAddEvent) NewMetric() telegraf.Metric {
+func (s teamAddEvent) NewMetric() telegraf.Metric {
 	event := "team_add"
 	t := map[string]string{
 		"event":      event,
@@ -624,12 +624,12 @@ func (s TeamAddEvent) NewMetric() telegraf.Metric {
 	return m
 }
 
-type WatchEvent struct {
-	Repository Repository `json:"repository"`
-	Sender     Sender     `json:"sender"`
+type watchEvent struct {
+	Repository repository `json:"repository"`
+	Sender     sender     `json:"sender"`
 }
 
-func (s WatchEvent) NewMetric() telegraf.Metric {
+func (s watchEvent) NewMetric() telegraf.Metric {
 	event := "delete"
 	t := map[string]string{
 		"event":      event,

--- a/plugins/inputs/webhooks/rollbar/rollbar_webhooks.go
+++ b/plugins/inputs/webhooks/rollbar/rollbar_webhooks.go
@@ -41,7 +41,7 @@ func (rb *RollbarWebhook) eventHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	dummyEvent := &DummyEvent{}
+	dummyEvent := &dummyEvent{}
 	err = json.Unmarshal(data, dummyEvent)
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
@@ -59,7 +59,7 @@ func (rb *RollbarWebhook) eventHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
-func generateEvent(event Event, data []byte) (Event, error) {
+func generateEvent(event event, data []byte) (event, error) {
 	err := json.Unmarshal(data, event)
 	if err != nil {
 		return nil, err
@@ -67,14 +67,14 @@ func generateEvent(event Event, data []byte) (Event, error) {
 	return event, nil
 }
 
-func NewEvent(dummyEvent *DummyEvent, data []byte) (Event, error) {
+func NewEvent(dummyEvent *dummyEvent, data []byte) (event, error) {
 	switch dummyEvent.EventName {
 	case "new_item":
-		return generateEvent(&NewItem{}, data)
+		return generateEvent(&newItem{}, data)
 	case "occurrence":
-		return generateEvent(&Occurrence{}, data)
+		return generateEvent(&occurrence{}, data)
 	case "deploy":
-		return generateEvent(&Deploy{}, data)
+		return generateEvent(&deploy{}, data)
 	default:
 		return nil, errors.New("Not implemented type: " + dummyEvent.EventName)
 	}

--- a/plugins/inputs/webhooks/rollbar/rollbar_webhooks_events.go
+++ b/plugins/inputs/webhooks/rollbar/rollbar_webhooks_events.go
@@ -2,37 +2,37 @@ package rollbar
 
 import "strconv"
 
-type Event interface {
+type event interface {
 	Tags() map[string]string
 	Fields() map[string]interface{}
 }
 
-type DummyEvent struct {
+type dummyEvent struct {
 	EventName string `json:"event_name"`
 }
 
-type NewItemDataItemLastOccurrence struct {
+type newItemDataItemLastOccurrence struct {
 	Language string `json:"language"`
 	Level    string `json:"level"`
 }
 
-type NewItemDataItem struct {
+type newItemDataItem struct {
 	ID             int                           `json:"id"`
 	Environment    string                        `json:"environment"`
 	ProjectID      int                           `json:"project_id"`
-	LastOccurrence NewItemDataItemLastOccurrence `json:"last_occurrence"`
+	LastOccurrence newItemDataItemLastOccurrence `json:"last_occurrence"`
 }
 
-type NewItemData struct {
-	Item NewItemDataItem `json:"item"`
+type newItemData struct {
+	Item newItemDataItem `json:"item"`
 }
 
-type NewItem struct {
+type newItem struct {
 	EventName string      `json:"event_name"`
-	Data      NewItemData `json:"data"`
+	Data      newItemData `json:"data"`
 }
 
-func (ni *NewItem) Tags() map[string]string {
+func (ni *newItem) Tags() map[string]string {
 	return map[string]string{
 		"event":       ni.EventName,
 		"environment": ni.Data.Item.Environment,
@@ -42,34 +42,34 @@ func (ni *NewItem) Tags() map[string]string {
 	}
 }
 
-func (ni *NewItem) Fields() map[string]interface{} {
+func (ni *newItem) Fields() map[string]interface{} {
 	return map[string]interface{}{
 		"id": ni.Data.Item.ID,
 	}
 }
 
-type OccurrenceDataOccurrence struct {
+type occurrenceDataOccurrence struct {
 	Language string `json:"language"`
 	Level    string `json:"level"`
 }
 
-type OccurrenceDataItem struct {
+type occurrenceDataItem struct {
 	ID          int    `json:"id"`
 	Environment string `json:"environment"`
 	ProjectID   int    `json:"project_id"`
 }
 
-type OccurrenceData struct {
-	Item       OccurrenceDataItem       `json:"item"`
-	Occurrence OccurrenceDataOccurrence `json:"occurrence"`
+type occurrenceData struct {
+	Item       occurrenceDataItem       `json:"item"`
+	Occurrence occurrenceDataOccurrence `json:"occurrence"`
 }
 
-type Occurrence struct {
+type occurrence struct {
 	EventName string         `json:"event_name"`
-	Data      OccurrenceData `json:"data"`
+	Data      occurrenceData `json:"data"`
 }
 
-func (o *Occurrence) Tags() map[string]string {
+func (o *occurrence) Tags() map[string]string {
 	return map[string]string{
 		"event":       o.EventName,
 		"environment": o.Data.Item.Environment,
@@ -79,28 +79,28 @@ func (o *Occurrence) Tags() map[string]string {
 	}
 }
 
-func (o *Occurrence) Fields() map[string]interface{} {
+func (o *occurrence) Fields() map[string]interface{} {
 	return map[string]interface{}{
 		"id": o.Data.Item.ID,
 	}
 }
 
-type DeployDataDeploy struct {
+type deployDataDeploy struct {
 	ID          int    `json:"id"`
 	Environment string `json:"environment"`
 	ProjectID   int    `json:"project_id"`
 }
 
-type DeployData struct {
-	Deploy DeployDataDeploy `json:"deploy"`
+type deployData struct {
+	Deploy deployDataDeploy `json:"deploy"`
 }
 
-type Deploy struct {
+type deploy struct {
 	EventName string     `json:"event_name"`
-	Data      DeployData `json:"data"`
+	Data      deployData `json:"data"`
 }
 
-func (ni *Deploy) Tags() map[string]string {
+func (ni *deploy) Tags() map[string]string {
 	return map[string]string{
 		"event":       ni.EventName,
 		"environment": ni.Data.Deploy.Environment,
@@ -108,7 +108,7 @@ func (ni *Deploy) Tags() map[string]string {
 	}
 }
 
-func (ni *Deploy) Fields() map[string]interface{} {
+func (ni *deploy) Fields() map[string]interface{} {
 	return map[string]interface{}{
 		"id": ni.Data.Deploy.ID,
 	}

--- a/plugins/inputs/win_eventlog/event.go
+++ b/plugins/inputs/win_eventlog/event.go
@@ -10,23 +10,23 @@ package win_eventlog
 // More info on schema, if there will be need to add more:
 // https://docs.microsoft.com/en-us/windows/win32/wes/eventschema-elements
 type Event struct {
-	Source        Provider       `xml:"System>Provider"`
+	Source        provider       `xml:"System>Provider"`
 	EventID       int            `xml:"System>EventID"`
 	Version       int            `xml:"System>Version"`
 	Level         int            `xml:"System>Level"`
 	Task          int            `xml:"System>Task"`
 	Opcode        int            `xml:"System>Opcode"`
 	Keywords      string         `xml:"System>Keywords"`
-	TimeCreated   TimeCreated    `xml:"System>TimeCreated"`
+	TimeCreated   timeCreated    `xml:"System>TimeCreated"`
 	EventRecordID int            `xml:"System>EventRecordID"`
-	Correlation   Correlation    `xml:"System>Correlation"`
-	Execution     Execution      `xml:"System>Execution"`
+	Correlation   correlation    `xml:"System>Correlation"`
+	Execution     execution      `xml:"System>Execution"`
 	Channel       string         `xml:"System>Channel"`
 	Computer      string         `xml:"System>Computer"`
-	Security      Security       `xml:"System>Security"`
-	UserData      UserData       `xml:"UserData"`
-	EventData     EventData      `xml:"EventData"`
-	RenderingInfo *RenderingInfo `xml:"RenderingInfo"`
+	Security      security       `xml:"System>Security"`
+	UserData      userData       `xml:"UserData"`
+	EventData     eventData      `xml:"EventData"`
+	RenderingInfo *renderingInfo `xml:"RenderingInfo"`
 
 	Message    string
 	LevelText  string
@@ -34,47 +34,47 @@ type Event struct {
 	OpcodeText string
 }
 
-// UserData Application-provided XML data
-type UserData struct {
+// userData Application-provided XML data
+type userData struct {
 	InnerXML []byte `xml:",innerxml"`
 }
 
-// EventData Application-provided XML data
-type EventData struct {
+// eventData Application-provided XML data
+type eventData struct {
 	InnerXML []byte `xml:",innerxml"`
 }
 
-// Provider is the Event provider information
-type Provider struct {
+// provider is the Event provider information
+type provider struct {
 	Name string `xml:"Name,attr"`
 }
 
-// Correlation is used for the event grouping
-type Correlation struct {
+// correlation is used for the event grouping
+type correlation struct {
 	ActivityID        string `xml:"ActivityID,attr"`
 	RelatedActivityID string `xml:"RelatedActivityID,attr"`
 }
 
-// Execution Info for Event
-type Execution struct {
+// execution Info for Event
+type execution struct {
 	ProcessID   uint32 `xml:"ProcessID,attr"`
 	ThreadID    uint32 `xml:"ThreadID,attr"`
 	ProcessName string
 }
 
-// Security Data for Event
-type Security struct {
+// security Data for Event
+type security struct {
 	UserID string `xml:"UserID,attr"`
 }
 
-// TimeCreated field for Event
-type TimeCreated struct {
+// timeCreated field for Event
+type timeCreated struct {
 	SystemTime string `xml:"SystemTime,attr"`
 }
 
-// RenderingInfo is provided for events forwarded by Windows Event Collector
+// renderingInfo is provided for events forwarded by Windows Event Collector
 // see https://learn.microsoft.com/en-us/windows/win32/api/winevt/nf-winevt-evtformatmessage#parameters
-type RenderingInfo struct {
+type renderingInfo struct {
 	Message  string   `xml:"Message"`
 	Level    string   `xml:"Level"`
 	Task     string   `xml:"Task"`

--- a/plugins/inputs/win_perf_counters/pdh.go
+++ b/plugins/inputs/win_perf_counters/pdh.go
@@ -299,7 +299,7 @@ func init() {
 // function PdhAddEnglishCounter instead. hQuery is the query handle, which has been fetched by PdhOpenQuery.
 // szFullCounterPath is a full, internationalized counter path (this will differ per Windows language version).
 // dwUserData is a 'user-defined value', which becomes part of the counter information. To retrieve this value
-// later, call PdhGetCounterInfo() and access dwQueryUserData of the PdhCounterInfo structure.
+// later, call PdhGetCounterInfo() and access dwQueryUserData of the pdhCounterInfo structure.
 //
 // Examples of szFullCounterPath (in an English version of Windows):
 //
@@ -435,7 +435,7 @@ func PdhCollectQueryDataWithTime(hQuery pdhQueryHandle) (uint32, time.Time) {
 
 // PdhGetFormattedCounterValueDouble formats the given hCounter using a 'double'. The result is set into the specialized union struct pValue.
 // This function does not directly translate to a Windows counterpart due to union specialization tricks.
-func PdhGetFormattedCounterValueDouble(hCounter pdhCounterHandle, lpdwType *uint32, pValue *PdhFmtCountervalueDouble) uint32 {
+func PdhGetFormattedCounterValueDouble(hCounter pdhCounterHandle, lpdwType *uint32, pValue *pdhFmtCountervalueDouble) uint32 {
 	ret, _, _ := pdhGetFormattedCounterValue.Call(
 		uintptr(hCounter),
 		uintptr(PdhFmtDouble|PdhFmtNocap100),
@@ -446,7 +446,7 @@ func PdhGetFormattedCounterValueDouble(hCounter pdhCounterHandle, lpdwType *uint
 }
 
 // PdhGetFormattedCounterArrayDouble returns an array of formatted counter values. Use this function when you want to format the counter values of a
-// counter that contains a wildcard character for the instance name. The itemBuffer must a slice of type PdhFmtCountervalueItemDouble.
+// counter that contains a wildcard character for the instance name. The itemBuffer must a slice of type pdhFmtCountervalueItemDouble.
 // An example of how this function can be used:
 //
 //	okPath := "\\Process(*)\\% Processor Time" // notice the wildcard * character
@@ -497,7 +497,7 @@ func PdhGetFormattedCounterArrayDouble(hCounter pdhCounterHandle, lpdwBufferSize
 // szDataSource is a null terminated string that specifies the name of the log file from which to
 // retrieve the performance data. If 0, performance data is collected from a real-time data source.
 // dwUserData is a user-defined value to associate with this query. To retrieve the user data later,
-// call PdhGetCounterInfo and access dwQueryUserData of the PdhCounterInfo structure. phQuery is
+// call PdhGetCounterInfo and access dwQueryUserData of the pdhCounterInfo structure. phQuery is
 // the handle to the query, and must be used in subsequent calls. This function returns a PDH_
 // constant error code, or ErrorSuccess if the call succeeded.
 func PdhOpenQuery(szDataSource uintptr, dwUserData uintptr, phQuery *pdhQueryHandle) uint32 {
@@ -587,7 +587,7 @@ func PdhFormatError(msgID uint32) string {
 // If the specified size on input is greater than zero but less than the required size, you should not rely on the returned size to reallocate the buffer.
 //
 // lpBuffer [out]
-// Caller-allocated buffer that receives a PdhCounterInfo structure.
+// Caller-allocated buffer that receives a pdhCounterInfo structure.
 // The structure is variable-length, because the string data is appended to the end of the fixed-format portion of the structure.
 // This is done so that all data is returned in a single buffer allocated by the caller. Set to NULL if pdwBufferSize is zero.
 func PdhGetCounterInfo(hCounter pdhCounterHandle, bRetrieveExplainText int, pdwBufferSize *uint32, lpBuffer *byte) uint32 {
@@ -602,7 +602,7 @@ func PdhGetCounterInfo(hCounter pdhCounterHandle, bRetrieveExplainText int, pdwB
 
 // PdhGetRawCounterValue returns the current raw value of the counter.
 // If the specified counter instance does not exist, this function will return ErrorSuccess
-// and the CStatus member of the PdhRawCounter structure will contain PdhCstatusNoInstance.
+// and the CStatus member of the pdhRawCounter structure will contain PdhCstatusNoInstance.
 //
 // hCounter [in]
 // Handle of the counter from which to retrieve the current raw value. The PdhAddCounter function returns this handle.
@@ -612,8 +612,8 @@ func PdhGetCounterInfo(hCounter pdhCounterHandle, bRetrieveExplainText int, pdwB
 // This parameter is optional.
 //
 // pValue [out]
-// A PdhRawCounter structure that receives the counter value.
-func PdhGetRawCounterValue(hCounter pdhCounterHandle, lpdwType *uint32, pValue *PdhRawCounter) uint32 {
+// A pdhRawCounter structure that receives the counter value.
+func PdhGetRawCounterValue(hCounter pdhCounterHandle, lpdwType *uint32, pValue *pdhRawCounter) uint32 {
 	ret, _, _ := pdhGetRawCounterValue.Call(
 		uintptr(hCounter),
 		uintptr(unsafe.Pointer(lpdwType)), //nolint:gosec // G103: Valid use of unsafe call to pass lpdwType
@@ -636,7 +636,7 @@ func PdhGetRawCounterValue(hCounter pdhCounterHandle, lpdwType *uint32, pValue *
 // Number of raw counter values in the ItemBuffer buffer.
 //
 // ItemBuffer
-// Caller-allocated buffer that receives the array of PdhRawCounterItem structures; the structures contain the raw instance counter values.
+// Caller-allocated buffer that receives the array of pdhRawCounterItem structures; the structures contain the raw instance counter values.
 // Set to NULL if lpdwBufferSize is zero.
 func PdhGetRawCounterArray(hCounter pdhCounterHandle, lpdwBufferSize *uint32, lpdwBufferCount *uint32, itemBuffer *byte) uint32 {
 	ret, _, _ := pdhGetRawCounterArrayW.Call(

--- a/plugins/inputs/win_perf_counters/pdh_386.go
+++ b/plugins/inputs/win_perf_counters/pdh_386.go
@@ -33,48 +33,34 @@
 package win_perf_counters
 
 // pdhFmtCountervalueDouble is a union specialization for double values
-type PdhFmtCountervalueDouble struct {
+type pdhFmtCountervalueDouble struct {
 	CStatus     uint32
 	padding     [4]byte
 	DoubleValue float64
 }
 
-// pdhFmtCountervalueLarge is a union specialization for 64-bit integer values
-type PdhFmtCountervalueLarge struct {
-	CStatus    uint32
-	padding    [4]byte //nolint:unused // Memory reservation
-	LargeValue int64
-}
-
 // pdhFmtCountervalueLong is a union specialization for long values
-type PdhFmtCountervalueLong struct {
+type pdhFmtCountervalueLong struct {
 	CStatus   uint32
 	LongValue int32
 	padding   [4]byte //nolint:unused // Memory reservation
 }
 
-type PdhFmtCountervalueItemDouble struct {
+type pdhFmtCountervalueItemDouble struct {
 	SzName   *uint16
 	padding  [4]byte //nolint:unused // Memory reservation
-	FmtValue PdhFmtCountervalueDouble
-}
-
-// pdhFmtCountervalueItemLarge is a union specialization for 'large' values, used by PdhGetFormattedCounterArrayLarge()
-type PdhFmtCountervalueItemLarge struct {
-	SzName   *uint16 // pointer to a string
-	padding  [4]byte //nolint:unused // Memory reservation
-	FmtValue PdhFmtCountervalueLarge
+	FmtValue pdhFmtCountervalueDouble
 }
 
 // pdhFmtCountervalueItemLong is a union specialization for long values, used by PdhGetFormattedCounterArrayLong()
 type PdhFmtCountervalueItemLong struct {
 	SzName   *uint16 // pointer to a string
 	padding  [4]byte //nolint:unused // Memory reservation
-	FmtValue PdhFmtCountervalueLong
+	FmtValue pdhFmtCountervalueLong
 }
 
 // pdhCounterInfo structure contains information describing the properties of a counter. This information also includes the counter path.
-type PdhCounterInfo struct {
+type pdhCounterInfo struct {
 	//Size of the structure, including the appended strings, in bytes.
 	DwLength uint32
 	//Counter type. For a list of counter types, see the Counter Types section of the
@@ -124,7 +110,7 @@ type PdhCounterInfo struct {
 
 // The pdhRawCounter structure returns the data as it was collected from the counter provider. No translation, formatting,
 // or other interpretation is performed on the data
-type PdhRawCounter struct {
+type pdhRawCounter struct {
 	// Counter status that indicates if the counter value is valid. Check this member before using the data in a calculation or displaying its value.
 	// For a list of possible values, see https://docs.microsoft.com/windows/desktop/PerfCtrs/checking-pdh-interface-return-values
 	CStatus uint32
@@ -139,9 +125,9 @@ type PdhRawCounter struct {
 	MultiCount uint32
 }
 
-type PdhRawCounterItem struct {
+type pdhRawCounterItem struct {
 	// Pointer to a null-terminated string that specifies the instance name of the counter. The string is appended to the end of this structure.
 	SzName *uint16
 	//A pdhRawCounter structure that contains the raw counter value of the instance
-	RawValue PdhRawCounter
+	RawValue pdhRawCounter
 }

--- a/plugins/inputs/win_perf_counters/pdh_386.go
+++ b/plugins/inputs/win_perf_counters/pdh_386.go
@@ -32,21 +32,21 @@
 
 package win_perf_counters
 
-// PdhFmtCountervalueDouble is a union specialization for double values
+// pdhFmtCountervalueDouble is a union specialization for double values
 type PdhFmtCountervalueDouble struct {
 	CStatus     uint32
 	padding     [4]byte
 	DoubleValue float64
 }
 
-// PdhFmtCountervalueLarge is a union specialization for 64-bit integer values
+// pdhFmtCountervalueLarge is a union specialization for 64-bit integer values
 type PdhFmtCountervalueLarge struct {
 	CStatus    uint32
 	padding    [4]byte //nolint:unused // Memory reservation
 	LargeValue int64
 }
 
-// PdhFmtCountervalueLong is a union specialization for long values
+// pdhFmtCountervalueLong is a union specialization for long values
 type PdhFmtCountervalueLong struct {
 	CStatus   uint32
 	LongValue int32
@@ -59,21 +59,21 @@ type PdhFmtCountervalueItemDouble struct {
 	FmtValue PdhFmtCountervalueDouble
 }
 
-// PdhFmtCountervalueItemLarge is a union specialization for 'large' values, used by PdhGetFormattedCounterArrayLarge()
+// pdhFmtCountervalueItemLarge is a union specialization for 'large' values, used by PdhGetFormattedCounterArrayLarge()
 type PdhFmtCountervalueItemLarge struct {
 	SzName   *uint16 // pointer to a string
 	padding  [4]byte //nolint:unused // Memory reservation
 	FmtValue PdhFmtCountervalueLarge
 }
 
-// PdhFmtCountervalueItemLong is a union specialization for long values, used by PdhGetFormattedCounterArrayLong()
+// pdhFmtCountervalueItemLong is a union specialization for long values, used by PdhGetFormattedCounterArrayLong()
 type PdhFmtCountervalueItemLong struct {
 	SzName   *uint16 // pointer to a string
 	padding  [4]byte //nolint:unused // Memory reservation
 	FmtValue PdhFmtCountervalueLong
 }
 
-// PdhCounterInfo structure contains information describing the properties of a counter. This information also includes the counter path.
+// pdhCounterInfo structure contains information describing the properties of a counter. This information also includes the counter path.
 type PdhCounterInfo struct {
 	//Size of the structure, including the appended strings, in bytes.
 	DwLength uint32
@@ -122,7 +122,7 @@ type PdhCounterInfo struct {
 	DataBuffer [1]uint32 // pointer to an extra space
 }
 
-// The PdhRawCounter structure returns the data as it was collected from the counter provider. No translation, formatting,
+// The pdhRawCounter structure returns the data as it was collected from the counter provider. No translation, formatting,
 // or other interpretation is performed on the data
 type PdhRawCounter struct {
 	// Counter status that indicates if the counter value is valid. Check this member before using the data in a calculation or displaying its value.
@@ -142,6 +142,6 @@ type PdhRawCounter struct {
 type PdhRawCounterItem struct {
 	// Pointer to a null-terminated string that specifies the instance name of the counter. The string is appended to the end of this structure.
 	SzName *uint16
-	//A PdhRawCounter structure that contains the raw counter value of the instance
+	//A pdhRawCounter structure that contains the raw counter value of the instance
 	RawValue PdhRawCounter
 }

--- a/plugins/inputs/win_perf_counters/pdh_amd64.go
+++ b/plugins/inputs/win_perf_counters/pdh_amd64.go
@@ -38,35 +38,10 @@ type pdhFmtCountervalueDouble struct {
 	DoubleValue float64
 }
 
-// pdhFmtCountervalueLarge is a union specialization for 64-bit integer values
-type pdhFmtCountervalueLarge struct {
-	CStatus    uint32
-	LargeValue int64
-}
-
-// pdhFmtCountervalueLong is a union specialization for long values
-type pdhFmtCountervalueLong struct {
-	CStatus   uint32
-	LongValue int32
-	padding   [4]byte //nolint:unused // Memory reservation
-}
-
 // pdhFmtCountervalueItemDouble is a union specialization for double values, used by PdhGetFormattedCounterArrayDouble
 type pdhFmtCountervalueItemDouble struct {
 	SzName   *uint16
 	FmtValue pdhFmtCountervalueDouble
-}
-
-// pdhFmtCountervalueItemLarge is a union specialization for 'large' values, used by PdhGetFormattedCounterArrayLarge()
-type pdhFmtCountervalueItemLarge struct {
-	SzName   *uint16 // pointer to a string
-	FmtValue pdhFmtCountervalueLarge
-}
-
-// pdhFmtCountervalueItemLong is a union specialization for long values, used by PdhGetFormattedCounterArrayLong()
-type pdhFmtCountervalueItemLong struct {
-	SzName   *uint16 // pointer to a string
-	FmtValue pdhFmtCountervalueLong
 }
 
 // pdhCounterInfo structure contains information describing the properties of a counter. This information also includes the counter path.

--- a/plugins/inputs/win_perf_counters/pdh_amd64.go
+++ b/plugins/inputs/win_perf_counters/pdh_amd64.go
@@ -32,45 +32,45 @@
 
 package win_perf_counters
 
-// PdhFmtCountervalueDouble is a union specialization for double values
-type PdhFmtCountervalueDouble struct {
+// pdhFmtCountervalueDouble is a union specialization for double values
+type pdhFmtCountervalueDouble struct {
 	CStatus     uint32
 	DoubleValue float64
 }
 
-// PdhFmtCountervalueLarge is a union specialization for 64-bit integer values
-type PdhFmtCountervalueLarge struct {
+// pdhFmtCountervalueLarge is a union specialization for 64-bit integer values
+type pdhFmtCountervalueLarge struct {
 	CStatus    uint32
 	LargeValue int64
 }
 
-// PdhFmtCountervalueLong is a union specialization for long values
-type PdhFmtCountervalueLong struct {
+// pdhFmtCountervalueLong is a union specialization for long values
+type pdhFmtCountervalueLong struct {
 	CStatus   uint32
 	LongValue int32
 	padding   [4]byte //nolint:unused // Memory reservation
 }
 
-// PdhFmtCountervalueItemDouble is a union specialization for double values, used by PdhGetFormattedCounterArrayDouble
-type PdhFmtCountervalueItemDouble struct {
+// pdhFmtCountervalueItemDouble is a union specialization for double values, used by PdhGetFormattedCounterArrayDouble
+type pdhFmtCountervalueItemDouble struct {
 	SzName   *uint16
-	FmtValue PdhFmtCountervalueDouble
+	FmtValue pdhFmtCountervalueDouble
 }
 
-// PdhFmtCountervalueItemLarge is a union specialization for 'large' values, used by PdhGetFormattedCounterArrayLarge()
-type PdhFmtCountervalueItemLarge struct {
+// pdhFmtCountervalueItemLarge is a union specialization for 'large' values, used by PdhGetFormattedCounterArrayLarge()
+type pdhFmtCountervalueItemLarge struct {
 	SzName   *uint16 // pointer to a string
-	FmtValue PdhFmtCountervalueLarge
+	FmtValue pdhFmtCountervalueLarge
 }
 
-// PdhFmtCountervalueItemLong is a union specialization for long values, used by PdhGetFormattedCounterArrayLong()
-type PdhFmtCountervalueItemLong struct {
+// pdhFmtCountervalueItemLong is a union specialization for long values, used by PdhGetFormattedCounterArrayLong()
+type pdhFmtCountervalueItemLong struct {
 	SzName   *uint16 // pointer to a string
-	FmtValue PdhFmtCountervalueLong
+	FmtValue pdhFmtCountervalueLong
 }
 
-// PdhCounterInfo structure contains information describing the properties of a counter. This information also includes the counter path.
-type PdhCounterInfo struct {
+// pdhCounterInfo structure contains information describing the properties of a counter. This information also includes the counter path.
+type pdhCounterInfo struct {
 	//Size of the structure, including the appended strings, in bytes.
 	DwLength uint32
 	//Counter type. For a list of counter types,
@@ -115,9 +115,9 @@ type PdhCounterInfo struct {
 	DataBuffer [1]uint32 // pointer to an extra space
 }
 
-// The PdhRawCounter structure returns the data as it was collected from the counter provider.
+// The pdhRawCounter structure returns the data as it was collected from the counter provider.
 // No translation, formatting, or other interpretation is performed on the data
-type PdhRawCounter struct {
+type pdhRawCounter struct {
 	// Counter status that indicates if the counter value is valid. Check this member before using the data in a calculation or displaying its value.
 	// For a list of possible values, see https://docs.microsoft.com/windows/desktop/PerfCtrs/checking-pdh-interface-return-values
 	CStatus uint32
@@ -132,9 +132,9 @@ type PdhRawCounter struct {
 	MultiCount uint32
 }
 
-type PdhRawCounterItem struct {
+type pdhRawCounterItem struct {
 	// Pointer to a null-terminated string that specifies the instance name of the counter. The string is appended to the end of this structure.
 	SzName *uint16
-	//A PdhRawCounter structure that contains the raw counter value of the instance
-	RawValue PdhRawCounter
+	//A pdhRawCounter structure that contains the raw counter value of the instance
+	RawValue pdhRawCounter
 }

--- a/plugins/inputs/win_perf_counters/pdh_arm64.go
+++ b/plugins/inputs/win_perf_counters/pdh_arm64.go
@@ -33,43 +33,18 @@
 package win_perf_counters
 
 // pdhFmtCountervalueDouble is a union specialization for double values
-type PdhFmtCountervalueDouble struct {
+type pdhFmtCountervalueDouble struct {
 	CStatus     uint32
 	DoubleValue float64
 }
 
-// pdhFmtCountervalueLarge is a union specialization for 64-bit integer values
-type PdhFmtCountervalueLarge struct {
-	CStatus    uint32
-	LargeValue int64
-}
-
-// pdhFmtCountervalueLong is a union specialization for long values
-type PdhFmtCountervalueLong struct {
-	CStatus   uint32
-	LongValue int32
-	padding   [4]byte //nolint:unused // Memory reservation
-}
-
-type PdhFmtCountervalueItemDouble struct {
+type pdhFmtCountervalueItemDouble struct {
 	SzName   *uint16
-	FmtValue PdhFmtCountervalueDouble
-}
-
-// pdhFmtCountervalueItemLarge is a union specialization for 'large' values, used by PdhGetFormattedCounterArrayLarge()
-type PdhFmtCountervalueItemLarge struct {
-	SzName   *uint16 // pointer to a string
-	FmtValue PdhFmtCountervalueLarge
-}
-
-// pdhFmtCountervalueItemLong is a union specialization for long values, used by PdhGetFormattedCounterArrayLong()
-type PdhFmtCountervalueItemLong struct {
-	SzName   *uint16 // pointer to a string
-	FmtValue PdhFmtCountervalueLong
+	FmtValue pdhFmtCountervalueDouble
 }
 
 // pdhCounterInfo structure contains information describing the properties of a counter. This information also includes the counter path.
-type PdhCounterInfo struct {
+type pdhCounterInfo struct {
 	//Size of the structure, including the appended strings, in bytes.
 	DwLength uint32
 	//Counter type. For a list of counter types, see the Counter Types section
@@ -117,7 +92,7 @@ type PdhCounterInfo struct {
 
 // The pdhRawCounter structure returns the data as it was collected from the counter provider.
 // No translation, formatting, or other interpretation is performed on the data.
-type PdhRawCounter struct {
+type pdhRawCounter struct {
 	// Counter status that indicates if the counter value is valid. Check this member before using the data in a calculation or displaying its value.
 	// For a list of possible values, see https://docs.microsoft.com/windows/desktop/PerfCtrs/checking-pdh-interface-return-values
 	CStatus uint32
@@ -132,9 +107,9 @@ type PdhRawCounter struct {
 	MultiCount uint32
 }
 
-type PdhRawCounterItem struct {
+type pdhRawCounterItem struct {
 	// Pointer to a null-terminated string that specifies the instance name of the counter. The string is appended to the end of this structure.
 	SzName *uint16
 	//A pdhRawCounter structure that contains the raw counter value of the instance
-	RawValue PdhRawCounter
+	RawValue pdhRawCounter
 }

--- a/plugins/inputs/win_perf_counters/pdh_arm64.go
+++ b/plugins/inputs/win_perf_counters/pdh_arm64.go
@@ -32,19 +32,19 @@
 
 package win_perf_counters
 
-// PdhFmtCountervalueDouble is a union specialization for double values
+// pdhFmtCountervalueDouble is a union specialization for double values
 type PdhFmtCountervalueDouble struct {
 	CStatus     uint32
 	DoubleValue float64
 }
 
-// PdhFmtCountervalueLarge is a union specialization for 64-bit integer values
+// pdhFmtCountervalueLarge is a union specialization for 64-bit integer values
 type PdhFmtCountervalueLarge struct {
 	CStatus    uint32
 	LargeValue int64
 }
 
-// PdhFmtCountervalueLong is a union specialization for long values
+// pdhFmtCountervalueLong is a union specialization for long values
 type PdhFmtCountervalueLong struct {
 	CStatus   uint32
 	LongValue int32
@@ -56,19 +56,19 @@ type PdhFmtCountervalueItemDouble struct {
 	FmtValue PdhFmtCountervalueDouble
 }
 
-// PdhFmtCountervalueItemLarge is a union specialization for 'large' values, used by PdhGetFormattedCounterArrayLarge()
+// pdhFmtCountervalueItemLarge is a union specialization for 'large' values, used by PdhGetFormattedCounterArrayLarge()
 type PdhFmtCountervalueItemLarge struct {
 	SzName   *uint16 // pointer to a string
 	FmtValue PdhFmtCountervalueLarge
 }
 
-// PdhFmtCountervalueItemLong is a union specialization for long values, used by PdhGetFormattedCounterArrayLong()
+// pdhFmtCountervalueItemLong is a union specialization for long values, used by PdhGetFormattedCounterArrayLong()
 type PdhFmtCountervalueItemLong struct {
 	SzName   *uint16 // pointer to a string
 	FmtValue PdhFmtCountervalueLong
 }
 
-// PdhCounterInfo structure contains information describing the properties of a counter. This information also includes the counter path.
+// pdhCounterInfo structure contains information describing the properties of a counter. This information also includes the counter path.
 type PdhCounterInfo struct {
 	//Size of the structure, including the appended strings, in bytes.
 	DwLength uint32
@@ -115,7 +115,7 @@ type PdhCounterInfo struct {
 	DataBuffer [1]uint32 // pointer to an extra space
 }
 
-// The PdhRawCounter structure returns the data as it was collected from the counter provider.
+// The pdhRawCounter structure returns the data as it was collected from the counter provider.
 // No translation, formatting, or other interpretation is performed on the data.
 type PdhRawCounter struct {
 	// Counter status that indicates if the counter value is valid. Check this member before using the data in a calculation or displaying its value.
@@ -135,6 +135,6 @@ type PdhRawCounter struct {
 type PdhRawCounterItem struct {
 	// Pointer to a null-terminated string that specifies the instance name of the counter. The string is appended to the end of this structure.
 	SzName *uint16
-	//A PdhRawCounter structure that contains the raw counter value of the instance
+	//A pdhRawCounter structure that contains the raw counter value of the instance
 	RawValue PdhRawCounter
 }

--- a/plugins/inputs/win_perf_counters/win_perf_counters.go
+++ b/plugins/inputs/win_perf_counters/win_perf_counters.go
@@ -399,7 +399,7 @@ func (m *WinPerfCounters) ParseConfig() error {
 }
 
 func (m *WinPerfCounters) checkError(err error) error {
-	var pdhErr *PdhError
+	var pdhErr *pdhError
 	if errors.As(err, &pdhErr) {
 		for _, ignoredErrors := range m.IgnoredErrors {
 			if PDHErrors[pdhErr.ErrorCode] == ignoredErrors {
@@ -491,7 +491,7 @@ func (m *WinPerfCounters) gatherComputerCounters(hostCounterInfo *hostCountersIn
 			}
 			addCounterMeasurement(metric, metric.instance, value, collectedFields)
 		} else {
-			var counterValues []CounterValue
+			var counterValues []counterValue
 			if metric.useRawValue {
 				counterValues, err = hostCounterInfo.query.GetRawCounterArray(metric.counterHandle)
 			} else {
@@ -543,7 +543,7 @@ func (m *WinPerfCounters) cleanQueries() error {
 	return nil
 }
 
-func shouldIncludeMetric(metric *counter, cValue CounterValue) bool {
+func shouldIncludeMetric(metric *counter, cValue counterValue) bool {
 	if metric.includeTotal {
 		// If IncludeTotal is set, include all.
 		return true
@@ -571,7 +571,7 @@ func addCounterMeasurement(metric *counter, instanceName string, value interface
 }
 
 func isKnownCounterDataError(err error) bool {
-	var pdhErr *PdhError
+	var pdhErr *pdhError
 	if errors.As(err, &pdhErr) && (pdhErr.ErrorCode == PdhInvalidData ||
 		pdhErr.ErrorCode == PdhCalcNegativeDenominator ||
 		pdhErr.ErrorCode == PdhCalcNegativeValue ||
@@ -627,7 +627,7 @@ func init() {
 			CountersRefreshInterval:    config.Duration(time.Second * 60),
 			LocalizeWildcardsExpansion: true,
 			MaxBufferSize:              defaultMaxBufferSize,
-			queryCreator:               &PerformanceQueryCreatorImpl{},
+			queryCreator:               &performanceQueryCreatorImpl{},
 		}
 	})
 }

--- a/plugins/inputs/win_perf_counters/win_perf_counters_integration_test.go
+++ b/plugins/inputs/win_perf_counters/win_perf_counters_integration_test.go
@@ -18,7 +18,7 @@ func TestWinPerformanceQueryImplIntegration(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
-	query := &PerformanceQueryImpl{maxBufferSize: uint32(defaultMaxBufferSize)}
+	query := &performanceQueryImpl{maxBufferSize: uint32(defaultMaxBufferSize)}
 
 	err := query.Close()
 	require.Error(t, err, "uninitialized query must return errors")
@@ -98,7 +98,7 @@ func TestWinPerformanceQueryImplIntegration(t *testing.T) {
 	require.NoError(t, query.CollectData())
 
 	farr, err := query.GetFormattedCounterArrayDouble(hCounter)
-	var phdErr *PdhError
+	var phdErr *pdhError
 	if errors.As(err, &phdErr) && phdErr.ErrorCode != PdhInvalidData && phdErr.ErrorCode != PdhCalcNegativeValue {
 		time.Sleep(time.Second)
 		farr, err = query.GetFormattedCounterArrayDouble(hCounter)
@@ -135,7 +135,7 @@ func TestWinPerfCountersConfigGet1Integration(t *testing.T) {
 		Object:        perfObjects,
 		MaxBufferSize: defaultMaxBufferSize,
 		Log:           testutil.Logger{},
-		queryCreator:  &PerformanceQueryCreatorImpl{},
+		queryCreator:  &performanceQueryCreatorImpl{},
 	}
 
 	require.NoError(t, m.ParseConfig())
@@ -163,7 +163,7 @@ func TestWinPerfCountersConfigGet2Integration(t *testing.T) {
 		Object:        perfObjects,
 		MaxBufferSize: defaultMaxBufferSize,
 		Log:           testutil.Logger{},
-		queryCreator:  &PerformanceQueryCreatorImpl{},
+		queryCreator:  &performanceQueryCreatorImpl{},
 	}
 
 	require.NoError(t, m.ParseConfig())
@@ -206,7 +206,7 @@ func TestWinPerfCountersConfigGet3Integration(t *testing.T) {
 		Object:        perfObjects,
 		MaxBufferSize: defaultMaxBufferSize,
 		Log:           testutil.Logger{},
-		queryCreator:  &PerformanceQueryCreatorImpl{},
+		queryCreator:  &performanceQueryCreatorImpl{},
 	}
 
 	require.NoError(t, m.ParseConfig())
@@ -247,7 +247,7 @@ func TestWinPerfCountersConfigGet4Integration(t *testing.T) {
 		Object:        perfObjects,
 		MaxBufferSize: defaultMaxBufferSize,
 		Log:           testutil.Logger{},
-		queryCreator:  &PerformanceQueryCreatorImpl{},
+		queryCreator:  &performanceQueryCreatorImpl{},
 	}
 
 	require.NoError(t, m.ParseConfig())
@@ -288,7 +288,7 @@ func TestWinPerfCountersConfigGet5Integration(t *testing.T) {
 		Object:        perfObjects,
 		MaxBufferSize: defaultMaxBufferSize,
 		Log:           testutil.Logger{},
-		queryCreator:  &PerformanceQueryCreatorImpl{},
+		queryCreator:  &performanceQueryCreatorImpl{},
 	}
 
 	require.NoError(t, m.ParseConfig())
@@ -329,7 +329,7 @@ func TestWinPerfCountersConfigGet6Integration(t *testing.T) {
 		Object:        perfObjects,
 		MaxBufferSize: defaultMaxBufferSize,
 		Log:           testutil.Logger{},
-		queryCreator:  &PerformanceQueryCreatorImpl{},
+		queryCreator:  &performanceQueryCreatorImpl{},
 	}
 
 	require.NoError(t, m.ParseConfig())
@@ -357,7 +357,7 @@ func TestWinPerfCountersConfigGet7Integration(t *testing.T) {
 		Object:        perfObjects,
 		MaxBufferSize: defaultMaxBufferSize,
 		Log:           testutil.Logger{},
-		queryCreator:  &PerformanceQueryCreatorImpl{},
+		queryCreator:  &performanceQueryCreatorImpl{},
 	}
 
 	require.NoError(t, m.ParseConfig())
@@ -398,7 +398,7 @@ func TestWinPerfCountersConfigError1Integration(t *testing.T) {
 		Object:        perfObjects,
 		MaxBufferSize: defaultMaxBufferSize,
 		Log:           testutil.Logger{},
-		queryCreator:  &PerformanceQueryCreatorImpl{},
+		queryCreator:  &performanceQueryCreatorImpl{},
 	}
 
 	require.Error(t, m.ParseConfig())
@@ -426,7 +426,7 @@ func TestWinPerfCountersConfigError2Integration(t *testing.T) {
 		Object:        perfObjects,
 		MaxBufferSize: defaultMaxBufferSize,
 		Log:           testutil.Logger{},
-		queryCreator:  &PerformanceQueryCreatorImpl{},
+		queryCreator:  &performanceQueryCreatorImpl{},
 	}
 
 	require.NoError(t, m.ParseConfig())
@@ -456,7 +456,7 @@ func TestWinPerfCountersConfigError3Integration(t *testing.T) {
 		Object:        perfObjects,
 		MaxBufferSize: defaultMaxBufferSize,
 		Log:           testutil.Logger{},
-		queryCreator:  &PerformanceQueryCreatorImpl{},
+		queryCreator:  &performanceQueryCreatorImpl{},
 	}
 
 	require.Error(t, m.ParseConfig())
@@ -484,7 +484,7 @@ func TestWinPerfCountersCollect1Integration(t *testing.T) {
 		Object:        perfObjects,
 		MaxBufferSize: defaultMaxBufferSize,
 		Log:           testutil.Logger{},
-		queryCreator:  &PerformanceQueryCreatorImpl{},
+		queryCreator:  &performanceQueryCreatorImpl{},
 	}
 
 	var acc testutil.Accumulator
@@ -524,7 +524,7 @@ func TestWinPerfCountersCollect2Integration(t *testing.T) {
 		UseWildcardsExpansion: true,
 		MaxBufferSize:         defaultMaxBufferSize,
 		Log:                   testutil.Logger{},
-		queryCreator:          &PerformanceQueryCreatorImpl{},
+		queryCreator:          &performanceQueryCreatorImpl{},
 	}
 
 	var acc testutil.Accumulator
@@ -565,7 +565,7 @@ func TestWinPerfCountersCollectRawIntegration(t *testing.T) {
 		UseWildcardsExpansion: true,
 		MaxBufferSize:         defaultMaxBufferSize,
 		Log:                   testutil.Logger{},
-		queryCreator:          &PerformanceQueryCreatorImpl{},
+		queryCreator:          &performanceQueryCreatorImpl{},
 	}
 	var acc testutil.Accumulator
 	require.NoError(t, m.Gather(&acc))
@@ -590,7 +590,7 @@ func TestWinPerfCountersCollectRawIntegration(t *testing.T) {
 		UseWildcardsExpansion: false,
 		MaxBufferSize:         defaultMaxBufferSize,
 		Log:                   testutil.Logger{},
-		queryCreator:          &PerformanceQueryCreatorImpl{},
+		queryCreator:          &performanceQueryCreatorImpl{},
 	}
 	var acc2 testutil.Accumulator
 	require.NoError(t, m.Gather(&acc))

--- a/plugins/inputs/win_perf_counters/win_perf_counters_test.go
+++ b/plugins/inputs/win_perf_counters/win_perf_counters_test.go
@@ -31,7 +31,7 @@ type FakePerformanceQuery struct {
 
 var MetricTime = time.Date(2018, 5, 28, 12, 0, 0, 0, time.UTC)
 
-func (m *testCounter) ToCounterValue(raw bool) *CounterValue {
+func (m *testCounter) ToCounterValue(raw bool) *counterValue {
 	//nolint:dogsled,errcheck // only instance is needed for this helper function in tests
 	_, _, inst, _, _ := extractCounterInfoFromCounterPath(m.path)
 	if inst == "" {
@@ -44,7 +44,7 @@ func (m *testCounter) ToCounterValue(raw bool) *CounterValue {
 		val = m.value
 	}
 
-	return &CounterValue{inst, val}
+	return &counterValue{inst, val}
 }
 
 func (m *FakePerformanceQuery) Open() error {
@@ -141,14 +141,14 @@ func (m *FakePerformanceQuery) findCounterByPath(counterPath string) *testCounte
 	return nil
 }
 
-func (m *FakePerformanceQuery) GetFormattedCounterArrayDouble(hCounter pdhCounterHandle) ([]CounterValue, error) {
+func (m *FakePerformanceQuery) GetFormattedCounterArrayDouble(hCounter pdhCounterHandle) ([]counterValue, error) {
 	if !m.openCalled {
 		return nil, errors.New("in GetFormattedCounterArrayDouble: uninitialized query")
 	}
 	for _, c := range m.counters {
 		if c.handle == hCounter {
 			if e, ok := m.expandPaths[c.path]; ok {
-				counters := make([]CounterValue, 0, len(e))
+				counters := make([]counterValue, 0, len(e))
 				for _, p := range e {
 					counter := m.findCounterByPath(p)
 					if counter == nil {
@@ -167,14 +167,14 @@ func (m *FakePerformanceQuery) GetFormattedCounterArrayDouble(hCounter pdhCounte
 	return nil, fmt.Errorf("in GetFormattedCounterArrayDouble: invalid counter: %q, no paths found", hCounter)
 }
 
-func (m *FakePerformanceQuery) GetRawCounterArray(hCounter pdhCounterHandle) ([]CounterValue, error) {
+func (m *FakePerformanceQuery) GetRawCounterArray(hCounter pdhCounterHandle) ([]counterValue, error) {
 	if !m.openCalled {
 		return nil, errors.New("in GetRawCounterArray: uninitialised query")
 	}
 	for _, c := range m.counters {
 		if c.handle == hCounter {
 			if e, ok := m.expandPaths[c.path]; ok {
-				counters := make([]CounterValue, 0, len(e))
+				counters := make([]counterValue, 0, len(e))
 				for _, p := range e {
 					counter := m.findCounterByPath(p)
 					if counter == nil {
@@ -2068,7 +2068,7 @@ func TestCheckError(t *testing.T) {
 	}{
 		{
 			Name: "Ignore PDH_NO_DATA",
-			Err: &PdhError{
+			Err: &pdhError{
 				ErrorCode: uint32(PdhNoData),
 			},
 			IgnoredErrors: []string{
@@ -2078,10 +2078,10 @@ func TestCheckError(t *testing.T) {
 		},
 		{
 			Name: "Don't ignore PDH_NO_DATA",
-			Err: &PdhError{
+			Err: &pdhError{
 				ErrorCode: uint32(PdhNoData),
 			},
-			ExpectedErr: &PdhError{
+			ExpectedErr: &pdhError{
 				ErrorCode: uint32(PdhNoData),
 			},
 		},

--- a/plugins/inputs/win_perf_counters/win_perf_counters_test.go
+++ b/plugins/inputs/win_perf_counters/win_perf_counters_test.go
@@ -2038,7 +2038,7 @@ func TestLocalizeWildcardsExpansion(t *testing.T) {
 
 	const counter = "% Processor Time"
 	m := WinPerfCounters{
-		queryCreator:            &PerformanceQueryCreatorImpl{},
+		queryCreator:            &performanceQueryCreatorImpl{},
 		CountersRefreshInterval: config.Duration(time.Second * 60),
 		Object: createPerfObject("", "measurement", "Processor Information",
 			[]string{"_Total"}, []string{counter}, true, false, false),

--- a/plugins/inputs/win_services/win_services.go
+++ b/plugins/inputs/win_services/win_services.go
@@ -23,18 +23,18 @@ import (
 //go:embed sample.conf
 var sampleConfig string
 
-type ServiceError struct {
+type serviceError struct {
 	Message string
 	Service string
 	Err     error
 }
 
-func (e *ServiceError) Error() string {
+func (e *serviceError) Error() string {
 	return fmt.Sprintf("%s: %q: %v", e.Message, e.Service, e.Err)
 }
 
 func IsPermission(err error) bool {
-	var serviceErr *ServiceError
+	var serviceErr *serviceError
 	if errors.As(err, &serviceErr) {
 		return errors.Is(serviceErr, fs.ErrPermission)
 	}
@@ -60,16 +60,16 @@ type WinServiceManager interface {
 	ListServices() ([]string, error)
 }
 
-// WinSvcMgr is wrapper for mgr.Mgr implementing WinServiceManager interface
-type WinSvcMgr struct {
+// winSvcMgr is wrapper for mgr.Mgr implementing WinServiceManager interface
+type winSvcMgr struct {
 	realMgr *mgr.Mgr
 }
 
-func (m *WinSvcMgr) Disconnect() error {
+func (m *winSvcMgr) Disconnect() error {
 	return m.realMgr.Disconnect()
 }
 
-func (m *WinSvcMgr) OpenService(name string) (WinService, error) {
+func (m *winSvcMgr) OpenService(name string) (WinService, error) {
 	serviceName, err := syscall.UTF16PtrFromString(name)
 	if err != nil {
 		return nil, fmt.Errorf("cannot convert service name %q: %w", name, err)
@@ -81,21 +81,21 @@ func (m *WinSvcMgr) OpenService(name string) (WinService, error) {
 	return &mgr.Service{Name: name, Handle: h}, nil
 }
 
-func (m *WinSvcMgr) ListServices() ([]string, error) {
+func (m *winSvcMgr) ListServices() ([]string, error) {
 	return m.realMgr.ListServices()
 }
 
-// MgProvider is an implementation of WinServiceManagerProvider interface returning WinSvcMgr
-type MgProvider struct {
+// mgProvider is an implementation of WinServiceManagerProvider interface returning winSvcMgr
+type mgProvider struct {
 }
 
-func (rmr *MgProvider) Connect() (WinServiceManager, error) {
+func (rmr *mgProvider) Connect() (WinServiceManager, error) {
 	h, err := windows.OpenSCManager(nil, nil, windows.GENERIC_READ)
 	if err != nil {
 		return nil, err
 	}
 	scmgr := &mgr.Mgr{Handle: h}
-	return &WinSvcMgr{scmgr}, nil
+	return &winSvcMgr{scmgr}, nil
 }
 
 // WinServices is an implementation if telegraf.Input interface, providing info about Windows Services
@@ -109,7 +109,7 @@ type WinServices struct {
 	servicesFilter filter.Filter
 }
 
-type ServiceInfo struct {
+type serviceInfo struct {
 	ServiceName string
 	DisplayName string
 	State       int
@@ -202,10 +202,10 @@ func (m *WinServices) listServices(scmgr WinServiceManager) ([]string, error) {
 }
 
 // collectServiceInfo gathers info about a service.
-func collectServiceInfo(scmgr WinServiceManager, serviceName string) (*ServiceInfo, error) {
+func collectServiceInfo(scmgr WinServiceManager, serviceName string) (*serviceInfo, error) {
 	srv, err := scmgr.OpenService(serviceName)
 	if err != nil {
-		return nil, &ServiceError{
+		return nil, &serviceError{
 			Message: "could not open service",
 			Service: serviceName,
 			Err:     err,
@@ -215,7 +215,7 @@ func collectServiceInfo(scmgr WinServiceManager, serviceName string) (*ServiceIn
 
 	srvStatus, err := srv.Query()
 	if err != nil {
-		return nil, &ServiceError{
+		return nil, &serviceError{
 			Message: "could not query service",
 			Service: serviceName,
 			Err:     err,
@@ -224,14 +224,14 @@ func collectServiceInfo(scmgr WinServiceManager, serviceName string) (*ServiceIn
 
 	srvCfg, err := srv.Config()
 	if err != nil {
-		return nil, &ServiceError{
+		return nil, &serviceError{
 			Message: "could not get config of service",
 			Service: serviceName,
 			Err:     err,
 		}
 	}
 
-	serviceInfo := &ServiceInfo{
+	serviceInfo := &serviceInfo{
 		ServiceName: serviceName,
 		DisplayName: srvCfg.DisplayName,
 		StartUpMode: int(srvCfg.StartType),
@@ -243,7 +243,7 @@ func collectServiceInfo(scmgr WinServiceManager, serviceName string) (*ServiceIn
 func init() {
 	inputs.Add("win_services", func() telegraf.Input {
 		return &WinServices{
-			mgrProvider: &MgProvider{},
+			mgrProvider: &mgProvider{},
 		}
 	})
 }

--- a/plugins/inputs/win_services/win_services_integration_test.go
+++ b/plugins/inputs/win_services/win_services_integration_test.go
@@ -17,7 +17,7 @@ func TestListIntegration(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
-	provider := &MgProvider{}
+	provider := &mgProvider{}
 	scmgr, err := provider.Connect()
 	require.NoError(t, err)
 	defer func() {
@@ -41,7 +41,7 @@ func TestEmptyListIntegration(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
-	provider := &MgProvider{}
+	provider := &mgProvider{}
 	scmgr, err := provider.Connect()
 	require.NoError(t, err)
 	defer func() {
@@ -66,7 +66,7 @@ func TestGatherErrorsIntegration(t *testing.T) {
 	ws := &WinServices{
 		Log:          testutil.Logger{},
 		ServiceNames: InvalidServices,
-		mgrProvider:  &MgProvider{},
+		mgrProvider:  &mgProvider{},
 	}
 
 	require.NoError(t, ws.Init())

--- a/plugins/inputs/xtremio/xtremio.go
+++ b/plugins/inputs/xtremio/xtremio.go
@@ -92,13 +92,13 @@ func (xio *XtremIO) Gather(acc telegraf.Accumulator) error {
 				return
 			}
 
-			data := CollectorResponse{}
+			data := collectorResponse{}
 			err = json.Unmarshal([]byte(resp), &data)
 			if err != nil {
 				acc.AddError(err)
 			}
 
-			var arr []HREF
+			var arr []href
 			switch collector {
 			case "bbus":
 				arr = data.BBUs
@@ -168,7 +168,7 @@ func (xio *XtremIO) gatherBBUs(acc telegraf.Accumulator, url string, wg *sync.Wa
 		return
 	}
 
-	data := BBU{}
+	data := bbu{}
 	err = json.Unmarshal([]byte(resp), &data)
 	if err != nil {
 		acc.AddError(err)
@@ -201,7 +201,7 @@ func (xio *XtremIO) gatherClusters(acc telegraf.Accumulator, url string, wg *syn
 		return
 	}
 
-	data := Clusters{}
+	data := clusters{}
 	err = json.Unmarshal([]byte(resp), &data)
 	if err != nil {
 		acc.AddError(err)
@@ -237,7 +237,7 @@ func (xio *XtremIO) gatherSSDs(acc telegraf.Accumulator, url string, wg *sync.Wa
 		return
 	}
 
-	data := SSD{}
+	data := ssd{}
 	err = json.Unmarshal([]byte(resp), &data)
 	if err != nil {
 		acc.AddError(err)
@@ -273,7 +273,7 @@ func (xio *XtremIO) gatherVolumes(acc telegraf.Accumulator, url string, wg *sync
 		return
 	}
 
-	data := Volumes{}
+	data := volumes{}
 	err = json.Unmarshal([]byte(resp), &data)
 	if err != nil {
 		acc.AddError(err)
@@ -306,7 +306,7 @@ func (xio *XtremIO) gatherXMS(acc telegraf.Accumulator, url string, wg *sync.Wai
 		return
 	}
 
-	data := XMS{}
+	data := xms{}
 	err = json.Unmarshal([]byte(resp), &data)
 	if err != nil {
 		acc.AddError(err)

--- a/plugins/inputs/xtremio/xtremio_types.go
+++ b/plugins/inputs/xtremio/xtremio_types.go
@@ -1,6 +1,6 @@
 package xtremio
 
-type BBU struct {
+type bbu struct {
 	Content struct {
 		Serial       string `json:"serial-number"`
 		GUID         string `json:"guid"`
@@ -15,7 +15,7 @@ type BBU struct {
 	}
 }
 
-type Clusters struct {
+type clusters struct {
 	Content struct {
 		HardwarePlatform   string  `json:"hardware-platform"`
 		LicenseID          string  `json:"license-id"`
@@ -33,7 +33,7 @@ type Clusters struct {
 	}
 }
 
-type SSD struct {
+type ssd struct {
 	Content struct {
 		ModelName       string `json:"model-name"`
 		FirmwareVersion string `json:"fw-version"`
@@ -51,7 +51,7 @@ type SSD struct {
 	}
 }
 
-type Volumes struct {
+type volumes struct {
 	Content struct {
 		GUID               string  `json:"guid"`
 		SysName            string  `json:"sys-name"`
@@ -66,7 +66,7 @@ type Volumes struct {
 	}
 }
 
-type XMS struct {
+type xms struct {
 	Content struct {
 		GUID            string  `json:"guid"`
 		Name            string  `json:"name"`
@@ -85,14 +85,14 @@ type XMS struct {
 	}
 }
 
-type HREF struct {
+type href struct {
 	Href string `json:"href"`
 }
 
-type CollectorResponse struct {
-	BBUs     []HREF `json:"bbus"`
-	Clusters []HREF `json:"clusters"`
-	SSDs     []HREF `json:"ssds"`
-	Volumes  []HREF `json:"volumes"`
-	XMS      []HREF `json:"xmss"`
+type collectorResponse struct {
+	BBUs     []href `json:"bbus"`
+	Clusters []href `json:"clusters"`
+	SSDs     []href `json:"ssds"`
+	Volumes  []href `json:"volumes"`
+	XMS      []href `json:"xmss"`
 }

--- a/plugins/inputs/zipkin/codec/codec.go
+++ b/plugins/inputs/zipkin/codec/codec.go
@@ -50,14 +50,14 @@ type Endpoint interface {
 	Name() string
 }
 
-// DefaultEndpoint is used if the annotations have no endpoints
-type DefaultEndpoint struct{}
+// defaultEndpoint is used if the annotations have no endpoints
+type defaultEndpoint struct{}
 
 // Host returns 0.0.0.0; used when the host is unknown
-func (d *DefaultEndpoint) Host() string { return "0.0.0.0" }
+func (d *defaultEndpoint) Host() string { return "0.0.0.0" }
 
 // Name returns "unknown" when an endpoint doesn't exist
-func (d *DefaultEndpoint) Name() string { return DefaultServiceName }
+func (d *defaultEndpoint) Name() string { return DefaultServiceName }
 
 // MicroToTime converts zipkin's native time of microseconds into time.Time
 func MicroToTime(micro int64) time.Time {
@@ -206,5 +206,5 @@ func serviceEndpoint(ann []Annotation, bann []BinaryAnnotation) Endpoint {
 			return a.Host()
 		}
 	}
-	return &DefaultEndpoint{}
+	return &defaultEndpoint{}
 }

--- a/plugins/inputs/zipkin/codec/codec_test.go
+++ b/plugins/inputs/zipkin/codec/codec_test.go
@@ -323,7 +323,7 @@ func Test_serviceEndpoint(t *testing.T) {
 					Val: "noop",
 				},
 			},
-			want: &DefaultEndpoint{},
+			want: &defaultEndpoint{},
 		},
 		{
 			name: "Binary annotation with local component",

--- a/plugins/outputs/influxdb/http.go
+++ b/plugins/outputs/influxdb/http.go
@@ -60,28 +60,28 @@ type DatabaseNotFoundError struct {
 	Database string
 }
 
-// QueryResponseError is the response body from the /query endpoint
-type QueryResponseError struct {
-	Results []QueryResult `json:"results"`
+// queryResponseError is the response body from the /query endpoint
+type queryResponseError struct {
+	Results []queryResult `json:"results"`
 }
 
-type QueryResult struct {
+type queryResult struct {
 	Err string `json:"error,omitempty"`
 }
 
-func (r QueryResponseError) Error() string {
+func (r queryResponseError) Error() string {
 	if len(r.Results) > 0 {
 		return r.Results[0].Err
 	}
 	return ""
 }
 
-// WriteResponseError is the response body from the /write endpoint
-type WriteResponseError struct {
+// writeResponseError is the response body from the /write endpoint
+type writeResponseError struct {
 	Err string `json:"error,omitempty"`
 }
 
-func (r WriteResponseError) Error() string {
+func (r writeResponseError) Error() string {
 	return r.Err
 }
 
@@ -241,7 +241,7 @@ func (c *httpClient) CreateDatabase(ctx context.Context, database string) error 
 		}
 	}
 
-	queryResp := &QueryResponseError{}
+	queryResp := &queryResponseError{}
 	dec := json.NewDecoder(body)
 	err = dec.Decode(queryResp)
 
@@ -374,7 +374,7 @@ func (c *httpClient) writeBatch(ctx context.Context, db, rp string, metrics []te
 		}
 	}
 
-	writeResp := &WriteResponseError{}
+	writeResp := &writeResponseError{}
 	dec := json.NewDecoder(body)
 
 	var desc string

--- a/plugins/outputs/prometheus_client/v1/collector.go
+++ b/plugins/outputs/prometheus_client/v1/collector.go
@@ -100,7 +100,7 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 	defer c.Unlock()
 
 	for name, family := range c.fam {
-		// Get list of all labels on MetricFamily
+		// Get list of all labels on metricFamily
 		var labelNames []string
 		for k, v := range family.LabelSet {
 			if v > 0 {

--- a/plugins/outputs/sensu/sensu_test.go
+++ b/plugins/outputs/sensu/sensu_test.go
@@ -49,7 +49,7 @@ func TestResolveEventEndpointUrl(t *testing.T) {
 			plugin: &Sensu{
 				AgentAPIURL:   &agentAPIURL,
 				BackendAPIURL: &backendAPIURL,
-				Entity: &SensuEntity{
+				Entity: &sensuEntity{
 					Namespace: &entityNamespace,
 				},
 				Log: testutil.Logger{},
@@ -95,14 +95,14 @@ func TestConnectAndWrite(t *testing.T) {
 		AgentAPIURL:   nil,
 		BackendAPIURL: &testURL,
 		APIKey:        &testAPIKey,
-		Check: &SensuCheck{
+		Check: &sensuCheck{
 			Name: &testCheck,
 		},
-		Entity: &SensuEntity{
+		Entity: &sensuEntity{
 			Name:      &testEntity,
 			Namespace: &testNamespace,
 		},
-		Metrics: &SensuMetrics{
+		Metrics: &sensuMetrics{
 			Handlers: []string{testHandler},
 		},
 		Tags: map[string]string{testTagName: testTagValue},

--- a/plugins/parsers/wavefront/parser.go
+++ b/plugins/parsers/wavefront/parser.go
@@ -39,18 +39,18 @@ type PointParser struct {
 	}
 	scanBuf  bytes.Buffer // buffer reused for scanning tokens
 	writeBuf bytes.Buffer // buffer reused for parsing elements
-	Elements []ElementParser
+	Elements []elementParser
 	parent   *Parser
 }
 
-// NewWavefrontElements returns a slice of ElementParser's for the Graphite format
-func NewWavefrontElements() []ElementParser {
-	var elements []ElementParser
-	wsParser := WhiteSpaceParser{}
-	wsParserNextOpt := WhiteSpaceParser{nextOptional: true}
-	repeatParser := LoopedParser{wrappedParser: &TagParser{}, wsParser: &wsParser}
-	elements = append(elements, &NameParser{}, &wsParser, &ValueParser{}, &wsParserNextOpt,
-		&TimestampParser{optional: true}, &wsParserNextOpt, &repeatParser)
+// NewWavefrontElements returns a slice of elementParser's for the Graphite format
+func NewWavefrontElements() []elementParser {
+	var elements []elementParser
+	wsParser := whiteSpaceParser{}
+	wsParserNextOpt := whiteSpaceParser{nextOptional: true}
+	repeatParser := loopedParser{wrappedParser: &tagParser{}, wsParser: &wsParser}
+	elements = append(elements, &nameParser{}, &wsParser, &valueParser{}, &wsParserNextOpt,
+		&timestampParser{optional: true}, &wsParserNextOpt, &repeatParser)
 	return elements
 }
 

--- a/plugins/serializers/prometheus/collection.go
+++ b/plugins/serializers/prometheus/collection.go
@@ -17,46 +17,46 @@ const helpString = "Telegraf collected metric"
 
 type TimeFunc func() time.Time
 
-type MetricFamily struct {
+type metricFamily struct {
 	Name string
 	Type telegraf.ValueType
 }
 
 type Metric struct {
-	Labels    []LabelPair
+	Labels    []labelPair
 	Time      time.Time
 	AddTime   time.Time
-	Scaler    *Scaler
-	Histogram *Histogram
-	Summary   *Summary
+	Scaler    *scaler
+	Histogram *histogram
+	Summary   *summary
 }
 
-type LabelPair struct {
+type labelPair struct {
 	Name  string
 	Value string
 }
 
-type Scaler struct {
+type scaler struct {
 	Value float64
 }
 
-type Bucket struct {
+type bucket struct {
 	Bound float64
 	Count uint64
 }
 
-type Quantile struct {
+type quantile struct {
 	Quantile float64
 	Value    float64
 }
 
-type Histogram struct {
-	Buckets []Bucket
+type histogram struct {
+	Buckets []bucket
 	Count   uint64
 	Sum     float64
 }
 
-func (h *Histogram) merge(b Bucket) {
+func (h *histogram) merge(b bucket) {
 	for i := range h.Buckets {
 		if h.Buckets[i].Bound == b.Bound {
 			h.Buckets[i].Count = b.Count
@@ -66,13 +66,13 @@ func (h *Histogram) merge(b Bucket) {
 	h.Buckets = append(h.Buckets, b)
 }
 
-type Summary struct {
-	Quantiles []Quantile
+type summary struct {
+	Quantiles []quantile
 	Count     uint64
 	Sum       float64
 }
 
-func (s *Summary) merge(q Quantile) {
+func (s *summary) merge(q quantile) {
 	for i := range s.Quantiles {
 		if s.Quantiles[i].Quantile == q.Quantile {
 			s.Quantiles[i].Value = q.Value
@@ -82,9 +82,9 @@ func (s *Summary) merge(q Quantile) {
 	s.Quantiles = append(s.Quantiles, q)
 }
 
-type MetricKey uint64
+type metricKey uint64
 
-func MakeMetricKey(labels []LabelPair) MetricKey {
+func makeMetricKey(labels []labelPair) metricKey {
 	h := fnv.New64a()
 	for _, label := range labels {
 		h.Write([]byte(label.Name))
@@ -92,28 +92,28 @@ func MakeMetricKey(labels []LabelPair) MetricKey {
 		h.Write([]byte(label.Value))
 		h.Write([]byte("\x00"))
 	}
-	return MetricKey(h.Sum64())
+	return metricKey(h.Sum64())
 }
 
-type Entry struct {
-	Family  MetricFamily
-	Metrics map[MetricKey]*Metric
+type entry struct {
+	Family  metricFamily
+	Metrics map[metricKey]*Metric
 }
 
 type Collection struct {
-	Entries map[MetricFamily]Entry
+	Entries map[metricFamily]entry
 	config  FormatConfig
 }
 
 func NewCollection(config FormatConfig) *Collection {
 	cache := &Collection{
-		Entries: make(map[MetricFamily]Entry),
+		Entries: make(map[metricFamily]entry),
 		config:  config,
 	}
 	return cache
 }
 
-func hasLabel(name string, labels []LabelPair) bool {
+func hasLabel(name string, labels []labelPair) bool {
 	for _, label := range labels {
 		if name == label.Name {
 			return true
@@ -122,8 +122,8 @@ func hasLabel(name string, labels []LabelPair) bool {
 	return false
 }
 
-func (c *Collection) createLabels(metric telegraf.Metric) []LabelPair {
-	labels := make([]LabelPair, 0, len(metric.TagList()))
+func (c *Collection) createLabels(metric telegraf.Metric) []labelPair {
+	labels := make([]labelPair, 0, len(metric.TagList()))
 	for _, tag := range metric.TagList() {
 		// Ignore special tags for histogram and summary types.
 		switch metric.Type() {
@@ -142,7 +142,7 @@ func (c *Collection) createLabels(metric telegraf.Metric) []LabelPair {
 			continue
 		}
 
-		labels = append(labels, LabelPair{Name: name, Value: tag.Value})
+		labels = append(labels, labelPair{Name: name, Value: tag.Value})
 	}
 
 	if !c.config.StringAsLabel {
@@ -167,7 +167,7 @@ func (c *Collection) createLabels(metric telegraf.Metric) []LabelPair {
 			continue
 		}
 
-		labels = append(labels, LabelPair{Name: name, Value: value})
+		labels = append(labels, labelPair{Name: name, Value: value})
 		addedFieldLabel = true
 	}
 
@@ -190,23 +190,23 @@ func (c *Collection) Add(metric telegraf.Metric, now time.Time) {
 		}
 		metricType := c.config.TypeMappings.DetermineType(metricName, metric)
 
-		family := MetricFamily{
+		family := metricFamily{
 			Name: metricName,
 			Type: metricType,
 		}
 
-		entry, ok := c.Entries[family]
+		singleEntry, ok := c.Entries[family]
 		if !ok {
-			entry = Entry{
+			singleEntry = entry{
 				Family:  family,
-				Metrics: make(map[MetricKey]*Metric),
+				Metrics: make(map[metricKey]*Metric),
 			}
-			c.Entries[family] = entry
+			c.Entries[family] = singleEntry
 		}
 
-		metricKey := MakeMetricKey(labels)
+		metricKey := makeMetricKey(labels)
 
-		m, ok := entry.Metrics[metricKey]
+		m, ok := singleEntry.Metrics[metricKey]
 		if ok {
 			// A batch of metrics can contain multiple values for a single
 			// Prometheus sample.  If this metric is older than the existing
@@ -231,17 +231,17 @@ func (c *Collection) Add(metric telegraf.Metric, now time.Time) {
 				Labels:  labels,
 				Time:    metric.Time(),
 				AddTime: now,
-				Scaler:  &Scaler{Value: value},
+				Scaler:  &scaler{Value: value},
 			}
 
-			entry.Metrics[metricKey] = m
+			singleEntry.Metrics[metricKey] = m
 		case telegraf.Histogram:
 			if m == nil {
 				m = &Metric{
 					Labels:    labels,
 					Time:      metric.Time(),
 					AddTime:   now,
-					Histogram: &Histogram{},
+					Histogram: &histogram{},
 				}
 			} else {
 				m.Time = metric.Time()
@@ -263,7 +263,7 @@ func (c *Collection) Add(metric telegraf.Metric, now time.Time) {
 					continue
 				}
 
-				m.Histogram.merge(Bucket{
+				m.Histogram.merge(bucket{
 					Bound: bound,
 					Count: count,
 				})
@@ -285,14 +285,14 @@ func (c *Collection) Add(metric telegraf.Metric, now time.Time) {
 				continue
 			}
 
-			entry.Metrics[metricKey] = m
+			singleEntry.Metrics[metricKey] = m
 		case telegraf.Summary:
 			if m == nil {
 				m = &Metric{
 					Labels:  labels,
 					Time:    metric.Time(),
 					AddTime: now,
-					Summary: &Summary{},
+					Summary: &summary{},
 				}
 			} else {
 				m.Time = metric.Time()
@@ -318,7 +318,7 @@ func (c *Collection) Add(metric telegraf.Metric, now time.Time) {
 				if !ok {
 					continue
 				}
-				quantile, err := strconv.ParseFloat(quantileTag, 64)
+				singleQuantile, err := strconv.ParseFloat(quantileTag, 64)
 				if err != nil {
 					continue
 				}
@@ -328,13 +328,13 @@ func (c *Collection) Add(metric telegraf.Metric, now time.Time) {
 					continue
 				}
 
-				m.Summary.merge(Quantile{
-					Quantile: quantile,
+				m.Summary.merge(quantile{
+					Quantile: singleQuantile,
 					Value:    value,
 				})
 			}
 
-			entry.Metrics[metricKey] = m
+			singleEntry.Metrics[metricKey] = m
 		}
 	}
 }
@@ -353,8 +353,8 @@ func (c *Collection) Expire(now time.Time, age time.Duration) {
 	}
 }
 
-func (c *Collection) GetEntries() []Entry {
-	entries := make([]Entry, 0, len(c.Entries))
+func (c *Collection) GetEntries() []entry {
+	entries := make([]entry, 0, len(c.Entries))
 	for _, entry := range c.Entries {
 		entries = append(entries, entry)
 	}
@@ -373,7 +373,7 @@ func (c *Collection) GetEntries() []Entry {
 	return entries
 }
 
-func (c *Collection) GetMetrics(entry Entry) []*Metric {
+func (c *Collection) GetMetrics(entry entry) []*Metric {
 	metrics := make([]*Metric, 0, len(entry.Metrics))
 	for _, metric := range entry.Metrics {
 		metrics = append(metrics, metric)


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

Address following findings for [revive:max-public-structs](https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#max-public-structs) in `plugins/inputs/[t-z]*` and rest:
```
plugins/inputs/tomcat/tomcat.go:2:1                                    revive  max-public-structs: you have exceeded the maximum number of public struct declarations
plugins/inputs/webhooks/artifactory/artifactory_webhook_models.go:1:1  revive  max-public-structs: you have exceeded the maximum number of public struct declarations
plugins/inputs/webhooks/github/github_webhooks_models.go:1:1           revive  max-public-structs: you have exceeded the maximum number of public struct declarations
plugins/inputs/webhooks/rollbar/rollbar_webhooks_events.go:1:1         revive  max-public-structs: you have exceeded the maximum number of public struct declarations
plugins/inputs/win_eventlog/event.go:6:1                               revive  max-public-structs: you have exceeded the maximum number of public struct declarations
plugins/inputs/win_perf_counters/pdh_amd64.go:33:1                     revive  max-public-structs: you have exceeded the maximum number of public struct declarations
plugins/inputs/win_perf_counters/performance_query.go:4:1              revive  max-public-structs: you have exceeded the maximum number of public struct declarations
plugins/inputs/win_services/win_services.go:4:1                        revive  max-public-structs: you have exceeded the maximum number of public struct declarations
plugins/inputs/xtremio/xtremio_types.go:1:1                            revive  max-public-structs: you have exceeded the maximum number of public struct declarations
plugins/inputs/zipkin/codec/codec.go:1:1                               revive  max-public-structs: you have exceeded the maximum number of public struct declarations
plugins/outputs/influxdb/http.go:1:1                                   revive  max-public-structs: you have exceeded the maximum number of public struct declarations
plugins/outputs/sensu/sensu.go:2:1                                     revive  max-public-structs: you have exceeded the maximum number of public struct declarations
plugins/parsers/json_v2/parser.go:1:1                                  revive  max-public-structs: you have exceeded the maximum number of public struct declarations
plugins/parsers/wavefront/element.go:1:1                               revive  max-public-structs: you have exceeded the maximum number of public struct declarations
plugins/serializers/prometheus/collection.go:1:1                       revive  max-public-structs: you have exceeded the maximum number of public struct declarations
```

As proposed here https://github.com/influxdata/telegraf/issues/15822, we will fix the errors found by the following configuration:
```
      - name: max-public-structs
        exclude: ["TEST"]
        arguments: [5]

  # Excluding configuration per-path, per-linter, per-text and per-source
  exclude-rules:
    - path-except: ^plugins/(aggregators|inputs|outputs|parsers|processors|serializers)/...
      text: "max-public-structs: you have exceeded the maximum number of public struct declarations"
```

It is only part of the bigger job.
After all findings of this type in whole project are handled, we can enable `revive:max-public-structs` rule in `golangci-lint`.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR
