### PR TITLE
chore(linters): Fix findings found by `testifylint`: `go-require` for `plugins/common` and `plugins/inputs`

### DIFF
--- a/plugins/common/proxy/socks5_test.go
+++ b/plugins/common/proxy/socks5_test.go
@@ -32,7 +32,11 @@ func TestSocks5ProxyConfigIntegration(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	go func() { require.NoError(t, server.ListenAndServe("tcp", proxyAddress)) }()
+	go func() {
+		if err := server.ListenAndServe("tcp", proxyAddress); err != nil {
+			t.Error(err)
+		}
+	}()
 
 	conf := Socks5ProxyConfig{
 		Socks5ProxyEnabled:  true,

--- a/plugins/common/shim/goshim_test.go
+++ b/plugins/common/shim/goshim_test.go
@@ -50,8 +50,9 @@ func runErroringInputPlugin(t *testing.T, interval time.Duration, stdin io.Reade
 	err := shim.AddInput(inp)
 	require.NoError(t, err)
 	go func() {
-		err := shim.Run(interval)
-		require.NoError(t, err)
+		if err := shim.Run(interval); err != nil {
+			t.Error(err)
+		}
 		exited <- true
 	}()
 	return metricProcessed, exited

--- a/plugins/common/shim/input_test.go
+++ b/plugins/common/shim/input_test.go
@@ -47,8 +47,9 @@ func TestInputShimStdinSignalingWorks(t *testing.T) {
 	err = stdinWriter.Close()
 	require.NoError(t, err)
 	go func() {
-		_, err = io.ReadAll(r)
-		require.NoError(t, err)
+		if _, err = io.ReadAll(r); err != nil {
+			t.Error(err)
+		}
 	}()
 	// check that it exits cleanly
 	<-exited
@@ -74,8 +75,9 @@ func runInputPlugin(t *testing.T, interval time.Duration, stdin io.Reader, stdou
 	err := shim.AddInput(inp)
 	require.NoError(t, err)
 	go func() {
-		err := shim.Run(interval)
-		require.NoError(t, err)
+		if err := shim.Run(interval); err != nil {
+			t.Error(err)
+		}
 		exited <- true
 	}()
 	return metricProcessed, exited

--- a/plugins/common/shim/output_test.go
+++ b/plugins/common/shim/output_test.go
@@ -28,8 +28,9 @@ func TestOutputShim(t *testing.T) {
 
 	wg.Add(1)
 	go func() {
-		err := s.RunOutput()
-		require.NoError(t, err)
+		if err := s.RunOutput(); err != nil {
+			t.Error(err)
+		}
 		wg.Done()
 	}()
 

--- a/plugins/common/shim/processor_test.go
+++ b/plugins/common/shim/processor_test.go
@@ -47,8 +47,9 @@ func testSendAndReceive(t *testing.T, fieldKey string, fieldValue string) {
 
 	wg.Add(1)
 	go func() {
-		err := s.RunProcessor()
-		require.NoError(t, err)
+		if err := s.RunProcessor(); err != nil {
+			t.Error(err)
+		}
 		wg.Done()
 	}()
 
@@ -88,8 +89,9 @@ func testSendAndReceive(t *testing.T, fieldKey string, fieldValue string) {
 	require.True(t, ok)
 	require.Equal(t, fieldValue, val2)
 	go func() {
-		_, err = io.ReadAll(r)
-		require.NoError(t, err)
+		if _, err = io.ReadAll(r); err != nil {
+			t.Error(err)
+		}
 	}()
 	wg.Wait()
 }

--- a/plugins/inputs/apcupsd/apcupsd_test.go
+++ b/plugins/inputs/apcupsd/apcupsd_test.go
@@ -1,6 +1,7 @@
 package apcupsd
 
 import (
+	"bytes"
 	"context"
 	"encoding/binary"
 	"net"
@@ -44,22 +45,34 @@ func listen(ctx context.Context, t *testing.T, out [][]byte) (string, error) {
 					return
 				}
 				defer conn.Close()
-				require.NoError(t, conn.SetReadDeadline(time.Now().Add(time.Second)))
+
+				if err = conn.SetReadDeadline(time.Now().Add(time.Second)); err != nil {
+					t.Error(err)
+					return
+				}
 
 				in := make([]byte, 128)
 				n, err := conn.Read(in)
-				require.NoError(t, err, "failed to read from connection")
+				if err != nil {
+					t.Errorf("Failed to read to connection: %v", err)
+					return
+				}
 
 				status := []byte{0, 6, 's', 't', 'a', 't', 'u', 's'}
 				want, got := status, in[:n]
-				require.Equal(t, want, got)
+				if !bytes.Equal(want, got) {
+					t.Errorf("expected %q, got %q", want, got)
+					return
+				}
 
 				// Run against test function and append EOF to end of output bytes
 				out = append(out, []byte{0, 0})
 
 				for _, o := range out {
-					_, err := conn.Write(o)
-					require.NoError(t, err, "failed to write to connection")
+					if _, err := conn.Write(o); err != nil {
+						t.Errorf("Failed to write to connection: %v", err)
+						return
+					}
 				}
 			}()
 		}

--- a/plugins/inputs/dovecot/dovecot_test.go
+++ b/plugins/inputs/dovecot/dovecot_test.go
@@ -59,25 +59,38 @@ func TestDovecotIntegration(t *testing.T) {
 		defer close(waitCh)
 
 		la, err := net.ResolveUnixAddr("unix", addr)
-		require.NoError(t, err)
+		if err != nil {
+			t.Error(err)
+			return
+		}
 
 		l, err := net.ListenUnix("unix", la)
-		require.NoError(t, err)
+		if err != nil {
+			t.Error(err)
+			return
+		}
 		defer l.Close()
 		defer os.Remove(addr)
 
 		waitCh <- 0
 		conn, err := l.Accept()
-		require.NoError(t, err)
+		if err != nil {
+			t.Error(err)
+			return
+		}
 		defer conn.Close()
 
 		readertp := textproto.NewReader(bufio.NewReader(conn))
-		_, err = readertp.ReadLine()
-		require.NoError(t, err)
+		if _, err = readertp.ReadLine(); err != nil {
+			t.Error(err)
+			return
+		}
 
 		buf := bytes.NewBufferString(sampleGlobal)
-		_, err = io.Copy(conn, buf)
-		require.NoError(t, err)
+		if _, err = io.Copy(conn, buf); err != nil {
+			t.Error(err)
+			return
+		}
 	}()
 
 	// Wait for server to start

--- a/plugins/inputs/dpdk/dpdk_test.go
+++ b/plugins/inputs/dpdk/dpdk_test.go
@@ -907,13 +907,21 @@ func createMultipleSocketsForTest(t *testing.T, numSockets int, dirPath string) 
 
 func simulateSocketResponse(socket net.Listener, t *testing.T) {
 	conn, err := socket.Accept()
-	require.NoError(t, err)
+	if err != nil {
+		t.Error(err)
+		return
+	}
 
 	initMessage, err := json.Marshal(initMessage{MaxOutputLen: 1})
-	require.NoError(t, err)
+	if err != nil {
+		t.Error(err)
+		return
+	}
 
-	_, err = conn.Write(initMessage)
-	require.NoError(t, err)
+	if _, err = conn.Write(initMessage); err != nil {
+		t.Error(err)
+		return
+	}
 }
 
 func prepareGlob(path string) (*globpath.GlobPath, error) {

--- a/plugins/inputs/execd/shim/shim_posix_test.go
+++ b/plugins/inputs/execd/shim/shim_posix_test.go
@@ -37,7 +37,11 @@ func TestShimUSR1SignalingWorks(t *testing.T) {
 				return // test is done
 			default:
 				// test isn't done, keep going.
-				require.NoError(t, process.Signal(syscall.SIGUSR1))
+				if err := process.Signal(syscall.SIGUSR1); err != nil {
+					t.Error(err)
+					metricProcessed <- false
+					return
+				}
 				time.Sleep(200 * time.Millisecond)
 			}
 		}

--- a/plugins/inputs/execd/shim/shim_test.go
+++ b/plugins/inputs/execd/shim/shim_test.go
@@ -73,8 +73,9 @@ func runInputPlugin(t *testing.T, interval time.Duration, stdin io.Reader, stdou
 
 	require.NoError(t, shim.AddInput(inp))
 	go func() {
-		err := shim.Run(interval)
-		require.NoError(t, err)
+		if err := shim.Run(interval); err != nil {
+			t.Error(err)
+		}
 		exited <- true
 	}()
 	return metricProcessed, exited

--- a/plugins/inputs/gnmi/gnmi_test.go
+++ b/plugins/inputs/gnmi/gnmi_test.go
@@ -95,8 +95,9 @@ func TestWaitError(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		err := grpcServer.Serve(listener)
-		require.NoError(t, err)
+		if err := grpcServer.Serve(listener); err != nil {
+			t.Error(err)
+		}
 	}()
 
 	acc.WaitError(1)
@@ -154,8 +155,9 @@ func TestUsernamePassword(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		err := grpcServer.Serve(listener)
-		require.NoError(t, err)
+		if err := grpcServer.Serve(listener); err != nil {
+			t.Error(err)
+		}
 	}()
 
 	acc.WaitError(1)
@@ -1011,8 +1013,9 @@ func TestNotification(t *testing.T) {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				err := grpcServer.Serve(listener)
-				require.NoError(t, err)
+				if err := grpcServer.Serve(listener); err != nil {
+					t.Error(err)
+				}
 			}()
 
 			acc.Wait(len(tt.expected))
@@ -1063,8 +1066,9 @@ func TestRedial(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		err := grpcServer.Serve(listener)
-		require.NoError(t, err)
+		if err := grpcServer.Serve(listener); err != nil {
+			t.Error(err)
+		}
 	}()
 
 	var acc testutil.Accumulator
@@ -1095,8 +1099,9 @@ func TestRedial(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		err := grpcServer.Serve(listener)
-		require.NoError(t, err)
+		if err := grpcServer.Serve(listener); err != nil {
+			t.Error(err)
+		}
 	}()
 
 	acc.Wait(4)
@@ -1199,8 +1204,9 @@ func TestCases(t *testing.T) {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				err := grpcServer.Serve(listener)
-				require.NoError(t, err)
+				if err := grpcServer.Serve(listener); err != nil {
+					t.Error(err)
+				}
 			}()
 
 			var acc testutil.Accumulator

--- a/plugins/inputs/hddtemp/go-hddtemp/hddtemp_test.go
+++ b/plugins/inputs/hddtemp/go-hddtemp/hddtemp_test.go
@@ -80,11 +80,19 @@ func serve(t *testing.T, data []byte) net.Listener {
 
 	go func(t *testing.T) {
 		conn, err := l.Accept()
-		require.NoError(t, err)
+		if err != nil {
+			t.Error(err)
+			return
+		}
 
-		_, err = conn.Write(data)
-		require.NoError(t, err)
-		require.NoError(t, conn.Close())
+		if _, err = conn.Write(data); err != nil {
+			t.Error(err)
+			return
+		}
+		if err = conn.Close(); err != nil {
+			t.Error(err)
+			return
+		}
 	}(t)
 
 	return l

--- a/plugins/inputs/intel_dlb/intel_dlb_test.go
+++ b/plugins/inputs/intel_dlb/intel_dlb_test.go
@@ -935,7 +935,10 @@ func simulateResponse(mockConn *mocks.Conn, response string, readErr error) {
 
 func simulateSocketResponseForGather(socket net.Listener, t *testing.T) {
 	conn, err := socket.Accept()
-	require.NoError(t, err)
+	if err != nil {
+		t.Error(err)
+		return
+	}
 
 	type initMessage struct {
 		Version      string `json:"version"`
@@ -947,14 +950,21 @@ func simulateSocketResponseForGather(socket net.Listener, t *testing.T) {
 		Pid:          1,
 		MaxOutputLen: 1024,
 	})
-	require.NoError(t, err)
-	_, err = conn.Write(initMsg)
-	require.NoError(t, err)
+	if err != nil {
+		t.Error(err)
+		return
+	}
 
-	require.NoError(t, err)
+	if _, err = conn.Write(initMsg); err != nil {
+		t.Error(err)
+		return
+	}
+
 	eventdevListWithSecondIndex := []string{"/eventdev/port_list", "/eventdev/queue_list"}
-	_, err = fmt.Fprintf(conn, `{%q: [0, 1]}`, eventdevListWithSecondIndex[0])
-	require.NoError(t, err)
+	if _, err = fmt.Fprintf(conn, `{%q: [0, 1]}`, eventdevListWithSecondIndex[0]); err != nil {
+		t.Error(err)
+		return
+	}
 }
 
 func createSocketForTest(t *testing.T) (string, net.Listener) {

--- a/plugins/inputs/kafka_consumer/kafka_consumer_test.go
+++ b/plugins/inputs/kafka_consumer/kafka_consumer_test.go
@@ -355,8 +355,14 @@ func TestConsumerGroupHandlerConsumeClaim(t *testing.T) {
 
 	go func() {
 		err := cg.ConsumeClaim(session, claim)
-		require.Error(t, err)
-		require.EqualValues(t, "context canceled", err.Error())
+		if err == nil {
+			t.Error("An error was expected.")
+			return
+		}
+		if err.Error() != "context canceled" {
+			t.Errorf("Expected 'context canceled' error, got: %v", err)
+			return
+		}
 	}()
 
 	acc.Wait(1)

--- a/plugins/inputs/net_response/net_response_test.go
+++ b/plugins/inputs/net_response/net_response_test.go
@@ -267,32 +267,75 @@ func TestUDPOK1(t *testing.T) {
 func UDPServer(t *testing.T, wg *sync.WaitGroup) {
 	defer wg.Done()
 	udpAddr, err := net.ResolveUDPAddr("udp", "127.0.0.1:2004")
-	require.NoError(t, err)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
 	conn, err := net.ListenUDP("udp", udpAddr)
-	require.NoError(t, err)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
 	wg.Done()
 	buf := make([]byte, 1024)
 	_, remoteaddr, err := conn.ReadFromUDP(buf)
-	require.NoError(t, err)
-	_, err = conn.WriteToUDP(buf, remoteaddr)
-	require.NoError(t, err)
-	require.NoError(t, conn.Close())
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	if _, err = conn.WriteToUDP(buf, remoteaddr); err != nil {
+		t.Error(err)
+		return
+	}
+
+	if err = conn.Close(); err != nil {
+		t.Error(err)
+		return
+	}
 }
 
 func TCPServer(t *testing.T, wg *sync.WaitGroup) {
 	defer wg.Done()
 	tcpAddr, err := net.ResolveTCPAddr("tcp", "127.0.0.1:2004")
-	require.NoError(t, err)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
 	tcpServer, err := net.ListenTCP("tcp", tcpAddr)
-	require.NoError(t, err)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
 	wg.Done()
 	conn, err := tcpServer.AcceptTCP()
-	require.NoError(t, err)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
 	buf := make([]byte, 1024)
-	_, err = conn.Read(buf)
-	require.NoError(t, err)
-	_, err = conn.Write(buf)
-	require.NoError(t, err)
-	require.NoError(t, conn.CloseWrite())
-	require.NoError(t, tcpServer.Close())
+	if _, err = conn.Read(buf); err != nil {
+		t.Error(err)
+		return
+	}
+
+	if _, err = conn.Write(buf); err != nil {
+		t.Error(err)
+		return
+	}
+
+	if err = conn.CloseWrite(); err != nil {
+		t.Error(err)
+		return
+	}
+
+	if err = tcpServer.Close(); err != nil {
+		t.Error(err)
+		return
+	}
 }

--- a/plugins/inputs/radius/radius_test.go
+++ b/plugins/inputs/radius/radius_test.go
@@ -50,7 +50,8 @@ func TestRadiusLocal(t *testing.T) {
 	go func() {
 		if err := server.Serve(conn); err != nil {
 			if !errors.Is(err, radius.ErrServerShutdown) {
-				require.NoError(t, err, "local radius server failed")
+				t.Errorf("Local radius server failed: %v", err)
+				return
 			}
 		}
 	}()
@@ -118,7 +119,8 @@ func TestRadiusNASIP(t *testing.T) {
 	go func() {
 		if err := server.Serve(conn); err != nil {
 			if !errors.Is(err, radius.ErrServerShutdown) {
-				require.NoError(t, err, "local radius server failed")
+				t.Errorf("Local radius server failed: %v", err)
+				return
 			}
 		}
 	}()

--- a/plugins/inputs/statsd/statsd_test.go
+++ b/plugins/inputs/statsd/statsd_test.go
@@ -202,8 +202,10 @@ func BenchmarkUDPThreads4(b *testing.B) {
 		go func() {
 			defer wg.Done()
 			for i := 0; i < 1000; i++ {
-				_, err := conn.Write([]byte(testMsg))
-				require.NoError(b, err)
+				if _, err := conn.Write([]byte(testMsg)); err != nil {
+					b.Error(err)
+					return
+				}
 			}
 		}()
 	}
@@ -239,8 +241,10 @@ func BenchmarkUDPThreads8(b *testing.B) {
 		go func() {
 			defer wg.Done()
 			for i := 0; i < 1000; i++ {
-				_, err := conn.Write([]byte(testMsg))
-				require.NoError(b, err)
+				if _, err := conn.Write([]byte(testMsg)); err != nil {
+					b.Error(err)
+					return
+				}
 			}
 		}()
 	}
@@ -276,8 +280,10 @@ func BenchmarkUDPThreads16(b *testing.B) {
 		go func() {
 			defer wg.Done()
 			for i := 0; i < 1000; i++ {
-				_, err := conn.Write([]byte(testMsg))
-				require.NoError(b, err)
+				if _, err := conn.Write([]byte(testMsg)); err != nil {
+					b.Error(err)
+					return
+				}
 			}
 		}()
 	}

--- a/plugins/inputs/teamspeak/teamspeak_test.go
+++ b/plugins/inputs/teamspeak/teamspeak_test.go
@@ -89,34 +89,51 @@ func TestGather(t *testing.T) {
 
 func handleRequest(l net.Listener, t *testing.T) {
 	c, err := l.Accept()
-	require.NoError(t, err, "Error accepting test connection")
-	_, err = c.Write([]byte("TS3\n\r" + welcome + "\n\r"))
-	require.NoError(t, err)
+	if err != nil {
+		t.Errorf("Error accepting test connection: %v", err)
+		return
+	}
+
+	if _, err = c.Write([]byte("TS3\n\r" + welcome + "\n\r")); err != nil {
+		t.Error(err)
+		return
+	}
+
 	for {
 		msg, _, err := bufio.NewReader(c).ReadLine()
 		if err != nil {
+			t.Error(err)
 			return
 		}
-		r, exists := cmd[strings.Split(string(msg), " ")[0]]
 
+		r, exists := cmd[strings.Split(string(msg), " ")[0]]
 		if exists {
 			switch r {
 			case "":
-				_, err = c.Write([]byte(ok + "\n\r"))
-				require.NoError(t, err)
+				if _, err = c.Write([]byte(ok + "\n\r")); err != nil {
+					t.Error(err)
+					return
+				}
 			case "quit":
-				_, err = c.Write([]byte(ok + "\n\r"))
-				require.NoError(t, err)
-				err = c.Close()
-				require.NoError(t, err)
+				if _, err = c.Write([]byte(ok + "\n\r")); err != nil {
+					t.Error(err)
+					return
+				}
+				if err = c.Close(); err != nil {
+					t.Error(err)
+				}
 				return
 			default:
-				_, err = c.Write([]byte(r + "\n\r" + ok + "\n\r"))
-				require.NoError(t, err)
+				if _, err = c.Write([]byte(r + "\n\r" + ok + "\n\r")); err != nil {
+					t.Error(err)
+					return
+				}
 			}
 		} else {
-			_, err = c.Write([]byte(errorMsg + "\n\r"))
-			require.NoError(t, err)
+			if _, err = c.Write([]byte(errorMsg + "\n\r")); err != nil {
+				t.Error(err)
+				return
+			}
 		}
 	}
 }

--- a/plugins/inputs/x509_cert/x509_cert_test.go
+++ b/plugins/inputs/x509_cert/x509_cert_test.go
@@ -89,18 +89,25 @@ func TestGatherRemoteIntegration(t *testing.T) {
 
 			go func() {
 				sconn, err := ln.Accept()
-				require.NoError(t, err)
+				if err != nil {
+					t.Error(err)
+					return
+				}
+
 				if test.close {
 					sconn.Close()
 				}
 
 				serverConfig := cfg.Clone()
-
 				srv := tls.Server(sconn, serverConfig)
 				if test.noshake {
 					srv.Close()
 				}
-				require.NoError(t, srv.Handshake())
+
+				if err = srv.Handshake(); err != nil {
+					t.Error(err)
+					return
+				}
 			}()
 
 			if test.server == "" {
@@ -318,8 +325,9 @@ func TestGatherUDPCertIntegration(t *testing.T) {
 	defer listener.Close()
 
 	go func() {
-		_, err := listener.Accept()
-		require.NoError(t, err)
+		if _, err := listener.Accept(); err != nil {
+			t.Error(err)
+		}
 	}()
 
 	m := &X509Cert{


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

This is only the first part of a larger effort to address the findings identified by `testifylint: go-require`: https://github.com/influxdata/telegraf/issues/15535
Once all the findings have been addressed, `testifylint: go-require` can be enabled in `.golangci.yml`.

In this PR, I’m focusing on `plugins/common` and `plugins/inputs`.

Here are the findings that this PR addresses:
```
plugins/common/proxy/socks5_test.go:35:14                   testifylint  go-require: require must only be used in the goroutine running the test function
plugins/common/shim/goshim_test.go:54:3                     testifylint  go-require: require must only be used in the goroutine running the test function
plugins/common/shim/input_test.go:51:3                      testifylint  go-require: require must only be used in the goroutine running the test function
plugins/common/shim/input_test.go:78:3                      testifylint  go-require: require must only be used in the goroutine running the test function
plugins/common/shim/output_test.go:32:3                     testifylint  go-require: require must only be used in the goroutine running the test function
plugins/common/shim/processor_test.go:51:3                  testifylint  go-require: require must only be used in the goroutine running the test function
plugins/common/shim/processor_test.go:92:3                  testifylint  go-require: require must only be used in the goroutine running the test function
plugins/inputs/apcupsd/apcupsd_test.go:47:5                 testifylint  go-require: require must only be used in the goroutine running the test function
plugins/inputs/apcupsd/apcupsd_test.go:51:5                 testifylint  go-require: require must only be used in the goroutine running the test function
plugins/inputs/apcupsd/apcupsd_test.go:55:5                 testifylint  go-require: require must only be used in the goroutine running the test function
plugins/inputs/apcupsd/apcupsd_test.go:62:6                 testifylint  go-require: require must only be used in the goroutine running the test function
plugins/inputs/chrony/chrony_test.go:746:5                  testifylint  go-require: s.serve contains assertions that must only be used in the goroutine running the test function
plugins/inputs/dovecot/dovecot_test.go:62:3                 testifylint  go-require: require must only be used in the goroutine running the test function
plugins/inputs/dovecot/dovecot_test.go:65:3                 testifylint  go-require: require must only be used in the goroutine running the test function
plugins/inputs/dovecot/dovecot_test.go:71:3                 testifylint  go-require: require must only be used in the goroutine running the test function
plugins/inputs/dovecot/dovecot_test.go:76:3                 testifylint  go-require: require must only be used in the goroutine running the test function
plugins/inputs/dovecot/dovecot_test.go:80:3                 testifylint  go-require: require must only be used in the goroutine running the test function
plugins/inputs/dpdk/dpdk_connector_test.go:99:6             testifylint  go-require: simulateSocketResponse contains assertions that must only be used in the goroutine running the test function
plugins/inputs/dpdk/dpdk_test.go:151:6                      testifylint  go-require: simulateSocketResponse contains assertions that must only be used in the goroutine running the test function
plugins/inputs/dpdk/dpdk_test.go:200:6                      testifylint  go-require: simulateSocketResponse contains assertions that must only be used in the goroutine running the test function
plugins/inputs/dpdk/dpdk_test.go:226:7                      testifylint  go-require: simulateSocketResponse contains assertions that must only be used in the goroutine running the test function
plugins/inputs/dpdk/dpdk_test.go:245:6                      testifylint  go-require: simulateSocketResponse contains assertions that must only be used in the goroutine running the test function
plugins/inputs/dpdk/dpdk_test.go:258:6                      testifylint  go-require: simulateSocketResponse contains assertions that must only be used in the goroutine running the test function
plugins/inputs/dpdk/dpdk_test.go:278:6                      testifylint  go-require: simulateSocketResponse contains assertions that must only be used in the goroutine running the test function
plugins/inputs/dpdk/dpdk_test.go:279:6                      testifylint  go-require: simulateSocketResponse contains assertions that must only be used in the goroutine running the test function
plugins/inputs/dpdk/dpdk_test.go:306:6                      testifylint  go-require: simulateSocketResponse contains assertions that must only be used in the goroutine running the test function
plugins/inputs/execd/shim/shim_posix_test.go:40:5           testifylint  go-require: require must only be used in the goroutine running the test function
plugins/inputs/execd/shim/shim_test.go:77:3                 testifylint  go-require: require must only be used in the goroutine running the test function
plugins/inputs/gnmi/gnmi_test.go:99:3                       testifylint  go-require: require must only be used in the goroutine running the test function
plugins/inputs/gnmi/gnmi_test.go:158:3                      testifylint  go-require: require must only be used in the goroutine running the test function
plugins/inputs/gnmi/gnmi_test.go:1015:5                     testifylint  go-require: require must only be used in the goroutine running the test function
plugins/inputs/gnmi/gnmi_test.go:1067:3                     testifylint  go-require: require must only be used in the goroutine running the test function
plugins/inputs/gnmi/gnmi_test.go:1099:3                     testifylint  go-require: require must only be used in the goroutine running the test function
plugins/inputs/gnmi/gnmi_test.go:1203:5                     testifylint  go-require: require must only be used in the goroutine running the test function
plugins/inputs/hddtemp/go-hddtemp/hddtemp_test.go:83:3      testifylint  go-require: require must only be used in the goroutine running the test function
plugins/inputs/hddtemp/go-hddtemp/hddtemp_test.go:86:3      testifylint  go-require: require must only be used in the goroutine running the test function
plugins/inputs/hddtemp/go-hddtemp/hddtemp_test.go:87:3      testifylint  go-require: require must only be used in the goroutine running the test function
plugins/inputs/intel_dlb/intel_dlb_test.go:429:6            testifylint  go-require: simulateSocketResponseForGather contains assertions that must only be used in the goroutine running the test function
plugins/inputs/kafka_consumer/kafka_consumer_test.go:358:3  testifylint  go-require: require must only be used in the goroutine running the test function
plugins/inputs/kafka_consumer/kafka_consumer_test.go:359:3  testifylint  go-require: require must only be used in the goroutine running the test function
plugins/inputs/net_response/net_response_test.go:109:5      testifylint  go-require: TCPServer contains assertions that must only be used in the goroutine running the test function
plugins/inputs/net_response/net_response_test.go:154:5      testifylint  go-require: TCPServer contains assertions that must only be used in the goroutine running the test function
plugins/inputs/net_response/net_response_test.go:236:5      testifylint  go-require: UDPServer contains assertions that must only be used in the goroutine running the test function
plugins/inputs/radius/radius_test.go:53:5                   testifylint  go-require: require must only be used in the goroutine running the test function
plugins/inputs/radius/radius_test.go:121:5                  testifylint  go-require: require must only be used in the goroutine running the test function
plugins/inputs/statsd/statsd_test.go:206:5                  testifylint  go-require: require must only be used in the goroutine running the test function
plugins/inputs/statsd/statsd_test.go:243:5                  testifylint  go-require: require must only be used in the goroutine running the test function
plugins/inputs/statsd/statsd_test.go:280:5                  testifylint  go-require: require must only be used in the goroutine running the test function
plugins/inputs/teamspeak/teamspeak_test.go:64:5             testifylint  go-require: handleRequest contains assertions that must only be used in the goroutine running the test function
plugins/inputs/x509_cert/x509_cert_test.go:92:5             testifylint  go-require: require must only be used in the goroutine running the test function
plugins/inputs/x509_cert/x509_cert_test.go:103:5            testifylint  go-require: require must only be used in the goroutine running the test function
plugins/inputs/x509_cert/x509_cert_test.go:322:3            testifylint  go-require: require must only be used in the goroutine running the test function
```

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR