### PR TITLE
chore: Fix linter findings for `revive:exported` in `plugins/inputs/c*`

### DIFF
--- a/plugins/inputs/ceph/ceph.go
+++ b/plugins/inputs/ceph/ceph.go
@@ -18,6 +18,19 @@ import (
 //go:embed sample.conf
 var sampleConfig string
 
+const (
+	measurement = "ceph"
+	typeMon     = "monitor"
+	typeOsd     = "osd"
+	typeMds     = "mds"
+	typeRgw     = "rgw"
+	osdPrefix   = "ceph-osd"
+	monPrefix   = "ceph-mon"
+	mdsPrefix   = "ceph-mds"
+	rgwPrefix   = "ceph-client"
+	sockSuffix  = "asok"
+)
+
 type Ceph struct {
 	CephBinary             string `toml:"ceph_binary"`
 	OsdPrefix              string `toml:"osd_prefix"`
@@ -34,19 +47,6 @@ type Ceph struct {
 	Log        telegraf.Logger `toml:"-"`
 	schemaMaps map[socket]perfSchemaMap
 }
-
-const (
-	measurement = "ceph"
-	typeMon     = "monitor"
-	typeOsd     = "osd"
-	typeMds     = "mds"
-	typeRgw     = "rgw"
-	osdPrefix   = "ceph-osd"
-	monPrefix   = "ceph-mon"
-	mdsPrefix   = "ceph-mds"
-	rgwPrefix   = "ceph-client"
-	sockSuffix  = "asok"
-)
 
 func (*Ceph) SampleConfig() string {
 	return sampleConfig

--- a/plugins/inputs/ceph/ceph.go
+++ b/plugins/inputs/ceph/ceph.go
@@ -18,19 +18,6 @@ import (
 //go:embed sample.conf
 var sampleConfig string
 
-const (
-	measurement = "ceph"
-	typeMon     = "monitor"
-	typeOsd     = "osd"
-	typeMds     = "mds"
-	typeRgw     = "rgw"
-	osdPrefix   = "ceph-osd"
-	monPrefix   = "ceph-mon"
-	mdsPrefix   = "ceph-mds"
-	rgwPrefix   = "ceph-client"
-	sockSuffix  = "asok"
-)
-
 type Ceph struct {
 	CephBinary             string `toml:"ceph_binary"`
 	OsdPrefix              string `toml:"osd_prefix"`
@@ -47,6 +34,19 @@ type Ceph struct {
 	Log        telegraf.Logger `toml:"-"`
 	schemaMaps map[socket]perfSchemaMap
 }
+
+const (
+	measurement = "ceph"
+	typeMon     = "monitor"
+	typeOsd     = "osd"
+	typeMds     = "mds"
+	typeRgw     = "rgw"
+	osdPrefix   = "ceph-osd"
+	monPrefix   = "ceph-mon"
+	mdsPrefix   = "ceph-mds"
+	rgwPrefix   = "ceph-client"
+	sockSuffix  = "asok"
+)
 
 func (*Ceph) SampleConfig() string {
 	return sampleConfig
@@ -147,24 +147,6 @@ func (c *Ceph) gatherClusterStats(acc telegraf.Accumulator) error {
 	}
 
 	return nil
-}
-
-func init() {
-	inputs.Add(measurement, func() telegraf.Input {
-		return &Ceph{
-			CephBinary:             "/usr/bin/ceph",
-			OsdPrefix:              osdPrefix,
-			MonPrefix:              monPrefix,
-			MdsPrefix:              mdsPrefix,
-			RgwPrefix:              rgwPrefix,
-			SocketDir:              "/var/run/ceph",
-			SocketSuffix:           sockSuffix,
-			CephUser:               "client.admin",
-			CephConfig:             "/etc/ceph/ceph.conf",
-			GatherAdminSocketStats: true,
-			GatherClusterStats:     false,
-		}
-	})
 }
 
 // Run ceph perf schema on the passed socket.  The output is a JSON string
@@ -428,8 +410,8 @@ func (c *Ceph) execute(command string) (string, error) {
 	return output, nil
 }
 
-// CephStatus is used to unmarshal "ceph -s" output
-type CephStatus struct {
+// status is used to unmarshal "ceph -s" output
+type status struct {
 	FSMap struct {
 		NumIn        float64 `json:"in"`
 		NumMax       float64 `json:"max"`
@@ -492,12 +474,12 @@ type CephStatus struct {
 
 // decodeStatus decodes the output of 'ceph -s'
 func decodeStatus(acc telegraf.Accumulator, input string) error {
-	data := &CephStatus{}
+	data := &status{}
 	if err := json.Unmarshal([]byte(input), data); err != nil {
 		return fmt.Errorf("failed to parse json: %q: %w", input, err)
 	}
 
-	decoders := []func(telegraf.Accumulator, *CephStatus) error{
+	decoders := []func(telegraf.Accumulator, *status) error{
 		decodeStatusFsmap,
 		decodeStatusHealth,
 		decodeStatusMonmap,
@@ -516,7 +498,7 @@ func decodeStatus(acc telegraf.Accumulator, input string) error {
 }
 
 // decodeStatusFsmap decodes the FS map portion of the output of 'ceph -s'
-func decodeStatusFsmap(acc telegraf.Accumulator, data *CephStatus) error {
+func decodeStatusFsmap(acc telegraf.Accumulator, data *status) error {
 	fields := map[string]interface{}{
 		"in":         data.FSMap.NumIn,
 		"max":        data.FSMap.NumMax,
@@ -528,7 +510,7 @@ func decodeStatusFsmap(acc telegraf.Accumulator, data *CephStatus) error {
 }
 
 // decodeStatusHealth decodes the health portion of the output of 'ceph status'
-func decodeStatusHealth(acc telegraf.Accumulator, data *CephStatus) error {
+func decodeStatusHealth(acc telegraf.Accumulator, data *status) error {
 	statusCodes := map[string]float64{
 		"HEALTH_ERR":  0,
 		"HEALTH_WARN": 1,
@@ -544,7 +526,7 @@ func decodeStatusHealth(acc telegraf.Accumulator, data *CephStatus) error {
 }
 
 // decodeStatusMonmap decodes the Mon map portion of the output of 'ceph -s'
-func decodeStatusMonmap(acc telegraf.Accumulator, data *CephStatus) error {
+func decodeStatusMonmap(acc telegraf.Accumulator, data *status) error {
 	fields := map[string]interface{}{
 		"num_mons": data.MonMap.NumMons,
 	}
@@ -553,7 +535,7 @@ func decodeStatusMonmap(acc telegraf.Accumulator, data *CephStatus) error {
 }
 
 // decodeStatusOsdmap decodes the OSD map portion of the output of 'ceph -s'
-func decodeStatusOsdmap(acc telegraf.Accumulator, data *CephStatus) error {
+func decodeStatusOsdmap(acc telegraf.Accumulator, data *status) error {
 	fields := map[string]interface{}{
 		"epoch":            data.OSDMap.Epoch,
 		"num_in_osds":      data.OSDMap.NumInOSDs,
@@ -578,7 +560,7 @@ func decodeStatusOsdmap(acc telegraf.Accumulator, data *CephStatus) error {
 }
 
 // decodeStatusPgmap decodes the PG map portion of the output of 'ceph -s'
-func decodeStatusPgmap(acc telegraf.Accumulator, data *CephStatus) error {
+func decodeStatusPgmap(acc telegraf.Accumulator, data *status) error {
 	fields := map[string]interface{}{
 		"bytes_avail":                data.PGMap.BytesAvail,
 		"bytes_total":                data.PGMap.BytesTotal,
@@ -609,7 +591,7 @@ func decodeStatusPgmap(acc telegraf.Accumulator, data *CephStatus) error {
 }
 
 // decodeStatusPgmapState decodes the PG map state portion of the output of 'ceph -s'
-func decodeStatusPgmapState(acc telegraf.Accumulator, data *CephStatus) error {
+func decodeStatusPgmapState(acc telegraf.Accumulator, data *status) error {
 	for _, pgState := range data.PGMap.PGsByState {
 		tags := map[string]string{
 			"state": pgState.StateName,
@@ -622,8 +604,8 @@ func decodeStatusPgmapState(acc telegraf.Accumulator, data *CephStatus) error {
 	return nil
 }
 
-// CephDF is used to unmarshal 'ceph df' output
-type CephDf struct {
+// df is used to unmarshal 'ceph df' output
+type df struct {
 	Stats struct {
 		NumOSDs            float64 `json:"num_osds"`
 		NumPerPoolOmapOSDs float64 `json:"num_per_pool_omap_osds"`
@@ -653,7 +635,7 @@ type CephDf struct {
 
 // decodeDf decodes the output of 'ceph df'
 func decodeDf(acc telegraf.Accumulator, input string) error {
-	data := &CephDf{}
+	data := &df{}
 	if err := json.Unmarshal([]byte(input), data); err != nil {
 		return fmt.Errorf("failed to parse json: %q: %w", input, err)
 	}
@@ -705,8 +687,8 @@ func decodeDf(acc telegraf.Accumulator, input string) error {
 	return nil
 }
 
-// CephOSDPoolStats is used to unmarshal 'ceph osd pool stats' output
-type CephOSDPoolStats []struct {
+// osdPoolStats is used to unmarshal 'ceph osd pool stats' output
+type osdPoolStats []struct {
 	PoolName     string `json:"pool_name"`
 	ClientIORate struct {
 		OpPerSec      float64 `json:"op_per_sec"` // This field is no longer reported in ceph 10 and later
@@ -732,7 +714,7 @@ type CephOSDPoolStats []struct {
 
 // decodeOsdPoolStats decodes the output of 'ceph osd pool stats'
 func decodeOsdPoolStats(acc telegraf.Accumulator, input string) error {
-	data := CephOSDPoolStats{}
+	data := osdPoolStats{}
 	if err := json.Unmarshal([]byte(input), &data); err != nil {
 		return fmt.Errorf("failed to parse json: %q: %w", input, err)
 	}
@@ -762,4 +744,22 @@ func decodeOsdPoolStats(acc telegraf.Accumulator, input string) error {
 	}
 
 	return nil
+}
+
+func init() {
+	inputs.Add(measurement, func() telegraf.Input {
+		return &Ceph{
+			CephBinary:             "/usr/bin/ceph",
+			OsdPrefix:              osdPrefix,
+			MonPrefix:              monPrefix,
+			MdsPrefix:              mdsPrefix,
+			RgwPrefix:              rgwPrefix,
+			SocketDir:              "/var/run/ceph",
+			SocketSuffix:           sockSuffix,
+			CephUser:               "client.admin",
+			CephConfig:             "/etc/ceph/ceph.conf",
+			GatherAdminSocketStats: true,
+			GatherClusterStats:     false,
+		}
+	})
 }

--- a/plugins/inputs/chrony/chrony.go
+++ b/plugins/inputs/chrony/chrony.go
@@ -46,43 +46,6 @@ func (*Chrony) SampleConfig() string {
 	return sampleConfig
 }
 
-// dialUnix opens an unixgram connection with chrony
-func (c *Chrony) dialUnix(address string) (*net.UnixConn, error) {
-	dir := path.Dir(address)
-	c.local = path.Join(dir, fmt.Sprintf("chrony-telegraf-%s.sock", uuid.New().String()))
-	conn, err := net.DialUnix("unixgram",
-		&net.UnixAddr{Name: c.local, Net: "unixgram"},
-		&net.UnixAddr{Name: address, Net: "unixgram"},
-	)
-
-	if err != nil {
-		return nil, err
-	}
-
-	filemode, err := strconv.ParseUint(c.SocketPerms, 8, 32)
-	if err != nil {
-		return nil, fmt.Errorf("parsing file mode %q failed: %w", c.SocketPerms, err)
-	}
-
-	if err := os.Chmod(c.local, os.FileMode(filemode)); err != nil {
-		return nil, fmt.Errorf("changing file mode of %q failed: %w", c.local, err)
-	}
-
-	group, err := user.LookupGroup(c.SocketGroup)
-	if err != nil {
-		return nil, fmt.Errorf("looking up group %q failed: %w", c.SocketGroup, err)
-	}
-	gid, err := strconv.Atoi(group.Gid)
-	if err != nil {
-		return nil, fmt.Errorf("parsing group ID %q failed: %w", group.Gid, err)
-	}
-	if err := os.Chown(c.local, os.Getuid(), gid); err != nil {
-		return nil, fmt.Errorf("changing group of %q failed: %w", c.local, err)
-	}
-
-	return conn, nil
-}
-
 func (c *Chrony) Init() error {
 	// Use the configured server, if none set, we try to guess it in Start()
 	if c.Server != "" {
@@ -182,19 +145,6 @@ func (c *Chrony) Start(_ telegraf.Accumulator) error {
 	return nil
 }
 
-func (c *Chrony) Stop() {
-	if c.conn != nil {
-		if err := c.conn.Close(); err != nil && !errors.Is(err, net.ErrClosed) && !errors.Is(err, syscall.EPIPE) {
-			c.Log.Errorf("Closing connection to %q failed: %v", c.Server, err)
-		}
-	}
-	if c.local != "" {
-		if err := os.Remove(c.local); err != nil {
-			c.Log.Errorf("Removing temporary socket %q failed: %v", c.local, err)
-		}
-	}
-}
-
 func (c *Chrony) Gather(acc telegraf.Accumulator) error {
 	for _, m := range c.Metrics {
 		switch m {
@@ -214,6 +164,56 @@ func (c *Chrony) Gather(acc telegraf.Accumulator) error {
 	}
 
 	return nil
+}
+
+func (c *Chrony) Stop() {
+	if c.conn != nil {
+		if err := c.conn.Close(); err != nil && !errors.Is(err, net.ErrClosed) && !errors.Is(err, syscall.EPIPE) {
+			c.Log.Errorf("Closing connection to %q failed: %v", c.Server, err)
+		}
+	}
+	if c.local != "" {
+		if err := os.Remove(c.local); err != nil {
+			c.Log.Errorf("Removing temporary socket %q failed: %v", c.local, err)
+		}
+	}
+}
+
+// dialUnix opens an unixgram connection with chrony
+func (c *Chrony) dialUnix(address string) (*net.UnixConn, error) {
+	dir := path.Dir(address)
+	c.local = path.Join(dir, fmt.Sprintf("chrony-telegraf-%s.sock", uuid.New().String()))
+	conn, err := net.DialUnix("unixgram",
+		&net.UnixAddr{Name: c.local, Net: "unixgram"},
+		&net.UnixAddr{Name: address, Net: "unixgram"},
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	filemode, err := strconv.ParseUint(c.SocketPerms, 8, 32)
+	if err != nil {
+		return nil, fmt.Errorf("parsing file mode %q failed: %w", c.SocketPerms, err)
+	}
+
+	if err := os.Chmod(c.local, os.FileMode(filemode)); err != nil {
+		return nil, fmt.Errorf("changing file mode of %q failed: %w", c.local, err)
+	}
+
+	group, err := user.LookupGroup(c.SocketGroup)
+	if err != nil {
+		return nil, fmt.Errorf("looking up group %q failed: %w", c.SocketGroup, err)
+	}
+	gid, err := strconv.Atoi(group.Gid)
+	if err != nil {
+		return nil, fmt.Errorf("parsing group ID %q failed: %w", group.Gid, err)
+	}
+	if err := os.Chown(c.local, os.Getuid(), gid); err != nil {
+		return nil, fmt.Errorf("changing group of %q failed: %w", c.local, err)
+	}
+
+	return conn, nil
 }
 
 func (c *Chrony) gatherActivity(acc telegraf.Accumulator) error {

--- a/plugins/inputs/cisco_telemetry_mdt/cisco_telemetry_mdt.go
+++ b/plugins/inputs/cisco_telemetry_mdt/cisco_telemetry_mdt.go
@@ -38,16 +38,11 @@ var sampleConfig string
 const (
 	// Maximum telemetry payload size (in bytes) to accept for GRPC dialout transport
 	tcpMaxMsgLen uint32 = 1024 * 1024
+
+	// default minimum time between successive pings
+	// this value is specified in the GRPC docs via GRPC_ARG_HTTP2_MIN_RECV_PING_INTERVAL_WITHOUT_DATA_MS
+	defaultKeepaliveMinTime = config.Duration(time.Second * 300)
 )
-
-// default minimum time between successive pings
-// this value is specified in the GRPC docs via GRPC_ARG_HTTP2_MIN_RECV_PING_INTERVAL_WITHOUT_DATA_MS
-const defaultKeepaliveMinTime = config.Duration(time.Second * 300)
-
-type GRPCEnforcementPolicy struct {
-	PermitKeepaliveWithoutCalls bool            `toml:"permit_keepalive_without_calls"`
-	KeepaliveMinTime            config.Duration `toml:"keepalive_minimum_time"`
-}
 
 // CiscoTelemetryMDT plugin for IOS XR, IOS XE and NXOS platforms
 type CiscoTelemetryMDT struct {
@@ -58,7 +53,7 @@ type CiscoTelemetryMDT struct {
 	Aliases            map[string]string     `toml:"aliases"`
 	Dmes               map[string]string     `toml:"dmes"`
 	EmbeddedTags       []string              `toml:"embedded_tags"`
-	EnforcementPolicy  GRPCEnforcementPolicy `toml:"grpc_enforcement_policy"`
+	EnforcementPolicy  grpcEnforcementPolicy `toml:"grpc_enforcement_policy"`
 	IncludeDeleteField bool                  `toml:"include_delete_field"`
 	SourceFieldName    string                `toml:"source_field_name"`
 
@@ -86,7 +81,12 @@ type CiscoTelemetryMDT struct {
 	mdtdialout.UnimplementedGRPCMdtDialoutServer
 }
 
-type NxPayloadXfromStructure struct {
+type grpcEnforcementPolicy struct {
+	PermitKeepaliveWithoutCalls bool            `toml:"permit_keepalive_without_calls"`
+	KeepaliveMinTime            config.Duration `toml:"keepalive_minimum_time"`
+}
+
+type nxPayloadXfromStructure struct {
 	Name string `json:"Name"`
 	Prop []struct {
 		Key   string `json:"Key"`
@@ -142,7 +142,7 @@ func (c *CiscoTelemetryMDT) Start(acc telegraf.Accumulator) error {
 				continue
 			}
 
-			var jsStruct NxPayloadXfromStructure
+			var jsStruct nxPayloadXfromStructure
 			err := json.Unmarshal([]byte(dmeKey), &jsStruct)
 			if err != nil {
 				continue
@@ -218,7 +218,67 @@ func (c *CiscoTelemetryMDT) Start(acc telegraf.Accumulator) error {
 	return nil
 }
 
-// AcceptTCPDialoutClients defines the TCP dialout server main routine
+func (c *CiscoTelemetryMDT) Gather(_ telegraf.Accumulator) error {
+	return nil
+}
+
+// Stop listener and cleanup
+func (c *CiscoTelemetryMDT) Stop() {
+	if c.grpcServer != nil {
+		// Stop server and terminate all running dialout routines
+		c.grpcServer.Stop()
+	}
+	if c.listener != nil {
+		c.listener.Close()
+	}
+	c.wg.Wait()
+}
+
+// MdtDialout RPC server method for grpc-dialout transport
+func (c *CiscoTelemetryMDT) MdtDialout(stream mdtdialout.GRPCMdtDialout_MdtDialoutServer) error {
+	peerInCtx, peerOK := peer.FromContext(stream.Context())
+	if peerOK {
+		c.Log.Debugf("Accepted Cisco MDT GRPC dialout connection from %s", peerInCtx.Addr)
+	}
+
+	var chunkBuffer bytes.Buffer
+
+	for {
+		packet, err := stream.Recv()
+		if err != nil {
+			if !errors.Is(err, io.EOF) {
+				c.acc.AddError(fmt.Errorf("receive error during GRPC dialout: %w", err))
+			}
+			break
+		}
+
+		if len(packet.Data) == 0 && len(packet.Errors) != 0 {
+			c.acc.AddError(fmt.Errorf("error during GRPC dialout: %s", packet.Errors))
+			break
+		}
+
+		// Reassemble chunked telemetry data received from NX-OS
+		if packet.TotalSize == 0 {
+			c.handleTelemetry(packet.Data)
+		} else if int(packet.TotalSize) <= c.MaxMsgSize {
+			chunkBuffer.Write(packet.Data)
+			if chunkBuffer.Len() >= int(packet.TotalSize) {
+				c.handleTelemetry(chunkBuffer.Bytes())
+				chunkBuffer.Reset()
+			}
+		} else {
+			c.acc.AddError(fmt.Errorf("dropped too large packet: %dB > %dB", packet.TotalSize, c.MaxMsgSize))
+		}
+	}
+
+	if peerOK {
+		c.Log.Debugf("Closed Cisco MDT GRPC dialout connection from %s", peerInCtx.Addr)
+	}
+
+	return nil
+}
+
+// acceptTCPClients defines the TCP dialout server main routine
 func (c *CiscoTelemetryMDT) acceptTCPClients() {
 	// Keep track of all active connections, so we can close them if necessary
 	var mutex sync.Mutex
@@ -309,50 +369,6 @@ func (c *CiscoTelemetryMDT) handleTCPClient(conn net.Conn) error {
 
 		c.handleTelemetry(payload.Bytes())
 	}
-}
-
-// MdtDialout RPC server method for grpc-dialout transport
-func (c *CiscoTelemetryMDT) MdtDialout(stream mdtdialout.GRPCMdtDialout_MdtDialoutServer) error {
-	peerInCtx, peerOK := peer.FromContext(stream.Context())
-	if peerOK {
-		c.Log.Debugf("Accepted Cisco MDT GRPC dialout connection from %s", peerInCtx.Addr)
-	}
-
-	var chunkBuffer bytes.Buffer
-
-	for {
-		packet, err := stream.Recv()
-		if err != nil {
-			if !errors.Is(err, io.EOF) {
-				c.acc.AddError(fmt.Errorf("receive error during GRPC dialout: %w", err))
-			}
-			break
-		}
-
-		if len(packet.Data) == 0 && len(packet.Errors) != 0 {
-			c.acc.AddError(fmt.Errorf("error during GRPC dialout: %s", packet.Errors))
-			break
-		}
-
-		// Reassemble chunked telemetry data received from NX-OS
-		if packet.TotalSize == 0 {
-			c.handleTelemetry(packet.Data)
-		} else if int(packet.TotalSize) <= c.MaxMsgSize {
-			chunkBuffer.Write(packet.Data)
-			if chunkBuffer.Len() >= int(packet.TotalSize) {
-				c.handleTelemetry(chunkBuffer.Bytes())
-				chunkBuffer.Reset()
-			}
-		} else {
-			c.acc.AddError(fmt.Errorf("dropped too large packet: %dB > %dB", packet.TotalSize, c.MaxMsgSize))
-		}
-	}
-
-	if peerOK {
-		c.Log.Debugf("Closed Cisco MDT GRPC dialout connection from %s", peerInCtx.Addr)
-	}
-
-	return nil
 }
 
 // Handle telemetry packet from any transport, decode and add as measurement
@@ -782,25 +798,8 @@ func (c *CiscoTelemetryMDT) parseContentField(
 	delete(tags, prefix)
 }
 
-func (c *CiscoTelemetryMDT) Address() net.Addr {
+func (c *CiscoTelemetryMDT) address() net.Addr {
 	return c.listener.Addr()
-}
-
-// Stop listener and cleanup
-func (c *CiscoTelemetryMDT) Stop() {
-	if c.grpcServer != nil {
-		// Stop server and terminate all running dialout routines
-		c.grpcServer.Stop()
-	}
-	if c.listener != nil {
-		c.listener.Close()
-	}
-	c.wg.Wait()
-}
-
-// Gather plugin measurements (unused)
-func (c *CiscoTelemetryMDT) Gather(_ telegraf.Accumulator) error {
-	return nil
 }
 
 func init() {

--- a/plugins/inputs/cisco_telemetry_mdt/cisco_telemetry_mdt.go
+++ b/plugins/inputs/cisco_telemetry_mdt/cisco_telemetry_mdt.go
@@ -798,10 +798,6 @@ func (c *CiscoTelemetryMDT) parseContentField(
 	delete(tags, prefix)
 }
 
-func (c *CiscoTelemetryMDT) address() net.Addr {
-	return c.listener.Addr()
-}
-
 func init() {
 	inputs.Add("cisco_telemetry_mdt", func() telegraf.Input {
 		return &CiscoTelemetryMDT{

--- a/plugins/inputs/cisco_telemetry_mdt/cisco_telemetry_mdt_test.go
+++ b/plugins/inputs/cisco_telemetry_mdt/cisco_telemetry_mdt_test.go
@@ -979,7 +979,7 @@ func TestTCPDialoutOverflow(t *testing.T) {
 		MsgLen        uint32
 	}{MsgLen: uint32(1000000000)}
 
-	addr := c.address()
+	addr := c.listener.Addr()
 	conn, err := net.Dial(addr.Network(), addr.String())
 	require.NoError(t, err)
 	require.NoError(t, binary.Write(conn, binary.BigEndian, hdr))
@@ -1104,7 +1104,7 @@ func TestTCPDialoutMultiple(t *testing.T) {
 		MsgLen        uint32
 	}{}
 
-	addr := c.address()
+	addr := c.listener.Addr()
 	conn, err := net.Dial(addr.Network(), addr.String())
 	require.NoError(t, err)
 
@@ -1186,7 +1186,7 @@ func TestGRPCDialoutError(t *testing.T) {
 	err := c.Start(acc)
 	require.NoError(t, err)
 
-	addr := c.address()
+	addr := c.listener.Addr()
 	conn, err := grpc.NewClient(addr.String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	require.NoError(t, err)
 	client := mdtdialout.NewGRPCMdtDialoutClient(conn)
@@ -1220,7 +1220,7 @@ func TestGRPCDialoutMultiple(t *testing.T) {
 	require.NoError(t, err)
 	tel := mockTelemetryMessage()
 
-	addr := c.address()
+	addr := c.listener.Addr()
 	conn, err := grpc.NewClient(addr.String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	require.NoError(t, err)
 	require.True(t, conn.WaitForStateChange(context.Background(), connectivity.Connecting))
@@ -1306,7 +1306,7 @@ func TestGRPCDialoutKeepalive(t *testing.T) {
 	err := c.Start(acc)
 	require.NoError(t, err)
 
-	addr := c.address()
+	addr := c.listener.Addr()
 	conn, err := grpc.NewClient(addr.String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	require.NoError(t, err)
 	client := mdtdialout.NewGRPCMdtDialoutClient(conn)

--- a/plugins/inputs/cisco_telemetry_mdt/cisco_telemetry_mdt_test.go
+++ b/plugins/inputs/cisco_telemetry_mdt/cisco_telemetry_mdt_test.go
@@ -979,7 +979,7 @@ func TestTCPDialoutOverflow(t *testing.T) {
 		MsgLen        uint32
 	}{MsgLen: uint32(1000000000)}
 
-	addr := c.Address()
+	addr := c.address()
 	conn, err := net.Dial(addr.Network(), addr.String())
 	require.NoError(t, err)
 	require.NoError(t, binary.Write(conn, binary.BigEndian, hdr))
@@ -1104,7 +1104,7 @@ func TestTCPDialoutMultiple(t *testing.T) {
 		MsgLen        uint32
 	}{}
 
-	addr := c.Address()
+	addr := c.address()
 	conn, err := net.Dial(addr.Network(), addr.String())
 	require.NoError(t, err)
 
@@ -1186,7 +1186,7 @@ func TestGRPCDialoutError(t *testing.T) {
 	err := c.Start(acc)
 	require.NoError(t, err)
 
-	addr := c.Address()
+	addr := c.address()
 	conn, err := grpc.NewClient(addr.String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	require.NoError(t, err)
 	client := mdtdialout.NewGRPCMdtDialoutClient(conn)
@@ -1220,7 +1220,7 @@ func TestGRPCDialoutMultiple(t *testing.T) {
 	require.NoError(t, err)
 	tel := mockTelemetryMessage()
 
-	addr := c.Address()
+	addr := c.address()
 	conn, err := grpc.NewClient(addr.String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	require.NoError(t, err)
 	require.True(t, conn.WaitForStateChange(context.Background(), connectivity.Connecting))
@@ -1297,7 +1297,7 @@ func TestGRPCDialoutKeepalive(t *testing.T) {
 		Log:            testutil.Logger{},
 		Transport:      "grpc",
 		ServiceAddress: "127.0.0.1:0",
-		EnforcementPolicy: GRPCEnforcementPolicy{
+		EnforcementPolicy: grpcEnforcementPolicy{
 			PermitKeepaliveWithoutCalls: true,
 			KeepaliveMinTime:            0,
 		},
@@ -1306,7 +1306,7 @@ func TestGRPCDialoutKeepalive(t *testing.T) {
 	err := c.Start(acc)
 	require.NoError(t, err)
 
-	addr := c.Address()
+	addr := c.address()
 	conn, err := grpc.NewClient(addr.String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 	require.NoError(t, err)
 	client := mdtdialout.NewGRPCMdtDialoutClient(conn)

--- a/plugins/inputs/clickhouse/clickhouse.go
+++ b/plugins/inputs/clickhouse/clickhouse.go
@@ -26,26 +26,6 @@ var sampleConfig string
 
 var defaultTimeout = 5 * time.Second
 
-type connect struct {
-	Cluster  string `json:"cluster"`
-	ShardNum int    `json:"shard_num"`
-	Hostname string `json:"host_name"`
-	url      *url.URL
-}
-
-func init() {
-	inputs.Add("clickhouse", func() telegraf.Input {
-		return &ClickHouse{
-			AutoDiscovery: true,
-			ClientConfig: tls.ClientConfig{
-				InsecureSkipVerify: false,
-			},
-			Timeout: config.Duration(defaultTimeout),
-		}
-	})
-}
-
-// ClickHouse Telegraf Input Plugin
 type ClickHouse struct {
 	Username       string          `toml:"username"`
 	Password       string          `toml:"password"`
@@ -58,6 +38,13 @@ type ClickHouse struct {
 
 	HTTPClient http.Client
 	tls.ClientConfig
+}
+
+type connect struct {
+	Cluster  string `json:"cluster"`
+	ShardNum int    `json:"shard_num"`
+	Hostname string `json:"host_name"`
+	url      *url.URL
 }
 
 func (*ClickHouse) SampleConfig() string {
@@ -638,3 +625,15 @@ var commonMetricsIsFloat = map[string]bool{
 }
 
 var _ telegraf.ServiceInput = &ClickHouse{}
+
+func init() {
+	inputs.Add("clickhouse", func() telegraf.Input {
+		return &ClickHouse{
+			AutoDiscovery: true,
+			ClientConfig: tls.ClientConfig{
+				InsecureSkipVerify: false,
+			},
+			Timeout: config.Duration(defaultTimeout),
+		}
+	})
+}

--- a/plugins/inputs/cloud_pubsub/cloud_pubsub.go
+++ b/plugins/inputs/cloud_pubsub/cloud_pubsub.go
@@ -25,11 +25,10 @@ var sampleConfig string
 
 var once sync.Once
 
-type empty struct{}
-type semaphore chan empty
-
-const defaultMaxUndeliveredMessages = 1000
-const defaultRetryDelaySeconds = 5
+const (
+	defaultMaxUndeliveredMessages = 1000
+	defaultRetryDelaySeconds      = 5
+)
 
 type PubSub struct {
 	sync.Mutex
@@ -70,12 +69,41 @@ type PubSub struct {
 	decoderMutex sync.Mutex
 }
 
+type (
+	empty     struct{}
+	semaphore chan empty
+)
+
 func (*PubSub) SampleConfig() string {
 	return sampleConfig
 }
 
-// Gather does nothing for this service input.
-func (ps *PubSub) Gather(_ telegraf.Accumulator) error {
+func (ps *PubSub) Init() error {
+	if ps.Subscription == "" {
+		return errors.New(`"subscription" is required`)
+	}
+
+	if ps.Project == "" {
+		return errors.New(`"project" is required`)
+	}
+
+	switch ps.ContentEncoding {
+	case "", "identity":
+		ps.ContentEncoding = "identity"
+	case "gzip":
+		var err error
+		var options []internal.DecodingOption
+		if ps.MaxDecompressionSize > 0 {
+			options = append(options, internal.WithMaxDecompressionSize(int64(ps.MaxDecompressionSize)))
+		}
+		ps.decoder, err = internal.NewContentDecoder(ps.ContentEncoding, options...)
+		if err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("invalid value %q for content_encoding", ps.ContentEncoding)
+	}
+
 	return nil
 }
 
@@ -120,6 +148,11 @@ func (ps *PubSub) Start(ac telegraf.Accumulator) error {
 		ps.receiveWithRetry(ctx)
 	}()
 
+	return nil
+}
+
+// Gather does nothing for this service input.
+func (ps *PubSub) Gather(_ telegraf.Accumulator) error {
 	return nil
 }
 
@@ -313,35 +346,6 @@ func (ps *PubSub) getGCPSubscription(subID string) (subscription, error) {
 		MaxOutstandingBytes:    ps.MaxOutstandingBytes,
 	}
 	return &gcpSubscription{s}, nil
-}
-
-func (ps *PubSub) Init() error {
-	if ps.Subscription == "" {
-		return errors.New(`"subscription" is required`)
-	}
-
-	if ps.Project == "" {
-		return errors.New(`"project" is required`)
-	}
-
-	switch ps.ContentEncoding {
-	case "", "identity":
-		ps.ContentEncoding = "identity"
-	case "gzip":
-		var err error
-		var options []internal.DecodingOption
-		if ps.MaxDecompressionSize > 0 {
-			options = append(options, internal.WithMaxDecompressionSize(int64(ps.MaxDecompressionSize)))
-		}
-		ps.decoder, err = internal.NewContentDecoder(ps.ContentEncoding, options...)
-		if err != nil {
-			return err
-		}
-	default:
-		return fmt.Errorf("invalid value %q for content_encoding", ps.ContentEncoding)
-	}
-
-	return nil
 }
 
 func init() {

--- a/plugins/inputs/cloud_pubsub/cloud_pubsub_test.go
+++ b/plugins/inputs/cloud_pubsub/cloud_pubsub_test.go
@@ -200,7 +200,7 @@ func TestRunInvalidMessages(t *testing.T) {
 	acc.WaitError(1)
 
 	// Make sure we acknowledged message so we don't receive it again.
-	testTracker.WaitForAck(1)
+	testTracker.waitForAck(1)
 
 	require.Equal(t, 0, acc.NFields())
 }
@@ -249,7 +249,7 @@ func TestRunOverlongMessages(t *testing.T) {
 	acc.WaitError(1)
 
 	// Make sure we acknowledged message so we don't receive it again.
-	testTracker.WaitForAck(1)
+	testTracker.waitForAck(1)
 
 	require.Equal(t, 0, acc.NFields())
 }

--- a/plugins/inputs/cloud_pubsub/subscription_stub.go
+++ b/plugins/inputs/cloud_pubsub/subscription_stub.go
@@ -51,11 +51,11 @@ type testMsg struct {
 }
 
 func (tm *testMsg) Ack() {
-	tm.tracker.Ack()
+	tm.tracker.ack()
 }
 
 func (tm *testMsg) Nack() {
-	tm.tracker.Nack()
+	tm.tracker.nack()
 }
 
 func (tm *testMsg) ID() string {
@@ -82,7 +82,7 @@ type testTracker struct {
 	numNacks int
 }
 
-func (t *testTracker) WaitForAck(num int) {
+func (t *testTracker) waitForAck(num int) {
 	t.Lock()
 	if t.Cond == nil {
 		t.Cond = sync.NewCond(&t.Mutex)
@@ -93,25 +93,14 @@ func (t *testTracker) WaitForAck(num int) {
 	t.Unlock()
 }
 
-func (t *testTracker) WaitForNack(num int) {
-	t.Lock()
-	if t.Cond == nil {
-		t.Cond = sync.NewCond(&t.Mutex)
-	}
-	for t.numNacks < num {
-		t.Wait()
-	}
-	t.Unlock()
-}
-
-func (t *testTracker) Ack() {
+func (t *testTracker) ack() {
 	t.Lock()
 	defer t.Unlock()
 
 	t.numAcks++
 }
 
-func (t *testTracker) Nack() {
+func (t *testTracker) nack() {
 	t.Lock()
 	defer t.Unlock()
 

--- a/plugins/inputs/cloud_pubsub_push/cloud_pubsub_push.go
+++ b/plugins/inputs/cloud_pubsub_push/cloud_pubsub_push.go
@@ -26,9 +26,11 @@ var once sync.Once
 
 // defaultMaxBodySize is the default maximum request body size, in bytes.
 // if the request body is over this size, we will return an HTTP 413 error.
-// 500 MB
-const defaultMaxBodySize = 500 * 1024 * 1024
-const defaultMaxUndeliveredMessages = 1000
+const (
+	// 500 MB
+	defaultMaxBodySize            = 500 * 1024 * 1024
+	defaultMaxUndeliveredMessages = 1000
+)
 
 type PubSubPush struct {
 	ServiceAddress string
@@ -56,24 +58,20 @@ type PubSubPush struct {
 	sem         chan struct{}
 }
 
-// Message defines the structure of a Google Pub/Sub message.
-type Message struct {
+// message defines the structure of a Google Pub/Sub message.
+type message struct {
 	Atts map[string]string `json:"attributes"`
 	Data string            `json:"data"` // Data is base64 encoded data
 }
 
-// Payload is the received Google Pub/Sub data. (https://cloud.google.com/pubsub/docs/push)
-type Payload struct {
-	Msg          Message `json:"message"`
+// payload is the received Google Pub/Sub data. (https://cloud.google.com/pubsub/docs/push)
+type payload struct {
+	Msg          message `json:"message"`
 	Subscription string  `json:"subscription"`
 }
 
 func (*PubSubPush) SampleConfig() string {
 	return sampleConfig
-}
-
-func (p *PubSubPush) Gather(_ telegraf.Accumulator) error {
-	return nil
 }
 
 func (p *PubSubPush) SetParser(parser telegraf.Parser) {
@@ -135,6 +133,10 @@ func (p *PubSubPush) Start(acc telegraf.Accumulator) error {
 	return nil
 }
 
+func (p *PubSubPush) Gather(_ telegraf.Accumulator) error {
+	return nil
+}
+
 // Stop cleans up all resources
 func (p *PubSubPush) Stop() {
 	p.cancel()
@@ -144,9 +146,9 @@ func (p *PubSubPush) Stop() {
 
 func (p *PubSubPush) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 	if req.URL.Path == p.Path {
-		p.AuthenticateIfSet(p.serveWrite, res, req)
+		p.authenticateIfSet(p.serveWrite, res, req)
 	} else {
-		p.AuthenticateIfSet(http.NotFound, res, req)
+		p.authenticateIfSet(http.NotFound, res, req)
 	}
 }
 
@@ -180,7 +182,7 @@ func (p *PubSubPush) serveWrite(res http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	var payload Payload
+	var payload payload
 	if err = json.Unmarshal(bytes, &payload); err != nil {
 		p.Log.Errorf("Error decoding payload %s", err.Error())
 		res.WriteHeader(http.StatusBadRequest)
@@ -262,7 +264,7 @@ func (p *PubSubPush) receiveDelivered() {
 	}
 }
 
-func (p *PubSubPush) AuthenticateIfSet(handler http.HandlerFunc, res http.ResponseWriter, req *http.Request) {
+func (p *PubSubPush) authenticateIfSet(handler http.HandlerFunc, res http.ResponseWriter, req *http.Request) {
 	if p.Token != "" {
 		if subtle.ConstantTimeCompare([]byte(req.FormValue("token")), []byte(p.Token)) != 1 {
 			http.Error(res, "Unauthorized.", http.StatusUnauthorized)

--- a/plugins/inputs/cloudwatch/cloudwatch_test.go
+++ b/plugins/inputs/cloudwatch/cloudwatch_test.go
@@ -379,10 +379,10 @@ func TestSelectMetrics(t *testing.T) {
 		Period:    internalDuration,
 		RateLimit: 200,
 		BatchSize: 500,
-		Metrics: []*Metric{
+		Metrics: []*cloudwatchMetric{
 			{
 				MetricNames: []string{"Latency", "RequestCount"},
-				Dimensions: []*Dimension{
+				Dimensions: []*dimension{
 					{
 						Name:  "LoadBalancerName",
 						Value: "lb*",

--- a/plugins/inputs/cloudwatch_metric_streams/cloudwatch_metric_streams_test.go
+++ b/plugins/inputs/cloudwatch_metric_streams/cloudwatch_metric_streams_test.go
@@ -304,8 +304,8 @@ func TestComposeMetrics(t *testing.T) {
 	require.NoError(t, metricStream.Start(acc))
 	defer metricStream.Stop()
 
-	// compose a Data object for writing
-	data := Data{
+	// compose a data object for writing
+	data := data{
 		MetricStreamName: "cloudwatch-metric-stream",
 		AccountID:        "546734499701",
 		Region:           "us-west-2",
@@ -335,8 +335,8 @@ func TestComposeAPICompatibleMetrics(t *testing.T) {
 	require.NoError(t, metricStream.Start(acc))
 	defer metricStream.Stop()
 
-	// compose a Data object for writing
-	data := Data{
+	// compose a data object for writing
+	data := data{
 		MetricStreamName: "cloudwatch-metric-stream",
 		AccountID:        "546734499701",
 		Region:           "us-west-2",

--- a/plugins/inputs/conntrack/conntrack.go
+++ b/plugins/inputs/conntrack/conntrack.go
@@ -21,38 +21,29 @@ import (
 //go:embed sample.conf
 var sampleConfig string
 
-type Conntrack struct {
-	ps      system.PS
-	Path    string
-	Dirs    []string
-	Files   []string
-	Collect []string
-}
+var (
+	dfltDirs = []string{
+		"/proc/sys/net/ipv4/netfilter",
+		"/proc/sys/net/netfilter",
+	}
+
+	dfltFiles = []string{
+		"ip_conntrack_count",
+		"ip_conntrack_max",
+		"nf_conntrack_count",
+		"nf_conntrack_max",
+	}
+)
 
 const (
 	inputName = "conntrack"
 )
 
-var dfltDirs = []string{
-	"/proc/sys/net/ipv4/netfilter",
-	"/proc/sys/net/netfilter",
-}
-
-var dfltFiles = []string{
-	"ip_conntrack_count",
-	"ip_conntrack_max",
-	"nf_conntrack_count",
-	"nf_conntrack_max",
-}
-
-func (c *Conntrack) setDefaults() {
-	if len(c.Dirs) == 0 {
-		c.Dirs = dfltDirs
-	}
-
-	if len(c.Files) == 0 {
-		c.Files = dfltFiles
-	}
+type Conntrack struct {
+	Collect []string `toml:"collect"`
+	Dirs    []string `toml:"dirs"`
+	Files   []string `toml:"files"`
+	ps      system.PS
 }
 
 func (*Conntrack) SampleConfig() string {
@@ -152,6 +143,16 @@ func (c *Conntrack) Gather(acc telegraf.Accumulator) error {
 
 	acc.AddFields(inputName, fields, nil)
 	return nil
+}
+
+func (c *Conntrack) setDefaults() {
+	if len(c.Dirs) == 0 {
+		c.Dirs = dfltDirs
+	}
+
+	if len(c.Files) == 0 {
+		c.Files = dfltFiles
+	}
 }
 
 func init() {

--- a/plugins/inputs/conntrack/conntrack_notlinux.go
+++ b/plugins/inputs/conntrack/conntrack_notlinux.go
@@ -17,11 +17,13 @@ type Conntrack struct {
 	Log telegraf.Logger `toml:"-"`
 }
 
+func (*Conntrack) SampleConfig() string { return sampleConfig }
+
 func (c *Conntrack) Init() error {
 	c.Log.Warn("current platform is not supported")
 	return nil
 }
-func (*Conntrack) SampleConfig() string                { return sampleConfig }
+
 func (*Conntrack) Gather(_ telegraf.Accumulator) error { return nil }
 
 func init() {

--- a/plugins/inputs/consul/consul_test.go
+++ b/plugins/inputs/consul/consul_test.go
@@ -43,7 +43,7 @@ func TestGatherHealthCheck(t *testing.T) {
 	var acc testutil.Accumulator
 
 	consul := &Consul{}
-	consul.GatherHealthCheck(&acc, sampleChecks)
+	consul.gatherHealthCheck(&acc, sampleChecks)
 
 	acc.AssertContainsTaggedFields(t, "consul_health_checks", expectedFields, expectedTags)
 }
@@ -72,7 +72,7 @@ func TestGatherHealthCheckWithDelimitedTags(t *testing.T) {
 	consul := &Consul{
 		TagDelimiter: ":",
 	}
-	consul.GatherHealthCheck(&acc, sampleChecks)
+	consul.gatherHealthCheck(&acc, sampleChecks)
 
 	acc.AssertContainsTaggedFields(t, "consul_health_checks", expectedFields, expectedTags)
 }
@@ -101,7 +101,7 @@ func TestGatherHealthCheckV2(t *testing.T) {
 	consul := &Consul{
 		MetricVersion: 2,
 	}
-	consul.GatherHealthCheck(&acc, sampleChecks)
+	consul.gatherHealthCheck(&acc, sampleChecks)
 
 	acc.AssertContainsTaggedFields(t, "consul_health_checks", expectedFields, expectedTags)
 }
@@ -131,7 +131,7 @@ func TestGatherHealthCheckWithDelimitedTagsV2(t *testing.T) {
 		MetricVersion: 2,
 		TagDelimiter:  ":",
 	}
-	consul.GatherHealthCheck(&acc, sampleChecks)
+	consul.gatherHealthCheck(&acc, sampleChecks)
 
 	acc.AssertContainsTaggedFields(t, "consul_health_checks", expectedFields, expectedTags)
 }

--- a/plugins/inputs/consul_agent/consul_structs.go
+++ b/plugins/inputs/consul_agent/consul_structs.go
@@ -1,25 +1,25 @@
 package consul_agent
 
-type AgentInfo struct {
+type agentInfo struct {
 	Timestamp string
-	Gauges    []GaugeValue
-	Points    []PointValue
-	Counters  []SampledValue
-	Samples   []SampledValue
+	Gauges    []gaugeValue
+	Points    []pointValue
+	Counters  []sampledValue
+	Samples   []sampledValue
 }
 
-type GaugeValue struct {
+type gaugeValue struct {
 	Name   string
 	Value  float32
 	Labels map[string]string
 }
 
-type PointValue struct {
+type pointValue struct {
 	Name   string
 	Points []float32
 }
 
-type SampledValue struct {
+type sampledValue struct {
 	Name   string
 	Count  int
 	Sum    float64

--- a/plugins/inputs/couchbase/couchbase.go
+++ b/plugins/inputs/couchbase/couchbase.go
@@ -22,6 +22,8 @@ import (
 //go:embed sample.conf
 var sampleConfig string
 
+var regexpURI = regexp.MustCompile(`(\S+://)?(\S+\:\S+@)`)
+
 type Couchbase struct {
 	Servers             []string `toml:"servers"`
 	BucketStatsIncluded []string `toml:"bucket_stats_included"`
@@ -42,13 +44,40 @@ type autoFailover struct {
 	Timeout  int  `json:"timeout"`
 }
 
-var regexpURI = regexp.MustCompile(`(\S+://)?(\S+\:\S+@)`)
-
 func (*Couchbase) SampleConfig() string {
 	return sampleConfig
 }
 
-// Reads stats from all configured clusters. Accumulates stats.
+func (cb *Couchbase) Init() error {
+	f, err := filter.NewIncludeExcludeFilter(cb.BucketStatsIncluded, []string{})
+	if err != nil {
+		return err
+	}
+
+	cb.bucketInclude = f
+
+	tlsConfig, err := cb.TLSConfig()
+	if err != nil {
+		return err
+	}
+
+	cb.client = &http.Client{
+		Timeout: 10 * time.Second,
+		Transport: &http.Transport{
+			MaxIdleConnsPerHost: couchbase.MaxIdleConnsPerHost,
+			TLSClientConfig:     tlsConfig,
+		},
+	}
+
+	couchbase.SetSkipVerify(cb.ClientConfig.InsecureSkipVerify)
+	couchbase.SetCertFile(cb.ClientConfig.TLSCert)
+	couchbase.SetKeyFile(cb.ClientConfig.TLSKey)
+	couchbase.SetRootFile(cb.ClientConfig.TLSCA)
+
+	return nil
+}
+
+// Gather reads stats from all configured clusters. Accumulates stats.
 // Returns one of the errors encountered while gathering stats (if any).
 func (cb *Couchbase) Gather(acc telegraf.Accumulator) error {
 	if len(cb.Servers) == 0 {
@@ -181,7 +210,7 @@ func (cb *Couchbase) basicBucketStats(basicStats map[string]interface{}) map[str
 }
 
 func (cb *Couchbase) gatherDetailedBucketStats(server, bucket, nodeHostname string, fields map[string]interface{}) error {
-	extendedBucketStats := &BucketStats{}
+	extendedBucketStats := &bucketStats{}
 	err := cb.queryDetailedBucketStats(server, bucket, nodeHostname, extendedBucketStats)
 	if err != nil {
 		return err
@@ -421,7 +450,7 @@ func (cb *Couchbase) addBucketFieldChecked(fields map[string]interface{}, fieldK
 	cb.addBucketField(fields, fieldKey, values[len(values)-1])
 }
 
-func (cb *Couchbase) queryDetailedBucketStats(server, bucket, nodeHostname string, bucketStats *BucketStats) error {
+func (cb *Couchbase) queryDetailedBucketStats(server, bucket, nodeHostname string, bucketStats *bucketStats) error {
 	url := server + "/pools/default/buckets/" + bucket
 	if nodeHostname != "" {
 		url += "/nodes/" + nodeHostname
@@ -442,35 +471,6 @@ func (cb *Couchbase) queryDetailedBucketStats(server, bucket, nodeHostname strin
 	defer r.Body.Close()
 
 	return json.NewDecoder(r.Body).Decode(bucketStats)
-}
-
-func (cb *Couchbase) Init() error {
-	f, err := filter.NewIncludeExcludeFilter(cb.BucketStatsIncluded, []string{})
-	if err != nil {
-		return err
-	}
-
-	cb.bucketInclude = f
-
-	tlsConfig, err := cb.TLSConfig()
-	if err != nil {
-		return err
-	}
-
-	cb.client = &http.Client{
-		Timeout: 10 * time.Second,
-		Transport: &http.Transport{
-			MaxIdleConnsPerHost: couchbase.MaxIdleConnsPerHost,
-			TLSClientConfig:     tlsConfig,
-		},
-	}
-
-	couchbase.SetSkipVerify(cb.ClientConfig.InsecureSkipVerify)
-	couchbase.SetCertFile(cb.ClientConfig.TLSCert)
-	couchbase.SetKeyFile(cb.ClientConfig.TLSKey)
-	couchbase.SetRootFile(cb.ClientConfig.TLSCA)
-
-	return nil
 }
 
 func init() {

--- a/plugins/inputs/couchbase/couchbase_data.go
+++ b/plugins/inputs/couchbase/couchbase_data.go
@@ -1,6 +1,6 @@
 package couchbase
 
-type BucketStats struct {
+type bucketStats struct {
 	Op struct {
 		Samples struct {
 			CouchTotalDiskSize                []float64 `json:"couch_total_disk_size"`

--- a/plugins/inputs/couchbase/couchbase_test.go
+++ b/plugins/inputs/couchbase/couchbase_test.go
@@ -132,7 +132,7 @@ func TestGatherDetailedBucketMetrics(t *testing.T) {
 			err = cb.Init()
 			require.NoError(t, err)
 			var acc testutil.Accumulator
-			bucketStats := &BucketStats{}
+			bucketStats := &bucketStats{}
 			if err := json.Unmarshal(test.response, bucketStats); err != nil {
 				t.Fatal("parse bucketResponse", err)
 			}

--- a/plugins/inputs/couchdb/couchdb.go
+++ b/plugins/inputs/couchdb/couchdb.go
@@ -16,6 +16,14 @@ import (
 //go:embed sample.conf
 var sampleConfig string
 
+type CouchDB struct {
+	Hosts         []string `toml:"hosts"`
+	BasicUsername string   `toml:"basic_username"`
+	BasicPassword string   `toml:"basic_password"`
+
+	client *http.Client
+}
+
 type (
 	metaData struct {
 		Current *float64 `json:"current"`
@@ -77,19 +85,11 @@ type (
 		ClientsRequestingChanges metaData `json:"clients_requesting_changes"`
 	}
 
-	Stats struct {
+	stats struct {
 		Couchdb             couchdb             `json:"couchdb"`
 		HttpdRequestMethods httpdRequestMethods `json:"httpd_request_methods"`
 		HttpdStatusCodes    httpdStatusCodes    `json:"httpd_status_codes"`
 		Httpd               httpd               `json:"httpd"`
-	}
-
-	CouchDB struct {
-		Hosts         []string `toml:"hosts"`
-		BasicUsername string   `toml:"basic_username"`
-		BasicPassword string   `toml:"basic_password"`
-
-		client *http.Client
 	}
 )
 
@@ -143,7 +143,7 @@ func (c *CouchDB) fetchAndInsertData(accumulator telegraf.Accumulator, host stri
 		return fmt.Errorf("failed to get stats from couchdb: HTTP responded %d", response.StatusCode)
 	}
 
-	stats := Stats{}
+	stats := stats{}
 	decoder := json.NewDecoder(response.Body)
 	if err := decoder.Decode(&stats); err != nil {
 		return fmt.Errorf("failed to decode stats from couchdb: HTTP body %q", response.Body)

--- a/plugins/inputs/cpu/cpu.go
+++ b/plugins/inputs/cpu/cpu.go
@@ -37,6 +37,25 @@ func (*CPUStats) SampleConfig() string {
 	return sampleConfig
 }
 
+func (c *CPUStats) Init() error {
+	if c.CoreTags {
+		cpuInfo, err := cpu.Info()
+		if err == nil {
+			c.coreID = cpuInfo[0].CoreID != ""
+			c.physicalID = cpuInfo[0].PhysicalID != ""
+
+			c.cpuInfo = make(map[string]cpu.InfoStat)
+			for _, ci := range cpuInfo {
+				c.cpuInfo[fmt.Sprintf("cpu%d", ci.CPU)] = ci
+			}
+		} else {
+			c.Log.Warnf("Failed to gather info about CPUs: %s", err)
+		}
+	}
+
+	return nil
+}
+
 func (c *CPUStats) Gather(acc telegraf.Accumulator) error {
 	times, err := c.ps.CPUTimes(c.PerCPU, c.TotalCPU)
 	if err != nil {
@@ -125,25 +144,6 @@ func (c *CPUStats) Gather(acc telegraf.Accumulator) error {
 	}
 
 	return err
-}
-
-func (c *CPUStats) Init() error {
-	if c.CoreTags {
-		cpuInfo, err := cpu.Info()
-		if err == nil {
-			c.coreID = cpuInfo[0].CoreID != ""
-			c.physicalID = cpuInfo[0].PhysicalID != ""
-
-			c.cpuInfo = make(map[string]cpu.InfoStat)
-			for _, ci := range cpuInfo {
-				c.cpuInfo[fmt.Sprintf("cpu%d", ci.CPU)] = ci
-			}
-		} else {
-			c.Log.Warnf("Failed to gather info about CPUs: %s", err)
-		}
-	}
-
-	return nil
 }
 
 func totalCPUTime(t cpu.TimesStat) float64 {

--- a/plugins/inputs/cpu/cpu_test.go
+++ b/plugins/inputs/cpu/cpu_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/influxdata/telegraf/testutil"
 )
 
-func NewCPUStats(ps system.PS) *CPUStats {
+func newCPUStats(ps system.PS) *CPUStats {
 	return &CPUStats{
 		ps:             ps,
 		CollectCPUTime: true,
@@ -54,7 +54,7 @@ func TestCPUStats(t *testing.T) {
 
 	mps.On("CPUTimes").Return([]cpu.TimesStat{cts}, nil)
 
-	cs := NewCPUStats(&mps)
+	cs := newCPUStats(&mps)
 
 	err := cs.Gather(&acc)
 	require.NoError(t, err)
@@ -159,7 +159,7 @@ func TestCPUCountIncrease(t *testing.T) {
 	var acc testutil.Accumulator
 	var err error
 
-	cs := NewCPUStats(&mps)
+	cs := newCPUStats(&mps)
 
 	mps.On("CPUTimes").Return(
 		[]cpu.TimesStat{
@@ -216,7 +216,7 @@ func TestCPUTimesDecrease(t *testing.T) {
 
 	mps.On("CPUTimes").Return([]cpu.TimesStat{cts}, nil)
 
-	cs := NewCPUStats(&mps)
+	cs := newCPUStats(&mps)
 
 	err := cs.Gather(&acc)
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

Address findings for [revive:exported ](https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#exported ) in `plugins/inputs/c*`.

As part of this effort for files from `plugins/inputs/c*`, the following actions were taken:
- Type names (`const`, `var`, `struct`, `func`, etc) were changed to unexported, wherever they didn't need to be exported.
- All remaining exported types were given comments in the appropriate form – this does not apply to exported methods that implement "known" plugin interfaces (`Gather|Init|Start|Stop|SampleConfig|Parse|Add|Apply|Serialize|SerializeBatch|SetParser`).
- The order of methods was organized (exported methods first, then unexported, with `init` at the very end).

It is only part of the bigger job (for issue: https://github.com/influxdata/telegraf/issues/15813).
After all findings of this type in whole project are handled, we can enable `revive:exported` rule in `golangci-lint`.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR


