### PR TITLE
feat(agent): Add --watch-interval option for polling config changes

### DIFF
--- a/cmd/telegraf/main.go
+++ b/cmd/telegraf/main.go
@@ -230,6 +230,7 @@ func runApp(args []string, outputBuffer io.Writer, pprof Server, c TelegrafConfi
 			configURLRetryAttempts: cCtx.Int("config-url-retry-attempts"),
 			configURLWatchInterval: cCtx.Duration("config-url-watch-interval"),
 			watchConfig:            cCtx.String("watch-config"),
+			watchInterval:          cCtx.Duration("watch-interval"),
 			pidFile:                cCtx.String("pidfile"),
 			plugindDir:             cCtx.String("plugin-directory"),
 			password:               cCtx.String("password"),
@@ -330,6 +331,12 @@ func runApp(args []string, outputBuffer io.Writer, pprof Server, c TelegrafConfi
 				},
 				//
 				// Duration flags
+				&cli.DurationFlag{
+					Name: "watch-interval",
+					Usage: "Time duration to check for updates to config files specified by --config and " +
+						"--config-directory options. Use with '--watch-config poll'",
+					DefaultText: "disabled",
+				},
 				&cli.DurationFlag{
 					Name:        "config-url-watch-interval",
 					Usage:       "Time duration to check for updates to URL based configuration files",

--- a/cmd/telegraf/telegraf.go
+++ b/cmd/telegraf/telegraf.go
@@ -40,6 +40,7 @@ type GlobalFlags struct {
 	configURLRetryAttempts int
 	configURLWatchInterval time.Duration
 	watchConfig            string
+	watchInterval          time.Duration
 	pidFile                string
 	plugindDir             string
 	password               string
@@ -213,7 +214,11 @@ func (t *Telegraf) watchLocalConfig(ctx context.Context, signals chan os.Signal,
 	var mytomb tomb.Tomb
 	var watcher watch.FileWatcher
 	if t.watchConfig == "poll" {
-		watcher = watch.NewPollingFileWatcher(fConfig)
+		if t.watchInterval > 0 {
+			watcher = watch.NewPollingFileWatcherWithDuration(fConfig, t.watchInterval)
+		} else {
+			watcher = watch.NewPollingFileWatcher(fConfig)
+		}
 	} else {
 		watcher = watch.NewInotifyFileWatcher(fConfig)
 	}

--- a/go.mod
+++ b/go.mod
@@ -117,7 +117,7 @@ require (
 	github.com/influxdata/influxdb-observability/influx2otel v0.5.12
 	github.com/influxdata/influxdb-observability/otel2influx v0.5.12
 	github.com/influxdata/line-protocol/v2 v2.2.1
-	github.com/influxdata/tail v1.0.1-0.20241010210018-7b1551f18204
+	github.com/influxdata/tail v1.0.1-0.20241014115250-3e0015cb677a
 	github.com/influxdata/toml v0.0.0-20190415235208-270119a8ce65
 	github.com/intel/iaevents v1.1.0
 	github.com/intel/powertelemetry v1.0.1

--- a/go.mod
+++ b/go.mod
@@ -117,7 +117,7 @@ require (
 	github.com/influxdata/influxdb-observability/influx2otel v0.5.12
 	github.com/influxdata/influxdb-observability/otel2influx v0.5.12
 	github.com/influxdata/line-protocol/v2 v2.2.1
-	github.com/influxdata/tail v1.0.1-0.20240719165826-3c9d721090d2
+	github.com/influxdata/tail v1.0.1-0.20241010210018-7b1551f18204
 	github.com/influxdata/toml v0.0.0-20190415235208-270119a8ce65
 	github.com/intel/iaevents v1.1.0
 	github.com/intel/powertelemetry v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -1582,8 +1582,8 @@ github.com/influxdata/line-protocol/v2 v2.0.0-20210312151457-c52fdecb625a/go.mod
 github.com/influxdata/line-protocol/v2 v2.1.0/go.mod h1:QKw43hdUBg3GTk2iC3iyCxksNj7PX9aUSeYOYE/ceHY=
 github.com/influxdata/line-protocol/v2 v2.2.1 h1:EAPkqJ9Km4uAxtMRgUubJyqAr6zgWM0dznKMLRauQRE=
 github.com/influxdata/line-protocol/v2 v2.2.1/go.mod h1:DmB3Cnh+3oxmG6LOBIxce4oaL4CPj3OmMPgvauXh+tM=
-github.com/influxdata/tail v1.0.1-0.20241010210018-7b1551f18204 h1:ryVyi+EHBrP/awaKjC2g4S1k26kQDdI7RDJl6yxK5ZM=
-github.com/influxdata/tail v1.0.1-0.20241010210018-7b1551f18204/go.mod h1:VeiWgI3qaGdJWust2fP27a6J+koITo/1c/UhxeOxgaM=
+github.com/influxdata/tail v1.0.1-0.20241014115250-3e0015cb677a h1:IJBVizlP2eArwAurfli2Em5N7pTK1YCbDsdDtnou024=
+github.com/influxdata/tail v1.0.1-0.20241014115250-3e0015cb677a/go.mod h1:VeiWgI3qaGdJWust2fP27a6J+koITo/1c/UhxeOxgaM=
 github.com/influxdata/toml v0.0.0-20190415235208-270119a8ce65 h1:vvyMtD5LTJc1W9sQKjDkAWdcg0478CszSdzlHtiAXCY=
 github.com/influxdata/toml v0.0.0-20190415235208-270119a8ce65/go.mod h1:zApaNFpP/bTpQItGZNNUMISDMDAnTXu9UqJ4yT3ocz8=
 github.com/intel/iaevents v1.1.0 h1:FzxMBfXk/apG2EUXUCfaq3gUQ+q+TgZ1HNMjjUILUGE=

--- a/go.sum
+++ b/go.sum
@@ -1582,8 +1582,8 @@ github.com/influxdata/line-protocol/v2 v2.0.0-20210312151457-c52fdecb625a/go.mod
 github.com/influxdata/line-protocol/v2 v2.1.0/go.mod h1:QKw43hdUBg3GTk2iC3iyCxksNj7PX9aUSeYOYE/ceHY=
 github.com/influxdata/line-protocol/v2 v2.2.1 h1:EAPkqJ9Km4uAxtMRgUubJyqAr6zgWM0dznKMLRauQRE=
 github.com/influxdata/line-protocol/v2 v2.2.1/go.mod h1:DmB3Cnh+3oxmG6LOBIxce4oaL4CPj3OmMPgvauXh+tM=
-github.com/influxdata/tail v1.0.1-0.20240719165826-3c9d721090d2 h1:W68O0w2sRiBXoD9kkaBj2dMJJO5FdQJ5cL0zGA3NWMU=
-github.com/influxdata/tail v1.0.1-0.20240719165826-3c9d721090d2/go.mod h1:VeiWgI3qaGdJWust2fP27a6J+koITo/1c/UhxeOxgaM=
+github.com/influxdata/tail v1.0.1-0.20241010210018-7b1551f18204 h1:ryVyi+EHBrP/awaKjC2g4S1k26kQDdI7RDJl6yxK5ZM=
+github.com/influxdata/tail v1.0.1-0.20241010210018-7b1551f18204/go.mod h1:VeiWgI3qaGdJWust2fP27a6J+koITo/1c/UhxeOxgaM=
 github.com/influxdata/toml v0.0.0-20190415235208-270119a8ce65 h1:vvyMtD5LTJc1W9sQKjDkAWdcg0478CszSdzlHtiAXCY=
 github.com/influxdata/toml v0.0.0-20190415235208-270119a8ce65/go.mod h1:zApaNFpP/bTpQItGZNNUMISDMDAnTXu9UqJ4yT3ocz8=
 github.com/intel/iaevents v1.1.0 h1:FzxMBfXk/apG2EUXUCfaq3gUQ+q+TgZ1HNMjjUILUGE=


### PR DESCRIPTION
## Summary
Adds a new option, `--watch-interval`, which when used with `--watch-config poll` changes the default polling rate from 250ms to a user supplied value.

## Checklist
- [X] No AI generated code was used in this PR

## Related issues
resolves #15793
