### PR TITLE
feat(inputs.proxmox): Allow to add VM-id and status as tag

### DIFF
--- a/plugins/inputs/proxmox/README.md
+++ b/plugins/inputs/proxmox/README.md
@@ -19,7 +19,8 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 ```toml @sample.conf
 # Provides metrics from Proxmox nodes (Proxmox Virtual Environment > 6.2).
 [[inputs.proxmox]]
-  ## API connection configuration. The API token was introduced in Proxmox v6.2. Required permissions for user and token: PVEAuditor role on /.
+  ## API connection configuration. The API token was introduced in Proxmox v6.2.
+  ## Required permissions for user and token: PVEAuditor role on /.
   base_url = "https://localhost:8006/api2/json"
   api_token = "USER@REALM!TOKENID=UUID"
 
@@ -30,7 +31,7 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   # node_name = ""
 
   ## Additional tags of the VM stats data to add as a tag
-  ## Available options are: "vmid" and "status"
+  ## Supported values are "vmid" and "status"
   # additional_vmstats_tags = []
 
   ## Optional TLS Config
@@ -40,7 +41,7 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## Use TLS but skip chain & host verification
   # insecure_skip_verify = false
 
-  # HTTP response timeout (default: 5s)
+  ## HTTP response timeout (default: 5s)
   # response_timeout = "5s"
 ```
 

--- a/plugins/inputs/proxmox/README.md
+++ b/plugins/inputs/proxmox/README.md
@@ -29,15 +29,19 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## leaving this empty will often lead to a "search domain is not set" error.
   # node_name = ""
 
+  ## Additional tags of the VM stats data to add as a tag
+  ## Available options are: "vmid" and "status"
+  # additional_vmstats_tags = []
+
   ## Optional TLS Config
   # tls_ca = "/etc/telegraf/ca.pem"
   # tls_cert = "/etc/telegraf/cert.pem"
   # tls_key = "/etc/telegraf/key.pem"
   ## Use TLS but skip chain & host verification
-  insecure_skip_verify = false
+  # insecure_skip_verify = false
 
   # HTTP response timeout (default: 5s)
-  response_timeout = "5s"
+  # response_timeout = "5s"
 ```
 
 ### Permissions

--- a/plugins/inputs/proxmox/README.md
+++ b/plugins/inputs/proxmox/README.md
@@ -88,9 +88,10 @@ See this [Proxmox docs example][1] for further details.
 - vm_name - Name of the VM/container
 - vm_fqdn - FQDN of the VM/container
 - vm_type - Type of the VM/container (lxc, qemu)
+- vm_id - ID of the VM/container
 
 ## Example Output
 
 ```text
-proxmox,host=pxnode,node_fqdn=pxnode.example.com,vm_fqdn=vm1.example.com,vm_name=vm1,vm_type=lxc cpuload=0.147998116735236,disk_free=4461129728i,disk_total=5217320960i,disk_used=756191232i,disk_used_percentage=14,mem_free=1046827008i,mem_total=1073741824i,mem_used=26914816i,mem_used_percentage=2,status="running",swap_free=536698880i,swap_total=536870912i,swap_used=172032i,swap_used_percentage=0,uptime=1643793i 1595457277000000000
+proxmox,host=pxnode,node_fqdn=pxnode.example.com,vm_fqdn=vm1.example.com,vm_id=112,vm_name=vm1,vm_type=lxc cpuload=0.147998116735236,disk_free=4461129728i,disk_total=5217320960i,disk_used=756191232i,disk_used_percentage=14,mem_free=1046827008i,mem_total=1073741824i,mem_used=26914816i,mem_used_percentage=2,status="running",swap_free=536698880i,swap_total=536870912i,swap_used=172032i,swap_used_percentage=0,uptime=1643793i 1595457277000000000
 ```

--- a/plugins/inputs/proxmox/proxmox.go
+++ b/plugins/inputs/proxmox/proxmox.go
@@ -264,6 +264,7 @@ func getTags(px *Proxmox, name string, vmConfig vmConfig, rt resourceType) map[s
 		"vm_name":   name,
 		"vm_fqdn":   fqdn,
 		"vm_type":   string(rt),
+		"vm_id":     string(vmID),
 	}
 }
 

--- a/plugins/inputs/proxmox/proxmox.go
+++ b/plugins/inputs/proxmox/proxmox.go
@@ -127,7 +127,7 @@ func gatherVMData(px *Proxmox, acc telegraf.Accumulator, rt resourceType) {
 			continue
 		}
 
-		tags := getTags(px, vmStat.Name, vmConfig, rt)
+		tags := getTags(px, vmStat.Name, vmConfig, rt, vmStat.ID)
 		currentVMStatus, err := getCurrentVMStatus(px, rt, vmStat.ID)
 		if err != nil {
 			px.Log.Errorf("Error getting VM current VM status: %v", err)
@@ -247,7 +247,7 @@ func jsonNumberToFloat64(value json.Number) float64 {
 	return float64Value
 }
 
-func getTags(px *Proxmox, name string, vmConfig vmConfig, rt resourceType) map[string]string {
+func getTags(px *Proxmox, name string, vmConfig vmConfig, rt resourceType, vmID json.Number) map[string]string {
 	domain := vmConfig.Data.Searchdomain
 	if len(domain) == 0 {
 		domain = px.nodeSearchDomain

--- a/plugins/inputs/proxmox/proxmox.go
+++ b/plugins/inputs/proxmox/proxmox.go
@@ -127,7 +127,7 @@ func gatherVMData(px *Proxmox, acc telegraf.Accumulator, rt resourceType) {
 			continue
 		}
 
-		tags := getTags(px, vmStat.Name, vmConfig, rt)
+		tags := getTags(px, vmStat.Name, vmConfig, rt, vm.ID.String())
 		currentVMStatus, err := getCurrentVMStatus(px, rt, vmStat.ID)
 		if err != nil {
 			px.Log.Errorf("Error getting VM current VM status: %v", err)
@@ -247,7 +247,7 @@ func jsonNumberToFloat64(value json.Number) float64 {
 	return float64Value
 }
 
-func getTags(px *Proxmox, name string, vmConfig vmConfig, rt resourceType) map[string]string {
+func getTags(px *Proxmox, name string, vmConfig vmConfig, vmID string, rt resourceType) map[string]string {
 	domain := vmConfig.Data.Searchdomain
 	if len(domain) == 0 {
 		domain = px.nodeSearchDomain
@@ -264,7 +264,7 @@ func getTags(px *Proxmox, name string, vmConfig vmConfig, rt resourceType) map[s
 		"vm_name":   name,
 		"vm_fqdn":   fqdn,
 		"vm_type":   string(rt),
-		"vm_id": vm.ID.String(),
+		"vm_id": vmID,
 	}
 }
 

--- a/plugins/inputs/proxmox/proxmox.go
+++ b/plugins/inputs/proxmox/proxmox.go
@@ -13,11 +13,28 @@ import (
 	"time"
 
 	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/config"
+	"github.com/influxdata/telegraf/plugins/common/tls"
 	"github.com/influxdata/telegraf/plugins/inputs"
 )
 
 //go:embed sample.conf
 var sampleConfig string
+
+type Proxmox struct {
+	BaseURL               string          `toml:"base_url"`
+	APIToken              string          `toml:"api_token"`
+	ResponseTimeout       config.Duration `toml:"response_timeout"`
+	NodeName              string          `toml:"node_name"`
+	AdditionalVmstatsTags []string        `toml:"additional_vmstats_tags"`
+	Log                   telegraf.Logger `toml:"-"`
+	tls.ClientConfig
+
+	httpClient       *http.Client
+	nodeSearchDomain string
+
+	requestFunction func(px *Proxmox, apiUrl string, method string, data url.Values) ([]byte, error)
+}
 
 func (*Proxmox) SampleConfig() string {
 	return sampleConfig

--- a/plugins/inputs/proxmox/proxmox.go
+++ b/plugins/inputs/proxmox/proxmox.go
@@ -127,7 +127,7 @@ func gatherVMData(px *Proxmox, acc telegraf.Accumulator, rt resourceType) {
 			continue
 		}
 
-		tags := getTags(px, vmStat.Name, vmConfig, rt, vm.ID.String())
+		tags := getTags(px, vmStat.Name, vmConfig, rt)
 		currentVMStatus, err := getCurrentVMStatus(px, rt, vmStat.ID)
 		if err != nil {
 			px.Log.Errorf("Error getting VM current VM status: %v", err)
@@ -247,7 +247,7 @@ func jsonNumberToFloat64(value json.Number) float64 {
 	return float64Value
 }
 
-func getTags(px *Proxmox, name string, vmConfig vmConfig, vmID string, rt resourceType) map[string]string {
+func getTags(px *Proxmox, name string, vmConfig vmConfig, rt resourceType) map[string]string {
 	domain := vmConfig.Data.Searchdomain
 	if len(domain) == 0 {
 		domain = px.nodeSearchDomain
@@ -264,7 +264,6 @@ func getTags(px *Proxmox, name string, vmConfig vmConfig, vmID string, rt resour
 		"vm_name":   name,
 		"vm_fqdn":   fqdn,
 		"vm_type":   string(rt),
-		"vm_id": vmID,
 	}
 }
 

--- a/plugins/inputs/proxmox/proxmox.go
+++ b/plugins/inputs/proxmox/proxmox.go
@@ -264,6 +264,7 @@ func getTags(px *Proxmox, name string, vmConfig vmConfig, rt resourceType) map[s
 		"vm_name":   name,
 		"vm_fqdn":   fqdn,
 		"vm_type":   string(rt),
+		"vm_id": vm.ID.String(),
 	}
 }
 

--- a/plugins/inputs/proxmox/proxmox.go
+++ b/plugins/inputs/proxmox/proxmox.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"slices"
 	"strings"
 	"time"
 
@@ -33,7 +34,7 @@ type Proxmox struct {
 	httpClient       *http.Client
 	nodeSearchDomain string
 
-	requestFunction func(px *Proxmox, apiUrl string, method string, data url.Values) ([]byte, error)
+	requestFunction func(apiUrl string, method string, data url.Values) ([]byte, error)
 }
 
 func (*Proxmox) SampleConfig() string {
@@ -59,24 +60,25 @@ func (px *Proxmox) Init() error {
 		Timeout: time.Duration(px.ResponseTimeout),
 	}
 
+	px.requestFunction = px.performRequest
+
 	return nil
 }
 
 func (px *Proxmox) Gather(acc telegraf.Accumulator) error {
-	err := getNodeSearchDomain(px)
-	if err != nil {
+	if err := px.getNodeSearchDomain(); err != nil {
 		return err
 	}
 
-	gatherLxcData(px, acc)
-	gatherQemuData(px, acc)
+	px.gatherVMData(acc, lxc)
+	px.gatherVMData(acc, qemu)
 
 	return nil
 }
 
-func getNodeSearchDomain(px *Proxmox) error {
+func (px *Proxmox) getNodeSearchDomain() error {
 	apiURL := "/nodes/" + px.NodeName + "/dns"
-	jsonData, err := px.requestFunction(px, apiURL, http.MethodGet, nil)
+	jsonData, err := px.requestFunction(apiURL, http.MethodGet, nil)
 	if err != nil {
 		return err
 	}
@@ -95,7 +97,7 @@ func getNodeSearchDomain(px *Proxmox) error {
 	return nil
 }
 
-func performRequest(px *Proxmox, apiURL, method string, data url.Values) ([]byte, error) {
+func (px *Proxmox) performRequest(apiURL, method string, data url.Values) ([]byte, error) {
 	request, err := http.NewRequest(method, px.BaseURL+apiURL, strings.NewReader(data.Encode()))
 	if err != nil {
 		return nil, err
@@ -116,24 +118,15 @@ func performRequest(px *Proxmox, apiURL, method string, data url.Values) ([]byte
 	return responseBody, nil
 }
 
-func gatherLxcData(px *Proxmox, acc telegraf.Accumulator) {
-	gatherVMData(px, acc, lxc)
-}
-
-func gatherQemuData(px *Proxmox, acc telegraf.Accumulator) {
-	gatherVMData(px, acc, qemu)
-}
-
-func gatherVMData(px *Proxmox, acc telegraf.Accumulator, rt resourceType) {
-	vmStats, err := getVMStats(px, rt)
+func (px *Proxmox) gatherVMData(acc telegraf.Accumulator, rt resourceType) {
+	vmStats, err := px.getVMStats(rt)
 	if err != nil {
 		px.Log.Errorf("Error getting VM stats: %v", err)
 		return
 	}
 
-	// For each VM add metrics to Accumulator
 	for _, vmStat := range vmStats.Data {
-		vmConfig, err := getVMConfig(px, vmStat.ID, rt)
+		vmConfig, err := px.getVMConfig(vmStat.ID, rt)
 		if err != nil {
 			px.Log.Errorf("Error getting VM config: %v", err)
 			return
@@ -144,22 +137,64 @@ func gatherVMData(px *Proxmox, acc telegraf.Accumulator, rt resourceType) {
 			continue
 		}
 
-		tags := getTags(px, vmStat.Name, vmConfig, rt, vmStat.ID)
-		currentVMStatus, err := getCurrentVMStatus(px, rt, vmStat.ID)
+		currentVMStatus, err := px.getCurrentVMStatus(rt, vmStat.ID)
 		if err != nil {
 			px.Log.Errorf("Error getting VM current VM status: %v", err)
 			return
 		}
 
-		fields := getFields(currentVMStatus)
+		hostname := vmConfig.Data.Hostname
+		if hostname == "" {
+			hostname = vmStat.Name
+		}
+		domain := vmConfig.Data.Searchdomain
+		if domain == "" {
+			domain = px.nodeSearchDomain
+		}
+		fqdn := hostname + "." + domain
+
+		tags := map[string]string{
+			"node_fqdn": px.NodeName + "." + px.nodeSearchDomain,
+			"vm_name":   vmStat.Name,
+			"vm_fqdn":   fqdn,
+			"vm_type":   string(rt),
+		}
+		if slices.Contains(px.AdditionalVmstatsTags, "vmid") {
+			tags["vm_id"] = vmStat.ID.String()
+		}
+		if slices.Contains(px.AdditionalVmstatsTags, "status") {
+			tags["status"] = currentVMStatus.Status
+		}
+
+		memMetrics := getByteMetrics(currentVMStatus.TotalMem, currentVMStatus.UsedMem)
+		swapMetrics := getByteMetrics(currentVMStatus.TotalSwap, currentVMStatus.UsedSwap)
+		diskMetrics := getByteMetrics(currentVMStatus.TotalDisk, currentVMStatus.UsedDisk)
+
+		fields := map[string]interface{}{
+			"status":               currentVMStatus.Status,
+			"uptime":               jsonNumberToInt64(currentVMStatus.Uptime),
+			"cpuload":              jsonNumberToFloat64(currentVMStatus.CPULoad),
+			"mem_used":             memMetrics.used,
+			"mem_total":            memMetrics.total,
+			"mem_free":             memMetrics.free,
+			"mem_used_percentage":  memMetrics.usedPercentage,
+			"swap_used":            swapMetrics.used,
+			"swap_total":           swapMetrics.total,
+			"swap_free":            swapMetrics.free,
+			"swap_used_percentage": swapMetrics.usedPercentage,
+			"disk_used":            diskMetrics.used,
+			"disk_total":           diskMetrics.total,
+			"disk_free":            diskMetrics.free,
+			"disk_used_percentage": diskMetrics.usedPercentage,
+		}
 		acc.AddFields("proxmox", fields, tags)
 	}
 }
 
-func getCurrentVMStatus(px *Proxmox, rt resourceType, id json.Number) (vmStat, error) {
+func (px *Proxmox) getCurrentVMStatus(rt resourceType, id json.Number) (vmStat, error) {
 	apiURL := "/nodes/" + px.NodeName + "/" + string(rt) + "/" + string(id) + "/status/current"
 
-	jsonData, err := px.requestFunction(px, apiURL, http.MethodGet, nil)
+	jsonData, err := px.requestFunction(apiURL, http.MethodGet, nil)
 	if err != nil {
 		return vmStat{}, err
 	}
@@ -173,9 +208,9 @@ func getCurrentVMStatus(px *Proxmox, rt resourceType, id json.Number) (vmStat, e
 	return currentVMStatus.Data, nil
 }
 
-func getVMStats(px *Proxmox, rt resourceType) (vmStats, error) {
+func (px *Proxmox) getVMStats(rt resourceType) (vmStats, error) {
 	apiURL := "/nodes/" + px.NodeName + "/" + string(rt)
-	jsonData, err := px.requestFunction(px, apiURL, http.MethodGet, nil)
+	jsonData, err := px.requestFunction(apiURL, http.MethodGet, nil)
 	if err != nil {
 		return vmStats{}, err
 	}
@@ -189,9 +224,9 @@ func getVMStats(px *Proxmox, rt resourceType) (vmStats, error) {
 	return vmStatistics, nil
 }
 
-func getVMConfig(px *Proxmox, vmID json.Number, rt resourceType) (vmConfig, error) {
+func (px *Proxmox) getVMConfig(vmID json.Number, rt resourceType) (vmConfig, error) {
 	apiURL := "/nodes/" + px.NodeName + "/" + string(rt) + "/" + string(vmID) + "/config"
-	jsonData, err := px.requestFunction(px, apiURL, http.MethodGet, nil)
+	jsonData, err := px.requestFunction(apiURL, http.MethodGet, nil)
 	if err != nil {
 		return vmConfig{}, err
 	}
@@ -203,30 +238,6 @@ func getVMConfig(px *Proxmox, vmID json.Number, rt resourceType) (vmConfig, erro
 	}
 
 	return vmCfg, nil
-}
-
-func getFields(vmStat vmStat) map[string]interface{} {
-	memMetrics := getByteMetrics(vmStat.TotalMem, vmStat.UsedMem)
-	swapMetrics := getByteMetrics(vmStat.TotalSwap, vmStat.UsedSwap)
-	diskMetrics := getByteMetrics(vmStat.TotalDisk, vmStat.UsedDisk)
-
-	return map[string]interface{}{
-		"status":               vmStat.Status,
-		"uptime":               jsonNumberToInt64(vmStat.Uptime),
-		"cpuload":              jsonNumberToFloat64(vmStat.CPULoad),
-		"mem_used":             memMetrics.used,
-		"mem_total":            memMetrics.total,
-		"mem_free":             memMetrics.free,
-		"mem_used_percentage":  memMetrics.usedPercentage,
-		"swap_used":            swapMetrics.used,
-		"swap_total":           swapMetrics.total,
-		"swap_free":            swapMetrics.free,
-		"swap_used_percentage": swapMetrics.usedPercentage,
-		"disk_used":            diskMetrics.used,
-		"disk_total":           diskMetrics.total,
-		"disk_free":            diskMetrics.free,
-		"disk_used_percentage": diskMetrics.usedPercentage,
-	}
 }
 
 func getByteMetrics(total, used json.Number) metrics {
@@ -264,31 +275,8 @@ func jsonNumberToFloat64(value json.Number) float64 {
 	return float64Value
 }
 
-func getTags(px *Proxmox, name string, vmConfig vmConfig, rt resourceType, vmID json.Number) map[string]string {
-	domain := vmConfig.Data.Searchdomain
-	if len(domain) == 0 {
-		domain = px.nodeSearchDomain
-	}
-
-	hostname := vmConfig.Data.Hostname
-	if len(hostname) == 0 {
-		hostname = name
-	}
-	fqdn := hostname + "." + domain
-
-	return map[string]string{
-		"node_fqdn": px.NodeName + "." + px.nodeSearchDomain,
-		"vm_name":   name,
-		"vm_fqdn":   fqdn,
-		"vm_type":   string(rt),
-		"vm_id":     string(vmID),
-	}
-}
-
 func init() {
 	inputs.Add("proxmox", func() telegraf.Input {
-		return &Proxmox{
-			requestFunction: performRequest,
-		}
+		return &Proxmox{}
 	})
 }

--- a/plugins/inputs/proxmox/proxmox.go
+++ b/plugins/inputs/proxmox/proxmox.go
@@ -5,6 +5,7 @@ import (
 	_ "embed"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -42,6 +43,16 @@ func (*Proxmox) SampleConfig() string {
 }
 
 func (px *Proxmox) Init() error {
+	// Check parameters
+	for _, v := range px.AdditionalVmstatsTags {
+		switch v {
+		case "vmid", "status":
+			// Do nothing as those are valid values
+		default:
+			return fmt.Errorf("invalid additional vmstats tag %q", v)
+		}
+	}
+
 	// Set hostname as default node name for backwards compatibility
 	if px.NodeName == "" {
 		//nolint:errcheck // best attempt setting of NodeName

--- a/plugins/inputs/proxmox/proxmox_test.go
+++ b/plugins/inputs/proxmox/proxmox_test.go
@@ -132,6 +132,7 @@ func TestGatherQemuData(t *testing.T) {
 		"vm_name":   "qemu1",
 		"vm_fqdn":   "qemu1.test.example.com",
 		"vm_type":   "qemu",
+		"vm_id":     "113",
 	}
 	acc.AssertContainsTaggedFields(t, "proxmox", testFields, testTags)
 }

--- a/plugins/inputs/proxmox/proxmox_test.go
+++ b/plugins/inputs/proxmox/proxmox_test.go
@@ -98,6 +98,7 @@ func TestGatherLxcData(t *testing.T) {
 		"vm_name":   "container1",
 		"vm_fqdn":   "container1.test.example.com",
 		"vm_type":   "lxc",
+		"vm_id":     "111",
 	}
 	acc.AssertContainsTaggedFields(t, "proxmox", testFields, testTags)
 }

--- a/plugins/inputs/proxmox/proxmox_test.go
+++ b/plugins/inputs/proxmox/proxmox_test.go
@@ -4,9 +4,12 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/metric"
 	"github.com/influxdata/telegraf/testutil"
 )
 
@@ -24,7 +27,7 @@ var lxcCurrentStatusTestData = `{"data":{"vmid":"111","type":"lxc","uptime":2078
 var qemuCurrentStatusTestData = `{"data":{"name":"qemu1","status":"running","maxdisk":10737418240,"cpu":0.029336643550795,"vmid":"113",` +
 	`"uptime":2159739,"disk":0,"maxmem":2147483648,"mem":1722451796}}`
 
-func performTestRequest(_ *Proxmox, apiURL, _ string, _ url.Values) ([]byte, error) {
+func performTestRequest(apiURL, _ string, _ url.Values) ([]byte, error) {
 	var bytedata = []byte("")
 
 	if strings.HasSuffix(apiURL, "dns") {
@@ -46,105 +49,208 @@ func performTestRequest(_ *Proxmox, apiURL, _ string, _ url.Values) ([]byte, err
 	return bytedata, nil
 }
 
-func setUp(t *testing.T) *Proxmox {
-	px := &Proxmox{
-		requestFunction: performTestRequest,
-		NodeName:        "testnode",
-	}
-
-	require.NoError(t, px.Init())
-
-	// Override logger for test
-	px.Log = testutil.Logger{}
-	return px
-}
-
 func TestGetNodeSearchDomain(t *testing.T) {
-	px := setUp(t)
+	px := &Proxmox{
+		NodeName: "testnode",
+		Log:      testutil.Logger{},
+	}
+	require.NoError(t, px.Init())
+	px.requestFunction = performTestRequest
 
-	err := getNodeSearchDomain(px)
-
-	require.NoError(t, err)
+	require.NoError(t, px.getNodeSearchDomain())
 	require.Equal(t, "test.example.com", px.nodeSearchDomain)
 }
 
 func TestGatherLxcData(t *testing.T) {
-	px := setUp(t)
-	px.nodeSearchDomain = "test.example.com"
-
-	acc := &testutil.Accumulator{}
-	gatherLxcData(px, acc)
-
-	require.Equal(t, 15, acc.NFields())
-	testFields := map[string]interface{}{
-		"status":               "running",
-		"uptime":               int64(2078164),
-		"cpuload":              float64(0.00371567669193613),
-		"mem_used":             int64(98500608),
-		"mem_total":            int64(536870912),
-		"mem_free":             int64(438370304),
-		"mem_used_percentage":  float64(18.34716796875),
-		"swap_used":            int64(9412608),
-		"swap_total":           int64(536870912),
-		"swap_free":            int64(527458304),
-		"swap_used_percentage": float64(1.75323486328125),
-		"disk_used":            int64(744189952),
-		"disk_total":           int64(5217320960),
-		"disk_free":            int64(4473131008),
-		"disk_used_percentage": float64(14.26383306117322),
+	px := &Proxmox{
+		NodeName:         "testnode",
+		Log:              testutil.Logger{},
+		nodeSearchDomain: "test.example.com",
 	}
-	testTags := map[string]string{
-		"node_fqdn": "testnode.test.example.com",
-		"vm_name":   "container1",
-		"vm_fqdn":   "container1.test.example.com",
-		"vm_type":   "lxc",
-		"vm_id":     "111",
+	require.NoError(t, px.Init())
+	px.requestFunction = performTestRequest
+
+	var acc testutil.Accumulator
+	px.gatherVMData(&acc, lxc)
+
+	expected := []telegraf.Metric{
+		metric.New(
+			"proxmox",
+			map[string]string{
+				"node_fqdn": "testnode.test.example.com",
+				"vm_name":   "container1",
+				"vm_fqdn":   "container1.test.example.com",
+				"vm_type":   "lxc",
+			},
+			map[string]interface{}{
+				"status":               "running",
+				"uptime":               int64(2078164),
+				"cpuload":              float64(0.00371567669193613),
+				"mem_used":             int64(98500608),
+				"mem_total":            int64(536870912),
+				"mem_free":             int64(438370304),
+				"mem_used_percentage":  float64(18.34716796875),
+				"swap_used":            int64(9412608),
+				"swap_total":           int64(536870912),
+				"swap_free":            int64(527458304),
+				"swap_used_percentage": float64(1.75323486328125),
+				"disk_used":            int64(744189952),
+				"disk_total":           int64(5217320960),
+				"disk_free":            int64(4473131008),
+				"disk_used_percentage": float64(14.26383306117322),
+			},
+			time.Unix(0, 0),
+		),
 	}
-	acc.AssertContainsTaggedFields(t, "proxmox", testFields, testTags)
+	testutil.RequireMetricsEqual(t, expected, acc.GetTelegrafMetrics(), testutil.IgnoreTime())
 }
 
 func TestGatherQemuData(t *testing.T) {
-	px := setUp(t)
-	px.nodeSearchDomain = "test.example.com"
-
-	acc := &testutil.Accumulator{}
-	gatherQemuData(px, acc)
-
-	require.Equal(t, 15, acc.NFields())
-	testFields := map[string]interface{}{
-		"status":               "running",
-		"uptime":               int64(2159739),
-		"cpuload":              float64(0.029336643550795),
-		"mem_used":             int64(1722451796),
-		"mem_total":            int64(2147483648),
-		"mem_free":             int64(425031852),
-		"mem_used_percentage":  float64(80.20791206508875),
-		"swap_used":            int64(0),
-		"swap_total":           int64(0),
-		"swap_free":            int64(0),
-		"swap_used_percentage": float64(0),
-		"disk_used":            int64(0),
-		"disk_total":           int64(10737418240),
-		"disk_free":            int64(10737418240),
-		"disk_used_percentage": float64(0),
+	px := &Proxmox{
+		NodeName:         "testnode",
+		Log:              testutil.Logger{},
+		nodeSearchDomain: "test.example.com",
 	}
-	testTags := map[string]string{
-		"node_fqdn": "testnode.test.example.com",
-		"vm_name":   "qemu1",
-		"vm_fqdn":   "qemu1.test.example.com",
-		"vm_type":   "qemu",
-		"vm_id":     "113",
+	require.NoError(t, px.Init())
+	px.requestFunction = performTestRequest
+
+	var acc testutil.Accumulator
+	px.gatherVMData(&acc, qemu)
+
+	expected := []telegraf.Metric{
+		metric.New(
+			"proxmox",
+			map[string]string{
+				"node_fqdn": "testnode.test.example.com",
+				"vm_name":   "qemu1",
+				"vm_fqdn":   "qemu1.test.example.com",
+				"vm_type":   "qemu",
+			},
+			map[string]interface{}{
+				"status":               "running",
+				"uptime":               int64(2159739),
+				"cpuload":              float64(0.029336643550795),
+				"mem_used":             int64(1722451796),
+				"mem_total":            int64(2147483648),
+				"mem_free":             int64(425031852),
+				"mem_used_percentage":  float64(80.20791206508875),
+				"swap_used":            int64(0),
+				"swap_total":           int64(0),
+				"swap_free":            int64(0),
+				"swap_used_percentage": float64(0),
+				"disk_used":            int64(0),
+				"disk_total":           int64(10737418240),
+				"disk_free":            int64(10737418240),
+				"disk_used_percentage": float64(0),
+			},
+			time.Unix(0, 0),
+		),
 	}
-	acc.AssertContainsTaggedFields(t, "proxmox", testFields, testTags)
+	testutil.RequireMetricsEqual(t, expected, acc.GetTelegrafMetrics(), testutil.IgnoreTime())
+}
+
+func TestGatherLxcDataWithID(t *testing.T) {
+	px := &Proxmox{
+		NodeName:              "testnode",
+		AdditionalVmstatsTags: []string{"vmid"},
+		Log:                   testutil.Logger{},
+		nodeSearchDomain:      "test.example.com",
+	}
+	require.NoError(t, px.Init())
+	px.requestFunction = performTestRequest
+
+	var acc testutil.Accumulator
+	px.gatherVMData(&acc, lxc)
+
+	expected := []telegraf.Metric{
+		metric.New(
+			"proxmox",
+			map[string]string{
+				"node_fqdn": "testnode.test.example.com",
+				"vm_name":   "container1",
+				"vm_fqdn":   "container1.test.example.com",
+				"vm_type":   "lxc",
+				"vm_id":     "111",
+			},
+			map[string]interface{}{
+				"status":               "running",
+				"uptime":               int64(2078164),
+				"cpuload":              float64(0.00371567669193613),
+				"mem_used":             int64(98500608),
+				"mem_total":            int64(536870912),
+				"mem_free":             int64(438370304),
+				"mem_used_percentage":  float64(18.34716796875),
+				"swap_used":            int64(9412608),
+				"swap_total":           int64(536870912),
+				"swap_free":            int64(527458304),
+				"swap_used_percentage": float64(1.75323486328125),
+				"disk_used":            int64(744189952),
+				"disk_total":           int64(5217320960),
+				"disk_free":            int64(4473131008),
+				"disk_used_percentage": float64(14.26383306117322),
+			},
+			time.Unix(0, 0),
+		),
+	}
+	testutil.RequireMetricsEqual(t, expected, acc.GetTelegrafMetrics(), testutil.IgnoreTime())
+}
+
+func TestGatherQemuDataWithID(t *testing.T) {
+	px := &Proxmox{
+		NodeName:              "testnode",
+		AdditionalVmstatsTags: []string{"vmid"},
+		Log:                   testutil.Logger{},
+		nodeSearchDomain:      "test.example.com",
+	}
+	require.NoError(t, px.Init())
+	px.requestFunction = performTestRequest
+
+	var acc testutil.Accumulator
+	px.gatherVMData(&acc, qemu)
+
+	expected := []telegraf.Metric{
+		metric.New(
+			"proxmox",
+			map[string]string{
+				"node_fqdn": "testnode.test.example.com",
+				"vm_name":   "qemu1",
+				"vm_fqdn":   "qemu1.test.example.com",
+				"vm_type":   "qemu",
+				"vm_id":     "113",
+			},
+			map[string]interface{}{
+				"status":               "running",
+				"uptime":               int64(2159739),
+				"cpuload":              float64(0.029336643550795),
+				"mem_used":             int64(1722451796),
+				"mem_total":            int64(2147483648),
+				"mem_free":             int64(425031852),
+				"mem_used_percentage":  float64(80.20791206508875),
+				"swap_used":            int64(0),
+				"swap_total":           int64(0),
+				"swap_free":            int64(0),
+				"swap_used_percentage": float64(0),
+				"disk_used":            int64(0),
+				"disk_total":           int64(10737418240),
+				"disk_free":            int64(10737418240),
+				"disk_used_percentage": float64(0),
+			},
+			time.Unix(0, 0),
+		),
+	}
+	testutil.RequireMetricsEqual(t, expected, acc.GetTelegrafMetrics(), testutil.IgnoreTime())
 }
 
 func TestGather(t *testing.T) {
-	px := setUp(t)
-	px.nodeSearchDomain = "test.example.com"
+	px := &Proxmox{
+		NodeName: "testnode",
+		Log:      testutil.Logger{},
+	}
+	require.NoError(t, px.Init())
+	px.requestFunction = performTestRequest
 
-	acc := &testutil.Accumulator{}
-	err := px.Gather(acc)
-	require.NoError(t, err)
+	var acc testutil.Accumulator
+	require.NoError(t, px.Gather(&acc))
 
 	// Results from both tests above
 	require.Equal(t, 30, acc.NFields())

--- a/plugins/inputs/proxmox/sample.conf
+++ b/plugins/inputs/proxmox/sample.conf
@@ -1,6 +1,7 @@
 # Provides metrics from Proxmox nodes (Proxmox Virtual Environment > 6.2).
 [[inputs.proxmox]]
-  ## API connection configuration. The API token was introduced in Proxmox v6.2. Required permissions for user and token: PVEAuditor role on /.
+  ## API connection configuration. The API token was introduced in Proxmox v6.2.
+  ## Required permissions for user and token: PVEAuditor role on /.
   base_url = "https://localhost:8006/api2/json"
   api_token = "USER@REALM!TOKENID=UUID"
 
@@ -11,7 +12,7 @@
   # node_name = ""
 
   ## Additional tags of the VM stats data to add as a tag
-  ## Available options are: "vmid" and "status"
+  ## Supported values are "vmid" and "status"
   # additional_vmstats_tags = []
 
   ## Optional TLS Config
@@ -21,5 +22,5 @@
   ## Use TLS but skip chain & host verification
   # insecure_skip_verify = false
 
-  # HTTP response timeout (default: 5s)
+  ## HTTP response timeout (default: 5s)
   # response_timeout = "5s"

--- a/plugins/inputs/proxmox/sample.conf
+++ b/plugins/inputs/proxmox/sample.conf
@@ -10,12 +10,16 @@
   ## leaving this empty will often lead to a "search domain is not set" error.
   # node_name = ""
 
+  ## Additional tags of the VM stats data to add as a tag
+  ## Available options are: "vmid" and "status"
+  # additional_vmstats_tags = []
+
   ## Optional TLS Config
   # tls_ca = "/etc/telegraf/ca.pem"
   # tls_cert = "/etc/telegraf/cert.pem"
   # tls_key = "/etc/telegraf/key.pem"
   ## Use TLS but skip chain & host verification
-  insecure_skip_verify = false
+  # insecure_skip_verify = false
 
   # HTTP response timeout (default: 5s)
-  response_timeout = "5s"
+  # response_timeout = "5s"

--- a/plugins/inputs/proxmox/structs.go
+++ b/plugins/inputs/proxmox/structs.go
@@ -2,34 +2,12 @@ package proxmox
 
 import (
 	"encoding/json"
-	"net/http"
-	"net/url"
-
-	"github.com/influxdata/telegraf"
-	"github.com/influxdata/telegraf/config"
-	"github.com/influxdata/telegraf/plugins/common/tls"
 )
 
 var (
 	qemu resourceType = "qemu"
 	lxc  resourceType = "lxc"
 )
-
-type Proxmox struct {
-	BaseURL               string          `toml:"base_url"`
-	APIToken              string          `toml:"api_token"`
-	ResponseTimeout       config.Duration `toml:"response_timeout"`
-	NodeName              string          `toml:"node_name"`
-	AdditionalVmstatsTags []string        `toml:"additional_vmstats_tags"`
-	tls.ClientConfig
-
-	Log telegraf.Logger `toml:"-"`
-
-	httpClient *http.Client
-
-	nodeSearchDomain string
-	requestFunction  func(px *Proxmox, apiUrl string, method string, data url.Values) ([]byte, error)
-}
 
 type resourceType string
 

--- a/plugins/inputs/proxmox/structs.go
+++ b/plugins/inputs/proxmox/structs.go
@@ -16,10 +16,11 @@ var (
 )
 
 type Proxmox struct {
-	BaseURL         string          `toml:"base_url"`
-	APIToken        string          `toml:"api_token"`
-	ResponseTimeout config.Duration `toml:"response_timeout"`
-	NodeName        string          `toml:"node_name"`
+	BaseURL               string          `toml:"base_url"`
+	APIToken              string          `toml:"api_token"`
+	ResponseTimeout       config.Duration `toml:"response_timeout"`
+	NodeName              string          `toml:"node_name"`
+	AdditionalVmstatsTags []string        `toml:"additional_vmstats_tags"`
 	tls.ClientConfig
 
 	Log telegraf.Logger `toml:"-"`


### PR DESCRIPTION
## Summary
<!-- Mandatory
This pull request originates from a personal need to filter the metrics based on the VM ID. 
-->

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
#16065 
-->

resolves #16065 
