### PR TITLE
chore(build): migrate to nFPM for packaging debs and rpms

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -358,18 +358,16 @@ $(include_packages):
 	@mkdir -p $(pkgdir)
 
 	@if [ "$(suffix $@)" = ".rpm" ]; then \
-		echo "# DO NOT EDIT OR REMOVE" > $(DESTDIR)$(sysconfdir)/telegraf/telegraf.d/.ignore; \
-		echo "# This file prevents the rpm from changing permissions on this directory" >> $(DESTDIR)$(sysconfdir)/telegraf/telegraf.d/.ignore; \
+		cd $(dir $(DESTDIR)) && \
 		nfpm package -p rpm -f scripts/nfpm.yaml -t $(pkgdir)/telegraf-$(rpm_version).$@ ;\
 	elif [ "$(suffix $@)" = ".deb" ]; then \
 		cd $(dir $(DESTDIR)) && \
 	    nfpm package -p deb -f scripts/nfpm.yaml -t $(pkgdir)/telegraf_$(deb_version)_$@ ;\
+	elif [ "$(suffix $@)" = ".zip" ]; then \
+		(cd $(dir $(DESTDIR)) && zip -r - ./*) > $(pkgdir)/telegraf-$(tar_version)_$@ ;\
+	elif [ "$(suffix $@)" = ".gz" ]; then \
+		tar --owner 0 --group 0 -czvf $(pkgdir)/telegraf-$(tar_version)_$@ -C $(dir $(DESTDIR)) . ;\
 	fi
-	#elif [ "$(suffix $@)" = ".zip" ]; then \
-	#	(cd $(dir $(DESTDIR)) && zip -r - ./*) > $(pkgdir)/telegraf-$(tar_version)_$@ ;\
-	#elif [ "$(suffix $@)" = ".gz" ]; then \
-	#	tar --owner 0 --group 0 -czvf $(pkgdir)/telegraf-$(tar_version)_$@ -C $(dir $(DESTDIR)) . ;\
-	#fi
 
 amd64.deb x86_64.rpm linux_amd64.tar.gz: export GOOS := linux
 amd64.deb x86_64.rpm linux_amd64.tar.gz: export GOARCH := amd64
@@ -443,14 +441,14 @@ windows_i386.zip windows_amd64.zip windows_arm64.zip: export EXEEXT := .exe
 %.deb: export conf_suffix := .sample
 %.deb: export sysconfdir := /etc
 %.deb: export localstatedir := /var
-%.deb: export FPM_VERSION := $(version)
-$.deb: export FPM_RELEASE := $(deb_iteration)
+%.deb: export fpm_version := $(version)
+$.deb: export fpm_release := $(deb_iteration)
 %.rpm: export pkg := rpm
 %.rpm: export prefix := /usr
 %.rpm: export sysconfdir := /etc
 %.rpm: export localstatedir := /var
-%.rpm: export FPM_VERSION := $(version)
-%.rpm: export FPM_RELEASE := $(rpm_iteration)
+%.rpm: export fpm_version := $(version)
+%.rpm: export fpm_release := $(rpm_iteration)
 %.tar.gz: export pkg := tar
 %.tar.gz: export prefix := /usr
 %.tar.gz: export sysconfdir := /etc

--- a/scripts/ci.docker
+++ b/scripts/ci.docker
@@ -11,8 +11,6 @@ RUN DEBIAN_FRONTEND=noninteractive \
 	make \
 	awscli \
 	rpm \
-	ruby \
-	ruby-dev \
 	zip && \
 	rm -rf /var/lib/apt/lists/*
 
@@ -20,4 +18,5 @@ RUN ln -sf /usr/share/zoneinfo/Etc/UTC /etc/localtime
 RUN locale-gen C.UTF-8 || true
 ENV LANG=C.UTF-8
 
-RUN gem install fpm
+RUN echo 'deb [trusted=yes] https://repo.goreleaser.com/apt/ /' | tee /etc/apt/sources.list.d/goreleaser.list
+RUN apt update && apt install -y --no-install-recommends nfpm

--- a/scripts/deb/post-install.sh
+++ b/scripts/deb/post-install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 SCRIPT_DIR=/usr/lib/telegraf/scripts
 
@@ -44,7 +44,8 @@ fi
 
 LOG_DIR=/var/log/telegraf
 test -d $LOG_DIR || mkdir -p $LOG_DIR
-chown -R -L telegraf:telegraf $LOG_DIR
+chown -L telegraf:telegraf $LOG_DIR
+chown -L telegraf:telegraf $LOG_DIR/*
 chmod 755 $LOG_DIR
 
 STATE_DIR=/var/lib/telegraf

--- a/scripts/deb/post-remove.sh
+++ b/scripts/deb/post-remove.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 function disable_systemd {
     systemctl disable telegraf

--- a/scripts/deb/pre-install.sh
+++ b/scripts/deb/pre-install.sh
@@ -1,6 +1,6 @@
-#!/bin/bash
+#!/bin/bash -e
 
-if ! grep "^telegraf:" /etc/group &>/dev/null; then
+if ! getent group telegraf &>/dev/null; then
     groupadd -r telegraf
 fi
 

--- a/scripts/deb/pre-remove.sh
+++ b/scripts/deb/pre-remove.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 if [ -d /run/systemd/system ]; then
 	if [ "$1" = remove ]; then

--- a/scripts/nfpm.yaml
+++ b/scripts/nfpm.yaml
@@ -1,0 +1,49 @@
+name: telegraf
+
+arch: ${GOARCH}
+platform: ${GOOS}
+
+version: ${FPM_VERSION}
+version_schema: semver
+release: ${FPM_RELEASE}
+epoch: 1
+
+section: net
+maintainer: InfluxData Support <support@influxdata.com>
+license: MIT
+homepage: https://github.com/influxdata/telegraf
+vendor: InfluxData
+description: Plugin-driven server agent for reporting metrics into InfluxDB.
+
+contents:
+  - src: ./etc/logrotate.d/telegraf
+    dst: /etc/logrotate.d/telegraf
+    type: config
+
+  - src: ./etc/telegraf.conf
+    dst: /etc/telegraf/telegraf.conf.sample
+    type: config
+
+  - src: ./etc/telegraf/telegraf.d/.ignore
+    dst: /etc/telegraf/telegraf.d/.ignore
+    type: config
+    packager: rpm
+
+overrides:
+  deb:
+    scripts:
+      preinstall: ./scripts/deb/pre-install.sh
+      postinstall: ./scripts/deb/post-install.sh
+      preremove: ./scripts/deb/pre-remove.sh
+      postremove: ./scripts/deb/post-remove.sh
+  rpm:
+    depends:
+      - coreutils
+    scripts:
+      preinstall: ./scripts/rpm/pre-install.sh
+      postinstall: ./scripts/rpm/post-install.sh
+      postremove: ./scripts/rpm/post-remove.sh
+
+rpm:
+  scripts:
+    posttrans: ./scripts/rpm/post-install.sh

--- a/scripts/nfpm.yaml
+++ b/scripts/nfpm.yaml
@@ -3,9 +3,9 @@ name: telegraf
 arch: ${GOARCH}
 platform: ${GOOS}
 
-version: ${FPM_VERSION}
+version: ${fpm_version}
 version_schema: semver
-release: ${FPM_RELEASE}
+release: ${fpm_release}
 epoch: 1
 
 section: net

--- a/scripts/rpm/post-install.sh
+++ b/scripts/rpm/post-install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 # Remove legacy symlink, if it exists
 if [[ -L /etc/init.d/telegraf ]]; then
@@ -23,7 +23,8 @@ fi
 # Set up log directories
 LOG_DIR=/var/log/telegraf
 mkdir -p $LOG_DIR
-chown -R -L telegraf:telegraf $LOG_DIR
+chown -L telegraf:telegraf $LOG_DIR
+chown -L telegraf:telegraf $LOG_DIR/*
 chmod 755 $LOG_DIR
 
 STATE_DIR=/var/lib/telegraf

--- a/scripts/rpm/post-remove.sh
+++ b/scripts/rpm/post-remove.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 # Telegraf is no longer installed, remove from systemd
 if [[ "$1" = "0" ]]; then

--- a/scripts/rpm/pre-install.sh
+++ b/scripts/rpm/pre-install.sh
@@ -1,6 +1,6 @@
-#!/bin/bash
+#!/bin/bash -e
 
-if ! grep "^telegraf:" /etc/group &>/dev/null; then
+if ! getent group telegraf &>/dev/null; then
     groupadd -r telegraf
 fi
 


### PR DESCRIPTION
## Summary
Migrates to nFPM over FPM for building telegraf debs and rpms.

FPM, while a great tool, has some limitations, and also introduces a ruby dependency for building. nFPM is packaged as part of goreleaser, and is a pure go solution to building these files.

Things remaining:
- Test the CI container build, and once ready, publish the CI container
- Clean up some of the environment variables
- Restore .zip and .gz issues (need to investigate why they complain when building)

Following the above, I have another set of fixes for #7770, which will include a lintian-overrides file as well as some fixes for the install and remove scripts which I have prepared already but want to do as a separate PR.

## Checklist
- [X] No AI generated code was used in this PR

## Related issues
#7770
