### PR TITLE
feat(outputs.postgres): Allow limiting of column names

### DIFF
--- a/plugins/outputs/postgresql/README.md
+++ b/plugins/outputs/postgresql/README.md
@@ -124,6 +124,12 @@ to use them.
   ## Each entry consumes approximately 34 bytes of memory.
   # tag_cache_size = 100000
 
+  ## Cut column names at the given length to not exceed PostgreSQL's
+  ## 'identifier length' limit (default: no limit)
+  ## (see https://www.postgresql.org/docs/current/limits.html)
+  ## Be careful to not create duplicate column names!
+  # column_name_length_limit = 0
+
   ## Enable & set the log level for the Postgres driver.
   # log_level = "warn" # trace, debug, info, warn, error, none
 ```
@@ -188,6 +194,19 @@ statements. This allows for complete control of the schema by the user.
 Documentation on how to write templates can be found [sqltemplate docs][1]
 
 [1]: https://pkg.go.dev/github.com/influxdata/telegraf/plugins/outputs/postgresql/sqltemplate
+
+## Long Column Names
+
+Postgres imposes a limit on the length of column identifiers, which can be found
+in the [official docs](https://www.postgresql.org/docs/current/limits.html). By
+default Telegraf does not enforce this limit as this limit can be modified on
+the server side. Furthermore, cutting off column names could lead to collisions
+if the columns are only different after the cut-off.
+
+> [!WARNING]
+> Make sure you will not cause column name collisions when setting
+> `column_name_length_limit`! If in doubt, explicitly shorten the field and tag
+> names using e.g. the regexp processor.
 
 ### Samples
 

--- a/plugins/outputs/postgresql/postgresql.go
+++ b/plugins/outputs/postgresql/postgresql.go
@@ -51,6 +51,7 @@ type Postgresql struct {
 	Uint64Type                 string                  `toml:"uint64_type"`
 	RetryMaxBackoff            config.Duration         `toml:"retry_max_backoff"`
 	TagCacheSize               int                     `toml:"tag_cache_size"`
+	ColumnNameLenLimit         int                     `toml:"column_name_length_limit"`
 	LogLevel                   string                  `toml:"log_level"`
 	Logger                     telegraf.Logger         `toml:"-"`
 

--- a/plugins/outputs/postgresql/sample.conf
+++ b/plugins/outputs/postgresql/sample.conf
@@ -85,5 +85,11 @@
   ## Each entry consumes approximately 34 bytes of memory.
   # tag_cache_size = 100000
 
+  ## Cut column names at the given length to not exceed PostgreSQL's
+  ## 'identifier length' limit (default: no limit)
+  ## (see https://www.postgresql.org/docs/current/limits.html)
+  ## Be careful to not create duplicate column names!
+  # column_name_length_limit = 0
+
   ## Enable & set the log level for the Postgres driver.
   # log_level = "warn" # trace, debug, info, warn, error, none


### PR DESCRIPTION
## Summary

PostgreSQL imposes a identifier length limit, leading to errors if column names (derived from field or tag names) are too long. Currently the default limit is 63 characters.

To allow cutting-off too long column names, this PR introduces a new option where you can set the cut-off limit. However, this should be used with care as it might cause column name collision if the differentiating part of column names is beyond the given limit.

Furthermore, the PR also limits logging the "too long" error to once per column name.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #15964 
