### PR TITLE
chore(deps): Bump github.com/harlow/kinesis-consumer from v0.3.6-0.20240606153816-553e2392fdf3 to v0.3.6-0.20240916192723-43900507c911

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/influxdata/telegraf
 
 go 1.23.0
 
-replace github.com/harlow/kinesis-consumer => github.com/mskonovalov/kinesis-consumer v0.3.6
-
 require (
 	cloud.google.com/go/bigquery v1.62.0
 	cloud.google.com/go/monitoring v1.20.2
@@ -111,7 +109,7 @@ require (
 	github.com/gosnmp/gosnmp v1.37.0
 	github.com/grid-x/modbus v0.0.0-20240503115206-582f2ab60a18
 	github.com/gwos/tcg/sdk v0.0.0-20231124052037-1e832b843240
-	github.com/harlow/kinesis-consumer v0.3.6-0.20240606153816-553e2392fdf3
+	github.com/harlow/kinesis-consumer v0.3.6-0.20240916192723-43900507c911
 	github.com/hashicorp/consul/api v1.29.2
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/golang-lru/v2 v2.0.7

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/influxdata/telegraf
 
 go 1.23.0
 
+replace github.com/harlow/kinesis-consumer => github.com/mskonovalov/kinesis-consumer v0.3.6
+
 require (
 	cloud.google.com/go/bigquery v1.62.0
 	cloud.google.com/go/monitoring v1.20.2

--- a/go.sum
+++ b/go.sum
@@ -1490,6 +1490,8 @@ github.com/gwos/tcg/sdk v0.0.0-20231124052037-1e832b843240 h1:dQUb3aqhbE1Z/QximD
 github.com/gwos/tcg/sdk v0.0.0-20231124052037-1e832b843240/go.mod h1:H3CAtDtRLVPIkShWzarGiKYVZqrBtWNJMMRtfqJ3rXI=
 github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed h1:5upAirOpQc1Q53c0bnx2ufif5kANL7bfZWcc6VJWJd8=
 github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed/go.mod h1:tMWxXQ9wFIaZeTI9F+hmhFiGpFmhOHzyShyFUhRm0H4=
+github.com/harlow/kinesis-consumer v0.3.6-0.20240916192723-43900507c911 h1:eLNkr0OcBl7pzM6DCLSgVp3VQyS5ZrLnanXPqH5EmE0=
+github.com/harlow/kinesis-consumer v0.3.6-0.20240916192723-43900507c911/go.mod h1:jTE9kH7IVx841D0GgxjykKieSP1yDSckuEg5ceSCjEU=
 github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBtguAZLlVdkD9Q=
 github.com/hashicorp/consul/api v1.29.2 h1:aYyRn8EdE2mSfG14S1+L9Qkjtz8RzmaWh6AcNGRNwPw=
 github.com/hashicorp/consul/api v1.29.2/go.mod h1:0YObcaLNDSbtlgzIRtmRXI1ZkeuK0trCBxwZQ4MYnIk=
@@ -1910,8 +1912,6 @@ github.com/montanaflynn/stats v0.7.1 h1:etflOAAHORrCC44V+aR6Ftzort912ZU+YLiSTuV8
 github.com/montanaflynn/stats v0.7.1/go.mod h1:etXPPgVO6n31NxCd9KQUMvCM+ve0ruNzt6R8Bnaayow=
 github.com/morikuni/aec v1.0.0 h1:nP9CBfwrvYnBRgY6qfDQkygYDmYwOilePFkwzv4dU8A=
 github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
-github.com/mskonovalov/kinesis-consumer v0.3.6 h1:yzjAGRX9DCwI0TJuoA4meU7OXF9O9Jr6vm/24tcH7BY=
-github.com/mskonovalov/kinesis-consumer v0.3.6/go.mod h1:jTE9kH7IVx841D0GgxjykKieSP1yDSckuEg5ceSCjEU=
 github.com/mtibben/percent v0.2.1 h1:5gssi8Nqo8QU/r2pynCm+hBQHpkB/uNK7BJCFogWdzs=
 github.com/mtibben/percent v0.2.1/go.mod h1:KG9uO+SZkUp+VkRHsCdYQV3XSZrrSpR3O9ibNBTZrns=
 github.com/muhlemmer/gu v0.3.1 h1:7EAqmFrW7n3hETvuAdmFmn4hS8W+z3LgKtrnow+YzNM=

--- a/go.sum
+++ b/go.sum
@@ -1490,8 +1490,6 @@ github.com/gwos/tcg/sdk v0.0.0-20231124052037-1e832b843240 h1:dQUb3aqhbE1Z/QximD
 github.com/gwos/tcg/sdk v0.0.0-20231124052037-1e832b843240/go.mod h1:H3CAtDtRLVPIkShWzarGiKYVZqrBtWNJMMRtfqJ3rXI=
 github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed h1:5upAirOpQc1Q53c0bnx2ufif5kANL7bfZWcc6VJWJd8=
 github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed/go.mod h1:tMWxXQ9wFIaZeTI9F+hmhFiGpFmhOHzyShyFUhRm0H4=
-github.com/harlow/kinesis-consumer v0.3.6-0.20240606153816-553e2392fdf3 h1:Yrtto57ANki/B58Q1YeFfLEn9XN/uB9EDFjLLDUA//c=
-github.com/harlow/kinesis-consumer v0.3.6-0.20240606153816-553e2392fdf3/go.mod h1:jTE9kH7IVx841D0GgxjykKieSP1yDSckuEg5ceSCjEU=
 github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBtguAZLlVdkD9Q=
 github.com/hashicorp/consul/api v1.29.2 h1:aYyRn8EdE2mSfG14S1+L9Qkjtz8RzmaWh6AcNGRNwPw=
 github.com/hashicorp/consul/api v1.29.2/go.mod h1:0YObcaLNDSbtlgzIRtmRXI1ZkeuK0trCBxwZQ4MYnIk=

--- a/go.sum
+++ b/go.sum
@@ -1912,6 +1912,8 @@ github.com/montanaflynn/stats v0.7.1 h1:etflOAAHORrCC44V+aR6Ftzort912ZU+YLiSTuV8
 github.com/montanaflynn/stats v0.7.1/go.mod h1:etXPPgVO6n31NxCd9KQUMvCM+ve0ruNzt6R8Bnaayow=
 github.com/morikuni/aec v1.0.0 h1:nP9CBfwrvYnBRgY6qfDQkygYDmYwOilePFkwzv4dU8A=
 github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
+github.com/mskonovalov/kinesis-consumer v0.3.6 h1:yzjAGRX9DCwI0TJuoA4meU7OXF9O9Jr6vm/24tcH7BY=
+github.com/mskonovalov/kinesis-consumer v0.3.6/go.mod h1:jTE9kH7IVx841D0GgxjykKieSP1yDSckuEg5ceSCjEU=
 github.com/mtibben/percent v0.2.1 h1:5gssi8Nqo8QU/r2pynCm+hBQHpkB/uNK7BJCFogWdzs=
 github.com/mtibben/percent v0.2.1/go.mod h1:KG9uO+SZkUp+VkRHsCdYQV3XSZrrSpR3O9ibNBTZrns=
 github.com/muhlemmer/gu v0.3.1 h1:7EAqmFrW7n3hETvuAdmFmn4hS8W+z3LgKtrnow+YzNM=


### PR DESCRIPTION
## Summary
OK, fixing this https://github.com/influxdata/telegraf/issues/13853
Specifically https://github.com/influxdata/telegraf/issues/13853#issuecomment-2269938413

There are a few issues:
1) the library [kinesis-consumer](https://github.com/harlow/kinesis-consumer) seem to be abandoned :(
2) recently (and it coincided with the switch to AWS SDK v2) 2 bugs were introduced into the library: https://github.com/harlow/kinesis-consumer/issues/158 and https://github.com/harlow/kinesis-consumer/issues/152
Here are the PRs https://github.com/harlow/kinesis-consumer/pull/159 (from Jun 12 2024, not reviewed, not accepted) and https://github.com/harlow/kinesis-consumer/pull/161 (from 16 Sept 2024)

Solution:
Unfortunately, I don't know how to handle the case with unmaintained library.
For now I made a personal fork, created a tag with 2 bug fixes and switched Telegraf to use this fork.
Not sure if it is a good idea in the long term, I don't think I will be able to maintain the fork properly (and not sure if I have an access to real Kinesis in the future, currently testing it against [localstack](https://www.localstack.cloud/))

There are no good alternatives to this library as far as I can tell.
Official AWS KClv2 is only in Java or Python https://docs.aws.amazon.com/streams/latest/dev/developing-consumers-with-kcl-v2.html
One potentially good option could be KCL lib from VMWare:
they had a first version https://github.com/vmware/vmware-go-kcl but only for AWS SDK v1.
Then they created a new one for AWS SDK v2 https://github.com/vmware/vmware-go-kcl-v2
but it only supports go 1.21 and last commit 6 months ago :( also no activity on PRs for a while.

So please let me know what is the preferred way forward



## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves https://github.com/influxdata/telegraf/issues/13853

