### PR TITLE
fix(inputs.tail): Fix `from_beginning` option behavior

### DIFF
--- a/plugins/inputs/tail/README.md
+++ b/plugins/inputs/tail/README.md
@@ -56,7 +56,7 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ##
   files = ["/var/mymetrics.out"]
 
-  ## Read file from beginning.
+  ## Read file from beginning for new discovered files (without a persisted offset).
   # from_beginning = false
 
   ## Whether file is a named pipe


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

Currently, after setting `from_beginning` to true, tail will start from the beginning of the file regardless of the previous persisted offset.

This PR makes setting `from_beginning` to true only start from the beginning of the file when there is no persisted offset.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #16237
