### PR TITLE
test(common.socket): Increase margin for memleak test to avoid flaky tests

### DIFF
--- a/plugins/common/socket/socket_test.go
+++ b/plugins/common/socket/socket_test.go
@@ -823,7 +823,7 @@ func TestTLSMemLeak(t *testing.T) {
 	final, err := testCycle(2000)
 	require.NoError(t, err)
 
-	require.Less(t, final, 2*initial)
+	require.Less(t, final, 3*initial)
 }
 
 func createClient(endpoint string, addr net.Addr, tlsCfg *tls.Config) (net.Conn, error) {


### PR DESCRIPTION
## Summary

Avoid flaky mem-leak test for sockets.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues
