### PR TITLE
chore(linters): Fix findings found by `testifylint`: `go-require` for handlers for `plugins/inputs/[a-m]`

### DIFF
--- a/plugins/inputs/activemq/activemq_test.go
+++ b/plugins/inputs/activemq/activemq_test.go
@@ -149,16 +149,25 @@ func TestURLs(t *testing.T) {
 		switch r.URL.Path {
 		case "/admin/xml/queues.jsp":
 			w.WriteHeader(http.StatusOK)
-			_, err := w.Write([]byte("<queues></queues>"))
-			require.NoError(t, err)
+			if _, err := w.Write([]byte("<queues></queues>")); err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				t.Error(err)
+				return
+			}
 		case "/admin/xml/topics.jsp":
 			w.WriteHeader(http.StatusOK)
-			_, err := w.Write([]byte("<topics></topics>"))
-			require.NoError(t, err)
+			if _, err := w.Write([]byte("<topics></topics>")); err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				t.Error(err)
+				return
+			}
 		case "/admin/xml/subscribers.jsp":
 			w.WriteHeader(http.StatusOK)
-			_, err := w.Write([]byte("<subscribers></subscribers>"))
-			require.NoError(t, err)
+			if _, err := w.Write([]byte("<subscribers></subscribers>")); err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				t.Error(err)
+				return
+			}
 		default:
 			w.WriteHeader(http.StatusNotFound)
 			t.Fatalf("unexpected path: %s", r.URL.Path)

--- a/plugins/inputs/apache/apache_test.go
+++ b/plugins/inputs/apache/apache_test.go
@@ -32,8 +32,11 @@ Scoreboard: WW_____W_RW_R_W__RRR____WR_W___WW________W_WW_W_____R__R_WR__WRWR_RR
 func TestHTTPApache(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		_, err := fmt.Fprintln(w, apacheStatus)
-		require.NoError(t, err)
+		if _, err := fmt.Fprintln(w, apacheStatus); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Error(err)
+			return
+		}
 	}))
 	defer ts.Close()
 

--- a/plugins/inputs/aurora/aurora_test.go
+++ b/plugins/inputs/aurora/aurora_test.go
@@ -248,11 +248,22 @@ func TestBasicAuth(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ts.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				username, password, _ := r.BasicAuth()
-				require.Equal(t, tt.username, username)
-				require.Equal(t, tt.password, password)
+				if username != tt.username {
+					w.WriteHeader(http.StatusInternalServerError)
+					t.Errorf("Not equal, expected: %q, actual: %q", tt.username, username)
+					return
+				}
+				if password != tt.password {
+					w.WriteHeader(http.StatusInternalServerError)
+					t.Errorf("Not equal, expected: %q, actual: %q", tt.password, password)
+					return
+				}
 				w.WriteHeader(http.StatusOK)
-				_, err := w.Write([]byte("{}"))
-				require.NoError(t, err)
+				if _, err := w.Write([]byte("{}")); err != nil {
+					w.WriteHeader(http.StatusInternalServerError)
+					t.Error(err)
+					return
+				}
 			})
 
 			var acc testutil.Accumulator

--- a/plugins/inputs/beat/beat_test.go
+++ b/plugins/inputs/beat/beat_test.go
@@ -29,13 +29,22 @@ func Test_BeatStats(t *testing.T) {
 		case suffixStats:
 			jsonFilePath = "beat6_stats.json"
 		default:
-			require.FailNow(t, "cannot handle request")
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Errorf("Cannot handle request")
+			return
 		}
 
 		data, err := os.ReadFile(jsonFilePath)
-		require.NoErrorf(t, err, "could not read from data file %s", jsonFilePath)
-		_, err = w.Write(data)
-		require.NoError(t, err, "could not write data")
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Errorf("Could not read from data file %q: %v", jsonFilePath, err)
+			return
+		}
+		if _, err = w.Write(data); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Error(err)
+			return
+		}
 	}))
 	requestURL, err := url.Parse(beatTest.URL)
 	require.NoErrorf(t, err, "can't parse URL %s", beatTest.URL)
@@ -173,18 +182,42 @@ func Test_BeatRequest(t *testing.T) {
 		case suffixStats:
 			jsonFilePath = "beat6_stats.json"
 		default:
-			require.FailNow(t, "cannot handle request")
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Errorf("Cannot handle request")
+			return
 		}
 
 		data, err := os.ReadFile(jsonFilePath)
-		require.NoErrorf(t, err, "could not read from data file %s", jsonFilePath)
-		require.Equal(t, "beat.test.local", request.Host)
-		require.Equal(t, "POST", request.Method)
-		require.Equal(t, "Basic YWRtaW46UFdE", request.Header.Get("Authorization"))
-		require.Equal(t, "test-value", request.Header.Get("X-Test"))
-
-		_, err = w.Write(data)
-		require.NoError(t, err, "could not write data")
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Errorf("Could not read from data file %q: %v", jsonFilePath, err)
+			return
+		}
+		if request.Host != "beat.test.local" {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Errorf("Not equal, expected: %q, actual: %q", "beat.test.local", request.Host)
+			return
+		}
+		if request.Method != "POST" {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Errorf("Not equal, expected: %q, actual: %q", "POST", request.Method)
+			return
+		}
+		if request.Header.Get("Authorization") != "Basic YWRtaW46UFdE" {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Errorf("Not equal, expected: %q, actual: %q", "Basic YWRtaW46UFdE", request.Header.Get("Authorization"))
+			return
+		}
+		if request.Header.Get("X-Test") != "test-value" {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Errorf("Not equal, expected: %q, actual: %q", "test-value", request.Header.Get("X-Test"))
+			return
+		}
+		if _, err = w.Write(data); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Error(err)
+			return
+		}
 	}))
 
 	requestURL, err := url.Parse(beatTest.URL)

--- a/plugins/inputs/clickhouse/clickhouse_test.go
+++ b/plugins/inputs/clickhouse/clickhouse_test.go
@@ -74,7 +74,11 @@ func TestGather(t *testing.T) {
 						},
 					},
 				})
-				require.NoError(t, err)
+				if err != nil {
+					w.WriteHeader(http.StatusInternalServerError)
+					t.Error(err)
+					return
+				}
 			case strings.Contains(query, "system.events"):
 				err := enc.Encode(result{
 					Data: []struct {
@@ -91,7 +95,11 @@ func TestGather(t *testing.T) {
 						},
 					},
 				})
-				require.NoError(t, err)
+				if err != nil {
+					w.WriteHeader(http.StatusInternalServerError)
+					t.Error(err)
+					return
+				}
 			case strings.Contains(query, "system.metrics"):
 				err := enc.Encode(result{
 					Data: []struct {
@@ -108,7 +116,11 @@ func TestGather(t *testing.T) {
 						},
 					},
 				})
-				require.NoError(t, err)
+				if err != nil {
+					w.WriteHeader(http.StatusInternalServerError)
+					t.Error(err)
+					return
+				}
 			case strings.Contains(query, "system.asynchronous_metrics"):
 				err := enc.Encode(result{
 					Data: []struct {
@@ -125,7 +137,11 @@ func TestGather(t *testing.T) {
 						},
 					},
 				})
-				require.NoError(t, err)
+				if err != nil {
+					w.WriteHeader(http.StatusInternalServerError)
+					t.Error(err)
+					return
+				}
 			case strings.Contains(query, "zk_exists"):
 				err := enc.Encode(result{
 					Data: []struct {
@@ -136,7 +152,11 @@ func TestGather(t *testing.T) {
 						},
 					},
 				})
-				require.NoError(t, err)
+				if err != nil {
+					w.WriteHeader(http.StatusInternalServerError)
+					t.Error(err)
+					return
+				}
 			case strings.Contains(query, "zk_root_nodes"):
 				err := enc.Encode(result{
 					Data: []struct {
@@ -147,7 +167,11 @@ func TestGather(t *testing.T) {
 						},
 					},
 				})
-				require.NoError(t, err)
+				if err != nil {
+					w.WriteHeader(http.StatusInternalServerError)
+					t.Error(err)
+					return
+				}
 			case strings.Contains(query, "replication_queue_exists"):
 				err := enc.Encode(result{
 					Data: []struct {
@@ -158,7 +182,11 @@ func TestGather(t *testing.T) {
 						},
 					},
 				})
-				require.NoError(t, err)
+				if err != nil {
+					w.WriteHeader(http.StatusInternalServerError)
+					t.Error(err)
+					return
+				}
 			case strings.Contains(query, "replication_too_many_tries_replicas"):
 				err := enc.Encode(result{
 					Data: []struct {
@@ -171,7 +199,11 @@ func TestGather(t *testing.T) {
 						},
 					},
 				})
-				require.NoError(t, err)
+				if err != nil {
+					w.WriteHeader(http.StatusInternalServerError)
+					t.Error(err)
+					return
+				}
 			case strings.Contains(query, "system.detached_parts"):
 				err := enc.Encode(result{
 					Data: []struct {
@@ -182,7 +214,11 @@ func TestGather(t *testing.T) {
 						},
 					},
 				})
-				require.NoError(t, err)
+				if err != nil {
+					w.WriteHeader(http.StatusInternalServerError)
+					t.Error(err)
+					return
+				}
 			case strings.Contains(query, "system.dictionaries"):
 				err := enc.Encode(result{
 					Data: []struct {
@@ -197,7 +233,11 @@ func TestGather(t *testing.T) {
 						},
 					},
 				})
-				require.NoError(t, err)
+				if err != nil {
+					w.WriteHeader(http.StatusInternalServerError)
+					t.Error(err)
+					return
+				}
 			case strings.Contains(query, "system.mutations"):
 				err := enc.Encode(result{
 					Data: []struct {
@@ -212,7 +252,11 @@ func TestGather(t *testing.T) {
 						},
 					},
 				})
-				require.NoError(t, err)
+				if err != nil {
+					w.WriteHeader(http.StatusInternalServerError)
+					t.Error(err)
+					return
+				}
 			case strings.Contains(query, "system.disks"):
 				err := enc.Encode(result{
 					Data: []struct {
@@ -229,7 +273,11 @@ func TestGather(t *testing.T) {
 						},
 					},
 				})
-				require.NoError(t, err)
+				if err != nil {
+					w.WriteHeader(http.StatusInternalServerError)
+					t.Error(err)
+					return
+				}
 			case strings.Contains(query, "system.processes"):
 				err := enc.Encode(result{
 					Data: []struct {
@@ -258,7 +306,11 @@ func TestGather(t *testing.T) {
 						},
 					},
 				})
-				require.NoError(t, err)
+				if err != nil {
+					w.WriteHeader(http.StatusInternalServerError)
+					t.Error(err)
+					return
+				}
 			case strings.Contains(query, "text_log_exists"):
 				err := enc.Encode(result{
 					Data: []struct {
@@ -269,7 +321,11 @@ func TestGather(t *testing.T) {
 						},
 					},
 				})
-				require.NoError(t, err)
+				if err != nil {
+					w.WriteHeader(http.StatusInternalServerError)
+					t.Error(err)
+					return
+				}
 			case strings.Contains(query, "system.text_log"):
 				err := enc.Encode(result{
 					Data: []struct {
@@ -298,7 +354,11 @@ func TestGather(t *testing.T) {
 						},
 					},
 				})
-				require.NoError(t, err)
+				if err != nil {
+					w.WriteHeader(http.StatusInternalServerError)
+					t.Error(err)
+					return
+				}
 			}
 		}))
 		ch = &ClickHouse{
@@ -451,7 +511,11 @@ func TestGatherWithSomeTablesNotExists(t *testing.T) {
 						},
 					},
 				})
-				require.NoError(t, err)
+				if err != nil {
+					w.WriteHeader(http.StatusInternalServerError)
+					t.Error(err)
+					return
+				}
 			case strings.Contains(query, "replication_queue_exists"):
 				err := enc.Encode(result{
 					Data: []struct {
@@ -462,7 +526,11 @@ func TestGatherWithSomeTablesNotExists(t *testing.T) {
 						},
 					},
 				})
-				require.NoError(t, err)
+				if err != nil {
+					w.WriteHeader(http.StatusInternalServerError)
+					t.Error(err)
+					return
+				}
 			case strings.Contains(query, "text_log_exists"):
 				err := enc.Encode(result{
 					Data: []struct {
@@ -473,7 +541,11 @@ func TestGatherWithSomeTablesNotExists(t *testing.T) {
 						},
 					},
 				})
-				require.NoError(t, err)
+				if err != nil {
+					w.WriteHeader(http.StatusInternalServerError)
+					t.Error(err)
+					return
+				}
 			}
 		}))
 		ch = &ClickHouse{
@@ -509,7 +581,11 @@ func TestGatherClickhouseCloud(t *testing.T) {
 					},
 				},
 			})
-			require.NoError(t, err)
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				t.Error(err)
+				return
+			}
 		case strings.Contains(query, "zk_root_nodes"):
 			err := enc.Encode(result{
 				Data: []struct {
@@ -520,7 +596,11 @@ func TestGatherClickhouseCloud(t *testing.T) {
 					},
 				},
 			})
-			require.NoError(t, err)
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				t.Error(err)
+				return
+			}
 		}
 	}))
 	defer ts.Close()
@@ -545,7 +625,11 @@ func TestWrongJSONMarshalling(t *testing.T) {
 			err := enc.Encode(result{
 				Data: []struct{}{},
 			})
-			require.NoError(t, err)
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				t.Error(err)
+				return
+			}
 		}))
 		ch = &ClickHouse{
 			Servers: []string{
@@ -631,7 +715,11 @@ func TestAutoDiscovery(t *testing.T) {
 						},
 					},
 				})
-				require.NoError(t, err)
+				if err != nil {
+					w.WriteHeader(http.StatusInternalServerError)
+					t.Error(err)
+					return
+				}
 			}
 		}))
 		ch = &ClickHouse{

--- a/plugins/inputs/consul_agent/consul_agent_test.go
+++ b/plugins/inputs/consul_agent/consul_agent_test.go
@@ -75,9 +75,16 @@ func TestConsulStats(t *testing.T) {
 				if r.RequestURI == "/v1/agent/metrics" {
 					w.WriteHeader(http.StatusOK)
 					responseKeyMetrics, err := os.ReadFile("testdata/response_key_metrics.json")
-					require.NoError(t, err)
-					_, err = fmt.Fprintln(w, string(responseKeyMetrics))
-					require.NoError(t, err)
+					if err != nil {
+						w.WriteHeader(http.StatusInternalServerError)
+						t.Error(err)
+						return
+					}
+					if _, err = fmt.Fprintln(w, string(responseKeyMetrics)); err != nil {
+						w.WriteHeader(http.StatusInternalServerError)
+						t.Error(err)
+						return
+					}
 				}
 			}))
 			defer ts.Close()

--- a/plugins/inputs/couchbase/couchbase_test.go
+++ b/plugins/inputs/couchbase/couchbase_test.go
@@ -17,17 +17,29 @@ func TestGatherServer(t *testing.T) {
 	bucket := "blastro-df"
 	fakeServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/pools" {
-			_, err := w.Write(readJSON(t, "testdata/pools_response.json"))
-			require.NoError(t, err)
+			if _, err := w.Write(readJSON(t, "testdata/pools_response.json")); err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				t.Error(err)
+				return
+			}
 		} else if r.URL.Path == "/pools/default" {
-			_, err := w.Write(readJSON(t, "testdata/pools_default_response.json"))
-			require.NoError(t, err)
+			if _, err := w.Write(readJSON(t, "testdata/pools_default_response.json")); err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				t.Error(err)
+				return
+			}
 		} else if r.URL.Path == "/pools/default/buckets" {
-			_, err := w.Write(readJSON(t, "testdata/bucket_response.json"))
-			require.NoError(t, err)
+			if _, err := w.Write(readJSON(t, "testdata/bucket_response.json")); err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				t.Error(err)
+				return
+			}
 		} else if r.URL.Path == "/pools/default/buckets/"+bucket+"/stats" {
-			_, err := w.Write(readJSON(t, "testdata/bucket_stats_response.json"))
-			require.NoError(t, err)
+			if _, err := w.Write(readJSON(t, "testdata/bucket_stats_response.json")); err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				t.Error(err)
+				return
+			}
 		} else {
 			w.WriteHeader(http.StatusNotFound)
 		}
