### PR TITLE
fix(common.http): Keep timeout after creating oauth client

### DIFF
--- a/plugins/common/http/config.go
+++ b/plugins/common/http/config.go
@@ -54,16 +54,12 @@ func (h *HTTPClientConfig) CreateClient(ctx context.Context, log telegraf.Logger
 	// Register "http+unix" and "https+unix" protocol handler.
 	unixtransport.Register(transport)
 
-	timeout := h.Timeout
-	if timeout == 0 {
-		timeout = config.Duration(time.Second * 5)
-	}
-
 	client := &http.Client{
 		Transport: transport,
-		Timeout:   time.Duration(timeout),
 	}
 
+	// While CreateOauth2Client returns a http.Client keeping the Transport configuration,
+	// it does not keep other http.Client parameters (e.g. Timeout).
 	client = h.OAuth2Config.CreateOauth2Client(ctx, client)
 
 	if h.CookieAuthConfig.URL != "" {
@@ -71,6 +67,12 @@ func (h *HTTPClientConfig) CreateClient(ctx context.Context, log telegraf.Logger
 			return nil, err
 		}
 	}
+
+	timeout := h.Timeout
+	if timeout == 0 {
+		timeout = config.Duration(time.Second * 5)
+	}
+	client.Timeout = time.Duration(timeout)
 
 	return client, nil
 }


### PR DESCRIPTION
## Summary

The HTTP client created by httpconfig loses Timeout configuration when oauth is enabled. More information on issue #15899 

This is the fix with the least moving parts I could come up with.  
For the future it's probably advisable to have oauth config return a properly wrapped client instead of a new client; or having a mechanism to keep the configuration of the original client.

## Checklist
- [x] No AI generated code was used in this PR

## Related issues
resolves #15899
