### PR TITLE
chore(deps): Bump golangci-lint from v1.61.0 to v1.62.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,7 +106,7 @@ jobs:
       - run: 'make check-deps'
       - run:
           name: "Install golangci-lint"
-          command: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.61.0
+          command: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.62.0
       - run:
           name: "golangci-lint/Linux"
           # There are only 4 vCPUs available for this executor, so use only 4 instead of the default number
@@ -120,7 +120,7 @@ jobs:
       - check-changed-files-or-halt
       - run:
           name: "Install golangci-lint"
-          command: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.61.0
+          command: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.62.0
       - run:
           name: "golangci-lint/macOS"
           # There are only 4 vCPUs available for this executor, so use only 4 instead of the default number
@@ -134,7 +134,7 @@ jobs:
       - check-changed-files-or-halt
       - run:
           name: "Install golangci-lint"
-          command: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.61.0
+          command: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.62.0
       - run:
           name: "golangci-lint/Windows"
           # There are only 4 vCPUs available for this executor, so use only 4 instead of the default number

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,7 +106,7 @@ jobs:
       - run: 'make check-deps'
       - run:
           name: "Install golangci-lint"
-          command: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.62.0
+          command: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.62.0
       - run:
           name: "golangci-lint/Linux"
           # There are only 4 vCPUs available for this executor, so use only 4 instead of the default number
@@ -120,7 +120,7 @@ jobs:
       - check-changed-files-or-halt
       - run:
           name: "Install golangci-lint"
-          command: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.62.0
+          command: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.62.0
       - run:
           name: "golangci-lint/macOS"
           # There are only 4 vCPUs available for this executor, so use only 4 instead of the default number
@@ -134,7 +134,7 @@ jobs:
       - check-changed-files-or-halt
       - run:
           name: "Install golangci-lint"
-          command: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.62.0
+          command: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.62.0
       - run:
           name: "golangci-lint/Windows"
           # There are only 4 vCPUs available for this executor, so use only 4 instead of the default number

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -280,9 +280,10 @@ linters-settings:
       - name: import-shadowing
       - name: increment-decrement
       - name: indent-error-flow
-      - name: max-public-structs
-        exclude: [ "TEST" ]
-        arguments: [ 5 ]
+# Enable again when https://github.com/mgechev/revive/issues/1103 is fixed
+#      - name: max-public-structs
+#        exclude: [ "TEST" ]
+#        arguments: [ 5 ]
       - name: modifies-parameter
       - name: modifies-value-receiver
       - name: optimize-operands-order

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -100,8 +100,8 @@ linters-settings:
       - codegenComment
       - commentedOutCode
       - deferInLoop
-      - dupArg
       - deprecatedComment
+      - dupArg
       - dupBranchBody
       - dupCase
       - dupSubExpr
@@ -130,8 +130,8 @@ linters-settings:
       # performance
       - appendCombine
       - equalFold
-      - indexAlloc
       - hugeParam
+      - indexAlloc
       - preferDecodeRune
       - preferFprint
       - preferStringWriter
@@ -296,16 +296,10 @@ linters-settings:
       - name: redundant-import-alias
       - name: string-format
         arguments:
-          - - 'fmt.Errorf[0]'
+          - - 'fmt.Errorf[0],errors.New[0]'
             - '/^([^A-Z]|$)/'
             - 'Error string must not start with a capital letter.'
-          - - 'fmt.Errorf[0]'
-            - '/(^|[^\.!?])$/'
-            - 'Error string must not end in punctuation.'
-          - - 'errors.New[0]'
-            - '/^([^A-Z]|$)/'
-            - 'Error string must not start with a capital letter.'
-          - - 'errors.New[0]'
+          - - 'fmt.Errorf[0],errors.New[0]'
             - '/(^|[^\.!?])$/'
             - 'Error string must not end in punctuation.'
           - - 'panic'
@@ -354,11 +348,6 @@ linters-settings:
       - suite-subtest-run
       - suite-thelper
       - useless-assert
-
-run:
-  # Timeout for analysis, e.g. 30s, 5m.
-  # Default: 1m
-  timeout: 10m
 
 issues:
   # List of regexps of issue texts to exclude.
@@ -479,3 +468,8 @@ output:
   # Show statistics per linter.
   # Default: false
   show-stats: true
