### PR TITLE
chore: Fix linter findings for `revive:exported` in `plugins/inputs/n*`

### DIFF
--- a/plugins/inputs/nats/nats.go
+++ b/plugins/inputs/nats/nats.go
@@ -23,8 +23,8 @@ import (
 var sampleConfig string
 
 type Nats struct {
-	Server          string
-	ResponseTimeout config.Duration
+	Server          string          `toml:"server"`
+	ResponseTimeout config.Duration `toml:"response_timeout"`
 
 	client *http.Client
 }

--- a/plugins/inputs/neoom_beaam/neoom_beaam.go
+++ b/plugins/inputs/neoom_beaam/neoom_beaam.go
@@ -68,12 +68,6 @@ func (n *NeoomBeaam) Start(telegraf.Accumulator) error {
 	return n.updateConfiguration()
 }
 
-func (n *NeoomBeaam) Stop() {
-	if n.client != nil {
-		n.client.CloseIdleConnections()
-	}
-}
-
 func (n *NeoomBeaam) Gather(acc telegraf.Accumulator) error {
 	// Refresh the config if requested
 	if n.RefreshConfig {
@@ -95,6 +89,12 @@ func (n *NeoomBeaam) Gather(acc telegraf.Accumulator) error {
 	}
 
 	return nil
+}
+
+func (n *NeoomBeaam) Stop() {
+	if n.client != nil {
+		n.client.CloseIdleConnections()
+	}
 }
 
 func (n *NeoomBeaam) updateConfiguration() error {

--- a/plugins/inputs/neptune_apex/neptune_apex.go
+++ b/plugins/inputs/neptune_apex/neptune_apex.go
@@ -27,6 +27,12 @@ var sampleConfig string
 // Measurement is constant across all metrics.
 const Measurement = "neptune_apex"
 
+type NeptuneApex struct {
+	Servers         []string        `toml:"servers"`
+	ResponseTimeout config.Duration `toml:"response_timeout"`
+	httpClient      *http.Client
+}
+
 type xmlReply struct {
 	SoftwareVersion string   `xml:"software,attr"`
 	HardwareVersion string   `xml:"hardware,attr"`
@@ -54,18 +60,10 @@ type outlet struct {
 	Xstatus  *string `xml:"xstatus"`
 }
 
-// NeptuneApex implements telegraf.Input.
-type NeptuneApex struct {
-	Servers         []string
-	ResponseTimeout config.Duration
-	httpClient      *http.Client
-}
-
 func (*NeptuneApex) SampleConfig() string {
 	return sampleConfig
 }
 
-// Gather implements telegraf.Input.Gather
 func (n *NeptuneApex) Gather(acc telegraf.Accumulator) error {
 	var wg sync.WaitGroup
 	for _, server := range n.Servers {

--- a/plugins/inputs/neptune_apex/neptune_apex_test.go
+++ b/plugins/inputs/neptune_apex/neptune_apex_test.go
@@ -69,7 +69,7 @@ func TestParseXML(t *testing.T) {
 	}{
 		{
 			name:        "Good test",
-			xmlResponse: []byte(APEX2016),
+			xmlResponse: []byte(apex2016),
 			wantMetrics: []telegraf.Metric{
 				testutil.MustMetric(
 					Measurement,
@@ -532,7 +532,7 @@ func fakeHTTPClient(h http.Handler) (*http.Client, func()) {
 }
 
 // Sample configuration from a 2016 version Neptune Apex.
-const APEX2016 = `<?xml version="1.0"?>
+const apex2016 = `<?xml version="1.0"?>
 <status software="5.04_7A18" hardware="1.0">
 <hostname>apex</hostname>
 <serial>AC5:12345</serial>

--- a/plugins/inputs/net/net.go
+++ b/plugins/inputs/net/net.go
@@ -21,20 +21,20 @@ import (
 //go:embed sample.conf
 var sampleConfig string
 
-type NetIOStats struct {
-	filter filter.Filter
-	ps     system.PS
+type Net struct {
+	Interfaces          []string `toml:"interfaces"`
+	IgnoreProtocolStats bool     `toml:"ignore_protocol_stats"`
 
-	skipChecks          bool
-	IgnoreProtocolStats bool
-	Interfaces          []string
+	filter     filter.Filter
+	ps         system.PS
+	skipChecks bool
 }
 
-func (*NetIOStats) SampleConfig() string {
+func (*Net) SampleConfig() string {
 	return sampleConfig
 }
 
-func (n *NetIOStats) Init() error {
+func (n *Net) Init() error {
 	if !n.IgnoreProtocolStats {
 		config.PrintOptionValueDeprecationNotice("inputs.net", "ignore_protocol_stats", "false",
 			telegraf.DeprecationInfo{
@@ -48,7 +48,7 @@ func (n *NetIOStats) Init() error {
 	return nil
 }
 
-func (n *NetIOStats) Gather(acc telegraf.Accumulator) error {
+func (n *Net) Gather(acc telegraf.Accumulator) error {
 	netio, err := n.ps.NetIO()
 	if err != nil {
 		return fmt.Errorf("error getting net io info: %w", err)
@@ -153,6 +153,6 @@ func getInterfaceSpeed(ioName string) int64 {
 
 func init() {
 	inputs.Add("net", func() telegraf.Input {
-		return &NetIOStats{ps: system.NewSystemPS()}
+		return &Net{ps: system.NewSystemPS()}
 	})
 }

--- a/plugins/inputs/net/net_test.go
+++ b/plugins/inputs/net/net_test.go
@@ -44,7 +44,7 @@ func TestNetIOStats(t *testing.T) {
 
 	t.Setenv("HOST_SYS", filepath.Join("testdata", "general", "sys"))
 
-	plugin := &NetIOStats{ps: &mps, skipChecks: true}
+	plugin := &Net{ps: &mps, skipChecks: true}
 
 	var acc testutil.Accumulator
 	require.NoError(t, plugin.Gather(&acc))
@@ -111,7 +111,7 @@ func TestNetIOStatsSpeedUnsupported(t *testing.T) {
 
 	t.Setenv("HOST_SYS", filepath.Join("testdata", "general", "sys"))
 
-	plugin := &NetIOStats{ps: &mps, skipChecks: true}
+	plugin := &Net{ps: &mps, skipChecks: true}
 
 	var acc testutil.Accumulator
 	require.NoError(t, plugin.Gather(&acc))
@@ -178,7 +178,7 @@ func TestNetIOStatsNoSpeedFile(t *testing.T) {
 
 	t.Setenv("HOST_SYS", filepath.Join("testdata", "general", "sys"))
 
-	plugin := &NetIOStats{ps: &mps, skipChecks: true}
+	plugin := &Net{ps: &mps, skipChecks: true}
 
 	var acc testutil.Accumulator
 	require.NoError(t, plugin.Gather(&acc))

--- a/plugins/inputs/net_response/net_response.go
+++ b/plugins/inputs/net_response/net_response.go
@@ -20,155 +20,29 @@ import (
 //go:embed sample.conf
 var sampleConfig string
 
-type ResultType uint64
+type resultType uint64
 
 const (
-	Success          ResultType = 0
-	Timeout          ResultType = 1
-	ConnectionFailed ResultType = 2
-	ReadFailed       ResultType = 3
-	StringMismatch   ResultType = 4
+	success          resultType = 0
+	timeout          resultType = 1
+	connectionFailed resultType = 2
+	readFailed       resultType = 3
+	stringMismatch   resultType = 4
 )
 
-// NetResponse struct
 type NetResponse struct {
-	Address     string
-	Timeout     config.Duration
-	ReadTimeout config.Duration
-	Send        string
-	Expect      string
-	Protocol    string
+	Address     string          `toml:"address"`
+	Timeout     config.Duration `toml:"timeout"`
+	ReadTimeout config.Duration `toml:"read_timeout"`
+	Send        string          `toml:"send"`
+	Expect      string          `toml:"expect"`
+	Protocol    string          `toml:"protocol"`
 }
 
 func (*NetResponse) SampleConfig() string {
 	return sampleConfig
 }
 
-// TCPGather will execute if there are TCP tests defined in the configuration.
-// It will return a map[string]interface{} for fields and a map[string]string for tags
-func (n *NetResponse) TCPGather() (map[string]string, map[string]interface{}, error) {
-	// Prepare returns
-	tags := make(map[string]string)
-	fields := make(map[string]interface{})
-	// Start Timer
-	start := time.Now()
-	// Connecting
-	conn, err := net.DialTimeout("tcp", n.Address, time.Duration(n.Timeout))
-	// Stop timer
-	responseTime := time.Since(start).Seconds()
-	// Handle error
-	if err != nil {
-		var e net.Error
-		if errors.As(err, &e) && e.Timeout() {
-			setResult(Timeout, fields, tags, n.Expect)
-		} else {
-			setResult(ConnectionFailed, fields, tags, n.Expect)
-		}
-		return tags, fields, nil
-	}
-	defer conn.Close()
-	// Send string if needed
-	if n.Send != "" {
-		msg := []byte(n.Send)
-		if _, gerr := conn.Write(msg); gerr != nil {
-			return nil, nil, gerr
-		}
-		// Stop timer
-		responseTime = time.Since(start).Seconds()
-	}
-	// Read string if needed
-	if n.Expect != "" {
-		// Set read timeout
-		if gerr := conn.SetReadDeadline(time.Now().Add(time.Duration(n.ReadTimeout))); gerr != nil {
-			return nil, nil, gerr
-		}
-		// Prepare reader
-		reader := bufio.NewReader(conn)
-		tp := textproto.NewReader(reader)
-		// Read
-		data, err := tp.ReadLine()
-		// Stop timer
-		responseTime = time.Since(start).Seconds()
-		// Handle error
-		if err != nil {
-			setResult(ReadFailed, fields, tags, n.Expect)
-		} else {
-			// Looking for string in answer
-			regEx := regexp.MustCompile(`.*` + n.Expect + `.*`)
-			find := regEx.FindString(data)
-			if find != "" {
-				setResult(Success, fields, tags, n.Expect)
-			} else {
-				setResult(StringMismatch, fields, tags, n.Expect)
-			}
-		}
-	} else {
-		setResult(Success, fields, tags, n.Expect)
-	}
-	fields["response_time"] = responseTime
-	return tags, fields, nil
-}
-
-// UDPGather will execute if there are UDP tests defined in the configuration.
-// It will return a map[string]interface{} for fields and a map[string]string for tags
-func (n *NetResponse) UDPGather() (map[string]string, map[string]interface{}, error) {
-	// Prepare returns
-	tags := make(map[string]string)
-	fields := make(map[string]interface{})
-	// Start Timer
-	start := time.Now()
-	// Resolving
-	udpAddr, err := net.ResolveUDPAddr("udp", n.Address)
-	// Handle error
-	if err != nil {
-		setResult(ConnectionFailed, fields, tags, n.Expect)
-		return tags, fields, nil
-	}
-	// Connecting
-	conn, err := net.DialUDP("udp", nil, udpAddr)
-	// Handle error
-	if err != nil {
-		setResult(ConnectionFailed, fields, tags, n.Expect)
-		return tags, fields, nil
-	}
-	defer conn.Close()
-	// Send string
-	msg := []byte(n.Send)
-	if _, gerr := conn.Write(msg); gerr != nil {
-		return nil, nil, gerr
-	}
-	// Read string
-	// Set read timeout
-	if gerr := conn.SetReadDeadline(time.Now().Add(time.Duration(n.ReadTimeout))); gerr != nil {
-		return nil, nil, gerr
-	}
-	// Read
-	buf := make([]byte, 1024)
-	_, _, err = conn.ReadFromUDP(buf)
-	// Stop timer
-	responseTime := time.Since(start).Seconds()
-	// Handle error
-	if err != nil {
-		setResult(ReadFailed, fields, tags, n.Expect)
-		return tags, fields, nil
-	}
-
-	// Looking for string in answer
-	regEx := regexp.MustCompile(`.*` + n.Expect + `.*`)
-	find := regEx.FindString(string(buf))
-	if find != "" {
-		setResult(Success, fields, tags, n.Expect)
-	} else {
-		setResult(StringMismatch, fields, tags, n.Expect)
-	}
-
-	fields["response_time"] = responseTime
-
-	return tags, fields, nil
-}
-
-// Init performs one time setup of the plugin and returns an error if the
-// configuration is invalid.
 func (n *NetResponse) Init() error {
 	// Set default values
 	if n.Timeout == 0 {
@@ -203,9 +77,6 @@ func (n *NetResponse) Init() error {
 	return nil
 }
 
-// Gather is called by telegraf when the plugin is executed on its interval.
-// It will call either UDPGather or TCPGather based on the configuration and
-// also fill an Accumulator that is supplied.
 func (n *NetResponse) Gather(acc telegraf.Accumulator) error {
 	// Prepare host and port
 	host, port, err := net.SplitHostPort(n.Address)
@@ -221,13 +92,13 @@ func (n *NetResponse) Gather(acc telegraf.Accumulator) error {
 	// Gather data
 	switch n.Protocol {
 	case "tcp":
-		returnTags, fields, err = n.TCPGather()
+		returnTags, fields, err = n.tcpGather()
 		if err != nil {
 			return err
 		}
 		tags["protocol"] = "tcp"
 	case "udp":
-		returnTags, fields, err = n.UDPGather()
+		returnTags, fields, err = n.udpGather()
 		if err != nil {
 			return err
 		}
@@ -243,18 +114,137 @@ func (n *NetResponse) Gather(acc telegraf.Accumulator) error {
 	return nil
 }
 
-func setResult(result ResultType, fields map[string]interface{}, tags map[string]string, expect string) {
+func (n *NetResponse) tcpGather() (map[string]string, map[string]interface{}, error) {
+	// Prepare returns
+	tags := make(map[string]string)
+	fields := make(map[string]interface{})
+	// Start Timer
+	start := time.Now()
+	// Connecting
+	conn, err := net.DialTimeout("tcp", n.Address, time.Duration(n.Timeout))
+	// Stop timer
+	responseTime := time.Since(start).Seconds()
+	// Handle error
+	if err != nil {
+		var e net.Error
+		if errors.As(err, &e) && e.Timeout() {
+			setResult(timeout, fields, tags, n.Expect)
+		} else {
+			setResult(connectionFailed, fields, tags, n.Expect)
+		}
+		return tags, fields, nil
+	}
+	defer conn.Close()
+	// Send string if needed
+	if n.Send != "" {
+		msg := []byte(n.Send)
+		if _, gerr := conn.Write(msg); gerr != nil {
+			return nil, nil, gerr
+		}
+		// Stop timer
+		responseTime = time.Since(start).Seconds()
+	}
+	// Read string if needed
+	if n.Expect != "" {
+		// Set read timeout
+		if gerr := conn.SetReadDeadline(time.Now().Add(time.Duration(n.ReadTimeout))); gerr != nil {
+			return nil, nil, gerr
+		}
+		// Prepare reader
+		reader := bufio.NewReader(conn)
+		tp := textproto.NewReader(reader)
+		// Read
+		data, err := tp.ReadLine()
+		// Stop timer
+		responseTime = time.Since(start).Seconds()
+		// Handle error
+		if err != nil {
+			setResult(readFailed, fields, tags, n.Expect)
+		} else {
+			// Looking for string in answer
+			regEx := regexp.MustCompile(`.*` + n.Expect + `.*`)
+			find := regEx.FindString(data)
+			if find != "" {
+				setResult(success, fields, tags, n.Expect)
+			} else {
+				setResult(stringMismatch, fields, tags, n.Expect)
+			}
+		}
+	} else {
+		setResult(success, fields, tags, n.Expect)
+	}
+	fields["response_time"] = responseTime
+	return tags, fields, nil
+}
+
+func (n *NetResponse) udpGather() (map[string]string, map[string]interface{}, error) {
+	// Prepare returns
+	tags := make(map[string]string)
+	fields := make(map[string]interface{})
+	// Start Timer
+	start := time.Now()
+	// Resolving
+	udpAddr, err := net.ResolveUDPAddr("udp", n.Address)
+	// Handle error
+	if err != nil {
+		setResult(connectionFailed, fields, tags, n.Expect)
+		return tags, fields, nil
+	}
+	// Connecting
+	conn, err := net.DialUDP("udp", nil, udpAddr)
+	// Handle error
+	if err != nil {
+		setResult(connectionFailed, fields, tags, n.Expect)
+		return tags, fields, nil
+	}
+	defer conn.Close()
+	// Send string
+	msg := []byte(n.Send)
+	if _, gerr := conn.Write(msg); gerr != nil {
+		return nil, nil, gerr
+	}
+	// Read string
+	// Set read timeout
+	if gerr := conn.SetReadDeadline(time.Now().Add(time.Duration(n.ReadTimeout))); gerr != nil {
+		return nil, nil, gerr
+	}
+	// Read
+	buf := make([]byte, 1024)
+	_, _, err = conn.ReadFromUDP(buf)
+	// Stop timer
+	responseTime := time.Since(start).Seconds()
+	// Handle error
+	if err != nil {
+		setResult(readFailed, fields, tags, n.Expect)
+		return tags, fields, nil
+	}
+
+	// Looking for string in answer
+	regEx := regexp.MustCompile(`.*` + n.Expect + `.*`)
+	find := regEx.FindString(string(buf))
+	if find != "" {
+		setResult(success, fields, tags, n.Expect)
+	} else {
+		setResult(stringMismatch, fields, tags, n.Expect)
+	}
+
+	fields["response_time"] = responseTime
+
+	return tags, fields, nil
+}
+
+func setResult(result resultType, fields map[string]interface{}, tags map[string]string, expect string) {
 	var tag string
 	switch result {
-	case Success:
+	case success:
 		tag = "success"
-	case Timeout:
+	case timeout:
 		tag = "timeout"
-	case ConnectionFailed:
+	case connectionFailed:
 		tag = "connection_failed"
-	case ReadFailed:
+	case readFailed:
 		tag = "read_failed"
-	case StringMismatch:
+	case stringMismatch:
 		tag = "string_mismatch"
 	}
 
@@ -266,7 +256,7 @@ func setResult(result ResultType, fields map[string]interface{}, tags map[string
 
 	// deprecated in 1.4; use result tag
 	if expect != "" {
-		fields["string_found"] = result == Success
+		fields["string_found"] = result == success
 	}
 }
 

--- a/plugins/inputs/net_response/net_response_test.go
+++ b/plugins/inputs/net_response/net_response_test.go
@@ -106,7 +106,7 @@ func TestTCPOK1(t *testing.T) {
 	require.NoError(t, c.Init())
 	// Start TCP server
 	wg.Add(1)
-	go TCPServer(t, &wg)
+	go tcpServer(t, &wg)
 	wg.Wait() // Wait for the server to spin up
 	wg.Add(1)
 	// Connect
@@ -151,7 +151,7 @@ func TestTCPOK2(t *testing.T) {
 	require.NoError(t, c.Init())
 	// Start TCP server
 	wg.Add(1)
-	go TCPServer(t, &wg)
+	go tcpServer(t, &wg)
 	wg.Wait()
 	wg.Add(1)
 
@@ -233,7 +233,7 @@ func TestUDPOK1(t *testing.T) {
 	require.NoError(t, c.Init())
 	// Start UDP server
 	wg.Add(1)
-	go UDPServer(t, &wg)
+	go udpServer(t, &wg)
 	wg.Wait()
 	wg.Add(1)
 
@@ -264,7 +264,7 @@ func TestUDPOK1(t *testing.T) {
 	wg.Wait()
 }
 
-func UDPServer(t *testing.T, wg *sync.WaitGroup) {
+func udpServer(t *testing.T, wg *sync.WaitGroup) {
 	defer wg.Done()
 	udpAddr, err := net.ResolveUDPAddr("udp", "127.0.0.1:2004")
 	if err != nil {
@@ -297,7 +297,7 @@ func UDPServer(t *testing.T, wg *sync.WaitGroup) {
 	}
 }
 
-func TCPServer(t *testing.T, wg *sync.WaitGroup) {
+func tcpServer(t *testing.T, wg *sync.WaitGroup) {
 	defer wg.Done()
 	tcpAddr, err := net.ResolveTCPAddr("tcp", "127.0.0.1:2004")
 	if err != nil {

--- a/plugins/inputs/netflow/netflow_v5.go
+++ b/plugins/inputs/netflow/netflow_v5.go
@@ -15,14 +15,14 @@ import (
 // Decoder structure
 type netflowv5Decoder struct{}
 
-func (d *netflowv5Decoder) Init() error {
+func (d *netflowv5Decoder) init() error {
 	if err := initL4ProtoMapping(); err != nil {
 		return fmt.Errorf("initializing layer 4 protocol mapping failed: %w", err)
 	}
 	return nil
 }
 
-func (d *netflowv5Decoder) Decode(srcIP net.IP, payload []byte) ([]telegraf.Metric, error) {
+func (d *netflowv5Decoder) decode(srcIP net.IP, payload []byte) ([]telegraf.Metric, error) {
 	src := srcIP.String()
 
 	// Decode the message

--- a/plugins/inputs/netflow/sflow_v5.go
+++ b/plugins/inputs/netflow/sflow_v5.go
@@ -19,13 +19,13 @@ import (
 
 // Decoder structure
 type sflowv5Decoder struct {
-	Log telegraf.Logger
+	log telegraf.Logger
 
 	warnedCounterRaw map[uint32]bool
 	warnedFlowRaw    map[int64]bool
 }
 
-func (d *sflowv5Decoder) Init() error {
+func (d *sflowv5Decoder) init() error {
 	if err := initL4ProtoMapping(); err != nil {
 		return fmt.Errorf("initializing layer 4 protocol mapping failed: %w", err)
 	}
@@ -35,7 +35,7 @@ func (d *sflowv5Decoder) Init() error {
 	return nil
 }
 
-func (d *sflowv5Decoder) Decode(srcIP net.IP, payload []byte) ([]telegraf.Metric, error) {
+func (d *sflowv5Decoder) decode(srcIP net.IP, payload []byte) ([]telegraf.Metric, error) {
 	t := time.Now()
 	src := srcIP.String()
 
@@ -448,11 +448,11 @@ func (d *sflowv5Decoder) decodeRawHeaderSample(record *sflow.SampledHeader) (map
 			if !d.warnedFlowRaw[ltype] {
 				contents := hex.EncodeToString(pkt.LayerContents())
 				payload := hex.EncodeToString(pkt.LayerPayload())
-				d.Log.Warnf("Unknown flow raw flow message %s (%d):", pkt.LayerType().String(), pkt.LayerType())
-				d.Log.Warnf("  contents: %s", contents)
-				d.Log.Warnf("  payload:  %s", payload)
+				d.log.Warnf("Unknown flow raw flow message %s (%d):", pkt.LayerType().String(), pkt.LayerType())
+				d.log.Warnf("  contents: %s", contents)
+				d.log.Warnf("  payload:  %s", payload)
 
-				d.Log.Warn("This message is only printed once.")
+				d.log.Warn("This message is only printed once.")
 			}
 			d.warnedFlowRaw[ltype] = true
 		}
@@ -524,8 +524,8 @@ func (d *sflowv5Decoder) decodeCounterRecords(records []sflow.CounterRecord) (ma
 			default:
 				if !d.warnedCounterRaw[r.Header.DataFormat] {
 					data := hex.EncodeToString(record.Data)
-					d.Log.Warnf("Unknown counter raw flow message %d: %s", r.Header.DataFormat, data)
-					d.Log.Warn("This message is only printed once.")
+					d.log.Warnf("Unknown counter raw flow message %d: %s", r.Header.DataFormat, data)
+					d.log.Warn("This message is only printed once.")
 				}
 				d.warnedCounterRaw[r.Header.DataFormat] = true
 			}

--- a/plugins/inputs/netstat/netstat.go
+++ b/plugins/inputs/netstat/netstat.go
@@ -14,16 +14,16 @@ import (
 //go:embed sample.conf
 var sampleConfig string
 
-type NetStats struct {
-	PS system.PS
+type NetStat struct {
+	ps system.PS
 }
 
-func (*NetStats) SampleConfig() string {
+func (*NetStat) SampleConfig() string {
 	return sampleConfig
 }
 
-func (ns *NetStats) Gather(acc telegraf.Accumulator) error {
-	netconns, err := ns.PS.NetConnections()
+func (ns *NetStat) Gather(acc telegraf.Accumulator) error {
+	netconns, err := ns.ps.NetConnections()
 	if err != nil {
 		return fmt.Errorf("error getting net connections info: %w", err)
 	}
@@ -66,6 +66,6 @@ func (ns *NetStats) Gather(acc telegraf.Accumulator) error {
 
 func init() {
 	inputs.Add("netstat", func() telegraf.Input {
-		return &NetStats{PS: system.NewSystemPS()}
+		return &NetStat{ps: system.NewSystemPS()}
 	})
 }

--- a/plugins/inputs/netstat/netstat_test.go
+++ b/plugins/inputs/netstat/netstat_test.go
@@ -32,7 +32,7 @@ func TestNetStats(t *testing.T) {
 	}, nil)
 
 	var acc testutil.Accumulator
-	require.NoError(t, (&NetStats{PS: &mps}).Gather(&acc))
+	require.NoError(t, (&NetStat{ps: &mps}).Gather(&acc))
 
 	expected := []telegraf.Metric{
 		metric.New(

--- a/plugins/inputs/nginx/nginx.go
+++ b/plugins/inputs/nginx/nginx.go
@@ -23,8 +23,8 @@ import (
 var sampleConfig string
 
 type Nginx struct {
-	Urls            []string
-	ResponseTimeout config.Duration
+	Urls            []string        `toml:"urls"`
+	ResponseTimeout config.Duration `toml:"response_timeout"`
 	tls.ClientConfig
 
 	// HTTP client

--- a/plugins/inputs/nginx_plus/nginx_plus.go
+++ b/plugins/inputs/nginx_plus/nginx_plus.go
@@ -276,11 +276,11 @@ func gatherStatusURL(r *bufio.Reader, tags map[string]string, acc telegraf.Accum
 	if err := dec.Decode(status); err != nil {
 		return errors.New("error while decoding JSON response")
 	}
-	status.Gather(tags, acc)
+	status.gather(tags, acc)
 	return nil
 }
 
-func (s *status) Gather(tags map[string]string, acc telegraf.Accumulator) {
+func (s *status) gather(tags map[string]string, acc telegraf.Accumulator) {
 	s.gatherProcessesMetrics(tags, acc)
 	s.gatherConnectionsMetrics(tags, acc)
 	s.gatherSslMetrics(tags, acc)

--- a/plugins/inputs/nginx_plus_api/nginx_plus_api.go
+++ b/plugins/inputs/nginx_plus_api/nginx_plus_api.go
@@ -18,15 +18,6 @@ import (
 //go:embed sample.conf
 var sampleConfig string
 
-type NginxPlusAPI struct {
-	Urls            []string        `toml:"urls"`
-	APIVersion      int64           `toml:"api_version"`
-	ResponseTimeout config.Duration `toml:"response_timeout"`
-	tls.ClientConfig
-
-	client *http.Client
-}
-
 const (
 	// Default settings
 	defaultAPIVersion = 3
@@ -48,6 +39,15 @@ const (
 	streamServerZonesPath = "stream/server_zones"
 	streamUpstreamsPath   = "stream/upstreams"
 )
+
+type NginxPlusAPI struct {
+	Urls            []string        `toml:"urls"`
+	APIVersion      int64           `toml:"api_version"`
+	ResponseTimeout config.Duration `toml:"response_timeout"`
+	tls.ClientConfig
+
+	client *http.Client
+}
 
 func (*NginxPlusAPI) SampleConfig() string {
 	return sampleConfig

--- a/plugins/inputs/nginx_sts/nginx_sts.go
+++ b/plugins/inputs/nginx_sts/nginx_sts.go
@@ -106,7 +106,7 @@ func (n *NginxSTS) gatherURL(addr *url.URL, acc telegraf.Accumulator) error {
 	}
 }
 
-type NginxSTSResponse struct {
+type nginxSTSResponse struct {
 	Connections struct {
 		Active   uint64 `json:"active"`
 		Reading  uint64 `json:"reading"`
@@ -117,12 +117,12 @@ type NginxSTSResponse struct {
 		Requests uint64 `json:"requests"`
 	} `json:"connections"`
 	Hostname            string                       `json:"hostName"`
-	StreamFilterZones   map[string]map[string]Server `json:"streamFilterZones"`
-	StreamServerZones   map[string]Server            `json:"streamServerZones"`
-	StreamUpstreamZones map[string][]Upstream        `json:"streamUpstreamZones"`
+	StreamFilterZones   map[string]map[string]server `json:"streamFilterZones"`
+	StreamServerZones   map[string]server            `json:"streamServerZones"`
+	StreamUpstreamZones map[string][]upstream        `json:"streamUpstreamZones"`
 }
 
-type Server struct {
+type server struct {
 	ConnectCounter     uint64 `json:"connectCounter"`
 	InBytes            uint64 `json:"inBytes"`
 	OutBytes           uint64 `json:"outBytes"`
@@ -137,7 +137,7 @@ type Server struct {
 	} `json:"responses"`
 }
 
-type Upstream struct {
+type upstream struct {
 	Server         string `json:"server"`
 	ConnectCounter uint64 `json:"connectCounter"`
 	InBytes        uint64 `json:"inBytes"`
@@ -166,7 +166,7 @@ type Upstream struct {
 
 func gatherStatusURL(r *bufio.Reader, tags map[string]string, acc telegraf.Accumulator) error {
 	dec := json.NewDecoder(r)
-	status := &NginxSTSResponse{}
+	status := &nginxSTSResponse{}
 	if err := dec.Decode(status); err != nil {
 		return errors.New("error while decoding JSON response")
 	}

--- a/plugins/inputs/nginx_upstream_check/nginx_upstream_check_test.go
+++ b/plugins/inputs/nginx_upstream_check/nginx_upstream_check_test.go
@@ -58,7 +58,7 @@ func TestNginxUpstreamCheckData(test *testing.T) {
 	}))
 	defer testServer.Close()
 
-	check := NewNginxUpstreamCheck()
+	check := newNginxUpstreamCheck()
 	check.URL = testServer.URL + "/status"
 
 	var accumulator testutil.Accumulator
@@ -139,7 +139,7 @@ func TestNginxUpstreamCheckRequest(test *testing.T) {
 	}))
 	defer testServer.Close()
 
-	check := NewNginxUpstreamCheck()
+	check := newNginxUpstreamCheck()
 	check.URL = testServer.URL + "/status"
 	check.Headers["X-test"] = "test-value"
 	check.HostHeader = "status.local"

--- a/plugins/inputs/nginx_vts/nginx_vts.go
+++ b/plugins/inputs/nginx_vts/nginx_vts.go
@@ -106,7 +106,7 @@ func (n *NginxVTS) gatherURL(addr *url.URL, acc telegraf.Accumulator) error {
 	}
 }
 
-type NginxVTSResponse struct {
+type nginxVTSResponse struct {
 	Connections struct {
 		Active   uint64 `json:"active"`
 		Reading  uint64 `json:"reading"`
@@ -116,13 +116,13 @@ type NginxVTSResponse struct {
 		Handled  uint64 `json:"handled"`
 		Requests uint64 `json:"requests"`
 	} `json:"connections"`
-	ServerZones   map[string]Server            `json:"serverZones"`
-	FilterZones   map[string]map[string]Server `json:"filterZones"`
-	UpstreamZones map[string][]Upstream        `json:"upstreamZones"`
-	CacheZones    map[string]Cache             `json:"cacheZones"`
+	ServerZones   map[string]server            `json:"serverZones"`
+	FilterZones   map[string]map[string]server `json:"filterZones"`
+	UpstreamZones map[string][]upstream        `json:"upstreamZones"`
+	CacheZones    map[string]cache             `json:"cacheZones"`
 }
 
-type Server struct {
+type server struct {
 	RequestCounter uint64 `json:"requestCounter"`
 	InBytes        uint64 `json:"inBytes"`
 	OutBytes       uint64 `json:"outBytes"`
@@ -144,7 +144,7 @@ type Server struct {
 	} `json:"responses"`
 }
 
-type Upstream struct {
+type upstream struct {
 	Server         string `json:"server"`
 	RequestCounter uint64 `json:"requestCounter"`
 	InBytes        uint64 `json:"inBytes"`
@@ -165,7 +165,7 @@ type Upstream struct {
 	Down         bool   `json:"down"`
 }
 
-type Cache struct {
+type cache struct {
 	MaxSize   uint64 `json:"maxSize"`
 	UsedSize  uint64 `json:"usedSize"`
 	InBytes   uint64 `json:"inBytes"`
@@ -184,7 +184,7 @@ type Cache struct {
 
 func gatherStatusURL(r *bufio.Reader, tags map[string]string, acc telegraf.Accumulator) error {
 	dec := json.NewDecoder(r)
-	status := &NginxVTSResponse{}
+	status := &nginxVTSResponse{}
 	if err := dec.Decode(status); err != nil {
 		return errors.New("error while decoding JSON response")
 	}

--- a/plugins/inputs/nomad/nomad.go
+++ b/plugins/inputs/nomad/nomad.go
@@ -18,25 +18,14 @@ import (
 //go:embed sample.conf
 var sampleConfig string
 
-// Nomad configuration object
+const timeLayout = "2006-01-02 15:04:05 -0700 MST"
+
 type Nomad struct {
-	URL string `toml:"url"`
-
+	URL             string          `toml:"url"`
 	ResponseTimeout config.Duration `toml:"response_timeout"`
-
 	tls.ClientConfig
 
 	roundTripper http.RoundTripper
-}
-
-const timeLayout = "2006-01-02 15:04:05 -0700 MST"
-
-func init() {
-	inputs.Add("nomad", func() telegraf.Input {
-		return &Nomad{
-			ResponseTimeout: config.Duration(5 * time.Second),
-		}
-	})
 }
 
 func (*Nomad) SampleConfig() string {
@@ -160,4 +149,12 @@ func buildNomadMetrics(acc telegraf.Accumulator, summaryMetrics *metricsSummary)
 	}
 
 	return nil
+}
+
+func init() {
+	inputs.Add("nomad", func() telegraf.Input {
+		return &Nomad{
+			ResponseTimeout: config.Duration(5 * time.Second),
+		}
+	})
 }

--- a/plugins/inputs/nomad/nomad_metrics.go
+++ b/plugins/inputs/nomad/nomad_metrics.go
@@ -37,6 +37,7 @@ type sampledValue struct {
 	DisplayLabels map[string]string `json:"Labels"`
 }
 
+// AggregateSample needs to be exported, because JSON decode cannot set embedded pointer to unexported struct
 type AggregateSample struct {
 	Count       int       `json:"count"`
 	Rate        float64   `json:"rate"`

--- a/plugins/inputs/nsd/nsd_test.go
+++ b/plugins/inputs/nsd/nsd_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/influxdata/telegraf/testutil"
 )
 
-func NSDControl(output string) func(string, config.Duration, bool, string, string) (*bytes.Buffer, error) {
+func nsdControl(output string) func(string, config.Duration, bool, string, string) (*bytes.Buffer, error) {
 	return func(string, config.Duration, bool, string, string) (*bytes.Buffer, error) {
 		return bytes.NewBufferString(output), nil
 	}
@@ -19,7 +19,7 @@ func NSDControl(output string) func(string, config.Duration, bool, string, strin
 func TestParseFullOutput(t *testing.T) {
 	acc := &testutil.Accumulator{}
 	v := &NSD{
-		run: NSDControl(fullOutput),
+		run: nsdControl(fullOutput),
 	}
 	err := v.Gather(acc)
 

--- a/plugins/inputs/nsq/nsq.go
+++ b/plugins/inputs/nsq/nsq.go
@@ -42,25 +42,15 @@ import (
 //go:embed sample.conf
 var sampleConfig string
 
-// Might add Lookupd endpoints for cluster discovery
-type NSQ struct {
-	Endpoints []string
-	tls.ClientConfig
-	httpClient *http.Client
-}
-
 const (
 	requestPattern = `%s/stats?format=json`
 )
 
-func init() {
-	inputs.Add("nsq", func() telegraf.Input {
-		return New()
-	})
-}
+type NSQ struct {
+	Endpoints []string `toml:"endpoints"`
 
-func New() *NSQ {
-	return &NSQ{}
+	tls.ClientConfig
+	httpClient *http.Client
 }
 
 func (*NSQ) SampleConfig() string {
@@ -304,4 +294,14 @@ type clientStats struct {
 	TLSVersion                    string `json:"tls_version"`
 	TLSNegotiatedProtocol         string `json:"tls_negotiated_protocol"`
 	TLSNegotiatedProtocolIsMutual bool   `json:"tls_negotiated_protocol_is_mutual"`
+}
+
+func newNSQ() *NSQ {
+	return &NSQ{}
+}
+
+func init() {
+	inputs.Add("nsq", func() telegraf.Input {
+		return newNSQ()
+	})
 }

--- a/plugins/inputs/nsq/nsq_test.go
+++ b/plugins/inputs/nsq/nsq_test.go
@@ -23,7 +23,7 @@ func TestNSQStatsV1(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	n := New()
+	n := newNSQ()
 	n.Endpoints = []string{ts.URL}
 
 	var acc testutil.Accumulator
@@ -283,7 +283,7 @@ func TestNSQStatsPreV1(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	n := New()
+	n := newNSQ()
 	n.Endpoints = []string{ts.URL}
 
 	var acc testutil.Accumulator

--- a/plugins/inputs/nstat/nstat.go
+++ b/plugins/inputs/nstat/nstat.go
@@ -20,20 +20,18 @@ var (
 	colonByte   = []byte(":")
 )
 
-// default file paths
 const (
-	NetNetstat = "/net/netstat"
-	NetSnmp    = "/net/snmp"
-	NetSnmp6   = "/net/snmp6"
-	NetProc    = "/proc"
-)
+	// default file paths
+	netNetstat = "/net/netstat"
+	netSnmp    = "/net/snmp"
+	netSnmp6   = "/net/snmp6"
+	netProc    = "/proc"
 
-// env variable names
-const (
-	EnvNetstat = "PROC_NET_NETSTAT"
-	EnvSnmp    = "PROC_NET_SNMP"
-	EnvSnmp6   = "PROC_NET_SNMP6"
-	EnvRoot    = "PROC_ROOT"
+	// env variable names
+	envNetstat = "PROC_NET_NETSTAT"
+	envSnmp    = "PROC_NET_SNMP"
+	envSnmp6   = "PROC_NET_SNMP6"
+	envRoot    = "PROC_ROOT"
 )
 
 type Nstat struct {
@@ -104,13 +102,13 @@ func (ns *Nstat) gatherSNMP6(data []byte, acc telegraf.Accumulator) {
 // if it is empty then try read from env variables
 func (ns *Nstat) loadPaths() {
 	if ns.ProcNetNetstat == "" {
-		ns.ProcNetNetstat = proc(EnvNetstat, NetNetstat)
+		ns.ProcNetNetstat = proc(envNetstat, netNetstat)
 	}
 	if ns.ProcNetSNMP == "" {
-		ns.ProcNetSNMP = proc(EnvSnmp, NetSnmp)
+		ns.ProcNetSNMP = proc(envSnmp, netSnmp)
 	}
 	if ns.ProcNetSNMP6 == "" {
-		ns.ProcNetSNMP6 = proc(EnvSnmp6, NetSnmp6)
+		ns.ProcNetSNMP6 = proc(envSnmp6, netSnmp6)
 	}
 }
 
@@ -188,9 +186,9 @@ func proc(env, path string) string {
 		return p
 	}
 	// try to read root path, or use default root path
-	root := os.Getenv(EnvRoot)
+	root := os.Getenv(envRoot)
 	if root == "" {
-		root = NetProc
+		root = netProc
 	}
 	return root + path
 }

--- a/plugins/inputs/nvidia_smi/common/setters.go
+++ b/plugins/inputs/nvidia_smi/common/setters.go
@@ -5,12 +5,14 @@ import (
 	"strings"
 )
 
+// SetTagIfUsed sets those tags whose value is different from empty string.
 func SetTagIfUsed(m map[string]string, k, v string) {
 	if v != "" {
 		m[k] = v
 	}
 }
 
+// SetIfUsed sets those fields whose value is different from empty string.
 func SetIfUsed(t string, m map[string]interface{}, k, v string) {
 	vals := strings.Fields(v)
 	if len(vals) < 1 {

--- a/plugins/inputs/nvidia_smi/schema_v11/parser.go
+++ b/plugins/inputs/nvidia_smi/schema_v11/parser.go
@@ -8,6 +8,7 @@ import (
 	"github.com/influxdata/telegraf/plugins/inputs/nvidia_smi/common"
 )
 
+// Parse parses the XML-encoded data from nvidia-smi and adds measurements.
 func Parse(acc telegraf.Accumulator, buf []byte) error {
 	var s smi
 	if err := xml.Unmarshal(buf, &s); err != nil {

--- a/plugins/inputs/nvidia_smi/schema_v12/parser.go
+++ b/plugins/inputs/nvidia_smi/schema_v12/parser.go
@@ -9,6 +9,7 @@ import (
 	"github.com/influxdata/telegraf/plugins/inputs/nvidia_smi/common"
 )
 
+// Parse parses the XML-encoded data from nvidia-smi and adds measurements.
 func Parse(acc telegraf.Accumulator, buf []byte) error {
 	var s smi
 	if err := xml.Unmarshal(buf, &s); err != nil {


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

Address findings for [revive:exported ](https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#exported ) in `plugins/inputs/n*`.

As part of this effort for files from `plugins/inputs/n*`, the following actions were taken:
- Type names (`const`, `var`, `struct`, `func`, etc) were changed to unexported, wherever they didn't need to be exported.
- All remaining exported types were given comments in the appropriate form – this does not apply to exported methods that implement "known" plugin interfaces (`Gather|Init|Start|Stop|SampleConfig|Parse|Add|Apply|Serialize|SerializeBatch|SetParser|SetParserFunc|GetState|SetState`).
- The order of methods was organized (exported methods first, then unexported, with `init` at the very end).

It is only part of the bigger work (for issue: https://github.com/influxdata/telegraf/issues/15813).
After all findings of this type in whole project are handled, we can enable `revive:exported` rule in `golangci-lint`.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR