### PR TITLE
chore: Fix `make docs` (lack of space in `sample.conf` for `wavefront`)

### DIFF
--- a/plugins/outputs/wavefront/sample.conf
+++ b/plugins/outputs/wavefront/sample.conf
@@ -70,7 +70,7 @@
   # timeout="10s"
 
   ## MaxIdleConns controls the maximum number of idle (keep-alive) connections
-  ##across all hosts. Zero means unlimited.
+  ## across all hosts. Zero means unlimited.
   # max_idle_conn = 0
 
   ## MaxIdleConnsPerHost, if non-zero, controls the maximum idle (keep-alive)


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

Fix `make docs` (lack of space in `sample.conf` for `wavefront`)
Problem introduced in https://github.com/influxdata/telegraf/pull/16079

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

