### PR TITLE
fix(logging): Add Close() func for redirectLogger

### DIFF
--- a/logger/handler.go
+++ b/logger/handler.go
@@ -125,3 +125,13 @@ func (l *redirectLogger) Print(level telegraf.LogLevel, ts time.Time, prefix str
 	msg := append([]interface{}{ts.In(time.UTC).Format(time.RFC3339), " ", level.Indicator(), " ", prefix + attrMsg}, args...)
 	fmt.Fprintln(l.writer, msg...)
 }
+
+func (l *redirectLogger) Close() error {
+	if l.writer == os.Stderr {
+		return nil
+	}
+	if closer, ok := l.writer.(io.Closer); ok {
+		return closer.Close()
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Telegraf provides the function [RedirectLogging(w io.Writer)](https://github.com/influxdata/telegraf/blob/master/logger/logger.go#L285C1-L285C34) which allows the user to optionally redirect the log to a customized sink by wrapping the [instance.impl](https://github.com/influxdata/telegraf/blob/master/logger/handler.go#L47) as a [redirectLogger](https://github.com/influxdata/telegraf/blob/master/logger/handler.go#L111). In this case, when the user tries to close this sink by calling [logger.CloseLogging()](https://github.com/influxdata/telegraf/blob/master/logger/logger.go#L289) func (which internally calls [handler.close()](https://github.com/influxdata/telegraf/blob/master/logger/handler.go#L103)), the sink closing will not take effect because redirectLogger is not an io.Closer, while the handler only do the close after [checking it is an io.Closer](https://github.com/influxdata/telegraf/blob/master/logger/handler.go#L103). This PR fixes this issue by implementing the Close() function for redirectLogger to make it as an io.Closer().

This issue only happens when [redirectLogger](https://github.com/influxdata/telegraf/blob/master/logger/handler.go#L111) is used. In comparion, other sink interface implementations (like [textLogger](https://github.com/influxdata/telegraf/blob/master/logger/text_logger.go#L23) and [structuredLogger](https://github.com/influxdata/telegraf/blob/master/logger/structured_logger.go#L23) don't have this issue as both of them have already implemented the Close() function.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [X] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #16218
