### PR TITLE
fix(inputs.netflow): Cast TCP ports to uint16

### DIFF
--- a/plugins/inputs/netflow/sflow_v5.go
+++ b/plugins/inputs/netflow/sflow_v5.go
@@ -411,8 +411,8 @@ func (d *sflowv5Decoder) decodeRawHeaderSample(record *sflow.SampledHeader) (map
 			fields["dst"] = l.DstIP.String()
 			fields["ip_total_len"] = l.Length
 		case *layers.TCP:
-			fields["src_port"] = l.SrcPort
-			fields["dst_port"] = l.DstPort
+			fields["src_port"] = uint16(l.SrcPort)
+			fields["dst_port"] = uint16(l.DstPort)
 			fields["tcp_seq_number"] = l.Seq
 			fields["tcp_ack_number"] = l.Ack
 			fields["tcp_window_size"] = l.Window


### PR DESCRIPTION
## Summary
This PR fixes issue #16139. TCP source port and TCP destination port of sFlow packages were not included in Telegraf metrics because their type was a complex one. By converting them to a primitive type `uint16`, the fields are properly included.

## Checklist
- [x] No AI generated code was used in this PR

## Related issues
resolves #16139
