### PR TITLE
chore: Enable `testifylint:go-require` checker

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -343,6 +343,7 @@ linters-settings:
       - expected-actual
       - float-compare
       - formatter
+      - go-require
       - len
       - negative-positive
       - nil-compare

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -520,8 +520,11 @@ func TestConfig_AzureMonitorNamespacePrefix(t *testing.T) {
 func TestGetDefaultConfigPathFromEnvURL(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		_, err := w.Write([]byte("[agent]\ndebug = true"))
-		require.NoError(t, err)
+		if _, err := w.Write([]byte("[agent]\ndebug = true")); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Error(err)
+			return
+		}
 	}))
 	defer ts.Close()
 

--- a/migrations/inputs_httpjson/migration_test.go
+++ b/migrations/inputs_httpjson/migration_test.go
@@ -112,8 +112,11 @@ func TestParsing(t *testing.T) {
 			// Start the test-server
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if r.URL.Path == "/stats" {
-					_, err = w.Write(input)
-					require.NoError(t, err)
+					if _, err = w.Write(input); err != nil {
+						w.WriteHeader(http.StatusInternalServerError)
+						t.Error(err)
+						return
+					}
 				} else {
 					w.WriteHeader(http.StatusNotFound)
 				}

--- a/plugins/common/cookie/cookie_test.go
+++ b/plugins/common/cookie/cookie_test.go
@@ -63,7 +63,11 @@ func newFakeServer(t *testing.T) fakeServer {
 				authed()
 			case authEndpointWithBody:
 				body, err := io.ReadAll(r.Body)
-				require.NoError(t, err)
+				if err != nil {
+					w.WriteHeader(http.StatusInternalServerError)
+					t.Error(err)
+					return
+				}
 				if !cmp.Equal([]byte(reqBody), body) {
 					w.WriteHeader(http.StatusUnauthorized)
 					return
@@ -89,8 +93,11 @@ func newFakeServer(t *testing.T) fakeServer {
 					w.WriteHeader(http.StatusForbidden)
 					return
 				}
-				_, err := w.Write([]byte("good test response"))
-				require.NoError(t, err)
+				if _, err := w.Write([]byte("good test response")); err != nil {
+					w.WriteHeader(http.StatusInternalServerError)
+					t.Error(err)
+					return
+				}
 			}
 		})),
 		int32: &c,

--- a/plugins/outputs/bigquery/bigquery_test.go
+++ b/plugins/outputs/bigquery/bigquery_test.go
@@ -271,19 +271,32 @@ func localBigQueryServer(t *testing.T) *httptest.Server {
 		case "/projects/test-project/datasets/test-dataset/tables/test1/insertAll",
 			"/projects/test-project/datasets/test-dataset/tables/test-metrics/insertAll":
 			decoder := json.NewDecoder(r.Body)
-			require.NoError(t, decoder.Decode(&receivedBody))
+			if err := decoder.Decode(&receivedBody); err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				t.Error(err)
+				return
+			}
 
 			w.WriteHeader(http.StatusOK)
-			_, err := w.Write([]byte(successfulResponse))
-			require.NoError(t, err)
+			if _, err := w.Write([]byte(successfulResponse)); err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				t.Error(err)
+				return
+			}
 		case "/projects/test-project/datasets/test-dataset/tables/test-metrics":
 			w.WriteHeader(http.StatusOK)
-			_, err := w.Write([]byte("{}"))
-			require.NoError(t, err)
+			if _, err := w.Write([]byte("{}")); err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				t.Error(err)
+				return
+			}
 		default:
 			w.WriteHeader(http.StatusNotFound)
-			_, err := w.Write([]byte(r.URL.String()))
-			require.NoError(t, err)
+			if _, err := w.Write([]byte(r.URL.String())); err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				t.Error(err)
+				return
+			}
 		}
 	})
 

--- a/plugins/outputs/dynatrace/dynatrace_test.go
+++ b/plugins/outputs/dynatrace/dynatrace_test.go
@@ -25,8 +25,11 @@ import (
 func TestNilMetrics(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		err := json.NewEncoder(w).Encode(`{"linesOk":10,"linesInvalid":0,"error":null}`)
-		require.NoError(t, err)
+		if err := json.NewEncoder(w).Encode(`{"linesOk":10,"linesInvalid":0,"error":null}`); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Error(err)
+			return
+		}
 	}))
 	defer ts.Close()
 
@@ -50,8 +53,11 @@ func TestNilMetrics(t *testing.T) {
 func TestEmptyMetricsSlice(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		err := json.NewEncoder(w).Encode(`{"linesOk":10,"linesInvalid":0,"error":null}`)
-		require.NoError(t, err)
+		if err := json.NewEncoder(w).Encode(`{"linesOk":10,"linesInvalid":0,"error":null}`); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Error(err)
+			return
+		}
 	}))
 	defer ts.Close()
 
@@ -73,8 +79,11 @@ func TestEmptyMetricsSlice(t *testing.T) {
 func TestMockURL(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		err := json.NewEncoder(w).Encode(`{"linesOk":10,"linesInvalid":0,"error":null}`)
-		require.NoError(t, err)
+		if err := json.NewEncoder(w).Encode(`{"linesOk":10,"linesInvalid":0,"error":null}`); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Error(err)
+			return
+		}
 	}))
 	defer ts.Close()
 
@@ -131,9 +140,13 @@ func TestSendMetrics(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// check the encoded result
 		bodyBytes, err := io.ReadAll(r.Body)
-		require.NoError(t, err)
-		bodyString := string(bodyBytes)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Error(err)
+			return
+		}
 
+		bodyString := string(bodyBytes)
 		lines := strings.Split(bodyString, "\n")
 
 		sort.Strings(lines)
@@ -143,10 +156,15 @@ func TestSendMetrics(t *testing.T) {
 		foundString := strings.Join(lines, "\n")
 		if foundString != expectedString {
 			t.Errorf("Metric encoding failed. expected: %#v but got: %#v", expectedString, foundString)
+			return
 		}
+
 		w.WriteHeader(http.StatusOK)
-		err = json.NewEncoder(w).Encode(fmt.Sprintf(`{"linesOk":%d,"linesInvalid":0,"error":null}`, len(lines)))
-		require.NoError(t, err)
+		if err = json.NewEncoder(w).Encode(fmt.Sprintf(`{"linesOk":%d,"linesInvalid":0,"error":null}`, len(lines))); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Error(err)
+			return
+		}
 	}))
 	defer ts.Close()
 
@@ -217,7 +235,12 @@ func TestSendMetricsWithPatterns(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// check the encoded result
 		bodyBytes, err := io.ReadAll(r.Body)
-		require.NoError(t, err)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Error(err)
+			return
+		}
+
 		bodyString := string(bodyBytes)
 
 		lines := strings.Split(bodyString, "\n")
@@ -229,10 +252,15 @@ func TestSendMetricsWithPatterns(t *testing.T) {
 		foundString := strings.Join(lines, "\n")
 		if foundString != expectedString {
 			t.Errorf("Metric encoding failed. expected: %#v but got: %#v", expectedString, foundString)
+			return
 		}
+
 		w.WriteHeader(http.StatusOK)
-		err = json.NewEncoder(w).Encode(fmt.Sprintf(`{"linesOk":%d,"linesInvalid":0,"error":null}`, len(lines)))
-		require.NoError(t, err)
+		if err = json.NewEncoder(w).Encode(fmt.Sprintf(`{"linesOk":%d,"linesInvalid":0,"error":null}`, len(lines))); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Error(err)
+			return
+		}
 	}))
 	defer ts.Close()
 
@@ -323,19 +351,55 @@ func TestSendSingleMetricWithUnorderedTags(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// check the encoded result
 		bodyBytes, err := io.ReadAll(r.Body)
-		require.NoError(t, err)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Error(err)
+			return
+		}
+
 		bodyString := string(bodyBytes)
 		// use regex because dimension order isn't guaranteed
-		require.Len(t, bodyString, 94)
-		require.Regexp(t, regexp.MustCompile(`^mymeasurement\.myfield`), bodyString)
-		require.Regexp(t, regexp.MustCompile(`a=test`), bodyString)
-		require.Regexp(t, regexp.MustCompile(`b=test`), bodyString)
-		require.Regexp(t, regexp.MustCompile(`c=test`), bodyString)
-		require.Regexp(t, regexp.MustCompile(`dt.metrics.source=telegraf`), bodyString)
-		require.Regexp(t, regexp.MustCompile(`gauge,3.14 1289430000000$`), bodyString)
+		if len(bodyString) != 94 {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Errorf("'bodyString' should have %d item(s), but has %d", 94, len(bodyString))
+			return
+		}
+		if regexp.MustCompile(`^mymeasurement\.myfield`).FindStringIndex(bodyString) == nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Errorf("Expect \"%v\" to match \"%v\"", bodyString, `^mymeasurement\.myfield`)
+			return
+		}
+		if regexp.MustCompile(`a=test`).FindStringIndex(bodyString) == nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Errorf("Expect \"%v\" to match \"%v\"", bodyString, `a=test`)
+			return
+		}
+		if regexp.MustCompile(`b=test`).FindStringIndex(bodyString) == nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Errorf("Expect \"%v\" to match \"%v\"", bodyString, `a=test`)
+			return
+		}
+		if regexp.MustCompile(`c=test`).FindStringIndex(bodyString) == nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Errorf("Expect \"%v\" to match \"%v\"", bodyString, `a=test`)
+			return
+		}
+		if regexp.MustCompile("dt.metrics.source=telegraf").FindStringIndex(bodyString) == nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Errorf("Expect \"%v\" to match \"%v\"", bodyString, "dt.metrics.source=telegraf")
+			return
+		}
+		if regexp.MustCompile("gauge,3.14 1289430000000$").FindStringIndex(bodyString) == nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Errorf("Expect \"%v\" to match \"%v\"", bodyString, "gauge,3.14 1289430000000$")
+			return
+		}
 		w.WriteHeader(http.StatusOK)
