### PR TITLE
test(outputs.sql): Fix failing integration test by excluding options

### DIFF
--- a/plugins/outputs/sql/sql_test.go
+++ b/plugins/outputs/sql/sql_test.go
@@ -289,9 +289,11 @@ func TestPostgresIntegration(t *testing.T) {
 	p.Convert.ConversionStyle = "literal"
 
 	require.NoError(t, p.Connect())
+	defer p.Close()
 	require.NoError(t, p.Write(
 		testMetrics,
 	))
+	require.NoError(t, p.Close())
 
 	expected, err := os.ReadFile("./testdata/postgres/expected.sql")
 	require.NoError(t, err)
@@ -312,7 +314,7 @@ func TestPostgresIntegration(t *testing.T) {
 				// each release. To prevent these changes from causing the
 				// test to fail, we strip out comments. Also strip out
 				// blank lines.
-				"|grep -E -v '(^--|^$)'",
+				"|grep -E -v '(^--|^$|^SET )'",
 		})
 		require.NoError(t, err)
 		require.Equal(t, 0, rc)

--- a/plugins/outputs/sql/testdata/postgres/expected.sql
+++ b/plugins/outputs/sql/testdata/postgres/expected.sql
@@ -1,15 +1,4 @@
-SET statement_timeout = 0;
-SET lock_timeout = 0;
-SET idle_in_transaction_session_timeout = 0;
-SET client_encoding = 'UTF8';
-SET standard_conforming_strings = on;
 SELECT pg_catalog.set_config('search_path', '', false);
-SET check_function_bodies = false;
-SET xmloption = content;
-SET client_min_messages = warning;
-SET row_security = off;
-SET default_tablespace = '';
-SET default_table_access_method = heap;
 CREATE TABLE public."metric three" (
     "timestamp" timestamp without time zone,
     "tag four" text,


### PR DESCRIPTION
## Summary

The Postgres integration test fails due to a different set of options being dumped compared to the reference. Fix the issue by removing all `SET` statements from the comparison as we are only interested in the data.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues
