### PR TITLE
feat(parser.prometheusremotewrite, serializer.prometheusremotewrite): Native histogram support end-to-end

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -91,7 +91,6 @@ require (
 	github.com/gobwas/glob v0.2.3
 	github.com/godbus/dbus/v5 v5.1.0
 	github.com/gofrs/uuid/v5 v5.3.0
-	github.com/gofrs/uuid/v5 v5.2.0
 	github.com/gogo/protobuf v1.3.2
 	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/golang/geo v0.0.0-20190916061304-5b978397cfec

--- a/go.mod
+++ b/go.mod
@@ -91,6 +91,8 @@ require (
 	github.com/gobwas/glob v0.2.3
 	github.com/godbus/dbus/v5 v5.1.0
 	github.com/gofrs/uuid/v5 v5.3.0
+	github.com/gofrs/uuid/v5 v5.2.0
+	github.com/gogo/protobuf v1.3.2
 	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/golang/geo v0.0.0-20190916061304-5b978397cfec
 	github.com/golang/snappy v0.0.4
@@ -341,7 +343,6 @@ require (
 	github.com/goccy/go-json v0.10.3 // indirect
 	github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2 // indirect
 	github.com/gofrs/uuid v4.4.0+incompatible // indirect
-	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v4 v4.5.0 // indirect
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
 	github.com/golang-sql/sqlexp v0.1.0 // indirect

--- a/plugins/parsers/prometheusremotewrite/README.md
+++ b/plugins/parsers/prometheusremotewrite/README.md
@@ -16,6 +16,9 @@ additional configuration options for Prometheus Remote Write Samples.
 
   ## Data format to consume.
   data_format = "prometheusremotewrite"
+
+  ## Whether to parse a native histogram into one Telegraf metric
+  keep_native_histograms_atomic = false
 ```
 
 ## Example Input

--- a/plugins/parsers/prometheusremotewrite/parser.go
+++ b/plugins/parsers/prometheusremotewrite/parser.go
@@ -71,7 +71,7 @@ func (p *Parser) Parse(buf []byte) ([]telegraf.Metric, error) {
 			}
 			if p.KeepNativeHistogramsAtomic {
 				// Ideally, we parse histograms into various fields into a Telegraf metric
-				// but for PoC we just marshall the histogram struct into a json string
+				// but for PoC we just marshall the histogram
 				serialized, err := proto.Marshal(&hp)
 				if err != nil {
 					return nil, fmt.Errorf("failed to marshal histogram: %w", err)

--- a/plugins/parsers/prometheusremotewrite/parser.go
+++ b/plugins/parsers/prometheusremotewrite/parser.go
@@ -13,8 +13,8 @@ import (
 	"github.com/influxdata/telegraf/metric"
 	"github.com/influxdata/telegraf/plugins/parsers"
 
-	_ "github.com/gogo/protobuf/gogoproto"
-	proto "github.com/gogo/protobuf/proto"
+	_ "github.com/gogo/protobuf/gogoproto" // for gogoproto support
+	"github.com/gogo/protobuf/proto"
 )
 
 type Parser struct {

--- a/plugins/parsers/prometheusremotewrite/parser.go
+++ b/plugins/parsers/prometheusremotewrite/parser.go
@@ -1,6 +1,7 @@
 package prometheusremotewrite
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math"
@@ -61,43 +62,23 @@ func (p *Parser) Parse(buf []byte) ([]telegraf.Metric, error) {
 		}
 
 		for _, hp := range ts.Histograms {
-			h := hp.ToFloatHistogram()
-
 			if hp.Timestamp > 0 {
 				t = time.Unix(0, hp.Timestamp*1000000)
 			}
 
+			// instead of parsing into several metrics we should just parse into ONE Telegraf metric
+			// ideally, we parse histograms into various fields into a Telegraf metric
+			// but for PoC we just marshall the histogram struct into a json string
+			serialized, err := json.Marshal(hp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to marshal histogram: %w", err)
+			}
 			fields := map[string]any{
-				metricName + "_sum": h.Sum,
+				metricName: string(serialized),
 			}
-			m := metric.New("prometheus_remote_write", tags, fields, t)
+
+			m := metric.New("prometheus_remote_write", tags, fields, t, telegraf.Histogram)
 			metrics = append(metrics, m)
-
-			fields = map[string]any{
-				metricName + "_count": h.Count,
-			}
-			m = metric.New("prometheus_remote_write", tags, fields, t)
-			metrics = append(metrics, m)
-
-			count := 0.0
-			iter := h.AllBucketIterator()
-			for iter.Next() {
-				bucket := iter.At()
-
-				count = count + bucket.Count
-				fields = map[string]any{
-					metricName: count,
-				}
-
-				localTags := make(map[string]string, len(tags)+1)
-				localTags[metricName+"_le"] = fmt.Sprintf("%g", bucket.Upper)
-				for k, v := range tags {
-					localTags[k] = v
-				}
-
-				m := metric.New("prometheus_remote_write", localTags, fields, t)
-				metrics = append(metrics, m)
-			}
 		}
 	}
 	return metrics, err

--- a/plugins/parsers/prometheusremotewrite/parser.go
+++ b/plugins/parsers/prometheusremotewrite/parser.go
@@ -9,12 +9,10 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/prompb"
 
+	"github.com/gogo/protobuf/proto"
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/metric"
 	"github.com/influxdata/telegraf/plugins/parsers"
-
-	_ "github.com/gogo/protobuf/gogoproto" // for gogoproto support
-	"github.com/gogo/protobuf/proto"
 )
 
 type Parser struct {
@@ -70,8 +68,9 @@ func (p *Parser) Parse(buf []byte) ([]telegraf.Metric, error) {
 				t = time.Unix(0, hp.Timestamp*1000000)
 			}
 			if p.KeepNativeHistogramsAtomic {
-				// Ideally, we parse histograms into various fields into a Telegraf metric
-				// but for PoC we just marshall the histogram
+				// If keeping it atomic, we serialize the histogram into one single Telegraf metric
+				// For now we keep the histogram as a serialized proto
+				// Another option is to convert it to multi-field Telegraf metric
 				serialized, err := proto.Marshal(&hp)
 				if err != nil {
 					return nil, fmt.Errorf("failed to marshal histogram: %w", err)

--- a/plugins/parsers/prometheusremotewrite/parser.go
+++ b/plugins/parsers/prometheusremotewrite/parser.go
@@ -1,7 +1,6 @@
 package prometheusremotewrite
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"math"
@@ -13,6 +12,9 @@ import (
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/metric"
 	"github.com/influxdata/telegraf/plugins/parsers"
+
+	_ "github.com/gogo/protobuf/gogoproto"
+	proto "github.com/gogo/protobuf/proto"
 )
 
 type Parser struct {
@@ -70,7 +72,7 @@ func (p *Parser) Parse(buf []byte) ([]telegraf.Metric, error) {
 			if p.KeepNativeHistogramsAtomic {
 				// Ideally, we parse histograms into various fields into a Telegraf metric
 				// but for PoC we just marshall the histogram struct into a json string
-				serialized, err := json.Marshal(hp)
+				serialized, err := proto.Marshal(&hp)
 				if err != nil {
 					return nil, fmt.Errorf("failed to marshal histogram: %w", err)
 				}

--- a/plugins/serializers/prometheusremotewrite/prometheusremotewrite.go
+++ b/plugins/serializers/prometheusremotewrite/prometheusremotewrite.go
@@ -356,7 +356,8 @@ func getPromTS(name string, labels []prompb.Label, value float64, ts time.Time, 
 	return MakeMetricKey(labelscopy), prompb.TimeSeries{Labels: labelscopy, Samples: sample}
 }
 
-func getPromNativeHistogramTS(name string, labels []prompb.Label, fh prompb.Histogram, ts time.Time, extraLabels ...prompb.Label) (MetricKey, prompb.TimeSeries) {
+func getPromNativeHistogramTS(name string, labels []prompb.Label, fh prompb.Histogram,
+	ts time.Time, extraLabels ...prompb.Label) (MetricKey, prompb.TimeSeries) {
 	labelscopy := make([]prompb.Label, len(labels), len(labels)+1)
 	copy(labelscopy, labels)
 

--- a/plugins/serializers/prometheusremotewrite/prometheusremotewrite.go
+++ b/plugins/serializers/prometheusremotewrite/prometheusremotewrite.go
@@ -16,8 +16,8 @@ import (
 	"github.com/influxdata/telegraf/plugins/serializers"
 	"github.com/influxdata/telegraf/plugins/serializers/prometheus"
 
-	_ "github.com/gogo/protobuf/gogoproto"
-	proto "github.com/gogo/protobuf/proto"
+	_ "github.com/gogo/protobuf/gogoproto" // for gogoproto support
+	"github.com/gogo/protobuf/proto"
 )
 
 type MetricKey uint64

--- a/plugins/serializers/prometheusremotewrite/prometheusremotewrite.go
+++ b/plugins/serializers/prometheusremotewrite/prometheusremotewrite.go
@@ -138,7 +138,17 @@ func (s *Serializer) SerializeBatch(metrics []telegraf.Metric) ([]byte, error) {
 					// This is a native histogram, if all above suffixes are not found
 					// we should unmarshal the json string back
 					var h prompb.Histogram
-					err := json.Unmarshal(field.Value.([]byte), &h)
+					var data []byte
+					switch v := field.Value.(type) {
+					case []byte:
+						data = v
+					case string:
+						data = []byte(v)
+					default:
+						traceAndKeepErr("unexpected type for field.Value: %T", field.Value)
+						continue
+					}
+					err := json.Unmarshal(data, &h)
 					if err != nil {
 						traceAndKeepErr("failed to unmarshal native histogram %q: %w", metricName, err)
 						continue

--- a/plugins/serializers/prometheusremotewrite/prometheusremotewrite.go
+++ b/plugins/serializers/prometheusremotewrite/prometheusremotewrite.go
@@ -207,7 +207,13 @@ func (s *Serializer) SerializeBatch(metrics []telegraf.Metric) ([]byte, error) {
 			// sample then we can skip over it.
 			m, ok := entries[metrickey]
 			if ok {
-				if metric.Time().Before(time.Unix(0, m.Samples[0].Timestamp*1_000_000)) {
+				var timestamp int64
+				if len(m.Samples) > 0 {
+					timestamp = m.Samples[0].Timestamp
+				} else {
+					timestamp = m.Histograms[0].Timestamp
+				}
+				if metric.Time().Before(time.Unix(0, timestamp*1_000_000)) {
 					traceAndKeepErr("metric %q has samples with timestamp %v older than already registered before", metric.Name(), metric.Time())
 					continue
 				}


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

Add a configuration field to `prometheusremotewrite` parser to change its behavior when parsing Prometheus native histogram.

Previously `prometheusremotewrite` parser parses a native histogram into multiple Telegraf metric (the conversion is not lossless and is irreversible); now it parses it into one single Telegraf metric. Correspondingly, add a code path to `prometheusremotewrite` serializer to be able to handle this single Telegraf "native histogram" metric and convert back to Prometheus native histogram. NOTE: logic that handles classic histogram is orthogonal and not changed.

This treatment of native histograms is able to preserve its benefits in terms of correctness guarantee (atomicity, no correctness issue due to write batching) and its performance gain (low cardinality, sparse data structure). More importantly, this means Telegraf can supports native histogram end-to-end: ingest a native histogram and write out a native histogram.

Detailed rationale, including a diagram, please see #16120

## Test

Previously, using a `prometheusremotewrite` HTTP listener v2 input to accept prometheus remote write, and a  `prometheusremotewrite` HTTP output, Telegraf ingests prometheus native histogram but writes out several counters, as if this were a classic histogram.

In the query here, a native histogram get translated into several "bucket" metrics (but without `_bucket` suffix and with a `<metric_name>_le` tag. 

<img width="833" alt="image" src="https://github.com/user-attachments/assets/1b09b5b8-4b89-4597-ac20-301537db5833">

Now, after this PR:

This native histogram now gets correctly written out as a native histogram.

<img width="831" alt="image" src="https://github.com/user-attachments/assets/e20a49df-8b63-440c-8d41-7214d76d1893">

I can add unit test / integration test when the community reaches some agreement on this implementation.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #16120