### PR TITLE
fix(agent): Fix buffer not flushing if all metrics are written

### DIFF
--- a/models/buffer_disk.go
+++ b/models/buffer_disk.go
@@ -93,10 +93,9 @@ func (b *DiskBuffer) Add(metrics ...telegraf.Metric) int {
 	for _, m := range metrics {
 		if !b.addSingleMetric(m) {
 			dropped++
-		} else if b.isEmpty {
-			// as soon as a new metric is added, if this was empty, try to flush the "empty" metric out
-			b.handleEmptyFile()
 		}
+		// as soon as a new metric is added, if this was empty, try to flush the "empty" metric out
+		b.handleEmptyFile()
 	}
 	b.BufferSize.Set(int64(b.length()))
 	return dropped
@@ -219,23 +218,23 @@ func (b *DiskBuffer) resetBatch() {
 // that at least one entry remains in them otherwise they return an error.
 // Related issue: https://github.com/tidwall/wal/issues/20
 func (b *DiskBuffer) handleEmptyFile() {
-	if b.isEmpty {
-		err := b.file.TruncateFront(b.readIndex() + 1)
-		if err != nil {
-			log.Printf("E! readIndex: %d, buffer len: %d", b.readIndex(), b.length())
-			panic(err)
-		}
-		b.isEmpty = false
+	if !b.isEmpty {
+		return
 	}
+	if err := b.file.TruncateFront(b.readIndex() + 1); err != nil {
+		log.Printf("E! readIndex: %d, buffer len: %d", b.readIndex(), b.length())
+		panic(err)
+	}
+	b.isEmpty = false
 }
 
 func (b *DiskBuffer) emptyFile() {
-	if !b.isEmpty && b.length() > 0 {
-		err := b.file.TruncateFront(b.writeIndex() - 1)
-		if err != nil {
-			log.Printf("E! writeIndex: %d, buffer len: %d", b.writeIndex(), b.length())
-			panic(err)
-		}
-		b.isEmpty = true
+	if b.isEmpty || b.length() == 0 {
+		return
 	}
+	if err := b.file.TruncateFront(b.writeIndex() - 1); err != nil {
+		log.Printf("E! writeIndex: %d, buffer len: %d", b.writeIndex(), b.length())
+		panic(err)
+	}
+	b.isEmpty = true
 }

--- a/models/buffer_suite_test.go
+++ b/models/buffer_suite_test.go
@@ -809,3 +809,26 @@ func (s *BufferSuiteTest) TestBuffer_RejectEmptyBatch() {
 		s.NotNil(m)
 	}
 }
+
+func (s *BufferSuiteTest) TestBuffer_FlushedPartial() {
+	b := s.newTestBuffer(5)
+	b.Add(MetricTime(1))
+	b.Add(MetricTime(2))
+	b.Add(MetricTime(3))
+	batch := b.Batch(2)
+	s.Len(batch, 2)
+
+	b.Accept(batch)
+	s.Equal(1, b.Len())
+}
+
+func (s *BufferSuiteTest) TestBuffer_FlushedFull() {
+	b := s.newTestBuffer(5)
+	b.Add(MetricTime(1))
+	b.Add(MetricTime(2))
+	batch := b.Batch(2)
+	s.Len(batch, 2)
+
+	b.Accept(batch)
+	s.Equal(0, b.Len())
+}


### PR DESCRIPTION
## Summary
Fixes an issue where the disk buffer would not always flush if the buffer was emptied entirely by a metric batch

## Checklist
- [X] No AI generated code was used in this PR

## Related issues
resolves #15868
