### PR TITLE
test(linters): Enable `testifylint`: `contains`, `encoded-compare` and `regexp`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -335,7 +335,9 @@ linters-settings:
       - blank-import
       - bool-compare
       - compares
+      - contains
       - empty
+      - encoded-compare
       - error-is-as
       - error-nil
       - expected-actual
@@ -345,6 +347,7 @@ linters-settings:
       - len
       - negative-positive
       - nil-compare
+      - regexp
       - require-error
       - suite-broken-parallel
       - suite-dont-use-pkg

--- a/plugins/serializers/json/json_test.go
+++ b/plugins/serializers/json/json_test.go
@@ -196,10 +196,10 @@ func TestSerializeBatch(t *testing.T) {
 	require.NoError(t, s.Init())
 	buf, err := s.SerializeBatch(metrics)
 	require.NoError(t, err)
-	require.Equal(
+	require.JSONEq(
 		t,
-		[]byte(`{"metrics":[{"fields":{"value":42},"name":"cpu","tags":{},"timestamp":0},{"fields":{"value":42},"name":"cpu","tags":{},"timestamp":0}]}`+"\n"),
-		buf,
+		`{"metrics":[{"fields":{"value":42},"name":"cpu","tags":{},"timestamp":0},{"fields":{"value":42},"name":"cpu","tags":{},"timestamp":0}]}`,
+		string(buf),
 	)
 }
 
@@ -220,7 +220,7 @@ func TestSerializeBatchSkipInf(t *testing.T) {
 	require.NoError(t, s.Init())
 	buf, err := s.SerializeBatch(metrics)
 	require.NoError(t, err)
-	require.Equal(t, []byte(`{"metrics":[{"fields":{"time_idle":42},"name":"cpu","tags":{},"timestamp":0}]}`+"\n"), buf)
+	require.JSONEq(t, `{"metrics":[{"fields":{"time_idle":42},"name":"cpu","tags":{},"timestamp":0}]}`, string(buf))
 }
 
 func TestSerializeBatchSkipInfAllFields(t *testing.T) {
@@ -239,7 +239,7 @@ func TestSerializeBatchSkipInfAllFields(t *testing.T) {
 	require.NoError(t, s.Init())
 	buf, err := s.SerializeBatch(metrics)
 	require.NoError(t, err)
-	require.Equal(t, []byte(`{"metrics":[{"fields":{},"name":"cpu","tags":{},"timestamp":0}]}`+"\n"), buf)
+	require.JSONEq(t, `{"metrics":[{"fields":{},"name":"cpu","tags":{},"timestamp":0}]}`, string(buf))
 }
 
 func TestSerializeTransformationNonBatch(t *testing.T) {

--- a/plugins/serializers/nowmetric/nowmetric_test.go
+++ b/plugins/serializers/nowmetric/nowmetric_test.go
@@ -191,13 +191,11 @@ func TestSerializeBatch(t *testing.T) {
 	s := &Serializer{}
 	buf, err := s.SerializeBatch(metrics)
 	require.NoError(t, err)
-	require.Equal(
+	require.JSONEq(
 		t,
-		[]byte(
-			`[{"metric_type":"value","resource":"","node":"","value":42,"timestamp":0,"ci2metric_id":null,"source":"Telegraf"},`+
-				`{"metric_type":"value","resource":"","node":"","value":42,"timestamp":0,"ci2metric_id":null,"source":"Telegraf"}]`,
-		),
-		buf,
+		`[{"metric_type":"value","resource":"","node":"","value":42,"timestamp":0,"ci2metric_id":null,"source":"Telegraf"},`+
+			`{"metric_type":"value","resource":"","node":"","value":42,"timestamp":0,"ci2metric_id":null,"source":"Telegraf"}]`,
+		string(buf),
 	)
 }
 
@@ -213,10 +211,10 @@ func TestSerializeJSONv2Format(t *testing.T) {
 	s := &Serializer{Format: "jsonv2"}
 	buf, err := s.Serialize(m)
 	require.NoError(t, err)
-	require.Equal(
+	require.JSONEq(
 		t,
-		[]byte(`{"records":[{"metric_type":"value","resource":"","node":"","value":42,"timestamp":0,"ci2metric_id":null,"source":"Telegraf"}]}`),
-		buf,
+		`{"records":[{"metric_type":"value","resource":"","node":"","value":42,"timestamp":0,"ci2metric_id":null,"source":"Telegraf"}]}`,
+		string(buf),
 	)
 }
 
@@ -233,15 +231,13 @@ func TestSerializeJSONv2FormatBatch(t *testing.T) {
 	metrics := []telegraf.Metric{m, m}
 	buf, err := s.SerializeBatch(metrics)
 	require.NoError(t, err)
-	require.Equal(
+	require.JSONEq(
 		t,
-		[]byte(
-			`{"records":[`+
-				`{"metric_type":"value","resource":"","node":"","value":42,"timestamp":0,"ci2metric_id":null,"source":"Telegraf"},`+
-				`{"metric_type":"value","resource":"","node":"","value":42,"timestamp":0,"ci2metric_id":null,"source":"Telegraf"}`+
-				`]}`,
-		),
-		buf,
+		`{"records":[`+
+			`{"metric_type":"value","resource":"","node":"","value":42,"timestamp":0,"ci2metric_id":null,"source":"Telegraf"},`+
+			`{"metric_type":"value","resource":"","node":"","value":42,"timestamp":0,"ci2metric_id":null,"source":"Telegraf"}`+
+			`]}`,
+		string(buf),
 	)
 }
 


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves https://github.com/influxdata/telegraf/issues/16183
resolves https://github.com/influxdata/telegraf/issues/16184
resolves https://github.com/influxdata/telegraf/issues/16185

