### PR TITLE
chore: Enable `revive:enforce-map-style` rule

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -262,6 +262,9 @@ linters-settings:
       - name: early-return
       - name: empty-block
       - name: empty-lines
+      - name: enforce-map-style
+        arguments: ["make"]
+        exclude: [ "TEST" ]
       - name: error-naming
       - name: error-return
       - name: error-strings

--- a/config/config.go
+++ b/config/config.go
@@ -115,7 +115,7 @@ func (op OrderedPlugins) Less(i, j int) bool { return op[i].Line < op[j].Line }
 // once the configuration is parsed.
 func NewConfig() *Config {
 	c := &Config{
-		UnusedFields:      map[string]bool{},
+		UnusedFields:      make(map[string]bool),
 		unusedFieldsMutex: &sync.Mutex{},
 
 		// Agent defaults:

--- a/internal/snmp/table.go
+++ b/internal/snmp/table.go
@@ -103,7 +103,7 @@ func (t *Table) initBuild() error {
 		t.Name = oidText
 	}
 
-	knownOIDs := map[string]bool{}
+	knownOIDs := make(map[string]bool, len(t.Fields))
 	for _, f := range t.Fields {
 		knownOIDs[f.Oid] = true
 	}
@@ -118,7 +118,7 @@ func (t *Table) initBuild() error {
 
 // Build retrieves all the fields specified in the table and constructs the RTable.
 func (t Table) Build(gs Connection, walk bool) (*RTable, error) {
-	rows := map[string]RTableRow{}
+	rows := make(map[string]RTableRow)
 
 	// translation table for secondary index (when performing join on two tables)
 	secIdxTab := make(map[string]string)
@@ -151,7 +151,7 @@ func (t Table) Build(gs Connection, walk bool) (*RTable, error) {
 		}
 
 		// ifv contains a mapping of table OID index to field value
-		ifv := map[string]interface{}{}
+		ifv := make(map[string]interface{})
 
 		if !walk {
 			// This is used when fetching non-table fields. Fields configured a the top
@@ -240,8 +240,8 @@ func (t Table) Build(gs Connection, walk bool) (*RTable, error) {
 			rtr, ok := rows[idx]
 			if !ok {
 				rtr = RTableRow{}
-				rtr.Tags = map[string]string{}
-				rtr.Fields = map[string]interface{}{}
+				rtr.Tags = make(map[string]string)
+				rtr.Fields = make(map[string]interface{})
 				rows[idx] = rtr
 			}
 			if t.IndexAsTag && idx != "" {

--- a/internal/snmp/translator_gosmi.go
+++ b/internal/snmp/translator_gosmi.go
@@ -92,10 +92,10 @@ func (g *gosmiTranslator) SnmpFormatDisplayHint(oid string, value interface{}) (
 
 func getIndex(mibPrefix string, node gosmi.SmiNode) (col []string, tagOids map[string]struct{}) {
 	// first attempt to get the table's tags
-	tagOids = map[string]struct{}{}
-
 	// mimcks grabbing INDEX {} that is returned from snmptranslate -Td MibName
-	for _, index := range node.GetIndex() {
+	indices := node.GetIndex()
+	tagOids = make(map[string]struct{}, len(indices))
+	for _, index := range indices {
 		tagOids[mibPrefix+index.Name] = struct{}{}
 	}
 

--- a/internal/templating/matcher.go
+++ b/internal/templating/matcher.go
@@ -21,7 +21,7 @@ func newMatcher(defaultTemplate *Template) *matcher {
 
 func (m *matcher) addSpec(tmplt templateSpec) error {
 	// Parse out the default tags specific to this template
-	tags := map[string]string{}
+	tags := make(map[string]string)
 	if tmplt.tagstring != "" {
 		for _, kv := range strings.Split(tmplt.tagstring, ",") {
 			parts := strings.Split(kv, "=")

--- a/models/buffer.go
+++ b/models/buffer.go
@@ -10,8 +10,8 @@ import (
 )
 
 var (
-	AgentMetricsWritten = selfstat.Register("agent", "metrics_written", map[string]string{})
-	AgentMetricsDropped = selfstat.Register("agent", "metrics_dropped", map[string]string{})
+	AgentMetricsWritten = selfstat.Register("agent", "metrics_written", make(map[string]string))
+	AgentMetricsDropped = selfstat.Register("agent", "metrics_dropped", make(map[string]string))
 
 	registerGob = sync.OnceFunc(func() { metric.Init() })
 )

--- a/models/running_input.go
+++ b/models/running_input.go
@@ -12,9 +12,9 @@ import (
 )
 
 var (
-	GlobalMetricsGathered = selfstat.Register("agent", "metrics_gathered", map[string]string{})
-	GlobalGatherErrors    = selfstat.Register("agent", "gather_errors", map[string]string{})
-	GlobalGatherTimeouts  = selfstat.Register("agent", "gather_timeouts", map[string]string{})
+	GlobalMetricsGathered = selfstat.Register("agent", "metrics_gathered", make(map[string]string))
+	GlobalGatherErrors    = selfstat.Register("agent", "gather_errors", make(map[string]string))
+	GlobalGatherTimeouts  = selfstat.Register("agent", "gather_timeouts", make(map[string]string))
 )
 
 type RunningInput struct {

--- a/plugins/inputs/win_eventlog/util.go
+++ b/plugins/inputs/win_eventlog/util.go
@@ -135,7 +135,7 @@ func walkXML(nodes []xmlnode, parents []string, separator string, f func(xmlnode
 // UniqueFieldNames forms unique field names
 // by adding _<num> if there are several of them
 func UniqueFieldNames(fields []EventField, fieldsUsage map[string]int, separator string) []EventField {
-	var fieldsCounter = map[string]int{}
+	var fieldsCounter = make(map[string]int, len(fields))
 	fieldsUnique := make([]EventField, 0, len(fields))
 	for _, field := range fields {
 		fieldName := field.Name

--- a/plugins/inputs/win_eventlog/win_eventlog.go
+++ b/plugins/inputs/win_eventlog/win_eventlog.go
@@ -156,10 +156,10 @@ func (w *WinEventLog) Gather(acc telegraf.Accumulator) error {
 
 		for i := range events {
 			// Prepare fields names usage counter
-			var fieldsUsage = map[string]int{}
+			fieldsUsage := make(map[string]int)
 
-			tags := map[string]string{}
-			fields := map[string]interface{}{}
+			tags := make(map[string]string)
+			fields := make(map[string]interface{})
 			event := events[i]
 			evt := reflect.ValueOf(&event).Elem()
 			timeStamp := time.Now()
@@ -168,7 +168,7 @@ func (w *WinEventLog) Gather(acc telegraf.Accumulator) error {
 				fieldName := evt.Type().Field(i).Name
 				fieldType := evt.Field(i).Type().String()
 				fieldValue := evt.Field(i).Interface()
-				computedValues := map[string]interface{}{}
+				computedValues := make(map[string]interface{})
 				switch fieldName {
 				case "Source":
 					fieldValue = event.Source.Name

--- a/plugins/inputs/win_wmi/method.go
+++ b/plugins/inputs/win_wmi/method.go
@@ -164,7 +164,7 @@ func (m *Method) execute(acc telegraf.Accumulator) error {
 	defer outputPropertiesRaw.Clear()
 
 	// Convert the results to fields and tags
-	tags, fields := map[string]string{}, map[string]interface{}{}
+	tags, fields := make(map[string]string), make(map[string]interface{})
 
 	// Add a source tag if we use remote queries
 	if m.host != "" {

--- a/plugins/inputs/win_wmi/query.go
+++ b/plugins/inputs/win_wmi/query.go
@@ -144,7 +144,7 @@ func (q *Query) execute(acc telegraf.Accumulator) error {
 }
 
 func (q *Query) extractProperties(acc telegraf.Accumulator, itemRaw *ole.VARIANT) error {
-	tags, fields := map[string]string{}, map[string]interface{}{}
+	tags, fields := make(map[string]string), make(map[string]interface{})
 
 	if q.host != "" {
 		tags["source"] = q.host

--- a/selfstat/selfstat.go
+++ b/selfstat/selfstat.go
@@ -84,7 +84,7 @@ func Metrics() []telegraf.Metric {
 		if len(stats) > 0 {
 			var tags map[string]string
 			var name string
-			fields := map[string]interface{}{}
+			fields := make(map[string]interface{}, len(stats))
 			j := 0
 			for fieldname, stat := range stats {
 				if j == 0 {

--- a/testutil/accumulator.go
+++ b/testutil/accumulator.go
@@ -109,12 +109,12 @@ func (a *Accumulator) addMeasurement(
 		return
 	}
 
-	tagsCopy := map[string]string{}
+	tagsCopy := make(map[string]string, len(tags))
 	for k, v := range tags {
 		tagsCopy[k] = v
 	}
 
-	fieldsCopy := map[string]interface{}{}
+	fieldsCopy := make(map[string]interface{}, len(fields))
 	for k, v := range fields {
 		fieldsCopy[k] = v
 	}

--- a/tools/custom_builder/config.go
+++ b/tools/custom_builder/config.go
@@ -60,7 +60,7 @@ func ImportConfigurations(files, dirs []string) (*selection, int, error) {
 
 func (s *selection) Filter(p packageCollection) (*packageCollection, error) {
 	enabled := packageCollection{
-		packages: map[string][]packageInfo{},
+		packages: make(map[string][]packageInfo),
 	}
 
 	implicitlyConfigured := make(map[string]bool)

--- a/tools/license_checker/main.go
+++ b/tools/license_checker/main.go
@@ -178,8 +178,8 @@ func main() {
 
 	// Get the superset of licenses
 	if debug {
-		licenseSet := map[string]bool{}
-		licenseNames := []string{}
+		licenseSet := make(map[string]bool, len(packageInfos))
+		licenseNames := make([]string, 0, len(packageInfos))
 		for _, info := range packageInfos {
 			if found := licenseSet[info.license]; !found {
 				licenseNames = append(licenseNames, info.license)


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

Address last findings for [revive:enforce-map-style](https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#enforce-map-style) and enable this rule.

As we agreed here https://github.com/influxdata/telegraf/issues/15810 and here https://github.com/influxdata/telegraf/pull/15981, we findings found by the following configuration were addressed:
```
      - name: enforce-map-style
        arguments: ["make"]
        exclude: [ "TEST" ]
```

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #15810