@@ -116,8 +128,11 @@ func TestGatherDetailedBucketMetrics(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			fakeServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if r.URL.Path == "/pools/default/buckets/"+bucket+"/stats" || r.URL.Path == "/pools/default/buckets/"+bucket+"/nodes/"+node+"/stats" {
-					_, err := w.Write(test.response)
-					require.NoError(t, err)
+					if _, err := w.Write(test.response); err != nil {
+						w.WriteHeader(http.StatusInternalServerError)
+						t.Error(err)
+						return
+					}
 				} else {
 					w.WriteHeader(http.StatusNotFound)
 				}
@@ -153,14 +168,23 @@ func TestGatherDetailedBucketMetrics(t *testing.T) {
 func TestGatherNodeOnly(t *testing.T) {
 	faker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/pools" {
-			_, err := w.Write(readJSON(t, "testdata/pools_response.json"))
-			require.NoError(t, err)
+			if _, err := w.Write(readJSON(t, "testdata/pools_response.json")); err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				t.Error(err)
+				return
+			}
 		} else if r.URL.Path == "/pools/default" {
-			_, err := w.Write(readJSON(t, "testdata/pools_default_response.json"))
-			require.NoError(t, err)
+			if _, err := w.Write(readJSON(t, "testdata/pools_default_response.json")); err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				t.Error(err)
+				return
+			}
 		} else if r.URL.Path == "/pools/default/buckets" {
-			_, err := w.Write(readJSON(t, "testdata/bucket_response.json"))
-			require.NoError(t, err)
+			if _, err := w.Write(readJSON(t, "testdata/bucket_response.json")); err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				t.Error(err)
+				return
+			}
 		} else {
 			w.WriteHeader(http.StatusNotFound)
 		}
@@ -183,17 +207,29 @@ func TestGatherFailover(t *testing.T) {
 	faker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/pools":
-			_, err := w.Write(readJSON(t, "testdata/pools_response.json"))
-			require.NoError(t, err)
+			if _, err := w.Write(readJSON(t, "testdata/pools_response.json")); err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				t.Error(err)
+				return
+			}
 		case "/pools/default":
-			_, err := w.Write(readJSON(t, "testdata/pools_default_response.json"))
-			require.NoError(t, err)
+			if _, err := w.Write(readJSON(t, "testdata/pools_default_response.json")); err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				t.Error(err)
+				return
+			}
 		case "/pools/default/buckets":
-			_, err := w.Write(readJSON(t, "testdata/bucket_response.json"))
-			require.NoError(t, err)
+			if _, err := w.Write(readJSON(t, "testdata/bucket_response.json")); err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				t.Error(err)
+				return
+			}
 		case "/settings/autoFailover":
-			_, err := w.Write(readJSON(t, "testdata/settings_autofailover.json"))
-			require.NoError(t, err)
+			if _, err := w.Write(readJSON(t, "testdata/settings_autofailover.json")); err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				t.Error(err)
+				return
+			}
 		default:
 			w.WriteHeader(http.StatusNotFound)
 		}