-		err = json.NewEncoder(w).Encode(`{"linesOk":1,"linesInvalid":0,"error":null}`)
-		require.NoError(t, err)
+		if err = json.NewEncoder(w).Encode(`{"linesOk":1,"linesInvalid":0,"error":null}`); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Error(err)
+			return
+		}
 	}))
 	defer ts.Close()
 
@@ -366,17 +430,27 @@ func TestSendSingleMetricWithUnorderedTags(t *testing.T) {
 
 func TestSendMetricWithoutTags(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
 		// check the encoded result
 		bodyBytes, err := io.ReadAll(r.Body)
-		require.NoError(t, err)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Error(err)
+			return
+		}
+
 		bodyString := string(bodyBytes)
 		expected := "mymeasurement.myfield,dt.metrics.source=telegraf gauge,3.14 1289430000000"
 		if bodyString != expected {
 			t.Errorf("Metric encoding failed. expected: %#v but got: %#v", expected, bodyString)
+			return
 		}
-		err = json.NewEncoder(w).Encode(`{"linesOk":1,"linesInvalid":0,"error":null}`)
-		require.NoError(t, err)
+
+		w.WriteHeader(http.StatusOK)
+		if err = json.NewEncoder(w).Encode(`{"linesOk":1,"linesInvalid":0,"error":null}`); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Error(err)
+			return
+		}
 	}))
 	defer ts.Close()
 
@@ -407,23 +481,58 @@ func TestSendMetricWithoutTags(t *testing.T) {
 
 func TestSendMetricWithUpperCaseTagKeys(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
 		// check the encoded result
 		bodyBytes, err := io.ReadAll(r.Body)
-		require.NoError(t, err)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Error(err)
+			return
+		}
 		bodyString := string(bodyBytes)
 
 		// use regex because dimension order isn't guaranteed
-		require.Len(t, bodyString, 100)
-		require.Regexp(t, regexp.MustCompile(`^mymeasurement\.myfield`), bodyString)
-		require.Regexp(t, regexp.MustCompile(`aaa=test`), bodyString)
-		require.Regexp(t, regexp.MustCompile(`b_b=test`), bodyString)
-		require.Regexp(t, regexp.MustCompile(`ccc=test`), bodyString)
-		require.Regexp(t, regexp.MustCompile(`dt.metrics.source=telegraf`), bodyString)
-		require.Regexp(t, regexp.MustCompile(`gauge,3.14 1289430000000$`), bodyString)
+		if len(bodyString) != 100 {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Errorf("'bodyString' should have %d item(s), but has %d", 100, len(bodyString))
+			return
+		}
+		if regexp.MustCompile(`^mymeasurement\.myfield`).FindStringIndex(bodyString) == nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Errorf("Expect \"%v\" to match \"%v\"", bodyString, `^mymeasurement\.myfield`)
+			return
+		}
+		if regexp.MustCompile(`aaa=test`).FindStringIndex(bodyString) == nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Errorf("Expect \"%v\" to match \"%v\"", bodyString, `aaa=test`)
+			return
+		}
+		if regexp.MustCompile(`b_b=test`).FindStringIndex(bodyString) == nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Errorf("Expect \"%v\" to match \"%v\"", bodyString, `b_b=test`)
+			return
+		}
+		if regexp.MustCompile(`ccc=test`).FindStringIndex(bodyString) == nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Errorf("Expect \"%v\" to match \"%v\"", bodyString, `ccc=test`)
+			return
+		}
+		if regexp.MustCompile("dt.metrics.source=telegraf").FindStringIndex(bodyString) == nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Errorf("Expect \"%v\" to match \"%v\"", bodyString, "dt.metrics.source=telegraf")
+			return
+		}
+		if regexp.MustCompile("gauge,3.14 1289430000000$").FindStringIndex(bodyString) == nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Errorf("Expect \"%v\" to match \"%v\"", bodyString, "gauge,3.14 1289430000000$")
+			return
+		}
 
-		err = json.NewEncoder(w).Encode(`{"linesOk":1,"linesInvalid":0,"error":null}`)
-		require.NoError(t, err)
+		w.WriteHeader(http.StatusOK)
+		if err = json.NewEncoder(w).Encode(`{"linesOk":1,"linesInvalid":0,"error":null}`); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Error(err)
+			return
+		}
 	}))
 	defer ts.Close()
 
@@ -454,17 +563,37 @@ func TestSendMetricWithUpperCaseTagKeys(t *testing.T) {
 
 func TestSendBooleanMetricWithoutTags(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
 		// check the encoded result
 		bodyBytes, err := io.ReadAll(r.Body)
-		require.NoError(t, err)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Error(err)
+			return
+		}
+
 		bodyString := string(bodyBytes)
 		// use regex because field order isn't guaranteed
-		require.Len(t, bodyString, 132)
-		require.Contains(t, bodyString, "mymeasurement.yes,dt.metrics.source=telegraf gauge,1 1289430000000")
-		require.Contains(t, bodyString, "mymeasurement.no,dt.metrics.source=telegraf gauge,0 1289430000000")
-		err = json.NewEncoder(w).Encode(`{"linesOk":1,"linesInvalid":0,"error":null}`)
-		require.NoError(t, err)
+		if len(bodyString) != 132 {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Errorf("'bodyString' should have %d item(s), but has %d", 132, len(bodyString))
+			return
+		}
+		if !strings.Contains(bodyString, "mymeasurement.yes,dt.metrics.source=telegraf gauge,1 1289430000000") {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Errorf("'bodyString' should contain %q", "mymeasurement.yes,dt.metrics.source=telegraf gauge,1 1289430000000")
+			return
+		}
+		if !strings.Contains(bodyString, "mymeasurement.no,dt.metrics.source=telegraf gauge,0 1289430000000") {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Errorf("'bodyString' should contain %q", "mymeasurement.no,dt.metrics.source=telegraf gauge,0 1289430000000")
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		if err = json.NewEncoder(w).Encode(`{"linesOk":1,"linesInvalid":0,"error":null}`); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Error(err)
+			return
+		}
 	}))
 	defer ts.Close()
 
@@ -495,19 +624,47 @@ func TestSendBooleanMetricWithoutTags(t *testing.T) {
 
 func TestSendMetricWithDefaultDimensions(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
 		// check the encoded result
 		bodyBytes, err := io.ReadAll(r.Body)
-		require.NoError(t, err)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Error(err)
+			return
+		}
+
 		bodyString := string(bodyBytes)
 		// use regex because field order isn't guaranteed
-		require.Len(t, bodyString, 78)
-		require.Regexp(t, regexp.MustCompile("^mymeasurement.value"), bodyString)
-		require.Regexp(t, regexp.MustCompile("dt.metrics.source=telegraf"), bodyString)
-		require.Regexp(t, regexp.MustCompile("dim=value"), bodyString)
-		require.Regexp(t, regexp.MustCompile("gauge,2 1289430000000$"), bodyString)
-		err = json.NewEncoder(w).Encode(`{"linesOk":1,"linesInvalid":0,"error":null}`)
-		require.NoError(t, err)
+		if len(bodyString) != 78 {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Errorf("'bodyString' should have %d item(s), but has %d", 78, len(bodyString))
+			return
+		}
+		if regexp.MustCompile("^mymeasurement.value").FindStringIndex(bodyString) == nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Errorf("Expect \"%v\" to match \"%v\"", bodyString, "^mymeasurement.value")
+			return
+		}
+		if regexp.MustCompile("dt.metrics.source=telegraf").FindStringIndex(bodyString) == nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Errorf("Expect \"%v\" to match \"%v\"", bodyString, "dt.metrics.source=telegraf")
+			return
+		}
+		if regexp.MustCompile("dim=value").FindStringIndex(bodyString) == nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Errorf("Expect \"%v\" to match \"%v\"", bodyString, "dim=metric")
+			return
+		}
+		if regexp.MustCompile("gauge,2 1289430000000$").FindStringIndex(bodyString) == nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Errorf("Expect \"%v\" to match \"%v\"", bodyString, "gauge,2 1289430000000$")
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		if err = json.NewEncoder(w).Encode(`{"linesOk":1,"linesInvalid":0,"error":null}`); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Error(err)
+			return
+		}
 	}))
 	defer ts.Close()
 
@@ -538,19 +695,46 @@ func TestSendMetricWithDefaultDimensions(t *testing.T) {
 
 func TestMetricDimensionsOverrideDefault(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
 		// check the encoded result
 		bodyBytes, err := io.ReadAll(r.Body)
-		require.NoError(t, err)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Error(err)
+			return
+		}
 		bodyString := string(bodyBytes)
 		// use regex because field order isn't guaranteed
-		require.Len(t, bodyString, 80)
-		require.Regexp(t, regexp.MustCompile("^mymeasurement.value"), bodyString)
-		require.Regexp(t, regexp.MustCompile("dt.metrics.source=telegraf"), bodyString)
-		require.Regexp(t, regexp.MustCompile("dim=metric"), bodyString)
-		require.Regexp(t, regexp.MustCompile("gauge,32 1289430000000$"), bodyString)
-		err = json.NewEncoder(w).Encode(`{"linesOk":1,"linesInvalid":0,"error":null}`)
-		require.NoError(t, err)
+		if len(bodyString) != 80 {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Errorf("'bodyString' should have %d item(s), but has %d", 80, len(bodyString))
+			return
+		}
+		if regexp.MustCompile("^mymeasurement.value").FindStringIndex(bodyString) == nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Errorf("Expect \"%v\" to match \"%v\"", bodyString, "^mymeasurement.value")
+			return
+		}
+		if regexp.MustCompile("dt.metrics.source=telegraf").FindStringIndex(bodyString) == nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Errorf("Expect \"%v\" to match \"%v\"", bodyString, "dt.metrics.source=telegraf")
+			return
+		}
+		if regexp.MustCompile("dim=metric").FindStringIndex(bodyString) == nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Errorf("Expect \"%v\" to match \"%v\"", bodyString, "dim=metric")
+			return
+		}
+		if regexp.MustCompile("gauge,32 1289430000000$").FindStringIndex(bodyString) == nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Errorf("Expect \"%v\" to match \"%v\"", bodyString, "gauge,32 1289430000000$")
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		if err = json.NewEncoder(w).Encode(`{"linesOk":1,"linesInvalid":0,"error":null}`); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Error(err)
+			return
+		}
 	}))
 	defer ts.Close()
 
