### PR TITLE
chore: Fix linter findings for `revive:exported` in `plugins/inputs/g*`

### DIFF
--- a/plugins/inputs/gnmi/gnmi.go
+++ b/plugins/inputs/gnmi/gnmi.go
@@ -7,7 +7,6 @@ import (
 	_ "embed"
 	"errors"
 	"fmt"
-	"github.com/influxdata/telegraf/plugins/inputs"
 	"strings"
 	"sync"
 	"time"
@@ -22,6 +21,7 @@ import (
 	"github.com/influxdata/telegraf/internal/choice"
 	common_tls "github.com/influxdata/telegraf/plugins/common/tls"
 	"github.com/influxdata/telegraf/plugins/common/yangmodel"
+	"github.com/influxdata/telegraf/plugins/inputs"
 )
 
 //go:embed sample.conf

--- a/plugins/inputs/gnmi/handler.go
+++ b/plugins/inputs/gnmi/handler.go
@@ -35,7 +35,7 @@ const eidJuniperTelemetryHeader = 1
 type handler struct {
 	address             string
 	aliases             map[*pathInfo]string
-	tagsubs             []TagSubscription
+	tagsubs             []tagSubscription
 	maxMsgSize          int
 	emptyNameWarnShown  bool
 	vendorExt           []string
@@ -170,7 +170,7 @@ func (h *handler) handleSubscribeResponseUpdate(acc telegraf.Accumulator, respon
 		h.log.Errorf("unable to parse address %s: %v", h.address, err)
 	}
 	if !prefix.empty() {
-		headerTags["path"] = prefix.FullPath()
+		headerTags["path"] = prefix.fullPath()
 	}
 
 	// Process and remove tag-updates from the response first so we can
@@ -192,7 +192,7 @@ func (h *handler) handleSubscribeResponseUpdate(acc telegraf.Accumulator, respon
 		for key, val := range headerTags {
 			tags[key] = val
 		}
-		for key, val := range fullPath.Tags(h.tagPathPrefix) {
+		for key, val := range fullPath.tags(h.tagPathPrefix) {
 			tags[key] = val
 		}
 
@@ -229,7 +229,7 @@ func (h *handler) handleSubscribeResponseUpdate(acc telegraf.Accumulator, respon
 		}
 
 		// Prepare tags from prefix
-		fieldTags := field.path.Tags(h.tagPathPrefix)
+		fieldTags := field.path.tags(h.tagPathPrefix)
 		tags := make(map[string]string, len(headerTags)+len(fieldTags))
 		for key, val := range headerTags {
 			tags[key] = val
@@ -278,7 +278,7 @@ func (h *handler) handleSubscribeResponseUpdate(acc telegraf.Accumulator, respon
 				key = relative
 			} else {
 				// Otherwise use the last path element as the field key
-				key = field.path.Base()
+				key = field.path.base()
 			}
 			key = strings.ReplaceAll(key, "-", "_")
 		}
@@ -328,7 +328,7 @@ func guessPrefixFromUpdate(fields []updateField) string {
 		return ""
 	}
 	if len(fields) == 1 {
-		return fields[0].path.Dir()
+		return fields[0].path.dir()
 	}
 	commonPath := &pathInfo{
 		origin:   fields[0].path.origin,

--- a/plugins/inputs/gnmi/path.go
+++ b/plugins/inputs/gnmi/path.go
@@ -290,7 +290,7 @@ func (pi *pathInfo) keepCommonPart(path *pathInfo) {
 	pi.segments = pi.segments[:matchLen]
 }
 
-func (pi *pathInfo) Dir() string {
+func (pi *pathInfo) dir() string {
 	if len(pi.segments) <= 1 {
 		return ""
 	}
@@ -309,7 +309,7 @@ func (pi *pathInfo) Dir() string {
 	return dir
 }
 
-func (pi *pathInfo) Base() string {
+func (pi *pathInfo) base() string {
 	if len(pi.segments) == 0 {
 		return ""
 	}
@@ -321,7 +321,7 @@ func (pi *pathInfo) Base() string {
 	return s.id
 }
 
-func (pi *pathInfo) Path() (origin, path string) {
+func (pi *pathInfo) path() (origin, path string) {
 	if len(pi.segments) == 0 {
 		return pi.origin, "/"
 	}
@@ -333,7 +333,7 @@ func (pi *pathInfo) Path() (origin, path string) {
 	return pi.origin, path
 }
 
-func (pi *pathInfo) FullPath() string {
+func (pi *pathInfo) fullPath() string {
 	var path string
 	if pi.origin != "" {
 		path = pi.origin + ":"
@@ -360,14 +360,14 @@ func (pi *pathInfo) String() string {
 		return ""
 	}
 
-	origin, path := pi.Path()
+	origin, path := pi.path()
 	if origin != "" {
 		return origin + ":" + path
 	}
 	return path
 }
 
-func (pi *pathInfo) Tags(pathPrefix bool) map[string]string {
+func (pi *pathInfo) tags(pathPrefix bool) map[string]string {
 	tags := make(map[string]string, len(pi.keyValues))
 	for _, s := range pi.keyValues {
 		var prefix string

--- a/plugins/inputs/gnmi/tag_store.go
+++ b/plugins/inputs/gnmi/tag_store.go
@@ -19,7 +19,7 @@ type elementsStore struct {
 	tags     map[string]map[string]string
 }
 
-func newTagStore(subs []TagSubscription) *tagStore {
+func newTagStore(subs []tagSubscription) *tagStore {
 	store := tagStore{
 		unconditional: make(map[string]string),
 		names:         make(map[string]map[string]string),
@@ -38,13 +38,13 @@ func newTagStore(subs []TagSubscription) *tagStore {
 }
 
 // Store tags extracted from TagSubscriptions
-func (s *tagStore) insert(subscription TagSubscription, path *pathInfo, values []updateField, tags map[string]string) error {
+func (s *tagStore) insert(subscription tagSubscription, path *pathInfo, values []updateField, tags map[string]string) error {
 	switch subscription.Match {
 	case "unconditional":
 		for _, f := range values {
 			tagName := subscription.Name
 			if len(f.path.segments) > 0 {
-				key := f.path.Base()
+				key := f.path.base()
 				key = strings.ReplaceAll(key, "-", "_")
 				tagName += "/" + key
 			}
@@ -74,7 +74,7 @@ func (s *tagStore) insert(subscription TagSubscription, path *pathInfo, values [
 		for _, f := range values {
 			tagName := subscription.Name
 			if len(f.path.segments) > 0 {
-				key := f.path.Base()
+				key := f.path.base()
 				key = strings.ReplaceAll(key, "-", "_")
 				tagName += "/" + key
 			}
@@ -103,7 +103,7 @@ func (s *tagStore) insert(subscription TagSubscription, path *pathInfo, values [
 		for _, f := range values {
 			tagName := subscription.Name
 			if len(f.path.segments) > 0 {
-				key := f.path.Base()
+				key := f.path.base()
 				key = strings.ReplaceAll(key, "-", "_")
 				tagName += "/" + key
 			}

--- a/plugins/inputs/gnmi/update_fields.go
+++ b/plugins/inputs/gnmi/update_fields.go
@@ -109,7 +109,7 @@ func (h *handler) processJSONIETF(path *pathInfo, data []byte) ([]updateField, e
 		// Try to lookup the full path to decode the field according to the
 		// YANG model if any
 		if h.decoder != nil {
-			origin, fieldPath := p.Path()
+			origin, fieldPath := p.path()
 			if decoded, err := h.decoder.DecodePathElement(origin, fieldPath, entry.value); err != nil {
 				h.log.Debugf("Decoding %s failed: %v", p, err)
 			} else {

--- a/plugins/inputs/graylog/graylog_test.go
+++ b/plugins/inputs/graylog/graylog_test.go
@@ -97,7 +97,7 @@ type mockHTTPClient struct {
 // Mock implementation of MakeRequest. Usually returns an http.Response with
 // hard-coded responseBody and statusCode. However, if the request uses a
 // nonstandard method, it uses status code 405 (method not allowed)
-func (c *mockHTTPClient) MakeRequest(req *http.Request) (*http.Response, error) {
+func (c *mockHTTPClient) makeRequest(req *http.Request) (*http.Response, error) {
 	resp := http.Response{}
 	resp.StatusCode = c.statusCode
 
@@ -119,10 +119,10 @@ func (c *mockHTTPClient) MakeRequest(req *http.Request) (*http.Response, error) 
 	return &resp, nil
 }
 
-func (c *mockHTTPClient) SetHTTPClient(_ *http.Client) {
+func (c *mockHTTPClient) setHTTPClient(_ *http.Client) {
 }
 
-func (c *mockHTTPClient) HTTPClient() *http.Client {
+func (c *mockHTTPClient) httpClient() *http.Client {
 	return nil
 }
 


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

Address findings for [revive:exported ](https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#exported ) in `plugins/inputs/g*`.

As part of this effort for files from `plugins/inputs/g*`, the following actions were taken:
- Type names (`const`, `var`, `struct`, `func`, etc) were changed to unexported, wherever they didn't need to be exported.
- All remaining exported types were given comments in the appropriate form – this does not apply to exported methods that implement "known" plugin interfaces (`Gather|Init|Start|Stop|SampleConfig|Parse|Add|Apply|Serialize|SerializeBatch|SetParser|SetParserFunc|GetState|SetState`).
- The order of methods was organized (exported methods first, then unexported, with `init` at the very end).

It is only part of the bigger work (for issue: https://github.com/influxdata/telegraf/issues/15813).
After all findings of this type in whole project are handled, we can enable `revive:exported` rule in `golangci-lint`.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR