### PR TITLE
fix(inputs.procstat): typo in findBySystemdUnits

### DIFF
--- a/plugins/inputs/procstat/filter.go
+++ b/plugins/inputs/procstat/filter.go
@@ -107,7 +107,7 @@ func (f *Filter) ApplyFilter() ([]processGroup, error) {
 		}
 		groups = append(groups, g...)
 	case len(f.SystemdUnits) > 0:
-		g, err := findBySystemdUnits(f.CGroups)
+		g, err := findBySystemdUnits(f.SystemdUnits)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Summary

While trying to use telegraf for monitoring processes through procstat, I found this bug (most probably a copy-pasta issue) : `CGroups` is used to filter `SystemdUnits` but `CGroups` case happens before so it is never possible to use `SystemdUnits` filter.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #16059 