+
+run:
+  # Timeout for analysis, e.g. 30s, 5m.
+  # Default: 1m
+  timeout: 10m

--- a/Makefile
+++ b/Makefile
@@ -180,7 +180,7 @@ vet:
 .PHONY: lint-install
 lint-install:
 	@echo "Installing golangci-lint"
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.61.0
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.62.0
 
 	@echo "Installing markdownlint"
 	npm install -g markdownlint-cli

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -59,7 +59,7 @@ func TestReadBinaryFile(t *testing.T) {
 	cmd.Stderr = &errb
 	err = cmd.Run()
 
-	require.NoError(t, err, fmt.Sprintf("stdout: %s, stderr: %s", outb.String(), errb.String()))
+	require.NoErrorf(t, err, "stdout: %s, stderr: %s", outb.String(), errb.String())
 	c := config.NewConfig()
 	err = c.LoadConfig(binaryFile)
 	require.Error(t, err)

--- a/plugins/common/parallel/parallel_test.go
+++ b/plugins/common/parallel/parallel_test.go
@@ -63,7 +63,7 @@ func TestUnorderedJobsDontDropAnyJobs(t *testing.T) {
 	p.Stop()
 
 	actualTotal := int64(0)
-	require.Len(t, acc.Metrics, 20000, "expected 20k metrics but got %d", len(acc.GetTelegrafMetrics()))
+	require.Len(t, acc.Metrics, 20000)
 	for _, m := range acc.GetTelegrafMetrics() {
 		v, ok := m.GetField("val")
 		require.True(t, ok)

--- a/plugins/common/parallel/parallel_test.go
+++ b/plugins/common/parallel/parallel_test.go
@@ -1,15 +1,15 @@
 package parallel_test
 
 import (
-	"fmt"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/metric"
 	"github.com/influxdata/telegraf/plugins/common/parallel"
 	"github.com/influxdata/telegraf/testutil"
-	"github.com/stretchr/testify/require"
 )
 
 func TestOrderedJobsStayOrdered(t *testing.T) {
@@ -31,7 +31,7 @@ func TestOrderedJobsStayOrdered(t *testing.T) {
 	p.Stop()
 
 	i := 0
-	require.Len(t, acc.Metrics, 20000, fmt.Sprintf("expected 20k metrics but got %d", len(acc.GetTelegrafMetrics())))
+	require.Len(t, acc.Metrics, 20000, "expected 20k metrics but got %d", len(acc.GetTelegrafMetrics()))
 	for _, m := range acc.GetTelegrafMetrics() {
 		v, ok := m.GetField("val")
 		require.True(t, ok)
@@ -63,7 +63,7 @@ func TestUnorderedJobsDontDropAnyJobs(t *testing.T) {
 	p.Stop()
 
 	actualTotal := int64(0)
-	require.Len(t, acc.Metrics, 20000, fmt.Sprintf("expected 20k metrics but got %d", len(acc.GetTelegrafMetrics())))
+	require.Len(t, acc.Metrics, 20000, "expected 20k metrics but got %d", len(acc.GetTelegrafMetrics()))
 	for _, m := range acc.GetTelegrafMetrics() {
 		v, ok := m.GetField("val")
 		require.True(t, ok)

--- a/plugins/common/parallel/parallel_test.go
+++ b/plugins/common/parallel/parallel_test.go
@@ -31,7 +31,7 @@ func TestOrderedJobsStayOrdered(t *testing.T) {
 	p.Stop()
 
 	i := 0
-	require.Len(t, acc.Metrics, 20000, "expected 20k metrics but got %d", len(acc.GetTelegrafMetrics()))
+	require.Len(t, acc.Metrics, 20000)
 	for _, m := range acc.GetTelegrafMetrics() {
 		v, ok := m.GetField("val")
 		require.True(t, ok)

--- a/plugins/inputs/aliyuncms/aliyuncms_test.go
+++ b/plugins/inputs/aliyuncms/aliyuncms_test.go
@@ -434,7 +434,7 @@ func TestGather(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var acc testutil.Accumulator
 			plugin.Metrics[0].MetricNames = tt.metricNames
-			require.Empty(t, acc.GatherError(plugin.Gather))
+			require.NoError(t, acc.GatherError(plugin.Gather))
 			require.Equal(t, acc.HasMeasurement("aliyuncms_acs_slb_dashboard"), tt.hasMeasurement)
 			if tt.hasMeasurement {
 				acc.AssertContainsTaggedFields(t, "aliyuncms_acs_slb_dashboard", tt.expected[0].Fields(), tt.expected[0].Tags())

--- a/plugins/inputs/dcos/dcos_test.go
+++ b/plugins/inputs/dcos/dcos_test.go
@@ -2,7 +2,6 @@ package dcos
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -200,7 +199,7 @@ func TestAddNodeMetrics(t *testing.T) {
 			dcos := &DCOS{}
 			dcos.addNodeMetrics(&acc, "a", tt.metrics)
 			for i, ok := range tt.check(&acc) {
-				require.True(t, ok, fmt.Sprintf("Index was not true: %d", i))
+				require.Truef(t, ok, "Index was not true: %d", i)
 			}
 		})
 	}
@@ -271,7 +270,7 @@ func TestAddContainerMetrics(t *testing.T) {
 			dcos := &DCOS{}
 			dcos.addContainerMetrics(&acc, "a", tt.metrics)
 			for i, ok := range tt.check(&acc) {
-				require.True(t, ok, fmt.Sprintf("Index was not true: %d", i))
+				require.Truef(t, ok, "Index was not true: %d", i)
 			}
 		})
 	}
@@ -345,7 +344,7 @@ func TestAddAppMetrics(t *testing.T) {
 			dcos := &DCOS{}
 			dcos.addAppMetrics(&acc, "a", tt.metrics)
 			for i, ok := range tt.check(&acc) {
-				require.True(t, ok, fmt.Sprintf("Index was not true: %d", i))
+				require.Truef(t, ok, "Index was not true: %d", i)
 			}
 		})
 	}
@@ -434,7 +433,7 @@ func TestGatherFilterNode(t *testing.T) {
 			err := dcos.Gather(&acc)
 			require.NoError(t, err)
 			for i, ok := range tt.check(&acc) {
-				require.True(t, ok, fmt.Sprintf("Index was not true: %d", i))
+				require.Truef(t, ok, "Index was not true: %d", i)
 			}
 		})
 	}

--- a/plugins/inputs/intel_rdt/intel_rdt_test.go
+++ b/plugins/inputs/intel_rdt/intel_rdt_test.go
@@ -62,8 +62,8 @@ func TestSplitCSVLineIntoValues(t *testing.T) {
 	splitCSV, err = splitCSVLineIntoValues(wrongLine)
 	require.Error(t, err)
 	require.Equal(t, "", splitCSV.timeValue)
-	require.Nil(t, nil, splitCSV.metricsValues)
-	require.Nil(t, nil, splitCSV.coreOrPIDsValues)
+	require.Nil(t, splitCSV.metricsValues)
+	require.Nil(t, splitCSV.coreOrPIDsValues)
 }
 
 func TestFindPIDsInMeasurement(t *testing.T) {

--- a/plugins/inputs/internal/internal_test.go
+++ b/plugins/inputs/internal/internal_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -108,7 +107,7 @@ func TestGostats(t *testing.T) {
 		switch value.(type) {
 		case int64, uint64, float64:
 		default:
-			require.True(t, false, fmt.Sprintf("field %s is of non-numeric type %T\n", name, value))
+			require.Truef(t, false, "field %s is of non-numeric type %T\n", name, value)
 		}
 	}
 }

--- a/plugins/inputs/postgresql_extensible/postgresql_extensible_test.go
+++ b/plugins/inputs/postgresql_extensible/postgresql_extensible_test.go
@@ -218,22 +218,22 @@ func TestPostgresqlFieldOutputIntegration(t *testing.T) {
 
 	for _, field := range intMetrics {
 		_, found := acc.Int64Field(measurement, field)
-		require.True(t, found, fmt.Sprintf("expected %s to be an integer", field))
+		require.Truef(t, found, "expected %s to be an integer", field)
 	}
 
 	for _, field := range int32Metrics {
 		_, found := acc.Int32Field(measurement, field)
-		require.True(t, found, fmt.Sprintf("expected %s to be an int32", field))
+		require.Truef(t, found, "expected %s to be an int32", field)
 	}
 
 	for _, field := range floatMetrics {
 		_, found := acc.FloatField(measurement, field)
-		require.True(t, found, fmt.Sprintf("expected %s to be a float64", field))
+		require.Truef(t, found, "expected %s to be a float64", field)
 	}
 
 	for _, field := range stringMetrics {
 		_, found := acc.StringField(measurement, field)
-		require.True(t, found, fmt.Sprintf("expected %s to be a str", field))
+		require.Truef(t, found, "expected %s to be a str", field)
 	}
 }
 

--- a/plugins/inputs/vsphere/vsphere_test.go
+++ b/plugins/inputs/vsphere/vsphere_test.go
@@ -3,7 +3,6 @@ package vsphere
 import (
 	"context"
 	"crypto/tls"
-	"fmt"
 	"net/url"
 	"os"
 	"strings"
@@ -518,7 +517,7 @@ func testCollection(t *testing.T, excludeClusters bool) {
 	require.NoError(t, v.Start(&acc))
 	defer v.Stop()
 	require.NoError(t, v.Gather(&acc))
-	require.Empty(t, acc.Errors, fmt.Sprintf("Errors found: %s", acc.Errors))
+	require.Emptyf(t, acc.Errors, "Errors found: %s", acc.Errors)
 	require.NotEmpty(t, acc.Metrics, "No metrics were collected")
 	cache := make(map[string]string)
 	client, err := v.endpoints[0].clientFactory.GetClient(context.Background())
@@ -621,6 +620,6 @@ func TestVersionLowerThan(t *testing.T) {
 	}
 	for _, tc := range tests {
 		result := versionLowerThan(tc.current, tc.major, tc.minor)
-		require.Equal(t, tc.result, result, fmt.Sprintf("%s < %d.%d", tc.current, tc.major, tc.minor))
+		require.Equalf(t, tc.result, result, "%s < %d.%d", tc.current, tc.major, tc.minor)
 	}
 }

--- a/plugins/inputs/win_perf_counters/win_perf_counters_integration_test.go
+++ b/plugins/inputs/win_perf_counters/win_perf_counters_integration_test.go
@@ -4,7 +4,6 @@ package win_perf_counters
 
 import (
 	"errors"
-	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -171,14 +170,10 @@ func TestWinPerfCountersConfigGet2Integration(t *testing.T) {
 	hostCounters, ok := m.hostCounters["localhost"]
 	require.True(t, ok)
 
-	if len(hostCounters.counters) == 1 {
-		require.NoError(t, nil)
-	} else if len(hostCounters.counters) == 0 {
-		err2 := fmt.Errorf("no results returned from the counterPath: %v", len(hostCounters.counters))
-		require.NoError(t, err2)
+	if len(hostCounters.counters) == 0 {
+		require.FailNow(t, "no results returned from the counterPath: %v", len(hostCounters.counters))
 	} else if len(hostCounters.counters) > 1 {
-		err2 := fmt.Errorf("too many results returned from the counterPath: %v", len(hostCounters.counters))
-		require.NoError(t, err2)
+		require.FailNow(t, "too many results returned from the counterPath: %v", len(hostCounters.counters))
 	}
 }
 
@@ -214,14 +209,10 @@ func TestWinPerfCountersConfigGet3Integration(t *testing.T) {
 	hostCounters, ok := m.hostCounters["localhost"]
 	require.True(t, ok)
 
-	if len(hostCounters.counters) == 2 {
-		require.NoError(t, nil)
-	} else if len(hostCounters.counters) < 2 {
-		err2 := fmt.Errorf("too few results returned from the counterPath: %v", len(hostCounters.counters))
-		require.NoError(t, err2)
+	if len(hostCounters.counters) < 2 {
+		require.FailNow(t, "too few results returned from the counterPath: %v", len(hostCounters.counters))
 	} else if len(hostCounters.counters) > 2 {
-		err2 := fmt.Errorf("too many results returned from the counterPath: %v", len(hostCounters.counters))
-		require.NoError(t, err2)
+		require.FailNow(t, "too many results returned from the counterPath: %v", len(hostCounters.counters))
 	}
 }
 
@@ -255,14 +246,10 @@ func TestWinPerfCountersConfigGet4Integration(t *testing.T) {
 	hostCounters, ok := m.hostCounters["localhost"]
 	require.True(t, ok)
 
-	if len(hostCounters.counters) == 2 {
-		require.NoError(t, nil)
-	} else if len(hostCounters.counters) < 2 {
-		err2 := fmt.Errorf("too few results returned from the counterPath: %v", len(hostCounters.counters))
-		require.NoError(t, err2)
+	if len(hostCounters.counters) < 2 {
+		require.FailNow(t, "too few results returned from the counterPath: %v", len(hostCounters.counters))
 	} else if len(hostCounters.counters) > 2 {
-		err2 := fmt.Errorf("too many results returned from the counterPath: %v", len(hostCounters.counters))
-		require.NoError(t, err2)
+		require.FailNow(t, "too many results returned from the counterPath: %v", len(hostCounters.counters))
 	}
 }
 
@@ -296,14 +283,10 @@ func TestWinPerfCountersConfigGet5Integration(t *testing.T) {
 	hostCounters, ok := m.hostCounters["localhost"]
 	require.True(t, ok)
 
-	if len(hostCounters.counters) == 4 {
-		require.NoError(t, nil)
-	} else if len(hostCounters.counters) < 4 {
-		err2 := fmt.Errorf("too few results returned from the counterPath: %v", len(hostCounters.counters))
-		require.NoError(t, err2)
+	if len(hostCounters.counters) < 4 {
+		require.FailNow(t, "too few results returned from the counterPath: %v", len(hostCounters.counters))
 	} else if len(hostCounters.counters) > 4 {
-		err2 := fmt.Errorf("too many results returned from the counterPath: %v", len(hostCounters.counters))
-		require.NoError(t, err2)
+		require.FailNow(t, "too many results returned from the counterPath: %v", len(hostCounters.counters))
 	}
 }
 
@@ -365,14 +348,10 @@ func TestWinPerfCountersConfigGet7Integration(t *testing.T) {
 	hostCounters, ok := m.hostCounters["localhost"]
 	require.True(t, ok)
 
-	if len(hostCounters.counters) == 2 {
-		require.NoError(t, nil)
-	} else if len(hostCounters.counters) < 2 {
-		err2 := fmt.Errorf("too few results returned from the counterPath: %v", len(hostCounters.counters))
-		require.NoError(t, err2)
+	if len(hostCounters.counters) < 2 {
+		require.FailNow(t, "too few results returned from the counterPath: %v", len(hostCounters.counters))
 	} else if len(hostCounters.counters) > 2 {
-		err2 := fmt.Errorf("too many results returned from the counterPath: %v", len(hostCounters.counters))
-		require.NoError(t, err2)
+		require.FailNow(t, "too many results returned from the counterPath: %v", len(hostCounters.counters))
 	}
 }
 

--- a/plugins/outputs/cloudwatch/cloudwatch_test.go
+++ b/plugins/outputs/cloudwatch/cloudwatch_test.go
@@ -1,7 +1,6 @@
 package cloudwatch
 
 import (
-	"fmt"
 	"math"
 	"sort"
 	"testing"
@@ -68,11 +67,11 @@ func TestBuildMetricDatums(t *testing.T) {
 	}
 	for _, point := range validMetrics {
 		datums := BuildMetricDatum(false, false, point)
-		require.Len(t, datums, 1, fmt.Sprintf("Valid point should create a Datum {value: %v}", point))
+		require.Lenf(t, datums, 1, "Valid point should create a Datum {value: %v}", point)
 	}
 	for _, point := range invalidMetrics {
 		datums := BuildMetricDatum(false, false, point)
-		require.Empty(t, datums, fmt.Sprintf("Valid point should not create a Datum {value: %v}", point))
+		require.Emptyf(t, datums, "Valid point should not create a Datum {value: %v}", point)
 	}
 
 	statisticMetric := metric.New(
@@ -82,7 +81,7 @@ func TestBuildMetricDatums(t *testing.T) {
 		time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC),
 	)
 	datums := BuildMetricDatum(true, false, statisticMetric)
-	require.Len(t, datums, 1, fmt.Sprintf("Valid point should create a Datum {value: %v}", statisticMetric))
+	require.Lenf(t, datums, 1, "Valid point should create a Datum {value: %v}", statisticMetric)
 
 	multiFieldsMetric := metric.New(
 		"test1",
@@ -91,7 +90,7 @@ func TestBuildMetricDatums(t *testing.T) {
 		time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC),
 	)
 	datums = BuildMetricDatum(true, false, multiFieldsMetric)
-	require.Len(t, datums, 4, fmt.Sprintf("Each field should create a Datum {value: %v}", multiFieldsMetric))
+	require.Lenf(t, datums, 4, "Each field should create a Datum {value: %v}", multiFieldsMetric)
 
 	multiStatisticMetric := metric.New(
 		"test1",
@@ -105,7 +104,7 @@ func TestBuildMetricDatums(t *testing.T) {
 		time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC),
 	)
 	datums = BuildMetricDatum(true, false, multiStatisticMetric)
-	require.Len(t, datums, 7, fmt.Sprintf("Valid point should create a Datum {value: %v}", multiStatisticMetric))
+	require.Lenf(t, datums, 7, "Valid point should create a Datum {value: %v}", multiStatisticMetric)
 }
 
 func TestMetricDatumResolution(t *testing.T) {

--- a/plugins/parsers/dropwizard/parser_test.go
+++ b/plugins/parsers/dropwizard/parser_test.go
@@ -1,7 +1,6 @@
 package dropwizard
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
@@ -111,7 +110,7 @@ func TestParseValidEmbeddedCounterJSON(t *testing.T) {
 		"tag2":                    "yellow",
 		"tag3 space,comma=equals": "red ,=",
 	}, metrics[0].Tags())
-	require.True(t, metricTime.Equal(metrics[0].Time()), fmt.Sprintf("%s should be equal to %s", metrics[0].Time(), metricTime))
+	require.Truef(t, metricTime.Equal(metrics[0].Time()), "%s should be equal to %s", metrics[0].Time(), metricTime)
 
 	// now test json tags through TagPathsMap
 	parser2 := &Parser{

--- a/plugins/processors/starlark/starlark_test.go
+++ b/plugins/processors/starlark/starlark_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/gob"
 	"errors"
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -3743,7 +3742,7 @@ func parseMetricsFrom(t *testing.T, lines []string, header string) (metrics []te
 			break
 		}
 	}
-	require.NotEqual(t, -1, startIdx, fmt.Sprintf("Header %q must exist in file", header))
+	require.NotEqualf(t, -1, startIdx, "Header %q must exist in file", header)
 	for i := startIdx; i < len(lines); i++ {
 		line := strings.TrimLeft(lines[i], "# ")
 		if line == "" || line == "'''" {
@@ -3753,7 +3752,7 @@ func parseMetricsFrom(t *testing.T, lines []string, header string) (metrics []te
 	}
 	for i := startIdx; i < endIdx; i++ {
 		m, err := parser.ParseLine(strings.TrimLeft(lines[i], "# "))
-		require.NoError(t, err, fmt.Sprintf("Expected to be able to parse %q metric, but found error", header))
+		require.NoErrorf(t, err, "Expected to be able to parse %q metric, but found error", header)
 		metrics = append(metrics, m)
 	}
 	return metrics
@@ -3772,7 +3771,7 @@ func parseErrorMessage(t *testing.T, lines []string, header string) string {
 	if startIdx == -1 {
 		return ""
 	}
-	require.Less(t, startIdx, len(lines), fmt.Sprintf("Expected to find the error message after %q, but found none", header))
+	require.Lessf(t, startIdx, len(lines), "Expected to find the error message after %q, but found none", header)
 	return strings.TrimLeft(lines[startIdx], "# ")
 }
 


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

- `golangci-lint` bumped to `v1.62.0`
- Matching the configuration file to the example from https://github.com/golangci/golangci-lint/blob/master/.golangci.reference.yml.
- `revive:max-public-structs` disabled for now because of following isue: https://github.com/mgechev/revive/issues/1103
  - we should re-enable it when issues is fixed, new version of `revive` is released and incorporated into new `golangci-lint` release
- Not recommended method of installing `golangci-lint` (from Sources) replaced for CircleCI. 
  - For now, I dind't change installation method for `lint-install` in `Makefile` - developers with Windows most likely will not have `curl` installed
  - https://golangci-lint.run/welcome/install/#install-from-sources
  - ![image](https://github.com/user-attachments/assets/e2171396-3a55-415a-869c-31dce59d560f)

- New findings addressed:
```
config/config_test.go:62:2                                                    testifylint  formatter: remove unnecessary fmt.Sprintf
plugins/common/parallel/parallel_test.go:34:2                                 testifylint  formatter: remove unnecessary fmt.Sprintf
plugins/common/parallel/parallel_test.go:66:2                                 testifylint  formatter: remove unnecessary fmt.Sprintf
plugins/inputs/aliyuncms/aliyuncms_test.go:437:4                              testifylint  error-nil: use require.NoError
plugins/inputs/dcos/dcos_test.go:203:5                                        testifylint  formatter: remove unnecessary fmt.Sprintf
plugins/inputs/dcos/dcos_test.go:274:5                                        testifylint  formatter: remove unnecessary fmt.Sprintf
plugins/inputs/dcos/dcos_test.go:348:5                                        testifylint  formatter: remove unnecessary fmt.Sprintf
plugins/inputs/dcos/dcos_test.go:437:5                                        testifylint  formatter: remove unnecessary fmt.Sprintf
plugins/inputs/intel_rdt/intel_rdt_test.go:65:2                               testifylint  useless-assert: meaningless assertion
plugins/inputs/intel_rdt/intel_rdt_test.go:66:2                               testifylint  useless-assert: meaningless assertion
plugins/inputs/internal/internal_test.go:111:4                                testifylint  formatter: remove unnecessary fmt.Sprintf
plugins/inputs/postgresql_extensible/postgresql_extensible_test.go:221:3      testifylint  formatter: remove unnecessary fmt.Sprintf
plugins/inputs/postgresql_extensible/postgresql_extensible_test.go:226:3      testifylint  formatter: remove unnecessary fmt.Sprintf
plugins/inputs/postgresql_extensible/postgresql_extensible_test.go:231:3      testifylint  formatter: remove unnecessary fmt.Sprintf
plugins/inputs/postgresql_extensible/postgresql_extensible_test.go:236:3      testifylint  formatter: remove unnecessary fmt.Sprintf
plugins/inputs/vsphere/vsphere_test.go:521:2                                  testifylint  formatter: remove unnecessary fmt.Sprintf
plugins/inputs/vsphere/vsphere_test.go:624:3                                  testifylint  formatter: remove unnecessary fmt.Sprintf
plugins/inputs/win_perf_counters/win_perf_counters_integration_test.go:175:3  testifylint  useless-assert: meaningless assertion
plugins/inputs/win_perf_counters/win_perf_counters_integration_test.go:218:3  testifylint  useless-assert: meaningless assertion
plugins/inputs/win_perf_counters/win_perf_counters_integration_test.go:259:3  testifylint  useless-assert: meaningless assertion
plugins/inputs/win_perf_counters/win_perf_counters_integration_test.go:300:3  testifylint  useless-assert: meaningless assertion
plugins/inputs/win_perf_counters/win_perf_counters_integration_test.go:369:3  testifylint  useless-assert: meaningless assertion
plugins/outputs/cloudwatch/cloudwatch_test.go:71:3                            testifylint  formatter: remove unnecessary fmt.Sprintf
plugins/outputs/cloudwatch/cloudwatch_test.go:75:3                            testifylint  formatter: remove unnecessary fmt.Sprintf
plugins/outputs/cloudwatch/cloudwatch_test.go:85:2                            testifylint  formatter: remove unnecessary fmt.Sprintf
plugins/outputs/cloudwatch/cloudwatch_test.go:94:2                            testifylint  formatter: remove unnecessary fmt.Sprintf
plugins/outputs/cloudwatch/cloudwatch_test.go:108:2                           testifylint  formatter: remove unnecessary fmt.Sprintf
plugins/parsers/dropwizard/parser_test.go:114:2                               testifylint  formatter: remove unnecessary fmt.Sprintf
plugins/processors/starlark/starlark_test.go:3746:2                           testifylint  formatter: remove unnecessary fmt.Sprintf
plugins/processors/starlark/starlark_test.go:3756:3                           testifylint  formatter: remove unnecessary fmt.Sprintf
plugins/processors/starlark/starlark_test.go:3775:2                           testifylint  formatter: remove unnecessary fmt.Sprintf
```

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR
