### PR TITLE
fix(inputs.vsphere): Add tags to VSAN ESA disks

### DIFF
--- a/plugins/inputs/vsphere/vsan.go
+++ b/plugins/inputs/vsphere/vsan.go
@@ -163,6 +163,7 @@ func getCmmdsMap(ctx context.Context, client *vim25.Client, clusterObj *object.C
 	queries := []types.HostVsanInternalSystemCmmdsQuery{
 		{Type: "HOSTNAME"},
 		{Type: "DISK"},
+		{Type: "DISK_CAPACITY_TIER"},
 	}
 
 	// Some esx host can be down or in maintenance mode. Hence cmmds query might fail on such hosts.
@@ -440,8 +441,10 @@ func populateCMMDSTags(tags map[string]string, entityName, uuid string, cmmds ma
 				newTags["hostname"] = host.Content.Hostname
 			}
 			newTags["devicename"] = e.Content.DevName
-			if int(e.Content.IsSsd) == 0 {
-				newTags["ssduuid"] = e.Content.SsdUUID
+			if !(strings.Contains(entityName, "-esa-")) {
+				if int(e.Content.IsSsd) == 0 {
+					newTags["ssduuid"] = e.Content.SsdUUID
+				}
 			}
 		}
 	case strings.Contains(entityName, "host-memory-"):

--- a/plugins/inputs/vsphere/vsan.go
+++ b/plugins/inputs/vsphere/vsan.go
@@ -441,6 +441,7 @@ func populateCMMDSTags(tags map[string]string, entityName, uuid string, cmmds ma
 				newTags["hostname"] = host.Content.Hostname
 			}
 			newTags["devicename"] = e.Content.DevName
+			// Skip adding ssduuid tag for VSAN ESA disks as this property is not returned in the CMMDS data
 			if !(strings.Contains(entityName, "-esa-")) {
 				if int(e.Content.IsSsd) == 0 {
 					newTags["ssduuid"] = e.Content.SsdUUID

--- a/plugins/inputs/vsphere/vsphere_test.go
+++ b/plugins/inputs/vsphere/vsphere_test.go
@@ -440,13 +440,15 @@ func TestVsanTags(t *testing.T) {
 	host := "5b860329-3bc4-a76c-48b6-246e963cfcc0"
 	disk := "52ee3be1-47cc-b50d-ecab-01af0f706381"
 	ssdDisk := "52f26fc8-0b9b-56d8-3a32-a9c3bfbc6148"
+	nvmeDisk := "5291e74f-74d3-fca2-6ffa-3655657dd3be"
 	ssd := "52173131-3384-bb63-4ef8-c00b0ce7e3e7"
 	hostname := "sc2-hs1-b2801.eng.vmware.com"
 	devName := "naa.55cd2e414d82c815:2"
 	var cmmds = map[string]CmmdsEntity{
-		disk:    {UUID: disk, Type: "DISK", Owner: host, Content: CmmdsContent{DevName: devName, IsSsd: 1.}},
-		ssdDisk: {UUID: ssdDisk, Type: "DISK", Owner: host, Content: CmmdsContent{DevName: devName, IsSsd: 0., SsdUUID: ssd}},
-		host:    {UUID: host, Type: "HOSTNAME", Owner: host, Content: CmmdsContent{Hostname: hostname}},
+		nvmeDisk: {UUID: nvmeDisk, Type: "DISK_CAPACITY_TIER", Owner: host, Content: CmmdsContent{DevName: devName}},
+		disk:     {UUID: disk, Type: "DISK", Owner: host, Content: CmmdsContent{DevName: devName, IsSsd: 1.}},
+		ssdDisk:  {UUID: ssdDisk, Type: "DISK", Owner: host, Content: CmmdsContent{DevName: devName, IsSsd: 0., SsdUUID: ssd}},
+		host:     {UUID: host, Type: "HOSTNAME", Owner: host, Content: CmmdsContent{Hostname: hostname}},
 	}
 	tags := populateCMMDSTags(make(map[string]string), "capacity-disk", disk, cmmds)
 	require.Len(t, tags, 2)
@@ -454,6 +456,8 @@ func TestVsanTags(t *testing.T) {
 	require.Len(t, tags, 3)
 	tags = populateCMMDSTags(make(map[string]string), "host-domclient", host, cmmds)
 	require.Len(t, tags, 1)
+	tags = populateCMMDSTags(make(map[string]string), "vsan-esa-disk-layer", nvmeDisk, cmmds)
+	require.Len(t, tags, 2)
 }
 
 func TestCollectionNoClusterMetrics(t *testing.T) {


### PR DESCRIPTION
Some VSAN metrics e.g. "vsan-esa-disk-layer" and "vsan-esa-disk-scsifw" are missing "hostname" and "devicename" tags.

Fixes: https://github.com/influxdata/telegraf/issues/15938