### PR TITLE
chore: Fix linter findings for `revive:exported` in `plugins/inputs/h*`

### DIFF
--- a/plugins/inputs/haproxy/haproxy_test.go
+++ b/plugins/inputs/haproxy/haproxy_test.go
@@ -66,7 +66,7 @@ func TestHaproxyGeneratesMetricsWithAuthentication(t *testing.T) {
 	defer ts.Close()
 
 	// Now we tested again above server, with our authentication data
-	r := &haproxy{
+	r := &HAProxy{
 		Servers: []string{strings.Replace(ts.URL, "http://", "http://user:password@", 1)},
 	}
 
@@ -82,11 +82,11 @@ func TestHaproxyGeneratesMetricsWithAuthentication(t *testing.T) {
 		"type":   "server",
 	}
 
-	fields := HaproxyGetFieldValues()
+	fields := haproxyGetFieldValues()
 	acc.AssertContainsTaggedFields(t, "haproxy", fields, tags)
 
 	// Here, we should get error because we don't pass authentication data
-	r = &haproxy{
+	r = &HAProxy{
 		Servers: []string{ts.URL},
 	}
 
@@ -101,7 +101,7 @@ func TestHaproxyGeneratesMetricsWithoutAuthentication(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	r := &haproxy{
+	r := &HAProxy{
 		Servers: []string{ts.URL},
 	}
 
@@ -116,7 +116,7 @@ func TestHaproxyGeneratesMetricsWithoutAuthentication(t *testing.T) {
 		"type":   "server",
 	}
 
-	fields := HaproxyGetFieldValues()
+	fields := haproxyGetFieldValues()
 	acc.AssertContainsTaggedFields(t, "haproxy", fields, tags)
 }
 
@@ -143,7 +143,7 @@ func TestHaproxyGeneratesMetricsUsingSocket(t *testing.T) {
 		go s.serverSocket(sock)
 	}
 
-	r := &haproxy{
+	r := &HAProxy{
 		Servers: []string{_globmask},
 	}
 
@@ -152,7 +152,7 @@ func TestHaproxyGeneratesMetricsUsingSocket(t *testing.T) {
 	err := r.Gather(&acc)
 	require.NoError(t, err)
 
-	fields := HaproxyGetFieldValues()
+	fields := haproxyGetFieldValues()
 
 	for _, sock := range sockets {
 		tags := map[string]string{
@@ -182,14 +182,14 @@ func TestHaproxyGeneratesMetricsUsingTcp(t *testing.T) {
 	s := statServer{}
 	go s.serverSocket(l)
 
-	r := &haproxy{
+	r := &HAProxy{
 		Servers: []string{"tcp://" + l.Addr().String()},
 	}
 
 	var acc testutil.Accumulator
 	require.NoError(t, r.Gather(&acc))
 
-	fields := HaproxyGetFieldValues()
+	fields := haproxyGetFieldValues()
 
 	tags := map[string]string{
 		"server": l.Addr().String(),
@@ -206,7 +206,7 @@ func TestHaproxyGeneratesMetricsUsingTcp(t *testing.T) {
 // When not passing server config, we default to localhost
 // We just want to make sure we did request stat from localhost
 func TestHaproxyDefaultGetFromLocalhost(t *testing.T) {
-	r := &haproxy{}
+	r := &HAProxy{}
 
 	var acc testutil.Accumulator
 
@@ -222,7 +222,7 @@ func TestHaproxyKeepFieldNames(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	r := &haproxy{
+	r := &HAProxy{
 		Servers:        []string{ts.URL},
 		KeepFieldNames: true,
 	}
@@ -238,7 +238,7 @@ func TestHaproxyKeepFieldNames(t *testing.T) {
 		"type":   "server",
 	}
 
-	fields := HaproxyGetFieldValues()
+	fields := haproxyGetFieldValues()
 	fields["act"] = fields["active_servers"]
 	delete(fields, "active_servers")
 	fields["bck"] = fields["backup_servers"]
@@ -273,7 +273,7 @@ func mustReadSampleOutput() []byte {
 	return data
 }
 
-func HaproxyGetFieldValues() map[string]interface{} {
+func haproxyGetFieldValues() map[string]interface{} {
 	fields := map[string]interface{}{
 		"active_servers":      uint64(1),
 		"backup_servers":      uint64(0),

--- a/plugins/inputs/hddtemp/go-hddtemp/hddtemp.go
+++ b/plugins/inputs/hddtemp/go-hddtemp/hddtemp.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 )
 
+// Disk contains disk data gathered from hddtemp
 type Disk struct {
 	DeviceName  string
 	Model       string
@@ -16,13 +17,14 @@ type Disk struct {
 	Status      string
 }
 
-type hddtemp struct {
-}
+type hddtemp struct{}
 
+// New creates hddtemp
 func New() *hddtemp {
 	return &hddtemp{}
 }
 
+// Fetch gathers disks data from hddtemp daemon.
 func (h *hddtemp) Fetch(address string) ([]Disk, error) {
 	var (
 		err    error

--- a/plugins/inputs/hddtemp/hddtemp.go
+++ b/plugins/inputs/hddtemp/hddtemp.go
@@ -16,12 +16,13 @@ var sampleConfig string
 const defaultAddress = "127.0.0.1:7634"
 
 type HDDTemp struct {
-	Address string
-	Devices []string
-	fetcher Fetcher
+	Address string   `toml:"address"`
+	Devices []string `toml:"devices"`
+
+	fetcher fetcher
 }
 
-type Fetcher interface {
+type fetcher interface {
 	Fetch(address string) ([]gohddtemp.Disk, error)
 }
 

--- a/plugins/inputs/hddtemp/hddtemp_test.go
+++ b/plugins/inputs/hddtemp/hddtemp_test.go
@@ -28,6 +28,7 @@ func (h *mockFetcher) Fetch(_ string) ([]hddtemp.Disk, error) {
 		},
 	}, nil
 }
+
 func newMockFetcher() *mockFetcher {
 	return &mockFetcher{}
 }

--- a/plugins/inputs/http/http.go
+++ b/plugins/inputs/http/http.go
@@ -82,12 +82,14 @@ func (h *HTTP) Init() error {
 	return nil
 }
 
+func (h *HTTP) SetParserFunc(fn telegraf.ParserFunc) {
+	h.parserFunc = fn
+}
+
 func (h *HTTP) Start(_ telegraf.Accumulator) error {
 	return nil
 }
 
-// Gather takes in an accumulator and adds the metrics that the Input
-// gathers. This is called every "interval"
 func (h *HTTP) Gather(acc telegraf.Accumulator) error {
 	var wg sync.WaitGroup
 	for _, u := range h.URLs {
@@ -109,11 +111,6 @@ func (h *HTTP) Stop() {
 	if h.client != nil {
 		h.client.CloseIdleConnections()
 	}
-}
-
-// SetParserFunc takes the data_format from the config and finds the right parser for that format
-func (h *HTTP) SetParserFunc(fn telegraf.ParserFunc) {
-	h.parserFunc = fn
 }
 
 // Gathers data from a particular URL

--- a/plugins/inputs/http/http_test.go
+++ b/plugins/inputs/http/http_test.go
@@ -317,7 +317,7 @@ func TestBodyAndContentEncoding(t *testing.T) {
 	}
 }
 
-type TestHandlerFunc func(t *testing.T, w http.ResponseWriter, r *http.Request)
+type testHandlerFunc func(t *testing.T, w http.ResponseWriter, r *http.Request)
 
 func TestOAuthClientCredentialsGrant(t *testing.T) {
 	ts := httptest.NewServer(http.NotFoundHandler())
@@ -331,8 +331,8 @@ func TestOAuthClientCredentialsGrant(t *testing.T) {
 	tests := []struct {
 		name         string
 		plugin       *httpplugin.HTTP
-		tokenHandler TestHandlerFunc
-		handler      TestHandlerFunc
+		tokenHandler testHandlerFunc
+		handler      testHandlerFunc
 	}{
 		{
 			name: "no credentials",

--- a/plugins/inputs/http_listener_v2/http_listener_v2_test.go
+++ b/plugins/inputs/http_listener_v2/http_listener_v2_test.go
@@ -61,7 +61,7 @@ func newTestHTTPListenerV2() (*HTTPListenerV2, error) {
 		Path:           "/write",
 		Methods:        []string{"POST"},
 		Parser:         parser,
-		TimeFunc:       time.Now,
+		timeFunc:       time.Now,
 		MaxBodySize:    config.Size(70000),
 		DataSource:     "body",
 		close:          make(chan struct{}),
@@ -92,7 +92,7 @@ func newTestHTTPSListenerV2() (*HTTPListenerV2, error) {
 		Methods:        []string{"POST"},
 		Parser:         parser,
 		ServerConfig:   *pki.TLSServerConfig(),
-		TimeFunc:       time.Now,
+		timeFunc:       time.Now,
 		close:          make(chan struct{}),
 	}
 
@@ -135,7 +135,7 @@ func TestInvalidListenerConfig(t *testing.T) {
 		Path:           "/write",
 		Methods:        []string{"POST"},
 		Parser:         parser,
-		TimeFunc:       time.Now,
+		timeFunc:       time.Now,
 		MaxBodySize:    config.Size(70000),
 		DataSource:     "body",
 		close:          make(chan struct{}),
@@ -373,7 +373,7 @@ func TestWriteHTTPExactMaxBodySize(t *testing.T) {
 		Methods:        []string{"POST"},
 		Parser:         parser,
 		MaxBodySize:    config.Size(len(hugeMetric)),
-		TimeFunc:       time.Now,
+		timeFunc:       time.Now,
 		close:          make(chan struct{}),
 	}
 
@@ -399,7 +399,7 @@ func TestWriteHTTPVerySmallMaxBody(t *testing.T) {
 		Methods:        []string{"POST"},
 		Parser:         parser,
 		MaxBodySize:    config.Size(4096),
-		TimeFunc:       time.Now,
+		timeFunc:       time.Now,
 		close:          make(chan struct{}),
 	}
 

--- a/plugins/inputs/hugepages/hugepages.go
+++ b/plugins/inputs/hugepages/hugepages.go
@@ -20,19 +20,6 @@ import (
 //go:embed sample.conf
 var sampleConfig string
 
-const (
-	// path to root huge page control directory
-	rootHugepagePath = "/sys/kernel/mm/hugepages"
-	// path where per NUMA node statistics are kept
-	numaNodePath = "/sys/devices/system/node"
-	// path to the meminfo file
-	meminfoPath = "/proc/meminfo"
-
-	rootHugepages    = "root"
-	perNodeHugepages = "per_node"
-	meminfoHugepages = "meminfo"
-)
-
 var (
 	newlineByte = []byte("\n")
 	colonByte   = []byte(":")
@@ -63,6 +50,19 @@ var (
 		"ShmemHugePages":  "shared_kb",
 		"FileHugePages":   "file_kb",
 	}
+)
+
+const (
+	// path to root huge page control directory
+	rootHugepagePath = "/sys/kernel/mm/hugepages"
+	// path where per NUMA node statistics are kept
+	numaNodePath = "/sys/devices/system/node"
+	// path to the meminfo file
+	meminfoPath = "/proc/meminfo"
+
+	rootHugepages    = "root"
+	perNodeHugepages = "per_node"
+	meminfoHugepages = "meminfo"
 )
 
 type Hugepages struct {

--- a/plugins/inputs/hugepages/hugepages_notlinux.go
+++ b/plugins/inputs/hugepages/hugepages_notlinux.go
@@ -17,11 +17,15 @@ type Hugepages struct {
 	Log telegraf.Logger `toml:"-"`
 }
 
+func (*Hugepages) SampleConfig() string {
+	return sampleConfig
+}
+
 func (h *Hugepages) Init() error {
 	h.Log.Warn("current platform is not supported")
 	return nil
 }
-func (*Hugepages) SampleConfig() string                { return sampleConfig }
+
 func (*Hugepages) Gather(_ telegraf.Accumulator) error { return nil }
 
 func init() {


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

Address findings for [revive:exported ](https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#exported ) in `plugins/inputs/h*`.

As part of this effort for files from `plugins/inputs/h*`, the following actions were taken:
- Type names (`const`, `var`, `struct`, `func`, etc) were changed to unexported, wherever they didn't need to be exported.
- All remaining exported types were given comments in the appropriate form – this does not apply to exported methods that implement "known" plugin interfaces (`Gather|Init|Start|Stop|SampleConfig|Parse|Add|Apply|Serialize|SerializeBatch|SetParser|SetParserFunc|GetState|SetState`).
- The order of methods was organized (exported methods first, then unexported, with `init` at the very end).

It is only part of the bigger work (for issue: https://github.com/influxdata/telegraf/issues/15813).
After all findings of this type in whole project are handled, we can enable `revive:exported` rule in `golangci-lint`.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR