### PR TITLE
feat(inputs.mock): Add sine phase

### DIFF
--- a/plugins/inputs/mock/README.md
+++ b/plugins/inputs/mock/README.md
@@ -40,6 +40,7 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   #   name = "wave"
   #   amplitude = 1.0
   #   period = 0.5
+  #   phase = 20.0
   #   base_line = 0.0
   # [[inputs.mock.step]]
   #   name = "plus_one"

--- a/plugins/inputs/mock/mock.go
+++ b/plugins/inputs/mock/mock.go
@@ -43,6 +43,7 @@ type sineWave struct {
 	Name      string  `toml:"name"`
 	Amplitude float64 `toml:"amplitude"`
 	Period    float64 `toml:"period"`
+	Phase     float64 `toml:"phase"`
 	BaseLine  float64 `toml:"base_line"`
 }
 
@@ -118,7 +119,7 @@ func (m *Mock) generateRandomFloat64(fields map[string]interface{}) {
 // Create sine waves
 func (m *Mock) generateSineWave(fields map[string]interface{}) {
 	for _, field := range m.SineWave {
-		fields[field.Name] = math.Sin(float64(m.counter)*field.Period*math.Pi)*field.Amplitude + field.BaseLine
+		fields[field.Name] = math.Sin((float64(m.counter)+field.Phase)*field.Period*math.Pi)*field.Amplitude + field.BaseLine
 	}
 }
 

--- a/plugins/inputs/mock/sample.conf
+++ b/plugins/inputs/mock/sample.conf
@@ -19,6 +19,7 @@
   #   name = "wave"
   #   amplitude = 1.0
   #   period = 0.5
+  #   phase = 20.0
   #   base_line = 0.0
   # [[inputs.mock.step]]
   #   name = "plus_one"


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Add a phase to the sine mock, so multiple signals can be mocked which are slightly out of phase.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
