### PR TITLE
fix(inputs.snmp): Fix crash when trying to format fields from unknown OIDs

### DIFF
--- a/internal/snmp/translator_gosmi.go
+++ b/internal/snmp/translator_gosmi.go
@@ -64,6 +64,10 @@ func (g *gosmiTranslator) SnmpFormatEnum(oid string, value interface{}, full boo
 		return "", err
 	}
 
+	if node.Type == nil {
+		return "", fmt.Errorf("cannot format %v as enum, unkown OID", oid)
+	}
+
 	var v models.Value
 	if full {
 		v = node.FormatValue(value, models.FormatEnumName, models.FormatEnumValue)
@@ -71,7 +75,7 @@ func (g *gosmiTranslator) SnmpFormatEnum(oid string, value interface{}, full boo
 		v = node.FormatValue(value, models.FormatEnumName)
 	}
 
-	return v.Formatted, nil
+	return v.String(), nil
 }
 
 func (g *gosmiTranslator) SnmpFormatDisplayHint(oid string, value interface{}) (string, error) {
@@ -85,9 +89,11 @@ func (g *gosmiTranslator) SnmpFormatDisplayHint(oid string, value interface{}) (
 		return "", err
 	}
 
-	v := node.FormatValue(value)
+	if node.Type == nil {
+		return "", fmt.Errorf("cannot format %v as displayhint, unkown OID", oid)
+	}
 
-	return v.Formatted, nil
+	return node.FormatValue(value).String(), nil
 }
 
 func getIndex(mibPrefix string, node gosmi.SmiNode) (col []string, tagOids map[string]struct{}) {

--- a/internal/snmp/translator_gosmi.go
+++ b/internal/snmp/translator_gosmi.go
@@ -12,6 +12,8 @@ import (
 	"github.com/influxdata/telegraf"
 )
 
+var errCannotFormatUnkownType = errors.New("cannot format value, unknown type")
+
 type gosmiTranslator struct {
 }
 
@@ -65,7 +67,7 @@ func (g *gosmiTranslator) SnmpFormatEnum(oid string, value interface{}, full boo
 	}
 
 	if node.Type == nil {
-		return "", fmt.Errorf("cannot format %v as enum, unkown OID", oid)
+		return "", errCannotFormatUnkownType
 	}
 
 	var v models.Value
@@ -90,7 +92,7 @@ func (g *gosmiTranslator) SnmpFormatDisplayHint(oid string, value interface{}) (
 	}
 
 	if node.Type == nil {
-		return "", fmt.Errorf("cannot format %v as displayhint, unkown OID", oid)
+		return "", errCannotFormatUnkownType
 	}
 
 	return node.FormatValue(value).String(), nil


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Check if the returned `Node` actually has a `Type` object.


## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #16153
