### PR TITLE
chore(inputs.leofs): Deprecate plugin and add migration to inputs.snmp

### DIFF
--- a/migrations/inputs_leofs/migration.go
+++ b/migrations/inputs_leofs/migration.go
@@ -1,0 +1,50 @@
+package inputs_leofs
+
+import (
+	"fmt"
+
+	"github.com/influxdata/toml"
+	"github.com/influxdata/toml/ast"
+
+	"github.com/influxdata/telegraf/migrations"
+	"github.com/influxdata/telegraf/migrations/common"
+)
+
+type leofs struct {
+	Servers []string `toml:"servers"`
+	common.InputOptions
+}
+
+func migrate(tbl *ast.Table) ([]byte, string, error) {
+	var old leofs
+	if err := toml.UnmarshalTable(tbl, &old); err != nil {
+		return nil, "", err
+	}
+
+	plugin := make(map[string]interface{})
+	old.InputOptions.Migrate()
+	general, err := toml.Marshal(old.InputOptions)
+	if err != nil {
+		return nil, "", fmt.Errorf("marshalling general options failed: %w", err)
+	}
+	if err := toml.Unmarshal(general, &plugin); err != nil {
+		return nil, "", fmt.Errorf("re-unmarshalling general options failed: %w", err)
+	}
+
+	plugin["agents"] = old.Servers
+
+	cfg := migrations.CreateTOMLStruct("inputs", "snmp")
+	cfg.Add("inputs", "snmp", plugin)
+
+	buf, err := toml.Marshal(cfg)
+	if err != nil {
+		return nil, "", err
+	}
+	buf = append(buf, []byte("\n")...)
+
+	return buf, "", nil
+}
+
+func init() {
+	migrations.AddPluginMigration("inputs.leofs", migrate)
+}

--- a/plugins/inputs/deprecations.go
+++ b/plugins/inputs/deprecations.go
@@ -49,6 +49,11 @@ var Deprecations = map[string]telegraf.DeprecationInfo{
 		RemovalIn: "1.35.0",
 		Notice:    "has been renamed to 'knx_listener'",
 	},
+	"leofs": {
+		Since:     "1.33.0",
+		RemovalIn: "1.40.0",
+		Notice:    "use 'snmp' instead",
+	},
 	"logparser": {
 		Since:     "1.15.0",
 		RemovalIn: "1.35.0",


### PR DESCRIPTION
## Summary
Deprecates the `inputs.leofs` plugin and adds a config migration to the `inputs.snmp` plugin

## Checklist
- [X] No AI generated code was used in this PR

## Related issues
resolves #9927