@@ -581,18 +765,41 @@ func TestMetricDimensionsOverrideDefault(t *testing.T) {
 
 func TestStaticDimensionsOverrideMetric(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
 		// check the encoded result
 		bodyBytes, err := io.ReadAll(r.Body)
-		require.NoError(t, err)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Error(err)
+			return
+		}
 		bodyString := string(bodyBytes)
 		// use regex because field order isn't guaranteed
-		require.Len(t, bodyString, 53)
-		require.Regexp(t, regexp.MustCompile("^mymeasurement.value"), bodyString)
-		require.Regexp(t, regexp.MustCompile("dim=static"), bodyString)
-		require.Regexp(t, regexp.MustCompile("gauge,32 1289430000000$"), bodyString)
-		err = json.NewEncoder(w).Encode(`{"linesOk":1,"linesInvalid":0,"error":null}`)
-		require.NoError(t, err)
+		if len(bodyString) != 53 {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Errorf("'bodyString' should have %d item(s), but has %d", 53, len(bodyString))
+			return
+		}
+		if regexp.MustCompile("^mymeasurement.value").FindStringIndex(bodyString) == nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Errorf("Expect \"%v\" to match \"%v\"", bodyString, "^mymeasurement.value")
+			return
+		}
+		if regexp.MustCompile("dim=static").FindStringIndex(bodyString) == nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Errorf("Expect \"%v\" to match \"%v\"", bodyString, "dim=static")
+			return
+		}
+		if regexp.MustCompile("gauge,32 1289430000000$").FindStringIndex(bodyString) == nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Errorf("Expect \"%v\" to match \"%v\"", bodyString, "gauge,32 1289430000000$")
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		if err = json.NewEncoder(w).Encode(`{"linesOk":1,"linesInvalid":0,"error":null}`); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Error(err)
+			return
+		}
 	}))
 	defer ts.Close()
 

--- a/plugins/outputs/elasticsearch/elasticsearch_test.go
+++ b/plugins/outputs/elasticsearch/elasticsearch_test.go
@@ -679,14 +679,27 @@ func TestRequestHeaderWhenGzipIsEnabled(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/_bulk":
-			require.Equal(t, "gzip", r.Header.Get("Content-Encoding"))
-			require.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
-			_, err := w.Write([]byte("{}"))
-			require.NoError(t, err)
+			if contentHeader := r.Header.Get("Content-Encoding"); contentHeader != "gzip" {
+				w.WriteHeader(http.StatusInternalServerError)
+				t.Errorf("Not equal, expected: %q, actual: %q", "gzip", contentHeader)
+				return
+			}
+			if acceptHeader := r.Header.Get("Accept-Encoding"); acceptHeader != "gzip" {
+				w.WriteHeader(http.StatusInternalServerError)
+				t.Errorf("Not equal, expected: %q, actual: %q", "gzip", acceptHeader)
+				return
+			}
+
+			if _, err := w.Write([]byte("{}")); err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				t.Error(err)
+			}
 			return
 		default:
-			_, err := w.Write([]byte(`{"version": {"number": "7.8"}}`))
-			require.NoError(t, err)
+			if _, err := w.Write([]byte(`{"version": {"number": "7.8"}}`)); err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				t.Error(err)
+			}
 			return
 		}
 	}))
@@ -714,13 +727,21 @@ func TestRequestHeaderWhenGzipIsDisabled(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/_bulk":
-			require.NotEqual(t, "gzip", r.Header.Get("Content-Encoding"))
-			_, err := w.Write([]byte("{}"))
-			require.NoError(t, err)
+			if contentHeader := r.Header.Get("Content-Encoding"); contentHeader == "gzip" {
+				w.WriteHeader(http.StatusInternalServerError)
+				t.Errorf("Not equal, expected: %q, actual: %q", "gzip", contentHeader)
+				return
+			}
+			if _, err := w.Write([]byte("{}")); err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				t.Error(err)
+			}
 			return
 		default:
-			_, err := w.Write([]byte(`{"version": {"number": "7.8"}}`))
-			require.NoError(t, err)
+			if _, err := w.Write([]byte(`{"version": {"number": "7.8"}}`)); err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				t.Error(err)
+			}
 			return
 		}
 	}))
@@ -748,13 +769,21 @@ func TestAuthorizationHeaderWhenBearerTokenIsPresent(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/_bulk":
-			require.Equal(t, "Bearer 0123456789abcdef", r.Header.Get("Authorization"))
-			_, err := w.Write([]byte("{}"))
-			require.NoError(t, err)
+			if authHeader := r.Header.Get("Authorization"); authHeader != "Bearer 0123456789abcdef" {
+				w.WriteHeader(http.StatusInternalServerError)
+				t.Errorf("Not equal, expected: %q, actual: %q", "Bearer 0123456789abcdef", authHeader)
+				return
+			}
+			if _, err := w.Write([]byte("{}")); err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				t.Error(err)
+			}
 			return
 		default:
-			_, err := w.Write([]byte(`{"version": {"number": "7.8"}}`))
-			require.NoError(t, err)
+			if _, err := w.Write([]byte(`{"version": {"number": "7.8"}}`)); err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				t.Error(err)
+			}
 			return
 		}
 	}))

--- a/plugins/outputs/groundwork/groundwork_test.go
+++ b/plugins/outputs/groundwork/groundwork_test.go
@@ -34,21 +34,39 @@ func TestWriteWithDebug(t *testing.T) {
 	// Simulate Groundwork server that should receive custom metrics
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, err := io.ReadAll(r.Body)
-		require.NoError(t, err)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Error(err)
+			return
+		}
 
 		// Decode body to use in assertions below
 		var obj transit.ResourcesWithServicesRequest
-		err = json.Unmarshal(body, &obj)
-		require.NoError(t, err)
+		if err = json.Unmarshal(body, &obj); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Error(err)
+			return
+		}
 
 		// Check if server gets proper data
-		require.Equal(t, "IntMetric", obj.Resources[0].Services[0].Name)
-		require.Equal(t, int64(42), *obj.Resources[0].Services[0].Metrics[0].Value.IntegerValue)
+		if obj.Resources[0].Services[0].Name != "IntMetric" {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Errorf("Not equal, expected: %q, actual: %q", "IntMetric", obj.Resources[0].Services[0].Name)
+			return
+		}
+		if *obj.Resources[0].Services[0].Metrics[0].Value.IntegerValue != int64(42) {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Errorf("Not equal, expected: %v, actual: %v", int64(42), *obj.Resources[0].Services[0].Metrics[0].Value.IntegerValue)
+			return
+		}
 
 		// Send back details
 		ans := "Content-type: application/json\n\n" + `{"message":"` + srvTok + `"}`
-		_, err = fmt.Fprintln(w, ans)
-		require.NoError(t, err)
+		if _, err = fmt.Fprintln(w, ans); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Error(err)
+			return
+		}
 	}))
 
 	i := Groundwork{
@@ -84,24 +102,62 @@ func TestWriteWithDefaults(t *testing.T) {
 	// Simulate Groundwork server that should receive custom metrics
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, err := io.ReadAll(r.Body)
-		require.NoError(t, err)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Error(err)
+			return
+		}
 
 		// Decode body to use in assertions below
 		var obj transit.ResourcesWithServicesRequest
-		err = json.Unmarshal(body, &obj)
-		require.NoError(t, err)
+		if err = json.Unmarshal(body, &obj); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Error(err)
+			return
+		}
 
 		// Check if server gets proper data
-		require.Equal(t, defaultTestAgentID, obj.Context.AgentID)
-		require.Equal(t, customAppType, obj.Context.AppType)
-		require.Equal(t, defaultHost, obj.Resources[0].Name)
-		require.Equal(t, transit.MonitorStatus("SERVICE_OK"), obj.Resources[0].Services[0].Status)
-		require.Equal(t, "IntMetric", obj.Resources[0].Services[0].Name)
-		require.Equal(t, int64(42), *obj.Resources[0].Services[0].Metrics[0].Value.IntegerValue)
-		require.Empty(t, obj.Groups)
+		if obj.Context.AgentID != defaultTestAgentID {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Errorf("Not equal, expected: %q, actual: %q", defaultTestAgentID, obj.Context.AgentID)
+			return
+		}
+		if obj.Context.AppType != customAppType {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Errorf("Not equal, expected: %q, actual: %q", customAppType, obj.Context.AppType)
+			return
+		}
+		if obj.Resources[0].Name != defaultHost {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Errorf("Not equal, expected: %q, actual: %q", defaultHost, obj.Resources[0].Name)
+			return
+		}
+		if obj.Resources[0].Services[0].Status != transit.MonitorStatus("SERVICE_OK") {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Errorf("Not equal, expected: %q, actual: %q", transit.MonitorStatus("SERVICE_OK"), obj.Resources[0].Services[0].Status)
+			return
+		}
+		if obj.Resources[0].Services[0].Name != "IntMetric" {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Errorf("Not equal, expected: %q, actual: %q", "IntMetric", obj.Resources[0].Services[0].Name)
+			return
+		}
+		if *obj.Resources[0].Services[0].Metrics[0].Value.IntegerValue != int64(42) {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Errorf("Not equal, expected: %v, actual: %v", int64(42), *obj.Resources[0].Services[0].Metrics[0].Value.IntegerValue)
+			return
+		}
+		if len(obj.Groups) != 0 {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Errorf("'obj.Groups' should not be empty")
+			return
+		}
 
-		_, err = fmt.Fprintln(w, "OK")
-		require.NoError(t, err)
+		if _, err = fmt.Fprintln(w, "OK"); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Error(err)
+			return
+		}
 	}))
 
 	i := Groundwork{
@@ -136,22 +192,55 @@ func TestWriteWithFields(t *testing.T) {
 	// Simulate Groundwork server that should receive custom metrics
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, err := io.ReadAll(r.Body)
-		require.NoError(t, err)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Error(err)
+			return
+		}
 
 		// Decode body to use in assertions below
 		var obj transit.ResourcesWithServicesRequest
-		err = json.Unmarshal(body, &obj)
-		require.NoError(t, err)
+		if err = json.Unmarshal(body, &obj); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Error(err)
+			return
+		}
 
 		// Check if server gets proper data
-		require.Equal(t, "Test Message", obj.Resources[0].Services[0].LastPluginOutput)
-		require.Equal(t, transit.MonitorStatus("SERVICE_WARNING"), obj.Resources[0].Services[0].Status)
-		require.InDelta(t, float64(1.0), *obj.Resources[0].Services[0].Metrics[0].Value.DoubleValue, testutil.DefaultDelta)
-		require.InDelta(t, float64(3.0), *obj.Resources[0].Services[0].Metrics[0].Thresholds[0].Value.DoubleValue, testutil.DefaultDelta)
-		require.InDelta(t, float64(2.0), *obj.Resources[0].Services[0].Metrics[0].Thresholds[1].Value.DoubleValue, testutil.DefaultDelta)
+		if obj.Resources[0].Services[0].LastPluginOutput != "Test Message" {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Errorf("Not equal, expected: %q, actual: %q", "Test Message", obj.Resources[0].Services[0].LastPluginOutput)
+			return
+		}
+		if obj.Resources[0].Services[0].Status != transit.MonitorStatus("SERVICE_WARNING") {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Errorf("Not equal, expected: %q, actual: %q", transit.MonitorStatus("SERVICE_WARNING"), obj.Resources[0].Services[0].Status)
+			return
+		}
+		if dt := float64(1.0) - *obj.Resources[0].Services[0].Metrics[0].Value.DoubleValue; !testutil.WithinDefaultDelta(dt) {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Errorf("Max difference between %v and %v allowed is %v, but difference was %v",
+				float64(1.0), *obj.Resources[0].Services[0].Metrics[0].Value.DoubleValue, testutil.DefaultDelta, dt)
+			return
+		}
+		if dt := float64(3.0) - *obj.Resources[0].Services[0].Metrics[0].Thresholds[0].Value.DoubleValue; !testutil.WithinDefaultDelta(dt) {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Errorf("Max difference between %v and %v allowed is %v, but difference was %v",
+				float64(3.0), *obj.Resources[0].Services[0].Metrics[0].Thresholds[0].Value.DoubleValue, testutil.DefaultDelta, dt)
+			return
+		}
+		if dt := float64(2.0) - *obj.Resources[0].Services[0].Metrics[0].Thresholds[1].Value.DoubleValue; !testutil.WithinDefaultDelta(dt) {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Errorf("Max difference between %v and %v allowed is %v, but difference was %v",
+				float64(2.0), *obj.Resources[0].Services[0].Metrics[0].Thresholds[1].Value.DoubleValue, testutil.DefaultDelta, dt)
+			return
+		}
 
-		_, err = fmt.Fprintln(w, "OK")
-		require.NoError(t, err)
+		if _, err = fmt.Fprintln(w, "OK"); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Error(err)
+			return
+		}
 	}))
 
 	i := Groundwork{
@@ -197,30 +286,95 @@ func TestWriteWithTags(t *testing.T) {
 	// Simulate Groundwork server that should receive custom metrics
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, err := io.ReadAll(r.Body)
-		require.NoError(t, err)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Error(err)
+			return
+		}
 
 		// Decode body to use in assertions below
 		var obj transit.ResourcesWithServicesRequest
-		err = json.Unmarshal(body, &obj)
-		require.NoError(t, err)
+		if err = json.Unmarshal(body, &obj); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Error(err)
+			return
+		}
 
 		// Check if server gets proper data
-		require.Equal(t, defaultTestAgentID, obj.Context.AgentID)
-		require.Equal(t, defaultAppType, obj.Context.AppType)
-		require.Equal(t, "Host01", obj.Resources[0].Name)
-		require.Equal(t, "Service01", obj.Resources[0].Services[0].Name)
-		require.Equal(t, "FACILITY", *obj.Resources[0].Services[0].Properties["facility"].StringValue)
-		require.Equal(t, "SEVERITY", *obj.Resources[0].Services[0].Properties["severity"].StringValue)
-		require.Equal(t, "Group01", obj.Groups[0].GroupName)
-		require.Equal(t, "Host01", obj.Groups[0].Resources[0].Name)
-		require.Equal(t, "Test Tag", obj.Resources[0].Services[0].LastPluginOutput)
-		require.Equal(t, transit.MonitorStatus("SERVICE_PENDING"), obj.Resources[0].Services[0].Status)
-		require.InDelta(t, float64(1.0), *obj.Resources[0].Services[0].Metrics[0].Value.DoubleValue, testutil.DefaultDelta)
-		require.InDelta(t, float64(9.0), *obj.Resources[0].Services[0].Metrics[0].Thresholds[0].Value.DoubleValue, testutil.DefaultDelta)
-		require.InDelta(t, float64(6.0), *obj.Resources[0].Services[0].Metrics[0].Thresholds[1].Value.DoubleValue, testutil.DefaultDelta)
+		if obj.Context.AgentID != defaultTestAgentID {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Errorf("Not equal, expected: %q, actual: %q", defaultTestAgentID, obj.Context.AgentID)
+			return
+		}
+		if obj.Context.AppType != defaultAppType {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Errorf("Not equal, expected: %q, actual: %q", defaultAppType, obj.Context.AppType)
+			return
+		}
+		if obj.Resources[0].Name != "Host01" {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Errorf("Not equal, expected: %q, actual: %q", "Host01", obj.Resources[0].Name)
+			return
+		}
+		if obj.Resources[0].Services[0].Name != "Service01" {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Errorf("Not equal, expected: %q, actual: %q", "Service01", obj.Resources[0].Services[0].Name)
+			return
+		}
+		if *obj.Resources[0].Services[0].Properties["facility"].StringValue != "FACILITY" {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Errorf("Not equal, expected: %q, actual: %q", "FACILITY", *obj.Resources[0].Services[0].Properties["facility"].StringValue)
+			return
+		}
+		if *obj.Resources[0].Services[0].Properties["severity"].StringValue != "SEVERITY" {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Errorf("Not equal, expected: %q, actual: %q", "SEVERITY", *obj.Resources[0].Services[0].Properties["severity"].StringValue)
+			return
+		}
+		if obj.Groups[0].GroupName != "Group01" {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Errorf("Not equal, expected: %q, actual: %q", "Group01", obj.Groups[0].GroupName)
+			return
+		}
+		if obj.Groups[0].Resources[0].Name != "Host01" {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Errorf("Not equal, expected: %q, actual: %q", "Host01", obj.Groups[0].Resources[0].Name)
+			return
+		}
+		if obj.Resources[0].Services[0].LastPluginOutput != "Test Tag" {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Errorf("Not equal, expected: %q, actual: %q", "Test Tag", obj.Resources[0].Services[0].LastPluginOutput)
+			return
+		}
+		if obj.Resources[0].Services[0].Status != transit.MonitorStatus("SERVICE_PENDING") {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Errorf("Not equal, expected: %q, actual: %q", transit.MonitorStatus("SERVICE_PENDING"), obj.Resources[0].Services[0].Status)
+			return
+		}
+		if dt := float64(1.0) - *obj.Resources[0].Services[0].Metrics[0].Value.DoubleValue; !testutil.WithinDefaultDelta(dt) {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Errorf("Max difference between %v and %v allowed is %v, but difference was %v",
+				float64(1.0), *obj.Resources[0].Services[0].Metrics[0].Value.DoubleValue, testutil.DefaultDelta, dt)
+			return
+		}
+		if dt := float64(9.0) - *obj.Resources[0].Services[0].Metrics[0].Thresholds[0].Value.DoubleValue; !testutil.WithinDefaultDelta(dt) {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Errorf("Max difference between %v and %v allowed is %v, but difference was %v",
+				float64(9.0), *obj.Resources[0].Services[0].Metrics[0].Thresholds[0].Value.DoubleValue, testutil.DefaultDelta, dt)
+			return
+		}
+		if dt := float64(6.0) - *obj.Resources[0].Services[0].Metrics[0].Thresholds[1].Value.DoubleValue; !testutil.WithinDefaultDelta(dt) {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Errorf("Max difference between %v and %v allowed is %v, but difference was %v",
+				float64(6.0), *obj.Resources[0].Services[0].Metrics[0].Thresholds[1].Value.DoubleValue, testutil.DefaultDelta, dt)
+			return
+		}
 
-		_, err = fmt.Fprintln(w, "OK")
-		require.NoError(t, err)
+		if _, err = fmt.Fprintln(w, "OK"); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Error(err)
+			return
+		}
 	}))
 
 	i := Groundwork{

--- a/plugins/outputs/http/http_test.go
+++ b/plugins/outputs/http/http_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -108,7 +109,11 @@ func TestMethod(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ts.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				require.Equal(t, tt.expectedMethod, r.Method)
+				if r.Method != tt.expectedMethod {
+					w.WriteHeader(http.StatusInternalServerError)
+					t.Errorf("Not equal, expected: %q, actual: %q", tt.expectedMethod, r.Method)
+					return
+				}
 				w.WriteHeader(http.StatusOK)
 			})
 
@@ -316,7 +321,11 @@ func TestContentType(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ts.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				require.Equal(t, tt.expected, r.Header.Get("Content-Type"))
+				if contentHeader := r.Header.Get("Content-Type"); contentHeader != tt.expected {
+					w.WriteHeader(http.StatusInternalServerError)
+					t.Errorf("Not equal, expected: %q, actual: %q", tt.expected, contentHeader)
+					return
+				}
 				w.WriteHeader(http.StatusOK)
 			})
 
@@ -365,18 +374,34 @@ func TestContentEncodingGzip(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ts.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				require.Equal(t, tt.expected, r.Header.Get("Content-Encoding"))
+				if contentHeader := r.Header.Get("Content-Encoding"); contentHeader != tt.expected {
+					w.WriteHeader(http.StatusInternalServerError)
+					t.Errorf("Not equal, expected: %q, actual: %q", tt.expected, contentHeader)
+					return
+				}
 
 				body := r.Body
 				var err error
 				if r.Header.Get("Content-Encoding") == "gzip" {
 					body, err = gzip.NewReader(r.Body)
-					require.NoError(t, err)
+					if err != nil {
+						w.WriteHeader(http.StatusInternalServerError)
+						t.Error(err)
+						return
+					}
 				}
 
 				payload, err := io.ReadAll(body)
-				require.NoError(t, err)
-				require.Contains(t, string(payload), "cpu value=42")
+				if err != nil {
+					w.WriteHeader(http.StatusInternalServerError)
+					t.Error(err)
+					return
+				}
+				if !strings.Contains(string(payload), "cpu value=42") {
+					w.WriteHeader(http.StatusInternalServerError)
+					t.Errorf("'payload' should contain %q", "cpu value=42")
+					return
+				}
 
 				w.WriteHeader(http.StatusNoContent)
 			})
@@ -432,8 +457,16 @@ func TestBasicAuth(t *testing.T) {
 			}
 			ts.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				username, password, _ := r.BasicAuth()
-				require.Equal(t, tt.username, username)
-				require.Equal(t, tt.password, password)
+				if username != tt.username {
+					w.WriteHeader(http.StatusInternalServerError)
+					t.Errorf("Not equal, expected: %q, actual: %q", tt.username, username)
+					return
+				}
+				if password != tt.password {
+					w.WriteHeader(http.StatusInternalServerError)
+					t.Errorf("Not equal, expected: %q, actual: %q", tt.password, password)
+					return
+				}
 				w.WriteHeader(http.StatusOK)
 			})
 
@@ -660,7 +693,11 @@ func TestDefaultUserAgent(t *testing.T) {
 
 	t.Run("default-user-agent", func(t *testing.T) {
 		ts.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			require.Equal(t, internal.ProductToken(), r.Header.Get("User-Agent"))
+			if userHeader := r.Header.Get("User-Agent"); userHeader != internal.ProductToken() {
+				w.WriteHeader(http.StatusInternalServerError)
+				t.Errorf("Not equal, expected: %q, actual: %q", internal.ProductToken(), userHeader)
+				return
+			}
 			w.WriteHeader(http.StatusOK)
 		})
 

--- a/plugins/outputs/nebius_cloud_monitoring/nebius_cloud_monitoring_test.go
+++ b/plugins/outputs/nebius_cloud_monitoring/nebius_cloud_monitoring_test.go
@@ -31,11 +31,17 @@ func TestWrite(t *testing.T) {
 					ExpiresIn:   123,
 				}
 				w.Header().Set("Content-Type", "application/json; charset=utf-8")
-				err := json.NewEncoder(w).Encode(token)
-				require.NoError(t, err)
+				if err := json.NewEncoder(w).Encode(token); err != nil {
+					w.WriteHeader(http.StatusInternalServerError)
+					t.Error(err)
+					return
+				}
 			} else if strings.HasSuffix(r.URL.Path, "/folder") {
-				_, err := io.WriteString(w, "folder1")
-				require.NoError(t, err)
+				if _, err := io.WriteString(w, "folder1"); err != nil {
+					w.WriteHeader(http.StatusInternalServerError)
+					t.Error(err)
+					return
+				}
 			}
 			w.WriteHeader(http.StatusOK)
 		}),

--- a/plugins/outputs/prometheus_client/prometheus_client_v1_test.go
+++ b/plugins/outputs/prometheus_client/prometheus_client_v1_test.go
@@ -440,8 +440,11 @@ rpc_duration_seconds_count 2693
 		t.Run(tt.name, func(t *testing.T) {
 			ts.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusOK)
-				_, err := w.Write(tt.data)
-				require.NoError(t, err)
+				if _, err := w.Write(tt.data); err != nil {
+					w.WriteHeader(http.StatusInternalServerError)
+					t.Error(err)
+					return
+				}
 			})
 
 			input := &inputs.Prometheus{

--- a/plugins/outputs/prometheus_client/prometheus_client_v2_test.go
+++ b/plugins/outputs/prometheus_client/prometheus_client_v2_test.go
@@ -469,8 +469,11 @@ rpc_duration_seconds_count 2693
 		t.Run(tt.name, func(t *testing.T) {
 			ts.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusOK)
-				_, err := w.Write(tt.data)
-				require.NoError(t, err)
+				if _, err := w.Write(tt.data); err != nil {
+					w.WriteHeader(http.StatusInternalServerError)
+					t.Error(err)
+					return
+				}
 			})
 
 			input := &inputs.Prometheus{

--- a/plugins/outputs/yandex_cloud_monitoring/yandex_cloud_monitoring_test.go
+++ b/plugins/outputs/yandex_cloud_monitoring/yandex_cloud_monitoring_test.go
@@ -32,11 +32,17 @@ func TestWrite(t *testing.T) {
 					ExpiresIn:   123,
 				}
 				w.Header().Set("Content-Type", "application/json; charset=utf-8")
-				err := json.NewEncoder(w).Encode(token)
-				require.NoError(t, err)
+				if err := json.NewEncoder(w).Encode(token); err != nil {
+					w.WriteHeader(http.StatusInternalServerError)
+					t.Error(err)
+					return
+				}
 			} else if strings.HasSuffix(r.URL.Path, "/folder") {
-				_, err := io.WriteString(w, "folder1")
-				require.NoError(t, err)
+				if _, err := io.WriteString(w, "folder1"); err != nil {
+					w.WriteHeader(http.StatusInternalServerError)
+					t.Error(err)
+					return
+				}
 			}
 			w.WriteHeader(http.StatusOK)
 		}),

--- a/plugins/secretstores/http/http_test.go
+++ b/plugins/secretstores/http/http_test.go
@@ -62,8 +62,11 @@ func TestCases(t *testing.T) {
 
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if r.URL.Path == "/secrets" {
-					_, err = w.Write(input)
-					require.NoError(t, err)
+					if _, err = w.Write(input); err != nil {
+						w.WriteHeader(http.StatusInternalServerError)
+						t.Error(err)
+						return
+					}
 				} else {
 					w.WriteHeader(http.StatusNotFound)
 				}
@@ -156,8 +159,11 @@ func TestGetErrors(t *testing.T) {
 
 func TestResolver(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		_, err := w.Write([]byte(`{"test": "aedMZXaLR246OHHjVtJKXQ=="}`))
-		require.NoError(t, err)
+		if _, err := w.Write([]byte(`{"test": "aedMZXaLR246OHHjVtJKXQ=="}`)); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Error(err)
+			return
+		}
 	}))
 	defer server.Close()
 
@@ -198,8 +204,11 @@ func TestGetResolverErrors(t *testing.T) {
 	dummy.Close()
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		_, err = w.Write([]byte(`[{"test": "aedMZXaLR246OHHjVtJKXQ=="}]`))
-		require.NoError(t, err)
+		if _, err = w.Write([]byte(`[{"test": "aedMZXaLR246OHHjVtJKXQ=="}]`)); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Error(err)
+			return
+		}
 	}))
 	defer server.Close()
 
@@ -232,8 +241,11 @@ func TestInvalidServerResponse(t *testing.T) {
 	defer dummy.Close()
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		_, err = w.Write([]byte(`[somerandomebytes`))
-		require.NoError(t, err)
+		if _, err = w.Write([]byte(`[somerandomebytes`)); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Error(err)
+			return
+		}
 	}))
 	defer server.Close()
 
@@ -267,8 +279,11 @@ func TestAdditionalHeaders(t *testing.T) {
 		if r.Host != "" {
 			actual.Add("host", r.Host)
 		}
-		_, err = w.Write([]byte(`{"test": "aedMZXaLR246OHHjVtJKXQ=="}`))
-		require.NoError(t, err)
+		if _, err = w.Write([]byte(`{"test": "aedMZXaLR246OHHjVtJKXQ=="}`)); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Error(err)
+			return
+		}
 	}))
 	defer server.Close()
 
@@ -310,14 +325,20 @@ func TestServerReturnCodes(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/", "/200":
-			_, err = w.Write([]byte(`{}`))
-			require.NoError(t, err)
+			if _, err = w.Write([]byte(`{}`)); err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				t.Error(err)
+				return
+			}
 		case "/201":
 			w.WriteHeader(201)
 		case "/300":
 			w.WriteHeader(300)
-			_, err = w.Write([]byte(`{}`))
-			require.NoError(t, err)
+			if _, err = w.Write([]byte(`{}`)); err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				t.Error(err)
+				return
+			}
 		case "/401":
 			w.WriteHeader(401)
 		default:
@@ -357,8 +378,11 @@ func TestAuthenticationBasic(t *testing.T) {
 	var header http.Header
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		header = r.Header
-		_, err = w.Write([]byte(`{}`))
-		require.NoError(t, err)
+		if _, err = w.Write([]byte(`{}`)); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Error(err)
+			return
+		}
 	}))
 	defer server.Close()
 
@@ -385,8 +409,11 @@ func TestAuthenticationToken(t *testing.T) {
 	var header http.Header
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		header = r.Header
-		_, err = w.Write([]byte(`{}`))
-		require.NoError(t, err)
+		if _, err = w.Write([]byte(`{}`)); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Error(err)
+			return
+		}
 	}))
 	defer server.Close()
 

--- a/plugins/secretstores/oauth2/oauth2_test.go
+++ b/plugins/secretstores/oauth2/oauth2_test.go
@@ -179,8 +179,11 @@ func TestGet(t *testing.T) {
 		func(w http.ResponseWriter, r *http.Request) {
 			body, err := io.ReadAll(r.Body)
 			if err != nil {
-				_, err := w.Write([]byte(err.Error()))
-				require.NoError(t, err)
+				if _, err := w.Write([]byte(err.Error())); err != nil {
+					w.WriteHeader(http.StatusInternalServerError)
+					t.Error(err)
+					return
+				}
 				w.WriteHeader(http.StatusInternalServerError)
 				return
 			}
@@ -220,8 +223,11 @@ func TestGetMultipleTimes(t *testing.T) {
 		func(w http.ResponseWriter, r *http.Request) {
 			body, err := io.ReadAll(r.Body)
 			if err != nil {
-				_, err := w.Write([]byte(err.Error()))
-				require.NoError(t, err)
+				if _, err := w.Write([]byte(err.Error())); err != nil {
+					w.WriteHeader(http.StatusInternalServerError)
+					t.Error(err)
+					return
+				}
 				w.WriteHeader(http.StatusInternalServerError)
 				return
 			}
@@ -267,8 +273,11 @@ func TestGetExpired(t *testing.T) {
 		func(w http.ResponseWriter, r *http.Request) {
 			body, err := io.ReadAll(r.Body)
 			if err != nil {
-				_, err := w.Write([]byte(err.Error()))
-				require.NoError(t, err)
+				if _, err := w.Write([]byte(err.Error())); err != nil {
+					w.WriteHeader(http.StatusInternalServerError)
+					t.Error(err)
+					return
+				}
 				w.WriteHeader(http.StatusInternalServerError)
 				return
 			}
@@ -309,8 +318,11 @@ func TestGetRefresh(t *testing.T) {
 		func(w http.ResponseWriter, r *http.Request) {
 			body, err := io.ReadAll(r.Body)
 			if err != nil {
-				_, err := w.Write([]byte(err.Error()))
-				require.NoError(t, err)
+				if _, err := w.Write([]byte(err.Error())); err != nil {
+					w.WriteHeader(http.StatusInternalServerError)
+					t.Error(err)
+					return
+				}
 				w.WriteHeader(http.StatusInternalServerError)
 				return
 			}

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -108,3 +108,7 @@ func DefaultSampleConfig(sampleConfig string) []byte {
 	re := regexp.MustCompile(`(?m)(^\s+)#\s*`)
 	return []byte(re.ReplaceAllString(sampleConfig, "$1"))
 }
+
+func WithinDefaultDelta(dt float64) bool {
+	return dt < -DefaultDelta || dt > DefaultDelta
+}


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

Address last findings inside `http-handlers` for [testifylint:go-require](https://github.com/Antonboom/testifylint?tab=readme-ov-file#go-require) and enable this checker.

Here are the findings that this PR addresses:
```
config/config_test.go:524:3                                                   testifylint  go-require: do not use require in http handlers
migrations/inputs_httpjson/migration_test.go:116:6                            testifylint  go-require: do not use require in http handlers
plugins/common/cookie/cookie_test.go:66:5                                     testifylint  go-require: do not use require in http handlers
plugins/common/cookie/cookie_test.go:93:5                                     testifylint  go-require: do not use require in http handlers
plugins/outputs/bigquery/bigquery_test.go:274:4                               testifylint  go-require: do not use require in http handlers
plugins/outputs/bigquery/bigquery_test.go:278:4                               testifylint  go-require: do not use require in http handlers
plugins/outputs/bigquery/bigquery_test.go:282:4                               testifylint  go-require: do not use require in http handlers
plugins/outputs/bigquery/bigquery_test.go:286:4                               testifylint  go-require: do not use require in http handlers
plugins/outputs/dynatrace/dynatrace_test.go:29:3                              testifylint  go-require: do not use require in http handlers
plugins/outputs/dynatrace/dynatrace_test.go:54:3                              testifylint  go-require: do not use require in http handlers
plugins/outputs/dynatrace/dynatrace_test.go:77:3                              testifylint  go-require: do not use require in http handlers
plugins/outputs/dynatrace/dynatrace_test.go:134:3                             testifylint  go-require: do not use require in http handlers
plugins/outputs/dynatrace/dynatrace_test.go:149:3                             testifylint  go-require: do not use require in http handlers
plugins/outputs/dynatrace/dynatrace_test.go:220:3                             testifylint  go-require: do not use require in http handlers
plugins/outputs/dynatrace/dynatrace_test.go:235:3                             testifylint  go-require: do not use require in http handlers
plugins/outputs/dynatrace/dynatrace_test.go:326:3                             testifylint  go-require: do not use require in http handlers
plugins/outputs/dynatrace/dynatrace_test.go:329:3                             testifylint  go-require: do not use require in http handlers
plugins/outputs/dynatrace/dynatrace_test.go:330:3                             testifylint  go-require: do not use require in http handlers
plugins/outputs/dynatrace/dynatrace_test.go:331:3                             testifylint  go-require: do not use require in http handlers
plugins/outputs/dynatrace/dynatrace_test.go:332:3                             testifylint  go-require: do not use require in http handlers
plugins/outputs/dynatrace/dynatrace_test.go:333:3                             testifylint  go-require: do not use require in http handlers
plugins/outputs/dynatrace/dynatrace_test.go:334:3                             testifylint  go-require: do not use require in http handlers
plugins/outputs/dynatrace/dynatrace_test.go:335:3                             testifylint  go-require: do not use require in http handlers
plugins/outputs/dynatrace/dynatrace_test.go:338:3                             testifylint  go-require: do not use require in http handlers
plugins/outputs/dynatrace/dynatrace_test.go:372:3                             testifylint  go-require: do not use require in http handlers
plugins/outputs/dynatrace/dynatrace_test.go:379:3                             testifylint  go-require: do not use require in http handlers
plugins/outputs/dynatrace/dynatrace_test.go:413:3                             testifylint  go-require: do not use require in http handlers
plugins/outputs/dynatrace/dynatrace_test.go:417:3                             testifylint  go-require: do not use require in http handlers
plugins/outputs/dynatrace/dynatrace_test.go:418:3                             testifylint  go-require: do not use require in http handlers
plugins/outputs/dynatrace/dynatrace_test.go:419:3                             testifylint  go-require: do not use require in http handlers
plugins/outputs/dynatrace/dynatrace_test.go:420:3                             testifylint  go-require: do not use require in http handlers
plugins/outputs/dynatrace/dynatrace_test.go:421:3                             testifylint  go-require: do not use require in http handlers
plugins/outputs/dynatrace/dynatrace_test.go:422:3                             testifylint  go-require: do not use require in http handlers
plugins/outputs/dynatrace/dynatrace_test.go:423:3                             testifylint  go-require: do not use require in http handlers
plugins/outputs/dynatrace/dynatrace_test.go:426:3                             testifylint  go-require: do not use require in http handlers
plugins/outputs/dynatrace/dynatrace_test.go:460:3                             testifylint  go-require: do not use require in http handlers
plugins/outputs/dynatrace/dynatrace_test.go:463:3                             testifylint  go-require: do not use require in http handlers
plugins/outputs/dynatrace/dynatrace_test.go:464:3                             testifylint  go-require: do not use require in http handlers
plugins/outputs/dynatrace/dynatrace_test.go:465:3                             testifylint  go-require: do not use require in http handlers
plugins/outputs/dynatrace/dynatrace_test.go:467:3                             testifylint  go-require: do not use require in http handlers
plugins/outputs/dynatrace/dynatrace_test.go:501:3                             testifylint  go-require: do not use require in http handlers
plugins/outputs/dynatrace/dynatrace_test.go:504:3                             testifylint  go-require: do not use require in http handlers
plugins/outputs/dynatrace/dynatrace_test.go:505:3                             testifylint  go-require: do not use require in http handlers
plugins/outputs/dynatrace/dynatrace_test.go:506:3                             testifylint  go-require: do not use require in http handlers
plugins/outputs/dynatrace/dynatrace_test.go:507:3                             testifylint  go-require: do not use require in http handlers
plugins/outputs/dynatrace/dynatrace_test.go:508:3                             testifylint  go-require: do not use require in http handlers
plugins/outputs/dynatrace/dynatrace_test.go:510:3                             testifylint  go-require: do not use require in http handlers
plugins/outputs/dynatrace/dynatrace_test.go:544:3                             testifylint  go-require: do not use require in http handlers
plugins/outputs/dynatrace/dynatrace_test.go:547:3                             testifylint  go-require: do not use require in http handlers
plugins/outputs/dynatrace/dynatrace_test.go:548:3                             testifylint  go-require: do not use require in http handlers
plugins/outputs/dynatrace/dynatrace_test.go:549:3                             testifylint  go-require: do not use require in http handlers
plugins/outputs/dynatrace/dynatrace_test.go:550:3                             testifylint  go-require: do not use require in http handlers
plugins/outputs/dynatrace/dynatrace_test.go:551:3                             testifylint  go-require: do not use require in http handlers
plugins/outputs/dynatrace/dynatrace_test.go:553:3                             testifylint  go-require: do not use require in http handlers
plugins/outputs/dynatrace/dynatrace_test.go:587:3                             testifylint  go-require: do not use require in http handlers
plugins/outputs/dynatrace/dynatrace_test.go:590:3                             testifylint  go-require: do not use require in http handlers
plugins/outputs/dynatrace/dynatrace_test.go:591:3                             testifylint  go-require: do not use require in http handlers
plugins/outputs/dynatrace/dynatrace_test.go:592:3                             testifylint  go-require: do not use require in http handlers
plugins/outputs/dynatrace/dynatrace_test.go:593:3                             testifylint  go-require: do not use require in http handlers
plugins/outputs/dynatrace/dynatrace_test.go:595:3                             testifylint  go-require: do not use require in http handlers
plugins/outputs/elasticsearch/elasticsearch_test.go:682:4                     testifylint  go-require: do not use require in http handlers
plugins/outputs/elasticsearch/elasticsearch_test.go:683:4                     testifylint  go-require: do not use require in http handlers
plugins/outputs/elasticsearch/elasticsearch_test.go:685:4                     testifylint  go-require: do not use require in http handlers
plugins/outputs/elasticsearch/elasticsearch_test.go:689:4                     testifylint  go-require: do not use require in http handlers
plugins/outputs/elasticsearch/elasticsearch_test.go:717:4                     testifylint  go-require: do not use require in http handlers
plugins/outputs/elasticsearch/elasticsearch_test.go:719:4                     testifylint  go-require: do not use require in http handlers
plugins/outputs/elasticsearch/elasticsearch_test.go:723:4                     testifylint  go-require: do not use require in http handlers
plugins/outputs/elasticsearch/elasticsearch_test.go:751:4                     testifylint  go-require: do not use require in http handlers
plugins/outputs/elasticsearch/elasticsearch_test.go:753:4                     testifylint  go-require: do not use require in http handlers
plugins/outputs/elasticsearch/elasticsearch_test.go:757:4                     testifylint  go-require: do not use require in http handlers
plugins/outputs/groundwork/groundwork_test.go:37:3                            testifylint  go-require: do not use require in http handlers
plugins/outputs/groundwork/groundwork_test.go:42:3                            testifylint  go-require: do not use require in http handlers
plugins/outputs/groundwork/groundwork_test.go:45:3                            testifylint  go-require: do not use require in http handlers
plugins/outputs/groundwork/groundwork_test.go:46:3                            testifylint  go-require: do not use require in http handlers
plugins/outputs/groundwork/groundwork_test.go:51:3                            testifylint  go-require: do not use require in http handlers
plugins/outputs/groundwork/groundwork_test.go:87:3                            testifylint  go-require: do not use require in http handlers
plugins/outputs/groundwork/groundwork_test.go:92:3                            testifylint  go-require: do not use require in http handlers
plugins/outputs/groundwork/groundwork_test.go:95:3                            testifylint  go-require: do not use require in http handlers
plugins/outputs/groundwork/groundwork_test.go:96:3                            testifylint  go-require: do not use require in http handlers
plugins/outputs/groundwork/groundwork_test.go:97:3                            testifylint  go-require: do not use require in http handlers
plugins/outputs/groundwork/groundwork_test.go:98:3                            testifylint  go-require: do not use require in http handlers
plugins/outputs/groundwork/groundwork_test.go:99:3                            testifylint  go-require: do not use require in http handlers
plugins/outputs/groundwork/groundwork_test.go:100:3                           testifylint  go-require: do not use require in http handlers
plugins/outputs/groundwork/groundwork_test.go:101:3                           testifylint  go-require: do not use require in http handlers
plugins/outputs/groundwork/groundwork_test.go:104:3                           testifylint  go-require: do not use require in http handlers
plugins/outputs/groundwork/groundwork_test.go:139:3                           testifylint  go-require: do not use require in http handlers
plugins/outputs/groundwork/groundwork_test.go:144:3                           testifylint  go-require: do not use require in http handlers
plugins/outputs/groundwork/groundwork_test.go:147:3                           testifylint  go-require: do not use require in http handlers
plugins/outputs/groundwork/groundwork_test.go:148:3                           testifylint  go-require: do not use require in http handlers
plugins/outputs/groundwork/groundwork_test.go:149:3                           testifylint  go-require: do not use require in http handlers
plugins/outputs/groundwork/groundwork_test.go:150:3                           testifylint  go-require: do not use require in http handlers
plugins/outputs/groundwork/groundwork_test.go:151:3                           testifylint  go-require: do not use require in http handlers
plugins/outputs/groundwork/groundwork_test.go:154:3                           testifylint  go-require: do not use require in http handlers
plugins/outputs/groundwork/groundwork_test.go:200:3                           testifylint  go-require: do not use require in http handlers
plugins/outputs/groundwork/groundwork_test.go:205:3                           testifylint  go-require: do not use require in http handlers
plugins/outputs/groundwork/groundwork_test.go:208:3                           testifylint  go-require: do not use require in http handlers
plugins/outputs/groundwork/groundwork_test.go:209:3                           testifylint  go-require: do not use require in http handlers
plugins/outputs/groundwork/groundwork_test.go:210:3                           testifylint  go-require: do not use require in http handlers
plugins/outputs/groundwork/groundwork_test.go:211:3                           testifylint  go-require: do not use require in http handlers
plugins/outputs/groundwork/groundwork_test.go:212:3                           testifylint  go-require: do not use require in http handlers
plugins/outputs/groundwork/groundwork_test.go:213:3                           testifylint  go-require: do not use require in http handlers
plugins/outputs/groundwork/groundwork_test.go:214:3                           testifylint  go-require: do not use require in http handlers
plugins/outputs/groundwork/groundwork_test.go:215:3                           testifylint  go-require: do not use require in http handlers
plugins/outputs/groundwork/groundwork_test.go:216:3                           testifylint  go-require: do not use require in http handlers
plugins/outputs/groundwork/groundwork_test.go:217:3                           testifylint  go-require: do not use require in http handlers
plugins/outputs/groundwork/groundwork_test.go:218:3                           testifylint  go-require: do not use require in http handlers
plugins/outputs/groundwork/groundwork_test.go:219:3                           testifylint  go-require: do not use require in http handlers
plugins/outputs/groundwork/groundwork_test.go:220:3                           testifylint  go-require: do not use require in http handlers
plugins/outputs/groundwork/groundwork_test.go:223:3                           testifylint  go-require: do not use require in http handlers
plugins/outputs/http/http_test.go:111:5                                       testifylint  go-require: do not use require in http handlers
plugins/outputs/http/http_test.go:319:5                                       testifylint  go-require: do not use require in http handlers
plugins/outputs/http/http_test.go:368:5                                       testifylint  go-require: do not use require in http handlers
plugins/outputs/http/http_test.go:374:6                                       testifylint  go-require: do not use require in http handlers
plugins/outputs/http/http_test.go:378:5                                       testifylint  go-require: do not use require in http handlers
plugins/outputs/http/http_test.go:379:5                                       testifylint  go-require: do not use require in http handlers
plugins/outputs/http/http_test.go:435:5                                       testifylint  go-require: do not use require in http handlers
plugins/outputs/http/http_test.go:436:5                                       testifylint  go-require: do not use require in http handlers
plugins/outputs/http/http_test.go:663:4                                       testifylint  go-require: do not use require in http handlers
plugins/outputs/influxdb/http_test.go:584:5                                   testifylint  go-require: do not use require in http handlers
plugins/outputs/influxdb/http_test.go:587:5                                   testifylint  go-require: do not use require in http handlers
plugins/outputs/influxdb/http_test.go:589:5                                   testifylint  go-require: do not use require in http handlers
plugins/outputs/influxdb/http_test.go:591:5                                   testifylint  go-require: do not use require in http handlers
plugins/outputs/influxdb/http_test.go:711:5                                   testifylint  go-require: do not use require in http handlers
plugins/outputs/influxdb/http_test.go:712:5                                   testifylint  go-require: do not use require in http handlers
plugins/outputs/influxdb/http_test.go:715:5                                   testifylint  go-require: do not use require in http handlers
plugins/outputs/influxdb/http_test.go:716:5                                   testifylint  go-require: do not use require in http handlers
plugins/outputs/influxdb/http_test.go:1028:6                                  testifylint  go-require: do not use require in http handlers
plugins/outputs/influxdb/http_test.go:1101:6                                  testifylint  go-require: do not use require in http handlers
plugins/outputs/influxdb/http_test.go:1111:6                                  testifylint  go-require: do not use require in http handlers
plugins/outputs/influxdb/http_test.go:1186:4                                  testifylint  go-require: do not use require in http handlers
plugins/outputs/influxdb_v2/influxdb_v2_test.go:141:5                         testifylint  go-require: do not use require in http handlers
plugins/outputs/influxdb_v2/influxdb_v2_test.go:142:5                         testifylint  go-require: do not use require in http handlers
plugins/outputs/influxdb_v2/influxdb_v2_test.go:145:5                         testifylint  go-require: do not use require in http handlers
plugins/outputs/influxdb_v2/influxdb_v2_test.go:146:5                         testifylint  go-require: do not use require in http handlers
plugins/outputs/influxdb_v2/influxdb_v2_test.go:196:5                         testifylint  go-require: do not use require in http handlers
plugins/outputs/influxdb_v2/influxdb_v2_test.go:197:5                         testifylint  go-require: do not use require in http handlers
plugins/outputs/influxdb_v2/influxdb_v2_test.go:200:5                         testifylint  go-require: do not use require in http handlers
plugins/outputs/influxdb_v2/influxdb_v2_test.go:201:5                         testifylint  go-require: do not use require in http handlers
plugins/outputs/influxdb_v2/influxdb_v2_test.go:249:5                         testifylint  go-require: do not use require in http handlers
plugins/outputs/influxdb_v2/influxdb_v2_test.go:252:5                         testifylint  go-require: do not use require in http handlers
plugins/outputs/logzio/logzio_test.go:75:3                                    testifylint  go-require: do not use require in http handlers
plugins/outputs/logzio/logzio_test.go:82:3                                    testifylint  go-require: do not use require in http handlers
plugins/outputs/logzio/logzio_test.go:83:3                                    testifylint  go-require: do not use require in http handlers
plugins/outputs/logzio/logzio_test.go:87:3                                    testifylint  go-require: do not use require in http handlers
plugins/outputs/logzio/logzio_test.go:89:3                                    testifylint  go-require: do not use require in http handlers
plugins/outputs/logzio/logzio_test.go:90:3                                    testifylint  go-require: do not use require in http handlers
plugins/outputs/logzio/logzio_test.go:91:3                                    testifylint  go-require: do not use require in http handlers
plugins/outputs/logzio/logzio_test.go:92:3                                    testifylint  go-require: do not use require in http handlers
plugins/outputs/loki/loki_test.go:164:5                                       testifylint  go-require: do not use require in http handlers
plugins/outputs/loki/loki_test.go:208:5                                       testifylint  go-require: do not use require in http handlers
plugins/outputs/loki/loki_test.go:214:6                                       testifylint  go-require: do not use require in http handlers
plugins/outputs/loki/loki_test.go:218:5                                       testifylint  go-require: do not use require in http handlers
plugins/outputs/loki/loki_test.go:222:5                                       testifylint  go-require: do not use require in http handlers
plugins/outputs/loki/loki_test.go:223:5                                       testifylint  go-require: do not use require in http handlers
plugins/outputs/loki/loki_test.go:224:5                                       testifylint  go-require: do not use require in http handlers
plugins/outputs/loki/loki_test.go:225:5                                       testifylint  go-require: do not use require in http handlers
plugins/outputs/loki/loki_test.go:226:5                                       testifylint  go-require: do not use require in http handlers
plugins/outputs/loki/loki_test.go:227:5                                       testifylint  go-require: do not use require in http handlers
plugins/outputs/loki/loki_test.go:228:5                                       testifylint  go-require: do not use require in http handlers
plugins/outputs/loki/loki_test.go:229:5                                       testifylint  go-require: do not use require in http handlers
plugins/outputs/loki/loki_test.go:267:5                                       testifylint  go-require: do not use require in http handlers
plugins/outputs/loki/loki_test.go:270:5                                       testifylint  go-require: do not use require in http handlers
plugins/outputs/loki/loki_test.go:274:6                                       testifylint  go-require: do not use require in http handlers
plugins/outputs/loki/loki_test.go:276:6                                       testifylint  go-require: do not use require in http handlers
plugins/outputs/loki/loki_test.go:318:5                                       testifylint  go-require: do not use require in http handlers
plugins/outputs/loki/loki_test.go:319:5                                       testifylint  go-require: do not use require in http handlers
plugins/outputs/loki/loki_test.go:415:4                                       testifylint  go-require: do not use require in http handlers
plugins/outputs/loki/loki_test.go:443:4                                       testifylint  go-require: do not use require in http handlers
plugins/outputs/loki/loki_test.go:447:4                                       testifylint  go-require: do not use require in http handlers
plugins/outputs/loki/loki_test.go:448:4                                       testifylint  go-require: do not use require in http handlers
plugins/outputs/loki/loki_test.go:449:4                                       testifylint  go-require: do not use require in http handlers
plugins/outputs/loki/loki_test.go:450:4                                       testifylint  go-require: do not use require in http handlers
plugins/outputs/loki/loki_test.go:451:4                                       testifylint  go-require: do not use require in http handlers
plugins/outputs/loki/loki_test.go:452:4                                       testifylint  go-require: do not use require in http handlers
plugins/outputs/loki/loki_test.go:453:4                                       testifylint  go-require: do not use require in http handlers
plugins/outputs/loki/loki_test.go:454:4                                       testifylint  go-require: do not use require in http handlers
plugins/outputs/loki/loki_test.go:455:4                                       testifylint  go-require: do not use require in http handlers
plugins/outputs/loki/loki_test.go:456:4                                       testifylint  go-require: do not use require in http handlers
plugins/outputs/loki/loki_test.go:457:4                                       testifylint  go-require: do not use require in http handlers
plugins/outputs/nebius_cloud_monitoring/nebius_cloud_monitoring_test.go:35:5  testifylint  go-require: do not use require in http handlers
plugins/outputs/nebius_cloud_monitoring/nebius_cloud_monitoring_test.go:38:5  testifylint  go-require: do not use require in http handlers
plugins/outputs/opensearch/opensearch_test.go:151:4                           testifylint  go-require: do not use require in http handlers
plugins/outputs/opensearch/opensearch_test.go:152:4                           testifylint  go-require: do not use require in http handlers
plugins/outputs/opensearch/opensearch_test.go:154:4                           testifylint  go-require: do not use require in http handlers
plugins/outputs/opensearch/opensearch_test.go:158:4                           testifylint  go-require: do not use require in http handlers
plugins/outputs/opensearch/opensearch_test.go:191:4                           testifylint  go-require: do not use require in http handlers
plugins/outputs/opensearch/opensearch_test.go:193:4                           testifylint  go-require: do not use require in http handlers
plugins/outputs/opensearch/opensearch_test.go:197:4                           testifylint  go-require: do not use require in http handlers
plugins/outputs/opensearch/opensearch_test.go:227:4                           testifylint  go-require: do not use require in http handlers
plugins/outputs/opensearch/opensearch_test.go:229:4                           testifylint  go-require: do not use require in http handlers
plugins/outputs/opensearch/opensearch_test.go:233:4                           testifylint  go-require: do not use require in http handlers
plugins/outputs/opensearch/opensearch_test.go:287:4                           testifylint  go-require: do not use require in http handlers
plugins/outputs/opensearch/opensearch_test.go:289:4                           testifylint  go-require: do not use require in http handlers
plugins/outputs/opensearch/opensearch_test.go:293:4                           testifylint  go-require: do not use require in http handlers
plugins/outputs/prometheus_client/prometheus_client_v1_test.go:444:5          testifylint  go-require: do not use require in http handlers
plugins/outputs/prometheus_client/prometheus_client_v2_test.go:473:5          testifylint  go-require: do not use require in http handlers
plugins/outputs/sensu/sensu_test.go:119:4                                     testifylint  go-require: do not use require in http handlers
plugins/outputs/sensu/sensu_test.go:120:4                                     testifylint  go-require: do not use require in http handlers
plugins/outputs/sensu/sensu_test.go:123:4                                     testifylint  go-require: do not use require in http handlers
plugins/outputs/sensu/sensu_test.go:126:4                                     testifylint  go-require: do not use require in http handlers
plugins/outputs/sensu/sensu_test.go:127:4                                     testifylint  go-require: do not use require in http handlers
plugins/outputs/sensu/sensu_test.go:128:4                                     testifylint  go-require: do not use require in http handlers
plugins/outputs/sensu/sensu_test.go:129:4                                     testifylint  go-require: do not use require in http handlers
plugins/outputs/sensu/sensu_test.go:130:4                                     testifylint  go-require: do not use require in http handlers
plugins/outputs/sensu/sensu_test.go:131:4                                     testifylint  go-require: do not use require in http handlers
plugins/outputs/sensu/sensu_test.go:137:6                                     testifylint  go-require: do not use require in http handlers
plugins/outputs/sensu/sensu_test.go:145:4                                     testifylint  go-require: do not use require in http handlers
plugins/outputs/sensu/sensu_test.go:146:4                                     testifylint  go-require: do not use require in http handlers
plugins/outputs/sumologic/sumologic_test.go:93:5                              testifylint  go-require: do not use require in http handlers
plugins/outputs/sumologic/sumologic_test.go:260:5                             testifylint  go-require: do not use require in http handlers
plugins/outputs/sumologic/sumologic_test.go:267:5                             testifylint  go-require: do not use require in http handlers
plugins/outputs/sumologic/sumologic_test.go:268:5                             testifylint  go-require: do not use require in http handlers
plugins/outputs/sumologic/sumologic_test.go:316:5                             testifylint  go-require: do not use require in http handlers
plugins/outputs/sumologic/sumologic_test.go:319:5                             testifylint  go-require: do not use require in http handlers
plugins/outputs/sumologic/sumologic_test.go:322:5                             testifylint  go-require: do not use require in http handlers
plugins/outputs/sumologic/sumologic_test.go:324:5                             testifylint  go-require: do not use require in http handlers
plugins/outputs/sumologic/sumologic_test.go:355:4                             testifylint  go-require: do not use require in http handlers
plugins/outputs/yandex_cloud_monitoring/yandex_cloud_monitoring_test.go:36:5  testifylint  go-require: do not use require in http handlers
plugins/outputs/yandex_cloud_monitoring/yandex_cloud_monitoring_test.go:39:5  testifylint  go-require: do not use require in http handlers
plugins/secretstores/http/http_test.go:66:6                                   testifylint  go-require: do not use require in http handlers
plugins/secretstores/http/http_test.go:160:3                                  testifylint  go-require: do not use require in http handlers
plugins/secretstores/http/http_test.go:202:3                                  testifylint  go-require: do not use require in http handlers
plugins/secretstores/http/http_test.go:236:3                                  testifylint  go-require: do not use require in http handlers
plugins/secretstores/http/http_test.go:271:3                                  testifylint  go-require: do not use require in http handlers
plugins/secretstores/http/http_test.go:314:4                                  testifylint  go-require: do not use require in http handlers
plugins/secretstores/http/http_test.go:320:4                                  testifylint  go-require: do not use require in http handlers
plugins/secretstores/http/http_test.go:361:3                                  testifylint  go-require: do not use require in http handlers
plugins/secretstores/http/http_test.go:389:3                                  testifylint  go-require: do not use require in http handlers
plugins/secretstores/oauth2/oauth2_test.go:183:5                              testifylint  go-require: do not use require in http handlers
plugins/secretstores/oauth2/oauth2_test.go:224:5                              testifylint  go-require: do not use require in http handlers
plugins/secretstores/oauth2/oauth2_test.go:271:5                              testifylint  go-require: do not use require in http handlers
plugins/secretstores/oauth2/oauth2_test.go:313:5                              testifylint  go-require: do not use require in http handlers
```

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #15535
