### PR TITLE
fix(config): Correctly print removal version info

### DIFF
--- a/config/deprecation.go
+++ b/config/deprecation.go
@@ -366,7 +366,7 @@ func PrintOptionDeprecationNotice(plugin, option string, info telegraf.Deprecati
 		prefix := deprecationPrefix(di.logLevel)
 		log.Printf(
 			"%s: Option %q of plugin %q deprecated since version %s and will be removed in %s: %s",
-			prefix, option, plugin, info.Since, info.RemovalIn, info.Notice,
+			prefix, option, plugin, di.info.Since, di.info.RemovalIn, di.info.Notice,
 		)
 	}
 }
@@ -387,7 +387,7 @@ func PrintOptionValueDeprecationNotice(plugin, option string, value interface{},
 		prefix := deprecationPrefix(di.logLevel)
 		log.Printf(
 			`%s: Value "%+v" for option %q of plugin %q deprecated since version %s and will be removed in %s: %s`,
-			prefix, value, option, plugin, info.Since, info.RemovalIn, info.Notice,
+			prefix, value, option, plugin, di.info.Since, di.info.RemovalIn, di.info.Notice,
 		)
 	}
 }

--- a/config/deprecation_test.go
+++ b/config/deprecation_test.go
@@ -107,6 +107,12 @@ func TestPluginOptionDeprecation(t *testing.T) {
 			expected:      `Option "option" of plugin "test" deprecated since version 1.23.0 and will be removed in 2.0.0: please check`,
 		},
 		{
+			name:          "No removal info",
+			since:         "1.23.0",
+			expectedLevel: telegraf.Warn,
+			expected:      `Option "option" of plugin "test" deprecated since version 1.23.0 and will be removed in 2.0.0: please check`,
+		},
+		{
 			name:          "None",
 			expectedLevel: telegraf.None,
 			expected:      ``,
@@ -186,6 +192,13 @@ func TestPluginOptionValueDeprecation(t *testing.T) {
 			name:          "Warn level",
 			since:         "1.25.0",
 			removal:       "2.0.0",
+			value:         "foobar",
+			expected:      `Value "foobar" for option "option" of plugin "test" deprecated since version 1.25.0 and will be removed in 2.0.0: please check`,
+			expectedLevel: telegraf.Warn,
+		},
+		{
+			name:          "No removal info",
+			since:         "1.25.0",
 			value:         "foobar",
 			expected:      `Value "foobar" for option "option" of plugin "test" deprecated since version 1.25.0 and will be removed in 2.0.0: please check`,
 			expectedLevel: telegraf.Warn,


### PR DESCRIPTION
## Summary

Some plugin options do not have a removal version set causing the log message being malformed.

### Before

> Option "option" of plugin "test" deprecated since version 1.23.0 and will be removed in : please check

### After

> Option "option" of plugin "test" deprecated since version 1.23.0 and will be removed in 2.0.0: please check

## Checklist

- [x] No AI generated code was used in this PR

