### PR TITLE
feat(inputs.diskio): Add field io await and util

### DIFF
--- a/plugins/inputs/diskio/README.md
+++ b/plugins/inputs/diskio/README.md
@@ -73,6 +73,9 @@ docker run --privileged -v /:/hostfs:ro -v /run/udev:/run/udev:ro -e HOST_PROC=/
     - iops_in_progress (integer, gauge)
     - merged_reads (integer, counter)
     - merged_writes (integer, counter)
+    - io_util (float64, gauge, percent)
+    - io_await (float64, gauge, milliseconds)
+    - io_svctm (float64, gauge, milliseconds)
 
 On linux these values correspond to the values in [`/proc/diskstats`][1] and
 [`/sys/block/<dev>/stat`][2].
@@ -123,6 +126,18 @@ efficiency.  Thus two 4K reads may become one 8K read before it is
 ultimately handed to the disk, and so it will be counted (and queued)
 as only one I/O. These fields lets you know how often this was done.
 
+### `io_await`
+
+The average time per I/O operation (ms)
+
+### `io_svctm`
+
+The service time per I/O operation, excluding wait time (ms)
+
+### `io_util`
+
+The percentage of time the disk (%)
+
 ## Sample Queries
 
 ### Calculate percent IO utilization per disk and host
@@ -146,4 +161,10 @@ SELECT non_negative_derivative(last("weighted_io_time"),1ms) from "diskio" WHERE
 diskio,name=sda1 merged_reads=0i,reads=2353i,writes=10i,write_bytes=2117632i,write_time=49i,io_time=1271i,weighted_io_time=1350i,read_bytes=31350272i,read_time=1303i,iops_in_progress=0i,merged_writes=0i 1578326400000000000
 diskio,name=centos/var_log reads=1063077i,writes=591025i,read_bytes=139325491712i,write_bytes=144233131520i,read_time=650221i,write_time=24368817i,io_time=852490i,weighted_io_time=25037394i,iops_in_progress=1i,merged_reads=0i,merged_writes=0i 1578326400000000000
 diskio,name=sda write_time=49i,io_time=1317i,weighted_io_time=1404i,reads=2495i,read_time=1357i,write_bytes=2117632i,iops_in_progress=0i,merged_reads=0i,merged_writes=0i,writes=10i,read_bytes=38956544i 1578326400000000000
