### PR TITLE
fix(inputs.snmp_trap): Remove timeout deprecation

### DIFF
--- a/plugins/inputs/snmp_trap/README.md
+++ b/plugins/inputs/snmp_trap/README.md
@@ -62,8 +62,8 @@ details.
   ## To add paths when translating with netsnmp, use the MIBDIRS environment variable
   # path = ["/usr/share/snmp/mibs"]
   ##
-  ## Deprecated in 1.20.0; no longer running snmptranslate
   ## Timeout running snmptranslate command
+  ## Used by the netsnmp translator
   # timeout = "5s"
   ## Snmp version; one of "1", "2c" or "3".
   # version = "2c"

--- a/plugins/inputs/snmp_trap/README.md
+++ b/plugins/inputs/snmp_trap/README.md
@@ -63,7 +63,7 @@ details.
   # path = ["/usr/share/snmp/mibs"]
   ##
   ## Timeout running snmptranslate command
-  ## Used by the netsnmp translator
+  ## Used by the netsnmp translator only
   # timeout = "5s"
   ## Snmp version; one of "1", "2c" or "3".
   # version = "2c"

--- a/plugins/inputs/snmp_trap/sample.conf
+++ b/plugins/inputs/snmp_trap/sample.conf
@@ -14,8 +14,8 @@
   ## To add paths when translating with netsnmp, use the MIBDIRS environment variable
   # path = ["/usr/share/snmp/mibs"]
   ##
-  ## Deprecated in 1.20.0; no longer running snmptranslate
   ## Timeout running snmptranslate command
+  ## Used by the netsnmp translator
   # timeout = "5s"
   ## Snmp version; one of "1", "2c" or "3".
   # version = "2c"

--- a/plugins/inputs/snmp_trap/sample.conf
+++ b/plugins/inputs/snmp_trap/sample.conf
@@ -15,7 +15,7 @@
   # path = ["/usr/share/snmp/mibs"]
   ##
   ## Timeout running snmptranslate command
-  ## Used by the netsnmp translator
+  ## Used by the netsnmp translator only
   # timeout = "5s"
   ## Snmp version; one of "1", "2c" or "3".
   # version = "2c"

--- a/plugins/inputs/snmp_trap/snmp_trap.go
+++ b/plugins/inputs/snmp_trap/snmp_trap.go
@@ -43,7 +43,7 @@ func (l wrapLog) Print(args ...interface{}) {
 
 type SnmpTrap struct {
 	ServiceAddress string          `toml:"service_address"`
-	Timeout        config.Duration `toml:"timeout" deprecated:"1.20.0;1.35.0;unused option"`
+	Timeout        config.Duration `toml:"timeout"`
 	Version        string          `toml:"version"`
 	Translator     string          `toml:"-"`
 	Path           []string        `toml:"path"`

--- a/plugins/inputs/snmp_trap/snmp_trap.go
+++ b/plugins/inputs/snmp_trap/snmp_trap.go
@@ -84,6 +84,7 @@ func init() {
 		return &SnmpTrap{
 			timeFunc:       time.Now,
 			ServiceAddress: "udp://:162",
+			Timeout:        defaultTimeout,
 			Path:           []string{"/usr/share/snmp/mibs"},
 			Version:        "2c",
 		}
@@ -103,9 +104,6 @@ func (s *SnmpTrap) Init() error {
 			return err
 		}
 	case "netsnmp":
-		if s.Timeout == 0 {
-			s.Timeout = defaultTimeout
-		}
 		s.transl = newNetsnmpTranslator(s.Timeout)
 	default:
 		return errors.New("invalid translator value")

--- a/plugins/inputs/snmp_trap/snmp_trap.go
+++ b/plugins/inputs/snmp_trap/snmp_trap.go
@@ -84,7 +84,6 @@ func init() {
 		return &SnmpTrap{
 			timeFunc:       time.Now,
 			ServiceAddress: "udp://:162",
-			Timeout:        defaultTimeout,
 			Path:           []string{"/usr/share/snmp/mibs"},
 			Version:        "2c",
 		}
@@ -104,6 +103,9 @@ func (s *SnmpTrap) Init() error {
 			return err
 		}
 	case "netsnmp":
+		if s.Timeout == 0 {
+			s.Timeout = defaultTimeout
+		}
 		s.transl = newNetsnmpTranslator(s.Timeout)
 	default:
 		return errors.New("invalid translator value")


### PR DESCRIPTION
## Summary
Removes the "unused" deprecation from the timeout field as it is still used

## Checklist
- [X] No AI generated code was used in this PR

## Related issues
resolves #16137
