### PR TITLE
fix(inputs.mysql): MariaDB example to include mariadb_dialect (#16159)

### DIFF
--- a/plugins/inputs/mysql/dev/docker-compose.yml
+++ b/plugins/inputs/mysql/dev/docker-compose.yml
@@ -13,11 +13,17 @@ services:
     image: mariadb
     restart: always
     environment:
-      MYSQL_ROOT_PASSWORD: telegraf
-      MYSQL_DATABASE: telegraf
-      MYSQL_USER: telegraf
-      MYSQL_PASSWORD: telegraf
-    command: mysqld --userstat=1
+      MARIADB_ROOT_PASSWORD: telegraf
+      MARIADB_DATABASE: telegraf
+      MARIADB_USER: telegraf
+      MARIADB_PASSWORD: telegraf
+    command: --userstat=1
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      start_period: 10s
+      interval: 10s
+      timeout: 5s
+      retries: 3
   percona:
     image: percona
     restart: always
@@ -30,12 +36,15 @@ services:
   telegraf:
     image: glinton/scratch
     depends_on:
-      - mysql
-      - maria
-      - percona
+      maria:
+        condition: service_healthy
+      mysql:
+        condition: service_started
+      percona:
+        condition: service_started
     volumes:
-      - ./telegraf.conf:/telegraf.conf
-      - ../../../../telegraf:/telegraf
+      - ./telegraf.conf:/telegraf.conf:z
+      - ../../../../telegraf:/telegraf:z
     entrypoint:
       - /telegraf
       - --config

--- a/plugins/inputs/mysql/dev/telegraf.conf
+++ b/plugins/inputs/mysql/dev/telegraf.conf
@@ -22,6 +22,7 @@
 ## mariadb
 #[[inputs.mysql]]
 #  servers = ["root:telegraf@tcp(maria:3306)/"]
+#  mariadb_dialect = true
 #  gather_table_schema = true
 #  gather_process_list = true
 #  gather_user_statistics = true


### PR DESCRIPTION

## Summary

Docker-compose example for inputs.mysql for the MariaDB didn't include mariadb_dialect = true. As all maintained versions of MariaDB are 10.5 it seemed prudent to include.

Also it was possible for telegraf to start before MariaDB was ready. Use the healthcheck mariadb has to ensure that docker compose orders this correctly.

The mariadb container can take straight command line arguments and this will pass though to the mariadb server (mariadbd).

<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #16159
