### PR TITLE
chore: Fix linter findings for `revive:exported` in `plugins/inputs/o*`

### DIFF
--- a/plugins/inputs/opcua/opcua.go
+++ b/plugins/inputs/opcua/opcua.go
@@ -16,26 +16,24 @@ import (
 var sampleConfig string
 
 type OpcUA struct {
-	ReadClientConfig
+	readClientConfig
 	Log telegraf.Logger `toml:"-"`
 
-	client *ReadClient
+	client *readClient
 }
 
 func (*OpcUA) SampleConfig() string {
 	return sampleConfig
 }
 
-// Init Initialise all required objects
 func (o *OpcUA) Init() (err error) {
-	o.client, err = o.ReadClientConfig.CreateReadClient(o.Log)
+	o.client, err = o.readClientConfig.createReadClient(o.Log)
 	return err
 }
 
-// Gather defines what data the plugin will gather.
 func (o *OpcUA) Gather(acc telegraf.Accumulator) error {
 	// Will (re)connect if the client is disconnected
-	metrics, err := o.client.CurrentValues()
+	metrics, err := o.client.currentValues()
 	if err != nil {
 		return err
 	}
@@ -51,7 +49,7 @@ func (o *OpcUA) Gather(acc telegraf.Accumulator) error {
 func init() {
 	inputs.Add("opcua", func() telegraf.Input {
 		return &OpcUA{
-			ReadClientConfig: ReadClientConfig{
+			readClientConfig: readClientConfig{
 				InputClientConfig: input.InputClientConfig{
 					OpcUAClientConfig: opcua.OpcUAClientConfig{
 						Endpoint:       "opc.tcp://localhost:4840",

--- a/plugins/inputs/opcua_listener/opcua_listener.go
+++ b/plugins/inputs/opcua_listener/opcua_listener.go
@@ -15,8 +15,8 @@ import (
 )
 
 type OpcUaListener struct {
-	SubscribeClientConfig
-	client *SubscribeClient
+	subscribeClientConfig
+	client *subscribeClient
 	Log    telegraf.Logger `toml:"-"`
 }
 
@@ -36,20 +36,35 @@ func (o *OpcUaListener) Init() (err error) {
 	default:
 		return fmt.Errorf("unknown setting %q for 'connect_fail_behavior'", o.ConnectFailBehavior)
 	}
-	o.client, err = o.SubscribeClientConfig.CreateSubscribeClient(o.Log)
+	o.client, err = o.subscribeClientConfig.createSubscribeClient(o.Log)
 	return err
 }
 
+func (o *OpcUaListener) Start(acc telegraf.Accumulator) error {
+	return o.connect(acc)
+}
+
 func (o *OpcUaListener) Gather(acc telegraf.Accumulator) error {
-	if o.client.State() == opcua.Connected || o.SubscribeClientConfig.ConnectFailBehavior == "ignore" {
+	if o.client.State() == opcua.Connected || o.subscribeClientConfig.ConnectFailBehavior == "ignore" {
 		return nil
 	}
 	return o.connect(acc)
 }
 
+func (o *OpcUaListener) Stop() {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	select {
+	case <-o.client.stop(ctx):
+		o.Log.Infof("Unsubscribed OPC UA successfully")
+	case <-ctx.Done(): // Timeout context
+		o.Log.Warn("Timeout while stopping OPC UA subscription")
+	}
+	cancel()
+}
+
 func (o *OpcUaListener) connect(acc telegraf.Accumulator) error {
 	ctx := context.Background()
-	ch, err := o.client.StartStreamValues(ctx)
+	ch, err := o.client.startStreamValues(ctx)
 	if err != nil {
 		return err
 	}
@@ -68,26 +83,10 @@ func (o *OpcUaListener) connect(acc telegraf.Accumulator) error {
 	return nil
 }
 
-func (o *OpcUaListener) Start(acc telegraf.Accumulator) error {
-	return o.connect(acc)
-}
-
-func (o *OpcUaListener) Stop() {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	select {
-	case <-o.client.Stop(ctx):
-		o.Log.Infof("Unsubscribed OPC UA successfully")
-	case <-ctx.Done(): // Timeout context
-		o.Log.Warn("Timeout while stopping OPC UA subscription")
-	}
-	cancel()
-}
-
-// Add this plugin to telegraf
 func init() {
 	inputs.Add("opcua_listener", func() telegraf.Input {
 		return &OpcUaListener{
-			SubscribeClientConfig: SubscribeClientConfig{
+			subscribeClientConfig: subscribeClientConfig{
 				InputClientConfig: input.InputClientConfig{
 					OpcUAClientConfig: opcua.OpcUAClientConfig{
 						Endpoint:       "opc.tcp://localhost:4840",

--- a/plugins/inputs/opcua_listener/opcua_listener_test.go
+++ b/plugins/inputs/opcua_listener/opcua_listener_test.go
@@ -21,25 +21,25 @@ import (
 
 const servicePort = "4840"
 
-type OPCTags struct {
-	Name           string
-	Namespace      string
-	IdentifierType string
-	Identifier     string
-	Want           interface{}
+type opcTags struct {
+	name           string
+	namespace      string
+	identifierType string
+	identifier     string
+	want           interface{}
 }
 
-func MapOPCTag(tags OPCTags) (out input.NodeSettings) {
-	out.FieldName = tags.Name
-	out.Namespace = tags.Namespace
-	out.IdentifierType = tags.IdentifierType
-	out.Identifier = tags.Identifier
+func mapOPCTag(tags opcTags) (out input.NodeSettings) {
+	out.FieldName = tags.name
+	out.Namespace = tags.namespace
+	out.IdentifierType = tags.identifierType
+	out.Identifier = tags.identifier
 	return out
 }
 
 func TestInitPluginWithBadConnectFailBehaviorValue(t *testing.T) {
 	plugin := OpcUaListener{
-		SubscribeClientConfig: SubscribeClientConfig{
+		subscribeClientConfig: subscribeClientConfig{
 			InputClientConfig: input.InputClientConfig{
 				OpcUAClientConfig: opcua.OpcUAClientConfig{
 					Endpoint:       "opc.tcp://notarealserver:4840",
@@ -69,7 +69,7 @@ func TestStartPlugin(t *testing.T) {
 	acc := &testutil.Accumulator{}
 
 	plugin := OpcUaListener{
-		SubscribeClientConfig: SubscribeClientConfig{
+		subscribeClientConfig: subscribeClientConfig{
 			InputClientConfig: input.InputClientConfig{
 				OpcUAClientConfig: opcua.OpcUAClientConfig{
 					Endpoint:       "opc.tcp://notarealserver:4840",
@@ -86,17 +86,17 @@ func TestStartPlugin(t *testing.T) {
 		},
 		Log: testutil.Logger{},
 	}
-	testopctags := []OPCTags{
+	testopctags := []opcTags{
 		{"ProductName", "0", "i", "2261", "open62541 OPC UA Server"},
 	}
 	for _, tags := range testopctags {
-		plugin.SubscribeClientConfig.RootNodes = append(plugin.SubscribeClientConfig.RootNodes, MapOPCTag(tags))
+		plugin.subscribeClientConfig.RootNodes = append(plugin.subscribeClientConfig.RootNodes, mapOPCTag(tags))
 	}
 	require.NoError(t, plugin.Init())
 	err := plugin.Start(acc)
 	require.ErrorContains(t, err, "could not resolve address")
 
-	plugin.SubscribeClientConfig.ConnectFailBehavior = "ignore"
+	plugin.subscribeClientConfig.ConnectFailBehavior = "ignore"
 	require.NoError(t, plugin.Init())
 	require.NoError(t, plugin.Start(acc))
 	require.Equal(t, opcua.Disconnected, plugin.client.OpcUAClient.State())
@@ -110,7 +110,7 @@ func TestStartPlugin(t *testing.T) {
 			wait.ForLog("TCP network layer listening on opc.tcp://"),
 		),
 	}
-	plugin.SubscribeClientConfig.ConnectFailBehavior = "retry"
+	plugin.subscribeClientConfig.ConnectFailBehavior = "retry"
 	require.NoError(t, plugin.Init())
 	require.NoError(t, plugin.Start(acc))
 	require.Equal(t, opcua.Disconnected, plugin.client.OpcUAClient.State())
@@ -144,7 +144,7 @@ func TestSubscribeClientIntegration(t *testing.T) {
 	require.NoError(t, err, "failed to start container")
 	defer container.Terminate()
 
-	testopctags := []OPCTags{
+	testopctags := []opcTags{
 		{"ProductName", "0", "i", "2261", "open62541 OPC UA Server"},
 		{"ProductUri", "0", "i", "2262", "http://open62541.org"},
 		{"ManufacturerName", "0", "i", "2263", "open62541"},
@@ -154,12 +154,12 @@ func TestSubscribeClientIntegration(t *testing.T) {
 	}
 	tagsRemaining := make([]string, 0, len(testopctags))
 	for i, tag := range testopctags {
-		if tag.Want != nil {
-			tagsRemaining = append(tagsRemaining, testopctags[i].Name)
+		if tag.want != nil {
+			tagsRemaining = append(tagsRemaining, testopctags[i].name)
 		}
 	}
 
-	subscribeConfig := SubscribeClientConfig{
+	subscribeConfig := subscribeClientConfig{
 		InputClientConfig: input.InputClientConfig{
 			OpcUAClientConfig: opcua.OpcUAClientConfig{
 				Endpoint:       fmt.Sprintf("opc.tcp://%s:%s", container.Address, container.Ports[servicePort]),
@@ -177,9 +177,9 @@ func TestSubscribeClientIntegration(t *testing.T) {
 		SubscriptionInterval: 0,
 	}
 	for _, tags := range testopctags {
-		subscribeConfig.RootNodes = append(subscribeConfig.RootNodes, MapOPCTag(tags))
+		subscribeConfig.RootNodes = append(subscribeConfig.RootNodes, mapOPCTag(tags))
 	}
-	o, err := subscribeConfig.CreateSubscribeClient(testutil.Logger{})
+	o, err := subscribeConfig.createSubscribeClient(testutil.Logger{})
 	require.NoError(t, err)
 
 	// give initial setup a couple extra attempts, as on CircleCI this can be
@@ -188,12 +188,12 @@ func TestSubscribeClientIntegration(t *testing.T) {
 		return o.SetupOptions() == nil
 	}, 5*time.Second, 10*time.Millisecond)
 
-	err = o.Connect()
+	err = o.connect()
 	require.NoError(t, err, "Connection failed")
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 	defer cancel()
-	res, err := o.StartStreamValues(ctx)
+	res, err := o.startStreamValues(ctx)
 	require.Equal(t, opcua.Connected, o.State())
 	require.NoError(t, err)
 
@@ -202,16 +202,16 @@ func TestSubscribeClientIntegration(t *testing.T) {
 		case m := <-res:
 			for fieldName, fieldValue := range m.Fields() {
 				for _, tag := range testopctags {
-					if fieldName != tag.Name {
+					if fieldName != tag.name {
 						continue
 					}
 
-					if tag.Want == nil {
-						t.Errorf("Tag: %s has value: %v", tag.Name, fieldValue)
+					if tag.want == nil {
+						t.Errorf("Tag: %s has value: %v", tag.name, fieldValue)
 						return
 					}
 
-					require.Equal(t, tag.Want, fieldValue)
+					require.Equal(t, tag.want, fieldValue)
 
 					newRemaining := make([]string, 0, len(tagsRemaining))
 					for _, remainingTag := range tagsRemaining {
@@ -257,7 +257,7 @@ func TestSubscribeClientIntegrationAdditionalFields(t *testing.T) {
 	require.NoError(t, container.Start(), "failed to start container")
 	defer container.Terminate()
 
-	testopctags := []OPCTags{
+	testopctags := []opcTags{
 		{"ProductName", "0", "i", "2261", "open62541 OPC UA Server"},
 		{"ProductUri", "0", "i", "2262", "http://open62541.org"},
 		{"ManufacturerName", "0", "i", "2263", "open62541"},
@@ -285,10 +285,10 @@ func TestSubscribeClientIntegrationAdditionalFields(t *testing.T) {
 	for i, x := range testopctags {
 		now := time.Now()
 		tags := map[string]string{
-			"id": fmt.Sprintf("ns=%s;%s=%s", x.Namespace, x.IdentifierType, x.Identifier),
+			"id": fmt.Sprintf("ns=%s;%s=%s", x.namespace, x.identifierType, x.identifier),
 		}
 		fields := map[string]interface{}{
-			x.Name:     x.Want,
+			x.name:     x.want,
 			"Quality":  testopcquality[i],
 			"DataType": testopctypes[i],
 		}
@@ -297,12 +297,12 @@ func TestSubscribeClientIntegrationAdditionalFields(t *testing.T) {
 
 	tagsRemaining := make([]string, 0, len(testopctags))
 	for i, tag := range testopctags {
-		if tag.Want != nil {
-			tagsRemaining = append(tagsRemaining, testopctags[i].Name)
+		if tag.want != nil {
+			tagsRemaining = append(tagsRemaining, testopctags[i].name)
 		}
 	}
 
-	subscribeConfig := SubscribeClientConfig{
+	subscribeConfig := subscribeClientConfig{
 		InputClientConfig: input.InputClientConfig{
 			OpcUAClientConfig: opcua.OpcUAClientConfig{
 				Endpoint:       fmt.Sprintf("opc.tcp://%s:%s", container.Address, container.Ports[servicePort]),
@@ -321,9 +321,9 @@ func TestSubscribeClientIntegrationAdditionalFields(t *testing.T) {
 		SubscriptionInterval: 0,
 	}
 	for _, tags := range testopctags {
-		subscribeConfig.RootNodes = append(subscribeConfig.RootNodes, MapOPCTag(tags))
+		subscribeConfig.RootNodes = append(subscribeConfig.RootNodes, mapOPCTag(tags))
 	}
-	o, err := subscribeConfig.CreateSubscribeClient(testutil.Logger{})
+	o, err := subscribeConfig.createSubscribeClient(testutil.Logger{})
 	require.NoError(t, err)
 
 	// give initial setup a couple extra attempts, as on CircleCI this can be
@@ -332,11 +332,11 @@ func TestSubscribeClientIntegrationAdditionalFields(t *testing.T) {
 		return o.SetupOptions() == nil
 	}, 5*time.Second, 10*time.Millisecond)
 
-	require.NoError(t, o.Connect(), "Connection failed")
+	require.NoError(t, o.connect(), "Connection failed")
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 	defer cancel()
-	res, err := o.StartStreamValues(ctx)
+	res, err := o.startStreamValues(ctx)
 	require.NoError(t, err)
 
 	for {
@@ -344,12 +344,12 @@ func TestSubscribeClientIntegrationAdditionalFields(t *testing.T) {
 		case m := <-res:
 			for fieldName, fieldValue := range m.Fields() {
 				for _, tag := range testopctags {
-					if fieldName != tag.Name {
+					if fieldName != tag.name {
 						continue
 					}
 					// nil-value tags should not be sent from server, error if one does
-					if tag.Want == nil {
-						t.Errorf("Tag: %s has value: %v", tag.Name, fieldValue)
+					if tag.want == nil {
+						t.Errorf("Tag: %s has value: %v", tag.name, fieldValue)
 						return
 					}
 
@@ -434,19 +434,19 @@ additional_valid_status_codes = ["0xC0"]
 	o, ok := c.Inputs[0].Input.(*OpcUaListener)
 	require.True(t, ok)
 
-	require.Equal(t, "localhost", o.SubscribeClientConfig.MetricName)
-	require.Equal(t, "opc.tcp://localhost:4840", o.SubscribeClientConfig.Endpoint)
-	require.Equal(t, config.Duration(10*time.Second), o.SubscribeClientConfig.ConnectTimeout)
-	require.Equal(t, config.Duration(5*time.Second), o.SubscribeClientConfig.RequestTimeout)
-	require.Equal(t, config.Duration(200*time.Millisecond), o.SubscribeClientConfig.SubscriptionInterval)
-	require.Equal(t, "error", o.SubscribeClientConfig.ConnectFailBehavior)
-	require.Equal(t, "auto", o.SubscribeClientConfig.SecurityPolicy)
-	require.Equal(t, "auto", o.SubscribeClientConfig.SecurityMode)
-	require.Equal(t, "/etc/telegraf/cert.pem", o.SubscribeClientConfig.Certificate)
-	require.Equal(t, "/etc/telegraf/key.pem", o.SubscribeClientConfig.PrivateKey)
-	require.Equal(t, "Anonymous", o.SubscribeClientConfig.AuthMethod)
-	require.True(t, o.SubscribeClientConfig.Username.Empty())
-	require.True(t, o.SubscribeClientConfig.Password.Empty())
+	require.Equal(t, "localhost", o.subscribeClientConfig.MetricName)
+	require.Equal(t, "opc.tcp://localhost:4840", o.subscribeClientConfig.Endpoint)
+	require.Equal(t, config.Duration(10*time.Second), o.subscribeClientConfig.ConnectTimeout)
+	require.Equal(t, config.Duration(5*time.Second), o.subscribeClientConfig.RequestTimeout)
+	require.Equal(t, config.Duration(200*time.Millisecond), o.subscribeClientConfig.SubscriptionInterval)
+	require.Equal(t, "error", o.subscribeClientConfig.ConnectFailBehavior)
+	require.Equal(t, "auto", o.subscribeClientConfig.SecurityPolicy)
+	require.Equal(t, "auto", o.subscribeClientConfig.SecurityMode)
+	require.Equal(t, "/etc/telegraf/cert.pem", o.subscribeClientConfig.Certificate)
+	require.Equal(t, "/etc/telegraf/key.pem", o.subscribeClientConfig.PrivateKey)
+	require.Equal(t, "Anonymous", o.subscribeClientConfig.AuthMethod)
+	require.True(t, o.subscribeClientConfig.Username.Empty())
+	require.True(t, o.subscribeClientConfig.Password.Empty())
 	require.Equal(t, []input.NodeSettings{
 		{
 			FieldName:      "name",
@@ -460,7 +460,7 @@ additional_valid_status_codes = ["0xC0"]
 			IdentifierType: "s",
 			Identifier:     "two",
 		},
-	}, o.SubscribeClientConfig.RootNodes)
+	}, o.subscribeClientConfig.RootNodes)
 	require.Equal(t, []input.NodeGroupSettings{
 		{
 			MetricName:     "foo",
@@ -484,9 +484,9 @@ additional_valid_status_codes = ["0xC0"]
 				TagsSlice:  [][]string{{"tag1", "override"}},
 			}},
 		},
-	}, o.SubscribeClientConfig.Groups)
-	require.Equal(t, opcua.OpcUAWorkarounds{AdditionalValidStatusCodes: []string{"0xC0"}}, o.SubscribeClientConfig.Workarounds)
-	require.Equal(t, []string{"DataType"}, o.SubscribeClientConfig.OptionalFields)
+	}, o.subscribeClientConfig.Groups)
+	require.Equal(t, opcua.OpcUAWorkarounds{AdditionalValidStatusCodes: []string{"0xC0"}}, o.subscribeClientConfig.Workarounds)
+	require.Equal(t, []string{"DataType"}, o.subscribeClientConfig.OptionalFields)
 }
 
 func TestSubscribeClientConfigWithMonitoringParams(t *testing.T) {
@@ -548,11 +548,11 @@ deadband_value = 100.0
 				},
 			}},
 		},
-	}, o.SubscribeClientConfig.Groups)
+	}, o.subscribeClientConfig.Groups)
 }
 
 func TestSubscribeClientConfigInvalidTrigger(t *testing.T) {
-	subscribeConfig := SubscribeClientConfig{
+	subscribeConfig := subscribeClientConfig{
 		InputClientConfig: input.InputClientConfig{
 			OpcUAClientConfig: opcua.OpcUAClientConfig{
 				Endpoint:       "opc.tcp://localhost:4840",
@@ -581,12 +581,12 @@ func TestSubscribeClientConfigInvalidTrigger(t *testing.T) {
 		},
 	})
 
-	_, err := subscribeConfig.CreateSubscribeClient(testutil.Logger{})
+	_, err := subscribeConfig.createSubscribeClient(testutil.Logger{})
 	require.ErrorContains(t, err, "trigger 'not_valid' not supported, node 'ns=3;i=1'")
 }
 
 func TestSubscribeClientConfigMissingTrigger(t *testing.T) {
-	subscribeConfig := SubscribeClientConfig{
+	subscribeConfig := subscribeClientConfig{
 		InputClientConfig: input.InputClientConfig{
 			OpcUAClientConfig: opcua.OpcUAClientConfig{
 				Endpoint:       "opc.tcp://localhost:4840",
@@ -615,12 +615,12 @@ func TestSubscribeClientConfigMissingTrigger(t *testing.T) {
 		},
 	})
 
-	_, err := subscribeConfig.CreateSubscribeClient(testutil.Logger{})
+	_, err := subscribeConfig.createSubscribeClient(testutil.Logger{})
 	require.ErrorContains(t, err, "trigger '' not supported, node 'ns=3;i=1'")
 }
 
 func TestSubscribeClientConfigInvalidDeadbandType(t *testing.T) {
-	subscribeConfig := SubscribeClientConfig{
+	subscribeConfig := subscribeClientConfig{
 		InputClientConfig: input.InputClientConfig{
 			OpcUAClientConfig: opcua.OpcUAClientConfig{
 				Endpoint:       "opc.tcp://localhost:4840",
@@ -650,12 +650,12 @@ func TestSubscribeClientConfigInvalidDeadbandType(t *testing.T) {
 		},
 	})
 
-	_, err := subscribeConfig.CreateSubscribeClient(testutil.Logger{})
+	_, err := subscribeConfig.createSubscribeClient(testutil.Logger{})
 	require.ErrorContains(t, err, "deadband_type 'not_valid' not supported, node 'ns=3;i=1'")
 }
 
 func TestSubscribeClientConfigMissingDeadbandType(t *testing.T) {
-	subscribeConfig := SubscribeClientConfig{
+	subscribeConfig := subscribeClientConfig{
 		InputClientConfig: input.InputClientConfig{
 			OpcUAClientConfig: opcua.OpcUAClientConfig{
 				Endpoint:       "opc.tcp://localhost:4840",
@@ -684,12 +684,12 @@ func TestSubscribeClientConfigMissingDeadbandType(t *testing.T) {
 		},
 	})
 
-	_, err := subscribeConfig.CreateSubscribeClient(testutil.Logger{})
+	_, err := subscribeConfig.createSubscribeClient(testutil.Logger{})
 	require.ErrorContains(t, err, "deadband_type '' not supported, node 'ns=3;i=1'")
 }
 
 func TestSubscribeClientConfigInvalidDeadbandValue(t *testing.T) {
-	subscribeConfig := SubscribeClientConfig{
+	subscribeConfig := subscribeClientConfig{
 		InputClientConfig: input.InputClientConfig{
 			OpcUAClientConfig: opcua.OpcUAClientConfig{
 				Endpoint:       "opc.tcp://localhost:4840",
@@ -721,12 +721,12 @@ func TestSubscribeClientConfigInvalidDeadbandValue(t *testing.T) {
 		},
 	})
 
-	_, err := subscribeConfig.CreateSubscribeClient(testutil.Logger{})
+	_, err := subscribeConfig.createSubscribeClient(testutil.Logger{})
 	require.ErrorContains(t, err, "negative deadband_value not supported, node 'ns=3;i=1'")
 }
 
 func TestSubscribeClientConfigMissingDeadbandValue(t *testing.T) {
-	subscribeConfig := SubscribeClientConfig{
+	subscribeConfig := subscribeClientConfig{
 		InputClientConfig: input.InputClientConfig{
 			OpcUAClientConfig: opcua.OpcUAClientConfig{
 				Endpoint:       "opc.tcp://localhost:4840",
@@ -756,12 +756,12 @@ func TestSubscribeClientConfigMissingDeadbandValue(t *testing.T) {
 		},
 	})
 
-	_, err := subscribeConfig.CreateSubscribeClient(testutil.Logger{})
+	_, err := subscribeConfig.createSubscribeClient(testutil.Logger{})
 	require.ErrorContains(t, err, "deadband_value was not set, node 'ns=3;i=1'")
 }
 
 func TestSubscribeClientConfigValidMonitoringParams(t *testing.T) {
-	subscribeConfig := SubscribeClientConfig{
+	subscribeConfig := subscribeClientConfig{
 		InputClientConfig: input.InputClientConfig{
 			OpcUAClientConfig: opcua.OpcUAClientConfig{
 				Endpoint:       "opc.tcp://localhost:4840",
@@ -799,7 +799,7 @@ func TestSubscribeClientConfigValidMonitoringParams(t *testing.T) {
 		},
 	})
 
-	subClient, err := subscribeConfig.CreateSubscribeClient(testutil.Logger{})
+	subClient, err := subscribeConfig.createSubscribeClient(testutil.Logger{})
 	require.NoError(t, err)
 	require.Equal(t, &ua.MonitoringParameters{
 		SamplingInterval: 50,

--- a/plugins/inputs/openntpd/openntpd_test.go
+++ b/plugins/inputs/openntpd/openntpd_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/influxdata/telegraf/testutil"
 )
 
-func OpenntpdCTL(output string) func(string, config.Duration, bool) (*bytes.Buffer, error) {
+func openntpdCTL(output string) func(string, config.Duration, bool) (*bytes.Buffer, error) {
 	return func(string, config.Duration, bool) (*bytes.Buffer, error) {
 		return bytes.NewBufferString(output), nil
 	}
@@ -19,7 +19,7 @@ func OpenntpdCTL(output string) func(string, config.Duration, bool) (*bytes.Buff
 func TestParseSimpleOutput(t *testing.T) {
 	acc := &testutil.Accumulator{}
 	v := &Openntpd{
-		run: OpenntpdCTL(simpleOutput),
+		run: openntpdCTL(simpleOutput),
 	}
 	err := v.Gather(acc)
 
@@ -50,7 +50,7 @@ func TestParseSimpleOutput(t *testing.T) {
 func TestParseSimpleOutputwithStatePrefix(t *testing.T) {
 	acc := &testutil.Accumulator{}
 	v := &Openntpd{
-		run: OpenntpdCTL(simpleOutputwithStatePrefix),
+		run: openntpdCTL(simpleOutputwithStatePrefix),
 	}
 	err := v.Gather(acc)
 
@@ -82,7 +82,7 @@ func TestParseSimpleOutputwithStatePrefix(t *testing.T) {
 func TestParseSimpleOutputInvalidPeer(t *testing.T) {
 	acc := &testutil.Accumulator{}
 	v := &Openntpd{
-		run: OpenntpdCTL(simpleOutputInvalidPeer),
+		run: openntpdCTL(simpleOutputInvalidPeer),
 	}
 	err := v.Gather(acc)
 
@@ -110,7 +110,7 @@ func TestParseSimpleOutputInvalidPeer(t *testing.T) {
 func TestParseSimpleOutputServersDNSError(t *testing.T) {
 	acc := &testutil.Accumulator{}
 	v := &Openntpd{
-		run: OpenntpdCTL(simpleOutputServersDNSError),
+		run: openntpdCTL(simpleOutputServersDNSError),
 	}
 	err := v.Gather(acc)
 
@@ -152,7 +152,7 @@ func TestParseSimpleOutputServersDNSError(t *testing.T) {
 func TestParseSimpleOutputServerDNSError(t *testing.T) {
 	acc := &testutil.Accumulator{}
 	v := &Openntpd{
-		run: OpenntpdCTL(simpleOutputServerDNSError),
+		run: openntpdCTL(simpleOutputServerDNSError),
 	}
 	err := v.Gather(acc)
 
@@ -180,7 +180,7 @@ func TestParseSimpleOutputServerDNSError(t *testing.T) {
 func TestParseFullOutput(t *testing.T) {
 	acc := &testutil.Accumulator{}
 	v := &Openntpd{
-		run: OpenntpdCTL(fullOutput),
+		run: openntpdCTL(fullOutput),
 	}
 	err := v.Gather(acc)
 

--- a/plugins/inputs/opensearch_query/aggregation.bucket.go
+++ b/plugins/inputs/opensearch_query/aggregation.bucket.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 )
 
-type BucketAggregationRequest map[string]*aggregationFunction
+type bucketAggregationRequest map[string]*aggregationFunction
 
-func (b BucketAggregationRequest) AddAggregation(name, aggType, field string) error {
+func (b bucketAggregationRequest) addAggregation(name, aggType, field string) error {
 	switch aggType {
 	case "terms":
 	default:
@@ -22,11 +22,11 @@ func (b BucketAggregationRequest) AddAggregation(name, aggType, field string) er
 	return nil
 }
 
-func (b BucketAggregationRequest) AddNestedAggregation(name string, a AggregationRequest) {
+func (b bucketAggregationRequest) addNestedAggregation(name string, a aggregationRequest) {
 	b[name].nested = a
 }
 
-func (b BucketAggregationRequest) BucketSize(name string, size int) error {
+func (b bucketAggregationRequest) bucketSize(name string, size int) error {
 	if size <= 0 {
 		return errors.New("invalid size; must be integer value > 0")
 	}
@@ -35,11 +35,11 @@ func (b BucketAggregationRequest) BucketSize(name string, size int) error {
 		return fmt.Errorf("aggregation %q not found", name)
 	}
 
-	b[name].Size(size)
+	b[name].setSize(size)
 
 	return nil
 }
 
-func (b BucketAggregationRequest) Missing(name, missing string) {
-	b[name].Missing(missing)
+func (b bucketAggregationRequest) missing(name, missing string) {
+	b[name].setMissing(missing)
 }

--- a/plugins/inputs/opensearch_query/aggregation.go
+++ b/plugins/inputs/opensearch_query/aggregation.go
@@ -4,14 +4,8 @@ import (
 	"encoding/json"
 )
 
-type AggregationRequest interface {
-	AddAggregation(string, string, string) error
-}
-
-type NestedAggregation interface {
-	Nested(string, AggregationRequest)
-	Missing(string)
-	Size(int)
+type aggregationRequest interface {
+	addAggregation(string, string, string) error
 }
 
 type aggregationFunction struct {
@@ -20,7 +14,7 @@ type aggregationFunction struct {
 	size    int
 	missing string
 
-	nested AggregationRequest
+	nested aggregationRequest
 }
 
 func (a *aggregationFunction) MarshalJSON() ([]byte, error) {
@@ -45,11 +39,11 @@ func (a *aggregationFunction) MarshalJSON() ([]byte, error) {
 	return json.Marshal(agg)
 }
 
-func (a *aggregationFunction) Size(size int) {
+func (a *aggregationFunction) setSize(size int) {
 	a.size = size
 }
 
-func (a *aggregationFunction) Missing(missing string) {
+func (a *aggregationFunction) setMissing(missing string) {
 	a.missing = missing
 }
 

--- a/plugins/inputs/opensearch_query/aggregation.metric.go
+++ b/plugins/inputs/opensearch_query/aggregation.metric.go
@@ -2,9 +2,9 @@ package opensearch_query
 
 import "fmt"
 
-type MetricAggregationRequest map[string]*aggregationFunction
+type metricAggregationRequest map[string]*aggregationFunction
 
-func (m MetricAggregationRequest) AddAggregation(name, aggType, field string) error {
+func (m metricAggregationRequest) addAggregation(name, aggType, field string) error {
 	if t := getAggregationFunctionType(aggType); t != "metric" {
 		return fmt.Errorf("aggregation function %q not supported", aggType)
 	}

--- a/plugins/inputs/opensearch_query/aggregation.response.go
+++ b/plugins/inputs/opensearch_query/aggregation.response.go
@@ -36,7 +36,7 @@ type bucketData struct {
 	subaggregation aggregation
 }
 
-func (a *aggregationResponse) GetMetrics(acc telegraf.Accumulator, measurement string) error {
+func (a *aggregationResponse) getMetrics(acc telegraf.Accumulator, measurement string) error {
 	// Simple case (no aggregations)
 	if a.Aggregations == nil {
 		tags := make(map[string]string)
@@ -47,20 +47,20 @@ func (a *aggregationResponse) GetMetrics(acc telegraf.Accumulator, measurement s
 		return nil
 	}
 
-	return a.Aggregations.GetMetrics(acc, measurement, a.Hits.TotalHits.Value, make(map[string]string))
+	return a.Aggregations.getMetrics(acc, measurement, a.Hits.TotalHits.Value, make(map[string]string))
 }
 
-func (a *aggregation) GetMetrics(acc telegraf.Accumulator, measurement string, docCount int64, tags map[string]string) error {
+func (a *aggregation) getMetrics(acc telegraf.Accumulator, measurement string, docCount int64, tags map[string]string) error {
 	var err error
 	fields := make(map[string]interface{})
 	for name, agg := range *a {
-		if agg.IsAggregation() {
+		if agg.isAggregation() {
 			for _, bucket := range agg.buckets {
 				tt := map[string]string{name: bucket.Key}
 				for k, v := range tags {
 					tt[k] = v
 				}
-				err = bucket.subaggregation.GetMetrics(acc, measurement, bucket.DocumentCount, tt)
+				err = bucket.subaggregation.getMetrics(acc, measurement, bucket.DocumentCount, tt)
 				if err != nil {
 					return err
 				}
@@ -101,7 +101,7 @@ func (a *aggregateValue) UnmarshalJSON(bytes []byte) error {
 	return json.Unmarshal(bytes, &a.metrics)
 }
 
-func (a *aggregateValue) IsAggregation() bool {
+func (a *aggregateValue) isAggregation() bool {
 	return !(a.buckets == nil)
 }
 

--- a/plugins/inputs/opensearch_query/opensearch_query_test.go
+++ b/plugins/inputs/opensearch_query/opensearch_query_test.go
@@ -12,13 +12,14 @@ import (
 	"time"
 
 	"github.com/docker/go-connections/nat"
+	"github.com/opensearch-project/opensearch-go/v2/opensearchutil"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go/wait"
+
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/plugins/common/tls"
 	"github.com/influxdata/telegraf/testutil"
-	"github.com/opensearch-project/opensearch-go/v2/opensearchutil"
-	"github.com/stretchr/testify/require"
-	"github.com/testcontainers/testcontainers-go/wait"
 )
 
 const (
@@ -674,18 +675,18 @@ func TestOpensearchQueryIntegration(t *testing.T) {
 }
 
 func TestMetricAggregationMarshal(t *testing.T) {
-	agg := &MetricAggregationRequest{}
-	err := agg.AddAggregation("sum_taxful_total_price", "sum", "taxful_total_price")
+	agg := &metricAggregationRequest{}
+	err := agg.addAggregation("sum_taxful_total_price", "sum", "taxful_total_price")
 	require.NoError(t, err)
 
 	_, err = json.Marshal(agg)
 	require.NoError(t, err)
 
-	bucket := &BucketAggregationRequest{}
-	err = bucket.AddAggregation("terms_by_currency", "terms", "currency")
+	bucket := &bucketAggregationRequest{}
+	err = bucket.addAggregation("terms_by_currency", "terms", "currency")
 	require.NoError(t, err)
 
-	bucket.AddNestedAggregation("terms_by_currency", agg)
+	bucket.addNestedAggregation("terms_by_currency", agg)
 	_, err = json.Marshal(bucket)
 	require.NoError(t, err)
 }

--- a/plugins/inputs/opensearch_query/query.go
+++ b/plugins/inputs/opensearch_query/query.go
@@ -5,13 +5,13 @@ import (
 	"time"
 )
 
-type Query struct {
+type query struct {
 	Size         int                `json:"size"`
-	Aggregations AggregationRequest `json:"aggregations"`
+	Aggregations aggregationRequest `json:"aggregations"`
 	Query        interface{}        `json:"query,omitempty"`
 }
 
-type BoolQuery struct {
+type boolQuery struct {
 	FilterQueryString string
 	TimestampField    string
 	TimeRangeFrom     time.Time
@@ -19,7 +19,7 @@ type BoolQuery struct {
 	DateFieldFormat   string
 }
 
-func (b *BoolQuery) MarshalJSON() ([]byte, error) {
+func (b *boolQuery) MarshalJSON() ([]byte, error) {
 	// Construct range
 	dateTimeRange := map[string]interface{}{
 		"from":          b.TimeRangeFrom,

--- a/plugins/inputs/opensmtpd/opensmtpd.go
+++ b/plugins/inputs/opensmtpd/opensmtpd.go
@@ -21,49 +21,29 @@ import (
 //go:embed sample.conf
 var sampleConfig string
 
-type runner func(cmdName string, timeout config.Duration, useSudo bool) (*bytes.Buffer, error)
+var (
+	defaultBinary  = "/usr/sbin/smtpctl"
+	defaultTimeout = config.Duration(time.Second)
+)
 
-// Opensmtpd is used to store configuration values
 type Opensmtpd struct {
-	Binary  string
-	Timeout config.Duration
-	UseSudo bool
+	Binary  string          `toml:"binary"`
+	Timeout config.Duration `toml:"timeout"`
+	UseSudo bool            `toml:"use_sudo"`
 
 	run runner
 }
 
-var defaultBinary = "/usr/sbin/smtpctl"
-var defaultTimeout = config.Duration(time.Second)
+type runner func(cmdName string, timeout config.Duration, useSudo bool) (*bytes.Buffer, error)
 
-// Shell out to opensmtpd_stat and return the output
-func opensmtpdRunner(cmdName string, timeout config.Duration, useSudo bool) (*bytes.Buffer, error) {
-	cmdArgs := []string{"show", "stats"}
-
-	cmd := exec.Command(cmdName, cmdArgs...)
-
-	if useSudo {
-		cmdArgs = append([]string{cmdName}, cmdArgs...)
-		cmd = exec.Command("sudo", cmdArgs...)
-	}
-
-	var out bytes.Buffer
-	cmd.Stdout = &out
-	err := internal.RunTimeout(cmd, time.Duration(timeout))
-	if err != nil {
-		return &out, fmt.Errorf("error running smtpctl: %w", err)
-	}
-
-	return &out, nil
-}
-
-// Gather collects the configured stats from smtpctl and adds them to the
-// Accumulator
 func (*Opensmtpd) SampleConfig() string {
 	return sampleConfig
 }
 
-// All the dots in stat name will replaced by underscores. Histogram statistics will not be collected.
 func (s *Opensmtpd) Gather(acc telegraf.Accumulator) error {
+	// All the dots in stat name will be replaced by underscores.
+	// Histogram statistics will not be collected.
+
 	// Always exclude uptime.human statistics
 	statExcluded := []string{"uptime.human"}
 	filterExcluded, err := filter.Compile(statExcluded)
@@ -106,6 +86,27 @@ func (s *Opensmtpd) Gather(acc telegraf.Accumulator) error {
 	acc.AddFields("opensmtpd", fields, nil)
 
 	return nil
+}
+
+// Shell out to opensmtpd_stat and return the output
+func opensmtpdRunner(cmdName string, timeout config.Duration, useSudo bool) (*bytes.Buffer, error) {
+	cmdArgs := []string{"show", "stats"}
+
+	cmd := exec.Command(cmdName, cmdArgs...)
+
+	if useSudo {
+		cmdArgs = append([]string{cmdName}, cmdArgs...)
+		cmd = exec.Command("sudo", cmdArgs...)
+	}
+
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := internal.RunTimeout(cmd, time.Duration(timeout))
+	if err != nil {
+		return &out, fmt.Errorf("error running smtpctl: %w", err)
+	}
+
+	return &out, nil
 }
 
 func init() {

--- a/plugins/inputs/opensmtpd/opensmtpd_test.go
+++ b/plugins/inputs/opensmtpd/opensmtpd_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/influxdata/telegraf/testutil"
 )
 
-func SMTPCTL(output string) func(string, config.Duration, bool) (*bytes.Buffer, error) {
+func smtpCTL(output string) func(string, config.Duration, bool) (*bytes.Buffer, error) {
 	return func(string, config.Duration, bool) (*bytes.Buffer, error) {
 		return bytes.NewBufferString(output), nil
 	}
@@ -19,7 +19,7 @@ func SMTPCTL(output string) func(string, config.Duration, bool) (*bytes.Buffer, 
 func TestFilterSomeStats(t *testing.T) {
 	acc := &testutil.Accumulator{}
 	v := &Opensmtpd{
-		run: SMTPCTL(fullOutput),
+		run: smtpCTL(fullOutput),
 	}
 	err := v.Gather(acc)
 

--- a/plugins/inputs/opentelemetry/opentelemetry.go
+++ b/plugins/inputs/opentelemetry/opentelemetry.go
@@ -46,10 +46,6 @@ func (*OpenTelemetry) SampleConfig() string {
 	return sampleConfig
 }
 
-func (*OpenTelemetry) Gather(telegraf.Accumulator) error {
-	return nil
-}
-
 func (o *OpenTelemetry) Init() error {
 	if o.ServiceAddress == "" {
 		o.ServiceAddress = "0.0.0.0:4317"
@@ -120,6 +116,10 @@ func (o *OpenTelemetry) Start(acc telegraf.Accumulator) error {
 		}
 	}()
 
+	return nil
+}
+
+func (*OpenTelemetry) Gather(telegraf.Accumulator) error {
 	return nil
 }
 

--- a/plugins/inputs/opentelemetry/opentelemetry_test.go
+++ b/plugins/inputs/opentelemetry/opentelemetry_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/influxdata/influxdb-observability/otel2influx"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
 	"go.opentelemetry.io/otel/sdk/metric"
@@ -24,7 +25,6 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/protobuf/encoding/protojson"
 
-	"github.com/influxdata/influxdb-observability/otel2influx"
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/plugins/inputs"

--- a/plugins/inputs/openweathermap/openweathermap.go
+++ b/plugins/inputs/openweathermap/openweathermap.go
@@ -174,7 +174,7 @@ func (n *OpenWeatherMap) gatherWeather(acc telegraf.Accumulator, city string) er
 		return fmt.Errorf("querying %q failed: %w", addr, err)
 	}
 
-	var e WeatherEntry
+	var e weatherEntry
 	if err := json.Unmarshal(buf, &e); err != nil {
 		return fmt.Errorf("parsing JSON response failed: %w", err)
 	}
@@ -223,7 +223,7 @@ func (n *OpenWeatherMap) gatherWeatherBatch(acc telegraf.Accumulator, cities str
 		return fmt.Errorf("querying %q failed: %w", addr, err)
 	}
 
-	var status Status
+	var status status
 	if err := json.Unmarshal(buf, &status); err != nil {
 		return fmt.Errorf("parsing JSON response failed: %w", err)
 	}
@@ -274,7 +274,7 @@ func (n *OpenWeatherMap) gatherForecast(acc telegraf.Accumulator, city string) e
 		return fmt.Errorf("querying %q failed: %w", addr, err)
 	}
 
-	var status Status
+	var status status
 	if err := json.Unmarshal(buf, &status); err != nil {
 		return fmt.Errorf("parsing JSON response failed: %w", err)
 	}

--- a/plugins/inputs/openweathermap/types.go
+++ b/plugins/inputs/openweathermap/types.go
@@ -1,6 +1,6 @@
 package openweathermap
 
-type WeatherEntry struct {
+type weatherEntry struct {
 	Dt     int64 `json:"dt"`
 	Clouds struct {
 		All int64 `json:"all"`
@@ -43,21 +43,21 @@ type WeatherEntry struct {
 	} `json:"weather"`
 }
 
-func (e WeatherEntry) snow() float64 {
+func (e weatherEntry) snow() float64 {
 	if e.Snow.Snow1 > 0 {
 		return e.Snow.Snow1
 	}
 	return e.Snow.Snow3
 }
 
-func (e WeatherEntry) rain() float64 {
+func (e weatherEntry) rain() float64 {
 	if e.Rain.Rain1 > 0 {
 		return e.Rain.Rain1
 	}
 	return e.Rain.Rain3
 }
 
-type Status struct {
+type status struct {
 	City struct {
 		Coord struct {
 			Lat float64 `json:"lat"`
@@ -67,5 +67,5 @@ type Status struct {
 		ID      int64  `json:"id"`
 		Name    string `json:"name"`
 	} `json:"city"`
-	List []WeatherEntry `json:"list"`
+	List []weatherEntry `json:"list"`
 }


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

Address findings for [revive:exported ](https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#exported ) in `plugins/inputs/o*`.

As part of this effort for files from `plugins/inputs/o*`, the following actions were taken:
- Type names (`const`, `var`, `struct`, `func`, etc) were changed to unexported, wherever they didn't need to be exported.
- All remaining exported types were given comments in the appropriate form – this does not apply to exported methods that implement "known" plugin interfaces (`Gather|Init|Start|Stop|SampleConfig|Parse|Add|Apply|Serialize|SerializeBatch|SetParser|SetParserFunc|GetState|SetState`).
- The order of methods was organized (exported methods first, then unexported, with `init` at the very end).

It is only part of the bigger work (for issue: https://github.com/influxdata/telegraf/issues/15813).
After all findings of this type in whole project are handled, we can enable `revive:exported` rule in `golangci-lint`.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR