### PR TITLE
fix(logging): Fix deplicated prefix+attrMsg in log message when redirectLogger is used

### DIFF
--- a/logger/handler.go
+++ b/logger/handler.go
@@ -122,7 +122,7 @@ func (l *redirectLogger) Print(level telegraf.LogLevel, ts time.Time, prefix str
 		attrMsg = "(" + strings.Join(parts, ",") + ")"
 	}
 
-	msg := []interface{}{ts.In(time.UTC).Format(time.RFC3339), level.Indicator(), prefix + attrMsg}
+	msg := []interface{}{ts.In(time.UTC).Format(time.RFC3339), level.Indicator()}
 	if prefix+attrMsg != "" {
 		msg = append(msg, prefix+attrMsg)
 	}


### PR DESCRIPTION

## Summary
This PR fixes a small regression issue I introduced in my previous PR #16255 which adds the `prefix + attrMsg` to the log message twice by mistake. 

The are added to the log message in [line 127](https://github.com/influxdata/telegraf/blob/master/logger/handler.go#L127) so it should not be added again in [line 125](https://github.com/influxdata/telegraf/blob/master/logger/handler.go#L125).

This PR removes the duplicated one.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [X] No AI generated code was used in this PR

## Related issues


resolves #16273
