### PR TITLE
feat(inputs.nvidia-smi): Add `probe_on_startup` option

### DIFF
--- a/plugins/inputs/nvidia_smi/README.md
+++ b/plugins/inputs/nvidia_smi/README.md
@@ -37,6 +37,12 @@ using the `startup_error_behavior` setting. Available values are:
 
   ## Optional: timeout for GPU polling
   # timeout = "5s"
+
+  ## Optional: Attempt to run nvidia-smi once on startup. If nvidia-smi returns a non-zero
+  ## exit code, the plugin will return an error. This is particularly useful
+  ## if used in conjunction with `startup_error_behavior` to allow the plugin to be 
+  ## disabled if nvidia-smi cannot run successfully.
+  # probe_on_startup = false
 ```
 
 ### Linux

--- a/plugins/inputs/nvidia_smi/nvidia_smi.go
+++ b/plugins/inputs/nvidia_smi/nvidia_smi.go
@@ -27,12 +27,14 @@ var sampleConfig string
 
 // NvidiaSMI holds the methods for this plugin
 type NvidiaSMI struct {
-	BinPath string          `toml:"bin_path"`
-	Timeout config.Duration `toml:"timeout"`
-	Log     telegraf.Logger `toml:"-"`
+	BinPath        string          `toml:"bin_path"`
+	Timeout        config.Duration `toml:"timeout"`
+	ProbeOnStartup bool            `toml:"probe_on_startup"`
+	Log            telegraf.Logger `toml:"-"`
 
-	ignorePlugin bool
-	once         sync.Once
+	ignorePlugin  bool
+	once          sync.Once
+	nvidiaSMIArgs []string
 }
 
 func (*NvidiaSMI) SampleConfig() string {
@@ -47,6 +49,11 @@ func (smi *NvidiaSMI) Start(telegraf.Accumulator) error {
 		}
 		smi.BinPath = binPath
 	}
+	if smi.ProbeOnStartup {
+		if _, err := internal.CombinedOutputTimeout(exec.Command(smi.BinPath, smi.nvidiaSMIArgs...), time.Duration(smi.Timeout)); err != nil {
+			return &internal.StartupError{Err: err}
+		}
+	}
 
 	return nil
 }
@@ -60,7 +67,7 @@ func (smi *NvidiaSMI) Gather(acc telegraf.Accumulator) error {
 	}
 
 	// Construct and execute metrics query
-	data, err := internal.CombinedOutputTimeout(exec.Command(smi.BinPath, "-q", "-x"), time.Duration(smi.Timeout))
+	data, err := internal.CombinedOutputTimeout(exec.Command(smi.BinPath, smi.nvidiaSMIArgs...), time.Duration(smi.Timeout))
 	if err != nil {
 		return fmt.Errorf("calling %q failed: %w", smi.BinPath, err)
 	}
@@ -119,8 +126,9 @@ func (smi *NvidiaSMI) parse(acc telegraf.Accumulator, data []byte) error {
 func init() {
 	inputs.Add("nvidia_smi", func() telegraf.Input {
 		return &NvidiaSMI{
-			BinPath: "/usr/bin/nvidia-smi",
-			Timeout: config.Duration(5 * time.Second),
+			BinPath:       "/usr/bin/nvidia-smi",
+			Timeout:       config.Duration(5 * time.Second),
+			nvidiaSMIArgs: []string{"-q", "-x"},
 		}
 	})
 }

--- a/plugins/inputs/nvidia_smi/nvidia_smi_test.go
+++ b/plugins/inputs/nvidia_smi/nvidia_smi_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
@@ -16,6 +17,16 @@ import (
 )
 
 func TestOnStartupError(t *testing.T) {
+	var binPath string
+	var nvidiaSMIArgs []string
+	if runtime.GOOS == "windows" {
+		binPath = `C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe`
+		nvidiaSMIArgs = []string{"-Command", "exit 1"}
+	} else {
+		binPath = "/bin/bash"
+		nvidiaSMIArgs = []string{"-c", "exit 1"}
+	}
+
 	tests := []struct {
 		ProbeOnStartup bool
 	}{
@@ -28,11 +39,11 @@ func TestOnStartupError(t *testing.T) {
 	}
 	for _, tt := range tests {
 		plugin := &NvidiaSMI{
-			BinPath:        "/bin/bash",
+			BinPath:        binPath,
 			ProbeOnStartup: tt.ProbeOnStartup,
 			Timeout:        config.Duration(time.Second),
 			Log:            &testutil.Logger{},
-			nvidiaSMIArgs:  []string{"-c", "exit 9"},
+			nvidiaSMIArgs:  nvidiaSMIArgs,
 		}
 		model := models.NewRunningInput(plugin, &models.InputConfig{
 			Name: "nvidia_smi",

--- a/plugins/inputs/nvidia_smi/sample.conf
+++ b/plugins/inputs/nvidia_smi/sample.conf
@@ -7,3 +7,9 @@
 
   ## Optional: timeout for GPU polling
   # timeout = "5s"
+
+  ## Optional: Attempt to run nvidia-smi once on startup. If nvidia-smi returns a non-zero
+  ## exit code, the plugin will return an error. This is particularly useful
+  ## if used in conjunction with `startup_error_behavior` to allow the plugin to be 
+  ## disabled if nvidia-smi cannot run successfully.
+  # probe_on_startup = false


### PR DESCRIPTION
## Summary
There are some cases where the nvidia-smi plugin might be found in PATH and executable, but upon running it might always return a non-zero exit code. For various reasons, in the environment I work in, this might be expected. It's thus disruptive for system logs to be polluted with infinite error messages. It's preferable in this situation to check if nvidia-smi returns a good result on plugin startup, and if not, allow the error to be bubbled up and handled according to `startup_error_behavior`.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #15915
