### PR TITLE
fix(inputs.win_eventlog): Handle XML data fields' filtering the same way as event fields

### DIFF
--- a/plugins/inputs/win_eventlog/win_eventlog_test.go
+++ b/plugins/inputs/win_eventlog/win_eventlog_test.go
@@ -7,6 +7,8 @@ package win_eventlog
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestWinEventLog_shouldExcludeEmptyField(t *testing.T) {
@@ -16,59 +18,59 @@ func TestWinEventLog_shouldExcludeEmptyField(t *testing.T) {
 		fieldValue interface{}
 	}
 	tests := []struct {
-		name       string
-		w          *WinEventLog
-		args       args
-		wantShould bool
+		name     string
+		w        *WinEventLog
+		args     args
+		expected bool
 	}{
 		{
-			name:       "Not in list",
-			args:       args{field: "qq", fieldType: "string", fieldValue: ""},
-			wantShould: false,
-			w:          &WinEventLog{ExcludeEmpty: []string{"te*"}},
+			name:     "Not in list",
+			args:     args{field: "qq", fieldType: "string", fieldValue: ""},
+			expected: false,
+			w:        &WinEventLog{ExcludeEmpty: []string{"te*"}},
 		},
 		{
-			name:       "Empty string",
-			args:       args{field: "test", fieldType: "string", fieldValue: ""},
-			wantShould: true,
-			w:          &WinEventLog{ExcludeEmpty: []string{"te*"}},
+			name:     "Empty string",
+			args:     args{field: "test", fieldType: "string", fieldValue: ""},
+			expected: true,
+			w:        &WinEventLog{ExcludeEmpty: []string{"te*"}},
 		},
 		{
-			name:       "Non-empty string",
-			args:       args{field: "test", fieldType: "string", fieldValue: "qq"},
-			wantShould: false,
-			w:          &WinEventLog{ExcludeEmpty: []string{"te*"}},
+			name:     "Non-empty string",
+			args:     args{field: "test", fieldType: "string", fieldValue: "qq"},
+			expected: false,
+			w:        &WinEventLog{ExcludeEmpty: []string{"te*"}},
 		},
 		{
-			name:       "Zero int",
-			args:       args{field: "test", fieldType: "int", fieldValue: int(0)},
-			wantShould: true,
-			w:          &WinEventLog{ExcludeEmpty: []string{"te*"}},
+			name:     "Zero int",
+			args:     args{field: "test", fieldType: "int", fieldValue: int(0)},
+			expected: true,
+			w:        &WinEventLog{ExcludeEmpty: []string{"te*"}},
 		},
 		{
-			name:       "Non-zero int",
-			args:       args{field: "test", fieldType: "int", fieldValue: int(-1)},
-			wantShould: false,
-			w:          &WinEventLog{ExcludeEmpty: []string{"te*"}},
+			name:     "Non-zero int",
+			args:     args{field: "test", fieldType: "int", fieldValue: int(-1)},
+			expected: false,
+			w:        &WinEventLog{ExcludeEmpty: []string{"te*"}},
 		},
 		{
-			name:       "Zero uint32",
-			args:       args{field: "test", fieldType: "uint32", fieldValue: uint32(0)},
-			wantShould: true,
-			w:          &WinEventLog{ExcludeEmpty: []string{"te*"}},
+			name:     "Zero uint32",
+			args:     args{field: "test", fieldType: "uint32", fieldValue: uint32(0)},
+			expected: true,
+			w:        &WinEventLog{ExcludeEmpty: []string{"te*"}},
 		},
 		{
-			name:       "Non-zero uint32",
-			args:       args{field: "test", fieldType: "uint32", fieldValue: uint32(0xc0fefeed)},
-			wantShould: false,
-			w:          &WinEventLog{ExcludeEmpty: []string{"te*"}},
+			name:     "Non-zero uint32",
+			args:     args{field: "test", fieldType: "uint32", fieldValue: uint32(0xc0fefeed)},
+			expected: false,
+			w:        &WinEventLog{ExcludeEmpty: []string{"te*"}},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if gotShould := tt.w.shouldExcludeEmptyField(tt.args.field, tt.args.fieldType, tt.args.fieldValue); gotShould != tt.wantShould {
-				t.Errorf("WinEventLog.shouldExcludeEmptyField() = %v, want %v", gotShould, tt.wantShould)
-			}
+			require.NoError(t, tt.w.Init())
+			actual := tt.w.shouldExcludeEmptyField(tt.args.field, tt.args.fieldType, tt.args.fieldValue)
+			require.Equal(t, tt.expected, actual)
 		})
 	}
 }
@@ -125,13 +127,10 @@ func TestWinEventLog_shouldProcessField(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotShould, gotList := tt.w.shouldProcessField(tt.args.field)
-			if gotShould != tt.wantShould {
-				t.Errorf("WinEventLog.shouldProcessField() gotShould = %v, want %v", gotShould, tt.wantShould)
-			}
-			if gotList != tt.wantList {
-				t.Errorf("WinEventLog.shouldProcessField() gotList = %v, want %v", gotList, tt.wantList)
-			}
+			require.NoError(t, tt.w.Init())
+			should, list := tt.w.shouldProcessField(tt.args.field)
+			require.Equal(t, tt.wantShould, should)
+			require.Equal(t, tt.wantList, list)
 		})
 	}
 }


### PR DESCRIPTION
## Summary

Currently, fields extracted from the event's XML cannot be used as tags due to the way the filtering is done. This PR changes the processing to handle those fields the same way as fields extracted from the event itself. Furthermore, the PR transitions the PR to use a `filter` instead of misusing filepath-matching.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #15958 
