### PR TITLE
fix(inputs.consul): Move config checking to Init method

### DIFF
--- a/plugins/inputs/consul/consul.go
+++ b/plugins/inputs/consul/consul.go
@@ -42,16 +42,6 @@ func (c *Consul) Init() error {
 		c.Log.Warnf("Use of deprecated configuration: 'metric_version = 1'; please update to 'metric_version = 2'")
 	}
 
-	newClient, err := c.createAPIClient()
-	if err != nil {
-		return err
-	}
-	c.client = newClient
-
-	return nil
-}
-
-func (c *Consul) createAPIClient() (*api.Client, error) {
 	config := api.DefaultConfig()
 
 	if c.Address != "" {
@@ -83,14 +73,15 @@ func (c *Consul) createAPIClient() (*api.Client, error) {
 
 	tlsCfg, err := c.ClientConfig.TLSConfig()
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	config.Transport = &http.Transport{
 		TLSClientConfig: tlsCfg,
 	}
 
-	return api.NewClient(config)
+	c.client, err = api.NewClient(config)
+	return err
 }
 
 func (c *Consul) GatherHealthCheck(acc telegraf.Accumulator, checks []*api.HealthCheck) {

--- a/plugins/inputs/consul/consul.go
+++ b/plugins/inputs/consul/consul.go
@@ -42,6 +42,12 @@ func (c *Consul) Init() error {
 		c.Log.Warnf("Use of deprecated configuration: 'metric_version = 1'; please update to 'metric_version = 2'")
 	}
 
+	newClient, err := c.createAPIClient()
+	if err != nil {
+		return err
+	}
+	c.client = newClient
+
 	return nil
 }
 
@@ -129,16 +135,6 @@ func (c *Consul) GatherHealthCheck(acc telegraf.Accumulator, checks []*api.Healt
 }
 
 func (c *Consul) Gather(acc telegraf.Accumulator) error {
-	if c.client == nil {
-		newClient, err := c.createAPIClient()
-
-		if err != nil {
-			return err
-		}
-
-		c.client = newClient
-	}
-
 	checks, _, err := c.client.Health().State("any", nil)
 
 	if err != nil {

--- a/plugins/inputs/consul/consul_test.go
+++ b/plugins/inputs/consul/consul_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/hashicorp/consul/api"
+	"github.com/stretchr/testify/require"
+
 	"github.com/influxdata/telegraf/testutil"
 )
 
@@ -43,6 +45,7 @@ func TestGatherHealthCheck(t *testing.T) {
 	var acc testutil.Accumulator
 
 	consul := &Consul{}
+	require.NoError(t, consul.Init())
 	consul.GatherHealthCheck(&acc, sampleChecks)
 
 	acc.AssertContainsTaggedFields(t, "consul_health_checks", expectedFields, expectedTags)
@@ -72,6 +75,7 @@ func TestGatherHealthCheckWithDelimitedTags(t *testing.T) {
 	consul := &Consul{
 		TagDelimiter: ":",
 	}
+	require.NoError(t, consul.Init())
 	consul.GatherHealthCheck(&acc, sampleChecks)
 
 	acc.AssertContainsTaggedFields(t, "consul_health_checks", expectedFields, expectedTags)
@@ -101,6 +105,7 @@ func TestGatherHealthCheckV2(t *testing.T) {
 	consul := &Consul{
 		MetricVersion: 2,
 	}
+	require.NoError(t, consul.Init())
 	consul.GatherHealthCheck(&acc, sampleChecks)
 
 	acc.AssertContainsTaggedFields(t, "consul_health_checks", expectedFields, expectedTags)
@@ -131,6 +136,7 @@ func TestGatherHealthCheckWithDelimitedTagsV2(t *testing.T) {
 		MetricVersion: 2,
 		TagDelimiter:  ":",
 	}
+	require.NoError(t, consul.Init())
 	consul.GatherHealthCheck(&acc, sampleChecks)
 
 	acc.AssertContainsTaggedFields(t, "consul_health_checks", expectedFields, expectedTags)

--- a/plugins/inputs/consul/consul_test.go
+++ b/plugins/inputs/consul/consul_test.go
@@ -4,8 +4,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/consul/api"
-	"github.com/stretchr/testify/require"
-
 	"github.com/influxdata/telegraf/testutil"
 )
 
@@ -45,7 +43,6 @@ func TestGatherHealthCheck(t *testing.T) {
 	var acc testutil.Accumulator
 
 	consul := &Consul{}
-	require.NoError(t, consul.Init())
 	consul.GatherHealthCheck(&acc, sampleChecks)
 
 	acc.AssertContainsTaggedFields(t, "consul_health_checks", expectedFields, expectedTags)
@@ -75,7 +72,6 @@ func TestGatherHealthCheckWithDelimitedTags(t *testing.T) {
 	consul := &Consul{
 		TagDelimiter: ":",
 	}
-	require.NoError(t, consul.Init())
 	consul.GatherHealthCheck(&acc, sampleChecks)
 
 	acc.AssertContainsTaggedFields(t, "consul_health_checks", expectedFields, expectedTags)
@@ -105,7 +101,6 @@ func TestGatherHealthCheckV2(t *testing.T) {
 	consul := &Consul{
 		MetricVersion: 2,
 	}
-	require.NoError(t, consul.Init())
 	consul.GatherHealthCheck(&acc, sampleChecks)
 
 	acc.AssertContainsTaggedFields(t, "consul_health_checks", expectedFields, expectedTags)
@@ -136,7 +131,6 @@ func TestGatherHealthCheckWithDelimitedTagsV2(t *testing.T) {
 		MetricVersion: 2,
 		TagDelimiter:  ":",
 	}
-	require.NoError(t, consul.Init())
 	consul.GatherHealthCheck(&acc, sampleChecks)
 
 	acc.AssertContainsTaggedFields(t, "consul_health_checks", expectedFields, expectedTags)


### PR DESCRIPTION
## Summary

In order to align all plugins, the config checking and initialisation should happen in Init.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

