### PR TITLE
test(inputs.postgresql): Fixing integration test

### DIFF
--- a/plugins/inputs/postgresql/postgresql_test.go
+++ b/plugins/inputs/postgresql/postgresql_test.go
@@ -79,15 +79,14 @@ func TestPostgresqlGeneratesMetricsIntegration(t *testing.T) {
 		"temp_bytes",
 		"deadlocks",
 		"buffers_alloc",
-		"buffers_backend",
-		"buffers_backend_fsync",
-		"buffers_checkpoint",
 		"buffers_clean",
-		"checkpoints_req",
-		"checkpoints_timed",
 		"maxwritten_clean",
 		"datid",
 		"numbackends",
+		"sessions",
+		"sessions_killed",
+		"sessions_fatal",
+		"sessions_abandoned",
 	}
 
 	int32Metrics := []string{}
@@ -95,8 +94,9 @@ func TestPostgresqlGeneratesMetricsIntegration(t *testing.T) {
 	floatMetrics := []string{
 		"blk_read_time",
 		"blk_write_time",
-		"checkpoint_write_time",
-		"checkpoint_sync_time",
+		"active_time",
+		"idle_in_transaction_time",
+		"session_time",
 	}
 
 	stringMetrics := []string{
@@ -106,22 +106,22 @@ func TestPostgresqlGeneratesMetricsIntegration(t *testing.T) {
 	metricsCounted := 0
 
 	for _, metric := range intMetrics {
-		require.True(t, acc.HasInt64Field("postgresql", metric))
+		require.True(t, acc.HasInt64Field("postgresql", metric), "%q not found in int metrics", metric)
 		metricsCounted++
 	}
 
 	for _, metric := range int32Metrics {
-		require.True(t, acc.HasInt32Field("postgresql", metric))
+		require.True(t, acc.HasInt32Field("postgresql", metric), "%q not found in int32 metrics", metric)
 		metricsCounted++
 	}
 
 	for _, metric := range floatMetrics {
-		require.True(t, acc.HasFloatField("postgresql", metric))
+		require.True(t, acc.HasFloatField("postgresql", metric), "%q not found in float metrics", metric)
 		metricsCounted++
 	}
 
 	for _, metric := range stringMetrics {
-		require.True(t, acc.HasStringField("postgresql", metric))
+		require.True(t, acc.HasStringField("postgresql", metric), "%q not found in string metrics", metric)
 		metricsCounted++
 	}
 


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

Fixing `inputs/postgresql` integration tests (example of fail: https://app.circleci.com/pipelines/github/influxdata/telegraf/22959/workflows/69cf611d-5609-4131-80c1-0c3c3d96c07c/jobs/357709)

The plugin by default queries two statistics tables: `pg_stat_bgwriter` and `pg_stat_database`. 
Some time ago, `buffers_backend` and `buffers_backend_fsync` were removed from the `pg_stat_bgwriter` table: https://git.postgresql.org/gitweb/?p=postgresql.git;a=commitdiff;h=74604a37f;ds=sidebyside
And some columns from this table were moved to the `pg_stat_checkpointer` table, and their names were changed: https://git.postgresql.org/gitweb/?p=postgresql.git;a=commitdiff;h=96f052613f35d07d001c8dd2f284ca8d95f82d1b;ds=sidebyside

In this PR, I'm removing the check for whether values from columns that no longer exist are present in the fields collected by the plugin, and I'm adding a check for the values from the new columns.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