--- a/plugins/inputs/couchdb/couchdb_test.go
+++ b/plugins/inputs/couchdb/couchdb_test.go
@@ -305,8 +305,11 @@ func TestBasic(t *testing.T) {
 `
 	fakeServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/_stats" {
-			_, err := w.Write([]byte(js))
-			require.NoError(t, err)
+			if _, err := w.Write([]byte(js)); err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				t.Error(err)
+				return
+			}
 		} else {
 			w.WriteHeader(http.StatusNotFound)
 		}

--- a/plugins/inputs/fibaro/fibaro_test.go
+++ b/plugins/inputs/fibaro/fibaro_test.go
@@ -42,20 +42,35 @@ func TestJSONSuccess(t *testing.T) {
 		switch r.URL.Path {
 		case "/api/sections":
 			content, err := os.ReadFile(path.Join("testdata", "sections.json"))
-			require.NoError(t, err)
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				t.Error(err)
+				return
+			}
 			payload = string(content)
 		case "/api/rooms":
 			content, err := os.ReadFile(path.Join("testdata", "rooms.json"))
-			require.NoError(t, err)
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				t.Error(err)
+				return
+			}
 			payload = string(content)
 		case "/api/devices":
 			content, err := os.ReadFile(path.Join("testdata", "device_hc2.json"))
-			require.NoError(t, err)
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				t.Error(err)
+				return
+			}
 			payload = string(content)
 		}
 		w.WriteHeader(http.StatusOK)
-		_, err := fmt.Fprintln(w, payload)
-		require.NoError(t, err)
+		if _, err := fmt.Fprintln(w, payload); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Error(err)
+			return
+		}
 	}))
 	defer ts.Close()
 
@@ -158,20 +173,35 @@ func TestHC3JSON(t *testing.T) {
 		switch r.URL.Path {
 		case "/api/sections":
 			content, err := os.ReadFile(path.Join("testdata", "sections.json"))
-			require.NoError(t, err)
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				t.Error(err)
+				return
+			}
 			payload = string(content)
 		case "/api/rooms":
 			content, err := os.ReadFile(path.Join("testdata", "rooms.json"))
-			require.NoError(t, err)
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				t.Error(err)
+				return
+			}
 			payload = string(content)
 		case "/api/devices":
 			content, err := os.ReadFile(path.Join("testdata", "device_hc3.json"))
-			require.NoError(t, err)
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				t.Error(err)
+				return
+			}
 			payload = string(content)
 		}
 		w.WriteHeader(http.StatusOK)
-		_, err := fmt.Fprintln(w, payload)
-		require.NoError(t, err)
+		if _, err := fmt.Fprintln(w, payload); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Error(err)
+			return
+		}
 	}))
 	defer ts.Close()
 

--- a/plugins/inputs/fireboard/fireboard_test.go
+++ b/plugins/inputs/fireboard/fireboard_test.go
@@ -17,8 +17,11 @@ func TestFireboard(t *testing.T) {
 	// Create a test server with the const response JSON
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		_, err := fmt.Fprintln(w, response)
-		require.NoError(t, err)
+		if _, err := fmt.Fprintln(w, response); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Error(err)
+			return
+		}
 	}))
 	defer ts.Close()
 

--- a/plugins/inputs/fluentd/fluentd_test.go
+++ b/plugins/inputs/fluentd/fluentd_test.go
@@ -171,8 +171,11 @@ func Test_Gather(t *testing.T) {
 
 	ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		_, err := fmt.Fprintf(w, "%s", string(sampleJSON))
-		require.NoError(t, err)
+		if _, err := fmt.Fprintf(w, "%s", sampleJSON); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Error(err)
+			return
+		}
 	}))
 
 	requestURL, err := url.Parse(fluentdTest.Endpoint)

--- a/plugins/inputs/google_cloud_storage/google_cloud_storage_test.go
+++ b/plugins/inputs/google_cloud_storage/google_cloud_storage_test.go
@@ -204,12 +204,18 @@ func startGCSServer(t *testing.T) *httptest.Server {
 		switch r.URL.Path {
 		case "/test-bucket/prefix/offset.json":
 			w.WriteHeader(http.StatusOK)
-			_, err := w.Write([]byte(currentOffSetKey))
-			require.NoError(t, err)
+			if _, err := w.Write([]byte(currentOffSetKey)); err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				t.Error(err)
+				return
+			}
 		case "/test-bucket/prefix/offset-key.json":
 			w.WriteHeader(http.StatusOK)
-			_, err := w.Write([]byte("{\"offSet\":\"offsetfile\"}"))
-			require.NoError(t, err)
+			if _, err := w.Write([]byte("{\"offSet\":\"offsetfile\"}")); err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				t.Error(err)
+				return
+			}
 		default:
 			failPath(r.URL.Path, t, w)
 		}
@@ -265,8 +271,11 @@ func startMultipleItemGCSServer(t *testing.T) *httptest.Server {
 
 			if data, err := json.Marshal(objListing); err == nil {
 				w.WriteHeader(http.StatusOK)
-				_, err := w.Write(data)
-				require.NoError(t, err)
+				if _, err := w.Write(data); err != nil {
+					w.WriteHeader(http.StatusInternalServerError)
+					t.Error(err)
+					return
+				}
 			} else {
 				w.WriteHeader(http.StatusNotFound)
 				t.Fatalf("unexpected path: %s", r.URL.Path)
@@ -314,17 +323,28 @@ func stateFullGCSServer(t *testing.T) *httptest.Server {
 
 			if data, err := json.Marshal(objListing); err == nil {
 				w.WriteHeader(http.StatusOK)
-				_, err := w.Write(data)
-				require.NoError(t, err)
+				if _, err := w.Write(data); err != nil {
+					w.WriteHeader(http.StatusInternalServerError)
+					t.Error(err)
+					return
+				}
 			} else {
 				failPath(r.URL.Path, t, w)
 			}
 		case "/upload/storage/v1/b/test-iteration-bucket/o":
 			_, params, err := mime.ParseMediaType(r.Header["Content-Type"][0])
-			require.NoError(t, err)
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				t.Error(err)
+				return
+			}
 			boundary := params["boundary"]
 			currentOffSetKey, err = fetchJSON(t, boundary, r.Body)
-			require.NoError(t, err)
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				t.Error(err)
+				return
+			}
 		default:
 			serveBlobs(t, w, r.URL.Path, currentOffSetKey)
 		}

--- a/plugins/inputs/haproxy/haproxy_test.go
+++ b/plugins/inputs/haproxy/haproxy_test.go
@@ -49,18 +49,27 @@ func TestHaproxyGeneratesMetricsWithAuthentication(t *testing.T) {
 		username, password, ok := r.BasicAuth()
 		if !ok {
 			w.WriteHeader(http.StatusNotFound)
-			_, err := fmt.Fprint(w, "Unauthorized")
-			require.NoError(t, err)
+			if _, err := fmt.Fprint(w, "Unauthorized"); err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				t.Error(err)
+				return
+			}
 			return
 		}
 
 		if username == "user" && password == "password" {
-			_, err := fmt.Fprint(w, string(csvOutputSample))
-			require.NoError(t, err)
+			if _, err := fmt.Fprint(w, string(csvOutputSample)); err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				t.Error(err)
+				return
+			}
 		} else {
 			w.WriteHeader(http.StatusNotFound)
-			_, err := fmt.Fprint(w, "Unauthorized")
-			require.NoError(t, err)
+			if _, err := fmt.Fprint(w, "Unauthorized"); err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				t.Error(err)
+				return
+			}
 		}
 	}))
 	defer ts.Close()
@@ -96,8 +105,11 @@ func TestHaproxyGeneratesMetricsWithAuthentication(t *testing.T) {
 
 func TestHaproxyGeneratesMetricsWithoutAuthentication(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		_, err := fmt.Fprint(w, string(csvOutputSample))
-		require.NoError(t, err)
+		if _, err := fmt.Fprint(w, string(csvOutputSample)); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Error(err)
+			return
+		}
 	}))
 	defer ts.Close()
 
@@ -217,8 +229,11 @@ func TestHaproxyDefaultGetFromLocalhost(t *testing.T) {
 
 func TestHaproxyKeepFieldNames(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		_, err := fmt.Fprint(w, string(csvOutputSample))
-		require.NoError(t, err)
+		if _, err := fmt.Fprint(w, string(csvOutputSample)); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Error(err)
+			return
+		}
 	}))
 	defer ts.Close()
 

--- a/plugins/inputs/http/http_test.go
+++ b/plugins/inputs/http/http_test.go
@@ -32,8 +32,11 @@ import (
 func TestHTTPWithJSONFormat(t *testing.T) {
 	fakeServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/endpoint" {
-			_, err := w.Write([]byte(simpleJSON))
-			require.NoError(t, err)
+			if _, err := w.Write([]byte(simpleJSON)); err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				t.Error(err)
+				return
+			}
 		} else {
 			w.WriteHeader(http.StatusNotFound)
 		}
@@ -73,8 +76,11 @@ func TestHTTPHeaders(t *testing.T) {
 	fakeServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/endpoint" {
 			if r.Header.Get(header) == headerValue {
-				_, err := w.Write([]byte(simpleJSON))
-				require.NoError(t, err)
+				if _, err := w.Write([]byte(simpleJSON)); err != nil {
+					w.WriteHeader(http.StatusInternalServerError)
+					t.Error(err)
+					return
+				}
 			} else {
 				w.WriteHeader(http.StatusForbidden)
 			}
@@ -107,8 +113,11 @@ func TestHTTPContentLengthHeader(t *testing.T) {
 	fakeServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/endpoint" {
 			if r.Header.Get("Content-Length") != "" {
-				_, err := w.Write([]byte(simpleJSON))
-				require.NoError(t, err)
+				if _, err := w.Write([]byte(simpleJSON)); err != nil {
+					w.WriteHeader(http.StatusInternalServerError)
+					t.Error(err)
+					return
+				}
 			} else {
 				w.WriteHeader(http.StatusForbidden)
 			}
@@ -408,8 +417,11 @@ func TestOAuthClientCredentialsGrant(t *testing.T) {
 func TestHTTPWithCSVFormat(t *testing.T) {
 	fakeServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/endpoint" {
-			_, err := w.Write([]byte(simpleCSVWithHeader))
-			require.NoError(t, err)
+			if _, err := w.Write([]byte(simpleCSVWithHeader)); err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				t.Error(err)
+				return
+			}
 		} else {
 			w.WriteHeader(http.StatusNotFound)
 		}
@@ -466,8 +478,11 @@ func TestConnectionOverUnixSocket(t *testing.T) {
 	ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/data" {
 			w.Header().Set("Content-Type", "text/csv")
-			_, err := w.Write([]byte(simpleCSVWithHeader))
-			require.NoError(t, err)
+			if _, err := w.Write([]byte(simpleCSVWithHeader)); err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				t.Error(err)
+				return
+			}
 		} else {
 			w.WriteHeader(http.StatusNotFound)
 		}

--- a/plugins/inputs/icinga2/icinga2_test.go
+++ b/plugins/inputs/icinga2/icinga2_test.go
@@ -69,8 +69,11 @@ func TestGatherServicesStatus(t *testing.T) {
 		if r.URL.Path == "/v1/objects/services" {
 			w.WriteHeader(http.StatusOK)
 			w.Header().Set("Content-Type", "application/json")
-			_, err := w.Write([]byte(icinga2ServiceResponse))
-			require.NoError(t, err)
+			if _, err := w.Write([]byte(icinga2ServiceResponse)); err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				t.Error(err)
+				return
+			}
 		} else {
 			w.WriteHeader(http.StatusNotFound)
 			t.Logf("Req: %s %s\n", r.Host, r.URL.Path)
@@ -132,8 +135,11 @@ func TestGatherHostsStatus(t *testing.T) {
 		if r.URL.Path == "/v1/objects/hosts" {
 			w.WriteHeader(http.StatusOK)
 			w.Header().Set("Content-Type", "application/json")
-			_, err := w.Write([]byte(icinga2HostResponse))
-			require.NoError(t, err)
+			if _, err := w.Write([]byte(icinga2HostResponse)); err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				t.Error(err)
+				return
+			}
 		} else {
 			w.WriteHeader(http.StatusNotFound)
 			t.Logf("Req: %s %s\n", r.Host, r.URL.Path)
@@ -191,8 +197,11 @@ func TestGatherStatusCIB(t *testing.T) {
 		if r.URL.Path == "/v1/status/CIB" {
 			w.WriteHeader(http.StatusOK)
 			w.Header().Set("Content-Type", "application/json")
-			_, err := w.Write([]byte(icinga2StatusCIB))
-			require.NoError(t, err)
+			if _, err := w.Write([]byte(icinga2StatusCIB)); err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				t.Error(err)
+				return
+			}
 		} else {
 			w.WriteHeader(http.StatusNotFound)
 			t.Logf("Req: %s %s\n", r.Host, r.URL.Path)
@@ -261,8 +270,11 @@ func TestGatherStatusPgsql(t *testing.T) {
 		if r.URL.Path == "/v1/status/IdoPgsqlConnection" {
 			w.WriteHeader(http.StatusOK)
 			w.Header().Set("Content-Type", "application/json")
-			_, err := w.Write([]byte(icinga2StatusPgsql))
-			require.NoError(t, err)
+			if _, err := w.Write([]byte(icinga2StatusPgsql)); err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				t.Error(err)
+				return
+			}
 		} else {
 			w.WriteHeader(http.StatusNotFound)
 			t.Logf("Req: %s %s\n", r.Host, r.URL.Path)

--- a/plugins/inputs/influxdb/influxdb_test.go
+++ b/plugins/inputs/influxdb/influxdb_test.go
@@ -18,8 +18,11 @@ import (
 func TestBasic(t *testing.T) {
 	fakeServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/endpoint" {
-			_, err := w.Write([]byte(basicJSON))
-			require.NoError(t, err)
+			if _, err := w.Write([]byte(basicJSON)); err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				t.Error(err)
+				return
+			}
 		} else {
 			w.WriteHeader(http.StatusNotFound)
 		}
@@ -69,8 +72,11 @@ func TestInfluxDB(t *testing.T) {
 
 	fakeInfluxServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/endpoint" {
-			_, err := w.Write(influxReturn)
-			require.NoError(t, err)
+			if _, err := w.Write(influxReturn); err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				t.Error(err)
+				return
+			}
 		} else {
 			w.WriteHeader(http.StatusNotFound)
 		}
@@ -141,8 +147,11 @@ func TestInfluxDB2(t *testing.T) {
 
 	fakeInfluxServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/endpoint" {
-			_, err := w.Write(influxReturn2)
-			require.NoError(t, err)
+			if _, err := w.Write(influxReturn2); err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				t.Error(err)
+				return
+			}
 		} else {
 			w.WriteHeader(http.StatusNotFound)
 		}
@@ -181,8 +190,11 @@ func TestCloud1(t *testing.T) {
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/endpoint" {
-			_, err := w.Write(input)
-			require.NoError(t, err)
+			if _, err := w.Write(input); err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				t.Error(err)
+				return
+			}
 		} else {
 			w.WriteHeader(http.StatusNotFound)
 		}
@@ -216,8 +228,11 @@ func TestCloud1(t *testing.T) {
 func TestErrorHandling(t *testing.T) {
 	badServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/endpoint" {
-			_, err := w.Write([]byte("not json"))
-			require.NoError(t, err)
+			if _, err := w.Write([]byte("not json")); err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				t.Error(err)
+				return
+			}
 		} else {
 			w.WriteHeader(http.StatusNotFound)
 		}
@@ -235,8 +250,11 @@ func TestErrorHandling(t *testing.T) {
 func TestErrorHandling404(t *testing.T) {
 	badServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/endpoint" {
-			_, err := w.Write([]byte(basicJSON))
-			require.NoError(t, err)
+			if _, err := w.Write([]byte(basicJSON)); err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				t.Error(err)
+				return
+			}
 		} else {
 			w.WriteHeader(http.StatusNotFound)
 		}
@@ -254,8 +272,11 @@ func TestErrorHandling404(t *testing.T) {
 func TestErrorResponse(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusUnauthorized)
-		_, err := w.Write([]byte(`{"error": "unable to parse authentication credentials"}`))
-		require.NoError(t, err)
+		if _, err := w.Write([]byte(`{"error": "unable to parse authentication credentials"}`)); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Error(err)
+			return
+		}
 	}))
 	defer ts.Close()
 

--- a/plugins/inputs/jolokia2_agent/jolokia2_agent_test.go
+++ b/plugins/inputs/jolokia2_agent/jolokia2_agent_test.go
@@ -628,8 +628,16 @@ func TestJolokia2_ClientAuthRequest(t *testing.T) {
 		username, password, _ = r.BasicAuth()
 
 		body, err := io.ReadAll(r.Body)
-		require.NoError(t, err)
-		require.NoError(t, json.Unmarshal(body, &requests))
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Error(err)
+			return
+		}
+		if err := json.Unmarshal(body, &requests); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Error(err)
+			return
+		}
 
 		w.WriteHeader(http.StatusOK)
 	}))

--- a/plugins/inputs/jolokia2_proxy/jolokia2_proxy_test.go
+++ b/plugins/inputs/jolokia2_proxy/jolokia2_proxy_test.go
@@ -85,11 +85,24 @@ func TestJolokia2_ClientProxyAuthRequest(t *testing.T) {
 		username, password, _ = r.BasicAuth()
 
 		body, err := io.ReadAll(r.Body)
-		require.NoError(t, err)
-		require.NoError(t, json.Unmarshal(body, &requests))
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Error(err)
+			return
+		}
+
+		if err := json.Unmarshal(body, &requests); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Error(err)
+			return
+		}
+
 		w.WriteHeader(http.StatusOK)
-		_, err = fmt.Fprintf(w, "[]")
-		require.NoError(t, err)
+		if _, err = fmt.Fprintf(w, "[]"); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Error(err)
+			return
+		}
 	}))
 	defer server.Close()
 

--- a/plugins/inputs/kapacitor/kapacitor_test.go
+++ b/plugins/inputs/kapacitor/kapacitor_test.go
@@ -18,8 +18,11 @@ func TestKapacitor(t *testing.T) {
 
 	fakeInfluxServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/endpoint" {
-			_, err := w.Write(kapacitorReturn)
-			require.NoError(t, err)
+			if _, err := w.Write(kapacitorReturn); err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				t.Error(err)
+				return
+			}
 		} else {
 			w.WriteHeader(http.StatusNotFound)
 		}
@@ -80,8 +83,11 @@ func TestKapacitor(t *testing.T) {
 
 func TestMissingStats(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		_, err := w.Write([]byte(`{}`))
-		require.NoError(t, err)
+		if _, err := w.Write([]byte(`{}`)); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Error(err)
+			return
+		}
 	}))
 	defer server.Close()
 
@@ -99,8 +105,11 @@ func TestMissingStats(t *testing.T) {
 func TestErrorHandling(t *testing.T) {
 	badServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/endpoint" {
-			_, err := w.Write([]byte("not json"))
-			require.NoError(t, err)
+			if _, err := w.Write([]byte("not json")); err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				t.Error(err)
+				return
+			}
 		} else {
 			w.WriteHeader(http.StatusNotFound)
 		}

--- a/plugins/inputs/kubernetes/kubernetes_test.go
+++ b/plugins/inputs/kubernetes/kubernetes_test.go
@@ -15,13 +15,19 @@ func TestKubernetesStats(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.RequestURI == "/stats/summary" {
 			w.WriteHeader(http.StatusOK)
-			_, err := fmt.Fprintln(w, responseStatsSummery)
-			require.NoError(t, err)
+			if _, err := fmt.Fprintln(w, responseStatsSummery); err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				t.Error(err)
+				return
+			}
 		}
 		if r.RequestURI == "/pods" {
 			w.WriteHeader(http.StatusOK)
-			_, err := fmt.Fprintln(w, responsePods)
-			require.NoError(t, err)
+			if _, err := fmt.Fprintln(w, responsePods); err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				t.Error(err)
+				return
+			}
 		}
 	}))
 	defer ts.Close()

--- a/plugins/inputs/logstash/logstash_test.go
+++ b/plugins/inputs/logstash/logstash_test.go
@@ -28,8 +28,11 @@ var (
 func Test_Logstash5GatherProcessStats(test *testing.T) {
 	fakeServer := httptest.NewUnstartedServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
 		writer.Header().Set("Content-Type", "application/json")
-		_, err := fmt.Fprintf(writer, "%s", string(logstash5ProcessJSON))
-		require.NoError(test, err)
+		if _, err := fmt.Fprintf(writer, "%s", logstash5ProcessJSON); err != nil {
+			writer.WriteHeader(http.StatusInternalServerError)
+			test.Error(err)
+			return
+		}
 	}))
 	requestURL, err := url.Parse(logstashTest.URL)
 	require.NoErrorf(test, err, "Can't connect to: %s", logstashTest.URL)
@@ -73,8 +76,11 @@ func Test_Logstash5GatherProcessStats(test *testing.T) {
 func Test_Logstash6GatherProcessStats(test *testing.T) {
 	fakeServer := httptest.NewUnstartedServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
 		writer.Header().Set("Content-Type", "application/json")
-		_, err := fmt.Fprintf(writer, "%s", string(logstash6ProcessJSON))
-		require.NoError(test, err)
+		if _, err := fmt.Fprintf(writer, "%s", logstash6ProcessJSON); err != nil {
+			writer.WriteHeader(http.StatusInternalServerError)
+			test.Error(err)
+			return
+		}
 	}))
 	requestURL, err := url.Parse(logstashTest.URL)
 	require.NoErrorf(test, err, "Can't connect to: %s", logstashTest.URL)
@@ -119,8 +125,11 @@ func Test_Logstash5GatherPipelineStats(test *testing.T) {
 	logstash5accPipelineStats.SetDebug(true)
 	fakeServer := httptest.NewUnstartedServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
 		writer.Header().Set("Content-Type", "application/json")
-		_, err := fmt.Fprintf(writer, "%s", string(logstash5PipelineJSON))
-		require.NoError(test, err)
+		if _, err := fmt.Fprintf(writer, "%s", logstash5PipelineJSON); err != nil {
+			writer.WriteHeader(http.StatusInternalServerError)
+			test.Error(err)
+			return
+		}
 	}))
 	requestURL, err := url.Parse(logstashTest.URL)
 	require.NoErrorf(test, err, "Can't connect to: %s", logstashTest.URL)
@@ -217,8 +226,11 @@ func Test_Logstash6GatherPipelinesStats(test *testing.T) {
 	logstash6accPipelinesStats.SetDebug(true)
 	fakeServer := httptest.NewUnstartedServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
 		writer.Header().Set("Content-Type", "application/json")
-		_, err := fmt.Fprintf(writer, "%s", string(logstash6PipelinesJSON))
-		require.NoError(test, err)
+		if _, err := fmt.Fprintf(writer, "%s", logstash6PipelinesJSON); err != nil {
+			writer.WriteHeader(http.StatusInternalServerError)
+			test.Error(err)
+			return
+		}
 	}))
 	requestURL, err := url.Parse(logstashTest.URL)
 	require.NoErrorf(test, err, "Can't connect to: %s", logstashTest.URL)
@@ -559,8 +571,11 @@ func Test_Logstash6GatherPipelinesStats(test *testing.T) {
 func Test_Logstash5GatherJVMStats(test *testing.T) {
 	fakeServer := httptest.NewUnstartedServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
 		writer.Header().Set("Content-Type", "application/json")
-		_, err := fmt.Fprintf(writer, "%s", string(logstash5JvmJSON))
-		require.NoError(test, err)
+		if _, err := fmt.Fprintf(writer, "%s", logstash5JvmJSON); err != nil {
+			writer.WriteHeader(http.StatusInternalServerError)
+			test.Error(err)
+			return
+		}
 	}))
 	requestURL, err := url.Parse(logstashTest.URL)
 	require.NoErrorf(test, err, "Can't connect to: %s", logstashTest.URL)
@@ -623,8 +638,11 @@ func Test_Logstash5GatherJVMStats(test *testing.T) {
 func Test_Logstash6GatherJVMStats(test *testing.T) {
 	fakeServer := httptest.NewUnstartedServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
 		writer.Header().Set("Content-Type", "application/json")
-		_, err := fmt.Fprintf(writer, "%s", string(logstash6JvmJSON))
-		require.NoError(test, err)
+		if _, err := fmt.Fprintf(writer, "%s", logstash6JvmJSON); err != nil {
+			writer.WriteHeader(http.StatusInternalServerError)
+			test.Error(err)
+			return
+		}
 	}))
 	requestURL, err := url.Parse(logstashTest.URL)
 	require.NoErrorf(test, err, "Can't connect to: %s", logstashTest.URL)

--- a/plugins/inputs/mailchimp/mailchimp_test.go
+++ b/plugins/inputs/mailchimp/mailchimp_test.go
@@ -17,8 +17,11 @@ func TestMailChimpGatherReports(t *testing.T) {
 		http.HandlerFunc(
 			func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusOK)
-				_, err := fmt.Fprintln(w, sampleReports)
-				require.NoError(t, err)
+				if _, err := fmt.Fprintln(w, sampleReports); err != nil {
+					w.WriteHeader(http.StatusInternalServerError)
+					t.Error(err)
+					return
+				}
 			},
 		))
 	defer ts.Close()
@@ -82,8 +85,11 @@ func TestMailChimpGatherReport(t *testing.T) {
 		http.HandlerFunc(
 			func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusOK)
-				_, err := fmt.Fprintln(w, sampleReport)
-				require.NoError(t, err)
+				if _, err := fmt.Fprintln(w, sampleReport); err != nil {
+					w.WriteHeader(http.StatusInternalServerError)
+					t.Error(err)
+					return
+				}
 			},
 		))
 	defer ts.Close()
@@ -148,8 +154,11 @@ func TestMailChimpGatherError(t *testing.T) {
 		http.HandlerFunc(
 			func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusOK)
-				_, err := fmt.Fprintln(w, sampleError)
-				require.NoError(t, err)
+				if _, err := fmt.Fprintln(w, sampleError); err != nil {
+					w.WriteHeader(http.StatusInternalServerError)
+					t.Error(err)
+					return
+				}
 			},
 		))
 	defer ts.Close()

--- a/plugins/inputs/marklogic/marklogic_test.go
+++ b/plugins/inputs/marklogic/marklogic_test.go
@@ -16,8 +16,11 @@ func TestMarklogic(t *testing.T) {
 	// Create a test server with the const response JSON
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		_, err := fmt.Fprintln(w, response)
-		require.NoError(t, err)
+		if _, err := fmt.Fprintln(w, response); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Error(err)
+			return
+		}
 	}))
 	defer ts.Close()
 

--- a/plugins/inputs/monit/monit_test.go
+++ b/plugins/inputs/monit/monit_test.go
@@ -591,7 +591,11 @@ func TestInvalidUsernameOrPassword(t *testing.T) {
 			return
 		}
 
-		require.Equal(t, "/_status", r.URL.Path, "Cannot handle request")
+		if r.URL.Path != "/_status" {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Errorf("Not equal, expected: %q, actual: %q", "/_status", r.URL.Path)
+			return
+		}
 		http.ServeFile(w, r, "testdata/response_servicetype_0.xml")
 	}))
 
@@ -618,7 +622,11 @@ func TestNoUsernameOrPasswordConfiguration(t *testing.T) {
 			return
 		}
 
-		require.Equal(t, "/_status", r.URL.Path, "Cannot handle request")
+		if r.URL.Path != "/_status" {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Errorf("Not equal, expected: %q, actual: %q", "/_status", r.URL.Path)
+			return
+		}
 		http.ServeFile(w, r, "testdata/response_servicetype_0.xml")
 	}))
 


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

This is only part of a larger effort to address the findings identified by `testifylint: go-require`: https://github.com/influxdata/telegraf/issues/15535
Once all the findings have been addressed, `testifylint: go-require` can be enabled in `.golangci.yml`.

In this PR, I’m focusing on fixing findings in `http-handlers` for `plugins/inputs/[a-m]`.

Here are the findings that this PR addresses:
```
plugins/inputs/activemq/activemq_test.go:153:4                                testifylint  go-require: do not use require in http handlers
plugins/inputs/activemq/activemq_test.go:157:4                                testifylint  go-require: do not use require in http handlers
plugins/inputs/activemq/activemq_test.go:161:4                                testifylint  go-require: do not use require in http handlers
plugins/inputs/apache/apache_test.go:36:3                                     testifylint  go-require: do not use require in http handlers
plugins/inputs/aurora/aurora_test.go:251:5                                    testifylint  go-require: do not use require in http handlers
plugins/inputs/aurora/aurora_test.go:252:5                                    testifylint  go-require: do not use require in http handlers
plugins/inputs/aurora/aurora_test.go:255:5                                    testifylint  go-require: do not use require in http handlers
plugins/inputs/beat/beat_test.go:32:4                                         testifylint  go-require: do not use require in http handlers
plugins/inputs/beat/beat_test.go:36:3                                         testifylint  go-require: do not use require in http handlers
plugins/inputs/beat/beat_test.go:38:3                                         testifylint  go-require: do not use require in http handlers
plugins/inputs/beat/beat_test.go:176:4                                        testifylint  go-require: do not use require in http handlers
plugins/inputs/beat/beat_test.go:180:3                                        testifylint  go-require: do not use require in http handlers
plugins/inputs/beat/beat_test.go:181:3                                        testifylint  go-require: do not use require in http handlers
plugins/inputs/beat/beat_test.go:182:3                                        testifylint  go-require: do not use require in http handlers
plugins/inputs/beat/beat_test.go:183:3                                        testifylint  go-require: do not use require in http handlers
plugins/inputs/beat/beat_test.go:184:3                                        testifylint  go-require: do not use require in http handlers
plugins/inputs/beat/beat_test.go:187:3                                        testifylint  go-require: do not use require in http handlers
plugins/inputs/clickhouse/clickhouse_test.go:77:5                             testifylint  go-require: do not use require in http handlers
plugins/inputs/clickhouse/clickhouse_test.go:94:5                             testifylint  go-require: do not use require in http handlers
plugins/inputs/clickhouse/clickhouse_test.go:111:5                            testifylint  go-require: do not use require in http handlers
plugins/inputs/clickhouse/clickhouse_test.go:128:5                            testifylint  go-require: do not use require in http handlers
plugins/inputs/clickhouse/clickhouse_test.go:139:5                            testifylint  go-require: do not use require in http handlers
plugins/inputs/clickhouse/clickhouse_test.go:150:5                            testifylint  go-require: do not use require in http handlers
plugins/inputs/clickhouse/clickhouse_test.go:161:5                            testifylint  go-require: do not use require in http handlers
plugins/inputs/clickhouse/clickhouse_test.go:174:5                            testifylint  go-require: do not use require in http handlers
plugins/inputs/clickhouse/clickhouse_test.go:185:5                            testifylint  go-require: do not use require in http handlers
plugins/inputs/clickhouse/clickhouse_test.go:200:5                            testifylint  go-require: do not use require in http handlers
plugins/inputs/clickhouse/clickhouse_test.go:215:5                            testifylint  go-require: do not use require in http handlers
plugins/inputs/clickhouse/clickhouse_test.go:232:5                            testifylint  go-require: do not use require in http handlers
plugins/inputs/clickhouse/clickhouse_test.go:261:5                            testifylint  go-require: do not use require in http handlers
plugins/inputs/clickhouse/clickhouse_test.go:272:5                            testifylint  go-require: do not use require in http handlers
plugins/inputs/clickhouse/clickhouse_test.go:301:5                            testifylint  go-require: do not use require in http handlers
plugins/inputs/clickhouse/clickhouse_test.go:454:5                            testifylint  go-require: do not use require in http handlers
plugins/inputs/clickhouse/clickhouse_test.go:465:5                            testifylint  go-require: do not use require in http handlers
plugins/inputs/clickhouse/clickhouse_test.go:476:5                            testifylint  go-require: do not use require in http handlers
plugins/inputs/clickhouse/clickhouse_test.go:512:4                            testifylint  go-require: do not use require in http handlers
plugins/inputs/clickhouse/clickhouse_test.go:523:4                            testifylint  go-require: do not use require in http handlers
plugins/inputs/clickhouse/clickhouse_test.go:548:4                            testifylint  go-require: do not use require in http handlers
plugins/inputs/clickhouse/clickhouse_test.go:634:5                            testifylint  go-require: do not use require in http handlers
plugins/inputs/consul_agent/consul_agent_test.go:78:6                         testifylint  go-require: do not use require in http handlers
plugins/inputs/consul_agent/consul_agent_test.go:80:6                         testifylint  go-require: do not use require in http handlers
plugins/inputs/couchbase/couchbase_test.go:21:4                               testifylint  go-require: do not use require in http handlers
plugins/inputs/couchbase/couchbase_test.go:24:4                               testifylint  go-require: do not use require in http handlers
plugins/inputs/couchbase/couchbase_test.go:27:4                               testifylint  go-require: do not use require in http handlers
plugins/inputs/couchbase/couchbase_test.go:30:4                               testifylint  go-require: do not use require in http handlers
plugins/inputs/couchbase/couchbase_test.go:120:6                              testifylint  go-require: do not use require in http handlers
plugins/inputs/couchbase/couchbase_test.go:157:4                              testifylint  go-require: do not use require in http handlers
plugins/inputs/couchbase/couchbase_test.go:160:4                              testifylint  go-require: do not use require in http handlers
plugins/inputs/couchbase/couchbase_test.go:163:4                              testifylint  go-require: do not use require in http handlers
plugins/inputs/couchbase/couchbase_test.go:187:4                              testifylint  go-require: do not use require in http handlers
plugins/inputs/couchbase/couchbase_test.go:190:4                              testifylint  go-require: do not use require in http handlers
plugins/inputs/couchbase/couchbase_test.go:193:4                              testifylint  go-require: do not use require in http handlers
plugins/inputs/couchbase/couchbase_test.go:196:4                              testifylint  go-require: do not use require in http handlers
plugins/inputs/couchdb/couchdb_test.go:309:4                                  testifylint  go-require: do not use require in http handlers
plugins/inputs/ctrlx_datalayer/ctrlx_datalayer_test.go:40:3                   testifylint  go-require: do not use require in http handlers
plugins/inputs/ctrlx_datalayer/ctrlx_datalayer_test.go:84:5                   testifylint  go-require: do not use require in http handlers
plugins/inputs/ctrlx_datalayer/ctrlx_datalayer_test.go:122:3                  testifylint  go-require: do not use require in http handlers
plugins/inputs/ctrlx_datalayer/ctrlx_datalayer_test.go:127:3                  testifylint  go-require: do not use require in http handlers
plugins/inputs/ctrlx_datalayer/ctrlx_datalayer_test.go:133:3                  testifylint  go-require: do not use require in http handlers
plugins/inputs/ctrlx_datalayer/ctrlx_datalayer_test.go:140:4                  testifylint  go-require: do not use require in http handlers
plugins/inputs/ctrlx_datalayer/ctrlx_datalayer_test.go:142:4                  testifylint  go-require: do not use require in http handlers
plugins/inputs/ctrlx_datalayer/ctrlx_datalayer_test.go:146:5                  testifylint  go-require: do not use require in http handlers
plugins/inputs/ctrlx_datalayer/ctrlx_datalayer_test.go:149:5                  testifylint  go-require: do not use require in http handlers
plugins/inputs/ctrlx_datalayer/ctrlx_datalayer_test.go:152:5                  testifylint  go-require: do not use require in http handlers
plugins/inputs/ctrlx_datalayer/ctrlx_datalayer_test.go:156:5                  testifylint  go-require: do not use require in http handlers
plugins/inputs/ctrlx_datalayer/ctrlx_datalayer_test.go:159:4                  testifylint  go-require: do not use require in http handlers
plugins/inputs/fibaro/fibaro_test.go:45:4                                     testifylint  go-require: do not use require in http handlers
plugins/inputs/fibaro/fibaro_test.go:49:4                                     testifylint  go-require: do not use require in http handlers
plugins/inputs/fibaro/fibaro_test.go:53:4                                     testifylint  go-require: do not use require in http handlers
plugins/inputs/fibaro/fibaro_test.go:58:3                                     testifylint  go-require: do not use require in http handlers
plugins/inputs/fibaro/fibaro_test.go:161:4                                    testifylint  go-require: do not use require in http handlers
plugins/inputs/fibaro/fibaro_test.go:165:4                                    testifylint  go-require: do not use require in http handlers
plugins/inputs/fibaro/fibaro_test.go:169:4                                    testifylint  go-require: do not use require in http handlers
plugins/inputs/fibaro/fibaro_test.go:174:3                                    testifylint  go-require: do not use require in http handlers
plugins/inputs/fireboard/fireboard_test.go:21:3                               testifylint  go-require: do not use require in http handlers
plugins/inputs/fluentd/fluentd_test.go:175:3                                  testifylint  go-require: do not use require in http handlers
plugins/inputs/google_cloud_storage/google_cloud_storage_test.go:208:4        testifylint  go-require: do not use require in http handlers
plugins/inputs/google_cloud_storage/google_cloud_storage_test.go:212:4        testifylint  go-require: do not use require in http handlers
plugins/inputs/google_cloud_storage/google_cloud_storage_test.go:269:5        testifylint  go-require: do not use require in http handlers
plugins/inputs/google_cloud_storage/google_cloud_storage_test.go:318:5        testifylint  go-require: do not use require in http handlers
plugins/inputs/google_cloud_storage/google_cloud_storage_test.go:324:4        testifylint  go-require: do not use require in http handlers
plugins/inputs/google_cloud_storage/google_cloud_storage_test.go:327:4        testifylint  go-require: do not use require in http handlers
plugins/inputs/haproxy/haproxy_test.go:53:4                                   testifylint  go-require: do not use require in http handlers
plugins/inputs/haproxy/haproxy_test.go:59:4                                   testifylint  go-require: do not use require in http handlers
plugins/inputs/haproxy/haproxy_test.go:63:4                                   testifylint  go-require: do not use require in http handlers
plugins/inputs/haproxy/haproxy_test.go:100:3                                  testifylint  go-require: do not use require in http handlers
plugins/inputs/haproxy/haproxy_test.go:221:3                                  testifylint  go-require: do not use require in http handlers
plugins/inputs/http/http_test.go:36:4                                         testifylint  go-require: do not use require in http handlers
plugins/inputs/http/http_test.go:77:5                                         testifylint  go-require: do not use require in http handlers
plugins/inputs/http/http_test.go:111:5                                        testifylint  go-require: do not use require in http handlers
plugins/inputs/http/http_test.go:412:4                                        testifylint  go-require: do not use require in http handlers
plugins/inputs/http/http_test.go:470:4                                        testifylint  go-require: do not use require in http handlers
plugins/inputs/http_response/http_response_test.go:175:3                      testifylint  go-require: do not use require in http handlers
plugins/inputs/http_response/http_response_test.go:176:3                      testifylint  go-require: do not use require in http handlers
plugins/inputs/http_response/http_response_test.go:177:3                      testifylint  go-require: do not use require in http handlers
plugins/inputs/http_response/http_response_test.go:1119:3                     testifylint  go-require: do not use require in http handlers
plugins/inputs/http_response/http_response_test.go:1162:3                     testifylint  go-require: do not use require in http handlers
plugins/inputs/http_response/http_response_test.go:1339:3                     testifylint  go-require: do not use require in http handlers
plugins/inputs/icinga2/icinga2_test.go:73:4                                   testifylint  go-require: do not use require in http handlers
plugins/inputs/icinga2/icinga2_test.go:136:4                                  testifylint  go-require: do not use require in http handlers
plugins/inputs/icinga2/icinga2_test.go:195:4                                  testifylint  go-require: do not use require in http handlers
plugins/inputs/icinga2/icinga2_test.go:265:4                                  testifylint  go-require: do not use require in http handlers
plugins/inputs/influxdb/influxdb_test.go:22:4                                 testifylint  go-require: do not use require in http handlers
plugins/inputs/influxdb/influxdb_test.go:73:4                                 testifylint  go-require: do not use require in http handlers
plugins/inputs/influxdb/influxdb_test.go:145:4                                testifylint  go-require: do not use require in http handlers
plugins/inputs/influxdb/influxdb_test.go:185:4                                testifylint  go-require: do not use require in http handlers
plugins/inputs/influxdb/influxdb_test.go:220:4                                testifylint  go-require: do not use require in http handlers
plugins/inputs/influxdb/influxdb_test.go:239:4                                testifylint  go-require: do not use require in http handlers
plugins/inputs/influxdb/influxdb_test.go:258:3                                testifylint  go-require: do not use require in http handlers
plugins/inputs/jolokia2_agent/jolokia2_agent_test.go:631:3                    testifylint  go-require: do not use require in http handlers
plugins/inputs/jolokia2_agent/jolokia2_agent_test.go:632:3                    testifylint  go-require: do not use require in http handlers
plugins/inputs/jolokia2_proxy/jolokia2_proxy_test.go:88:3                     testifylint  go-require: do not use require in http handlers
plugins/inputs/jolokia2_proxy/jolokia2_proxy_test.go:89:3                     testifylint  go-require: do not use require in http handlers
plugins/inputs/jolokia2_proxy/jolokia2_proxy_test.go:92:3                     testifylint  go-require: do not use require in http handlers
plugins/inputs/kapacitor/kapacitor_test.go:22:4                               testifylint  go-require: do not use require in http handlers
plugins/inputs/kapacitor/kapacitor_test.go:84:3                               testifylint  go-require: do not use require in http handlers
plugins/inputs/kapacitor/kapacitor_test.go:103:4                              testifylint  go-require: do not use require in http handlers
plugins/inputs/kubernetes/kubernetes_test.go:19:4                             testifylint  go-require: do not use require in http handlers
plugins/inputs/kubernetes/kubernetes_test.go:24:4                             testifylint  go-require: do not use require in http handlers
plugins/inputs/logstash/logstash_test.go:32:3                                 testifylint  go-require: do not use require in http handlers
plugins/inputs/logstash/logstash_test.go:77:3                                 testifylint  go-require: do not use require in http handlers
plugins/inputs/logstash/logstash_test.go:123:3                                testifylint  go-require: do not use require in http handlers
plugins/inputs/logstash/logstash_test.go:221:3                                testifylint  go-require: do not use require in http handlers
plugins/inputs/logstash/logstash_test.go:563:3                                testifylint  go-require: do not use require in http handlers
plugins/inputs/logstash/logstash_test.go:627:3                                testifylint  go-require: do not use require in http handlers
plugins/inputs/mailchimp/mailchimp_test.go:21:5                               testifylint  go-require: do not use require in http handlers
plugins/inputs/mailchimp/mailchimp_test.go:86:5                               testifylint  go-require: do not use require in http handlers
plugins/inputs/mailchimp/mailchimp_test.go:152:5                              testifylint  go-require: do not use require in http handlers
plugins/inputs/marklogic/marklogic_test.go:20:3                               testifylint  go-require: do not use require in http handlers
plugins/inputs/monit/monit_test.go:594:3                                      testifylint  go-require: do not use require in http handlers
plugins/inputs/monit/monit_test.go:621:3                                      testifylint  go-require: do not use require in http handlers
```

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR