### PR TITLE
feat(inputs.chrony): Add probe_on_startup option

### DIFF
--- a/plugins/inputs/chrony/README.md
+++ b/plugins/inputs/chrony/README.md
@@ -46,6 +46,12 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## with the following group and permissions.
   # socket_group = "chrony"
   # socket_perms = "0660"
+
+  ## Optional: Attempt to communicate with the chrony server once on startup. If
+  ## communication fails, the plugin will return an error. This is particularly
+  ## useful if used in conjunction with `startup_error_behavior` to allow the
+  ## plugin to be disabled if chrony cannot be queried successfully.
+  # probe_on_startup = false
 ```
 
 ## Local socket permissions

--- a/plugins/inputs/chrony/chrony_test.go
+++ b/plugins/inputs/chrony/chrony_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/testcontainers/testcontainers-go/wait"
 
 	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/internal"
 	"github.com/influxdata/telegraf/metric"
 	"github.com/influxdata/telegraf/testutil"
@@ -25,6 +26,7 @@ func TestProbeOnStartupFailure(t *testing.T) {
 	plugin := &Chrony{
 		Metrics:        []string{"activity"},
 		Log:            testutil.Logger{},
+		Timeout:        config.Duration(1 * time.Second),
 		ProbeOnStartup: true,
 	}
 	require.NoError(t, plugin.Init())

--- a/plugins/inputs/chrony/sample.conf
+++ b/plugins/inputs/chrony/sample.conf
@@ -27,3 +27,9 @@
   ## with the following group and permissions.
   # socket_group = "chrony"
   # socket_perms = "0660"
+
+  ## Optional: Attempt to communicate with the chrony server once on startup. If
+  ## communication fails, the plugin will return an error. This is particularly
+  ## useful if used in conjunction with `startup_error_behavior` to allow the
+  ## plugin to be disabled if chrony cannot be queried successfully.
+  # probe_on_startup = false


### PR DESCRIPTION
## Summary

This option introduces the same behavior to `inputs.chrony` as was done to `inputs.nvidia_smi` in https://github.com/influxdata/telegraf/commit/b6e59aac594f95589dbcdb1a00638e15c76d217a. The plugin will attempt to read metrics from the chrony server once, and if a failure occurs, it will return `internal.StartupError`.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues

Related to:

- https://github.com/influxdata/telegraf/issues/15915
- https://github.com/influxdata/telegraf/pull/15916
