### PR TITLE
Add timeout check to health output plugin

### DIFF
--- a/plugins/outputs/health/README.md
+++ b/plugins/outputs/health/README.md
@@ -65,6 +65,10 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ##
   ## [[outputs.health.contains]]
   ##   field = "buffer_size"
+  ##
+  ## [[outputs.health.time_between_metrics]]
+  ##  field = "buffer_size"
+  ##  max_time_between_metrics = "1m"
 ```
 
 ### compares
@@ -81,3 +85,9 @@ The `contains` check can be used to require a field key to exist on at least
 one metric.
 
 If the field is found on any metric the check passes.
+
+### time_between_metrics
+
+The `time_between_metrics` check can be used to require a certain period between metrics with the provided fields.
+The check will be healthy until the first metric that matches is received, and will later fail if the time passed
+since the last message received is greated than `max_time_between_metrics`.

--- a/plugins/outputs/health/time_between_metrics.go
+++ b/plugins/outputs/health/time_between_metrics.go
@@ -1,0 +1,41 @@
+package health
+
+import (
+	"time"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/config"
+)
+
+type TimeBetweenMetrics struct {
+	Field                 string          `toml:"field"`
+	MaxTimeBetweenMetrics config.Duration `toml:"max_time_between_metrics"`
+	LatestMetricTimestamp time.Time
+	WaitingForFirstMetric bool
+}
+
+func (d *TimeBetweenMetrics) Init() {
+	d.WaitingForFirstMetric = true
+	d.LatestMetricTimestamp = time.Time{}
+}
+
+func (d *TimeBetweenMetrics) Check(current_time time.Time) bool {
+	if d.WaitingForFirstMetric {
+		return true
+	}
+	time_since_last_metric := current_time.Sub(d.LatestMetricTimestamp)
+	return time_since_last_metric < time.Duration(d.MaxTimeBetweenMetrics)
+}
+
+func (d *TimeBetweenMetrics) Process(metrics []telegraf.Metric) {
+	for _, m := range metrics {
+		if !m.HasField(d.Field) {
+			continue
+		}
+
+		if m.Time().After(d.LatestMetricTimestamp) {
+			d.LatestMetricTimestamp = m.Time()
+		}
+		d.WaitingForFirstMetric = false
+	}
+}

--- a/plugins/outputs/health/time_between_metrics_test.go
+++ b/plugins/outputs/health/time_between_metrics_test.go
@@ -1,0 +1,124 @@
+package health_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/config"
+	"github.com/influxdata/telegraf/plugins/outputs/health"
+	"github.com/influxdata/telegraf/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTimeBetweenMetricsFieldFound(t *testing.T) {
+	metrics := []telegraf.Metric{
+		testutil.MustMetric(
+			"cpu",
+			map[string]string{},
+			map[string]interface{}{
+				"time_idle": 42.0,
+			},
+			time.Now()),
+	}
+
+	time_between := &health.TimeBetweenMetrics{
+		Field:                 "time_idle",
+		MaxTimeBetweenMetrics: config.Duration(1.0),
+	}
+
+	time_between.Init()
+	require.True(t, time_between.WaitingForFirstMetric)
+	time_between.Process(metrics)
+	require.False(t, time_between.WaitingForFirstMetric)
+}
+
+func TestTimeBetweenMetricsFieldIgnore(t *testing.T) {
+	metrics := []telegraf.Metric{
+		testutil.MustMetric(
+			"cpu",
+			map[string]string{},
+			map[string]interface{}{
+				"not_the_field": 42.0,
+			},
+			time.Now()),
+	}
+
+	time_between := &health.TimeBetweenMetrics{
+		Field:                 "time_idle",
+		MaxTimeBetweenMetrics: config.Duration(1.0),
+	}
+
+	time_between.Init()
+	require.True(t, time_between.WaitingForFirstMetric)
+	time_between.Process(metrics)
+	require.True(t, time_between.WaitingForFirstMetric)
+}
+
+func TestTimeBetweenMetricsLatestTimestampSaved(t *testing.T) {
+	metrics := []telegraf.Metric{
+		testutil.MustMetric(
+			"cpu",
+			map[string]string{},
+			map[string]interface{}{
+				"time_idle": 42.0,
+			},
+			time.Time{}.AddDate(2000, 0, 0)),
+		testutil.MustMetric(
+			"cpu",
+			map[string]string{},
+			map[string]interface{}{
+				"time_idle": 43.0,
+			},
+			time.Time{}.AddDate(2001, 0, 0)),
+		testutil.MustMetric(
+			"cpu",
+			map[string]string{},
+			map[string]interface{}{
+				"time_idle": 44.0,
+			},
+			time.Time{}.AddDate(2002, 0, 0)),
+	}
+
+	time_between := &health.TimeBetweenMetrics{
+		Field:                 "time_idle",
+		MaxTimeBetweenMetrics: config.Duration(1.0),
+	}
+
+	time_between.Init()
+	require.Equal(t, time_between.LatestMetricTimestamp.Compare(time.Time{}), 0)
+	time_between.Process(metrics)
+	require.Equal(t, time_between.LatestMetricTimestamp.Compare(time.Time{}.AddDate(2002, 0, 0)), 0)
+}
+
+func TestTimeBetweenMetricsCheckHealthy(t *testing.T) {
+	timestamp := time.Time{}
+	metrics := []telegraf.Metric{
+		testutil.MustMetric(
+			"cpu",
+			map[string]string{},
+			map[string]interface{}{
+				"time_idle": 42.0,
+			},
+			timestamp),
+	}
+	time_between := &health.TimeBetweenMetrics{
+		Field:                 "time_idle",
+		MaxTimeBetweenMetrics: config.Duration(48 * time.Hour),
+	}
+
+	time_between.Init()
+	time_between.Process(metrics)
+	require.Equal(t, time_between.LatestMetricTimestamp.Compare(time.Time{}), 0)
+	require.True(t, time_between.Check(timestamp.AddDate(0, 0, 1)))
+	require.False(t, time_between.Check(timestamp.AddDate(0, 0, 3)))
+}
+
+func TestTimeBetweenMetricsHealthyBeforeMessage(t *testing.T) {
+	time_between := &health.TimeBetweenMetrics{
+		Field:                 "time_idle",
+		MaxTimeBetweenMetrics: config.Duration(1.0),
+	}
+	time_between.Init()
+	require.True(t, time_between.Check(time.Time{}))
+}


### PR DESCRIPTION
## Summary
Adds a new check to the `health` output plugin. This check fails when no metrics with the required fields are received for a maximum time.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->
(I didn't create an issue yet, this PR is mostly to explore this new feature)
resolves #
