### PR TITLE
fix(inputs.cisco_telemetry_mdt): Handle NXOS DME subtree telemetry format

### DIFF
--- a/plugins/inputs/cisco_telemetry_mdt/cisco_telemetry_mdt.go
+++ b/plugins/inputs/cisco_telemetry_mdt/cisco_telemetry_mdt.go
@@ -631,7 +631,7 @@ func (c *CiscoTelemetryMDT) parseClassAttributeField(grouper *metric.SeriesGroup
 			break
 		}
 	}
-    // Add attributes to grouper with consistent dn tag
+	// Add attributes to grouper with consistent dn tag
 	for _, subfield := range nxAttributes.Fields {
 		c.parseContentField(grouper, subfield, "", encodingPath, tags, timestamp)
 	}

--- a/plugins/inputs/cisco_telemetry_mdt/cisco_telemetry_mdt.go
+++ b/plugins/inputs/cisco_telemetry_mdt/cisco_telemetry_mdt.go
@@ -624,16 +624,18 @@ func (c *CiscoTelemetryMDT) parseClassAttributeField(grouper *metric.SeriesGroup
 	}
 	nxAttributes = field.Fields[0].Fields[0].Fields[0].Fields[0]
 
+	// Find dn tag among list of attributes
 	for _, subfield := range nxAttributes.Fields {
 		if subfield.Name == "dn" {
 			tags["dn"] = decodeTag(subfield)
 			break
 		}
 	}
-
+    // Add attributes to grouper with consistent dn tag
 	for _, subfield := range nxAttributes.Fields {
 		c.parseContentField(grouper, subfield, "", encodingPath, tags, timestamp)
 	}
+	// Delete dn tag to prevent it from being added to the next node's attributes
 	delete(tags, "dn")
 }
 

--- a/plugins/inputs/cisco_telemetry_mdt/cisco_telemetry_mdt.go
+++ b/plugins/inputs/cisco_telemetry_mdt/cisco_telemetry_mdt.go
@@ -627,10 +627,13 @@ func (c *CiscoTelemetryMDT) parseClassAttributeField(grouper *metric.SeriesGroup
 	for _, subfield := range nxAttributes.Fields {
 		if subfield.Name == "dn" {
 			tags["dn"] = decodeTag(subfield)
-		} else {
-			c.parseContentField(grouper, subfield, "", encodingPath, tags, timestamp)
 		}
 	}
+
+	for _, subfield := range nxAttributes.Fields {
+		c.parseContentField(grouper, subfield, "", encodingPath, tags, timestamp)
+	}
+	delete(tags, "dn")
 }
 
 func (c *CiscoTelemetryMDT) getMeasurementName(encodingPath string) string {

--- a/plugins/inputs/cisco_telemetry_mdt/cisco_telemetry_mdt.go
+++ b/plugins/inputs/cisco_telemetry_mdt/cisco_telemetry_mdt.go
@@ -627,6 +627,7 @@ func (c *CiscoTelemetryMDT) parseClassAttributeField(grouper *metric.SeriesGroup
 	for _, subfield := range nxAttributes.Fields {
 		if subfield.Name == "dn" {
 			tags["dn"] = decodeTag(subfield)
+			break
 		}
 	}
 

--- a/plugins/inputs/cisco_telemetry_mdt/cisco_telemetry_mdt_test.go
+++ b/plugins/inputs/cisco_telemetry_mdt/cisco_telemetry_mdt_test.go
@@ -868,12 +868,16 @@ func TestHandleNXDMESubtree(t *testing.T) {
 																			{
 																				Fields: []*telemetryBis.TelemetryField{
 																					{
-																						Name:        "foo",
-																						ValueByType: &telemetryBis.TelemetryField_StringValue{StringValue: "bar1"},
+																						Name: "foo",
+																						ValueByType: &telemetryBis.TelemetryField_StringValue{
+																							StringValue: "bar1",
+																						},
 																					},
 																					{
-																						Name:        "dn",
-																						ValueByType: &telemetryBis.TelemetryField_StringValue{StringValue: "eth1/1"},
+																						Name: "dn",
+																						ValueByType: &telemetryBis.TelemetryField_StringValue{
+																							StringValue: "eth1/1",
+																						},
 																					},
 																				},
 																			},
@@ -898,12 +902,16 @@ func TestHandleNXDMESubtree(t *testing.T) {
 																			{
 																				Fields: []*telemetryBis.TelemetryField{
 																					{
-																						Name:        "foo",
-																						ValueByType: &telemetryBis.TelemetryField_StringValue{StringValue: "bar2"},
+																						Name: "foo",
+																						ValueByType: &telemetryBis.TelemetryField_StringValue{
+																							StringValue: "bar2",
+																						},
 																					},
 																					{
-																						Name:        "dn",
-																						ValueByType: &telemetryBis.TelemetryField_StringValue{StringValue: "eth1/2"},
+																						Name: "dn",
+																						ValueByType: &telemetryBis.TelemetryField_StringValue{
+																							StringValue: "eth1/2",
+																						},
 																					},
 																				},
 																			},
@@ -930,7 +938,7 @@ func TestHandleNXDMESubtree(t *testing.T) {
 	c.handleTelemetry(data)
 	require.Empty(t, acc.Errors)
 
-	require.Equal(t, 2, len(acc.Metrics))
+	require.Len(t, acc.Metrics, 2)
 
 	tags1 := map[string]string{
 		"dn":           "eth1/1",


### PR DESCRIPTION
## Summary
Fixes the alignment of `dn` tags with their corresponding fields for telemetry paths on NXOS where `query-target=subtree`. 

## Checklist
- [x] No AI generated code was used in this PR

## Related issues
resolves https://github.com/influxdata/telegraf/issues/15922
