### PR TITLE
chore: Fix linter findings for `revive:exported` in `plugins/inputs/f*`

### DIFF
--- a/plugins/inputs/fail2ban/fail2ban.go
+++ b/plugins/inputs/fail2ban/fail2ban.go
@@ -17,30 +17,29 @@ import (
 var sampleConfig string
 
 var (
-	execCommand = exec.Command // execCommand is used to mock commands in tests.
+	execCommand    = exec.Command // execCommand is used to mock commands in tests.
+	metricsTargets = []struct {
+		target string
+		field  string
+	}{
+		{
+			target: "Currently failed:",
+			field:  "failed",
+		},
+		{
+			target: "Currently banned:",
+			field:  "banned",
+		},
+	}
 )
+
+const cmd = "fail2ban-client"
 
 type Fail2ban struct {
 	UseSudo bool   `toml:"use_sudo"`
 	Socket  string `toml:"socket"`
 	path    string
 }
-
-var metricsTargets = []struct {
-	target string
-	field  string
-}{
-	{
-		target: "Currently failed:",
-		field:  "failed",
-	},
-	{
-		target: "Currently banned:",
-		field:  "banned",
-	},
-}
-
-const cmd = "fail2ban-client"
 
 func (*Fail2ban) SampleConfig() string {
 	return sampleConfig

--- a/plugins/inputs/fibaro/hc2/parser.go
+++ b/plugins/inputs/fibaro/hc2/parser.go
@@ -7,7 +7,8 @@ import (
 	"github.com/influxdata/telegraf"
 )
 
-func Parse(acc telegraf.Accumulator, sectionBytes, roomBytes, deviecsBytes []byte) error {
+// Parse parses data from sections, rooms and devices, and adds measurements containing parsed data.
+func Parse(acc telegraf.Accumulator, sectionBytes, roomBytes, devicesBytes []byte) error {
 	var tmpSections []Sections
 	if err := json.Unmarshal(sectionBytes, &tmpSections); err != nil {
 		return err
@@ -28,7 +29,7 @@ func Parse(acc telegraf.Accumulator, sectionBytes, roomBytes, deviecsBytes []byt
 	}
 
 	var devices []Devices
-	if err := json.Unmarshal(deviecsBytes, &devices); err != nil {
+	if err := json.Unmarshal(devicesBytes, &devices); err != nil {
 		return err
 	}
 

--- a/plugins/inputs/fibaro/hc3/parser.go
+++ b/plugins/inputs/fibaro/hc3/parser.go
@@ -9,7 +9,8 @@ import (
 	"github.com/influxdata/telegraf/internal"
 )
 
-func Parse(acc telegraf.Accumulator, sectionBytes, roomBytes, deviecsBytes []byte) error {
+// Parse parses data from sections, rooms and devices, and adds measurements containing parsed data.
+func Parse(acc telegraf.Accumulator, sectionBytes, roomBytes, devicesBytes []byte) error {
 	var tmpSections []Sections
 	if err := json.Unmarshal(sectionBytes, &tmpSections); err != nil {
 		return err
@@ -29,7 +30,7 @@ func Parse(acc telegraf.Accumulator, sectionBytes, roomBytes, deviecsBytes []byt
 	}
 
 	var devices []Devices
-	if err := json.Unmarshal(deviecsBytes, &devices); err != nil {
+	if err := json.Unmarshal(devicesBytes, &devices); err != nil {
 		return err
 	}
 

--- a/plugins/inputs/file/file.go
+++ b/plugins/inputs/file/file.go
@@ -45,6 +45,10 @@ func (f *File) Init() error {
 	return err
 }
 
+func (f *File) SetParserFunc(fn telegraf.ParserFunc) {
+	f.parserFunc = fn
+}
+
 func (f *File) Gather(acc telegraf.Accumulator) error {
 	err := f.refreshFilePaths()
 	if err != nil {
@@ -69,10 +73,6 @@ func (f *File) Gather(acc telegraf.Accumulator) error {
 		}
 	}
 	return nil
-}
-
-func (f *File) SetParserFunc(fn telegraf.ParserFunc) {
-	f.parserFunc = fn
 }
 
 func (f *File) refreshFilePaths() error {

--- a/plugins/inputs/filecount/filecount_test.go
+++ b/plugins/inputs/filecount/filecount_test.go
@@ -13,10 +13,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/testutil"
-	"github.com/stretchr/testify/require"
 )
 
 func TestNoFilters(t *testing.T) {
@@ -147,7 +148,7 @@ func TestDirectoryWithTrailingSlash(t *testing.T) {
 		Directories: []string{getTestdataDir() + string(filepath.Separator)},
 		Name:        "*",
 		Recursive:   true,
-		Fs:          getFakeFileSystem(getTestdataDir()),
+		fs:          getFakeFileSystem(getTestdataDir()),
 	}
 
 	var acc testutil.Accumulator
@@ -184,7 +185,7 @@ func getNoFilterFileCount() FileCount {
 		Size:        config.Size(0),
 		MTime:       config.Duration(0),
 		fileFilters: nil,
-		Fs:          getFakeFileSystem(getTestdataDir()),
+		fs:          getFakeFileSystem(getTestdataDir()),
 	}
 }
 

--- a/plugins/inputs/filecount/filesystem_helpers.go
+++ b/plugins/inputs/filecount/filesystem_helpers.go
@@ -12,9 +12,9 @@ import (
 */
 
 type fileSystem interface {
-	Open(name string) (file, error)
-	Stat(name string) (os.FileInfo, error)
-	Lstat(name string) (os.FileInfo, error)
+	open(name string) (file, error)
+	stat(name string) (os.FileInfo, error)
+	lstat(name string) (os.FileInfo, error)
 }
 
 type file interface {
@@ -28,6 +28,6 @@ type file interface {
 // osFS implements fileSystem using the local disk
 type osFS struct{}
 
-func (osFS) Open(name string) (file, error)         { return os.Open(name) }
-func (osFS) Stat(name string) (os.FileInfo, error)  { return os.Stat(name) }
-func (osFS) Lstat(name string) (os.FileInfo, error) { return os.Lstat(name) }
+func (osFS) open(name string) (file, error)         { return os.Open(name) }
+func (osFS) stat(name string) (os.FileInfo, error)  { return os.Stat(name) }
+func (osFS) lstat(name string) (os.FileInfo, error) { return os.Lstat(name) }

--- a/plugins/inputs/filecount/filesystem_helpers_notwindows.go
+++ b/plugins/inputs/filecount/filesystem_helpers_notwindows.go
@@ -40,18 +40,18 @@ func (f fakeFileInfo) ModTime() time.Time { return f.modtime }
 func (f fakeFileInfo) IsDir() bool        { return f.isdir }
 func (f fakeFileInfo) Sys() interface{}   { return f.sys }
 
-func (f fakeFileSystem) Open(name string) (file, error) {
+func (f fakeFileSystem) open(name string) (file, error) {
 	return nil, &os.PathError{Op: "Open", Path: name, Err: errors.New("not implemented by fake filesystem")}
 }
 
-func (f fakeFileSystem) Stat(name string) (os.FileInfo, error) {
+func (f fakeFileSystem) stat(name string) (os.FileInfo, error) {
 	if fakeInfo, found := f.files[name]; found {
 		return fakeInfo, nil
 	}
 	return nil, &os.PathError{Op: "Stat", Path: name, Err: errors.New("no such file or directory")}
 }
 
-func (f fakeFileSystem) Lstat(name string) (os.FileInfo, error) {
+func (f fakeFileSystem) lstat(name string) (os.FileInfo, error) {
 	// not able to test with symlinks currently
-	return f.Stat(name)
+	return f.stat(name)
 }

--- a/plugins/inputs/filecount/filesystem_helpers_test.go
+++ b/plugins/inputs/filecount/filesystem_helpers_test.go
@@ -17,7 +17,7 @@ func TestMTime(t *testing.T) {
 	mtime := time.Date(2015, time.December, 14, 18, 25, 5, 0, time.UTC)
 
 	fs := getTestFileSystem()
-	fileInfo, err := fs.Stat("/testdata/foo")
+	fileInfo, err := fs.stat("/testdata/foo")
 	require.NoError(t, err)
 	require.Equal(t, mtime, fileInfo.ModTime())
 }
@@ -26,25 +26,24 @@ func TestSize(t *testing.T) {
 	// this is the time our foo file should have
 	size := int64(4096)
 	fs := getTestFileSystem()
-	fileInfo, err := fs.Stat("/testdata")
+	fileInfo, err := fs.stat("/testdata")
 	require.NoError(t, err)
 	require.Equal(t, size, fileInfo.Size())
 }
 
 func TestIsDir(t *testing.T) {
 	// this is the time our foo file should have
-	dir := true
 	fs := getTestFileSystem()
-	fileInfo, err := fs.Stat("/testdata")
+	fileInfo, err := fs.stat("/testdata")
 	require.NoError(t, err)
-	require.Equal(t, dir, fileInfo.IsDir())
+	require.True(t, fileInfo.IsDir())
 }
 
 func TestRealFS(t *testing.T) {
 	// test that the default (non-test) empty FS causes expected behaviour
 	var fs fileSystem = osFS{}
 	// the following file exists on disk - and not in our fake fs
-	fileInfo, err := fs.Stat(getTestdataDir() + "/qux")
+	fileInfo, err := fs.stat(getTestdataDir() + "/qux")
 	require.NoError(t, err)
 	require.False(t, fileInfo.IsDir())
 	require.Equal(t, int64(446), fileInfo.Size())
@@ -53,10 +52,10 @@ func TestRealFS(t *testing.T) {
 	fs = getTestFileSystem()
 	// now, the same test as above will return an error as the file doesn't exist in our fake fs
 	expectedError := "Stat " + getTestdataDir() + "/qux: No such file or directory"
-	_, err = fs.Stat(getTestdataDir() + "/qux")
+	_, err = fs.stat(getTestdataDir() + "/qux")
 	require.Error(t, err, expectedError)
 	// and verify that what we DO expect to find, we do
-	fileInfo, err = fs.Stat("/testdata/foo")
+	fileInfo, err = fs.stat("/testdata/foo")
 	require.NoError(t, err)
 	require.NotNil(t, fileInfo)
 }

--- a/plugins/inputs/filestat/filestat.go
+++ b/plugins/inputs/filestat/filestat.go
@@ -17,10 +17,10 @@ import (
 var sampleConfig string
 
 type FileStat struct {
-	Md5   bool
-	Files []string
+	Md5   bool     `toml:"md5"`
+	Files []string `toml:"files"`
 
-	Log telegraf.Logger
+	Log telegraf.Logger `toml:"-"`
 
 	// maps full file paths to globmatch obj
 	globs map[string]*globpath.GlobPath
@@ -29,14 +29,6 @@ type FileStat struct {
 	missingFiles map[string]bool
 	// files that had an error in Stat - we only log the first error.
 	filesWithErrors map[string]bool
-}
-
-func NewFileStat() *FileStat {
-	return &FileStat{
-		globs:           make(map[string]*globpath.GlobPath),
-		missingFiles:    make(map[string]bool),
-		filesWithErrors: make(map[string]bool),
-	}
 }
 
 func (*FileStat) SampleConfig() string {
@@ -134,8 +126,16 @@ func getMd5(file string) (string, error) {
 	return hex.EncodeToString(hash.Sum(nil)), nil
 }
 
+func newFileStat() *FileStat {
+	return &FileStat{
+		globs:           make(map[string]*globpath.GlobPath),
+		missingFiles:    make(map[string]bool),
+		filesWithErrors: make(map[string]bool),
+	}
+}
+
 func init() {
 	inputs.Add("filestat", func() telegraf.Input {
-		return NewFileStat()
+		return newFileStat()
 	})
 }

--- a/plugins/inputs/filestat/filestat_test.go
+++ b/plugins/inputs/filestat/filestat_test.go
@@ -15,12 +15,10 @@ import (
 	"github.com/influxdata/telegraf/testutil"
 )
 
-var (
-	testdataDir = getTestdataDir()
-)
+var testdataDir = getTestdataDir()
 
 func TestGatherNoMd5(t *testing.T) {
-	fs := NewFileStat()
+	fs := newFileStat()
 	fs.Log = testutil.Logger{}
 	fs.Files = []string{
 		filepath.Join(testdataDir, "log1.log"),
@@ -50,7 +48,7 @@ func TestGatherNoMd5(t *testing.T) {
 }
 
 func TestGatherExplicitFiles(t *testing.T) {
-	fs := NewFileStat()
+	fs := newFileStat()
 	fs.Log = testutil.Logger{}
 	fs.Md5 = true
 	fs.Files = []string{
@@ -83,7 +81,7 @@ func TestGatherExplicitFiles(t *testing.T) {
 }
 
 func TestNonExistentFile(t *testing.T) {
-	fs := NewFileStat()
+	fs := newFileStat()
 	fs.Log = testutil.Logger{}
 	fs.Md5 = true
 	fs.Files = []string{
@@ -100,7 +98,7 @@ func TestNonExistentFile(t *testing.T) {
 }
 
 func TestGatherGlob(t *testing.T) {
-	fs := NewFileStat()
+	fs := newFileStat()
 	fs.Log = testutil.Logger{}
 	fs.Md5 = true
 	fs.Files = []string{
@@ -126,7 +124,7 @@ func TestGatherGlob(t *testing.T) {
 }
 
 func TestGatherSuperAsterisk(t *testing.T) {
-	fs := NewFileStat()
+	fs := newFileStat()
 	fs.Log = testutil.Logger{}
 	fs.Md5 = true
 	fs.Files = []string{
@@ -159,7 +157,7 @@ func TestGatherSuperAsterisk(t *testing.T) {
 }
 
 func TestModificationTime(t *testing.T) {
-	fs := NewFileStat()
+	fs := newFileStat()
 	fs.Log = testutil.Logger{}
 	fs.Files = []string{
 		filepath.Join(testdataDir, "log1.log"),
@@ -177,7 +175,7 @@ func TestModificationTime(t *testing.T) {
 }
 
 func TestNoModificationTime(t *testing.T) {
-	fs := NewFileStat()
+	fs := newFileStat()
 	fs.Log = testutil.Logger{}
 	fs.Files = []string{
 		filepath.Join(testdataDir, "non_existent_file"),

--- a/plugins/inputs/fireboard/fireboard.go
+++ b/plugins/inputs/fireboard/fireboard.go
@@ -18,7 +18,6 @@ import (
 //go:embed sample.conf
 var sampleConfig string
 
-// Fireboard gathers statistics from the fireboard.io servers
 type Fireboard struct {
 	AuthToken   string          `toml:"auth_token"`
 	URL         string          `toml:"url"`
@@ -27,35 +26,23 @@ type Fireboard struct {
 	client *http.Client
 }
 
-// NewFireboard return a new instance of Fireboard with a default http client
-func NewFireboard() *Fireboard {
-	tr := &http.Transport{ResponseHeaderTimeout: 3 * time.Second}
-	client := &http.Client{
-		Transport: tr,
-		Timeout:   4 * time.Second,
-	}
-	return &Fireboard{client: client}
-}
-
-// RTT fireboardStats represents the data that is received from Fireboard
-type RTT struct {
+type rtt struct {
 	Temp       float64 `json:"temp"`
 	Channel    int64   `json:"channel"`
-	Degreetype int     `json:"degreetype"`
+	DegreeType int     `json:"degreetype"`
 	Created    string  `json:"created"`
 }
 
 type fireboardStats struct {
 	Title       string `json:"title"`
 	UUID        string `json:"uuid"`
-	Latesttemps []RTT  `json:"latest_temps"`
+	LatestTemps []rtt  `json:"latest_temps"`
 }
 
 func (*Fireboard) SampleConfig() string {
 	return sampleConfig
 }
 
-// Init the things
 func (r *Fireboard) Init() error {
 	if len(r.AuthToken) == 0 {
 		return errors.New("you must specify an authToken")
@@ -73,7 +60,6 @@ func (r *Fireboard) Init() error {
 	return nil
 }
 
-// Gather Reads stats from all configured servers.
 func (r *Fireboard) Gather(acc telegraf.Accumulator) error {
 	// Perform the GET request to the fireboard servers
 	req, err := http.NewRequest("GET", r.URL, nil)
@@ -122,12 +108,12 @@ func scale(n int) string {
 func (r *Fireboard) gatherTemps(s fireboardStats, acc telegraf.Accumulator) {
 	// Construct lookup for scale values
 
-	for _, t := range s.Latesttemps {
+	for _, t := range s.LatestTemps {
 		tags := map[string]string{
 			"title":   s.Title,
 			"uuid":    s.UUID,
 			"channel": strconv.FormatInt(t.Channel, 10),
-			"scale":   scale(t.Degreetype),
+			"scale":   scale(t.DegreeType),
 		}
 		fields := map[string]interface{}{
 			"temperature": t.Temp,
@@ -136,8 +122,17 @@ func (r *Fireboard) gatherTemps(s fireboardStats, acc telegraf.Accumulator) {
 	}
 }
 
+func newFireboard() *Fireboard {
+	tr := &http.Transport{ResponseHeaderTimeout: 3 * time.Second}
+	client := &http.Client{
+		Transport: tr,
+		Timeout:   4 * time.Second,
+	}
+	return &Fireboard{client: client}
+}
+
 func init() {
 	inputs.Add("fireboard", func() telegraf.Input {
-		return NewFireboard()
+		return newFireboard()
 	})
 }

--- a/plugins/inputs/fireboard/fireboard_test.go
+++ b/plugins/inputs/fireboard/fireboard_test.go
@@ -27,7 +27,7 @@ func TestFireboard(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create a new fb instance with our given test server
-	fireboard := NewFireboard()
+	fireboard := newFireboard()
 	fireboard.AuthToken = "b4bb6e6a7b6231acb9f71b304edb2274693d8849"
 	fireboard.URL = u.String()
 

--- a/plugins/inputs/fluentd/fluentd.go
+++ b/plugins/inputs/fluentd/fluentd.go
@@ -20,11 +20,11 @@ var sampleConfig string
 
 const measurement = "fluentd"
 
-// Fluentd - plugin main structure
 type Fluentd struct {
-	Endpoint string
-	Exclude  []string
-	client   *http.Client
+	Endpoint string   `toml:"endpoint"`
+	Exclude  []string `toml:"exclude"`
+
+	client *http.Client
 }
 
 type endpointInfo struct {
@@ -51,32 +51,10 @@ type pluginData struct {
 	AvailBufferSpaceRatios *float64 `json:"buffer_available_buffer_space_ratios"`
 }
 
-// parse JSON from fluentd Endpoint
-// Parameters:
-//
-//	data: unprocessed json received from endpoint
-//
-// Returns:
-//
-//	pluginData:		slice that contains parsed plugins
-//	error:			error that may have occurred
-func parse(data []byte) (datapointArray []pluginData, err error) {
-	var endpointData endpointInfo
-
-	if err = json.Unmarshal(data, &endpointData); err != nil {
-		err = errors.New("processing JSON structure")
-		return nil, err
-	}
-
-	datapointArray = append(datapointArray, endpointData.Payload...)
-	return datapointArray, err
-}
-
 func (*Fluentd) SampleConfig() string {
 	return sampleConfig
 }
 
-// Gather - Main code responsible for gathering, processing and creating metrics
 func (h *Fluentd) Gather(acc telegraf.Accumulator) error {
 	_, err := url.Parse(h.Endpoint)
 	if err != nil {
@@ -217,6 +195,27 @@ func (h *Fluentd) Gather(acc telegraf.Accumulator) error {
 	}
 
 	return nil
+}
+
+// parse JSON from fluentd Endpoint
+// Parameters:
+//
+//	data: unprocessed json received from endpoint
+//
+// Returns:
+//
+//	pluginData:		slice that contains parsed plugins
+//	error:			error that may have occurred
+func parse(data []byte) (datapointArray []pluginData, err error) {
+	var endpointData endpointInfo
+
+	if err = json.Unmarshal(data, &endpointData); err != nil {
+		err = errors.New("processing JSON structure")
+		return nil, err
+	}
+
+	datapointArray = append(datapointArray, endpointData.Payload...)
+	return datapointArray, err
 }
 
 func init() {


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

Address findings for [revive:exported ](https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#exported ) in `plugins/inputs/f*`.

As part of this effort for files from `plugins/inputs/f*`, the following actions were taken:
- Type names (`const`, `var`, `struct`, `func`, etc) were changed to unexported, wherever they didn't need to be exported.
- All remaining exported types were given comments in the appropriate form – this does not apply to exported methods that implement "known" plugin interfaces (`Gather|Init|Start|Stop|SampleConfig|Parse|Add|Apply|Serialize|SerializeBatch|SetParser|SetParserFunc|GetState|SetState`).
- The order of methods was organized (exported methods first, then unexported, with `init` at the very end).

It is only part of the bigger work (for issue: https://github.com/influxdata/telegraf/issues/15813).
After all findings of this type in whole project are handled, we can enable `revive:exported` rule in `golangci-lint`.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR