### PR TITLE
fix(common.socket): Use read buffer size config setting as a datagram reader buffer size.

### DIFF
--- a/plugins/common/socket/datagram.go
+++ b/plugins/common/socket/datagram.go
@@ -49,7 +49,7 @@ func (l *packetListener) listenData(onData CallbackData, onError CallbackError) 
 	go func() {
 		defer l.wg.Done()
 
-		buf := make([]byte, 64*1024) // 64kb - maximum size of IP packet
+		buf := make([]byte, l.ReadBufferSize)
 		for {
 			n, src, err := l.conn.ReadFrom(buf)
 			receiveTime := time.Now()
@@ -88,7 +88,7 @@ func (l *packetListener) listenConnection(onConnection CallbackConnection, onErr
 		defer l.wg.Done()
 		defer l.conn.Close()
 
-		buf := make([]byte, 64*1024) // 64kb - maximum size of IP packet
+		buf := make([]byte, l.ReadBufferSize)
 		for {
 			// Wait for packets and read them
 			n, src, err := l.conn.ReadFrom(buf)
@@ -133,7 +133,7 @@ func (l *packetListener) listenConnection(onConnection CallbackConnection, onErr
 	}()
 }
 
-func (l *packetListener) setupUnixgram(u *url.URL, socketMode string) error {
+func (l *packetListener) setupUnixgram(u *url.URL, socketMode string, bufferSize int) error {
 	l.path = filepath.FromSlash(u.Path)
 	if runtime.GOOS == "windows" && strings.Contains(l.path, ":") {
 		l.path = strings.TrimPrefix(l.path, `\`)
@@ -161,6 +161,10 @@ func (l *packetListener) setupUnixgram(u *url.URL, socketMode string) error {
 			return fmt.Errorf("changing socket permissions failed: %w", err)
 		}
 	}
+
+    if bufferSize > 0 {
+        l.ReadBufferSize = bufferSize
+    }
 
 	return l.setupDecoder()
 }
@@ -194,8 +198,9 @@ func (l *packetListener) setupUDP(u *url.URL, ifname string, bufferSize int) err
 
 	if bufferSize > 0 {
 		if err := conn.SetReadBuffer(bufferSize); err != nil {
-			l.Log.Warnf("Setting read buffer on %s socket failed: %v", u.Scheme, err)
+			l.Log.Errorf("Setting read buffer on %s socket failed: %v", u.Scheme, err)
 		}
+        l.ReadBufferSize = bufferSize
 	}
 
 	l.conn = conn

--- a/plugins/common/socket/datagram.go
+++ b/plugins/common/socket/datagram.go
@@ -164,6 +164,8 @@ func (l *packetListener) setupUnixgram(u *url.URL, socketMode string, bufferSize
 
 	if bufferSize > 0 {
 		l.ReadBufferSize = bufferSize
+	} else {
+		l.ReadBufferSize = 64 * 1024 // 64kb - IP packet size
 	}
 
 	return l.setupDecoder()
@@ -198,9 +200,11 @@ func (l *packetListener) setupUDP(u *url.URL, ifname string, bufferSize int) err
 
 	if bufferSize > 0 {
 		if err := conn.SetReadBuffer(bufferSize); err != nil {
-			l.Log.Errorf("Setting read buffer on %s socket failed: %v", u.Scheme, err)
+			l.Log.Warnf("Setting read buffer on %s socket failed: %v", u.Scheme, err)
 		}
 		l.ReadBufferSize = bufferSize
+	} else {
+		l.ReadBufferSize = 64 * 1024 // 64kb - IP packet size
 	}
 
 	l.conn = conn

--- a/plugins/common/socket/datagram.go
+++ b/plugins/common/socket/datagram.go
@@ -162,9 +162,9 @@ func (l *packetListener) setupUnixgram(u *url.URL, socketMode string, bufferSize
 		}
 	}
 
-    if bufferSize > 0 {
-        l.ReadBufferSize = bufferSize
-    }
+	if bufferSize > 0 {
+		l.ReadBufferSize = bufferSize
+	}
 
 	return l.setupDecoder()
 }
@@ -200,7 +200,7 @@ func (l *packetListener) setupUDP(u *url.URL, ifname string, bufferSize int) err
 		if err := conn.SetReadBuffer(bufferSize); err != nil {
 			l.Log.Errorf("Setting read buffer on %s socket failed: %v", u.Scheme, err)
 		}
-        l.ReadBufferSize = bufferSize
+		l.ReadBufferSize = bufferSize
 	}
 
 	l.conn = conn

--- a/plugins/common/socket/datagram.go
+++ b/plugins/common/socket/datagram.go
@@ -202,11 +202,9 @@ func (l *packetListener) setupUDP(u *url.URL, ifname string, bufferSize int) err
 		if err := conn.SetReadBuffer(bufferSize); err != nil {
 			l.Log.Warnf("Setting read buffer on %s socket failed: %v", u.Scheme, err)
 		}
-		l.ReadBufferSize = bufferSize
-	} else {
-		l.ReadBufferSize = 64 * 1024 // 64kb - IP packet size
 	}
 
+    l.ReadBufferSize = 64 * 1024 // 64kb - IP packet size
 	l.conn = conn
 	return l.setupDecoder()
 }
@@ -217,6 +215,7 @@ func (l *packetListener) setupIP(u *url.URL) error {
 		return fmt.Errorf("listening (ip) failed: %w", err)
 	}
 
+    l.ReadBufferSize = 64 * 1024 // 64kb - IP packet size
 	l.conn = conn
 	return l.setupDecoder()
 }

--- a/plugins/common/socket/datagram.go
+++ b/plugins/common/socket/datagram.go
@@ -204,7 +204,7 @@ func (l *packetListener) setupUDP(u *url.URL, ifname string, bufferSize int) err
 		}
 	}
 
-    l.ReadBufferSize = 64 * 1024 // 64kb - IP packet size
+	l.ReadBufferSize = 64 * 1024 // 64kb - IP packet size
 	l.conn = conn
 	return l.setupDecoder()
 }
@@ -215,7 +215,7 @@ func (l *packetListener) setupIP(u *url.URL) error {
 		return fmt.Errorf("listening (ip) failed: %w", err)
 	}
 
-    l.ReadBufferSize = 64 * 1024 // 64kb - IP packet size
+	l.ReadBufferSize = 64 * 1024 // 64kb - IP packet size
 	l.conn = conn
 	return l.setupDecoder()
 }

--- a/plugins/common/socket/socket.go
+++ b/plugins/common/socket/socket.go
@@ -136,7 +136,7 @@ func (s *Socket) Setup() error {
 		s.listener = l
 	case "unixgram":
 		l := newPacketListener(s.ContentEncoding, s.MaxDecompressionSize, s.MaxParallelParsers)
-		if err := l.setupUnixgram(s.url, s.SocketMode); err != nil {
+		if err := l.setupUnixgram(s.url, s.SocketMode, int(s.ReadBufferSize)); err != nil {
 			return err
 		}
 		s.listener = l

--- a/plugins/inputs/socket_listener/socket_listener_test.go
+++ b/plugins/inputs/socket_listener/socket_listener_test.go
@@ -12,7 +12,6 @@ import (
 	"runtime"
 	"sort"
 	"strings"
-	"syscall"
 	"testing"
 	"time"
 
@@ -322,12 +321,9 @@ func TestLargeReadBufferUnixgram(t *testing.T) {
 	// Check the socket write buffer size
 	unixConn, ok := client.(*net.UnixConn)
 	require.True(t, ok, "client is not a *net.UnixConn")
-	fd, err := unixConn.File()
-	require.NoError(t, err)
-	wmemMax, err := syscall.GetsockoptInt(int(fd.Fd()), syscall.SOL_SOCKET, syscall.SO_SNDBUF)
-	require.NoError(t, err)
-	if wmemMax < int(bufsize) {
-		t.Skip("Unixgram write buffer size is too small to write the message, skipping test")
+	err = unixConn.SetWriteBuffer(len(message))
+	if err != nil {
+		t.Skipf("Failed to set write buffer size: %v. Skipping test.", err)
 	}
 
 	// Write the message

--- a/plugins/inputs/socket_listener/socket_listener_test.go
+++ b/plugins/inputs/socket_listener/socket_listener_test.go
@@ -269,8 +269,8 @@ func TestLargeReadBufferUnixgram(t *testing.T) {
 		t.Skip("Skipping on Windows, as unixgram sockets are not supported")
 	}
 
-	if runtime.GOOS == "mac" {
-		t.Skip("Skipping on macOS, as unixgram write buffer size cannot be changed (default 2048 bytes)")
+	if runtime.GOOS == "darwin" {
+		t.Skip("Skipping on macOS (darwin), as unixgram write buffer size cannot be changed (default 2048 bytes)")
 	}
 
 	var bufsize config.Size

--- a/plugins/inputs/socket_listener/socket_listener_test.go
+++ b/plugins/inputs/socket_listener/socket_listener_test.go
@@ -269,6 +269,10 @@ func TestLargeReadBufferUnixgram(t *testing.T) {
 		t.Skip("Skipping on Windows, as unixgram sockets are not supported")
 	}
 
+	if runtime.GOOS == "mac" {
+		t.Skip("Skipping on macOS, as unixgram write buffer size cannot be changed (default 2048 bytes)")
+	}
+
 	var bufsize config.Size
 	require.NoError(t, bufsize.UnmarshalText([]byte("100KiB")))
 
@@ -328,13 +332,7 @@ func TestLargeReadBufferUnixgram(t *testing.T) {
 
 	// Write the message
 	_, err = client.Write(message)
-	if err != nil {
-		if strings.Contains(err.Error(), "message too long") || strings.Contains(err.Error(), "no buffer space available") {
-			t.Skipf("No buffer space available. Skipping test.")
-		} else {
-			require.NoError(t, err)
-		}
-	}
+	require.NoError(t, err)
 	client.Close()
 
 	getError := func() error {

--- a/plugins/inputs/socket_listener/socket_listener_test.go
+++ b/plugins/inputs/socket_listener/socket_listener_test.go
@@ -324,7 +324,6 @@ func TestLargeReadBufferUnixgram(t *testing.T) {
 	require.True(t, ok, "client is not a *net.UnixConn")
 	fd, err := unixConn.File()
 	require.NoError(t, err)
-	//nolint:all // This is for ignoring golint windows parser error
 	wmemMax, err := syscall.GetsockoptInt(int(fd.Fd()), syscall.SOL_SOCKET, syscall.SO_SNDBUF)
 	require.NoError(t, err)
 	if wmemMax < int(bufsize) {

--- a/plugins/inputs/socket_listener/socket_listener_test.go
+++ b/plugins/inputs/socket_listener/socket_listener_test.go
@@ -270,7 +270,7 @@ func TestLargeReadBufferUnixgram(t *testing.T) {
 	}
 
 	var bufsize config.Size
-	require.NoError(t, bufsize.UnmarshalText([]byte("10000KiB")))
+	require.NoError(t, bufsize.UnmarshalText([]byte("100KiB")))
 
 	// Create a socket
 	sock, err := os.CreateTemp("", "sock-")

--- a/plugins/inputs/socket_listener/socket_listener_test.go
+++ b/plugins/inputs/socket_listener/socket_listener_test.go
@@ -270,7 +270,7 @@ func TestLargeReadBufferUnixgram(t *testing.T) {
 	}
 
 	var bufsize config.Size
-	require.NoError(t, bufsize.UnmarshalText([]byte("100KiB")))
+	require.NoError(t, bufsize.UnmarshalText([]byte("10000KiB")))
 
 	// Create a socket
 	sock, err := os.CreateTemp("", "sock-")
@@ -328,7 +328,13 @@ func TestLargeReadBufferUnixgram(t *testing.T) {
 
 	// Write the message
 	_, err = client.Write(message)
-	require.NoError(t, err)
+	if err != nil {
+		if strings.Contains(err.Error(), "message too long") || strings.Contains(err.Error(), "no buffer space available") {
+			t.Skipf("No buffer space available. Skipping test.")
+		} else {
+			require.NoError(t, err)
+		}
+	}
 	client.Close()
 
 	getError := func() error {

--- a/plugins/inputs/socket_listener/socket_listener_test.go
+++ b/plugins/inputs/socket_listener/socket_listener_test.go
@@ -278,7 +278,7 @@ func TestLargeReadBufferUnixgram(t *testing.T) {
 	require.NoError(t, err)
 	defer sock.Close()
 	defer os.Remove(sock.Name())
-	serverAddr = sock.Name()
+	var serverAddr = sock.Name()
 
 	// Setup plugin with a sufficient read buffer
 	plugin := &SocketListener{

--- a/plugins/inputs/socket_listener/socket_listener_test.go
+++ b/plugins/inputs/socket_listener/socket_listener_test.go
@@ -315,9 +315,11 @@ func TestLargeReadBufferUnixgram(t *testing.T) {
 	// Check the socket write buffer size
 	unixConn, ok := client.(*net.UnixConn)
 	require.True(t, ok, "client is not a *net.UnixConn")
-	fd, _ := unixConn.File()
-	value, _ := syscall.GetsockoptInt(int(fd.Fd()), syscall.SOL_SOCKET, syscall.SO_SNDBUF)
-	if value < int(bufsize) {
+	fd, err := unixConn.File()
+	require.NoError(t, err)
+	wmemMax, err := syscall.GetsockoptInt(int(fd.Fd()), syscall.SOL_SOCKET, syscall.SO_SNDBUF)
+	require.NoError(t, err)
+	if wmemMax < int(bufsize) {
 		t.Skip("Unixgram write buffer size is too small to write the message, skipping test")
 	}
 

--- a/plugins/inputs/socket_listener/socket_listener_test.go
+++ b/plugins/inputs/socket_listener/socket_listener_test.go
@@ -325,8 +325,7 @@ func TestLargeReadBufferUnixgram(t *testing.T) {
 	// Check the socket write buffer size
 	unixConn, ok := client.(*net.UnixConn)
 	require.True(t, ok, "client is not a *net.UnixConn")
-	err = unixConn.SetWriteBuffer(len(message))
-	if err != nil {
+	if err := unixConn.SetWriteBuffer(len(message)); err != nil {
 		t.Skipf("Failed to set write buffer size: %v. Skipping test.", err)
 	}
 


### PR DESCRIPTION
## Summary
Currently, the datagram read buffer size is fixed at 64 KB, which is leading
to data loss when receiving large datagrams (metrics) over Unix Domain Sockets (unixgram).
This fix ensures that the buffer size matches read-buffer-size
configuration, preventing truncation of incoming data.

## Checklist
- [X] No AI generated code was used in this PR

## Related issues
resolves #16118
