### PR TITLE
chore(outputs.remotefile): Deprecate trace option

### DIFF
--- a/plugins/outputs/remotefile/README.md
+++ b/plugins/outputs/remotefile/README.md
@@ -63,10 +63,6 @@ to use them.
   ## Maximum size of the cache on disk (infinite by default)
   # cache_max_size = -1
 
-  ## Output log messages of the underlying library as debug messages
-  ## NOTE: You need to enable this option AND run Telegraf in debug mode!
-  # trace = false
-
   ## Data format to output.
   ## Each data format has its own unique set of configuration options, read
   ## more about them here:

--- a/plugins/outputs/remotefile/remotefile.go
+++ b/plugins/outputs/remotefile/remotefile.go
@@ -34,7 +34,7 @@ type File struct {
 	WriteBackInterval config.Duration `toml:"cache_write_back"`
 	MaxCacheSize      config.Size     `toml:"cache_max_size"`
 	UseBatchFormat    bool            `toml:"use_batch_format"`
-	Trace             bool            `toml:"trace"`
+	Trace             bool            `toml:"trace" deprecated:"1.33.0;1.35.0;use 'log_level = \"trace\"' instead"`
 	Log               telegraf.Logger `toml:"-"`
 
 	root     *vfs.VFS
@@ -81,10 +81,11 @@ func (f *File) Init() error {
 
 	// Redirect logging
 	fs.LogPrint = func(level fs.LogLevel, text string) {
-		if !f.Trace {
-			return
+		if f.Trace {
+			f.Log.Debugf("[%s] %s", level.String(), text)
+		} else {
+			f.Log.Tracef("[%s] %s", level.String(), text)
 		}
-		f.Log.Debugf("[%s] %s", level.String(), text)
 	}
 
 	// Setup custom template functions

--- a/plugins/outputs/remotefile/sample.conf
+++ b/plugins/outputs/remotefile/sample.conf
@@ -33,10 +33,6 @@
   ## Maximum size of the cache on disk (infinite by default)
   # cache_max_size = -1
 
-  ## Output log messages of the underlying library as debug messages
-  ## NOTE: You need to enable this option AND run Telegraf in debug mode!
-  # trace = false
-
   ## Data format to output.
   ## Each data format has its own unique set of configuration options, read
   ## more about them here:


### PR DESCRIPTION
## Summary

Remove the `trace` setting in favor of the new Trace log-level.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues
