### PR TITLE
feat(outputs): Only copy metric if its not filtered out

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -873,10 +873,10 @@ func (a *Agent) runOutputs(
 
 	for metric := range unit.src {
 		for i, output := range unit.outputs {
-			if i == len(a.Config.Outputs)-1 {
-				output.AddMetric(metric)
+			if i == len(unit.outputs)-1 {
+				output.AddMetricNoCopy(metric)
 			} else {
-				output.AddMetric(metric.Copy())
+				output.AddMetric(metric)
 			}
 		}
 	}

--- a/models/running_output.go
+++ b/models/running_output.go
@@ -217,7 +217,7 @@ func (r *RunningOutput) AddMetric(metric telegraf.Metric) {
 		return
 	}
 
-	r.addMetric(metric.Copy())
+	r._addMetric(metric.Copy())
 }
 
 // AddMetricNoCopy adds a metric to the output.
@@ -231,10 +231,10 @@ func (r *RunningOutput) AddMetricNoCopy(metric telegraf.Metric) {
 		return
 	}
 
-	r.addMetric(metric)
+	r._addMetric(metric)
 }
 
-func (r *RunningOutput) addMetric(metric telegraf.Metric) {
+func (r *RunningOutput) _addMetric(metric telegraf.Metric) {
 	r.Config.Filter.Modify(metric)
 	if len(metric.FieldList()) == 0 {
 		r.metricFiltered(metric)

--- a/models/running_output.go
+++ b/models/running_output.go
@@ -207,8 +207,22 @@ func (r *RunningOutput) Close() {
 }
 
 // AddMetric adds a metric to the output.
-// Takes ownership of metric
+// The given metric will be copied if the output selects the metric.
 func (r *RunningOutput) AddMetric(metric telegraf.Metric) {
+	ok, err := r.Config.Filter.Select(metric)
+	if err != nil {
+		r.log.Errorf("filtering failed: %v", err)
+	} else if !ok {
+		r.MetricsFiltered.Incr(1)
+		return
+	}
+
+	r.addMetric(metric.Copy())
+}
+
+// AddMetricNoCopy adds a metric to the output.
+// Takes ownership of metric regardless of whether the output selects it for outputting.
+func (r *RunningOutput) AddMetricNoCopy(metric telegraf.Metric) {
 	ok, err := r.Config.Filter.Select(metric)
 	if err != nil {
 		r.log.Errorf("filtering failed: %v", err)
@@ -217,6 +231,10 @@ func (r *RunningOutput) AddMetric(metric telegraf.Metric) {
 		return
 	}
 
+	r.addMetric(metric)
+}
+
+func (r *RunningOutput) addMetric(metric telegraf.Metric) {
 	r.Config.Filter.Modify(metric)
 	if len(metric.FieldList()) == 0 {
 		r.metricFiltered(metric)

--- a/models/running_output.go
+++ b/models/running_output.go
@@ -217,7 +217,7 @@ func (r *RunningOutput) AddMetric(metric telegraf.Metric) {
 		return
 	}
 
-	r._addMetric(metric.Copy())
+	r.add(metric.Copy())
 }
 
 // AddMetricNoCopy adds a metric to the output.
@@ -231,10 +231,10 @@ func (r *RunningOutput) AddMetricNoCopy(metric telegraf.Metric) {
 		return
 	}
 
-	r._addMetric(metric)
+	r.add(metric)
 }
 
-func (r *RunningOutput) _addMetric(metric telegraf.Metric) {
+func (r *RunningOutput) add(metric telegraf.Metric) {
 	r.Config.Filter.Modify(metric)
 	if len(metric.FieldList()) == 0 {
 		r.metricFiltered(metric)

--- a/plugins/inputs/cloud_pubsub_push/cloud_pubsub_push_test.go
+++ b/plugins/inputs/cloud_pubsub_push/cloud_pubsub_push_test.go
@@ -196,6 +196,7 @@ func TestServeHTTP(t *testing.T) {
 			for m := range d {
 				ro.AddMetric(m)
 				ro.Write() //nolint:errcheck // test will fail anyway if the write fails
+				m.Accept()
 			}
 		}(dst)
 


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
This PR makes sure that an output plugin will really select a metric for outputting, before copying it. This improvement had a big impact on runtime/gc time in real world performance. After this change the amount of gc time went down from 55% of the CPU time to 25%. 

In our real world case every output plugin was only interested in a subset of the metric and there was no overlap between the subsets. This means that (x-1)/x% of all the copied metrics were immediately discarded, where x is the number of outputs.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #15882
