### PR TITLE
chore(linters): Fix findings found by `testifylint`: `go-require` for`instrumental` and parsers/processors

### DIFF
--- a/plugins/parsers/influx/influx_upstream/parser_test.go
+++ b/plugins/parsers/influx/influx_upstream/parser_test.go
@@ -1006,9 +1006,11 @@ func TestStreamParserProducesAllAvailableMetrics(t *testing.T) {
 	parser := NewStreamParser(r)
 	parser.SetTimeFunc(DefaultTime)
 
+	ch := make(chan error)
 	go func() {
 		_, err := w.Write([]byte("metric value=1\nmetric2 value=1\n"))
-		require.NoError(t, err)
+		ch <- err
+		close(ch)
 	}()
 
 	_, err := parser.Next()
@@ -1016,6 +1018,9 @@ func TestStreamParserProducesAllAvailableMetrics(t *testing.T) {
 
 	// should not block on second read
 	_, err = parser.Next()
+	require.NoError(t, err)
+
+	err = <-ch
 	require.NoError(t, err)
 }
 

--- a/plugins/parsers/influx/parser_test.go
+++ b/plugins/parsers/influx/parser_test.go
@@ -973,9 +973,11 @@ func TestStreamParserProducesAllAvailableMetrics(t *testing.T) {
 	parser := NewStreamParser(r)
 	parser.SetTimeFunc(DefaultTime)
 
+	ch := make(chan error)
 	go func() {
 		_, err := w.Write([]byte("metric value=1\nmetric2 value=1\n"))
-		require.NoError(t, err)
+		ch <- err
+		close(ch)
 	}()
 
 	_, err := parser.Next()
@@ -983,6 +985,9 @@ func TestStreamParserProducesAllAvailableMetrics(t *testing.T) {
 
 	// should not block on second read
 	_, err = parser.Next()
+	require.NoError(t, err)
+
+	err = <-ch
 	require.NoError(t, err)
 }
 

--- a/plugins/processors/reverse_dns/rdnscache_test.go
+++ b/plugins/processors/reverse_dns/rdnscache_test.go
@@ -46,24 +46,23 @@ func TestParallelReverseDNSLookup(t *testing.T) {
 	defer d.Stop()
 
 	d.Resolver = &localResolver{}
-	var answer1 []string
-	var answer2 []string
+	var answer1, answer2 []string
+	var err1, err2 error
 	wg := &sync.WaitGroup{}
 	wg.Add(2)
 	go func() {
-		answer, err := d.Lookup("127.0.0.1")
-		require.NoError(t, err)
-		answer1 = answer
+		answer1, err1 = d.Lookup("127.0.0.1")
 		wg.Done()
 	}()
 	go func() {
-		answer, err := d.Lookup("127.0.0.1")
-		require.NoError(t, err)
-		answer2 = answer
+		answer2, err2 = d.Lookup("127.0.0.1")
 		wg.Done()
 	}()
 
 	wg.Wait()
+
+	require.NoError(t, err1)
+	require.NoError(t, err2)
 
 	t.Log(answer1)
 	t.Log(answer2)


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

This is only the first part of a larger effort to address the findings identified by `testifylint: go-require`: https://github.com/influxdata/telegraf/issues/15535
Once all the findings have been addressed, `testifylint: go-require` can be enabled in `.golangci.yml`.

In this PR, I’m focusing on parser/processors tests and `instrumental_test.go`. While fixing the parser/processors tests is quite straightforward, it seems that the approach to testing the simulation of the TCP Server's response in a separate goroutine requires discussion – because there are quite a few such tests in Telegraf’s test code, and it would be great to have a consistent approach in future PRs.

Here are the findings that this PR addresses:
```
plugins/outputs/instrumental/instrumental_test.go:92:3        testifylint  go-require: require must only be used in the goroutine running the test function
plugins/outputs/instrumental/instrumental_test.go:94:3        testifylint  go-require: require must only be used in the goroutine running the test function
plugins/outputs/instrumental/instrumental_test.go:99:3        testifylint  go-require: require must only be used in the goroutine running the test function
plugins/outputs/instrumental/instrumental_test.go:100:3       testifylint  go-require: require must only be used in the goroutine running the test function
plugins/outputs/instrumental/instrumental_test.go:102:3       testifylint  go-require: require must only be used in the goroutine running the test function
plugins/outputs/instrumental/instrumental_test.go:103:3       testifylint  go-require: require must only be used in the goroutine running the test function
plugins/outputs/instrumental/instrumental_test.go:105:3       testifylint  go-require: require must only be used in the goroutine running the test function
plugins/outputs/instrumental/instrumental_test.go:108:3       testifylint  go-require: require must only be used in the goroutine running the test function
plugins/outputs/instrumental/instrumental_test.go:109:3       testifylint  go-require: require must only be used in the goroutine running the test function
plugins/outputs/instrumental/instrumental_test.go:111:3       testifylint  go-require: require must only be used in the goroutine running the test function
plugins/outputs/instrumental/instrumental_test.go:112:3       testifylint  go-require: require must only be used in the goroutine running the test function
plugins/outputs/instrumental/instrumental_test.go:115:3       testifylint  go-require: require must only be used in the goroutine running the test function
plugins/outputs/instrumental/instrumental_test.go:117:3       testifylint  go-require: require must only be used in the goroutine running the test function
plugins/outputs/instrumental/instrumental_test.go:122:3       testifylint  go-require: require must only be used in the goroutine running the test function
plugins/outputs/instrumental/instrumental_test.go:123:3       testifylint  go-require: require must only be used in the goroutine running the test function
plugins/outputs/instrumental/instrumental_test.go:125:3       testifylint  go-require: require must only be used in the goroutine running the test function
plugins/outputs/instrumental/instrumental_test.go:126:3       testifylint  go-require: require must only be used in the goroutine running the test function
plugins/outputs/instrumental/instrumental_test.go:128:3       testifylint  go-require: require must only be used in the goroutine running the test function
plugins/outputs/instrumental/instrumental_test.go:131:3       testifylint  go-require: require must only be used in the goroutine running the test function
plugins/outputs/instrumental/instrumental_test.go:132:3       testifylint  go-require: require must only be used in the goroutine running the test function
plugins/outputs/instrumental/instrumental_test.go:135:3       testifylint  go-require: require must only be used in the goroutine running the test function
plugins/outputs/instrumental/instrumental_test.go:136:3       testifylint  go-require: require must only be used in the goroutine running the test function
plugins/outputs/instrumental/instrumental_test.go:139:3       testifylint  go-require: require must only be used in the goroutine running the test function
plugins/outputs/instrumental/instrumental_test.go:140:3       testifylint  go-require: require must only be used in the goroutine running the test function
plugins/outputs/instrumental/instrumental_test.go:143:3       testifylint  go-require: require must only be used in the goroutine running the test function
plugins/outputs/instrumental/instrumental_test.go:144:3       testifylint  go-require: require must only be used in the goroutine running the test function
plugins/outputs/instrumental/instrumental_test.go:147:3       testifylint  go-require: require must only be used in the goroutine running the test function
plugins/parsers/influx/influx_upstream/parser_test.go:1011:3  testifylint  go-require: require must only be used in the goroutine running the test function
plugins/parsers/influx/parser_test.go:978:3                   testifylint  go-require: require must only be used in the goroutine running the test function
plugins/processors/ifname/ifname_test.go:129:4                testifylint  go-require: require must only be used in the goroutine running the test function
plugins/processors/ifname/ifname_test.go:130:4                testifylint  go-require: require must only be used in the goroutine running the test function
plugins/processors/ifname/ifname_test.go:131:4                testifylint  go-require: require must only be used in the goroutine running the test function
plugins/processors/reverse_dns/rdnscache_test.go:55:3         testifylint  go-require: require must only be used in the goroutine running the test function
plugins/processors/reverse_dns/rdnscache_test.go:61:3         testifylint  go-require: require must only be used in the goroutine running the test function
```

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR