### PR TITLE
fix(logging): Clean up extra empty spaces when redirectLogger is used

### DIFF
--- a/logger/handler.go
+++ b/logger/handler.go
@@ -119,10 +119,15 @@ func (l *redirectLogger) Print(level telegraf.LogLevel, ts time.Time, prefix str
 		for k, v := range attr {
 			parts = append(parts, fmt.Sprintf("%s=%v", k, v))
 		}
-		attrMsg = " (" + strings.Join(parts, ",") + ")"
+		attrMsg = "(" + strings.Join(parts, ",") + ")"
 	}
 
-	msg := append([]interface{}{ts.In(time.UTC).Format(time.RFC3339), " ", level.Indicator(), " ", prefix + attrMsg}, args...)
+	msg := []interface{}{ts.In(time.UTC).Format(time.RFC3339), level.Indicator(), prefix + attrMsg}
+	if prefix+attrMsg != "" {
+		msg = append(msg, prefix+attrMsg)
+	}
+	msg = append(msg, args)
+
 	fmt.Fprintln(l.writer, msg...)
 }
 

--- a/logger/handler.go
+++ b/logger/handler.go
@@ -126,7 +126,7 @@ func (l *redirectLogger) Print(level telegraf.LogLevel, ts time.Time, prefix str
 	if prefix+attrMsg != "" {
 		msg = append(msg, prefix+attrMsg)
 	}
-	msg = append(msg, args)
+	msg = append(msg, args...)
 
 	fmt.Fprintln(l.writer, msg...)
 }


### PR DESCRIPTION
## Summary
This PR removes the extra spaces in logging when [redirectLogger](https://github.com/influxdata/telegraf/blob/master/logger/handler.go#L111) is used.
- 3 spaces between the timestamp and log level
- 3 or 4 spaces between the log level and log messages
- 2 spaces between `prefix` and `attrMsg`

Example log contents:
![image](https://github.com/user-attachments/assets/eb3a415e-587b-42dc-8a33-469f45509903)

The fix includes 3 aspects:
 1. Based on fmt.Println func's definition,  [spaces are always added between operands](https://pkg.go.dev/fmt#Fprintln). Because of this, adding `" "` among `ts.In(time.UTC).Format(time.RFC3339)` , `level.Indicator()` and `prefix + attrMsg` will cause extra spaces to be generated (3 spaces rather than 1 space). This PR removes the `" "`  among them.
 
![image](https://github.com/user-attachments/assets/f4e9282b-b46a-4c0d-9781-aea8fa64f3cb)

2. When `prefix` is not empty, a space is added behind `]`:
<img width="278" alt="image" src="https://github.com/user-attachments/assets/42b35b5d-79da-4006-9ba5-5741ad5b8bc0">

At the same time, another space is added in front of `(`:
<img width="360" alt="image" src="https://github.com/user-attachments/assets/ddd2ca2f-ce9e-468e-803f-a213fb36b9ee">

Because of this, 2 spaces are added between `prefix` and `attrMsg`:
![image](https://github.com/user-attachments/assets/9f44ceea-e05f-4bf1-b445-360e1a3bbf98)
This PR removes one space between them.

3.  When both `prefix` and `attrMsg` are empty, adding `prefix + attrMsg` into msg will cause the empty string of `prefix + attrMsg` being wrapped by 2 extra empty spaces: 
![image](https://github.com/user-attachments/assets/10b318c8-5c57-4cf0-953f-8838402c485d)

This PR updates the logic to only add `prefix + attrMsg` into msg if it is not empty


Note: the above issues only appears when[redirectLogger](https://github.com/influxdata/telegraf/blob/master/logger/handler.go#L111) is used.

## Checklist

- [X] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #16254
