### PR TITLE
fix(logger): Avoid setting the log-format default too early

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -123,7 +123,6 @@ func NewConfig() *Config {
 			Interval:                   Duration(10 * time.Second),
 			RoundInterval:              true,
 			FlushInterval:              Duration(10 * time.Second),
-			LogFormat:                  "text",
 			LogfileRotationMaxArchives: 5,
 		},
 

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -227,6 +227,10 @@ func SetupLogging(cfg *Config) error {
 		return fmt.Errorf("invalid deprecated 'logtarget' setting %q", cfg.LogTarget)
 	}
 
+	if cfg.LogFormat == "" {
+		cfg.LogFormat = "text"
+	}
+
 	if cfg.Debug {
 		cfg.logLevel = telegraf.Debug
 	}


### PR DESCRIPTION
## Summary

When using the old `logtarget` setting with `eventlog` we cannot detect if the `logformat` was set because it is already initialized with the `text` default in the agent-config. This PR moves the default handling to later in order to not error if the new `logformat` was not set.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #16100
