### PR TITLE
fix(processors.aws_ec2): Remove leading slash and cancel worker only if it exists

### DIFF
--- a/plugins/processors/aws_ec2/ec2.go
+++ b/plugins/processors/aws_ec2/ec2.go
@@ -163,7 +163,10 @@ func (r *AwsEc2Processor) Stop() {
 	if r.parallel != nil {
 		r.parallel.Stop()
 	}
-	r.cancelCleanupWorker()
+	if r.cancelCleanupWorker != nil {
+		r.cancelCleanupWorker()
+		r.cancelCleanupWorker = nil
+	}
 }
 
 func (r *AwsEc2Processor) logCacheStatistics(ctx context.Context) {
@@ -268,7 +271,7 @@ func (r *AwsEc2Processor) lookupMetadata(metric telegraf.Metric) telegraf.Metric
 			key = strings.ReplaceAll(key, "/", "_")
 		} else {
 			if idx := strings.LastIndex(key, "/"); idx > 0 {
-				key = key[idx:]
+				key = key[idx+1:]
 			}
 		}
 


### PR DESCRIPTION
## Summary

Currently, tags added by the AWS EC2 processor with "metadata" contain a leading slash. This PR fixes this issue and avoids a panic when running Telegraf with ` --test`.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #15906 
