### PR TITLE
feat(logging): Allow overriding message key for structured logging

### DIFF
--- a/cmd/telegraf/agent.conf
+++ b/cmd/telegraf/agent.conf
@@ -57,6 +57,10 @@
   ## "structured" or, on Windows, "eventlog".
   # logformat = "text"
 
+  ## Message key for structured logs, to override the default of "msg".
+  ## Ignored if `logformat` is not "structured".
+  # structured_log_message_key = "message"
+
   ## Name of the file to be logged to or stderr if unset or empty. This
   ## setting is ignored for the "eventlog" format.
   # logfile = ""

--- a/cmd/telegraf/telegraf.go
+++ b/cmd/telegraf/telegraf.go
@@ -364,15 +364,16 @@ func (t *Telegraf) runAgent(ctx context.Context, reloadConfig bool) error {
 
 	// Setup logging as configured.
 	logConfig := &logger.Config{
-		Debug:               c.Agent.Debug || t.debug,
-		Quiet:               c.Agent.Quiet || t.quiet,
-		LogTarget:           c.Agent.LogTarget,
-		LogFormat:           c.Agent.LogFormat,
-		Logfile:             c.Agent.Logfile,
-		RotationInterval:    time.Duration(c.Agent.LogfileRotationInterval),
-		RotationMaxSize:     int64(c.Agent.LogfileRotationMaxSize),
-		RotationMaxArchives: c.Agent.LogfileRotationMaxArchives,
-		LogWithTimezone:     c.Agent.LogWithTimezone,
+		Debug:                   c.Agent.Debug || t.debug,
+		Quiet:                   c.Agent.Quiet || t.quiet,
+		LogTarget:               c.Agent.LogTarget,
+		LogFormat:               c.Agent.LogFormat,
+		Logfile:                 c.Agent.Logfile,
+		StructuredLogMessageKey: c.Agent.StructuredLogMessageKey,
+		RotationInterval:        time.Duration(c.Agent.LogfileRotationInterval),
+		RotationMaxSize:         int64(c.Agent.LogfileRotationMaxSize),
+		RotationMaxArchives:     c.Agent.LogfileRotationMaxArchives,
+		LogWithTimezone:         c.Agent.LogWithTimezone,
 	}
 
 	if err := logger.SetupLogging(logConfig); err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -236,6 +236,10 @@ type AgentConfig struct {
 	// Name of the file to be logged to or stderr if empty. Ignored for "eventlog" format.
 	Logfile string `toml:"logfile"`
 
+	// Message key for structured logs, to override the default of "msg".
+	// Ignored if "logformat" is not "structured".
+	StructuredLogMessageKey string `toml:"structured_log_message_key"`
+
 	// The file will be rotated after the time interval specified.  When set
 	// to 0 no time based rotation is performed.
 	LogfileRotationInterval Duration `toml:"logfile_rotation_interval"`

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -307,6 +307,10 @@ The agent table configures Telegraf and the defaults used across all plugins.
   "structured" or, on Windows, "eventlog". The output file (if any) is
   determined by the `logfile` setting.
 
+- **structured_log_message_key**:
+  Message key for structured logs, to override the default of "msg".
+  Ignored if `logformat` is not "structured".
+
 - **logfile**:
   Name of the file to be logged to or stderr if unset or empty. This
   setting is ignored for the "eventlog" format.

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -195,6 +195,8 @@ type Config struct {
 	LogWithTimezone string
 	// Logger instance name
 	InstanceName string
+	// Structured logging message key
+	StructuredLogMessageKey string
 
 	// internal  log-level
 	logLevel telegraf.LogLevel


### PR DESCRIPTION
## Summary

This PR adds a config option which controls the message key used for structured logs, which currently defaults to the `slog.MessageKey` value of "msg".

This is particularly useful for changing the key from `msg` to `message`, to allow automatic log parsing into certain log processing pipelines (without having to use another tool like fluentbit).

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #16241
