### PR TITLE
feat(processors.enum): Allow mapping to be applied to multiple fields

### DIFF
--- a/plugins/processors/enum/README.md
+++ b/plugins/processors/enum/README.md
@@ -24,8 +24,8 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 # Map enum values according to given table.
 [[processors.enum]]
   [[processors.enum.mapping]]
-    ## Name of the field to map. Globs accepted.
-    field = "status"
+    ## Names of the fields to map. Globs accepted.
+    fields = ["status"]
 
     ## Name of the tag to map. Globs accepted.
     # tag = "status"

--- a/plugins/processors/enum/enum.go
+++ b/plugins/processors/enum/enum.go
@@ -20,7 +20,7 @@ type EnumMapper struct {
 
 type Mapping struct {
 	Tag     string      `toml:"tag"`
-	Field   string      `toml:"field" deprecated:"1.33.0;1.40.0;use 'fields' instead"`
+	Field   string      `toml:"field" deprecated:"1.35.0;1.40.0;use 'fields' instead"`
 	Fields  []string    `toml:"fields"`
 	Dest    string      `toml:"dest"`
 	Default interface{} `toml:"default"`

--- a/plugins/processors/enum/enum_test.go
+++ b/plugins/processors/enum/enum_test.go
@@ -205,6 +205,18 @@ func TestDoNotWriteToDestinationWithoutDefaultOrDefinedMapping(t *testing.T) {
 	require.False(t, present, "value of field '"+field+"' was present")
 }
 
+func TestMultipleFields(t *testing.T) {
+	mapper := EnumMapper{Mappings: []Mapping{{
+		Fields:        []string{"string_value", "duplicate_string_value"},
+		ValueMappings: map[string]interface{}{"test": "multiple"},
+	}}}
+	require.NoError(t, mapper.Init())
+	fields := calculateProcessedValues(mapper, createTestMetric())
+
+	assertFieldValue(t, "multiple", "string_value", fields)
+	assertFieldValue(t, "multiple", "duplicate_string_value", fields)
+}
+
 func TestFieldGlobMatching(t *testing.T) {
 	mapper := EnumMapper{Mappings: []Mapping{{
 		Fields:        []string{"*"},

--- a/plugins/processors/enum/enum_test.go
+++ b/plugins/processors/enum/enum_test.go
@@ -71,7 +71,10 @@ func TestRetainsMetric(t *testing.T) {
 }
 
 func TestMapsSingleStringValueTag(t *testing.T) {
-	mapper := EnumMapper{Mappings: []Mapping{{Tag: "tag", ValueMappings: map[string]interface{}{"tag_value": "valuable"}}}}
+	mapper := EnumMapper{Mappings: []Mapping{{
+		Tag:           "tag",
+		ValueMappings: map[string]interface{}{"tag_value": "valuable"},
+	}}}
 	err := mapper.Init()
 	require.NoError(t, err)
 	tags := calculateProcessedTags(mapper, createTestMetric())
@@ -118,7 +121,12 @@ func TestMappings(t *testing.T) {
 		for index := range mapping["target_value"] {
 			mapper := EnumMapper{
 				Mappings: []Mapping{
-					{Field: fieldName, ValueMappings: map[string]interface{}{mapping["target_value"][index].(string): mapping["mapped_value"][index]}},
+					{
+						Fields: []string{fieldName},
+						ValueMappings: map[string]interface{}{
+							mapping["target_value"][index].(string): mapping["mapped_value"][index],
+						},
+					},
 				},
 			}
 			err := mapper.Init()
@@ -130,7 +138,11 @@ func TestMappings(t *testing.T) {
 }
 
 func TestMapsToDefaultValueOnUnknownSourceValue(t *testing.T) {
-	mapper := EnumMapper{Mappings: []Mapping{{Field: "string_value", Default: int64(42), ValueMappings: map[string]interface{}{"other": int64(1)}}}}
+	mapper := EnumMapper{Mappings: []Mapping{{
+		Fields:        []string{"string_value"},
+		Default:       int64(42),
+		ValueMappings: map[string]interface{}{"other": int64(1)},
+	}}}
 	err := mapper.Init()
 	require.NoError(t, err)
 	fields := calculateProcessedValues(mapper, createTestMetric())
@@ -139,7 +151,11 @@ func TestMapsToDefaultValueOnUnknownSourceValue(t *testing.T) {
 }
 
 func TestDoNotMapToDefaultValueKnownSourceValue(t *testing.T) {
-	mapper := EnumMapper{Mappings: []Mapping{{Field: "string_value", Default: int64(42), ValueMappings: map[string]interface{}{"test": int64(1)}}}}
+	mapper := EnumMapper{Mappings: []Mapping{{
+		Fields:        []string{"string_value"},
+		Default:       int64(42),
+		ValueMappings: map[string]interface{}{"test": int64(1)},
+	}}}
 	err := mapper.Init()
 	require.NoError(t, err)
 	fields := calculateProcessedValues(mapper, createTestMetric())
@@ -148,7 +164,10 @@ func TestDoNotMapToDefaultValueKnownSourceValue(t *testing.T) {
 }
 
 func TestNoMappingWithoutDefaultOrDefinedMappingValue(t *testing.T) {
-	mapper := EnumMapper{Mappings: []Mapping{{Field: "string_value", ValueMappings: map[string]interface{}{"other": int64(1)}}}}
+	mapper := EnumMapper{Mappings: []Mapping{{
+		Fields:        []string{"string_value"},
+		ValueMappings: map[string]interface{}{"other": int64(1)},
+	}}}
 	err := mapper.Init()
 	require.NoError(t, err)
 	fields := calculateProcessedValues(mapper, createTestMetric())
@@ -157,7 +176,11 @@ func TestNoMappingWithoutDefaultOrDefinedMappingValue(t *testing.T) {
 }
 
 func TestWritesToDestination(t *testing.T) {
-	mapper := EnumMapper{Mappings: []Mapping{{Field: "string_value", Dest: "string_code", ValueMappings: map[string]interface{}{"test": int64(1)}}}}
+	mapper := EnumMapper{Mappings: []Mapping{{
+		Fields:        []string{"string_value"},
+		Dest:          "string_code",
+		ValueMappings: map[string]interface{}{"test": int64(1)},
+	}}}
 	err := mapper.Init()
 	require.NoError(t, err)
 	fields := calculateProcessedValues(mapper, createTestMetric())
@@ -168,7 +191,11 @@ func TestWritesToDestination(t *testing.T) {
 
 func TestDoNotWriteToDestinationWithoutDefaultOrDefinedMapping(t *testing.T) {
 	field := "string_code"
-	mapper := EnumMapper{Mappings: []Mapping{{Field: "string_value", Dest: field, ValueMappings: map[string]interface{}{"other": int64(1)}}}}
+	mapper := EnumMapper{Mappings: []Mapping{{
+		Fields:        []string{"string_value"},
+		Dest:          field,
+		ValueMappings: map[string]interface{}{"other": int64(1)},
+	}}}
 	err := mapper.Init()
 	require.NoError(t, err)
 	fields := calculateProcessedValues(mapper, createTestMetric())
@@ -179,7 +206,10 @@ func TestDoNotWriteToDestinationWithoutDefaultOrDefinedMapping(t *testing.T) {
 }
 
 func TestFieldGlobMatching(t *testing.T) {
-	mapper := EnumMapper{Mappings: []Mapping{{Field: "*", ValueMappings: map[string]interface{}{"test": "glob"}}}}
+	mapper := EnumMapper{Mappings: []Mapping{{
+		Fields:        []string{"*"},
+		ValueMappings: map[string]interface{}{"test": "glob"},
+	}}}
 	err := mapper.Init()
 	require.NoError(t, err)
 	fields := calculateProcessedValues(mapper, createTestMetric())
@@ -189,7 +219,10 @@ func TestFieldGlobMatching(t *testing.T) {
 }
 
 func TestTagGlobMatching(t *testing.T) {
-	mapper := EnumMapper{Mappings: []Mapping{{Tag: "*", ValueMappings: map[string]interface{}{"tag_value": "glob"}}}}
+	mapper := EnumMapper{Mappings: []Mapping{{
+		Tag:           "*",
+		ValueMappings: map[string]interface{}{"tag_value": "glob"},
+	}}}
 	err := mapper.Init()
 	require.NoError(t, err)
 	tags := calculateProcessedTags(mapper, createTestMetric())
@@ -205,7 +238,10 @@ func TestTracking(t *testing.T) {
 	}
 	m, _ = metric.WithTracking(m, notify)
 
-	mapper := EnumMapper{Mappings: []Mapping{{Tag: "*", ValueMappings: map[string]interface{}{"tag_value": "glob"}}}}
+	mapper := EnumMapper{Mappings: []Mapping{{
+		Tag:           "*",
+		ValueMappings: map[string]interface{}{"tag_value": "glob"},
+	}}}
 	err := mapper.Init()
 	require.NoError(t, err)
 

--- a/plugins/processors/enum/enum_test.go
+++ b/plugins/processors/enum/enum_test.go
@@ -267,8 +267,9 @@ func TestCollidingValueMappings(t *testing.T) {
 	)
 
 	output := mapper.Apply(input)[0]
-	require.Equal(t, int64(1), output.Fields()["status"])
-	require.Equal(t, int64(3), output.Fields()["status_reverse"])
+	fields := output.Fields()
+	assertFieldValue(t, int64(1), "status", fields)
+	assertFieldValue(t, int64(3), "status_reverse", fields)
 }
 
 func TestTracking(t *testing.T) {

--- a/plugins/processors/enum/sample.conf
+++ b/plugins/processors/enum/sample.conf
@@ -1,8 +1,8 @@
 # Map enum values according to given table.
 [[processors.enum]]
   [[processors.enum.mapping]]
-    ## Name of the field to map. Globs accepted.
-    field = "status"
+    ## Names of the fields to map. Globs accepted.
+    fields = ["status"]
 
     ## Name of the tag to map. Globs accepted.
     # tag = "status"


### PR DESCRIPTION
## Summary
Adds a new `fields` option to the enum processor, deprecating the old `field` option. Allows mapping multiple fields with one enum mapping when a glob does not work

## Checklist
- [X] No AI generated code was used in this PR

## Related issues
resolves #10892
