### PR TITLE
feat(inputs): Add option to choose the metric time source

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1488,7 +1488,7 @@ func (c *Config) buildInput(name string, tbl *ast.Table) (*models.InputConfig, e
 	cp.CollectionJitter, _ = c.getFieldDuration(tbl, "collection_jitter")
 	cp.CollectionOffset, _ = c.getFieldDuration(tbl, "collection_offset")
 	cp.StartupErrorBehavior = c.getFieldString(tbl, "startup_error_behavior")
-	cp.TimeSource = models.TimeSourceType(c.getFieldString(tbl, "time_source"))
+	cp.TimeSource = c.getFieldString(tbl, "time_source")
 
 	cp.MeasurementPrefix = c.getFieldString(tbl, "name_prefix")
 	cp.MeasurementSuffix = c.getFieldString(tbl, "name_suffix")

--- a/config/config.go
+++ b/config/config.go
@@ -1488,6 +1488,8 @@ func (c *Config) buildInput(name string, tbl *ast.Table) (*models.InputConfig, e
 	cp.CollectionJitter, _ = c.getFieldDuration(tbl, "collection_jitter")
 	cp.CollectionOffset, _ = c.getFieldDuration(tbl, "collection_offset")
 	cp.StartupErrorBehavior = c.getFieldString(tbl, "startup_error_behavior")
+	cp.TimeSource = models.TimeSourceType(c.getFieldString(tbl, "time_source"))
+
 	cp.MeasurementPrefix = c.getFieldString(tbl, "name_prefix")
 	cp.MeasurementSuffix = c.getFieldString(tbl, "name_suffix")
 	cp.NameOverride = c.getFieldString(tbl, "name_override")

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -396,6 +396,15 @@ Parameters that can be used with any input plugin:
 
   When this value is set on a service input, multiple events occurring at the
   same timestamp may be merged by the output database.
+- **time_source**:
+  Specifies what time any gathered metrics should be assigned. Possible values 
+  are:
+  - `metric` will not alter the metric (default)
+  - `collection_start` sets the timestamp to when collection started
+  - `collection_end` set the timestamp to when collection finished
+
+  `time_source` will NOT be used for service inputs. It is up to each individual
+  service input to set the timestamp.
 - **collection_jitter**:
   Overrides the `collection_jitter` setting of the [agent][Agent] for the
   plugin.  Collection jitter is used to jitter the collection by a random

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -397,7 +397,7 @@ Parameters that can be used with any input plugin:
   When this value is set on a service input, multiple events occurring at the
   same timestamp may be merged by the output database.
 - **time_source**:
-  Specifies what time any gathered metrics should be assigned. Possible values 
+  Specifies what time any gathered metrics should be assigned. Possible values
   are:
   - `metric` will not alter the metric (default)
   - `collection_start` sets the timestamp to when collection started

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -397,8 +397,7 @@ Parameters that can be used with any input plugin:
   When this value is set on a service input, multiple events occurring at the
   same timestamp may be merged by the output database.
 - **time_source**:
-  Specifies what time any gathered metrics should be assigned. Possible values
-  are:
+  Specifies the source of the timestamp on metrics. Possible values are:
   - `metric` will not alter the metric (default)
   - `collection_start` sets the timestamp to when collection started
   - `collection_end` set the timestamp to when collection finished

--- a/models/running_input.go
+++ b/models/running_input.go
@@ -117,14 +117,12 @@ func (r *RunningInput) Init() error {
 		return fmt.Errorf("invalid 'startup_error_behavior' setting %q", r.Config.StartupErrorBehavior)
 	}
 
-	if _, ok := r.Input.(telegraf.ServiceInput); !ok {
-		switch r.Config.TimeSource {
-		case "":
-			r.Config.TimeSource = "metric"
-		case "metric", "collection_start", "collection_end":
-		default:
-			return fmt.Errorf("invalid 'time_source' setting %q", r.Config.TimeSource)
-		}
+	switch r.Config.TimeSource {
+	case "":
+		r.Config.TimeSource = "metric"
+	case "metric", "collection_start", "collection_end":
+	default:
+		return fmt.Errorf("invalid 'time_source' setting %q", r.Config.TimeSource)
 	}
 
 	if p, ok := r.Input.(telegraf.Initializer); ok {
@@ -219,14 +217,12 @@ func (r *RunningInput) MakeMetric(metric telegraf.Metric) telegraf.Metric {
 		makemetric(metric, "", "", "", local, global)
 	}
 
-	if _, ok := r.Input.(telegraf.ServiceInput); !ok {
-		switch r.Config.TimeSource {
-		case "collection_start":
-			metric.SetTime(r.gatherStart)
-		case "collection_end":
-			metric.SetTime(r.gatherEnd)
-		default:
-		}
+	switch r.Config.TimeSource {
+	case "collection_start":
+		metric.SetTime(r.gatherStart)
+	case "collection_end":
+		metric.SetTime(r.gatherEnd)
+	default:
 	}
 
 	r.MetricsGathered.Incr(1)

--- a/models/running_input.go
+++ b/models/running_input.go
@@ -17,14 +17,6 @@ var (
 	GlobalGatherTimeouts  = selfstat.Register("agent", "gather_timeouts", map[string]string{})
 )
 
-type TimeSourceType string
-
-const (
-	TimeSourceMetric          TimeSourceType = "metric"
-	TimeSourceCollectionStart TimeSourceType = "collection_start"
-	TimeSourceCollectionEnd   TimeSourceType = "collection_end"
-)
-
 type RunningInput struct {
 	Input  telegraf.Input
 	Config *InputConfig
@@ -97,7 +89,7 @@ type InputConfig struct {
 	CollectionJitter     time.Duration
 	CollectionOffset     time.Duration
 	Precision            time.Duration
-	TimeSource           TimeSourceType
+	TimeSource           string
 	StartupErrorBehavior string
 	LogLevel             string
 
@@ -128,8 +120,8 @@ func (r *RunningInput) Init() error {
 	if _, ok := r.Input.(telegraf.ServiceInput); !ok {
 		switch r.Config.TimeSource {
 		case "":
-			r.Config.TimeSource = TimeSourceMetric
-		case TimeSourceMetric, TimeSourceCollectionStart, TimeSourceCollectionEnd:
+			r.Config.TimeSource = "metric"
+		case "metric", "collection_start", "collection_end":
 		default:
 			return fmt.Errorf("invalid 'time_source' setting %q", r.Config.TimeSource)
 		}
@@ -229,9 +221,9 @@ func (r *RunningInput) MakeMetric(metric telegraf.Metric) telegraf.Metric {
 
 	if _, ok := r.Input.(telegraf.ServiceInput); !ok {
 		switch r.Config.TimeSource {
-		case TimeSourceCollectionStart:
+		case "collection_start":
 			metric.SetTime(r.gatherStart)
-		case TimeSourceCollectionEnd:
+		case "collection_end":
 			metric.SetTime(r.gatherEnd)
 		default:
 		}

--- a/models/running_input.go
+++ b/models/running_input.go
@@ -125,12 +125,14 @@ func (r *RunningInput) Init() error {
 		return fmt.Errorf("invalid 'startup_error_behavior' setting %q", r.Config.StartupErrorBehavior)
 	}
 
-	switch r.Config.TimeSource {
-	case "":
-		r.Config.TimeSource = TimeSourceMetric
-	case TimeSourceMetric, TimeSourceCollectionStart, TimeSourceCollectionEnd:
-	default:
-		return fmt.Errorf("invalid 'time_source' setting %q", r.Config.TimeSource)
+	if _, ok := r.Input.(telegraf.ServiceInput); !ok {
+		switch r.Config.TimeSource {
+		case "":
+			r.Config.TimeSource = TimeSourceMetric
+		case TimeSourceMetric, TimeSourceCollectionStart, TimeSourceCollectionEnd:
+		default:
+			return fmt.Errorf("invalid 'time_source' setting %q", r.Config.TimeSource)
+		}
 	}
 
 	if p, ok := r.Input.(telegraf.Initializer); ok {

--- a/models/running_input_test.go
+++ b/models/running_input_test.go
@@ -435,7 +435,7 @@ func TestMakeMetricWithGatherMetricTimeSource(t *testing.T) {
 		Filter:                  Filter{},
 		AlwaysIncludeLocalTags:  false,
 		AlwaysIncludeGlobalTags: false,
-		TimeSource:              TimeSourceMetric,
+		TimeSource:              "metric",
 	})
 	start := time.Now()
 	ri.gatherStart = start
@@ -457,7 +457,7 @@ func TestMakeMetricWithGatherStartTimeSource(t *testing.T) {
 		Filter:                  Filter{},
 		AlwaysIncludeLocalTags:  false,
 		AlwaysIncludeGlobalTags: false,
-		TimeSource:              TimeSourceCollectionStart,
+		TimeSource:              "collection_start",
 	})
 	ri.gatherStart = start
 
@@ -474,7 +474,7 @@ func TestMakeMetricWithGatherEndTimeSource(t *testing.T) {
 	end := time.Now()
 	ri := NewRunningInput(&testInput{}, &InputConfig{
 		Name:       "TestRunningInput",
-		TimeSource: TimeSourceCollectionEnd,
+		TimeSource: "collection_end",
 	})
 	ri.gatherEnd = end
 

--- a/models/running_input_test.go
+++ b/models/running_input_test.go
@@ -428,6 +428,65 @@ func TestMakeMetricWithAlwaysKeepingPluginTagsEnabled(t *testing.T) {
 	require.Equal(t, expected, actual)
 }
 
+func TestMakeMetricWithGatherMetricTimeSource(t *testing.T) {
+	ri := NewRunningInput(&testInput{}, &InputConfig{
+		Name:                    "TestRunningInput",
+		Tags:                    make(map[string]string),
+		Filter:                  Filter{},
+		AlwaysIncludeLocalTags:  false,
+		AlwaysIncludeGlobalTags: false,
+		TimeSource:              TimeSourceMetric,
+	})
+	start := time.Now()
+	ri.gatherStart = start
+	ri.gatherEnd = start.Add(time.Second)
+
+	expected := testutil.MockMetrics()[0]
+
+	m := testutil.MockMetrics()[0]
+	actual := ri.MakeMetric(m)
+
+	require.Equal(t, expected, actual)
+}
+
+func TestMakeMetricWithGatherStartTimeSource(t *testing.T) {
+	start := time.Now()
+	ri := NewRunningInput(&testInput{}, &InputConfig{
+		Name:                    "TestRunningInput",
+		Tags:                    make(map[string]string),
+		Filter:                  Filter{},
+		AlwaysIncludeLocalTags:  false,
+		AlwaysIncludeGlobalTags: false,
+		TimeSource:              TimeSourceCollectionStart,
+	})
+	ri.gatherStart = start
+
+	expected := testutil.MockMetrics()[0]
+	expected.SetTime(start)
+
+	m := testutil.MockMetrics()[0]
+	actual := ri.MakeMetric(m)
+
+	require.Equal(t, expected, actual)
+}
+
+func TestMakeMetricWithGatherEndTimeSource(t *testing.T) {
+	end := time.Now()
+	ri := NewRunningInput(&testInput{}, &InputConfig{
+		Name:       "TestRunningInput",
+		TimeSource: TimeSourceCollectionEnd,
+	})
+	ri.gatherEnd = end
+
+	expected := testutil.MockMetrics()[0]
+	expected.SetTime(end)
+
+	m := testutil.MockMetrics()[0]
+	actual := ri.MakeMetric(m)
+
+	require.Equal(t, expected, actual)
+}
+
 type testInput struct{}
 
 func (t *testInput) Description() string                 { return "" }


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Adds the option to set the timestamp to when gathering started/ended

Discussed in #15891

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->