+```
+
+```text
+diskio,name=sda io_await:0.3317307692307692,io_svctm:0.07692307692307693,io_util:0.5329780146568954 1578326400000000000
+diskio,name=sda1 io_await:0.3317307692307692,io_svctm:0.07692307692307693,io_util:0.5329780146568954 1578326400000000000
+diskio,name=sda2 io_await:0.3317307692307692,io_svctm:0.07692307692307693,io_util:0.5329780146568954 1578326400000000000
 ```

--- a/plugins/inputs/diskio/README.md
+++ b/plugins/inputs/diskio/README.md
@@ -136,7 +136,7 @@ The service time per I/O operation, excluding wait time (ms)
 
 ### `io_util`
 
-The percentage of time the disk (%)
+The percentage of time the disk was active (%)
 
 ## Sample Queries
 

--- a/plugins/inputs/diskio/diskio.go
+++ b/plugins/inputs/diskio/diskio.go
@@ -118,7 +118,7 @@ func (d *DiskIO) Gather(acc telegraf.Accumulator) error {
 			}
 		}
 
-		fieldsC := map[string]interface{}{
+		fields := map[string]interface{}{
 			"reads":            io.ReadCount,
 			"writes":           io.WriteCount,
 			"read_bytes":       io.ReadBytes,
@@ -127,27 +127,24 @@ func (d *DiskIO) Gather(acc telegraf.Accumulator) error {
 			"write_time":       io.WriteTime,
 			"io_time":          io.IoTime,
 			"weighted_io_time": io.WeightedIO,
+			"iops_in_progress": io.IopsInProgress,
 			"merged_reads":     io.MergedReadCount,
 			"merged_writes":    io.MergedWriteCount,
-		}
-		fieldsG := map[string]interface{}{
-			"iops_in_progress": io.IopsInProgress,
 		}
 		if lastValue, exists := d.lastIOCounterStat[k]; exists {
 			deltaRWCount := float64(io.ReadCount + io.WriteCount - lastValue.ReadCount - lastValue.WriteCount)
 			deltaRWTime := float64(io.ReadTime + io.WriteTime - lastValue.ReadTime - lastValue.WriteTime)
 			deltaIOTime := float64(io.IoTime - lastValue.IoTime)
 			if deltaRWCount > 0 {
-				fieldsG["io_await"] = deltaRWTime / deltaRWCount
-				fieldsG["io_svctm"] = deltaIOTime / deltaRWCount
+				fields["io_await"] = deltaRWTime / deltaRWCount
+				fields["io_svctm"] = deltaIOTime / deltaRWCount
 			}
 			itv := float64(collectTime.Sub(d.lastCollectTime).Milliseconds())
 			if itv > 0 {
-				fieldsG["io_util"] = 100 * deltaIOTime / itv
+				fields["io_util"] = 100 * deltaIOTime / itv
 			}
 		}
-		acc.AddGauge("diskio", fieldsG, tags)
-		acc.AddCounter("diskio", fieldsC, tags)
+		acc.AddCounter("diskio", fields, tags)
 	}
 	d.lastCollectTime = collectTime
 	d.lastIOCounterStat = diskio

--- a/plugins/inputs/diskio/diskio.go
+++ b/plugins/inputs/diskio/diskio.go
@@ -127,15 +127,16 @@ func (d *DiskIO) Gather(acc telegraf.Accumulator) error {
 			"write_time":       io.WriteTime,
 			"io_time":          io.IoTime,
 			"weighted_io_time": io.WeightedIO,
-			"iops_in_progress": io.IopsInProgress,
 			"merged_reads":     io.MergedReadCount,
 			"merged_writes":    io.MergedWriteCount,
+		}
+		fieldsG := map[string]interface{}{
+			"iops_in_progress": io.IopsInProgress,
 		}
 		if lastValue, exists := d.lastIOCounterStat[k]; exists {
 			deltaRWCount := float64(io.ReadCount + io.WriteCount - lastValue.ReadCount - lastValue.WriteCount)
 			deltaRWTime := float64(io.ReadTime + io.WriteTime - lastValue.ReadTime - lastValue.WriteTime)
 			deltaIOTime := float64(io.IoTime - lastValue.IoTime)
-			fieldsG := make(map[string]interface{})
 			if deltaRWCount > 0 {
 				fieldsG["io_await"] = deltaRWTime / deltaRWCount
 				fieldsG["io_svctm"] = deltaIOTime / deltaRWCount
@@ -144,10 +145,8 @@ func (d *DiskIO) Gather(acc telegraf.Accumulator) error {
 			if itv > 0 {
 				fieldsG["io_util"] = 100 * deltaIOTime / itv
 			}
-			if len(fieldsG) > 0 {
-				acc.AddGauge("diskio", fieldsG, tags)
-			}
 		}
+		acc.AddGauge("diskio", fieldsG, tags)
 		acc.AddCounter("diskio", fieldsC, tags)
 	}
 	d.lastCollectTime = collectTime

--- a/plugins/inputs/diskio/diskio_test.go
+++ b/plugins/inputs/diskio/diskio_test.go
@@ -129,7 +129,7 @@ func TestDiskIO(t *testing.T) {
 	}
 }
 
-func TestDiskIO_util(t *testing.T) {
+func TestDiskIOUtil(t *testing.T) {
 	cts := map[string]disk.IOCountersStat{
 		"sda": {
 			ReadCount:        888,
@@ -172,16 +172,15 @@ func TestDiskIO_util(t *testing.T) {
 	}
 	require.NoError(t, diskio.Init())
 	// gather
-	err := diskio.Gather(&acc)
-	require.NoError(t, err)
+	require.NoError(t, diskio.Gather(&acc))
 	// sleep
-	time.Sleep(10 * time.Second)
+	time.Sleep(1 * time.Second)
 	// gather twice
 	mps2 := system.MockPS{}
 	mps2.On("DiskIO").Return(cts2, nil)
 	diskio.ps = &mps2
 
-	err = diskio.Gather(&acc)
+	err := diskio.Gather(&acc)
 	require.NoError(t, err)
 	require.True(t, acc.HasField("diskio", "io_util"), "miss io util")
 	require.True(t, acc.HasField("diskio", "io_svctm"), "miss io_svctm")


### PR DESCRIPTION
## Summary
In practical scenarios, it may be necessary to check the values for disk I/O wait, I/O util, and I/O svctm. 
Therefore, I would like to add these three metrics.