### PR TITLE
chore(inputs): Add removal version for old plugins

### DIFF
--- a/plugins/inputs/deprecations.go
+++ b/plugins/inputs/deprecations.go
@@ -15,12 +15,14 @@ var Deprecations = map[string]telegraf.DeprecationInfo{
 		Notice:    "use 'inputs.jolokia2' with the 'cassandra.conf' example configuration instead",
 	},
 	"cisco_telemetry_gnmi": {
-		Since:  "1.15.0",
-		Notice: "has been renamed to 'gnmi'",
+		Since:     "1.15.0",
+		RemovalIn: "1.35.0",
+		Notice:    "has been renamed to 'gnmi'",
 	},
 	"http_listener": {
-		Since:  "1.9.0",
-		Notice: "has been renamed to 'influxdb_listener', use 'inputs.influxdb_listener' or 'inputs.http_listener_v2' instead",
+		Since:     "1.9.0",
+		RemovalIn: "1.35.0",
+		Notice:    "has been renamed to 'influxdb_listener', use 'inputs.influxdb_listener' or 'inputs.http_listener_v2' instead",
 	},
 	"httpjson": {
 		Since:     "1.6.0",
@@ -43,8 +45,9 @@ var Deprecations = map[string]telegraf.DeprecationInfo{
 		Notice:    "use 'inputs.kafka_consumer' instead, NOTE: 'kafka_consumer' only supports Kafka v0.8+",
 	},
 	"KNXListener": {
-		Since:  "1.20.1",
-		Notice: "has been renamed to 'knx_listener'",
+		Since:     "1.20.1",
+		RemovalIn: "1.35.0",
+		Notice:    "has been renamed to 'knx_listener'",
 	},
 	"logparser": {
 		Since:     "1.15.0",


### PR DESCRIPTION
## Summary

This PR sets removal versions to **v1.35.0** for the old `cisco_telemetry_gnmi`, `http_listener` and `KNXListener` input plugins. All of those plugins have long be replaced or renamed.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues
