### PR TITLE
feat(outputs.mqtt): Add sprig functions for topic name generator

### DIFF
--- a/plugins/outputs/mqtt/topic_name_generator.go
+++ b/plugins/outputs/mqtt/topic_name_generator.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/Masterminds/sprig/v3"
 	"github.com/influxdata/telegraf"
 )
 
@@ -17,7 +18,7 @@ type TopicNameGenerator struct {
 }
 
 func NewTopicNameGenerator(topicPrefix, topic string) (*TopicNameGenerator, error) {
-	tt, err := template.New("topic_name").Parse(topic)
+	tt, err := template.New("topic_name").Funcs(sprig.TxtFuncMap()).Parse(topic)
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/outputs/mqtt/topic_name_generator.go
+++ b/plugins/outputs/mqtt/topic_name_generator.go
@@ -6,6 +6,7 @@ import (
 	"text/template"
 
 	"github.com/Masterminds/sprig/v3"
+
 	"github.com/influxdata/telegraf"
 )
 


### PR DESCRIPTION
## Summary
Simple minor improvement allow to use sprig functions inside topic name templates
