### PR TITLE
feat(agent): Print plugins source information

### DIFF
--- a/cmd/telegraf/main.go
+++ b/cmd/telegraf/main.go
@@ -224,23 +224,23 @@ func runApp(args []string, outputBuffer io.Writer, pprof Server, c TelegrafConfi
 		filters := processFilterFlags(cCtx)
 
 		g := GlobalFlags{
-			config:                 cCtx.StringSlice("config"),
-			configDir:              cCtx.StringSlice("config-directory"),
-			testWait:               cCtx.Int("test-wait"),
-			configURLRetryAttempts: cCtx.Int("config-url-retry-attempts"),
-			configURLWatchInterval: cCtx.Duration("config-url-watch-interval"),
-			watchConfig:            cCtx.String("watch-config"),
-			watchInterval:          cCtx.Duration("watch-interval"),
-			pidFile:                cCtx.String("pidfile"),
-			plugindDir:             cCtx.String("plugin-directory"),
-			password:               cCtx.String("password"),
-			oldEnvBehavior:         cCtx.Bool("old-env-behavior"),
-			newPluginPrintBehavior: cCtx.Bool("new-plugin-print-behavior"),
-			test:                   cCtx.Bool("test"),
-			debug:                  cCtx.Bool("debug"),
-			once:                   cCtx.Bool("once"),
-			quiet:                  cCtx.Bool("quiet"),
-			unprotected:            cCtx.Bool("unprotected"),
+			config:                  cCtx.StringSlice("config"),
+			configDir:               cCtx.StringSlice("config-directory"),
+			testWait:                cCtx.Int("test-wait"),
+			configURLRetryAttempts:  cCtx.Int("config-url-retry-attempts"),
+			configURLWatchInterval:  cCtx.Duration("config-url-watch-interval"),
+			watchConfig:             cCtx.String("watch-config"),
+			watchInterval:           cCtx.Duration("watch-interval"),
+			pidFile:                 cCtx.String("pidfile"),
+			plugindDir:              cCtx.String("plugin-directory"),
+			password:                cCtx.String("password"),
+			oldEnvBehavior:          cCtx.Bool("old-env-behavior"),
+			printPluginConfigSource: cCtx.Bool("print-plugin-config-source"),
+			test:                    cCtx.Bool("test"),
+			debug:                   cCtx.Bool("debug"),
+			once:                    cCtx.Bool("once"),
+			quiet:                   cCtx.Bool("quiet"),
+			unprotected:             cCtx.Bool("unprotected"),
 		}
 
 		w := WindowFlags{
@@ -310,8 +310,8 @@ func runApp(args []string, outputBuffer io.Writer, pprof Server, c TelegrafConfi
 					Usage: "switch back to pre v1.27 environment replacement behavior",
 				},
 				&cli.BoolFlag{
-					Name:  "new-plugin-print-behavior",
-					Usage: "switch to the new plugin print behavior",
+					Name:  "print-plugin-config-source",
+					Usage: "print the source for a given plugin",
 				},
 				&cli.BoolFlag{
 					Name:  "once",

--- a/cmd/telegraf/main.go
+++ b/cmd/telegraf/main.go
@@ -235,6 +235,7 @@ func runApp(args []string, outputBuffer io.Writer, pprof Server, c TelegrafConfi
 			plugindDir:             cCtx.String("plugin-directory"),
 			password:               cCtx.String("password"),
 			oldEnvBehavior:         cCtx.Bool("old-env-behavior"),
+			newPluginPrintBehavior: cCtx.Bool("new-plugin-print-behavior"),
 			test:                   cCtx.Bool("test"),
 			debug:                  cCtx.Bool("debug"),
 			once:                   cCtx.Bool("once"),
@@ -307,6 +308,10 @@ func runApp(args []string, outputBuffer io.Writer, pprof Server, c TelegrafConfi
 				&cli.BoolFlag{
 					Name:  "old-env-behavior",
 					Usage: "switch back to pre v1.27 environment replacement behavior",
+				},
+				&cli.BoolFlag{
+					Name:  "new-plugin-print-behavior",
+					Usage: "switch to the new plugin print behavior",
 				},
 				&cli.BoolFlag{
 					Name:  "once",

--- a/cmd/telegraf/telegraf.go
+++ b/cmd/telegraf/telegraf.go
@@ -45,6 +45,7 @@ type GlobalFlags struct {
 	plugindDir             string
 	password               string
 	oldEnvBehavior         bool
+	newPluginPrintBehavior bool
 	test                   bool
 	debug                  bool
 	once                   bool
@@ -105,6 +106,8 @@ func (t *Telegraf) Init(pprofErr <-chan error, f Filters, g GlobalFlags, w Windo
 
 	// Set environment replacement behavior
 	config.OldEnvVarReplacement = g.oldEnvBehavior
+
+	config.NewPluginPrintBehaviour = g.newPluginPrintBehavior
 }
 
 func (t *Telegraf) ListSecretStores() ([]string, error) {
@@ -392,7 +395,7 @@ func (t *Telegraf) runAgent(ctx context.Context, reloadConfig bool) error {
 	log.Printf("I! Loaded inputs: %s", c.InputNames())
 	log.Printf("I! Loaded aggregators: %s", c.AggregatorNames())
 	log.Printf("I! Loaded processors: %s", c.ProcessorNames())
-	log.Printf("I! Loaded secretstores: %s", strings.Join(c.SecretstoreNames(), " "))
+	log.Printf("I! Loaded secretstores: %s", c.SecretstoreNames())
 	if !t.once && (t.test || t.testWait != 0) {
 		log.Print("W! " + color.RedString("Outputs are not used in testing mode!"))
 	} else {

--- a/cmd/telegraf/telegraf.go
+++ b/cmd/telegraf/telegraf.go
@@ -389,14 +389,14 @@ func (t *Telegraf) runAgent(ctx context.Context, reloadConfig bool) error {
 		len(outputs.Outputs),
 		len(secretstores.SecretStores),
 	)
-	log.Printf("I! Loaded inputs: %s", strings.Join(c.InputNames(), " "))
-	log.Printf("I! Loaded aggregators: %s", strings.Join(c.AggregatorNames(), " "))
-	log.Printf("I! Loaded processors: %s", strings.Join(c.ProcessorNames(), " "))
+	log.Printf("I! Loaded inputs: %s", c.InputNames())
+	log.Printf("I! Loaded aggregators: %s", c.AggregatorNames())
+	log.Printf("I! Loaded processors: %s", c.ProcessorNames())
 	log.Printf("I! Loaded secretstores: %s", strings.Join(c.SecretstoreNames(), " "))
 	if !t.once && (t.test || t.testWait != 0) {
 		log.Print("W! " + color.RedString("Outputs are not used in testing mode!"))
 	} else {
-		log.Printf("I! Loaded outputs: %s", strings.Join(c.OutputNames(), " "))
+		log.Printf("I! Loaded outputs: %s", c.OutputNames())
 	}
 	log.Printf("I! Tags enabled: %s", c.ListTags())
 

--- a/cmd/telegraf/telegraf.go
+++ b/cmd/telegraf/telegraf.go
@@ -34,23 +34,23 @@ import (
 var stop chan struct{}
 
 type GlobalFlags struct {
-	config                 []string
-	configDir              []string
-	testWait               int
-	configURLRetryAttempts int
-	configURLWatchInterval time.Duration
-	watchConfig            string
-	watchInterval          time.Duration
-	pidFile                string
-	plugindDir             string
-	password               string
-	oldEnvBehavior         bool
-	newPluginPrintBehavior bool
-	test                   bool
-	debug                  bool
-	once                   bool
-	quiet                  bool
-	unprotected            bool
+	config                  []string
+	configDir               []string
+	testWait                int
+	configURLRetryAttempts  int
+	configURLWatchInterval  time.Duration
+	watchConfig             string
+	watchInterval           time.Duration
+	pidFile                 string
+	plugindDir              string
+	password                string
+	oldEnvBehavior          bool
+	printPluginConfigSource bool
+	test                    bool
+	debug                   bool
+	once                    bool
+	quiet                   bool
+	unprotected             bool
 }
 
 type WindowFlags struct {
@@ -107,7 +107,7 @@ func (t *Telegraf) Init(pprofErr <-chan error, f Filters, g GlobalFlags, w Windo
 	// Set environment replacement behavior
 	config.OldEnvVarReplacement = g.oldEnvBehavior
 
-	config.NewPluginPrintBehaviour = g.newPluginPrintBehavior
+	config.PrintPluginConfigSource = g.printPluginConfigSource
 }
 
 func (t *Telegraf) ListSecretStores() ([]string, error) {

--- a/cmd/telegraf/telegraf.go
+++ b/cmd/telegraf/telegraf.go
@@ -392,14 +392,14 @@ func (t *Telegraf) runAgent(ctx context.Context, reloadConfig bool) error {
 		len(outputs.Outputs),
 		len(secretstores.SecretStores),
 	)
-	log.Printf("I! Loaded inputs: %s", c.InputNames())
-	log.Printf("I! Loaded aggregators: %s", c.AggregatorNames())
-	log.Printf("I! Loaded processors: %s", c.ProcessorNames())
-	log.Printf("I! Loaded secretstores: %s", c.SecretstoreNames())
+	log.Printf("I! Loaded inputs: %s\n%s", strings.Join(c.InputNames(), " "), c.InputNamesWithSources())
+	log.Printf("I! Loaded aggregators: %s\n%s", strings.Join(c.AggregatorNames(), " "), c.AggregatorNamesWithSources())
+	log.Printf("I! Loaded processors: %s\n%s", strings.Join(c.ProcessorNames(), " "), c.ProcessorNamesWithSources())
+	log.Printf("I! Loaded secretstores: %s\n%s", strings.Join(c.SecretstoreNames(), " "), c.SecretstoreNamesWithSources())
 	if !t.once && (t.test || t.testWait != 0) {
 		log.Print("W! " + color.RedString("Outputs are not used in testing mode!"))
 	} else {
-		log.Printf("I! Loaded outputs: %s", c.OutputNames())
+		log.Printf("I! Loaded outputs: %s\n%s", strings.Join(c.OutputNames(), " "), c.OutputNamesWithSources())
 	}
 	log.Printf("I! Tags enabled: %s", c.ListTags())
 

--- a/config/config.go
+++ b/config/config.go
@@ -53,6 +53,8 @@ var (
 	// environment variable replacement behavior
 	OldEnvVarReplacement = false
 
+	NewPluginPrintBehaviour = false
+
 	// Password specified via command-line
 	Password Secret
 
@@ -303,7 +305,16 @@ func (c *Config) InputNames() string {
 			source: input.Config.Source,
 		})
 	}
-	return plugins.String()
+	return getPluginPrintString(plugins)
+}
+
+func getPluginPrintString(plugins pluginNames) string {
+	output := PluginNameCounts(plugins)
+	if NewPluginPrintBehaviour {
+		return output + plugins.String()
+	}
+
+	return output
 }
 
 // AggregatorNames returns a list of strings of the configured aggregators.
@@ -315,7 +326,7 @@ func (c *Config) AggregatorNames() string {
 			source: aggregator.Config.Source,
 		})
 	}
-	return plugins.String()
+	return getPluginPrintString(plugins)
 }
 
 // ProcessorNames returns a list of strings of the configured processors.
@@ -327,12 +338,11 @@ func (c *Config) ProcessorNames() string {
 			source: processor.Config.Source,
 		})
 	}
-	return plugins.String()
+	return getPluginPrintString(plugins)
 }
 
 // OutputNames returns a list of strings of the configured outputs.
 func (c *Config) OutputNames() string {
-
 	plugins := make(pluginNames, 0, len(c.Outputs))
 	for _, output := range c.Outputs {
 		plugins = append(plugins, pluginPrinter{
@@ -340,23 +350,25 @@ func (c *Config) OutputNames() string {
 			source: output.Config.Source,
 		})
 	}
-	return plugins.String()
+	return getPluginPrintString(plugins)
 }
 
 // SecretstoreNames returns a list of strings of the configured secret-stores.
-func (c *Config) SecretstoreNames() []string {
-	names := make([]string, 0, len(c.SecretStores))
+func (c *Config) SecretstoreNames() string {
+	plugins := make([]pluginPrinter, 0, len(c.SecretStores))
 	for name := range c.SecretStores {
-		names = append(names, name)
+		plugins = append(plugins, pluginPrinter{
+			name: name,
+		})
 	}
-	return PluginNameCounts(names)
+	return PluginNameCounts(plugins)
 }
 
 // PluginNameCounts returns a list of sorted plugin names and their count
-func PluginNameCounts(plugins []string) []string {
+func PluginNameCounts(plugins pluginNames) string {
 	names := make(map[string]int)
 	for _, plugin := range plugins {
-		names[plugin]++
+		names[plugin.name]++
 	}
 
 	var namecount []string
@@ -369,7 +381,7 @@ func PluginNameCounts(plugins []string) []string {
 	}
 
 	sort.Strings(namecount)
-	return namecount
+	return strings.Join(namecount, " ")
 }
 
 // ListTags returns a string of tags specified in the config,

--- a/config/config.go
+++ b/config/config.go
@@ -53,7 +53,8 @@ var (
 	// environment variable replacement behavior
 	OldEnvVarReplacement = false
 
-	NewPluginPrintBehaviour = false
+	// PrintPluginConfigSource is a switch to enable printing of plugin sources
+	PrintPluginConfigSource = false
 
 	// Password specified via command-line
 	Password Secret
@@ -307,7 +308,7 @@ type AgentConfig struct {
 // based on the NewPluginPrintBehaviour flag
 func getPluginPrintString(plugins pluginNames) string {
 	output := PluginNameCounts(plugins)
-	if NewPluginPrintBehaviour {
+	if PrintPluginConfigSource {
 		return output + plugins.String()
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -366,10 +366,7 @@ func (c *Config) OutputNames() string {
 func (c *Config) SecretstoreNames() string {
 	plugins := make([]pluginPrinter, 0, len(c.SecretStores))
 	for _, secretStore := range c.secretStoreSource {
-		plugins = append(plugins, pluginPrinter{
-			name:   secretStore.name,
-			source: secretStore.source,
-		})
+		plugins = append(plugins, pluginPrinter(secretStore))
 	}
 	return getPluginPrintString(plugins)
 }
@@ -908,7 +905,7 @@ func parseConfig(contents []byte) (*ast.Table, error) {
 	return toml.Parse(outputBytes)
 }
 
-func (c *Config) addAggregator(name string, source string, table *ast.Table) error {
+func (c *Config) addAggregator(name, source string, table *ast.Table) error {
 	creator, ok := aggregators.Aggregators[name]
 	if !ok {
 		// Handle removed, deprecated plugins
@@ -937,7 +934,7 @@ func (c *Config) addAggregator(name string, source string, table *ast.Table) err
 	return nil
 }
 
-func (c *Config) addSecretStore(name string, source string, table *ast.Table) error {
+func (c *Config) addSecretStore(name, source string, table *ast.Table) error {
 	if len(c.SecretStoreFilters) > 0 && !sliceContains(name, c.SecretStoreFilters) {
 		return nil
 	}
@@ -1110,7 +1107,7 @@ func (c *Config) addSerializer(parentname string, table *ast.Table) (*models.Run
 	return running, err
 }
 
-func (c *Config) addProcessor(name string, source string, table *ast.Table) error {
+func (c *Config) addProcessor(name, source string, table *ast.Table) error {
 	creator, ok := processors.Processors[name]
 	if !ok {
 		// Handle removed, deprecated plugins
@@ -1233,7 +1230,7 @@ func (c *Config) setupProcessor(name string, creator processors.StreamingCreator
 	return streamingProcessor, optionTestCount, err
 }
 
-func (c *Config) addOutput(name string, source string, table *ast.Table) error {
+func (c *Config) addOutput(name, source string, table *ast.Table) error {
 	if len(c.OutputFilters) > 0 && !sliceContains(name, c.OutputFilters) {
 		return nil
 	}
@@ -1316,7 +1313,7 @@ func (c *Config) addOutput(name string, source string, table *ast.Table) error {
 	return nil
 }
 
-func (c *Config) addInput(name string, source string, table *ast.Table) error {
+func (c *Config) addInput(name, source string, table *ast.Table) error {
 	if len(c.InputFilters) > 0 && !sliceContains(name, c.InputFilters) {
 		return nil
 	}
@@ -1404,7 +1401,7 @@ func (c *Config) addInput(name string, source string, table *ast.Table) error {
 // buildAggregator parses Aggregator specific items from the ast.Table,
 // builds the filter and returns a
 // models.AggregatorConfig to be inserted into models.RunningAggregator
-func (c *Config) buildAggregator(name string, source string, tbl *ast.Table) (*models.AggregatorConfig, error) {
+func (c *Config) buildAggregator(name, source string, tbl *ast.Table) (*models.AggregatorConfig, error) {
 	conf := &models.AggregatorConfig{
 		Name:   name,
 		Source: source,
@@ -1566,7 +1563,7 @@ func (c *Config) buildFilter(plugin string, tbl *ast.Table) (models.Filter, erro
 // buildInput parses input specific items from the ast.Table,
 // builds the filter and returns a
 // models.InputConfig to be inserted into models.RunningInput
-func (c *Config) buildInput(name string, source string, tbl *ast.Table) (*models.InputConfig, error) {
+func (c *Config) buildInput(name, source string, tbl *ast.Table) (*models.InputConfig, error) {
 	cp := &models.InputConfig{
 		Name:                    name,
 		Source:                  source,
@@ -1614,7 +1611,7 @@ func (c *Config) buildInput(name string, source string, tbl *ast.Table) (*models
 // builds the filter and returns a
 // models.OutputConfig to be inserted into models.RunningInput
 // Note: error exists in the return for future calls that might require error
-func (c *Config) buildOutput(name string, source string, tbl *ast.Table) (*models.OutputConfig, error) {
+func (c *Config) buildOutput(name, source string, tbl *ast.Table) (*models.OutputConfig, error) {
 	filter, err := c.buildFilter("outputs."+name, tbl)
 	if err != nil {
 		return nil, err

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -70,7 +70,7 @@ func TestConfig_LoadSingleInputWithEnvVars(t *testing.T) {
 	c := config.NewConfig()
 	t.Setenv("MY_TEST_SERVER", "192.168.1.1")
 	t.Setenv("TEST_INTERVAL", "10s")
-	confFile := "./testdata/single_plugin_env_vars.toml"
+	confFile := filepath.Join("testdata", "single_plugin_env_vars.toml")
 	require.NoError(t, c.LoadConfig(confFile))
 
 	input := inputs.Inputs["memcached"]().(*MockupInputPlugin)
@@ -115,7 +115,7 @@ func TestConfig_LoadSingleInputWithEnvVars(t *testing.T) {
 
 func TestConfig_LoadSingleInput(t *testing.T) {
 	c := config.NewConfig()
-	confFile := "./testdata/single_plugin.toml"
+	confFile := filepath.Join("testdata", "single_plugin.toml")
 	require.NoError(t, c.LoadConfig(confFile))
 
 	input := inputs.Inputs["memcached"]().(*MockupInputPlugin)
@@ -158,7 +158,7 @@ func TestConfig_LoadSingleInput(t *testing.T) {
 
 func TestConfig_LoadSingleInput_WithSeparators(t *testing.T) {
 	c := config.NewConfig()
-	confFile := "./testdata/single_plugin_with_separators.toml"
+	confFile := filepath.Join("testdata", "single_plugin_with_separators.toml")
 	require.NoError(t, c.LoadConfig(confFile))
 
 	input := inputs.Inputs["memcached"]().(*MockupInputPlugin)
@@ -214,7 +214,7 @@ func TestConfig_LoadDirectory(t *testing.T) {
 	c := config.NewConfig()
 
 	files, err := config.WalkDirectory("./testdata/subconfig")
-	confFile := "./testdata/single_plugin.toml"
+	confFile := filepath.Join("testdata", "single_plugin.toml")
 	files = append([]string{confFile}, files...)
 	require.NoError(t, err)
 	require.NoError(t, c.LoadAll(files...))
@@ -264,7 +264,7 @@ func TestConfig_LoadDirectory(t *testing.T) {
 	expectedPlugins[1].Command = "/usr/bin/myothercollector --foo=bar"
 	expectedConfigs[1] = &models.InputConfig{
 		Name:              "exec",
-		Source:            "testdata/subconfig/exec.conf", // This is the source of the input
+		Source:            filepath.Join("testdata", "subconfig", "exec.conf"), // This is the source of the input
 		MeasurementSuffix: "_myothercollector",
 	}
 	expectedConfigs[1].Tags = make(map[string]string)
@@ -293,7 +293,7 @@ func TestConfig_LoadDirectory(t *testing.T) {
 	require.NoError(t, filterMemcached.Compile())
 	expectedConfigs[2] = &models.InputConfig{
 		Name:     "memcached",
-		Source:   "testdata/subconfig/memcached.conf", // This is the source of the input
+		Source:   filepath.Join("testdata", "subconfig", "memcached.conf"), // This is the source of the input
 		Filter:   filterMemcached,
 		Interval: 5 * time.Second,
 	}
@@ -303,7 +303,7 @@ func TestConfig_LoadDirectory(t *testing.T) {
 	expectedPlugins[3].PidFile = "/var/run/grafana-server.pid"
 	expectedConfigs[3] = &models.InputConfig{
 		Name:   "procstat",
-		Source: "testdata/subconfig/procstat.conf", // This is the source of the input
+		Source: filepath.Join("testdata", "subconfig", "procstat.conf"), // This is the source of the input
 	}
 	expectedConfigs[3].Tags = make(map[string]string)
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -70,7 +70,8 @@ func TestConfig_LoadSingleInputWithEnvVars(t *testing.T) {
 	c := config.NewConfig()
 	t.Setenv("MY_TEST_SERVER", "192.168.1.1")
 	t.Setenv("TEST_INTERVAL", "10s")
-	require.NoError(t, c.LoadConfig("./testdata/single_plugin_env_vars.toml"))
+	confFile := "./testdata/single_plugin_env_vars.toml"
+	require.NoError(t, c.LoadConfig(confFile))
 
 	input := inputs.Inputs["memcached"]().(*MockupInputPlugin)
 	input.Servers = []string{"192.168.1.1"}
@@ -98,6 +99,7 @@ func TestConfig_LoadSingleInputWithEnvVars(t *testing.T) {
 	require.NoError(t, filter.Compile())
 	inputConfig := &models.InputConfig{
 		Name:     "memcached",
+		Source:   confFile,
 		Filter:   filter,
 		Interval: 10 * time.Second,
 	}
@@ -113,7 +115,8 @@ func TestConfig_LoadSingleInputWithEnvVars(t *testing.T) {
 
 func TestConfig_LoadSingleInput(t *testing.T) {
 	c := config.NewConfig()
-	require.NoError(t, c.LoadConfig("./testdata/single_plugin.toml"))
+	confFile := "./testdata/single_plugin.toml"
+	require.NoError(t, c.LoadConfig(confFile))
 
 	input := inputs.Inputs["memcached"]().(*MockupInputPlugin)
 	input.Servers = []string{"localhost"}
@@ -139,6 +142,7 @@ func TestConfig_LoadSingleInput(t *testing.T) {
 	require.NoError(t, filter.Compile())
 	inputConfig := &models.InputConfig{
 		Name:     "memcached",
+		Source:   confFile,
 		Filter:   filter,
 		Interval: 5 * time.Second,
 	}
@@ -154,7 +158,8 @@ func TestConfig_LoadSingleInput(t *testing.T) {
 
 func TestConfig_LoadSingleInput_WithSeparators(t *testing.T) {
 	c := config.NewConfig()
-	require.NoError(t, c.LoadConfig("./testdata/single_plugin_with_separators.toml"))
+	confFile := "./testdata/single_plugin_with_separators.toml"
+	require.NoError(t, c.LoadConfig(confFile))
 
 	input := inputs.Inputs["memcached"]().(*MockupInputPlugin)
 	input.Servers = []string{"localhost"}
@@ -182,6 +187,7 @@ func TestConfig_LoadSingleInput_WithSeparators(t *testing.T) {
 	require.NoError(t, filter.Compile())
 	inputConfig := &models.InputConfig{
 		Name:     "memcached",
+		Source:   confFile,
 		Filter:   filter,
 		Interval: 5 * time.Second,
 	}
@@ -208,7 +214,8 @@ func TestConfig_LoadDirectory(t *testing.T) {
 	c := config.NewConfig()
 
 	files, err := config.WalkDirectory("./testdata/subconfig")
-	files = append([]string{"./testdata/single_plugin.toml"}, files...)
+	confFile := "./testdata/single_plugin.toml"
+	files = append([]string{confFile}, files...)
 	require.NoError(t, err)
 	require.NoError(t, c.LoadAll(files...))
 
@@ -240,6 +247,7 @@ func TestConfig_LoadDirectory(t *testing.T) {
 	require.NoError(t, filterMockup.Compile())
 	expectedConfigs[0] = &models.InputConfig{
 		Name:     "memcached",
+		Source:   confFile,
 		Filter:   filterMockup,
 		Interval: 5 * time.Second,
 	}
@@ -256,6 +264,7 @@ func TestConfig_LoadDirectory(t *testing.T) {
 	expectedPlugins[1].Command = "/usr/bin/myothercollector --foo=bar"
 	expectedConfigs[1] = &models.InputConfig{
 		Name:              "exec",
+		Source:            "testdata/subconfig/exec.conf", // This is the source of the input
 		MeasurementSuffix: "_myothercollector",
 	}
 	expectedConfigs[1].Tags = make(map[string]string)
@@ -284,6 +293,7 @@ func TestConfig_LoadDirectory(t *testing.T) {
 	require.NoError(t, filterMemcached.Compile())
 	expectedConfigs[2] = &models.InputConfig{
 		Name:     "memcached",
+		Source:   "testdata/subconfig/memcached.conf", // This is the source of the input
 		Filter:   filterMemcached,
 		Interval: 5 * time.Second,
 	}
@@ -291,7 +301,10 @@ func TestConfig_LoadDirectory(t *testing.T) {
 
 	expectedPlugins[3] = inputs.Inputs["procstat"]().(*MockupInputPlugin)
 	expectedPlugins[3].PidFile = "/var/run/grafana-server.pid"
-	expectedConfigs[3] = &models.InputConfig{Name: "procstat"}
+	expectedConfigs[3] = &models.InputConfig{
+		Name:   "procstat",
+		Source: "testdata/subconfig/procstat.conf", // This is the source of the input
+	}
 	expectedConfigs[3].Tags = make(map[string]string)
 
 	// Check the generated plugins

--- a/config/plugin_printer.go
+++ b/config/plugin_printer.go
@@ -1,0 +1,135 @@
+package config
+
+import (
+	"bytes"
+	"fmt"
+	"sort"
+	"strings"
+	"text/tabwriter"
+)
+
+type pluginPrinter struct {
+	name   string
+	source string
+}
+
+type pluginNames []pluginPrinter
+
+func (p *pluginNames) String() string {
+	pluginMap := make(map[string][]string)
+	for _, plugin := range *p {
+		if _, ok := pluginMap[plugin.name]; !ok {
+			pluginMap[plugin.name] = make([]string, 0)
+		}
+		pluginMap[plugin.name] = append(pluginMap[plugin.name], plugin.source)
+	}
+
+	data := make([][]any, 0, len(pluginMap))
+	for name, sources := range pluginMap {
+		var nameCountStr string
+		if len(sources) > 1 {
+			nameCountStr = fmt.Sprintf("%s (%dx)", name, len(sources))
+		} else {
+			nameCountStr = name
+		}
+		data = append(data, []any{nameCountStr, sources})
+	}
+	// sort the data based on counts(i.e number of sources)
+	sort.Slice(data, func(i, j int) bool {
+		return len(data[i][1].([]string)) > len(data[j][1].([]string))
+	})
+
+	if len(data) == 0 {
+		return ""
+	}
+
+	return GetPluginTableContent([]string{"Name", "Source(s)"}, data)
+}
+
+// GetPluginTableContent prints a bordered ASCII table.
+func GetPluginTableContent(headers []string, data [][]any) string {
+	// Initialize the buffer
+	var b bytes.Buffer
+
+	// Initialize the tab writer
+	writer := tabwriter.NewWriter(&b, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(writer)
+	// Helper function to convert data into multi-line strings
+	convertToLines := func(value interface{}) []string {
+		switch v := value.(type) {
+		case []string: // If the value is a slice of strings, return as-is
+			return v
+		default: // Handle other types as single-line strings
+			return []string{fmt.Sprintf("%v", v)}
+		}
+	}
+
+	// Prepare processed data with multi-line values
+	processedData := make([][][]string, len(data))
+	columnWidths := make([]int, len(headers))
+	maxLinesPerRow := make([]int, len(data))
+
+	for i, row := range data {
+		processedData[i] = make([][]string, len(row))
+		for j, cell := range row {
+			lines := convertToLines(cell)
+			processedData[i][j] = lines
+
+			// Calculate the maximum width for each column
+			for _, line := range lines {
+				if len(line) > columnWidths[j] {
+					columnWidths[j] = len(line)
+				}
+			}
+
+			// Update maximum lines per row
+			if len(lines) > maxLinesPerRow[i] {
+				maxLinesPerRow[i] = len(lines)
+			}
+		}
+	}
+
+	// Function to create a horizontal line
+	createLine := func() string {
+		line := "+"
+		for _, width := range columnWidths {
+			line += strings.Repeat("-", width+4) + "+"
+		}
+		return line
+	}
+
+	// Print top border
+	fmt.Fprintln(writer, createLine())
+
+	// Print headers with borders
+	fmt.Fprint(writer, "|")
+	for i, header := range headers {
+		fmt.Fprintf(writer, " %-*s |", columnWidths[i]+2, header)
+	}
+	fmt.Fprintln(writer)
+
+	// Print separator line
+	fmt.Fprintln(writer, createLine())
+
+	// Print rows with borders
+	for rowIndex, row := range processedData {
+		for lineIndex := 0; lineIndex < maxLinesPerRow[rowIndex]; lineIndex++ {
+			fmt.Fprint(writer, "|")
+			for colIndex, cell := range row {
+				if lineIndex < len(cell) {
+					fmt.Fprintf(writer, " %-*s |", columnWidths[colIndex]+2, cell[lineIndex])
+				} else {
+					fmt.Fprintf(writer, " %-*s |", columnWidths[colIndex]+2, "") // Empty space for missing lines
+				}
+			}
+			fmt.Fprintln(writer)
+		}
+		// Print separator line after each row
+		fmt.Fprintln(writer, createLine())
+	}
+
+	// Flush the writer
+	writer.Flush()
+
+	return b.String()
+}

--- a/config/plugin_printer.go
+++ b/config/plugin_printer.go
@@ -5,7 +5,8 @@ import (
 	"fmt"
 	"sort"
 	"strings"
-	"text/tabwriter"
+
+	"github.com/jedib0t/go-pretty/v6/table"
 )
 
 var headers = []string{"Name", "Source(s)"}
@@ -17,17 +18,21 @@ type pluginPrinter struct {
 
 type pluginNames []pluginPrinter
 
-func (p *pluginNames) String() string {
-	pluginMap := make(map[string][]string)
-	for _, plugin := range *p {
-		if _, ok := pluginMap[plugin.name]; !ok {
-			pluginMap[plugin.name] = make([]string, 0)
-		}
-		pluginMap[plugin.name] = append(pluginMap[plugin.name], plugin.source)
+func GetPluginSourcesTable(pluginNames []pluginPrinter) string {
+	if !PrintPluginConfigSource {
+		return ""
 	}
 
-	data := make([][]any, 0, len(pluginMap))
-	for name, sources := range pluginMap {
+	data := make([][]any, 0, len(pluginNames))
+	rows := make(map[string][]string)
+	for _, plugin := range pluginNames {
+		if _, ok := rows[plugin.name]; !ok {
+			rows[plugin.name] = make([]string, 0)
+		}
+		rows[plugin.name] = append(rows[plugin.name], plugin.source)
+	}
+
+	for name, sources := range rows {
 		var nameCountStr string
 		if len(sources) > 1 {
 			nameCountStr = fmt.Sprintf("%s (%dx)", name, len(sources))
@@ -36,108 +41,42 @@ func (p *pluginNames) String() string {
 		}
 		data = append(data, []any{nameCountStr, sources})
 	}
-	// sort the data based on counts(i.e number of sources)
 	sort.Slice(data, func(i, j int) bool {
 		return len(data[i][1].([]string)) > len(data[j][1].([]string))
 	})
-
-	if len(data) == 0 {
-		return ""
-	}
-
-	return GetPluginTableContent(headers, data)
+	return getTableString(headers, data)
 }
 
-// GetPluginTableContent prints a bordered ASCII table.
-//
-// Inputs:
-//
-//	headers: slice of strings containing the headers of the table
-//	data: slice of slices of strings containing the data to be printed
-//
-// Reference: https://github.com/olekukonko/tablewriter
-func GetPluginTableContent(headers []string, data [][]any) string {
-	// processedData will hold processed data with multi-line values(for multiple sources)
-	processedData := make([][][]string, len(data))
-	columnWidths := make([]int, len(headers))
-	maxLinesPerRow := make([]int, len(data))
+func getTableString(headers []string, data [][]any) string {
+	buff := new(bytes.Buffer)
 
-	var b bytes.Buffer
+	t := table.NewWriter()
+	t.SetOutputMirror(buff)
+	t.AppendHeader(convertToRow(headers))
 
-	writer := tabwriter.NewWriter(&b, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(writer)
-
-	// Helper function to convert data into multi-line strings
-	convertToLines := func(value interface{}) []string {
-		switch v := value.(type) {
-		case []string:
-			return v
-		default:
-			return []string{fmt.Sprintf("%v", v)}
-		}
-	}
-
-	// Function to create a horizontal line
-	createLine := func() string {
-		line := "+"
-		for _, width := range columnWidths {
-			line += strings.Repeat("-", width+4) + "+"
-		}
-		return line
-	}
-
-	for i, row := range data {
-		processedData[i] = make([][]string, len(row))
-		for j, cell := range row {
-			lines := convertToLines(cell)
-			processedData[i][j] = lines
-
-			// maximum width for each column
-			for _, line := range lines {
-				if len(line) > columnWidths[j] {
-					columnWidths[j] = len(line)
-				}
-			}
-
-			// maximum lines per row
-			if len(lines) > maxLinesPerRow[i] {
-				maxLinesPerRow[i] = len(lines)
+	// Append rows
+	for _, row := range data {
+		processedRow := make([]interface{}, len(row))
+		for i, col := range row {
+			switch v := col.(type) {
+			case []string: // Convert slices to multi-line strings
+				processedRow[i] = strings.Join(v, "\n")
+			default:
+				processedRow[i] = v
 			}
 		}
+		t.AppendRow(processedRow)
 	}
 
-	// Print top line border
-	// ex  + ---- +
-	fmt.Fprintln(writer, createLine())
+	t.Style().Options.SeparateRows = true
+	return t.Render()
+}
 
-	// Print headers with borders
-	// ex  | Name | Source(s) |
-	fmt.Fprint(writer, "|")
-	for i, header := range headers {
-		fmt.Fprintf(writer, " %-*s |", columnWidths[i]+2, header)
+// Helper function to convert headers to table.Row
+func convertToRow(data []string) table.Row {
+	row := make(table.Row, len(data))
+	for i, val := range data {
+		row[i] = val
 	}
-	fmt.Fprintln(writer)
-
-	// Print separator line
-	fmt.Fprintln(writer, createLine())
-
-	// rows
-	for rowIndex, row := range processedData {
-		for lineIndex := 0; lineIndex < maxLinesPerRow[rowIndex]; lineIndex++ {
-			fmt.Fprint(writer, "|")
-			for colIndex, cell := range row {
-				if lineIndex < len(cell) {
-					fmt.Fprintf(writer, " %-*s |", columnWidths[colIndex]+2, cell[lineIndex])
-				} else {
-					fmt.Fprintf(writer, " %-*s |", columnWidths[colIndex]+2, "") // Empty space for missing lines
-				}
-			}
-			fmt.Fprintln(writer)
-		}
-		// separator line
-		fmt.Fprintln(writer, createLine())
-	}
-	writer.Flush()
-
-	return b.String()
+	return row
 }

--- a/config/plugin_printer.go
+++ b/config/plugin_printer.go
@@ -18,7 +18,7 @@ type pluginPrinter struct {
 
 type pluginNames []pluginPrinter
 
-func GetPluginSourcesTable(pluginNames []pluginPrinter) string {
+func getPluginSourcesTable(pluginNames []pluginPrinter) string {
 	if !PrintPluginConfigSource {
 		return ""
 	}

--- a/config/secret_test.go
+++ b/config/secret_test.go
@@ -151,7 +151,7 @@ func TestSecretConstant(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := NewConfig()
-			require.NoError(t, c.LoadConfigData(tt.cfg))
+			require.NoError(t, c.LoadConfigData(tt.cfg, EmptySourcePath))
 			require.Len(t, c.Inputs, 1)
 
 			// Create a mockup secretstore
@@ -302,7 +302,7 @@ func TestSecretUnquote(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := NewConfig()
-			require.NoError(t, c.LoadConfigData(tt.cfg))
+			require.NoError(t, c.LoadConfigData(tt.cfg, EmptySourcePath))
 			require.Len(t, c.Inputs, 1)
 
 			// Create a mockup secretstore
@@ -331,7 +331,7 @@ func TestSecretEnvironmentVariable(t *testing.T) {
 	t.Setenv("SOME_ENV_SECRET", "an env secret")
 
 	c := NewConfig()
-	err := c.LoadConfigData(cfg)
+	err := c.LoadConfigData(cfg, EmptySourcePath)
 	require.NoError(t, err)
 	require.Len(t, c.Inputs, 1)
 
@@ -364,7 +364,7 @@ func TestSecretCount(t *testing.T) {
 `)
 
 	c := NewConfig()
-	require.NoError(t, c.LoadConfigData(cfg))
+	require.NoError(t, c.LoadConfigData(cfg, EmptySourcePath))
 	require.Len(t, c.Inputs, 3)
 	require.Equal(t, int64(2), secretCount.Load())
 
@@ -390,7 +390,7 @@ func TestSecretStoreStatic(t *testing.T) {
 `)
 
 	c := NewConfig()
-	err := c.LoadConfigData(cfg)
+	err := c.LoadConfigData(cfg, EmptySourcePath)
 	require.NoError(t, err)
 	require.Len(t, c.Inputs, 4)
 
@@ -431,7 +431,7 @@ func TestSecretStoreInvalidKeys(t *testing.T) {
 `)
 
 	c := NewConfig()
-	err := c.LoadConfigData(cfg)
+	err := c.LoadConfigData(cfg, EmptySourcePath)
 	require.NoError(t, err)
 	require.Len(t, c.Inputs, 4)
 
@@ -469,7 +469,7 @@ func TestSecretStoreDeclarationMissingID(t *testing.T) {
 	cfg := []byte(`[[secretstores.mockup]]`)
 
 	c := NewConfig()
-	err := c.LoadConfigData(cfg)
+	err := c.LoadConfigData(cfg, EmptySourcePath)
 	require.ErrorContains(t, err, `error parsing mockup, "mockup" secret-store without ID`)
 }
 
@@ -485,7 +485,7 @@ func TestSecretStoreDeclarationInvalidID(t *testing.T) {
 		t.Run(id, func(t *testing.T) {
 			cfg := []byte(fmt.Sprintf(tmpl, id))
 			c := NewConfig()
-			err := c.LoadConfigData(cfg)
+			err := c.LoadConfigData(cfg, EmptySourcePath)
 			require.ErrorContains(t, err, `error parsing mockup, invalid secret-store ID`)
 		})
 	}
@@ -503,7 +503,7 @@ func TestSecretStoreDeclarationValidID(t *testing.T) {
 		t.Run(id, func(t *testing.T) {
 			cfg := []byte(fmt.Sprintf(tmpl, id))
 			c := NewConfig()
-			err := c.LoadConfigData(cfg)
+			err := c.LoadConfigData(cfg, EmptySourcePath)
 			require.NoError(t, err)
 		})
 	}
@@ -555,7 +555,7 @@ func (tsuite *SecretImplTestSuite) TestSecretStoreInvalidReference() {
 `)
 
 	c := NewConfig()
-	require.NoError(t, c.LoadConfigData(cfg))
+	require.NoError(t, c.LoadConfigData(cfg, EmptySourcePath))
 	require.Len(t, c.Inputs, 1)
 
 	// Create a mockup secretstore
@@ -585,7 +585,7 @@ func (tsuite *SecretImplTestSuite) TestSecretStoreStaticChanging() {
 `)
 
 	c := NewConfig()
-	err := c.LoadConfigData(cfg)
+	err := c.LoadConfigData(cfg, EmptySourcePath)
 	require.NoError(t, err)
 	require.Len(t, c.Inputs, 1)
 
@@ -627,7 +627,7 @@ func (tsuite *SecretImplTestSuite) TestSecretStoreDynamic() {
 `)
 
 	c := NewConfig()
-	err := c.LoadConfigData(cfg)
+	err := c.LoadConfigData(cfg, EmptySourcePath)
 	require.NoError(t, err)
 	require.Len(t, c.Inputs, 1)
 
@@ -661,7 +661,7 @@ func (tsuite *SecretImplTestSuite) TestSecretSet() {
 	    secret = "a secret"
 	`)
 	c := NewConfig()
-	require.NoError(t, c.LoadConfigData(cfg))
+	require.NoError(t, c.LoadConfigData(cfg, EmptySourcePath))
 	require.Len(t, c.Inputs, 1)
 	require.NoError(t, c.LinkSecrets())
 
@@ -686,7 +686,7 @@ func (tsuite *SecretImplTestSuite) TestSecretSetResolve() {
 	    secret = "@{mock:secret}"
 	`)
 	c := NewConfig()
-	require.NoError(t, c.LoadConfigData(cfg))
+	require.NoError(t, c.LoadConfigData(cfg, EmptySourcePath))
 	require.Len(t, c.Inputs, 1)
 
 	// Create a mockup secretstore
@@ -720,7 +720,7 @@ func (tsuite *SecretImplTestSuite) TestSecretSetResolveInvalid() {
 	    secret = "@{mock:secret}"
 	`)
 	c := NewConfig()
-	require.NoError(t, c.LoadConfigData(cfg))
+	require.NoError(t, c.LoadConfigData(cfg, EmptySourcePath))
 	require.Len(t, c.Inputs, 1)
 
 	// Create a mockup secretstore
@@ -757,7 +757,7 @@ func (tsuite *SecretImplTestSuite) TestSecretInvalidWarn() {
 	    secret = "server=a user=@{mock:secret-with-invalid-chars} pass=@{mock:secret_pass}"
 	`)
 	c := NewConfig()
-	require.NoError(t, c.LoadConfigData(cfg))
+	require.NoError(t, c.LoadConfigData(cfg, EmptySourcePath))
 	require.Len(t, c.Inputs, 1)
 
 	require.Contains(t, buf.String(), `W! Secret "@{mock:secret-with-invalid-chars}" contains invalid character(s)`)

--- a/config/types_test.go
+++ b/config/types_test.go
@@ -23,7 +23,7 @@ func TestConfigDuration(t *testing.T) {
   [[processors.reverse_dns.lookup]]
     field = "source_ip"
     dest = "source_name"
-`))
+`), config.EmptySourcePath)
 	require.NoError(t, err)
 	require.Len(t, c.Processors, 1)
 	p := c.Processors[0].Processor.(*reverse_dns.ReverseDNS)
@@ -121,7 +121,7 @@ func TestTOMLParsingStringDurations(t *testing.T) {
 
 	// Load the data
 	c := config.NewConfig()
-	err := c.LoadConfigData(cfg)
+	err := c.LoadConfigData(cfg, config.EmptySourcePath)
 	require.NoError(t, err)
 	require.Len(t, c.Inputs, 1)
 	plugin := c.Inputs[0].Input.(*MockupTypesPlugin)
@@ -151,7 +151,7 @@ func TestTOMLParsingIntegerDurations(t *testing.T) {
 
 	// Load the data
 	c := config.NewConfig()
-	err := c.LoadConfigData(cfg)
+	err := c.LoadConfigData(cfg, config.EmptySourcePath)
 	require.NoError(t, err)
 	require.Len(t, c.Inputs, 1)
 	plugin := c.Inputs[0].Input.(*MockupTypesPlugin)
@@ -179,7 +179,7 @@ func TestTOMLParsingFloatDurations(t *testing.T) {
 
 	// Load the data
 	c := config.NewConfig()
-	err := c.LoadConfigData(cfg)
+	err := c.LoadConfigData(cfg, config.EmptySourcePath)
 	require.NoError(t, err)
 	require.Len(t, c.Inputs, 1)
 	plugin := c.Inputs[0].Input.(*MockupTypesPlugin)
@@ -217,7 +217,7 @@ func TestTOMLParsingStringSizes(t *testing.T) {
 
 	// Load the data
 	c := config.NewConfig()
-	err := c.LoadConfigData(cfg)
+	err := c.LoadConfigData(cfg, config.EmptySourcePath)
 	require.NoError(t, err)
 	require.Len(t, c.Inputs, 1)
 	plugin := c.Inputs[0].Input.(*MockupTypesPlugin)
@@ -249,7 +249,7 @@ func TestTOMLParsingIntegerSizes(t *testing.T) {
 
 	// Load the data
 	c := config.NewConfig()
-	err := c.LoadConfigData(cfg)
+	err := c.LoadConfigData(cfg, config.EmptySourcePath)
 	require.NoError(t, err)
 	require.Len(t, c.Inputs, 1)
 	plugin := c.Inputs[0].Input.(*MockupTypesPlugin)

--- a/docs/LICENSE_OF_DEPENDENCIES.md
+++ b/docs/LICENSE_OF_DEPENDENCIES.md
@@ -458,6 +458,9 @@ following works:
 - sigs.k8s.io/json [Apache License 2.0](https://github.com/kubernetes/client-go/blob/master/LICENSE)
 - sigs.k8s.io/structured-merge-diff [Apache License 2.0](https://github.com/kubernetes/client-go/blob/master/LICENSE)
 - sigs.k8s.io/yaml [Apache License 2.0](https://github.com/kubernetes/client-go/blob/master/LICENSE)
+- github.com/jedib0t/go-pretty [MIT License](https://github.com/jedib0t/go-pretty/blob/main/LICENSE)
+- github.com/mattn/go-runewidth [MIT License](https://github.com/mattn/go-runewidth/blob/master/LICENSE)
+- github.com/rivo/uniseg [MIT License](https://github.com/rivo/uniseg/blob/master/LICENSE.txt)
 
 ## Telegraf used and modified code from these projects
 

--- a/docs/LICENSE_OF_DEPENDENCIES.md
+++ b/docs/LICENSE_OF_DEPENDENCIES.md
@@ -236,6 +236,7 @@ following works:
 - github.com/jcmturner/goidentity [Apache License 2.0](https://github.com/jcmturner/goidentity/blob/master/LICENSE)
 - github.com/jcmturner/gokrb5 [Apache License 2.0](https://github.com/jcmturner/gokrb5/blob/master/LICENSE)
 - github.com/jcmturner/rpc [Apache License 2.0](https://github.com/jcmturner/rpc/blob/master/LICENSE)
+- github.com/jedib0t/go-pretty [MIT License](https://github.com/jedib0t/go-pretty/blob/main/LICENSE)
 - github.com/jeremywohl/flatten [MIT License](https://github.com/jeremywohl/flatten/blob/master/LICENSE)
 - github.com/jhump/protoreflect [Apache License 2.0](https://github.com/jhump/protoreflect/blob/master/LICENSE)
 - github.com/jmespath/go-jmespath [Apache License 2.0](https://github.com/jmespath/go-jmespath/blob/master/LICENSE)
@@ -262,6 +263,7 @@ following works:
 - github.com/mattn/go-colorable [MIT License](https://github.com/mattn/go-colorable/blob/master/LICENSE)
 - github.com/mattn/go-ieproxy [MIT License](https://github.com/mattn/go-ieproxy/blob/master/LICENSE)
 - github.com/mattn/go-isatty [MIT License](https://github.com/mattn/go-isatty/blob/master/LICENSE)
+- github.com/mattn/go-runewidth [MIT License](https://github.com/mattn/go-runewidth/blob/master/LICENSE)
 - github.com/mdlayher/apcupsd [MIT License](https://github.com/mdlayher/apcupsd/blob/master/LICENSE.md)
 - github.com/mdlayher/genetlink [MIT License](https://github.com/mdlayher/genetlink/blob/master/LICENSE.md)
 - github.com/mdlayher/netlink [MIT License](https://github.com/mdlayher/netlink/blob/master/LICENSE.md)
@@ -336,6 +338,7 @@ following works:
 - github.com/remyoudompheng/bigfft [BSD 3-Clause "New" or "Revised" License](https://github.com/remyoudompheng/bigfft/blob/master/LICENSE)
 - github.com/rfjakob/eme [MIT License](https://github.com/rfjakob/eme/blob/master/LICENSE)
 - github.com/riemann/riemann-go-client [MIT License](https://github.com/riemann/riemann-go-client/blob/master/LICENSE)
+- github.com/rivo/uniseg [MIT License](https://github.com/rivo/uniseg/blob/master/LICENSE.txt)
 - github.com/robbiet480/go.nut [MIT License](https://github.com/robbiet480/go.nut/blob/master/LICENSE)
 - github.com/robinson/gos7 [BSD 3-Clause "New" or "Revised" License](https://github.com/robinson/gos7/blob/master/LICENSE)
 - github.com/russross/blackfriday [BSD 2-Clause "Simplified" License](https://github.com/russross/blackfriday/blob/master/LICENSE.txt)
@@ -458,9 +461,6 @@ following works:
 - sigs.k8s.io/json [Apache License 2.0](https://github.com/kubernetes/client-go/blob/master/LICENSE)
 - sigs.k8s.io/structured-merge-diff [Apache License 2.0](https://github.com/kubernetes/client-go/blob/master/LICENSE)
 - sigs.k8s.io/yaml [Apache License 2.0](https://github.com/kubernetes/client-go/blob/master/LICENSE)
-- github.com/jedib0t/go-pretty [MIT License](https://github.com/jedib0t/go-pretty/blob/main/LICENSE)
-- github.com/mattn/go-runewidth [MIT License](https://github.com/mattn/go-runewidth/blob/master/LICENSE)
-- github.com/rivo/uniseg [MIT License](https://github.com/rivo/uniseg/blob/master/LICENSE.txt)
 
 ## Telegraf used and modified code from these projects
 

--- a/go.mod
+++ b/go.mod
@@ -124,6 +124,7 @@ require (
 	github.com/jackc/pgio v1.0.0
 	github.com/jackc/pgtype v1.14.4
 	github.com/jackc/pgx/v4 v4.18.3
+	github.com/jedib0t/go-pretty/v6 v6.6.5
 	github.com/jeremywohl/flatten/v2 v2.0.0-20211013061545-07e4a09fb8e4
 	github.com/jhump/protoreflect v1.16.0
 	github.com/jmespath/go-jmespath v0.4.0
@@ -391,7 +392,6 @@ require (
 	github.com/jcmturner/goidentity/v6 v6.0.1 // indirect
 	github.com/jcmturner/gokrb5/v8 v8.4.4 // indirect
 	github.com/jcmturner/rpc/v2 v2.0.3 // indirect
-	github.com/jedib0t/go-pretty/v6 v6.6.5
 	github.com/jmhodges/clock v1.2.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/josharian/native v1.1.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -237,11 +237,6 @@ require (
 )
 
 require (
-	github.com/mattn/go-runewidth v0.0.16 // indirect
-	github.com/rivo/uniseg v0.4.7 // indirect
-)
-
-require (
 	cel.dev/expr v0.16.1 // indirect
 	cloud.google.com/go v0.116.0 // indirect
 	cloud.google.com/go/auth v0.11.0 // indirect
@@ -414,6 +409,7 @@ require (
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-ieproxy v0.0.11 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
+	github.com/mattn/go-runewidth v0.0.16 // indirect
 	github.com/mdlayher/genetlink v1.2.0 // indirect
 	github.com/mdlayher/netlink v1.7.2 // indirect
 	github.com/mdlayher/socket v0.5.1 // indirect
@@ -461,6 +457,7 @@ require (
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/rfjakob/eme v1.1.2 // indirect
+	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/robertkrimen/otto v0.0.0-20191219234010-c382bd3c16ff // indirect
 	github.com/robfig/cron/v3 v3.0.1 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -237,6 +237,11 @@ require (
 )
 
 require (
+	github.com/mattn/go-runewidth v0.0.16 // indirect
+	github.com/rivo/uniseg v0.4.7 // indirect
+)
+
+require (
 	cel.dev/expr v0.16.1 // indirect
 	cloud.google.com/go v0.116.0 // indirect
 	cloud.google.com/go/auth v0.11.0 // indirect
@@ -391,6 +396,7 @@ require (
 	github.com/jcmturner/goidentity/v6 v6.0.1 // indirect
 	github.com/jcmturner/gokrb5/v8 v8.4.4 // indirect
 	github.com/jcmturner/rpc/v2 v2.0.3 // indirect
+	github.com/jedib0t/go-pretty/v6 v6.6.5
 	github.com/jmhodges/clock v1.2.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/josharian/native v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1686,6 +1686,8 @@ github.com/jcmturner/gokrb5/v8 v8.4.4 h1:x1Sv4HaTpepFkXbt2IkL29DXRf8sOfZXo8eRKh6
 github.com/jcmturner/gokrb5/v8 v8.4.4/go.mod h1:1btQEpgT6k+unzCwX1KdWMEwPPkkgBtP+F6aCACiMrs=
 github.com/jcmturner/rpc/v2 v2.0.3 h1:7FXXj8Ti1IaVFpSAziCZWNzbNuZmnvw/i6CqLNdWfZY=
 github.com/jcmturner/rpc/v2 v2.0.3/go.mod h1:VUJYCIDm3PVOEHw8sgt091/20OJjskO/YJki3ELg/Hc=
+github.com/jedib0t/go-pretty/v6 v6.6.5 h1:9PgMJOVBedpgYLI56jQRJYqngxYAAzfEUua+3NgSqAo=
+github.com/jedib0t/go-pretty/v6 v6.6.5/go.mod h1:Uq/HrbhuFty5WSVNfjpQQe47x16RwVGXIveNGEyGtHs=
 github.com/jeremija/gosubmit v0.2.7 h1:At0OhGCFGPXyjPYAsCchoBUhE099pcBXmsb4iZqROIc=
 github.com/jeremija/gosubmit v0.2.7/go.mod h1:Ui+HS073lCFREXBbdfrJzMB57OI/bdxTiLtrDHHhFPI=
 github.com/jeremywohl/flatten/v2 v2.0.0-20211013061545-07e4a09fb8e4 h1:eA9wi6ZzpIRobvXkn/S2Lyw1hr2pc71zxzOPl7Xjs4w=
@@ -1845,6 +1847,8 @@ github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27k
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/mattn/go-runewidth v0.0.16 h1:E5ScNMtiwvlvB5paMFdw9p4kSQzbXFikJ5SQO6TULQc=
+github.com/mattn/go-runewidth v0.0.16/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/mattn/go-sqlite3 v1.9.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/mattn/go-sqlite3 v1.14.14/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
@@ -2173,6 +2177,9 @@ github.com/rfjakob/eme v1.1.2 h1:SxziR8msSOElPayZNFfQw4Tjx/Sbaeeh3eRvrHVMUs4=
 github.com/rfjakob/eme v1.1.2/go.mod h1:cVvpasglm/G3ngEfcfT/Wt0GwhkuO32pf/poW6Nyk1k=
 github.com/riemann/riemann-go-client v0.5.1-0.20211206220514-f58f10cdce16 h1:bGXoxRwUpPTCaQ86DRE+3wqE9vh3aH8W0HH5L/ygOFM=
 github.com/riemann/riemann-go-client v0.5.1-0.20211206220514-f58f10cdce16/go.mod h1:4rS0vfmzOMwfFPhi6Zve4k/59TsBepqd6WESNULE0ho=
+github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
+github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
+github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/robbiet480/go.nut v0.0.0-20220219091450-bd8f121e1fa1 h1:YmFqprZILGlF/X3tvMA4Rwn3ySxyE3hGUajBHkkaZbM=
 github.com/robbiet480/go.nut v0.0.0-20220219091450-bd8f121e1fa1/go.mod h1:pL1huxuIlWub46MsMVJg4p7OXkzbPp/APxh9IH0eJjQ=
 github.com/robertkrimen/otto v0.0.0-20191219234010-c382bd3c16ff h1:+6NUiITWwE5q1KO6SAfUX918c+Tab0+tGAM/mtdlUyA=

--- a/migrations/general_metricfilter/migration_test.go
+++ b/migrations/general_metricfilter/migration_test.go
@@ -67,7 +67,7 @@ func TestCases(t *testing.T) {
 			require.NotEmpty(t, output)
 			require.GreaterOrEqual(t, n, uint64(1))
 			actual := config.NewConfig()
-			require.NoError(t, actual.LoadConfigData(output))
+			require.NoError(t, actual.LoadConfigData(output, config.EmptySourcePath))
 
 			// Test the output
 			require.Len(t, actual.Inputs, len(expected.Inputs))

--- a/migrations/global_agent/migration_test.go
+++ b/migrations/global_agent/migration_test.go
@@ -24,7 +24,7 @@ func TestNoMigration(t *testing.T) {
 	expectedBuffer, err := os.ReadFile(fn)
 	require.NoError(t, err)
 	expected := config.NewConfig()
-	require.NoError(t, expected.LoadConfigData(expectedBuffer))
+	require.NoError(t, expected.LoadConfigData(expectedBuffer, config.EmptySourcePath))
 	require.NotNil(t, expected.Agent)
 
 	// Migrate
@@ -34,7 +34,7 @@ func TestNoMigration(t *testing.T) {
 	require.Zero(t, n)
 
 	actual := config.NewConfig()
-	require.NoError(t, actual.LoadConfigData(output))
+	require.NoError(t, actual.LoadConfigData(output, config.EmptySourcePath))
 	require.NotNil(t, actual.Agent)
 
 	// Test the output
@@ -90,7 +90,7 @@ func TestCases(t *testing.T) {
 			require.NotEmpty(t, output)
 			require.Positive(t, n, "expected migration application but none applied")
 			actual := config.NewConfig()
-			require.NoError(t, actual.LoadConfigData(output))
+			require.NoError(t, actual.LoadConfigData(output, config.EmptySourcePath))
 			require.NotNil(t, actual.Agent)
 
 			// Test the output

--- a/migrations/inputs_cassandra/migration_test.go
+++ b/migrations/inputs_cassandra/migration_test.go
@@ -45,7 +45,7 @@ func TestCases(t *testing.T) {
 			require.NotEmpty(t, output)
 			require.GreaterOrEqual(t, n, uint64(1))
 			actual := config.NewConfig()
-			require.NoError(t, actual.LoadConfigData(output))
+			require.NoError(t, actual.LoadConfigData(output, config.EmptySourcePath))
 
 			// Test the output
 			require.Len(t, actual.Inputs, len(expected.Inputs))

--- a/migrations/inputs_disk/migration_test.go
+++ b/migrations/inputs_disk/migration_test.go
@@ -70,7 +70,7 @@ func TestCases(t *testing.T) {
 			require.NotEmpty(t, output)
 			require.GreaterOrEqual(t, n, uint64(1))
 			actual := config.NewConfig()
-			require.NoError(t, actual.LoadConfigData(output))
+			require.NoError(t, actual.LoadConfigData(output, config.EmptySourcePath))
 
 			// Test the output
 			require.Len(t, actual.Inputs, len(expected.Inputs))

--- a/migrations/inputs_gnmi/migration_test.go
+++ b/migrations/inputs_gnmi/migration_test.go
@@ -57,7 +57,7 @@ func TestCases(t *testing.T) {
 			require.NotEmpty(t, output)
 			require.GreaterOrEqual(t, n, uint64(1))
 			actual := config.NewConfig()
-			require.NoError(t, actual.LoadConfigData(output))
+			require.NoError(t, actual.LoadConfigData(output, config.EmptySourcePath))
 
 			// Test the output
 			require.Len(t, actual.Inputs, len(expected.Inputs))

--- a/migrations/inputs_httpjson/migration_test.go
+++ b/migrations/inputs_httpjson/migration_test.go
@@ -53,7 +53,7 @@ func TestCases(t *testing.T) {
 			require.NotEmpty(t, output)
 			require.GreaterOrEqual(t, n, uint64(1))
 			actual := config.NewConfig()
-			require.NoError(t, actual.LoadConfigData(output))
+			require.NoError(t, actual.LoadConfigData(output, config.EmptySourcePath))
 
 			// Test the output
 			require.Len(t, actual.Inputs, len(expected.Inputs))

--- a/migrations/inputs_io/migration_test.go
+++ b/migrations/inputs_io/migration_test.go
@@ -45,7 +45,7 @@ func TestCases(t *testing.T) {
 			require.NotEmpty(t, output)
 			require.GreaterOrEqual(t, n, uint64(1))
 			actual := config.NewConfig()
-			require.NoError(t, actual.LoadConfigData(output))
+			require.NoError(t, actual.LoadConfigData(output, config.EmptySourcePath))
 
 			// Test the output
 			require.Len(t, actual.Inputs, len(expected.Inputs))

--- a/migrations/inputs_jolokia/migration_test.go
+++ b/migrations/inputs_jolokia/migration_test.go
@@ -46,7 +46,7 @@ func TestCases(t *testing.T) {
 			require.NotEmpty(t, output)
 			require.GreaterOrEqual(t, n, uint64(1))
 			actual := config.NewConfig()
-			require.NoError(t, actual.LoadConfigData(output))
+			require.NoError(t, actual.LoadConfigData(output, config.EmptySourcePath))
 
 			// Test the output
 			require.Len(t, actual.Inputs, len(expected.Inputs))

--- a/migrations/inputs_mqtt_consumer/migration_test.go
+++ b/migrations/inputs_mqtt_consumer/migration_test.go
@@ -145,7 +145,7 @@ func TestCases(t *testing.T) {
 			require.NotEmpty(t, output)
 			require.GreaterOrEqual(t, n, uint64(1))
 			actual := config.NewConfig()
-			require.NoError(t, actual.LoadConfigData(output))
+			require.NoError(t, actual.LoadConfigData(output, config.EmptySourcePath))
 
 			// Test the output
 			require.Len(t, actual.Inputs, len(expected.Inputs))

--- a/migrations/inputs_nats_consumer/migration_test.go
+++ b/migrations/inputs_nats_consumer/migration_test.go
@@ -119,7 +119,7 @@ func TestCases(t *testing.T) {
 			require.NotEmpty(t, output)
 			require.GreaterOrEqual(t, n, uint64(1))
 			actual := config.NewConfig()
-			require.NoError(t, actual.LoadConfigData(output))
+			require.NoError(t, actual.LoadConfigData(output, config.EmptySourcePath))
 
 			// Test the output
 			require.Len(t, actual.Inputs, len(expected.Inputs))

--- a/migrations/inputs_procstat/migration_test.go
+++ b/migrations/inputs_procstat/migration_test.go
@@ -57,7 +57,7 @@ func TestCases(t *testing.T) {
 			require.NotEmpty(t, output)
 			require.GreaterOrEqual(t, n, uint64(1))
 			actual := config.NewConfig()
-			require.NoError(t, actual.LoadConfigData(output))
+			require.NoError(t, actual.LoadConfigData(output, config.EmptySourcePath))
 
 			// Test the output
 			require.Len(t, actual.Inputs, len(expected.Inputs))

--- a/migrations/inputs_sflow/migration_test.go
+++ b/migrations/inputs_sflow/migration_test.go
@@ -46,7 +46,7 @@ func TestCases(t *testing.T) {
 			require.NotEmpty(t, output)
 			require.GreaterOrEqual(t, n, uint64(1))
 			actual := config.NewConfig()
-			require.NoError(t, actual.LoadConfigData(output))
+			require.NoError(t, actual.LoadConfigData(output, config.EmptySourcePath))
 
 			// Test the output
 			require.Len(t, actual.Inputs, len(expected.Inputs))

--- a/migrations/inputs_tcp_listener/migration_test.go
+++ b/migrations/inputs_tcp_listener/migration_test.go
@@ -46,7 +46,7 @@ func TestCases(t *testing.T) {
 			require.NotEmpty(t, output)
 			require.GreaterOrEqual(t, n, uint64(1))
 			actual := config.NewConfig()
-			require.NoError(t, actual.LoadConfigData(output))
+			require.NoError(t, actual.LoadConfigData(output, config.EmptySourcePath))
 
 			// Test the output
 			require.Len(t, actual.Inputs, len(expected.Inputs))

--- a/migrations/inputs_udp_listener/migration_test.go
+++ b/migrations/inputs_udp_listener/migration_test.go
@@ -46,7 +46,7 @@ func TestCases(t *testing.T) {
 			require.NotEmpty(t, output)
 			require.GreaterOrEqual(t, n, uint64(1))
 			actual := config.NewConfig()
-			require.NoError(t, actual.LoadConfigData(output))
+			require.NoError(t, actual.LoadConfigData(output, config.EmptySourcePath))
 
 			// Test the output
 			require.Len(t, actual.Inputs, len(expected.Inputs))

--- a/migrations/outputs_influxdb/migration_test.go
+++ b/migrations/outputs_influxdb/migration_test.go
@@ -57,7 +57,7 @@ func TestCases(t *testing.T) {
 			require.NotEmpty(t, output)
 			require.GreaterOrEqual(t, n, uint64(1))
 			actual := config.NewConfig()
-			require.NoError(t, actual.LoadConfigData(output))
+			require.NoError(t, actual.LoadConfigData(output, config.EmptySourcePath))
 
 			// Test the output
 			require.Len(t, actual.Outputs, len(expected.Outputs))

--- a/migrations/outputs_riemann_legacy/migration_test.go
+++ b/migrations/outputs_riemann_legacy/migration_test.go
@@ -45,7 +45,7 @@ func TestCases(t *testing.T) {
 			require.NotEmpty(t, output)
 			require.GreaterOrEqual(t, n, uint64(1))
 			actual := config.NewConfig()
-			require.NoError(t, actual.LoadConfigData(output))
+			require.NoError(t, actual.LoadConfigData(output, config.EmptySourcePath))
 
 			// Test the output
 			require.Len(t, actual.Outputs, len(expected.Outputs))

--- a/models/running_aggregator.go
+++ b/models/running_aggregator.go
@@ -70,6 +70,7 @@ func NewRunningAggregator(aggregator telegraf.Aggregator, config *AggregatorConf
 // AggregatorConfig is the common config for all aggregators.
 type AggregatorConfig struct {
 	Name         string
+	Source       string
 	Alias        string
 	ID           string
 	DropOriginal bool

--- a/models/running_input.go
+++ b/models/running_input.go
@@ -83,6 +83,7 @@ func NewRunningInput(input telegraf.Input, config *InputConfig) *RunningInput {
 // InputConfig is the common config for all inputs.
 type InputConfig struct {
 	Name                 string
+	Source               string
 	Alias                string
 	ID                   string
 	Interval             time.Duration

--- a/models/running_output.go
+++ b/models/running_output.go
@@ -24,6 +24,7 @@ const (
 // OutputConfig containing name and filter
 type OutputConfig struct {
 	Name                 string
+	Source               string
 	Alias                string
 	ID                   string
 	StartupErrorBehavior string

--- a/models/running_processor.go
+++ b/models/running_processor.go
@@ -24,6 +24,7 @@ func (rp RunningProcessors) Less(i, j int) bool { return rp[i].Config.Order < rp
 // ProcessorConfig containing a name and filter
 type ProcessorConfig struct {
 	Name     string
+	Source   string
 	Alias    string
 	ID       string
 	Order    int64

--- a/plugins/inputs/exec/exec_test.go
+++ b/plugins/inputs/exec/exec_test.go
@@ -417,7 +417,7 @@ func TestCases(t *testing.T) {
 	commands = [ "echo \"a,b\n1,2\n3,4\"" ]
 	data_format = "csv"
 	csv_header_row_count = 1
-`)))
+`), config.EmptySourcePath))
 	require.Len(t, cfg.Inputs, 1)
 	plugin := cfg.Inputs[0]
 	require.NoError(t, plugin.Init())

--- a/plugins/inputs/execd/execd_test.go
+++ b/plugins/inputs/execd/execd_test.go
@@ -32,7 +32,7 @@ func TestSettingConfigWorks(t *testing.T) {
 		signal = "SIGHUP"
 	`
 	conf := config.NewConfig()
-	require.NoError(t, conf.LoadConfigData([]byte(cfg)))
+	require.NoError(t, conf.LoadConfigData([]byte(cfg), config.EmptySourcePath))
 
 	require.Len(t, conf.Inputs, 1)
 	inp, ok := conf.Inputs[0].Input.(*Execd)

--- a/plugins/inputs/opcua/opcua_test.go
+++ b/plugins/inputs/opcua/opcua_test.go
@@ -361,7 +361,7 @@ use_unregistered_reads = true
 `
 
 	c := config.NewConfig()
-	err := c.LoadConfigData([]byte(toml))
+	err := c.LoadConfigData([]byte(toml), config.EmptySourcePath)
 	require.NoError(t, err)
 
 	require.Len(t, c.Inputs, 1)

--- a/plugins/inputs/opcua_listener/opcua_listener_test.go
+++ b/plugins/inputs/opcua_listener/opcua_listener_test.go
@@ -426,7 +426,7 @@ additional_valid_status_codes = ["0xC0"]
 `
 
 	c := config.NewConfig()
-	err := c.LoadConfigData([]byte(toml))
+	err := c.LoadConfigData([]byte(toml), config.EmptySourcePath)
 	require.NoError(t, err)
 
 	require.Len(t, c.Inputs, 1)
@@ -515,7 +515,7 @@ deadband_value = 100.0
 `
 
 	c := config.NewConfig()
-	err := c.LoadConfigData([]byte(toml))
+	err := c.LoadConfigData([]byte(toml), config.EmptySourcePath)
 	require.NoError(t, err)
 
 	require.Len(t, c.Inputs, 1)

--- a/plugins/outputs/sumologic/sumologic_test.go
+++ b/plugins/outputs/sumologic/sumologic_test.go
@@ -489,9 +489,9 @@ func TestTOMLConfig(t *testing.T) {
 			c := config.NewConfig()
 
 			if tt.expectedError {
-				require.Error(t, c.LoadConfigData(tt.configBytes))
+				require.Error(t, c.LoadConfigData(tt.configBytes, config.EmptySourcePath))
 			} else {
-				require.NoError(t, c.LoadConfigData(tt.configBytes))
+				require.NoError(t, c.LoadConfigData(tt.configBytes, config.EmptySourcePath))
 			}
 		})
 	}

--- a/plugins/processors/snmp_lookup/lookup_test.go
+++ b/plugins/processors/snmp_lookup/lookup_test.go
@@ -6,15 +6,15 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gosnmp/gosnmp"
+	"github.com/stretchr/testify/require"
+
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/internal/snmp"
 	"github.com/influxdata/telegraf/metric"
 	"github.com/influxdata/telegraf/plugins/processors"
 	"github.com/influxdata/telegraf/testutil"
-
-	"github.com/gosnmp/gosnmp"
-	"github.com/stretchr/testify/require"
 )
 
 type testSNMPConnection struct {
@@ -60,7 +60,7 @@ func TestRegistry(t *testing.T) {
 func TestSampleConfig(t *testing.T) {
 	cfg := config.NewConfig()
 
-	require.NoError(t, cfg.LoadConfigData(testutil.DefaultSampleConfig((&Lookup{}).SampleConfig())))
+	require.NoError(t, cfg.LoadConfigData(testutil.DefaultSampleConfig((&Lookup{}).SampleConfig()), config.EmptySourcePath))
 }
 
 func TestInit(t *testing.T) {

--- a/plugins/processors/starlark/starlark_test.go
+++ b/plugins/processors/starlark/starlark_test.go
@@ -2647,7 +2647,7 @@ def apply(metric):
 // Build a Starlark plugin from the provided configuration.
 func buildPlugin(configContent string) (*Starlark, error) {
 	c := config.NewConfig()
-	err := c.LoadConfigData([]byte(configContent))
+	err := c.LoadConfigData([]byte(configContent), config.EmptySourcePath)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

Print the source information for the plugins.

Put this feature behind a flag to preserve backward compatibility in systems relying on Loaded inputs, Outputs strings for validations. 
Flag introduced: `--print-plugin-config-source` Default: false

If required, we can eliminate this flag.

Sample output on telegraf init
```console
2024-12-06T19:05:36Z I! Loaded inputs: cpu disk (2x) internal interrupts mem (2x) net (3x)
+--------------+------------------------------------------------------+
| Name         | Source(s)                                            |
+--------------+------------------------------------------------------+
| net (3x)     | /Users/user-of-unix/telegraf/configs1/config3.conf   |
|              | /Users/user-of-unix/telegraf/configs1/config1.conf   |
|              | /Users/user-of-unix/telegraf/configs1/config2.conf   |
+--------------+------------------------------------------------------+
| disk (2x)    | /Users/user-of-unix/telegraf/configs1/config2.conf   |
|              | /Users/user-of-unix/telegraf/configs1/config2.conf   |
+--------------+------------------------------------------------------+
| mem (2x)     | /Users/user-of-unix/telegraf/configs1/config4.conf   |
|              | /Users/user-of-unix/telegraf/configs1/config2.conf   |
+--------------+------------------------------------------------------+
| internal     | /Users/user-of-unix/telegraf/configs1/config2.conf   |
+--------------+------------------------------------------------------+
| interrupts   | /Users/user-of-unix/telegraf/configs1/config2.conf   |
+--------------+------------------------------------------------------+
| cpu          | /Users/user-of-unix/telegraf/configs1/config5.conf   |
+--------------+------------------------------------------------------+
```


## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #16269
