### PR TITLE
feat(inputs.ipset): Add metric for number of entries and individual IPs

### DIFF
--- a/plugins/inputs/ipset/README.md
+++ b/plugins/inputs/ipset/README.md
@@ -66,7 +66,7 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
     ## the telegraf.service systemd service.
     use_sudo = false
     ## Add number of entries and number of individual IPs (resolve CIDR syntax) for each ipset
-    add_num_entries = false
+    count_per_ip_entries = false
     ## The default timeout of 1s for ipset execution can be overridden here:
     # timeout = "1s"
 ```

--- a/plugins/inputs/ipset/README.md
+++ b/plugins/inputs/ipset/README.md
@@ -65,9 +65,10 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
     ## You can avoid using sudo or root, by setting appropriate privileges for
     ## the telegraf.service systemd service.
     use_sudo = false
+    ## Add number of entries and number of individual IPs (resolve CIDR syntax) for each ipset
+    add_num_entries = false
     ## The default timeout of 1s for ipset execution can be overridden here:
     # timeout = "1s"
-
 ```
 
 ## Metrics

--- a/plugins/inputs/ipset/ipset.go
+++ b/plugins/inputs/ipset/ipset.go
@@ -60,7 +60,10 @@ func (i *Ipset) Gather(acc telegraf.Accumulator) error {
 		line := scanner.Text()
 
 		if i.CountPerIPEntries {
-			i.entriesParser.addLine(line, acc)
+			err := i.entriesParser.addLine(line, acc)
+			if err != nil {
+				acc.AddError(err)
+			}
 		}
 
 		// Ignore sets created without the "counters" option
@@ -143,9 +146,8 @@ func setList(timeout config.Duration, useSudo bool) (*bytes.Buffer, error) {
 func init() {
 	inputs.Add("ipset", func() telegraf.Input {
 		return &Ipset{
-			lister:        setList,
-			entriesParser: ipsetEntries{},
-			Timeout:       defaultTimeout,
+			lister:  setList,
+			Timeout: defaultTimeout,
 		}
 	})
 }

--- a/plugins/inputs/ipset/ipset.go
+++ b/plugins/inputs/ipset/ipset.go
@@ -60,8 +60,7 @@ func (i *Ipset) Gather(acc telegraf.Accumulator) error {
 		line := scanner.Text()
 
 		if i.CountPerIPEntries {
-			err := i.entriesParser.addLine(line, acc)
-			acc.AddError(err)
+			acc.AddError(i.entriesParser.addLine(line, acc))
 		}
 
 		// Ignore sets created without the "counters" option

--- a/plugins/inputs/ipset/ipset.go
+++ b/plugins/inputs/ipset/ipset.go
@@ -61,9 +61,7 @@ func (i *Ipset) Gather(acc telegraf.Accumulator) error {
 
 		if i.CountPerIPEntries {
 			err := i.entriesParser.addLine(line, acc)
-			if err != nil {
-				acc.AddError(err)
-			}
+			acc.AddError(err)
 		}
 
 		// Ignore sets created without the "counters" option

--- a/plugins/inputs/ipset/ipset_entries.go
+++ b/plugins/inputs/ipset/ipset_entries.go
@@ -1,0 +1,88 @@
+//go:generate ../../../tools/readme_config_includer/generator
+package ipset
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+
+	"github.com/influxdata/telegraf"
+)
+
+type IpsetEntries struct {
+	acc          telegraf.Accumulator
+	initizalized bool
+	setName      string
+	numEntries   int
+	numIps       int
+}
+
+func NewIpsetEntries(acc telegraf.Accumulator) *IpsetEntries {
+	return &IpsetEntries{acc: acc}
+}
+
+func getCountInCidr(cidr string) (int, error) {
+	_, ipNet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		// check if single IP
+		if net.ParseIP(cidr) == nil {
+			return 0, errors.New("invalid IP address format. Not CIDR format and not a single IP address")
+		}
+		return 1, nil // Single IP has only one address
+	}
+
+	ones, bits := ipNet.Mask.Size()
+	if ones == 0 && bits == 0 {
+		return 0, errors.New("invalid CIDR range")
+	}
+	numIps := 1 << (bits - ones)
+
+	// exclude network and broadcast addresses if IPv4 and range > /31
+	if bits == 32 && numIps > 2 {
+		numIps -= 2
+	}
+
+	return numIps, nil
+}
+
+func (counter *IpsetEntries) reset(setName string) {
+	counter.initizalized = true
+	counter.setName = setName
+	counter.numEntries = 0
+	counter.numIps = 0
+}
+
+func (counter *IpsetEntries) addLine(line string) {
+	data := strings.Fields(line)
+	if strings.HasPrefix(line, "create ") {
+		counter.commit()
+		counter.reset(data[1])
+	} else if strings.HasPrefix(line, "add ") {
+		counter.numEntries++
+
+		ip := data[2]
+		count, err := getCountInCidr(ip)
+		if err != nil {
+			fmt.Println("Error:", err)
+			return
+		}
+		counter.numIps += count
+	}
+}
+
+func (counter *IpsetEntries) commit() {
+	if !counter.initizalized {
+		return
+	}
+
+	fields := make(map[string]interface{}, 3)
+	fields["num_entries"] = counter.numEntries
+	fields["num_ips"] = counter.numIps
+
+	tags := map[string]string{
+		"set": counter.setName,
+	}
+
+	counter.acc.AddGauge(measurement, fields, tags)
+}

--- a/plugins/inputs/ipset/ipset_entries_test.go
+++ b/plugins/inputs/ipset/ipset_entries_test.go
@@ -44,7 +44,7 @@ func TestIpsetEntries(t *testing.T) {
 }
 
 func TestIpsetEntriesCidr(t *testing.T) {
-	acc := new(testutil.Accumulator)
+	var acc testutil.Accumulator
 
 	lines := []string{
 		"create mylist0 hash:net family inet hashsize 16384 maxelem 131072 timeout 300 bucketsize 12 initval 0x4effa9ad",

--- a/plugins/inputs/ipset/ipset_entries_test.go
+++ b/plugins/inputs/ipset/ipset_entries_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestIpsetEntries(t *testing.T) {
-	acc := new(testutil.Accumulator)
+	var acc testutil.Accumulator
 
 	lines := []string{
 		"create mylist hash:net family inet hashsize 16384 maxelem 131072 timeout 300 bucketsize 12 initval 0x4effa9ad",

--- a/plugins/inputs/ipset/ipset_entries_test.go
+++ b/plugins/inputs/ipset/ipset_entries_test.go
@@ -21,9 +21,9 @@ func TestIpsetEntries(t *testing.T) {
 
 	entries := ipsetEntries{}
 	for _, line := range lines {
-		require.NoError(t, entries.addLine(line, acc))
+		require.NoError(t, entries.addLine(line, &acc))
 	}
-	entries.commit(acc)
+	entries.commit(&acc)
 
 	expected := []telegraf.Metric{
 		testutil.MustMetric(

--- a/plugins/inputs/ipset/ipset_entries_test.go
+++ b/plugins/inputs/ipset/ipset_entries_test.go
@@ -12,10 +12,21 @@ func TestIpsetEntries(t *testing.T) {
 	acc := new(testutil.Accumulator)
 
 	i := ipsetEntries{}
-	i.addLine("create mylist hash:net family inet hashsize 16384 maxelem 131072 timeout 300 bucketsize 12 initval 0x4effa9ad", acc)
-	i.addLine("add mylist 89.101.238.143 timeout 161558", acc)
-	i.addLine("add mylist 122.224.15.166 timeout 186758", acc)
-	i.addLine("add mylist 47.128.40.145 timeout 431559", acc)
+	if i.addLine("create mylist hash:net family inet hashsize 16384 maxelem 131072 timeout 300 bucketsize 12 initval 0x4effa9ad", acc) != nil {
+		t.Error("addLine returned an error")
+	}
+
+	if i.addLine("add mylist 89.101.238.143 timeout 161558", acc) != nil {
+		t.Error("addLine returned an error")
+	}
+
+	if i.addLine("add mylist 122.224.15.166 timeout 186758", acc) != nil {
+		t.Error("addLine returned an error")
+	}
+
+	if i.addLine("add mylist 47.128.40.145 timeout 431559", acc) != nil {
+		t.Error("addLine returned an error")
+	}
 
 	i.commit(acc)
 
@@ -41,16 +52,42 @@ func TestIpsetEntriesCidr(t *testing.T) {
 	acc := new(testutil.Accumulator)
 
 	i := ipsetEntries{}
-	i.addLine("create mylist0 hash:net family inet hashsize 16384 maxelem 131072 timeout 300 bucketsize 12 initval 0x4effa9ad", acc)
-	i.addLine("add mylist0 89.101.238.143 timeout 161558", acc)
-	i.addLine("add mylist0 122.224.5.0/24 timeout 186758", acc)
-	i.addLine("add mylist0 47.128.40.145 timeout 431559", acc)
 
-	i.addLine("create mylist1 hash:net family inet hashsize 16384 maxelem 131072 timeout 300 bucketsize 12 initval 0x4effa9ad", acc)
-	i.addLine("add mylist1 90.101.238.143 timeout 161558", acc)
-	i.addLine("add mylist1 44.128.40.145 timeout 431559", acc)
-	i.addLine("add mylist1 122.224.5.0/8 timeout 186758", acc)
-	i.addLine("add mylist1 45.128.40.145 timeout 431559", acc)
+	if i.addLine("create mylist0 hash:net family inet hashsize 16384 maxelem 131072 timeout 300 bucketsize 12 initval 0x4effa9ad", acc) != nil {
+		t.Error("addLine returned an error")
+	}
+
+	if i.addLine("add mylist0 89.101.238.143 timeout 161558", acc) != nil {
+		t.Error("addLine returned an error")
+	}
+
+	if i.addLine("add mylist0 122.224.5.0/24 timeout 186758", acc) != nil {
+		t.Error("addLine returned an error")
+	}
+
+	if i.addLine("add mylist0 47.128.40.145 timeout 431559", acc) != nil {
+		t.Error("addLine returned an error")
+	}
+
+	if i.addLine("create mylist1 hash:net family inet hashsize 16384 maxelem 131072 timeout 300 bucketsize 12 initval 0x4effa9ad", acc) != nil {
+		t.Error("addLine returned an error")
+	}
+
+	if i.addLine("add mylist1 90.101.238.143 timeout 161558", acc) != nil {
+		t.Error("addLine returned an error")
+	}
+
+	if i.addLine("add mylist1 44.128.40.145 timeout 431559", acc) != nil {
+		t.Error("addLine returned an error")
+	}
+
+	if i.addLine("add mylist1 122.224.5.0/8 timeout 186758", acc) != nil {
+		t.Error("addLine returned an error")
+	}
+
+	if i.addLine("add mylist1 45.128.40.145 timeout 431559", acc) != nil {
+		t.Error("addLine returned an error")
+	}
 
 	i.commit(acc)
 

--- a/plugins/inputs/ipset/ipset_entries_test.go
+++ b/plugins/inputs/ipset/ipset_entries_test.go
@@ -1,0 +1,64 @@
+package ipset
+
+import (
+	"testing"
+
+	"github.com/influxdata/telegraf/testutil"
+)
+
+func assertIpsetEntries(t *testing.T, acc *testutil.Accumulator, numMetrics int, numEntries []int, numIps []int) {
+	if len(acc.Errors) > 0 {
+		t.Errorf("Errors in Accumulator")
+	}
+
+	if len(acc.Metrics) != numMetrics {
+		t.Errorf("Expected %d metric", numMetrics)
+	}
+
+	for index := range numEntries {
+		if len(acc.Metrics[index].Fields) != 2 {
+			t.Errorf("Expected 2 fields")
+		}
+		if acc.Metrics[index].Fields["num_entries"] != numEntries[index] {
+			t.Errorf("Expected num_entries length to be %d", numEntries[index])
+		}
+
+		if acc.Metrics[index].Fields["num_ips"] != numIps[index] {
+			t.Errorf("Expected num_ips length to be %d", numIps[index])
+		}
+	}
+}
+
+func TestIpsetEntries(t *testing.T) {
+	acc := new(testutil.Accumulator)
+
+	i := NewIpsetEntries(acc)
+	i.addLine("create mylist hash:net family inet hashsize 16384 maxelem 131072 timeout 300 bucketsize 12 initval 0x4effa9ad")
+	i.addLine("add mylist 89.101.238.143 timeout 161558")
+	i.addLine("add mylist 122.224.15.166 timeout 186758")
+	i.addLine("add mylist 47.128.40.145 timeout 431559")
+
+	i.commit()
+
+	assertIpsetEntries(t, acc, 1, []int{3}, []int{3})
+}
+
+func TestIpsetEntriesCidr(t *testing.T) {
+	acc := new(testutil.Accumulator)
+
+	i := NewIpsetEntries(acc)
+	i.addLine("create mylist0 hash:net family inet hashsize 16384 maxelem 131072 timeout 300 bucketsize 12 initval 0x4effa9ad")
+	i.addLine("add mylist0 89.101.238.143 timeout 161558")
+	i.addLine("add mylist0 122.224.5.0/24 timeout 186758")
+	i.addLine("add mylist0 47.128.40.145 timeout 431559")
+
+	i.addLine("create mylist1 hash:net family inet hashsize 16384 maxelem 131072 timeout 300 bucketsize 12 initval 0x4effa9ad")
+	i.addLine("add mylist1 90.101.238.143 timeout 161558")
+	i.addLine("add mylist1 44.128.40.145 timeout 431559")
+	i.addLine("add mylist1 122.224.5.0/8 timeout 186758")
+	i.addLine("add mylist1 45.128.40.145 timeout 431559")
+
+	i.commit()
+
+	assertIpsetEntries(t, acc, 2, []int{3, 4}, []int{256, 16777217})
+}

--- a/plugins/inputs/ipset/ipset_entries_test.go
+++ b/plugins/inputs/ipset/ipset_entries_test.go
@@ -2,63 +2,84 @@ package ipset
 
 import (
 	"testing"
+	"time"
 
+	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/testutil"
 )
-
-func assertIpsetEntries(t *testing.T, acc *testutil.Accumulator, numMetrics int, numEntries []int, numIps []int) {
-	if len(acc.Errors) > 0 {
-		t.Errorf("Errors in Accumulator")
-	}
-
-	if len(acc.Metrics) != numMetrics {
-		t.Errorf("Expected %d metric", numMetrics)
-	}
-
-	for index := range numEntries {
-		if len(acc.Metrics[index].Fields) != 2 {
-			t.Errorf("Expected 2 fields")
-		}
-		if acc.Metrics[index].Fields["num_entries"] != numEntries[index] {
-			t.Errorf("Expected num_entries length to be %d", numEntries[index])
-		}
-
-		if acc.Metrics[index].Fields["num_ips"] != numIps[index] {
-			t.Errorf("Expected num_ips length to be %d", numIps[index])
-		}
-	}
-}
 
 func TestIpsetEntries(t *testing.T) {
 	acc := new(testutil.Accumulator)
 
-	i := NewIpsetEntries(acc)
-	i.addLine("create mylist hash:net family inet hashsize 16384 maxelem 131072 timeout 300 bucketsize 12 initval 0x4effa9ad")
-	i.addLine("add mylist 89.101.238.143 timeout 161558")
-	i.addLine("add mylist 122.224.15.166 timeout 186758")
-	i.addLine("add mylist 47.128.40.145 timeout 431559")
+	i := ipsetEntries{}
+	i.addLine("create mylist hash:net family inet hashsize 16384 maxelem 131072 timeout 300 bucketsize 12 initval 0x4effa9ad", acc)
+	i.addLine("add mylist 89.101.238.143 timeout 161558", acc)
+	i.addLine("add mylist 122.224.15.166 timeout 186758", acc)
+	i.addLine("add mylist 47.128.40.145 timeout 431559", acc)
 
-	i.commit()
+	i.commit(acc)
 
-	assertIpsetEntries(t, acc, 1, []int{3}, []int{3})
+	expected := []telegraf.Metric{
+		testutil.MustMetric(
+			"ipset",
+			map[string]string{
+				"set": "mylist",
+			},
+			map[string]interface{}{
+				"entries": 3,
+				"ips":     3,
+			},
+			time.Unix(0, 0),
+			telegraf.Gauge,
+		),
+	}
+
+	testutil.RequireMetricsEqual(t, expected, acc.GetTelegrafMetrics(), testutil.IgnoreTime())
 }
 
 func TestIpsetEntriesCidr(t *testing.T) {
 	acc := new(testutil.Accumulator)
 
-	i := NewIpsetEntries(acc)
-	i.addLine("create mylist0 hash:net family inet hashsize 16384 maxelem 131072 timeout 300 bucketsize 12 initval 0x4effa9ad")
-	i.addLine("add mylist0 89.101.238.143 timeout 161558")
-	i.addLine("add mylist0 122.224.5.0/24 timeout 186758")
-	i.addLine("add mylist0 47.128.40.145 timeout 431559")
+	i := ipsetEntries{}
+	i.addLine("create mylist0 hash:net family inet hashsize 16384 maxelem 131072 timeout 300 bucketsize 12 initval 0x4effa9ad", acc)
+	i.addLine("add mylist0 89.101.238.143 timeout 161558", acc)
+	i.addLine("add mylist0 122.224.5.0/24 timeout 186758", acc)
+	i.addLine("add mylist0 47.128.40.145 timeout 431559", acc)
 
-	i.addLine("create mylist1 hash:net family inet hashsize 16384 maxelem 131072 timeout 300 bucketsize 12 initval 0x4effa9ad")
-	i.addLine("add mylist1 90.101.238.143 timeout 161558")
-	i.addLine("add mylist1 44.128.40.145 timeout 431559")
-	i.addLine("add mylist1 122.224.5.0/8 timeout 186758")
-	i.addLine("add mylist1 45.128.40.145 timeout 431559")
+	i.addLine("create mylist1 hash:net family inet hashsize 16384 maxelem 131072 timeout 300 bucketsize 12 initval 0x4effa9ad", acc)
+	i.addLine("add mylist1 90.101.238.143 timeout 161558", acc)
+	i.addLine("add mylist1 44.128.40.145 timeout 431559", acc)
+	i.addLine("add mylist1 122.224.5.0/8 timeout 186758", acc)
+	i.addLine("add mylist1 45.128.40.145 timeout 431559", acc)
 
-	i.commit()
+	i.commit(acc)
 
-	assertIpsetEntries(t, acc, 2, []int{3, 4}, []int{256, 16777217})
+	expected := []telegraf.Metric{
+		testutil.MustMetric(
+			"ipset",
+			map[string]string{
+				"set": "mylist0",
+			},
+			map[string]interface{}{
+				"entries": 3,
+				"ips":     256,
+			},
+			time.Now().Add(time.Millisecond*0),
+			telegraf.Gauge,
+		),
+		testutil.MustMetric(
+			"ipset",
+			map[string]string{
+				"set": "mylist1",
+			},
+			map[string]interface{}{
+				"entries": 4,
+				"ips":     16777217,
+			},
+			time.Unix(0, 0),
+			telegraf.Gauge,
+		),
+	}
+
+	testutil.RequireMetricsEqual(t, expected, acc.GetTelegrafMetrics(), testutil.IgnoreTime())
 }

--- a/plugins/inputs/ipset/ipset_entries_test.go
+++ b/plugins/inputs/ipset/ipset_entries_test.go
@@ -61,9 +61,9 @@ func TestIpsetEntriesCidr(t *testing.T) {
 
 	entries := ipsetEntries{}
 	for _, line := range lines {
-		require.NoError(t, entries.addLine(line, acc))
+		require.NoError(t, entries.addLine(line, &acc))
 	}
-	entries.commit(acc)
+	entries.commit(&acc)
 
 	expected := []telegraf.Metric{
 		testutil.MustMetric(

--- a/plugins/inputs/ipset/sample.conf
+++ b/plugins/inputs/ipset/sample.conf
@@ -8,6 +8,6 @@
     ## the telegraf.service systemd service.
     use_sudo = false
     ## Add number of entries and number of individual IPs (resolve CIDR syntax) for each ipset
-    add_num_entries = false
+    count_per_ip_entries = false
     ## The default timeout of 1s for ipset execution can be overridden here:
     # timeout = "1s"

--- a/plugins/inputs/ipset/sample.conf
+++ b/plugins/inputs/ipset/sample.conf
@@ -7,6 +7,7 @@
     ## You can avoid using sudo or root, by setting appropriate privileges for
     ## the telegraf.service systemd service.
     use_sudo = false
+    ## Add number of entries and number of individual IPs (resolve CIDR syntax) for each ipset
+    add_num_entries = false
     ## The default timeout of 1s for ipset execution can be overridden here:
     # timeout = "1s"
-


### PR DESCRIPTION
## Summary
Some automatic blacklist systems (like e.g. FireHOL) are feeding known malicious IP addresses regularly into ipsets to be blocked by firewalls (e.g. iptables/nftables). It would be useful to be able to track the number of entries of such ipsets over time.

As entries can use CIDR notation to target a range of IPs (e.g. 10.12.4.0/8) with a single ipset entry, it is also useful to see the number of actualy IPs affected by one ipset.


## Checklist
- [x] No AI generated code was used in this PR

## Related issues
resolves #16103 