### PR TITLE
test(testutil): Fix value comparison

### DIFF
--- a/testutil/metric.go
+++ b/testutil/metric.go
@@ -61,7 +61,7 @@ func lessFunc(lhs, rhs *metricDiff) bool {
 
 		if lhs.Fields[i].Value != rhs.Fields[i].Value {
 			ltype := reflect.TypeOf(lhs.Fields[i].Value)
-			rtype := reflect.TypeOf(lhs.Fields[i].Value)
+			rtype := reflect.TypeOf(rhs.Fields[i].Value)
 
 			if ltype.Kind() != rtype.Kind() {
 				return ltype.Kind() < rtype.Kind()
@@ -69,13 +69,13 @@ func lessFunc(lhs, rhs *metricDiff) bool {
 
 			switch v := lhs.Fields[i].Value.(type) {
 			case int64:
-				return v < lhs.Fields[i].Value.(int64)
+				return v < rhs.Fields[i].Value.(int64)
 			case uint64:
-				return v < lhs.Fields[i].Value.(uint64)
+				return v < rhs.Fields[i].Value.(uint64)
 			case float64:
-				return v < lhs.Fields[i].Value.(float64)
+				return v < rhs.Fields[i].Value.(float64)
 			case string:
-				return v < lhs.Fields[i].Value.(string)
+				return v < rhs.Fields[i].Value.(string)
 			case bool:
 				return !v
 			default:


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
One of my tests failed, but it was because the comparison function for test cmp opts didn't work properly

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #15885
