### PR TITLE
fix(common.opcua): Support LocalizedText Datatype

### DIFF
--- a/plugins/common/opcua/input/input_client.go
+++ b/plugins/common/opcua/input/input_client.go
@@ -410,6 +410,11 @@ func (o *OpcUAInputClient) UpdateNodeValue(nodeIdx int, d *ua.DataValue) {
 				o.LastReceivedData[nodeIdx].Value = t.Format(o.Config.TimestampFormat)
 			}
 		}
+		if o.LastReceivedData[nodeIdx].DataType == ua.TypeIDLocalizedText {
+			if t, ok := d.Value.Value().(*ua.LocalizedText); ok {
+				o.LastReceivedData[nodeIdx].Value = t.Text
+			}
+		}
 	}
 	o.LastReceivedData[nodeIdx].ServerTime = d.ServerTimestamp
 	o.LastReceivedData[nodeIdx].SourceTime = d.SourceTimestamp


### PR DESCRIPTION
## Summary
This PR adds support for returning OPCUA LocalizedText values via the opc-ua input plugin. Prior to this PR, we silently drop those values. 
This PR is heavily inspired by https://github.com/influxdata/telegraf/pull/12101

I've converted Localizedtext text parameter to string,

## Checklist
- [x] No AI generated code was used in this PR

## Related issues
resolves #16194

I'm not proficient in Go, but needed this to work, any help or guidelines to this PR are appreciated!
