### PR TITLE
chore: Update go to v1.23.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
     working_directory: '/go/src/github.com/influxdata/telegraf'
     resource_class: large
     docker:
-      - image: 'quay.io/influxdb/telegraf-ci:1.23.1'
+      - image: 'quay.io/influxdb/telegraf-ci:1.23.2'
     environment:
       GOFLAGS: -p=4
   mac:

--- a/.github/workflows/readme-linter.yml
+++ b/.github/workflows/readme-linter.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.23.1'
+          go-version: '1.23.2'
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0

--- a/Makefile
+++ b/Makefile
@@ -257,8 +257,8 @@ plugins/parsers/influx/machine.go: plugins/parsers/influx/machine.go.rl
 
 .PHONY: ci
 ci:
-	docker build -t quay.io/influxdb/telegraf-ci:1.23.1 - < scripts/ci.docker
-	docker push quay.io/influxdb/telegraf-ci:1.23.1
+	docker build -t quay.io/influxdb/telegraf-ci:1.23.2 - < scripts/ci.docker
+	docker push quay.io/influxdb/telegraf-ci:1.23.2
 
 .PHONY: install
 install: $(buildbin)

--- a/scripts/ci.docker
+++ b/scripts/ci.docker
@@ -1,4 +1,4 @@
-FROM golang:1.23.1
+FROM golang:1.23.2
 
 RUN chmod -R 755 "$GOPATH"
 

--- a/scripts/installgo_linux.sh
+++ b/scripts/installgo_linux.sh
@@ -2,7 +2,7 @@
 
 set -eux
 
-GO_VERSION="1.23.1"
+GO_VERSION="1.23.2"
 GO_ARCH="linux-amd64"
 # from https://go.dev/dl
 GO_VERSION_SHA="542d3c1705f1c6a1c5a80d5dc62e2e45171af291e755d591c5e6531ef63b454e"

--- a/scripts/installgo_linux.sh
+++ b/scripts/installgo_linux.sh
@@ -4,8 +4,8 @@ set -eux
 
 GO_VERSION="1.23.1"
 GO_ARCH="linux-amd64"
-# from https://golang.org/dl
-GO_VERSION_SHA="49bbb517cfa9eee677e1e7897f7cf9cfdbcf49e05f61984a2789136de359f9bd"
+# from https://go.dev/dl
+GO_VERSION_SHA="542d3c1705f1c6a1c5a80d5dc62e2e45171af291e755d591c5e6531ef63b454e"
 
 # Download Go and verify Go tarball
 setup_go () {

--- a/scripts/installgo_mac.sh
+++ b/scripts/installgo_mac.sh
@@ -3,9 +3,9 @@
 set -eux
 
 ARCH=$(uname -m)
-GO_VERSION="1.23.1"
-GO_VERSION_SHA_arm64="e223795ca340e285a760a6446ce57a74500b30e57469a4109961d36184d3c05a" # from https://golang.org/dl
-GO_VERSION_SHA_amd64="488d9e4ca3e3ed513ee4edd91bef3a2360c65fa6d6be59cf79640bf840130a58" # from https://golang.org/dl
+GO_VERSION="1.23.2"
+GO_VERSION_SHA_arm64="d87031194fe3e01abdcaf3c7302148ade97a7add6eac3fec26765bcb3207b80f" # from https://go.dev/dl
+GO_VERSION_SHA_amd64="445c0ef19d8692283f4c3a92052cc0568f5a048f4e546105f58e991d4aea54f5" # from https://go.dev/dl
 
 if [ "$ARCH" = 'arm64' ]; then
     GO_ARCH="darwin-arm64"

--- a/scripts/installgo_windows.sh
+++ b/scripts/installgo_windows.sh
@@ -2,7 +2,7 @@
 
 set -eux
 
-GO_VERSION="1.23.1"
+GO_VERSION="1.23.2"
 
 setup_go () {
     choco upgrade golang --allow-downgrade --version=${GO_VERSION}


### PR DESCRIPTION
## Summary
Update go to v1.23.2. Still requires the CI to be built and pushed, which is why this is a draft PR still.

## Checklist
- [X] No AI generated code was used in this PR

## Related issues
resolves #15977
