### PR TITLE
fix(outputs.remotefile): Create a new serializer instance per output file

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1010,6 +1010,25 @@ func (c *Config) addParser(parentcategory, parentname string, table *ast.Table) 
 	return running, err
 }
 
+func (c *Config) probeSerializer(table *ast.Table) bool {
+	dataFormat := c.getFieldString(table, "data_format")
+	if dataFormat == "" {
+		dataFormat = "influx"
+	}
+
+	creator, ok := serializers.Serializers[dataFormat]
+	if !ok {
+		return false
+	}
+
+	// Try to parse the options to detect if any of them is misspelled
+	serializer := creator()
+	//nolint:errcheck // We don't actually use the parser, so no need to check the error.
+	c.toml.UnmarshalTable(table, serializer)
+
+	return true
+}
+
 func (c *Config) addSerializer(parentname string, table *ast.Table) (*models.RunningSerializer, error) {
 	conf := &models.SerializerConfig{
 		Parent: parentname,
@@ -1140,6 +1159,15 @@ func (c *Config) setupProcessor(name string, creator processors.StreamingCreator
 		t.SetSerializer(serializer)
 		optionTestCount++
 	}
+	if t, ok := processor.(telegraf.SerializerFuncPlugin); ok {
+		if !c.probeSerializer(table) {
+			return nil, 0, errors.New("serializer not found")
+		}
+		t.SetSerializerFunc(func() (telegraf.Serializer, error) {
+			return c.addSerializer(name, table)
+		})
+		optionTestCount++
+	}
 
 	if err := c.toml.UnmarshalTable(table, processor); err != nil {
 		return nil, 0, fmt.Errorf("unmarshalling failed: %w", err)
@@ -1154,8 +1182,8 @@ func (c *Config) addOutput(name string, table *ast.Table) error {
 		return nil
 	}
 
-	// For inputs with parsers we need to compute the set of
-	// options that is not covered by both, the parser and the input.
+	// For outputs with serializers we need to compute the set of
+	// options that is not covered by both, the serializer and the input.
 	// We achieve this by keeping a local book of missing entries
 	// that counts the number of misses. In case we have a parser
 	// for the input both need to miss the entry. We count the
@@ -1194,6 +1222,16 @@ func (c *Config) addOutput(name string, table *ast.Table) error {
 			return err
 		}
 		t.SetSerializer(serializer)
+	}
+
+	if t, ok := output.(telegraf.SerializerFuncPlugin); ok {
+		missThreshold = 1
+		if !c.probeSerializer(table) {
+			return errors.New("serializer not found")
+		}
+		t.SetSerializerFunc(func() (telegraf.Serializer, error) {
+			return c.addSerializer(name, table)
+		})
 	}
 
 	outputConfig, err := c.buildOutput(name, table)

--- a/parser.go
+++ b/parser.go
@@ -22,6 +22,7 @@ type Parser interface {
 	SetDefaultTags(tags map[string]string)
 }
 
+// ParserFunc is a function to create a new instance of a parser
 type ParserFunc func() (Parser, error)
 
 // ParserPlugin is an interface for plugins that are able to parse

--- a/plugins/outputs/remotefile/README.md
+++ b/plugins/outputs/remotefile/README.md
@@ -63,6 +63,19 @@ to use them.
   ## Maximum size of the cache on disk (infinite by default)
   # cache_max_size = -1
 
+  ## Forget files after not being touched for longer than the given time
+  ## This is useful to prevent memory leaks when using time-based filenames
+  ## as it allows internal structures to be cleaned up.
+  ## Note: When writing to a file after is has been forgotten, the file is
+  ##       treated as a new file which might cause file-headers to be appended
+  ##       again by certain serializers like CSV.
+  ## By default files will be kept indefinitely.
+  # forget_files_after = "0s"
+
+  ## Output log messages of the underlying library as debug messages
+  ## NOTE: You need to enable this option AND run Telegraf in debug mode!
+  # trace = false
+
   ## Data format to output.
   ## Each data format has its own unique set of configuration options, read
   ## more about them here:

--- a/plugins/outputs/remotefile/README.md
+++ b/plugins/outputs/remotefile/README.md
@@ -72,10 +72,6 @@ to use them.
   ## By default files will be kept indefinitely.
   # forget_files_after = "0s"
 
-  ## Output log messages of the underlying library as debug messages
-  ## NOTE: You need to enable this option AND run Telegraf in debug mode!
-  # trace = false
-
   ## Data format to output.
   ## Each data format has its own unique set of configuration options, read
   ## more about them here:

--- a/plugins/outputs/remotefile/remotefile_test.go
+++ b/plugins/outputs/remotefile/remotefile_test.go
@@ -326,9 +326,10 @@ func TestCSVSerialization(t *testing.T) {
 	// Check the result
 	for expectedFilename, expectedContent := range expected {
 		require.FileExists(t, filepath.Join(tmpdir, expectedFilename))
-		actual, err := os.ReadFile(filepath.Join(tmpdir, expectedFilename))
+		buf, err := os.ReadFile(filepath.Join(tmpdir, expectedFilename))
 		require.NoError(t, err)
-		require.Equal(t, expectedContent, string(actual))
+		actual := strings.ReplaceAll(string(buf), "\r\n", "\n")
+		require.Equal(t, expectedContent, actual)
 	}
 
 	require.Len(t, plugin.modified, 2)

--- a/plugins/outputs/remotefile/sample.conf
+++ b/plugins/outputs/remotefile/sample.conf
@@ -33,6 +33,15 @@
   ## Maximum size of the cache on disk (infinite by default)
   # cache_max_size = -1
 
+  ## Forget files after not being touched for longer than the given time
+  ## This is useful to prevent memory leaks when using time-based filenames
+  ## as it allows internal structures to be cleaned up.
+  ## Note: When writing to a file after is has been forgotten, the file is
+  ##       treated as a new file which might cause file-headers to be appended
+  ##       again by certain serializers like CSV.
+  ## By default files will be kept indefinitely.
+  # forget_files_after = "0s"
+
   ## Data format to output.
   ## Each data format has its own unique set of configuration options, read
   ## more about them here:

--- a/serializer.go
+++ b/serializer.go
@@ -1,12 +1,5 @@
 package telegraf
 
-// SerializerPlugin is an interface for plugins that are able to
-// serialize telegraf metrics into arbitrary data formats.
-type SerializerPlugin interface {
-	// SetSerializer sets the serializer function for the interface.
-	SetSerializer(serializer Serializer)
-}
-
 // Serializer is an interface defining functions that a serializer plugin must
 // satisfy.
 //
@@ -25,4 +18,21 @@ type Serializer interface {
 	// a byte buffer.  This method is not required to be suitable for use with
 	// line oriented framing.
 	SerializeBatch(metrics []Metric) ([]byte, error)
+}
+
+// SerializerFunc is a function to create a new instance of a serializer
+type SerializerFunc func() (Serializer, error)
+
+// SerializerPlugin is an interface for plugins that are able to
+// serialize telegraf metrics into arbitrary data formats.
+type SerializerPlugin interface {
+	// SetSerializer sets the serializer function for the interface.
+	SetSerializer(serializer Serializer)
+}
+
+// SerializerFuncPlugin is an interface for plugins that are able to serialize
+// arbitrary data formats and require multiple instances of a parser.
+type SerializerFuncPlugin interface {
+	// GetParser returns a new parser.
+	SetSerializerFunc(fn SerializerFunc)
 }


### PR DESCRIPTION
## Summary

Some serializers require a new instance per output stream such as CSV. This PR adds the framework to pass a creator function to plugins if they need it and converts the remotefile output to the new code.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #15912 
