### PR TITLE
feat(parsers.avro): Allow union fields to be specified as tags

### DIFF
--- a/plugins/parsers/avro/testcases/union-nullable-tag/expected.out
+++ b/plugins/parsers/avro/testcases/union-nullable-tag/expected.out
@@ -1,0 +1,1 @@
+Switch,switch_wwn=10:00:50:EB:1A:0B:84:3A,some_union_in_a_tag=some_value statistics_collection_time=1682509200092i,up_time=1166984904i,memory_utilization=20.0 1682509200092000

--- a/plugins/parsers/avro/testcases/union-nullable-tag/message.json
+++ b/plugins/parsers/avro/testcases/union-nullable-tag/message.json
@@ -1,0 +1,14 @@
+{
+    "some_union_in_a_tag": {
+      "string": "some_value"
+    },
+    "switch_wwn": "10:00:50:EB:1A:0B:84:3A",
+    "statistics_collection_time": 1682509200092,
+    "up_time": 1166984904,
+    "cpu_utilization": {
+      "null": null
+    },
+    "memory_utilization": {
+      "float": 20.0
+    }
+}

--- a/plugins/parsers/avro/testcases/union-nullable-tag/telegraf.conf
+++ b/plugins/parsers/avro/testcases/union-nullable-tag/telegraf.conf
@@ -1,0 +1,27 @@
+[[ inputs.file ]]
+  files = ["./testcases/union-nullable-tag/message.json"]
+  data_format = "avro"
+
+  avro_format = "json"
+  avro_measurement = "Switch"
+  avro_tags = ["switch_wwn", "some_union_in_a_tag"]
+  avro_fields = ["up_time", "cpu_utilization", "memory_utilization", "statistics_collection_time"]
+  avro_timestamp = "statistics_collection_time"
+  avro_timestamp_format = "unix_ms"
+  avro_union_mode = "nullable"
+  avro_schema = '''
+        {
+                "namespace": "com.brocade.streaming",
+                "name": "fibrechannel_switch_statistics",
+                "type": "record",
+                "version": "1",
+                "fields": [
+                        {"name": "some_union_in_a_tag", "type": ["null", "string"], "default": null, "doc": "Some union that is used in a tag"},
+                        {"name": "switch_wwn", "type": "string", "doc": "WWN of the Physical Switch."},
+                        {"name": "statistics_collection_time", "type": "long", "doc": "Epoch time when statistics is collected."},
+                        {"name": "up_time", "type": "long", "doc": "Switch Up Time (in hundredths of a second)"},
+                        {"name": "cpu_utilization", "type": ["null","float"], "default": null, "doc": "CPU Utilization in %"},
+                        {"name": "memory_utilization", "type": ["null", "float"], "default": null, "doc": "Memory Utilization in %"}
+                ]
+        }
+  '''


### PR DESCRIPTION
## Summary

Flatten any fields specified in `avro_tags` before trying to convert their values to strings.

Without flattening, any union fields included in `avro_tags` do not actually get converted into Influx tags. This warning is logged:
```2024-12-06T19:43:12Z W! [parsers.avro::file] Could not convert map[string:some_value] to string for tag "some_union_in_a_tag": type "map[string]interface {}" unsupported```

## Checklist

- [x ] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #16271 
