### PR TITLE
fix(common.socket): Make sure the scanner buffer matches the read-buffer size

### DIFF
--- a/plugins/common/socket/stream.go
+++ b/plugins/common/socket/stream.go
@@ -335,6 +335,9 @@ func (l *streamListener) read(conn net.Conn, onData CallbackData) error {
 	timeout := time.Duration(l.ReadTimeout)
 
 	scanner := bufio.NewScanner(decoder)
+	if l.ReadBufferSize > bufio.MaxScanTokenSize {
+		scanner.Buffer(make([]byte, l.ReadBufferSize), l.ReadBufferSize)
+	}
 	scanner.Split(l.Splitter)
 	for {
 		// Set the read deadline, if any, then start reading. The read


### PR DESCRIPTION
## Summary

The current socket implementation allows to specify a read-buffer-size used when receiving data. However, when splitting the received message, the scanner currently uses the default scanner buffer size of 64KiB.

This PR makes sure the scanner buffer matches the read-buffer-size if the latter is larger than the default and adds a unit-test for the socket listener.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #16082 
