### PR TITLE
chore: Enable `revive:enforce-repeated-arg-type-style` rule

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -265,6 +265,8 @@ linters-settings:
       - name: enforce-map-style
         arguments: ["make"]
         exclude: [ "TEST" ]
+      - name: enforce-repeated-arg-type-style
+        arguments: ["short"]
       - name: error-naming
       - name: error-return
       - name: error-strings

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -672,11 +672,7 @@ func (a *Agent) runProcessors(
 }
 
 // startAggregators sets up the aggregator unit and returns the source channel.
-func (a *Agent) startAggregators(
-	aggC chan<- telegraf.Metric,
-	outputC chan<- telegraf.Metric,
-	aggregators []*models.RunningAggregator,
-) (chan<- telegraf.Metric, *aggregatorUnit) {
+func (a *Agent) startAggregators(aggC, outputC chan<- telegraf.Metric, aggregators []*models.RunningAggregator) (chan<- telegraf.Metric, *aggregatorUnit) {
 	src := make(chan telegraf.Metric, 100)
 	unit := &aggregatorUnit{
 		src:         src,

--- a/config/config.go
+++ b/config/config.go
@@ -951,10 +951,10 @@ func (c *Config) LinkSecrets() error {
 	return nil
 }
 
-func (c *Config) probeParser(parentcategory string, parentname string, table *ast.Table) bool {
+func (c *Config) probeParser(parentCategory, parentName string, table *ast.Table) bool {
 	dataFormat := c.getFieldString(table, "data_format")
 	if dataFormat == "" {
-		dataFormat = setDefaultParser(parentcategory, parentname)
+		dataFormat = setDefaultParser(parentCategory, parentName)
 	}
 
 	creator, ok := parsers.Parsers[dataFormat]
@@ -1812,7 +1812,7 @@ func keys(m map[string]bool) []string {
 	return result
 }
 
-func setDefaultParser(category string, name string) string {
+func setDefaultParser(category, name string) string {
 	// Legacy support, exec plugin originally parsed JSON by default.
 	if category == "inputs" && name == "exec" {
 		return "json"

--- a/config/secret.go
+++ b/config/secret.go
@@ -308,7 +308,7 @@ func resolve(secret []byte, resolvers map[string]telegraf.ResolveFunc) ([]byte, 
 	return newsecret, remaining, replaceErrs
 }
 
-func splitLink(s string) (storeid string, key string) {
+func splitLink(s string) (storeID, key string) {
 	// There should _ALWAYS_ be two parts due to the regular expression match
 	parts := strings.SplitN(s[2:len(s)-1], ":", 2)
 	return parts[0], parts[1]

--- a/filter/filter.go
+++ b/filter/filter.go
@@ -101,19 +101,11 @@ type IncludeExcludeFilter struct {
 	excludeDefault bool
 }
 
-func NewIncludeExcludeFilter(
-	include []string,
-	exclude []string,
-) (Filter, error) {
+func NewIncludeExcludeFilter(include, exclude []string) (Filter, error) {
 	return NewIncludeExcludeFilterDefaults(include, exclude, true, false)
 }
 
-func NewIncludeExcludeFilterDefaults(
-	include []string,
-	exclude []string,
-	includeDefault bool,
-	excludeDefault bool,
-) (Filter, error) {
+func NewIncludeExcludeFilterDefaults(include, exclude []string, includeDefault, excludeDefault bool) (Filter, error) {
 	in, err := Compile(include)
 	if err != nil {
 		return nil, err

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -4,7 +4,7 @@ import "strings"
 
 // ParseImage Adapts some of the logic from the actual Docker library's image parsing routines:
 // https://github.com/docker/distribution/blob/release/2.7/reference/normalize.go
-func ParseImage(image string) (imageName string, imageVersion string) {
+func ParseImage(image string) (imageName, imageVersion string) {
 	domain := ""
 	remainder := ""
 

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -359,7 +359,7 @@ func sanitizeTimestamp(timestamp string, decimalSeparator []string) string {
 }
 
 // parseTime parses a string timestamp according to the format string.
-func parseTime(format string, timestamp string, location *time.Location) (time.Time, error) {
+func parseTime(format, timestamp string, location *time.Location) (time.Time, error) {
 	loc := location
 	if loc == nil {
 		loc = time.UTC

--- a/internal/process/process.go
+++ b/internal/process/process.go
@@ -37,7 +37,7 @@ type Process struct {
 }
 
 // New creates a new process wrapper
-func New(command []string, envs []string) (*Process, error) {
+func New(command, envs []string) (*Process, error) {
 	if len(command) == 0 {
 		return nil, errors.New("no command")
 	}

--- a/internal/templating/template.go
+++ b/internal/templating/template.go
@@ -81,9 +81,8 @@ func NewDefaultTemplateWithPattern(pattern string) (*Template, error) {
 	return NewTemplate(DefaultSeparator, pattern, nil)
 }
 
-// NewTemplate returns a new template ensuring it has a measurement
-// specified.
-func NewTemplate(separator string, pattern string, defaultTags map[string]string) (*Template, error) {
+// NewTemplate returns a new template ensuring it has a measurement specified.
+func NewTemplate(separator, pattern string, defaultTags map[string]string) (*Template, error) {
 	parts := strings.Split(pattern, separator)
 	hasMeasurement := false
 	template := &Template{

--- a/models/buffer.go
+++ b/models/buffer.go
@@ -67,7 +67,7 @@ func NewBuffer(name, id, alias string, capacity int, strategy, path string) (Buf
 	return nil, fmt.Errorf("invalid buffer strategy %q", strategy)
 }
 
-func NewBufferStats(name string, alias string, capacity int) BufferStats {
+func NewBufferStats(name, alias string, capacity int) BufferStats {
 	tags := map[string]string{"output": name}
 	if alias != "" {
 		tags["alias"] = alias

--- a/models/filter.go
+++ b/models/filter.go
@@ -284,7 +284,7 @@ func (f *Filter) compileMetricFilter() error {
 	return err
 }
 
-func ShouldPassFilters(include filter.Filter, exclude filter.Filter, key string) bool {
+func ShouldPassFilters(include, exclude filter.Filter, key string) bool {
 	if include != nil && exclude != nil {
 		return include.Match(key) && !exclude.Match(key)
 	} else if include != nil {
@@ -295,7 +295,7 @@ func ShouldPassFilters(include filter.Filter, exclude filter.Filter, key string)
 	return true
 }
 
-func ShouldTagsPass(passFilters []TagFilter, dropFilters []TagFilter, tags []*telegraf.Tag) bool {
+func ShouldTagsPass(passFilters, dropFilters []TagFilter, tags []*telegraf.Tag) bool {
 	pass := func(tpf []TagFilter) bool {
 		for _, pat := range tpf {
 			if pat.filter == nil {

--- a/models/makemetric.go
+++ b/models/makemetric.go
@@ -4,16 +4,8 @@ import (
 	"github.com/influxdata/telegraf"
 )
 
-// makemetric applies new metric plugin and agent measurement and tag
-// settings.
-func makemetric(
-	metric telegraf.Metric,
-	nameOverride string,
-	namePrefix string,
-	nameSuffix string,
-	tags map[string]string,
-	globalTags map[string]string,
-) telegraf.Metric {
+// makeMetric applies new metric plugin and agent measurement and tag settings.
+func makeMetric(metric telegraf.Metric, nameOverride, namePrefix, nameSuffix string, tags, globalTags map[string]string) telegraf.Metric {
 	if len(nameOverride) != 0 {
 		metric.SetName(nameOverride)
 	}

--- a/models/running_aggregator.go
+++ b/models/running_aggregator.go
@@ -121,7 +121,7 @@ func (r *RunningAggregator) UpdateWindow(start, until time.Time) {
 }
 
 func (r *RunningAggregator) MakeMetric(telegrafMetric telegraf.Metric) telegraf.Metric {
-	m := makemetric(
+	m := makeMetric(
 		telegrafMetric,
 		r.Config.NameOverride,
 		r.Config.MeasurementPrefix,

--- a/models/running_input.go
+++ b/models/running_input.go
@@ -192,7 +192,7 @@ func (r *RunningInput) MakeMetric(metric telegraf.Metric) telegraf.Metric {
 		return nil
 	}
 
-	makemetric(
+	makeMetric(
 		metric,
 		r.Config.NameOverride,
 		r.Config.MeasurementPrefix,
@@ -214,7 +214,7 @@ func (r *RunningInput) MakeMetric(metric telegraf.Metric) telegraf.Metric {
 		if r.Config.AlwaysIncludeGlobalTags {
 			global = r.defaultTags
 		}
-		makemetric(metric, "", "", "", local, global)
+		makeMetric(metric, "", "", "", local, global)
 	}
 
 	switch r.Config.TimeSource {

--- a/models/running_output.go
+++ b/models/running_output.go
@@ -70,12 +70,7 @@ type RunningOutput struct {
 	aggMutex sync.Mutex
 }
 
-func NewRunningOutput(
-	output telegraf.Output,
-	config *OutputConfig,
-	batchSize int,
-	bufferLimit int,
-) *RunningOutput {
+func NewRunningOutput(output telegraf.Output, config *OutputConfig, batchSize, bufferLimit int) *RunningOutput {
 	tags := map[string]string{"output": config.Name}
 	if config.Alias != "" {
 		tags["alias"] = config.Alias

--- a/plugins/aggregators/histogram/histogram.go
+++ b/plugins/aggregators/histogram/histogram.go
@@ -164,11 +164,7 @@ func (h *HistogramAggregator) Push(acc telegraf.Accumulator) {
 
 // groupFieldsByBuckets groups fields by metric buckets which are represented as tags
 func (h *HistogramAggregator) groupFieldsByBuckets(
-	metricsWithGroupedFields *[]groupedByCountFields,
-	name string,
-	field string,
-	tags map[string]string,
-	counts []int64,
+	metricsWithGroupedFields *[]groupedByCountFields, name, field string, tags map[string]string, counts []int64,
 ) {
 	sum := int64(0)
 	buckets := h.getBuckets(name, field) // note that len(buckets) + 1 == len(counts)
@@ -194,13 +190,7 @@ func (h *HistogramAggregator) groupFieldsByBuckets(
 }
 
 // groupField groups field by count value
-func (h *HistogramAggregator) groupField(
-	metricsWithGroupedFields *[]groupedByCountFields,
-	name string,
-	field string,
-	count int64,
-	tags map[string]string,
-) {
+func (h *HistogramAggregator) groupField(metricsWithGroupedFields *[]groupedByCountFields, name, field string, count int64, tags map[string]string) {
 	for key, metric := range *metricsWithGroupedFields {
 		if name == metric.name && isTagsIdentical(tags, metric.tags) {
 			(*metricsWithGroupedFields)[key].fieldsWithCount[field] = count
@@ -234,7 +224,7 @@ func (h *HistogramAggregator) resetCache() {
 }
 
 // getBuckets finds buckets and returns them
-func (h *HistogramAggregator) getBuckets(metric string, field string) []float64 {
+func (h *HistogramAggregator) getBuckets(metric, field string) []float64 {
 	if buckets, ok := h.buckets[metric][field]; ok {
 		return buckets
 	}

--- a/plugins/aggregators/histogram/histogram_test.go
+++ b/plugins/aggregators/histogram/histogram_test.go
@@ -17,16 +17,12 @@ type fields map[string]interface{}
 type tags map[string]string
 
 // NewTestHistogram creates new test histogram aggregation with specified config
-func NewTestHistogram(cfg []bucketConfig, reset bool, cumulative bool, pushOnlyOnUpdate bool) telegraf.Aggregator {
+func NewTestHistogram(cfg []bucketConfig, reset, cumulative, pushOnlyOnUpdate bool) telegraf.Aggregator {
 	return NewTestHistogramWithExpirationInterval(cfg, reset, cumulative, pushOnlyOnUpdate, 0)
 }
 
 func NewTestHistogramWithExpirationInterval(
-	cfg []bucketConfig,
-	reset bool,
-	cumulative bool,
-	pushOnlyOnUpdate bool,
-	expirationInterval config.Duration,
+	cfg []bucketConfig, reset, cumulative, pushOnlyOnUpdate bool, expirationInterval config.Duration,
 ) telegraf.Aggregator {
 	htm := NewHistogramAggregator()
 	htm.Configs = cfg

--- a/plugins/all_test.go
+++ b/plugins/all_test.go
@@ -46,7 +46,7 @@ func testPluginDirectory(t *testing.T, directory string) {
 	require.NoError(t, err)
 }
 
-func parseSourceFile(t *testing.T, goPluginFile string, pluginCategory string) {
+func parseSourceFile(t *testing.T, goPluginFile, pluginCategory string) {
 	fset := token.NewFileSet()
 	node, err := parser.ParseFile(fset, goPluginFile, nil, parser.ParseComments)
 	require.NoError(t, err)
@@ -80,7 +80,7 @@ func resolvePluginFromImports(t *testing.T, imports []*ast.ImportSpec) string {
 	return filepath.Base(importPath)
 }
 
-func testBuildTags(t *testing.T, buildComment string, pluginCategory string, plugin string) {
+func testBuildTags(t *testing.T, buildComment, pluginCategory, plugin string) {
 	tags := strings.Split(buildComment, "||")
 	// tags might contain spaces and hence trim
 	tags = stringMap(tags, strings.TrimSpace)

--- a/plugins/common/opcua/opcua_util.go
+++ b/plugins/common/opcua/opcua_util.go
@@ -31,7 +31,7 @@ func newTempDir() (string, error) {
 	return dir, err
 }
 
-func generateCert(host string, rsaBits int, certFile, keyFile string, dur time.Duration) (cert string, key string, err error) {
+func generateCert(host string, rsaBits int, certFile, keyFile string, dur time.Duration) (cert, key string, err error) {
 	dir, err := newTempDir()
 	if err != nil {
 		return "", "", fmt.Errorf("failed to create certificate: %w", err)

--- a/plugins/common/parallel/ordered.go
+++ b/plugins/common/parallel/ordered.go
@@ -17,12 +17,7 @@ type Ordered struct {
 	queue chan futureMetric
 }
 
-func NewOrdered(
-	acc telegraf.Accumulator,
-	fn func(telegraf.Metric) []telegraf.Metric,
-	orderedQueueSize int,
-	workerCount int,
-) *Ordered {
+func NewOrdered(acc telegraf.Accumulator, fn func(telegraf.Metric) []telegraf.Metric, orderedQueueSize, workerCount int) *Ordered {
 	p := &Ordered{
 		fn:          fn,
 		workerQueue: make(chan job, workerCount),

--- a/plugins/common/shim/processor_test.go
+++ b/plugins/common/shim/processor_test.go
@@ -30,7 +30,7 @@ func TestProcessorShimWithLargerThanDefaultScannerBufferSize(t *testing.T) {
 	testSendAndReceive(t, "f1", string(b))
 }
 
-func testSendAndReceive(t *testing.T, fieldKey string, fieldValue string) {
+func testSendAndReceive(t *testing.T, fieldKey, fieldValue string) {
 	p := &testProcessor{"hi", "mom"}
 
 	stdinReader, stdinWriter := io.Pipe()

--- a/plugins/inputs/kinesis_consumer/kinesis_consumer.go
+++ b/plugins/inputs/kinesis_consumer/kinesis_consumer.go
@@ -355,8 +355,8 @@ func (t *telegrafLoggerWrapper) Logf(classification logging.Classification, form
 // noopStore implements the storage interface with discard
 type noopStore struct{}
 
-func (n noopStore) SetCheckpoint(string, string, string) error   { return nil }
-func (n noopStore) GetCheckpoint(string, string) (string, error) { return "", nil }
+func (n noopStore) SetCheckpoint(_, _, _ string) error        { return nil }
+func (n noopStore) GetCheckpoint(_, _ string) (string, error) { return "", nil }
 
 func init() {
 	negOne, _ = new(big.Int).SetString("-1", 10)

--- a/plugins/inputs/win_eventlog/win_eventlog.go
+++ b/plugins/inputs/win_eventlog/win_eventlog.go
@@ -294,7 +294,7 @@ func (w *WinEventLog) shouldProcessField(field string) (should bool, list string
 	return false, "excluded"
 }
 
-func (w *WinEventLog) shouldExcludeEmptyField(field string, fieldType string, fieldValue interface{}) (should bool) {
+func (w *WinEventLog) shouldExcludeEmptyField(field, fieldType string, fieldValue interface{}) (should bool) {
 	if w.fieldEmptyFilter == nil || !w.fieldEmptyFilter.Match(field) {
 		return false
 	}
@@ -496,11 +496,7 @@ func (w *WinEventLog) renderRemoteMessage(event Event) (Event, error) {
 	return event, nil
 }
 
-func formatEventString(
-	messageFlag EvtFormatMessageFlag,
-	eventHandle EvtHandle,
-	publisherHandle EvtHandle,
-) (string, error) {
+func formatEventString(messageFlag EvtFormatMessageFlag, eventHandle, publisherHandle EvtHandle) (string, error) {
 	var bufferUsed uint32
 	err := _EvtFormatMessage(publisherHandle, eventHandle, 0, 0, 0, messageFlag,
 		0, nil, &bufferUsed)

--- a/plugins/inputs/win_eventlog/zsyscall_windows.go
+++ b/plugins/inputs/win_eventlog/zsyscall_windows.go
@@ -156,7 +156,7 @@ func _EvtClose(object EvtHandle) error {
 	return err
 }
 
-func _EvtNext(resultSet EvtHandle, eventArraySize uint32, eventArray *EvtHandle, timeout uint32, flags uint32, numReturned *uint32) error {
+func _EvtNext(resultSet EvtHandle, eventArraySize uint32, eventArray *EvtHandle, timeout, flags uint32, numReturned *uint32) error {
 	r1, _, e1 := syscall.SyscallN(
 		procEvtNext.Addr(),
 		uintptr(resultSet),
@@ -214,7 +214,7 @@ func _EvtFormatMessage(
 	return err
 }
 
-func _EvtOpenPublisherMetadata(session EvtHandle, publisherIdentity *uint16, logFilePath *uint16, locale uint32, flags uint32) (EvtHandle, error) {
+func _EvtOpenPublisherMetadata(session EvtHandle, publisherIdentity, logFilePath *uint16, locale, flags uint32) (EvtHandle, error) {
 	r0, _, e1 := syscall.SyscallN(
 		procEvtOpenPublisherMetadata.Addr(),
 		uintptr(session),

--- a/plugins/inputs/win_perf_counters/pdh.go
+++ b/plugins/inputs/win_perf_counters/pdh.go
@@ -482,7 +482,7 @@ func PdhGetFormattedCounterValueDouble(hCounter pdhCounterHandle, lpdwType *uint
 //			time.Sleep(2000 * time.Millisecond)
 //		}
 //	}
-func PdhGetFormattedCounterArrayDouble(hCounter pdhCounterHandle, lpdwBufferSize *uint32, lpdwBufferCount *uint32, itemBuffer *byte) uint32 {
+func PdhGetFormattedCounterArrayDouble(hCounter pdhCounterHandle, lpdwBufferSize, lpdwBufferCount *uint32, itemBuffer *byte) uint32 {
 	ret, _, _ := pdhGetFormattedCounterArrayW.Call(
 		uintptr(hCounter),
 		uintptr(PdhFmtDouble|PdhFmtNocap100),
@@ -500,7 +500,7 @@ func PdhGetFormattedCounterArrayDouble(hCounter pdhCounterHandle, lpdwBufferSize
 // call PdhGetCounterInfo and access dwQueryUserData of the pdhCounterInfo structure. phQuery is
 // the handle to the query, and must be used in subsequent calls. This function returns a PDH_
 // constant error code, or ErrorSuccess if the call succeeded.
-func PdhOpenQuery(szDataSource uintptr, dwUserData uintptr, phQuery *pdhQueryHandle) uint32 {
+func PdhOpenQuery(szDataSource, dwUserData uintptr, phQuery *pdhQueryHandle) uint32 {
 	ret, _, _ := pdhOpenQuery.Call(
 		szDataSource,
 		dwUserData,
@@ -638,7 +638,7 @@ func PdhGetRawCounterValue(hCounter pdhCounterHandle, lpdwType *uint32, pValue *
 // ItemBuffer
 // Caller-allocated buffer that receives the array of pdhRawCounterItem structures; the structures contain the raw instance counter values.
 // Set to NULL if lpdwBufferSize is zero.
-func PdhGetRawCounterArray(hCounter pdhCounterHandle, lpdwBufferSize *uint32, lpdwBufferCount *uint32, itemBuffer *byte) uint32 {
+func PdhGetRawCounterArray(hCounter pdhCounterHandle, lpdwBufferSize, lpdwBufferCount *uint32, itemBuffer *byte) uint32 {
 	ret, _, _ := pdhGetRawCounterArrayW.Call(
 		uintptr(hCounter),
 		uintptr(unsafe.Pointer(lpdwBufferSize)),  //nolint:gosec // G103: Valid use of unsafe call to pass lpdwBufferSize

--- a/plugins/outputs/influxdb/udp_test.go
+++ b/plugins/outputs/influxdb/udp_test.go
@@ -62,7 +62,7 @@ type MockDialer struct {
 	DialContextF func() (influxdb.Conn, error)
 }
 
-func (d *MockDialer) DialContext(context.Context, string, string) (influxdb.Conn, error) {
+func (d *MockDialer) DialContext(_ context.Context, _, _ string) (influxdb.Conn, error) {
 	return d.DialContextF()
 }
 

--- a/plugins/parsers/dropwizard/parser_test.go
+++ b/plugins/parsers/dropwizard/parser_test.go
@@ -504,7 +504,7 @@ func search(metrics []telegraf.Metric, name string, tags map[string]string, fiel
 	return nil
 }
 
-func containsAll(t1 map[string]string, t2 map[string]string) bool {
+func containsAll(t1, t2 map[string]string) bool {
 	for k, v := range t2 {
 		if foundValue, ok := t1[k]; !ok || v != foundValue {
 			return false

--- a/plugins/parsers/influx/machine_test.go
+++ b/plugins/parsers/influx/machine_test.go
@@ -27,7 +27,7 @@ func (h *TestingHandler) SetMeasurement(name []byte) error {
 	return nil
 }
 
-func (h *TestingHandler) AddTag(key []byte, value []byte) error {
+func (h *TestingHandler) AddTag(key, value []byte) error {
 	k := make([]byte, 0, len(key))
 	v := make([]byte, 0, len(value))
 
@@ -43,7 +43,7 @@ func (h *TestingHandler) AddTag(key []byte, value []byte) error {
 	return nil
 }
 
-func (h *TestingHandler) AddInt(key []byte, value []byte) error {
+func (h *TestingHandler) AddInt(key, value []byte) error {
 	k := make([]byte, 0, len(key))
 	v := make([]byte, 0, len(value))
 
@@ -59,7 +59,7 @@ func (h *TestingHandler) AddInt(key []byte, value []byte) error {
 	return nil
 }
 
-func (h *TestingHandler) AddUint(key []byte, value []byte) error {
+func (h *TestingHandler) AddUint(key, value []byte) error {
 	k := make([]byte, 0, len(key))
 	v := make([]byte, 0, len(value))
 
@@ -75,7 +75,7 @@ func (h *TestingHandler) AddUint(key []byte, value []byte) error {
 	return nil
 }
 
-func (h *TestingHandler) AddFloat(key []byte, value []byte) error {
+func (h *TestingHandler) AddFloat(key, value []byte) error {
 	k := make([]byte, 0, len(key))
 	v := make([]byte, 0, len(value))
 
@@ -91,7 +91,7 @@ func (h *TestingHandler) AddFloat(key []byte, value []byte) error {
 	return nil
 }
 
-func (h *TestingHandler) AddString(key []byte, value []byte) error {
+func (h *TestingHandler) AddString(key, value []byte) error {
 	k := make([]byte, 0, len(key))
 	v := make([]byte, 0, len(value))
 
@@ -107,7 +107,7 @@ func (h *TestingHandler) AddString(key []byte, value []byte) error {
 	return nil
 }
 
-func (h *TestingHandler) AddBool(key []byte, value []byte) error {
+func (h *TestingHandler) AddBool(key, value []byte) error {
 	k := make([]byte, 0, len(key))
 	v := make([]byte, 0, len(value))
 
@@ -160,27 +160,27 @@ func (h *BenchmarkingHandler) SetMeasurement(_ []byte) error {
 	return nil
 }
 
-func (h *BenchmarkingHandler) AddTag(_ []byte, _ []byte) error {
+func (h *BenchmarkingHandler) AddTag(_, _ []byte) error {
 	return nil
 }
 
-func (h *BenchmarkingHandler) AddInt(_ []byte, _ []byte) error {
+func (h *BenchmarkingHandler) AddInt(_, _ []byte) error {
 	return nil
 }
 
-func (h *BenchmarkingHandler) AddUint(_ []byte, _ []byte) error {
+func (h *BenchmarkingHandler) AddUint(_, _ []byte) error {
 	return nil
 }
 
-func (h *BenchmarkingHandler) AddFloat(_ []byte, _ []byte) error {
+func (h *BenchmarkingHandler) AddFloat(_, _ []byte) error {
 	return nil
 }
 
-func (h *BenchmarkingHandler) AddString(_ []byte, _ []byte) error {
+func (h *BenchmarkingHandler) AddString(_, _ []byte) error {
 	return nil
 }
 
-func (h *BenchmarkingHandler) AddBool(_ []byte, _ []byte) error {
+func (h *BenchmarkingHandler) AddBool(_, _ []byte) error {
 	return nil
 }
 

--- a/plugins/parsers/json_v2/parser.go
+++ b/plugins/parsers/json_v2/parser.go
@@ -307,7 +307,7 @@ func cartesianProduct(a, b []telegraf.Metric) []telegraf.Metric {
 	return p
 }
 
-func mergeMetric(a telegraf.Metric, m telegraf.Metric) {
+func mergeMetric(a, m telegraf.Metric) {
 	for _, f := range a.FieldList() {
 		m.AddField(f.Key, f.Value)
 	}
@@ -657,7 +657,7 @@ func (p *Parser) SetDefaultTags(tags map[string]string) {
 }
 
 // convertType will convert the value parsed from the input JSON to the specified type in the config
-func (p *Parser) convertType(input gjson.Result, desiredType string, name string) (interface{}, error) {
+func (p *Parser) convertType(input gjson.Result, desiredType, name string) (interface{}, error) {
 	switch inputType := input.Value().(type) {
 	case string:
 		switch desiredType {

--- a/plugins/processors/enum/enum.go
+++ b/plugins/processors/enum/enum.go
@@ -153,7 +153,7 @@ func writeField(metric telegraf.Metric, name string, value interface{}) {
 	metric.AddField(name, value)
 }
 
-func writeTag(metric telegraf.Metric, name string, value string) {
+func writeTag(metric telegraf.Metric, name, value string) {
 	metric.RemoveTag(name)
 	metric.AddTag(name, value)
 }

--- a/plugins/processors/snmp_lookup/store.go
+++ b/plugins/processors/snmp_lookup/store.go
@@ -82,7 +82,7 @@ func (s *store) enqueue(agent string) {
 	})
 }
 
-func (s *store) lookup(agent string, index string) {
+func (s *store) lookup(agent, index string) {
 	entry, cached := s.cache.Get(agent)
 	if !cached {
 		// There is no cache at all, so we need to enqueue an update.

--- a/plugins/processors/topk/topk_test.go
+++ b/plugins/processors/topk/topk_test.go
@@ -109,7 +109,7 @@ func belongs(m telegraf.Metric, ms []telegraf.Metric) bool {
 	return false
 }
 
-func subSet(a []telegraf.Metric, b []telegraf.Metric) bool {
+func subSet(a, b []telegraf.Metric) bool {
 	subset := true
 	for _, m := range a {
 		if !belongs(m, b) {
@@ -120,11 +120,11 @@ func subSet(a []telegraf.Metric, b []telegraf.Metric) bool {
 	return subset
 }
 
-func equalSets(l1 []telegraf.Metric, l2 []telegraf.Metric) bool {
+func equalSets(l1, l2 []telegraf.Metric) bool {
 	return subSet(l1, l2) && subSet(l2, l1)
 }
 
-func runAndCompare(topk *TopK, metrics []telegraf.Metric, answer []telegraf.Metric, testID string, t *testing.T) {
+func runAndCompare(topk *TopK, metrics, answer []telegraf.Metric, testID string, t *testing.T) {
 	// Sleep for `period`, otherwise the processor will only
 	// cache the metrics, but it will not process them
 	time.Sleep(time.Duration(topk.Period))

--- a/plugins/serializers/graphite/graphite.go
+++ b/plugins/serializers/graphite/graphite.go
@@ -184,12 +184,7 @@ func formatValue(value interface{}) string {
 // FIELDNAME. It is up to the user to replace this. This is so that
 // SerializeBucketName can be called just once per measurement, rather than
 // once per field. See GraphiteSerializer.InsertField() function.
-func SerializeBucketName(
-	measurement string,
-	tags map[string]string,
-	template string,
-	prefix string,
-) string {
+func SerializeBucketName(measurement string, tags map[string]string, template, prefix string) string {
 	if template == "" {
 		template = DefaultTemplate
 	}
@@ -278,14 +273,7 @@ func InitGraphiteTemplates(templates []string) ([]*GraphiteTemplate, string, err
 // SerializeBucketNameWithTags will take the given measurement name and tags and
 // produce a graphite bucket. It will use the Graphite11Serializer.
 // http://graphite.readthedocs.io/en/latest/tags.html
-func (s *GraphiteSerializer) SerializeBucketNameWithTags(
-	measurement string,
-	tags map[string]string,
-	prefix string,
-	separator string,
-	field string,
-	tagSanitizeMode string,
-) string {
+func (s *GraphiteSerializer) SerializeBucketNameWithTags(measurement string, tags map[string]string, prefix, separator, field, tagSanitizeMode string) string {
 	var out string
 	var tagsCopy []string
 	for k, v := range tags {
@@ -358,7 +346,7 @@ func (s *GraphiteSerializer) strictSanitize(value string) string {
 	return s.strictAllowedChars.ReplaceAllLiteralString(value, "_")
 }
 
-func compatibleSanitize(name string, value string) string {
+func compatibleSanitize(name, value string) string {
 	name = compatibleAllowedCharsName.ReplaceAllLiteralString(name, "_")
 	value = compatibleAllowedCharsValue.ReplaceAllLiteralString(value, "_")
 	value = compatibleLeadingTildeDrop.FindStringSubmatch(value)[1]

--- a/testutil/accumulator.go
+++ b/testutil/accumulator.go
@@ -292,7 +292,7 @@ func (a *Accumulator) Get(measurement string) (*Metric, bool) {
 	return nil, false
 }
 
-func (a *Accumulator) HasTag(measurement string, key string) bool {
+func (a *Accumulator) HasTag(measurement, key string) bool {
 	for _, p := range a.Metrics {
 		if p.Measurement == measurement {
 			_, ok := p.Tags[key]
@@ -302,7 +302,7 @@ func (a *Accumulator) HasTag(measurement string, key string) bool {
 	return false
 }
 
-func (a *Accumulator) TagSetValue(measurement string, key string) string {
+func (a *Accumulator) TagSetValue(measurement, key string) string {
 	for _, p := range a.Metrics {
 		if p.Measurement == measurement {
 			v, ok := p.Tags[key]
@@ -314,7 +314,7 @@ func (a *Accumulator) TagSetValue(measurement string, key string) string {
 	return ""
 }
 
-func (a *Accumulator) TagValue(measurement string, key string) string {
+func (a *Accumulator) TagValue(measurement, key string) string {
 	for _, p := range a.Metrics {
 		if p.Measurement == measurement {
 			v, ok := p.Tags[key]
@@ -492,7 +492,7 @@ func (a *Accumulator) HasTimestamp(measurement string, timestamp time.Time) bool
 
 // HasField returns true if the given measurement has a field with the given
 // name
-func (a *Accumulator) HasField(measurement string, field string) bool {
+func (a *Accumulator) HasField(measurement, field string) bool {
 	a.Lock()
 	defer a.Unlock()
 	for _, p := range a.Metrics {
@@ -507,7 +507,7 @@ func (a *Accumulator) HasField(measurement string, field string) bool {
 }
 
 // HasIntField returns true if the measurement has an Int value
-func (a *Accumulator) HasIntField(measurement string, field string) bool {
+func (a *Accumulator) HasIntField(measurement, field string) bool {
 	a.Lock()
 	defer a.Unlock()
 	for _, p := range a.Metrics {
@@ -525,7 +525,7 @@ func (a *Accumulator) HasIntField(measurement string, field string) bool {
 }
 
 // HasInt64Field returns true if the measurement has an Int64 value
-func (a *Accumulator) HasInt64Field(measurement string, field string) bool {
+func (a *Accumulator) HasInt64Field(measurement, field string) bool {
 	a.Lock()
 	defer a.Unlock()
 	for _, p := range a.Metrics {
@@ -543,7 +543,7 @@ func (a *Accumulator) HasInt64Field(measurement string, field string) bool {
 }
 
 // HasInt32Field returns true if the measurement has an Int value
-func (a *Accumulator) HasInt32Field(measurement string, field string) bool {
+func (a *Accumulator) HasInt32Field(measurement, field string) bool {
 	a.Lock()
 	defer a.Unlock()
 	for _, p := range a.Metrics {
@@ -561,7 +561,7 @@ func (a *Accumulator) HasInt32Field(measurement string, field string) bool {
 }
 
 // HasStringField returns true if the measurement has a String value
-func (a *Accumulator) HasStringField(measurement string, field string) bool {
+func (a *Accumulator) HasStringField(measurement, field string) bool {
 	a.Lock()
 	defer a.Unlock()
 	for _, p := range a.Metrics {
@@ -579,7 +579,7 @@ func (a *Accumulator) HasStringField(measurement string, field string) bool {
 }
 
 // HasUIntField returns true if the measurement has a UInt value
-func (a *Accumulator) HasUIntField(measurement string, field string) bool {
+func (a *Accumulator) HasUIntField(measurement, field string) bool {
 	a.Lock()
 	defer a.Unlock()
 	for _, p := range a.Metrics {
@@ -597,7 +597,7 @@ func (a *Accumulator) HasUIntField(measurement string, field string) bool {
 }
 
 // HasFloatField returns true if the given measurement has a float value
-func (a *Accumulator) HasFloatField(measurement string, field string) bool {
+func (a *Accumulator) HasFloatField(measurement, field string) bool {
 	a.Lock()
 	defer a.Unlock()
 	for _, p := range a.Metrics {
@@ -628,7 +628,7 @@ func (a *Accumulator) HasMeasurement(measurement string) bool {
 }
 
 // IntField returns the int value of the given measurement and field or false.
-func (a *Accumulator) IntField(measurement string, field string) (int, bool) {
+func (a *Accumulator) IntField(measurement, field string) (int, bool) {
 	a.Lock()
 	defer a.Unlock()
 	for _, p := range a.Metrics {
@@ -646,7 +646,7 @@ func (a *Accumulator) IntField(measurement string, field string) (int, bool) {
 }
 
 // Int64Field returns the int64 value of the given measurement and field or false.
-func (a *Accumulator) Int64Field(measurement string, field string) (int64, bool) {
+func (a *Accumulator) Int64Field(measurement, field string) (int64, bool) {
 	a.Lock()
 	defer a.Unlock()
 	for _, p := range a.Metrics {
@@ -664,7 +664,7 @@ func (a *Accumulator) Int64Field(measurement string, field string) (int64, bool)
 }
 
 // Uint64Field returns the int64 value of the given measurement and field or false.
-func (a *Accumulator) Uint64Field(measurement string, field string) (uint64, bool) {
+func (a *Accumulator) Uint64Field(measurement, field string) (uint64, bool) {
 	a.Lock()
 	defer a.Unlock()
 	for _, p := range a.Metrics {
@@ -682,7 +682,7 @@ func (a *Accumulator) Uint64Field(measurement string, field string) (uint64, boo
 }
 
 // Int32Field returns the int32 value of the given measurement and field or false.
-func (a *Accumulator) Int32Field(measurement string, field string) (int32, bool) {
+func (a *Accumulator) Int32Field(measurement, field string) (int32, bool) {
 	a.Lock()
 	defer a.Unlock()
 	for _, p := range a.Metrics {
@@ -700,7 +700,7 @@ func (a *Accumulator) Int32Field(measurement string, field string) (int32, bool)
 }
 
 // FloatField returns the float64 value of the given measurement and field or false.
-func (a *Accumulator) FloatField(measurement string, field string) (float64, bool) {
+func (a *Accumulator) FloatField(measurement, field string) (float64, bool) {
 	a.Lock()
 	defer a.Unlock()
 	for _, p := range a.Metrics {
@@ -718,7 +718,7 @@ func (a *Accumulator) FloatField(measurement string, field string) (float64, boo
 }
 
 // StringField returns the string value of the given measurement and field or false.
-func (a *Accumulator) StringField(measurement string, field string) (string, bool) {
+func (a *Accumulator) StringField(measurement, field string) (string, bool) {
 	a.Lock()
 	defer a.Unlock()
 	for _, p := range a.Metrics {
@@ -735,7 +735,7 @@ func (a *Accumulator) StringField(measurement string, field string) (string, boo
 }
 
 // BoolField returns the bool value of the given measurement and field or false.
-func (a *Accumulator) BoolField(measurement string, field string) (v bool, ok bool) {
+func (a *Accumulator) BoolField(measurement, field string) (v, ok bool) {
 	a.Lock()
 	defer a.Unlock()
 	for _, p := range a.Metrics {

--- a/tools/package_incus_test/incus.go
+++ b/tools/package_incus_test/incus.go
@@ -41,7 +41,7 @@ func (c *IncusClient) Connect() error {
 }
 
 // Create a container using a specific remote and alias.
-func (c *IncusClient) Create(name string, remote string, alias string) error {
+func (c *IncusClient) Create(name, remote, alias string) error {
 	fmt.Printf("creating %s with %s:%s\n", name, remote, alias)
 
 	if c.Client == nil {
@@ -147,7 +147,7 @@ func (c *IncusClient) Exec(name string, command ...string) error {
 }
 
 // Push file to container.
-func (c *IncusClient) Push(name string, src string, dst string) error {
+func (c *IncusClient) Push(name, src, dst string) error {
 	fmt.Printf("cp %s %s%s\n", src, name, dst)
 	f, err := os.Open(src)
 	if err != nil {

--- a/tools/package_incus_test/main.go
+++ b/tools/package_incus_test/main.go
@@ -93,7 +93,7 @@ func launchTests(packageFile string, images []string) error {
 	return nil
 }
 
-func runTest(image string, name string, packageFile string) error {
+func runTest(image, name, packageFile string) error {
 	c := Container{Name: name}
 	if err := c.Create(image); err != nil {
 		return err


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

Address last findings for [revive:enforce-repeated-arg-type-style](https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#enforce-repeated-arg-type-style) and enable this rule.

As we agreed here https://github.com/influxdata/telegraf/issues/15811, findings found by the following configuration were addressed:
```
      - name: enforce-repeated-arg-type-style
        arguments: ["short"]
```

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #15811
