### PR TITLE
chore: Fix linter findings for `revive:exported` in `plugins/inputs/m*`

### DIFF
--- a/plugins/inputs/mailchimp/chimp_api.go
+++ b/plugins/inputs/mailchimp/chimp_api.go
@@ -22,7 +22,7 @@ const (
 var mailchimpDatacenter = regexp.MustCompile("[a-z]+[0-9]+$")
 
 type chimpAPI struct {
-	Transport http.RoundTripper
+	transport http.RoundTripper
 	debug     bool
 
 	sync.Mutex
@@ -32,30 +32,30 @@ type chimpAPI struct {
 }
 
 type reportsParams struct {
-	Count          string
-	Offset         string
-	SinceSendTime  string
-	BeforeSendTime string
+	count          string
+	offset         string
+	sinceSendTime  string
+	beforeSendTime string
 }
 
 func (p *reportsParams) String() string {
 	v := url.Values{}
-	if p.Count != "" {
-		v.Set("count", p.Count)
+	if p.count != "" {
+		v.Set("count", p.count)
 	}
-	if p.Offset != "" {
-		v.Set("offset", p.Offset)
+	if p.offset != "" {
+		v.Set("offset", p.offset)
 	}
-	if p.BeforeSendTime != "" {
-		v.Set("before_send_time", p.BeforeSendTime)
+	if p.beforeSendTime != "" {
+		v.Set("before_send_time", p.beforeSendTime)
 	}
-	if p.SinceSendTime != "" {
-		v.Set("since_send_time", p.SinceSendTime)
+	if p.sinceSendTime != "" {
+		v.Set("since_send_time", p.sinceSendTime)
 	}
 	return v.Encode()
 }
 
-func NewChimpAPI(apiKey string, log telegraf.Logger) *chimpAPI {
+func newChimpAPI(apiKey string, log telegraf.Logger) *chimpAPI {
 	u := &url.URL{}
 	u.Scheme = "https"
 	u.Host = mailchimpDatacenter.FindString(apiKey) + ".api.mailchimp.com"
@@ -86,7 +86,7 @@ func chimpErrorCheck(body []byte) error {
 	return nil
 }
 
-func (a *chimpAPI) GetReports(params reportsParams) (reportsResponse, error) {
+func (a *chimpAPI) getReports(params reportsParams) (reportsResponse, error) {
 	a.Lock()
 	defer a.Unlock()
 	a.url.Path = reportsEndpoint
@@ -105,7 +105,7 @@ func (a *chimpAPI) GetReports(params reportsParams) (reportsResponse, error) {
 	return response, nil
 }
 
-func (a *chimpAPI) GetReport(campaignID string) (report, error) {
+func (a *chimpAPI) getReport(campaignID string) (report, error) {
 	a.Lock()
 	defer a.Unlock()
 	a.url.Path = fmt.Sprintf(reportsEndpointCampaign, campaignID)
@@ -126,7 +126,7 @@ func (a *chimpAPI) GetReport(campaignID string) (report, error) {
 
 func (a *chimpAPI) runChimp(params reportsParams) ([]byte, error) {
 	client := &http.Client{
-		Transport: a.Transport,
+		Transport: a.transport,
 		Timeout:   4 * time.Second,
 	}
 

--- a/plugins/inputs/mailchimp/mailchimp.go
+++ b/plugins/inputs/mailchimp/mailchimp.go
@@ -14,13 +14,12 @@ import (
 var sampleConfig string
 
 type MailChimp struct {
+	APIKey     string          `toml:"api_key"`
+	DaysOld    int             `toml:"days_old"`
+	CampaignID string          `toml:"campaign_id"`
+	Log        telegraf.Logger `toml:"-"`
+
 	api *chimpAPI
-
-	APIKey     string `toml:"api_key"`
-	DaysOld    int    `toml:"days_old"`
-	CampaignID string `toml:"campaign_id"`
-
-	Log telegraf.Logger `toml:"-"`
 }
 
 func (*MailChimp) SampleConfig() string {
@@ -28,7 +27,7 @@ func (*MailChimp) SampleConfig() string {
 }
 
 func (m *MailChimp) Init() error {
-	m.api = NewChimpAPI(m.APIKey, m.Log)
+	m.api = newChimpAPI(m.APIKey, m.Log)
 
 	return nil
 }
@@ -45,8 +44,8 @@ func (m *MailChimp) Gather(acc telegraf.Accumulator) error {
 			since = now.Add(-d).Format(time.RFC3339)
 		}
 
-		reports, err := m.api.GetReports(reportsParams{
-			SinceSendTime: since,
+		reports, err := m.api.getReports(reportsParams{
+			sinceSendTime: since,
 		})
 		if err != nil {
 			return err
@@ -57,7 +56,7 @@ func (m *MailChimp) Gather(acc telegraf.Accumulator) error {
 			gatherReport(acc, report, now)
 		}
 	} else {
-		report, err := m.api.GetReport(m.CampaignID)
+		report, err := m.api.getReport(m.CampaignID)
 		if err != nil {
 			return err
 		}

--- a/plugins/inputs/marklogic/marklogic.go
+++ b/plugins/inputs/marklogic/marklogic.go
@@ -19,69 +19,69 @@ import (
 //go:embed sample.conf
 var sampleConfig string
 
-// Marklogic configuration toml
+const (
+	// MarkLogic v2 management api endpoints for hosts status
+	statsPath  = "/manage/v2/hosts/"
+	viewFormat = "view=status&format=json"
+)
+
 type Marklogic struct {
 	URL      string   `toml:"url"`
 	Hosts    []string `toml:"hosts"`
 	Username string   `toml:"username"`
 	Password string   `toml:"password"`
-	Sources  []string
-
 	tls.ClientConfig
 
-	client *http.Client
+	client  *http.Client
+	sources []string
 }
 
-type MlPointInt struct {
+type mlPointInt struct {
 	Value int `json:"value"`
 }
 
-type MlPointFloat struct {
+type mlPointFloat struct {
 	Value float64 `json:"value"`
 }
 
-type MlPointBool struct {
+type mlPointBool struct {
 	Value bool `json:"value"`
 }
 
-// MarkLogic v2 management api endpoints for hosts status
-const statsPath = "/manage/v2/hosts/"
-const viewFormat = "view=status&format=json"
-
-type MlHost struct {
+type mlHost struct {
 	HostStatus struct {
 		ID               string `json:"id"`
 		Name             string `json:"name"`
 		StatusProperties struct {
-			Online         MlPointBool `json:"online"`
+			Online         mlPointBool `json:"online"`
 			LoadProperties struct {
-				TotalLoad MlPointFloat `json:"total-load"`
+				TotalLoad mlPointFloat `json:"total-load"`
 			} `json:"load-properties"`
 			RateProperties struct {
-				TotalRate MlPointFloat `json:"total-rate"`
+				TotalRate mlPointFloat `json:"total-rate"`
 			} `json:"rate-properties"`
 			StatusDetail struct {
-				Cpus                   MlPointInt `json:"cpus"`
-				Cores                  MlPointInt `json:"cores"`
+				Cpus                   mlPointInt `json:"cpus"`
+				Cores                  mlPointInt `json:"cores"`
 				TotalCPUStatUser       float64    `json:"total-cpu-stat-user"`
 				TotalCPUStatSystem     float64    `json:"total-cpu-stat-system"`
 				TotalCPUStatIdle       float64    `json:"total-cpu-stat-idle"`
 				TotalCPUStatIowait     float64    `json:"total-cpu-stat-iowait"`
-				MemoryProcessSize      MlPointInt `json:"memory-process-size"`
-				MemoryProcessRss       MlPointInt `json:"memory-process-rss"`
-				MemorySystemTotal      MlPointInt `json:"memory-system-total"`
-				MemorySystemFree       MlPointInt `json:"memory-system-free"`
-				MemoryProcessSwapSize  MlPointInt `json:"memory-process-swap-size"`
-				MemorySize             MlPointInt `json:"memory-size"`
-				HostSize               MlPointInt `json:"host-size"`
-				LogDeviceSpace         MlPointInt `json:"log-device-space"`
-				DataDirSpace           MlPointInt `json:"data-dir-space"`
-				QueryReadBytes         MlPointInt `json:"query-read-bytes"`
-				QueryReadLoad          MlPointInt `json:"query-read-load"`
-				MergeReadLoad          MlPointInt `json:"merge-read-load"`
-				MergeWriteLoad         MlPointInt `json:"merge-write-load"`
-				HTTPServerReceiveBytes MlPointInt `json:"http-server-receive-bytes"`
-				HTTPServerSendBytes    MlPointInt `json:"http-server-send-bytes"`
+				MemoryProcessSize      mlPointInt `json:"memory-process-size"`
+				MemoryProcessRss       mlPointInt `json:"memory-process-rss"`
+				MemorySystemTotal      mlPointInt `json:"memory-system-total"`
+				MemorySystemFree       mlPointInt `json:"memory-system-free"`
+				MemoryProcessSwapSize  mlPointInt `json:"memory-process-swap-size"`
+				MemorySize             mlPointInt `json:"memory-size"`
+				HostSize               mlPointInt `json:"host-size"`
+				LogDeviceSpace         mlPointInt `json:"log-device-space"`
+				DataDirSpace           mlPointInt `json:"data-dir-space"`
+				QueryReadBytes         mlPointInt `json:"query-read-bytes"`
+				QueryReadLoad          mlPointInt `json:"query-read-load"`
+				MergeReadLoad          mlPointInt `json:"merge-read-load"`
+				MergeWriteLoad         mlPointInt `json:"merge-write-load"`
+				HTTPServerReceiveBytes mlPointInt `json:"http-server-receive-bytes"`
+				HTTPServerSendBytes    mlPointInt `json:"http-server-send-bytes"`
 			} `json:"status-detail"`
 		} `json:"status-properties"`
 	} `json:"host-status"`
@@ -91,7 +91,6 @@ func (*Marklogic) SampleConfig() string {
 	return sampleConfig
 }
 
-// Init parse all source URLs and place on the Marklogic struct
 func (c *Marklogic) Init() error {
 	if len(c.URL) == 0 {
 		c.URL = "http://localhost:8002/"
@@ -108,12 +107,11 @@ func (c *Marklogic) Init() error {
 
 		addr.RawQuery = viewFormat
 		u := addr.String()
-		c.Sources = append(c.Sources, u)
+		c.sources = append(c.sources, u)
 	}
 	return nil
 }
 
-// Gather metrics from HTTP Server.
 func (c *Marklogic) Gather(accumulator telegraf.Accumulator) error {
 	var wg sync.WaitGroup
 
@@ -127,7 +125,7 @@ func (c *Marklogic) Gather(accumulator telegraf.Accumulator) error {
 	}
 
 	// Range over all source URL's appended to the struct
-	for _, serv := range c.Sources {
+	for _, serv := range c.sources {
 		wg.Add(1)
 		go func(serv string) {
 			defer wg.Done()
@@ -143,7 +141,7 @@ func (c *Marklogic) Gather(accumulator telegraf.Accumulator) error {
 }
 
 func (c *Marklogic) fetchAndInsertData(acc telegraf.Accumulator, address string) error {
-	ml := &MlHost{}
+	ml := &mlHost{}
 	if err := c.gatherJSONData(address, ml); err != nil {
 		return err
 	}

--- a/plugins/inputs/marklogic/marklogic_test.go
+++ b/plugins/inputs/marklogic/marklogic_test.go
@@ -33,7 +33,7 @@ func TestMarklogic(t *testing.T) {
 	ml := &Marklogic{
 		Hosts: []string{"example1"},
 		URL:   ts.URL,
-		// Sources: []string{"http://localhost:8002/manage/v2/hosts/hostname1?view=status&format=json"},
+		// sources: []string{"http://localhost:8002/manage/v2/hosts/hostname1?view=status&format=json"},
 	}
 
 	// Create a test accumulator

--- a/plugins/inputs/mcrouter/mcrouter_test.go
+++ b/plugins/inputs/mcrouter/mcrouter_test.go
@@ -32,7 +32,7 @@ func TestAddressParsing(t *testing.T) {
 	}
 
 	for _, args := range acceptTests {
-		address, protocol, err := m.ParseAddress(args[0])
+		address, protocol, err := m.parseAddress(args[0])
 
 		require.NoError(t, err, args[0])
 		require.Equal(t, args[1], address, args[0])
@@ -40,7 +40,7 @@ func TestAddressParsing(t *testing.T) {
 	}
 
 	for _, addr := range rejectTests {
-		address, protocol, err := m.ParseAddress(addr)
+		address, protocol, err := m.parseAddress(addr)
 
 		require.Error(t, err, addr)
 		require.Empty(t, address, addr)

--- a/plugins/inputs/mdstat/mdstat.go
+++ b/plugins/inputs/mdstat/mdstat.go
@@ -44,6 +44,10 @@ var (
 	componentDeviceRE    = regexp.MustCompile(`(.*)\[\d+\]`)
 )
 
+type Mdstat struct {
+	FileName string `toml:"file_name"`
+}
+
 type statusLine struct {
 	active int64
 	total  int64
@@ -56,10 +60,6 @@ type recoveryLine struct {
 	pct          float64
 	finish       float64
 	speed        float64
-}
-
-type MdstatConf struct {
-	FileName string `toml:"file_name"`
 }
 
 func evalStatusLine(deviceLine, statusLineStr string) (statusLine, error) {
@@ -173,11 +173,11 @@ func evalComponentDevices(deviceFields []string) string {
 	return strings.Join(mdComponentDevices, ",")
 }
 
-func (*MdstatConf) SampleConfig() string {
+func (*Mdstat) SampleConfig() string {
 	return sampleConfig
 }
 
-func (k *MdstatConf) Gather(acc telegraf.Accumulator) error {
+func (k *Mdstat) Gather(acc telegraf.Accumulator) error {
 	data, err := k.getProcMdstat()
 	if err != nil {
 		return err
@@ -267,7 +267,7 @@ func (k *MdstatConf) Gather(acc telegraf.Accumulator) error {
 	return nil
 }
 
-func (k *MdstatConf) getProcMdstat() ([]byte, error) {
+func (k *Mdstat) getProcMdstat() ([]byte, error) {
 	var mdStatFile string
 	if k.FileName == "" {
 		mdStatFile = internal.GetProcPath() + "/mdstat"
@@ -289,5 +289,5 @@ func (k *MdstatConf) getProcMdstat() ([]byte, error) {
 }
 
 func init() {
-	inputs.Add("mdstat", func() telegraf.Input { return &MdstatConf{} })
+	inputs.Add("mdstat", func() telegraf.Input { return &Mdstat{} })
 }

--- a/plugins/inputs/mdstat/mdstat_notlinux.go
+++ b/plugins/inputs/mdstat/mdstat_notlinux.go
@@ -17,12 +17,14 @@ type Mdstat struct {
 	Log telegraf.Logger `toml:"-"`
 }
 
+func (*Mdstat) SampleConfig() string { return sampleConfig }
+
 func (m *Mdstat) Init() error {
-	m.Log.Warn("current platform is not supported")
+	m.Log.Warn("Current platform is not supported")
 	return nil
 }
-func (*Mdstat) SampleConfig() string                { return sampleConfig }
-func (*Mdstat) Gather(_ telegraf.Accumulator) error { return nil }
+
+func (*Mdstat) Gather(telegraf.Accumulator) error { return nil }
 
 func init() {
 	inputs.Add("mdstat", func() telegraf.Input {

--- a/plugins/inputs/mdstat/mdstat_test.go
+++ b/plugins/inputs/mdstat/mdstat_test.go
@@ -14,7 +14,7 @@ import (
 func TestFullMdstatProcFile(t *testing.T) {
 	filename := makeFakeMDStatFile([]byte(mdStatFileFull))
 	defer os.Remove(filename)
-	k := MdstatConf{
+	k := Mdstat{
 		FileName: filename,
 	}
 	acc := testutil.Accumulator{}
@@ -39,7 +39,7 @@ func TestFullMdstatProcFile(t *testing.T) {
 func TestMdstatSyncStart(t *testing.T) {
 	filename := makeFakeMDStatFile([]byte(mdStatSyncStart))
 	defer os.Remove(filename)
-	k := MdstatConf{
+	k := Mdstat{
 		FileName: filename,
 	}
 	acc := testutil.Accumulator{}
@@ -65,7 +65,7 @@ func TestFailedDiskMdStatProcFile1(t *testing.T) {
 	filename := makeFakeMDStatFile([]byte(mdStatFileFailedDisk))
 	defer os.Remove(filename)
 
-	k := MdstatConf{
+	k := Mdstat{
 		FileName: filename,
 	}
 
@@ -92,7 +92,7 @@ func TestEmptyMdStatProcFile1(t *testing.T) {
 	filename := makeFakeMDStatFile([]byte(mdStatFileEmpty))
 	defer os.Remove(filename)
 
-	k := MdstatConf{
+	k := Mdstat{
 		FileName: filename,
 	}
 
@@ -105,7 +105,7 @@ func TestInvalidMdStatProcFile1(t *testing.T) {
 	filename := makeFakeMDStatFile([]byte(mdStatFileInvalid))
 	defer os.Remove(filename)
 
-	k := MdstatConf{
+	k := Mdstat{
 		FileName: filename,
 	}
 

--- a/plugins/inputs/mem/mem.go
+++ b/plugins/inputs/mem/mem.go
@@ -14,21 +14,21 @@ import (
 //go:embed sample.conf
 var sampleConfig string
 
-type MemStats struct {
+type Mem struct {
 	ps       system.PS
 	platform string
 }
 
-func (*MemStats) SampleConfig() string {
+func (*Mem) SampleConfig() string {
 	return sampleConfig
 }
 
-func (ms *MemStats) Init() error {
+func (ms *Mem) Init() error {
 	ms.platform = runtime.GOOS
 	return nil
 }
 
-func (ms *MemStats) Gather(acc telegraf.Accumulator) error {
+func (ms *Mem) Gather(acc telegraf.Accumulator) error {
 	vm, err := ms.ps.VMStat()
 	if err != nil {
 		return fmt.Errorf("error getting virtual memory info: %w", err)
@@ -102,6 +102,6 @@ func (ms *MemStats) Gather(acc telegraf.Accumulator) error {
 func init() {
 	ps := system.NewSystemPS()
 	inputs.Add("mem", func() telegraf.Input {
-		return &MemStats{ps: ps}
+		return &Mem{ps: ps}
 	})
 }

--- a/plugins/inputs/mem/mem_test.go
+++ b/plugins/inputs/mem/mem_test.go
@@ -4,11 +4,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/shirou/gopsutil/v4/mem"
+	"github.com/stretchr/testify/require"
+
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/plugins/inputs/system"
 	"github.com/influxdata/telegraf/testutil"
-	"github.com/shirou/gopsutil/v4/mem"
-	"github.com/stretchr/testify/require"
 )
 
 func TestMemStats(t *testing.T) {
@@ -55,7 +56,7 @@ func TestMemStats(t *testing.T) {
 	}
 
 	mps.On("VMStat").Return(vms, nil)
-	plugin := &MemStats{ps: &mps}
+	plugin := &Mem{ps: &mps}
 
 	err = plugin.Init()
 	require.NoError(t, err)

--- a/plugins/inputs/memcached/memcached.go
+++ b/plugins/inputs/memcached/memcached.go
@@ -22,7 +22,82 @@ import (
 //go:embed sample.conf
 var sampleConfig string
 
-// Memcached is a memcached plugin
+var (
+	defaultTimeout = 5 * time.Second
+
+	// The list of metrics that should be sent
+	sendMetrics = []string{
+		"accepting_conns",
+		"auth_cmds",
+		"auth_errors",
+		"bytes",
+		"bytes_read",
+		"bytes_written",
+		"cas_badval",
+		"cas_hits",
+		"cas_misses",
+		"cmd_flush",
+		"cmd_get",
+		"cmd_set",
+		"cmd_touch",
+		"conn_yields",
+		"connection_structures",
+		"curr_connections",
+		"curr_items",
+		"decr_hits",
+		"decr_misses",
+		"delete_hits",
+		"delete_misses",
+		"evicted_active",
+		"evicted_unfetched",
+		"evictions",
+		"expired_unfetched",
+		"extstore_compact_lost",
+		"extstore_compact_rescues",
+		"extstore_compact_resc_cold",
+		"extstore_compact_resc_old",
+		"extstore_compact_skipped",
+		"extstore_page_allocs",
+		"extstore_page_evictions",
+		"extstore_page_reclaims",
+		"extstore_pages_free",
+		"extstore_pages_used",
+		"extstore_objects_evicted",
+		"extstore_objects_read",
+		"extstore_objects_written",
+		"extstore_objects_used",
+		"extstore_bytes_evicted",
+		"extstore_bytes_written",
+		"extstore_bytes_read",
+		"extstore_bytes_used",
+		"extstore_bytes_fragmented",
+		"extstore_limit_maxbytes",
+		"extstore_io_queue",
+		"get_expired",
+		"get_flushed",
+		"get_hits",
+		"get_misses",
+		"hash_bytes",
+		"hash_is_expanding",
+		"hash_power_level",
+		"incr_hits",
+		"incr_misses",
+		"limit_maxbytes",
+		"listen_disabled_num",
+		"max_connections",
+		"reclaimed",
+		"rejected_connections",
+		"store_no_memory",
+		"store_too_large",
+		"threads",
+		"total_connections",
+		"total_items",
+		"touch_hits",
+		"touch_misses",
+		"uptime",
+	}
+)
+
 type Memcached struct {
 	Servers     []string `toml:"servers"`
 	UnixSockets []string `toml:"unix_sockets"`
@@ -30,85 +105,10 @@ type Memcached struct {
 	common_tls.ClientConfig
 }
 
-var defaultTimeout = 5 * time.Second
-
-// The list of metrics that should be sent
-var sendMetrics = []string{
-	"accepting_conns",
-	"auth_cmds",
-	"auth_errors",
-	"bytes",
-	"bytes_read",
-	"bytes_written",
-	"cas_badval",
-	"cas_hits",
-	"cas_misses",
-	"cmd_flush",
-	"cmd_get",
-	"cmd_set",
-	"cmd_touch",
-	"conn_yields",
-	"connection_structures",
-	"curr_connections",
-	"curr_items",
-	"decr_hits",
-	"decr_misses",
-	"delete_hits",
-	"delete_misses",
-	"evicted_active",
-	"evicted_unfetched",
-	"evictions",
-	"expired_unfetched",
-	"extstore_compact_lost",
-	"extstore_compact_rescues",
-	"extstore_compact_resc_cold",
-	"extstore_compact_resc_old",
-	"extstore_compact_skipped",
-	"extstore_page_allocs",
-	"extstore_page_evictions",
-	"extstore_page_reclaims",
-	"extstore_pages_free",
-	"extstore_pages_used",
-	"extstore_objects_evicted",
-	"extstore_objects_read",
-	"extstore_objects_written",
-	"extstore_objects_used",
-	"extstore_bytes_evicted",
-	"extstore_bytes_written",
-	"extstore_bytes_read",
-	"extstore_bytes_used",
-	"extstore_bytes_fragmented",
-	"extstore_limit_maxbytes",
-	"extstore_io_queue",
-	"get_expired",
-	"get_flushed",
-	"get_hits",
-	"get_misses",
-	"hash_bytes",
-	"hash_is_expanding",
-	"hash_power_level",
-	"incr_hits",
-	"incr_misses",
-	"limit_maxbytes",
-	"listen_disabled_num",
-	"max_connections",
-	"reclaimed",
-	"rejected_connections",
-	"store_no_memory",
-	"store_too_large",
-	"threads",
-	"total_connections",
-	"total_items",
-	"touch_hits",
-	"touch_misses",
-	"uptime",
-}
-
 func (*Memcached) SampleConfig() string {
 	return sampleConfig
 }
 
-// Gather reads stats from all configured servers accumulates stats
 func (m *Memcached) Gather(acc telegraf.Accumulator) error {
 	if len(m.Servers) == 0 && len(m.UnixSockets) == 0 {
 		return m.gatherServer(":11211", false, acc)
@@ -125,11 +125,7 @@ func (m *Memcached) Gather(acc telegraf.Accumulator) error {
 	return nil
 }
 
-func (m *Memcached) gatherServer(
-	address string,
-	unix bool,
-	acc telegraf.Accumulator,
-) error {
+func (m *Memcached) gatherServer(address string, unix bool, acc telegraf.Accumulator) error {
 	var conn net.Conn
 	var err error
 	var dialer proxy.Dialer

--- a/plugins/inputs/mesos/mesos_test.go
+++ b/plugins/inputs/mesos/mesos_test.go
@@ -333,11 +333,11 @@ func TestMasterFilter(t *testing.T) {
 		"messages", "evqueue", "tasks",
 	}
 
-	m.filterMetrics(MASTER, &masterMetrics)
+	m.filterMetrics(master, &masterMetrics)
 
 	// Assert expected metrics are present.
 	for _, v := range m.MasterCols {
-		for _, x := range m.getMetrics(MASTER, v) {
+		for _, x := range m.getMetrics(master, v) {
 			_, ok := masterMetrics[x]
 			require.Truef(t, ok, "Didn't find key %s, it should present.", x)
 		}
@@ -354,7 +354,7 @@ func TestMasterFilter(t *testing.T) {
 
 	// Assert unexpected metrics are not present.
 	for _, v := range b {
-		for _, x := range m.getMetrics(MASTER, v) {
+		for _, x := range m.getMetrics(master, v) {
 			_, ok := masterMetrics[x]
 			require.Falsef(t, ok, "Found key %s, it should be gone.", x)
 		}
@@ -395,16 +395,16 @@ func TestSlaveFilter(t *testing.T) {
 		"system", "executors", "messages",
 	}
 
-	m.filterMetrics(SLAVE, &slaveMetrics)
+	m.filterMetrics(slave, &slaveMetrics)
 
 	for _, v := range b {
-		for _, x := range m.getMetrics(SLAVE, v) {
+		for _, x := range m.getMetrics(slave, v) {
 			_, ok := slaveMetrics[x]
 			require.Falsef(t, ok, "Found key %s, it should be gone.", x)
 		}
 	}
 	for _, v := range m.MasterCols {
-		for _, x := range m.getMetrics(SLAVE, v) {
+		for _, x := range m.getMetrics(slave, v) {
 			_, ok := slaveMetrics[x]
 			require.Truef(t, ok, "Didn't find key %s, it should present.", x)
 		}

--- a/plugins/inputs/minecraft/client_test.go
+++ b/plugins/inputs/minecraft/client_test.go
@@ -6,19 +6,19 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type MockConnection struct {
+type mockConnection struct {
 	commands map[string]string
 }
 
-func (c *MockConnection) Execute(command string) (string, error) {
+func (c *mockConnection) Execute(command string) (string, error) {
 	return c.commands[command], nil
 }
 
-type MockConnector struct {
-	conn *MockConnection
+type mockConnector struct {
+	conn *mockConnection
 }
 
-func (c *MockConnector) Connect() (Connection, error) {
+func (c *mockConnector) connect() (connection, error) {
 	return c.conn, nil
 }
 
@@ -92,12 +92,12 @@ func TestClient_Player(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			connector := &MockConnector{
-				conn: &MockConnection{commands: tt.commands},
+			connector := &mockConnector{
+				conn: &mockConnection{commands: tt.commands},
 			}
 
 			client := newClient(connector)
-			actual, err := client.Players()
+			actual, err := client.players()
 			require.NoError(t, err)
 
 			require.Equal(t, tt.expected, actual)
@@ -110,7 +110,7 @@ func TestClient_Scores(t *testing.T) {
 		name     string
 		player   string
 		commands map[string]string
-		expected []Score
+		expected []score
 	}{
 		{
 			name:   "minecraft 1.12 player with no scores",
@@ -125,8 +125,8 @@ func TestClient_Scores(t *testing.T) {
 			commands: map[string]string{
 				"scoreboard players list Etho": "Showing 1 tracked objective(s) for Etho:- jump: 2 (jump)",
 			},
-			expected: []Score{
-				{Name: "jump", Value: 2},
+			expected: []score{
+				{name: "jump", value: 2},
 			},
 		},
 		{
@@ -135,10 +135,10 @@ func TestClient_Scores(t *testing.T) {
 			commands: map[string]string{
 				"scoreboard players list Etho": "Showing 3 tracked objective(s) for Etho:- hopper: 2 (hopper)- dropper: 2 (dropper)- redstone: 1 (redstone)",
 			},
-			expected: []Score{
-				{Name: "hopper", Value: 2},
-				{Name: "dropper", Value: 2},
-				{Name: "redstone", Value: 1},
+			expected: []score{
+				{name: "hopper", value: 2},
+				{name: "dropper", value: 2},
+				{name: "redstone", value: 1},
 			},
 		},
 		{
@@ -154,8 +154,8 @@ func TestClient_Scores(t *testing.T) {
 			commands: map[string]string{
 				"scoreboard players list Etho": "Etho has 1 scores:[jumps]: 1",
 			},
-			expected: []Score{
-				{Name: "jumps", Value: 1},
+			expected: []score{
+				{name: "jumps", value: 1},
 			},
 		},
 		{
@@ -164,21 +164,21 @@ func TestClient_Scores(t *testing.T) {
 			commands: map[string]string{
 				"scoreboard players list Etho": "Etho has 3 scores:[hopper]: 2[dropper]: 2[redstone]: 1",
 			},
-			expected: []Score{
-				{Name: "hopper", Value: 2},
-				{Name: "dropper", Value: 2},
-				{Name: "redstone", Value: 1},
+			expected: []score{
+				{name: "hopper", value: 2},
+				{name: "dropper", value: 2},
+				{name: "redstone", value: 1},
 			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			connector := &MockConnector{
-				conn: &MockConnection{commands: tt.commands},
+			connector := &mockConnector{
+				conn: &mockConnection{commands: tt.commands},
 			}
 
 			client := newClient(connector)
-			actual, err := client.Scores(tt.player)
+			actual, err := client.scores(tt.player)
 			require.NoError(t, err)
 
 			require.Equal(t, tt.expected, actual)

--- a/plugins/inputs/minecraft/minecraft_test.go
+++ b/plugins/inputs/minecraft/minecraft_test.go
@@ -9,22 +9,22 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type MockClient struct {
-	ConnectF func() error
-	PlayersF func() ([]string, error)
-	ScoresF  func(player string) ([]Score, error)
+type mockClient struct {
+	connectF func() error
+	playersF func() ([]string, error)
+	scoresF  func(player string) ([]score, error)
 }
 
-func (c *MockClient) Connect() error {
-	return c.ConnectF()
+func (c *mockClient) connect() error {
+	return c.connectF()
 }
 
-func (c *MockClient) Players() ([]string, error) {
-	return c.PlayersF()
+func (c *mockClient) players() ([]string, error) {
+	return c.playersF()
 }
 
-func (c *MockClient) Scores(player string) ([]Score, error) {
-	return c.ScoresF(player)
+func (c *mockClient) scores(player string) ([]score, error) {
+	return c.scoresF(player)
 }
 
 func TestGather(t *testing.T) {
@@ -32,31 +32,31 @@ func TestGather(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		client  *MockClient
+		client  *mockClient
 		metrics []telegraf.Metric
 		err     error
 	}{
 		{
 			name: "no players",
-			client: &MockClient{
-				ConnectF: func() error {
+			client: &mockClient{
+				connectF: func() error {
 					return nil
 				},
-				PlayersF: func() ([]string, error) {
+				playersF: func() ([]string, error) {
 					return nil, nil
 				},
 			},
 		},
 		{
 			name: "one player without scores",
-			client: &MockClient{
-				ConnectF: func() error {
+			client: &mockClient{
+				connectF: func() error {
 					return nil
 				},
-				PlayersF: func() ([]string, error) {
+				playersF: func() ([]string, error) {
 					return []string{"Etho"}, nil
 				},
-				ScoresF: func(player string) ([]Score, error) {
+				scoresF: func(player string) ([]score, error) {
 					switch player {
 					case "Etho":
 						return nil, nil
@@ -68,17 +68,17 @@ func TestGather(t *testing.T) {
 		},
 		{
 			name: "one player with scores",
-			client: &MockClient{
-				ConnectF: func() error {
+			client: &mockClient{
+				connectF: func() error {
 					return nil
 				},
-				PlayersF: func() ([]string, error) {
+				playersF: func() ([]string, error) {
 					return []string{"Etho"}, nil
 				},
-				ScoresF: func(player string) ([]Score, error) {
+				scoresF: func(player string) ([]score, error) {
 					switch player {
 					case "Etho":
-						return []Score{{Name: "jumps", Value: 42}}, nil
+						return []score{{name: "jumps", value: 42}}, nil
 					default:
 						panic("unknown player")
 					}

--- a/plugins/inputs/mock/mock.go
+++ b/plugins/inputs/mock/mock.go
@@ -48,22 +48,22 @@ type sineWave struct {
 }
 
 type step struct {
-	latest float64
-
 	Name  string  `toml:"name"`
 	Start float64 `toml:"start"`
 	Step  float64 `toml:"step"`
 
 	Min float64 `toml:"min" deprecated:"1.28.2;1.35.0;use 'start' instead"`
 	Max float64 `toml:"max" deprecated:"1.28.2;1.35.0;use 'step' instead"`
+
+	latest float64
 }
 
 type stock struct {
-	latest float64
-
 	Name       string  `toml:"name"`
 	Price      float64 `toml:"price"`
 	Volatility float64 `toml:"volatility"`
+
+	latest float64
 }
 
 func (*Mock) SampleConfig() string {

--- a/plugins/inputs/modbus/configuration.go
+++ b/plugins/inputs/modbus/configuration.go
@@ -9,10 +9,10 @@ const (
 	maxQuantityHoldingRegisters = uint16(125)
 )
 
-type Configuration interface {
-	Check() error
-	Process() (map[byte]requestSet, error)
-	SampleConfigPart() string
+type configuration interface {
+	check() error
+	process() (map[byte]requestSet, error)
+	sampleConfigPart() string
 }
 
 func removeDuplicates(elements []uint16) []uint16 {

--- a/plugins/inputs/modbus/configuration_metric_test.go
+++ b/plugins/inputs/modbus/configuration_metric_test.go
@@ -371,7 +371,7 @@ func TestMetricAddressOverflow(t *testing.T) {
 		Controller:        "tcp://localhost:1502",
 		ConfigurationType: "metric",
 		Log:               logger,
-		Workarounds:       ModbusWorkarounds{ReadCoilsStartingAtZero: true},
+		Workarounds:       workarounds{ReadCoilsStartingAtZero: true},
 	}
 	plugin.Metrics = []metricDefinition{
 		{

--- a/plugins/inputs/modbus/configuration_request_test.go
+++ b/plugins/inputs/modbus/configuration_request_test.go
@@ -3177,7 +3177,7 @@ func TestRequestWorkaroundsOneRequestPerField(t *testing.T) {
 		Controller:        "tcp://localhost:1502",
 		ConfigurationType: "request",
 		Log:               testutil.Logger{},
-		Workarounds:       ModbusWorkarounds{OnRequestPerField: true},
+		Workarounds:       workarounds{OnRequestPerField: true},
 	}
 	plugin.Requests = []requestDefinition{
 		{
@@ -3223,7 +3223,7 @@ func TestRequestWorkaroundsReadCoilsStartingAtZeroRequest(t *testing.T) {
 		Controller:        "tcp://localhost:1502",
 		ConfigurationType: "request",
 		Log:               testutil.Logger{},
-		Workarounds:       ModbusWorkarounds{ReadCoilsStartingAtZero: true},
+		Workarounds:       workarounds{ReadCoilsStartingAtZero: true},
 	}
 	plugin.SlaveID = 1
 	plugin.Requests = []requestDefinition{
@@ -3262,7 +3262,7 @@ func TestRequestOverlap(t *testing.T) {
 		Controller:        "tcp://localhost:1502",
 		ConfigurationType: "request",
 		Log:               logger,
-		Workarounds:       ModbusWorkarounds{ReadCoilsStartingAtZero: true},
+		Workarounds:       workarounds{ReadCoilsStartingAtZero: true},
 	}
 	plugin.Requests = []requestDefinition{
 		{
@@ -3320,7 +3320,7 @@ func TestRequestAddressOverflow(t *testing.T) {
 		Controller:        "tcp://localhost:1502",
 		ConfigurationType: "request",
 		Log:               logger,
-		Workarounds:       ModbusWorkarounds{ReadCoilsStartingAtZero: true},
+		Workarounds:       workarounds{ReadCoilsStartingAtZero: true},
 	}
 	plugin.Requests = []requestDefinition{
 		{

--- a/plugins/inputs/modbus/modbus_test.go
+++ b/plugins/inputs/modbus/modbus_test.go
@@ -491,7 +491,7 @@ func TestRegisterWorkaroundsOneRequestPerField(t *testing.T) {
 		Controller:        "tcp://localhost:1502",
 		ConfigurationType: "register",
 		Log:               testutil.Logger{Quiet: true},
-		Workarounds:       ModbusWorkarounds{OnRequestPerField: true},
+		Workarounds:       workarounds{OnRequestPerField: true},
 	}
 	plugin.SlaveID = 1
 	plugin.HoldingRegisters = []fieldDefinition{
@@ -541,7 +541,7 @@ func TestRequestsWorkaroundsReadCoilsStartingAtZeroRegister(t *testing.T) {
 		Controller:        "tcp://localhost:1502",
 		ConfigurationType: "register",
 		Log:               testutil.Logger{Quiet: true},
-		Workarounds:       ModbusWorkarounds{ReadCoilsStartingAtZero: true},
+		Workarounds:       workarounds{ReadCoilsStartingAtZero: true},
 	}
 	plugin.SlaveID = 1
 	plugin.Coils = []fieldDefinition{
@@ -688,8 +688,8 @@ func TestWorkaroundsStringRegisterLocation(t *testing.T) {
 				Controller:        "tcp://localhost:1502",
 				ConfigurationType: "request",
 				Log:               testutil.Logger{Quiet: true},
-				Workarounds:       ModbusWorkarounds{StringRegisterLocation: tt.location},
-				ConfigurationPerRequest: ConfigurationPerRequest{
+				Workarounds:       workarounds{StringRegisterLocation: tt.location},
+				configurationPerRequest: configurationPerRequest{
 					Requests: []requestDefinition{
 						{
 							SlaveID:      1,
@@ -738,7 +738,7 @@ func TestWorkaroundsStringRegisterLocationInvalid(t *testing.T) {
 		Controller:        "tcp://localhost:1502",
 		ConfigurationType: "request",
 		Log:               testutil.Logger{Quiet: true},
-		Workarounds:       ModbusWorkarounds{StringRegisterLocation: "foo"},
+		Workarounds:       workarounds{StringRegisterLocation: "foo"},
 	}
 	require.ErrorContains(t, plugin.Init(), `invalid 'string_register_location'`)
 }

--- a/plugins/inputs/mongodb/mongodb_data.go
+++ b/plugins/inputs/mongodb/mongodb_data.go
@@ -8,29 +8,29 @@ import (
 	"github.com/influxdata/telegraf"
 )
 
-type MongodbData struct {
+type mongodbData struct {
 	StatLine      *statLine
 	Fields        map[string]interface{}
 	Tags          map[string]string
-	DbData        []DbData
-	ColData       []ColData
-	ShardHostData []DbData
-	TopStatsData  []DbData
+	DbData        []bbData
+	ColData       []colData
+	ShardHostData []bbData
+	TopStatsData  []bbData
 }
 
-type DbData struct {
+type bbData struct {
 	Name   string
 	Fields map[string]interface{}
 }
 
-type ColData struct {
+type colData struct {
 	Name   string
 	DbName string
 	Fields map[string]interface{}
 }
 
-func NewMongodbData(statLine *statLine, tags map[string]string) *MongodbData {
-	return &MongodbData{
+func newMongodbData(statLine *statLine, tags map[string]string) *mongodbData {
+	return &mongodbData{
 		StatLine: statLine,
 		Tags:     tags,
 		Fields:   make(map[string]interface{}),
@@ -297,11 +297,11 @@ var topDataStats = map[string]string{
 	"commands_count":   "CommandsCount",
 }
 
-func (d *MongodbData) AddDbStats() {
+func (d *mongodbData) addDbStats() {
 	for i := range d.StatLine.DbStatsLines {
 		dbstat := d.StatLine.DbStatsLines[i]
 		dbStatLine := reflect.ValueOf(&dbstat).Elem()
-		newDbData := &DbData{
+		newDbData := &bbData{
 			Name:   dbstat.Name,
 			Fields: make(map[string]interface{}),
 		}
@@ -314,11 +314,11 @@ func (d *MongodbData) AddDbStats() {
 	}
 }
 
-func (d *MongodbData) AddColStats() {
+func (d *mongodbData) addColStats() {
 	for i := range d.StatLine.ColStatsLines {
 		colstat := d.StatLine.ColStatsLines[i]
 		colStatLine := reflect.ValueOf(&colstat).Elem()
-		newColData := &ColData{
+		newColData := &colData{
 			Name:   colstat.Name,
 			DbName: colstat.DbName,
 			Fields: make(map[string]interface{}),
@@ -332,11 +332,11 @@ func (d *MongodbData) AddColStats() {
 	}
 }
 
-func (d *MongodbData) AddShardHostStats() {
+func (d *mongodbData) addShardHostStats() {
 	for host := range d.StatLine.ShardHostStatsLines {
 		hostStat := d.StatLine.ShardHostStatsLines[host]
 		hostStatLine := reflect.ValueOf(&hostStat).Elem()
-		newDbData := &DbData{
+		newDbData := &bbData{
 			Name:   host,
 			Fields: make(map[string]interface{}),
 		}
@@ -349,11 +349,11 @@ func (d *MongodbData) AddShardHostStats() {
 	}
 }
 
-func (d *MongodbData) AddTopStats() {
+func (d *mongodbData) addTopStats() {
 	for i := range d.StatLine.TopStatLines {
 		topStat := d.StatLine.TopStatLines[i]
 		topStatLine := reflect.ValueOf(&topStat).Elem()
-		newTopStatData := &DbData{
+		newTopStatData := &bbData{
 			Name:   topStat.CollectionName,
 			Fields: make(map[string]interface{}),
 		}
@@ -366,7 +366,7 @@ func (d *MongodbData) AddTopStats() {
 	}
 }
 
-func (d *MongodbData) AddDefaultStats() {
+func (d *mongodbData) addDefaultStats() {
 	statLine := reflect.ValueOf(d.StatLine).Elem()
 	d.addStat(statLine, defaultStats)
 	if d.StatLine.NodeType != "" {
@@ -414,18 +414,18 @@ func (d *MongodbData) AddDefaultStats() {
 	}
 }
 
-func (d *MongodbData) addStat(statLine reflect.Value, stats map[string]string) {
+func (d *mongodbData) addStat(statLine reflect.Value, stats map[string]string) {
 	for key, value := range stats {
 		val := statLine.FieldByName(value).Interface()
 		d.add(key, val)
 	}
 }
 
-func (d *MongodbData) add(key string, val interface{}) {
+func (d *mongodbData) add(key string, val interface{}) {
 	d.Fields[key] = val
 }
 
-func (d *MongodbData) flush(acc telegraf.Accumulator) {
+func (d *mongodbData) flush(acc telegraf.Accumulator) {
 	acc.AddFields(
 		"mongodb",
 		d.Fields,

--- a/plugins/inputs/mongodb/mongodb_data_test.go
+++ b/plugins/inputs/mongodb/mongodb_data_test.go
@@ -13,7 +13,7 @@ import (
 var tags = make(map[string]string)
 
 func TestAddNonReplStats(t *testing.T) {
-	d := NewMongodbData(
+	d := newMongodbData(
 		&statLine{
 			StorageEngine:       "",
 			Time:                time.Now(),
@@ -62,7 +62,7 @@ func TestAddNonReplStats(t *testing.T) {
 	)
 	var acc testutil.Accumulator
 
-	d.AddDefaultStats()
+	d.addDefaultStats()
 	d.flush(&acc)
 
 	for key := range defaultStats {
@@ -71,7 +71,7 @@ func TestAddNonReplStats(t *testing.T) {
 }
 
 func TestAddReplStats(t *testing.T) {
-	d := NewMongodbData(
+	d := newMongodbData(
 		&statLine{
 			StorageEngine: "mmapv1",
 			Mapped:        0,
@@ -83,7 +83,7 @@ func TestAddReplStats(t *testing.T) {
 
 	var acc testutil.Accumulator
 
-	d.AddDefaultStats()
+	d.addDefaultStats()
 	d.flush(&acc)
 
 	for key := range mmapStats {
@@ -92,7 +92,7 @@ func TestAddReplStats(t *testing.T) {
 }
 
 func TestAddWiredTigerStats(t *testing.T) {
-	d := NewMongodbData(
+	d := newMongodbData(
 		&statLine{
 			StorageEngine:              "wiredTiger",
 			CacheDirtyPercent:          0,
@@ -124,7 +124,7 @@ func TestAddWiredTigerStats(t *testing.T) {
 
 	var acc testutil.Accumulator
 
-	d.AddDefaultStats()
+	d.addDefaultStats()
 	d.flush(&acc)
 
 	for key := range wiredTigerStats {
@@ -139,7 +139,7 @@ func TestAddWiredTigerStats(t *testing.T) {
 }
 
 func TestAddShardStats(t *testing.T) {
-	d := NewMongodbData(
+	d := newMongodbData(
 		&statLine{
 			TotalInUse:      0,
 			TotalAvailable:  0,
@@ -151,7 +151,7 @@ func TestAddShardStats(t *testing.T) {
 
 	var acc testutil.Accumulator
 
-	d.AddDefaultStats()
+	d.addDefaultStats()
 	d.flush(&acc)
 
 	for key := range defaultShardStats {
@@ -160,7 +160,7 @@ func TestAddShardStats(t *testing.T) {
 }
 
 func TestAddLatencyStats(t *testing.T) {
-	d := NewMongodbData(
+	d := newMongodbData(
 		&statLine{
 			CommandOpsCnt:  73,
 			CommandLatency: 364,
@@ -174,7 +174,7 @@ func TestAddLatencyStats(t *testing.T) {
 
 	var acc testutil.Accumulator
 
-	d.AddDefaultStats()
+	d.addDefaultStats()
 	d.flush(&acc)
 
 	for key := range defaultLatencyStats {
@@ -183,7 +183,7 @@ func TestAddLatencyStats(t *testing.T) {
 }
 
 func TestAddAssertsStats(t *testing.T) {
-	d := NewMongodbData(
+	d := newMongodbData(
 		&statLine{
 			Regular:   3,
 			Warning:   9,
@@ -196,7 +196,7 @@ func TestAddAssertsStats(t *testing.T) {
 
 	var acc testutil.Accumulator
 
-	d.AddDefaultStats()
+	d.addDefaultStats()
 	d.flush(&acc)
 
 	for key := range defaultAssertsStats {
@@ -205,7 +205,7 @@ func TestAddAssertsStats(t *testing.T) {
 }
 
 func TestAddCommandsStats(t *testing.T) {
-	d := NewMongodbData(
+	d := newMongodbData(
 		&statLine{
 			AggregateCommandTotal:      12,
 			AggregateCommandFailed:     2,
@@ -231,7 +231,7 @@ func TestAddCommandsStats(t *testing.T) {
 
 	var acc testutil.Accumulator
 
-	d.AddDefaultStats()
+	d.addDefaultStats()
 	d.flush(&acc)
 
 	for key := range defaultCommandsStats {
@@ -240,7 +240,7 @@ func TestAddCommandsStats(t *testing.T) {
 }
 
 func TestAddTCMallocStats(t *testing.T) {
-	d := NewMongodbData(
+	d := newMongodbData(
 		&statLine{
 			TCMallocCurrentAllocatedBytes:        5877253096,
 			TCMallocHeapSize:                     8067108864,
@@ -267,7 +267,7 @@ func TestAddTCMallocStats(t *testing.T) {
 
 	var acc testutil.Accumulator
 
-	d.AddDefaultStats()
+	d.addDefaultStats()
 	d.flush(&acc)
 
 	for key := range defaultTCMallocStats {
@@ -276,7 +276,7 @@ func TestAddTCMallocStats(t *testing.T) {
 }
 
 func TestAddStorageStats(t *testing.T) {
-	d := NewMongodbData(
+	d := newMongodbData(
 		&statLine{
 			StorageFreelistSearchBucketExhausted: 0,
 			StorageFreelistSearchRequests:        0,
@@ -287,7 +287,7 @@ func TestAddStorageStats(t *testing.T) {
 
 	var acc testutil.Accumulator
 
-	d.AddDefaultStats()
+	d.addDefaultStats()
 	d.flush(&acc)
 
 	for key := range defaultStorageStats {
@@ -307,7 +307,7 @@ func TestAddShardHostStats(t *testing.T) {
 		}
 	}
 
-	d := NewMongodbData(
+	d := newMongodbData(
 		&statLine{
 			ShardHostStatsLines: hostStatLines,
 		},
@@ -315,7 +315,7 @@ func TestAddShardHostStats(t *testing.T) {
 	)
 
 	var acc testutil.Accumulator
-	d.AddShardHostStats()
+	d.addShardHostStats()
 	d.flush(&acc)
 
 	hostsFound := make([]string, 0, len(hostStatLines))
@@ -333,7 +333,7 @@ func TestAddShardHostStats(t *testing.T) {
 }
 
 func TestStateTag(t *testing.T) {
-	d := NewMongodbData(
+	d := newMongodbData(
 		&statLine{
 			StorageEngine: "",
 			Time:          time.Now(),
@@ -353,7 +353,7 @@ func TestStateTag(t *testing.T) {
 
 	var acc testutil.Accumulator
 
-	d.AddDefaultStats()
+	d.addDefaultStats()
 	d.flush(&acc)
 	fields := map[string]interface{}{
 		"active_reads":                              int64(0),
@@ -524,7 +524,7 @@ func TestAddTopStats(t *testing.T) {
 		topStatLines = append(topStatLines, topStatLine)
 	}
 
-	d := NewMongodbData(
+	d := newMongodbData(
 		&statLine{
 			TopStatLines: topStatLines,
 		},
@@ -532,7 +532,7 @@ func TestAddTopStats(t *testing.T) {
 	)
 
 	var acc testutil.Accumulator
-	d.AddTopStats()
+	d.addTopStats()
 	d.flush(&acc)
 
 	for range topStatLines {

--- a/plugins/inputs/mongodb/mongodb_server_test.go
+++ b/plugins/inputs/mongodb/mongodb_server_test.go
@@ -11,15 +11,15 @@ import (
 	"github.com/influxdata/telegraf/testutil"
 )
 
-var ServicePort = "27017"
+var servicePort = "27017"
 var unreachableMongoEndpoint = "mongodb://user:pass@127.0.0.1:27017/nop"
 
 func createTestServer(t *testing.T) *testutil.Container {
 	container := testutil.Container{
 		Image:        "mongo",
-		ExposedPorts: []string{ServicePort},
+		ExposedPorts: []string{servicePort},
 		WaitingFor: wait.ForAll(
-			wait.NewHTTPStrategy("/").WithPort(nat.Port(ServicePort)),
+			wait.NewHTTPStrategy("/").WithPort(nat.Port(servicePort)),
 			wait.ForLog("Waiting for connections"),
 		),
 	}
@@ -40,7 +40,7 @@ func TestGetDefaultTagsIntegration(t *testing.T) {
 	m := &MongoDB{
 		Log: testutil.Logger{},
 		Servers: []string{
-			fmt.Sprintf("mongodb://%s:%s", container.Address, container.Ports[ServicePort]),
+			fmt.Sprintf("mongodb://%s:%s", container.Address, container.Ports[servicePort]),
 		},
 	}
 	err := m.Init()
@@ -76,7 +76,7 @@ func TestAddDefaultStatsIntegration(t *testing.T) {
 	m := &MongoDB{
 		Log: testutil.Logger{},
 		Servers: []string{
-			fmt.Sprintf("mongodb://%s:%s", container.Address, container.Ports[ServicePort]),
+			fmt.Sprintf("mongodb://%s:%s", container.Address, container.Ports[servicePort]),
 		},
 	}
 	err := m.Init()

--- a/plugins/inputs/mongodb/mongostat_test.go
+++ b/plugins/inputs/mongodb/mongostat_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestLatencyStats(t *testing.T) {
-	sl := NewStatLine(
+	sl := newStatLine(
 		mongoStatus{
 			ServerStatus: &serverStatus{
 				Connections: &connectionStats{},
@@ -49,7 +49,6 @@ func TestLatencyStats(t *testing.T) {
 			},
 		},
 		"foo",
-		true,
 		60,
 	)
 
@@ -62,7 +61,7 @@ func TestLatencyStats(t *testing.T) {
 }
 
 func TestLatencyStatsDiffZero(t *testing.T) {
-	sl := NewStatLine(
+	sl := newStatLine(
 		mongoStatus{
 			ServerStatus: &serverStatus{
 				Connections: &connectionStats{},
@@ -118,7 +117,6 @@ func TestLatencyStatsDiffZero(t *testing.T) {
 			},
 		},
 		"foo",
-		true,
 		60,
 	)
 
@@ -131,7 +129,7 @@ func TestLatencyStatsDiffZero(t *testing.T) {
 }
 
 func TestLatencyStatsDiff(t *testing.T) {
-	sl := NewStatLine(
+	sl := newStatLine(
 		mongoStatus{
 			ServerStatus: &serverStatus{
 				Connections: &connectionStats{},
@@ -187,7 +185,6 @@ func TestLatencyStatsDiff(t *testing.T) {
 			},
 		},
 		"foo",
-		true,
 		60,
 	)
 
@@ -200,7 +197,7 @@ func TestLatencyStatsDiff(t *testing.T) {
 }
 
 func TestLocksStatsNilWhenLocksMissingInOldStat(t *testing.T) {
-	sl := NewStatLine(
+	sl := newStatLine(
 		mongoStatus{
 			ServerStatus: &serverStatus{
 				Connections: &connectionStats{},
@@ -223,7 +220,6 @@ func TestLocksStatsNilWhenLocksMissingInOldStat(t *testing.T) {
 			},
 		},
 		"foo",
-		true,
 		60,
 	)
 
@@ -231,7 +227,7 @@ func TestLocksStatsNilWhenLocksMissingInOldStat(t *testing.T) {
 }
 
 func TestLocksStatsNilWhenGlobalLockStatsMissingInOldStat(t *testing.T) {
-	sl := NewStatLine(
+	sl := newStatLine(
 		mongoStatus{
 			ServerStatus: &serverStatus{
 				Connections: &connectionStats{},
@@ -255,7 +251,6 @@ func TestLocksStatsNilWhenGlobalLockStatsMissingInOldStat(t *testing.T) {
 			},
 		},
 		"foo",
-		true,
 		60,
 	)
 
@@ -263,7 +258,7 @@ func TestLocksStatsNilWhenGlobalLockStatsMissingInOldStat(t *testing.T) {
 }
 
 func TestLocksStatsNilWhenGlobalLockStatsEmptyInOldStat(t *testing.T) {
-	sl := NewStatLine(
+	sl := newStatLine(
 		mongoStatus{
 			ServerStatus: &serverStatus{
 				Connections: &connectionStats{},
@@ -289,7 +284,6 @@ func TestLocksStatsNilWhenGlobalLockStatsEmptyInOldStat(t *testing.T) {
 			},
 		},
 		"foo",
-		true,
 		60,
 	)
 
@@ -297,7 +291,7 @@ func TestLocksStatsNilWhenGlobalLockStatsEmptyInOldStat(t *testing.T) {
 }
 
 func TestLocksStatsNilWhenCollectionLockStatsMissingInOldStat(t *testing.T) {
-	sl := NewStatLine(
+	sl := newStatLine(
 		mongoStatus{
 			ServerStatus: &serverStatus{
 				Connections: &connectionStats{},
@@ -325,7 +319,6 @@ func TestLocksStatsNilWhenCollectionLockStatsMissingInOldStat(t *testing.T) {
 			},
 		},
 		"foo",
-		true,
 		60,
 	)
 
@@ -333,7 +326,7 @@ func TestLocksStatsNilWhenCollectionLockStatsMissingInOldStat(t *testing.T) {
 }
 
 func TestLocksStatsNilWhenCollectionLockStatsEmptyInOldStat(t *testing.T) {
-	sl := NewStatLine(
+	sl := newStatLine(
 		mongoStatus{
 			ServerStatus: &serverStatus{
 				Connections: &connectionStats{},
@@ -362,7 +355,6 @@ func TestLocksStatsNilWhenCollectionLockStatsEmptyInOldStat(t *testing.T) {
 			},
 		},
 		"foo",
-		true,
 		60,
 	)
 
@@ -370,7 +362,7 @@ func TestLocksStatsNilWhenCollectionLockStatsEmptyInOldStat(t *testing.T) {
 }
 
 func TestLocksStatsNilWhenLocksMissingInNewStat(t *testing.T) {
-	sl := NewStatLine(
+	sl := newStatLine(
 		mongoStatus{
 			ServerStatus: &serverStatus{
 				Connections: &connectionStats{},
@@ -393,7 +385,6 @@ func TestLocksStatsNilWhenLocksMissingInNewStat(t *testing.T) {
 			},
 		},
 		"foo",
-		true,
 		60,
 	)
 
@@ -401,7 +392,7 @@ func TestLocksStatsNilWhenLocksMissingInNewStat(t *testing.T) {
 }
 
 func TestLocksStatsNilWhenGlobalLockStatsMissingInNewStat(t *testing.T) {
-	sl := NewStatLine(
+	sl := newStatLine(
 		mongoStatus{
 			ServerStatus: &serverStatus{
 				Connections: &connectionStats{},
@@ -425,7 +416,6 @@ func TestLocksStatsNilWhenGlobalLockStatsMissingInNewStat(t *testing.T) {
 			},
 		},
 		"foo",
-		true,
 		60,
 	)
 
@@ -433,7 +423,7 @@ func TestLocksStatsNilWhenGlobalLockStatsMissingInNewStat(t *testing.T) {
 }
 
 func TestLocksStatsNilWhenGlobalLockStatsEmptyInNewStat(t *testing.T) {
-	sl := NewStatLine(
+	sl := newStatLine(
 		mongoStatus{
 			ServerStatus: &serverStatus{
 				Connections: &connectionStats{},
@@ -459,7 +449,6 @@ func TestLocksStatsNilWhenGlobalLockStatsEmptyInNewStat(t *testing.T) {
 			},
 		},
 		"foo",
-		true,
 		60,
 	)
 
@@ -467,7 +456,7 @@ func TestLocksStatsNilWhenGlobalLockStatsEmptyInNewStat(t *testing.T) {
 }
 
 func TestLocksStatsNilWhenCollectionLockStatsMissingInNewStat(t *testing.T) {
-	sl := NewStatLine(
+	sl := newStatLine(
 		mongoStatus{
 			ServerStatus: &serverStatus{
 				Connections: &connectionStats{},
@@ -495,7 +484,6 @@ func TestLocksStatsNilWhenCollectionLockStatsMissingInNewStat(t *testing.T) {
 			},
 		},
 		"foo",
-		true,
 		60,
 	)
 
@@ -503,7 +491,7 @@ func TestLocksStatsNilWhenCollectionLockStatsMissingInNewStat(t *testing.T) {
 }
 
 func TestLocksStatsNilWhenCollectionLockStatsEmptyInNewStat(t *testing.T) {
-	sl := NewStatLine(
+	sl := newStatLine(
 		mongoStatus{
 			ServerStatus: &serverStatus{
 				Connections: &connectionStats{},
@@ -532,7 +520,6 @@ func TestLocksStatsNilWhenCollectionLockStatsEmptyInNewStat(t *testing.T) {
 			},
 		},
 		"foo",
-		true,
 		60,
 	)
 
@@ -540,7 +527,7 @@ func TestLocksStatsNilWhenCollectionLockStatsEmptyInNewStat(t *testing.T) {
 }
 
 func TestLocksStatsPopulated(t *testing.T) {
-	sl := NewStatLine(
+	sl := newStatLine(
 		mongoStatus{
 			ServerStatus: &serverStatus{
 				Connections: &connectionStats{},
@@ -596,7 +583,6 @@ func TestLocksStatsPopulated(t *testing.T) {
 			},
 		},
 		"foo",
-		true,
 		60,
 	)
 

--- a/plugins/inputs/monit/monit.go
+++ b/plugins/inputs/monit/monit.go
@@ -19,6 +19,8 @@ import (
 //go:embed sample.conf
 var sampleConfig string
 
+var pendingActions = []string{"ignore", "alert", "restart", "stop", "exec", "unmonitor", "start", "monitor"}
+
 const (
 	fileSystem = "0"
 	directory  = "1"
@@ -31,7 +33,14 @@ const (
 	network    = "8"
 )
 
-var pendingActions = []string{"ignore", "alert", "restart", "stop", "exec", "unmonitor", "start", "monitor"}
+type Monit struct {
+	Address  string          `toml:"address"`
+	Username string          `toml:"username"`
+	Password string          `toml:"password"`
+	Timeout  config.Duration `toml:"timeout"`
+	client   http.Client
+	tls.ClientConfig
+}
 
 type status struct {
 	Server   server    `xml:"server"`
@@ -177,15 +186,6 @@ type system struct {
 		Percent  float64 `xml:"percent"`
 		Kilobyte float64 `xml:"kilobyte"`
 	} `xml:"swap"`
-}
-
-type Monit struct {
-	Address  string `toml:"address"`
-	Username string `toml:"username"`
-	Password string `toml:"password"`
-	client   http.Client
-	tls.ClientConfig
-	Timeout config.Duration `toml:"timeout"`
 }
 
 func (*Monit) SampleConfig() string {

--- a/plugins/inputs/mqtt_consumer/mqtt_logger.go
+++ b/plugins/inputs/mqtt_consumer/mqtt_logger.go
@@ -8,9 +8,12 @@ type mqttLogger struct {
 	telegraf.Logger
 }
 
+// Printf implements mqtt.Logger
 func (l mqttLogger) Printf(fmt string, args ...interface{}) {
 	l.Logger.Debugf(fmt, args...)
 }
+
+// Println implements mqtt.Logger
 func (l mqttLogger) Println(args ...interface{}) {
 	l.Logger.Debug(args...)
 }

--- a/plugins/inputs/mqtt_consumer/topic_parser.go
+++ b/plugins/inputs/mqtt_consumer/topic_parser.go
@@ -9,7 +9,7 @@ import (
 	"github.com/influxdata/telegraf"
 )
 
-type TopicParsingConfig struct {
+type topicParsingConfig struct {
 	Topic       string            `toml:"topic"`
 	Measurement string            `toml:"measurement"`
 	Tags        string            `toml:"tags"`
@@ -17,7 +17,7 @@ type TopicParsingConfig struct {
 	FieldTypes  map[string]string `toml:"types"`
 }
 
-type TopicParser struct {
+type topicParser struct {
 	topicIndices   map[string]int
 	topicVarLength bool
 	topicMinLength int
@@ -29,8 +29,8 @@ type TopicParser struct {
 	fieldTypes         map[string]string
 }
 
-func (cfg *TopicParsingConfig) NewParser() (*TopicParser, error) {
-	p := &TopicParser{
+func (cfg *topicParsingConfig) newParser() (*topicParser, error) {
+	p := &topicParser{
 		fieldTypes: cfg.FieldTypes,
 	}
 
@@ -150,7 +150,7 @@ func (cfg *TopicParsingConfig) NewParser() (*TopicParser, error) {
 	return p, nil
 }
 
-func (p *TopicParser) Parse(metric telegraf.Metric, topic string) error {
+func (p *topicParser) parse(metric telegraf.Metric, topic string) error {
 	// Split the actual topic into its elements and check for a match
 	topicParts := strings.Split(topic, "/")
 	if p.topicVarLength && len(topicParts) < p.topicMinLength || !p.topicVarLength && len(topicParts) != p.topicMinLength {
@@ -200,7 +200,7 @@ func (p *TopicParser) Parse(metric telegraf.Metric, topic string) error {
 	return nil
 }
 
-func (p *TopicParser) convertToFieldType(value, key string) (interface{}, error) {
+func (p *topicParser) convertToFieldType(value, key string) (interface{}, error) {
 	// If the user configured inputs.mqtt_consumer.topic.types, check for the desired type
 	desiredType, ok := p.fieldTypes[key]
 	if !ok {

--- a/plugins/inputs/multifile/multifile.go
+++ b/plugins/inputs/multifile/multifile.go
@@ -19,15 +19,15 @@ import (
 var sampleConfig string
 
 type MultiFile struct {
-	BaseDir   string
-	FailEarly bool
-	Files     []File `toml:"file"`
+	BaseDir   string `toml:"base_dir"`
+	FailEarly bool   `toml:"fail_early"`
+	Files     []file `toml:"file"`
 }
 
-type File struct {
+type file struct {
 	Name       string `toml:"file"`
-	Dest       string
-	Conversion string
+	Dest       string `toml:"dest"`
+	Conversion string `toml:"conversion"`
 }
 
 func (*MultiFile) SampleConfig() string {

--- a/plugins/inputs/multifile/multifile_test.go
+++ b/plugins/inputs/multifile/multifile_test.go
@@ -17,7 +17,7 @@ func TestFileTypes(t *testing.T) {
 	m := MultiFile{
 		BaseDir:   path.Join(wd, `testdata`),
 		FailEarly: true,
-		Files: []File{
+		Files: []file{
 			{Name: `bool.txt`, Dest: `examplebool`, Conversion: `bool`},
 			{Name: `float.txt`, Dest: `examplefloat`, Conversion: `float`},
 			{Name: `int.txt`, Dest: `examplefloatX`, Conversion: `float(3)`},
@@ -43,14 +43,14 @@ func TestFileTypes(t *testing.T) {
 	}, acc.Metrics[0].Fields)
 }
 
-func FailEarly(failEarly bool, t *testing.T) error {
+func failEarly(failEarly bool, t *testing.T) error {
 	wd, err := os.Getwd()
 	require.NoError(t, err)
 
 	m := MultiFile{
 		BaseDir:   path.Join(wd, `testdata`),
 		FailEarly: failEarly,
-		Files: []File{
+		Files: []file{
 			{Name: `int.txt`, Dest: `exampleint`, Conversion: `int`},
 			{Name: `int.txt`, Dest: `exampleerror`, Conversion: `bool`},
 		},
@@ -71,8 +71,8 @@ func FailEarly(failEarly bool, t *testing.T) error {
 }
 
 func TestFailEarly(t *testing.T) {
-	err := FailEarly(false, t)
+	err := failEarly(false, t)
 	require.NoError(t, err)
-	err = FailEarly(true, t)
+	err = failEarly(true, t)
 	require.Error(t, err)
 }

--- a/plugins/inputs/mysql/mysql.go
+++ b/plugins/inputs/mysql/mysql.go
@@ -29,6 +29,14 @@ var sampleConfig string
 
 var tlsRe = regexp.MustCompile(`([\?&])(?:tls=custom)($|&)`)
 
+const (
+	defaultPerfEventsStatementsDigestTextLimit = 120
+	defaultPerfEventsStatementsLimit           = 250
+	defaultPerfEventsStatementsTimeLimit       = 86400
+	defaultGatherGlobalVars                    = true
+	localhost                                  = ""
+)
+
 type Mysql struct {
 	Servers                             []*config.Secret `toml:"servers"`
 	PerfEventsStatementsDigestTextLimit int64            `toml:"perf_events_statements_digest_text_limit"`
@@ -63,15 +71,6 @@ type Mysql struct {
 	getStatusQuery      string
 	loggedConvertFields map[string]bool
 }
-
-const (
-	defaultPerfEventsStatementsDigestTextLimit = 120
-	defaultPerfEventsStatementsLimit           = 250
-	defaultPerfEventsStatementsTimeLimit       = 86400
-	defaultGatherGlobalVars                    = true
-)
-
-const localhost = ""
 
 func (*Mysql) SampleConfig() string {
 	return sampleConfig

--- a/plugins/inputs/mysql/v2/convert.go
+++ b/plugins/inputs/mysql/v2/convert.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 )
 
-type ConversionFunc func(value sql.RawBytes) (interface{}, error)
+type conversionFunc func(value sql.RawBytes) (interface{}, error)
 
 func ParseInt(value sql.RawBytes) (interface{}, error) {
 	v, err := strconv.ParseInt(string(value), 10, 64)
@@ -86,7 +86,7 @@ func ParseValue(value sql.RawBytes) (interface{}, error) {
 	return nil, fmt.Errorf("unconvertible value: %q", string(value))
 }
 
-var GlobalStatusConversions = map[string]ConversionFunc{
+var globalStatusConversions = map[string]conversionFunc{
 	"innodb_available_undo_logs":    ParseUint,
 	"innodb_buffer_pool_pages_misc": ParseUint,
 	"innodb_data_pending_fsyncs":    ParseUint,
@@ -108,7 +108,7 @@ var GlobalStatusConversions = map[string]ConversionFunc{
 	"wsrep_local_send_queue_avg": ParseFloat,
 }
 
-var GlobalVariableConversions = map[string]ConversionFunc{
+var globalVariableConversions = map[string]conversionFunc{
 	// see https://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html
 	// see https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html
 	"delay_key_write":                ParseString,        // ON, OFF, ALL
@@ -140,7 +140,7 @@ func ConvertGlobalStatus(key string, value sql.RawBytes) (interface{}, error) {
 		return nil, nil
 	}
 
-	if conv, ok := GlobalStatusConversions[key]; ok {
+	if conv, ok := globalStatusConversions[key]; ok {
 		return conv(value)
 	}
 
@@ -152,7 +152,7 @@ func ConvertGlobalVariables(key string, value sql.RawBytes) (interface{}, error)
 		return nil, nil
 	}
 
-	if conv, ok := GlobalVariableConversions[key]; ok {
+	if conv, ok := globalVariableConversions[key]; ok {
 		return conv(value)
 	}
 


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

Address findings for [revive:exported ](https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#exported ) in `plugins/inputs/m*`.

As part of this effort for files from `plugins/inputs/m*`, the following actions were taken:
- Type names (`const`, `var`, `struct`, `func`, etc) were changed to unexported, wherever they didn't need to be exported.
- All remaining exported types were given comments in the appropriate form – this does not apply to exported methods that implement "known" plugin interfaces (`Gather|Init|Start|Stop|SampleConfig|Parse|Add|Apply|Serialize|SerializeBatch|SetParser|SetParserFunc|GetState|SetState`).
- The order of methods was organized (exported methods first, then unexported, with `init` at the very end).

It is only part of the bigger work (for issue: https://github.com/influxdata/telegraf/issues/15813).
After all findings of this type in whole project are handled, we can enable `revive:exported` rule in `golangci-lint`.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR