### PR TITLE
chore(inputs.modbus): Improve modbus error messages

### DIFF
--- a/plugins/inputs/modbus/modbus.go
+++ b/plugins/inputs/modbus/modbus.go
@@ -230,7 +230,7 @@ func (m *Modbus) Gather(acc telegraf.Accumulator) error {
 	for slaveID, requests := range m.requests {
 		m.Log.Debugf("Reading slave %d for %s...", slaveID, m.Controller)
 		if err := m.readSlaveData(slaveID, requests); err != nil {
-			acc.AddError(fmt.Errorf("slave %d: %w", slaveID, err))
+			acc.AddError(fmt.Errorf("host: %s - slave %d: %w", m.Name, slaveID, err))
 			var mbErr *mb.Error
 			if !errors.As(err, &mbErr) || mbErr.ExceptionCode != mb.ExceptionCodeServerDeviceBusy {
 				m.Log.Debugf("Reconnecting to %s...", m.Controller)
@@ -238,7 +238,7 @@ func (m *Modbus) Gather(acc telegraf.Accumulator) error {
 					return fmt.Errorf("disconnecting failed: %w", err)
 				}
 				if err := m.connect(); err != nil {
-					return fmt.Errorf("slave %d: connecting failed: %w", slaveID, err)
+					return fmt.Errorf("host: %s - slave %d: connecting failed: %w", m.Name, slaveID, err)
 				}
 			}
 			continue


### PR DESCRIPTION
## Summary
If debugMode is off, I couldn't see which host the Error generated. Adding the hostname in the error messages makes thinks easier.

## Checklist
- [ x] No AI generated code was used in this PR

## Related issues

resolves #16112
