### PR TITLE
fix(agent): Restore setup order of stateful plugins to Init() then SetState()

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -106,6 +106,11 @@ func (a *Agent) Run(ctx context.Context) error {
 		time.Duration(a.Config.Agent.Interval), a.Config.Agent.Quiet,
 		a.Config.Agent.Hostname, time.Duration(a.Config.Agent.FlushInterval))
 
+	log.Printf("D! [agent] Initializing plugins")
+	if err := a.InitPlugins(); err != nil {
+		return err
+	}
+
 	if a.Config.Persister != nil {
 		log.Printf("D! [agent] Initializing plugin states")
 		if err := a.initPersister(); err != nil {
@@ -117,11 +122,6 @@ func (a *Agent) Run(ctx context.Context) error {
 			}
 			log.Print("I! [agent] State file does not exist... Skip restoring states...")
 		}
-	}
-
-	log.Printf("D! [agent] Initializing plugins")
-	if err := a.InitPlugins(); err != nil {
-		return err
 	}
 
 	startTime := time.Now()

--- a/docs/specs/tsd-003-state-persistence.md
+++ b/docs/specs/tsd-003-state-persistence.md
@@ -31,15 +31,17 @@ It is intended to
 
 The persistence will use the following steps:
 
+- Compute an unique ID for each of the plugin _instances_
+- Startup Telegraf plugins calling `Init()`, etc.
 - Initialize persistence framework with the user specified `statefile` location
   and load the state if present
 - Determine all stateful plugin instances by fulfilling the `StatefulPlugin`
   interface
-- Compute an unique ID for each of the plugin _instances_
 - Restore plugin states (if any) for each plugin ID present in the state-file
-- Startup Telegraf plugins calling `Init()`, etc.
 - Run data-collection etc...
-- On shutdown, query the state of all registered stateful plugins state
+- On shutdown, stopping all Telegraf plugins calling `Stop()` or `Close()`
+  depending on the plugin type
+- Query the state of all registered stateful plugins state
 - Create an overall state-map with the plugin instance ID as a key and the
   serialized plugin state as value.
 - Marshal the overall state-map and store to disk
@@ -85,7 +87,7 @@ for the overall state. On-disk, the overall state of Telegraf is stored as JSON.
 To restore the state of a plugin, the overall Telegraf state is first
 deserialized from the on-disk JSON data and a lookup for the plugin ID is
 performed in the resulting map. The value, if found, is then deserialized to the
-plugin's state data-structure and provided to the plugin before calling `Init()`.
+plugin's state data-structure and provided to the plugin after calling `Init()`.
 
 ## Is / Is-not
 

--- a/plugins/inputs/tail/tail.go
+++ b/plugins/inputs/tail/tail.go
@@ -30,10 +30,6 @@ var sampleConfig string
 
 var once sync.Once
 
-const (
-	defaultWatchMethod = "inotify"
-)
-
 var (
 	offsets      = make(map[string]int64)
 	offsetsMutex = new(sync.Mutex)

--- a/plugins/processors/starlark/starlark.go
+++ b/plugins/processors/starlark/starlark.go
@@ -120,8 +120,7 @@ func (s *Starlark) Add(origMetric telegraf.Metric, acc telegraf.Accumulator) err
 	return nil
 }
 
-func (s *Starlark) Stop() {
-}
+func (s *Starlark) Stop() {}
 
 func containsMetric(metrics []telegraf.Metric, target telegraf.Metric) bool {
 	for _, m := range metrics {

--- a/plugins/processors/starlark/starlark_test.go
+++ b/plugins/processors/starlark/starlark_test.go
@@ -3681,13 +3681,13 @@ def apply(metric):
 			Log:              testutil.Logger{},
 		},
 	}
+	require.NoError(t, plugin.Init())
 
 	// Setup the "persisted" state
 	var pi telegraf.StatefulPlugin = plugin
 	var buf bytes.Buffer
 	require.NoError(t, gob.NewEncoder(&buf).Encode(map[string]interface{}{"instance": "myhost"}))
 	require.NoError(t, pi.SetState(buf.Bytes()))
-	require.NoError(t, plugin.Init())
 
 	var acc testutil.Accumulator
 	require.NoError(t, plugin.Start(&acc))


### PR DESCRIPTION
## Summary

PR #15170 changed the startup sequence of stateful plugins from `Init -> SetState` to `SetState -> Init` and in turn broke all stateful users (`inputs.tail`, `inputs.docker_log`, `inputs.win_eventlog` and `processors.dedup`) to make starlark state-persistence work.

As a code sequence of `Init -> SetState` is the expected behavior and what works for all previous users, this PR restores the old order and fixes `common.starlark` to also work with this sequencing. The PR furthermore adds unit-tests where possible to make sure the sequence works. Last but not least, the PR updates the spec and also defines the shutdown order to be `Close/Stop -> GetState`.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #16037 
