### PR TITLE
feat(inputs.snmp): Convert uneven bytes to int

### DIFF
--- a/internal/snmp/field.go
+++ b/internal/snmp/field.go
@@ -253,31 +253,36 @@ func (f *Field) Convert(ent gosnmp.SnmpPDU) (interface{}, error) {
 			return v, nil
 		}
 
+		var b []byte
+		switch bit {
+		case "uint64":
+			b = make([]byte, 8)
+		case "uint32":
+			b = make([]byte, 4)
+		case "uint16":
+			b = make([]byte, 2)
+		default:
+			return nil, fmt.Errorf("invalid bit value (%s) for hex to int conversion", bit)
+		}
+		copy(b, bv)
+
+		var byteOrder binary.ByteOrder
 		switch endian {
 		case "LittleEndian":
-			switch bit {
-			case "uint64":
-				v = binary.LittleEndian.Uint64(bv)
-			case "uint32":
-				v = binary.LittleEndian.Uint32(bv)
-			case "uint16":
-				v = binary.LittleEndian.Uint16(bv)
-			default:
-				return nil, fmt.Errorf("invalid bit value (%s) for hex to int conversion", bit)
-			}
+			byteOrder = binary.LittleEndian
 		case "BigEndian":
-			switch bit {
-			case "uint64":
-				v = binary.BigEndian.Uint64(bv)
-			case "uint32":
-				v = binary.BigEndian.Uint32(bv)
-			case "uint16":
-				v = binary.BigEndian.Uint16(bv)
-			default:
-				return nil, fmt.Errorf("invalid bit value (%s) for hex to int conversion", bit)
-			}
+			byteOrder = binary.BigEndian
 		default:
 			return nil, fmt.Errorf("invalid Endian value (%s) for hex to int conversion", endian)
+		}
+
+		switch bit {
+		case "uint64":
+			v = byteOrder.Uint64(b)
+		case "uint32":
+			v = byteOrder.Uint32(b)
+		case "uint16":
+			v = byteOrder.Uint16(b)
 		}
 
 		return v, nil

--- a/internal/snmp/field_test.go
+++ b/internal/snmp/field_test.go
@@ -212,6 +212,15 @@ func TestConvertHextoint(t *testing.T) {
 			expected: uint16(0xc884),
 		},
 		{
+			name:       "little endian single byte",
+			conversion: "hextoint:LittleEndian:uint16",
+			ent: gosnmp.SnmpPDU{
+				Type:  gosnmp.OctetString,
+				Value: []byte{0x84},
+			},
+			expected: uint16(0x84),
+		},
+		{
 			name:       "little endian invalid",
 			conversion: "hextoint:LittleEndian:invalid",
 			ent:        gosnmp.SnmpPDU{Type: gosnmp.OctetString, Value: []byte{}},


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

Support byte arrays of unfixed size (1, 3, 5, 6, 7) to be converted to int.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #15963
