### PR TITLE
feat(inputs.systemd_units): Add active_enter_timestamp_us field

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -89,7 +89,6 @@ require (
 	github.com/go-sql-driver/mysql v1.8.1
 	github.com/go-stomp/stomp v2.1.4+incompatible
 	github.com/gobwas/glob v0.2.3
-	github.com/godbus/dbus/v5 v5.1.0
 	github.com/gofrs/uuid/v5 v5.3.0
 	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/golang/geo v0.0.0-20190916061304-5b978397cfec
@@ -348,6 +347,7 @@ require (
 	github.com/goburrow/serial v0.1.1-0.20211022031912-bfb69110f8dd // indirect
 	github.com/goccy/go-json v0.10.3 // indirect
 	github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2 // indirect
+	github.com/godbus/dbus/v5 v5.1.0 // indirect
 	github.com/gofrs/uuid v4.4.0+incompatible // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v4 v4.5.1 // indirect

--- a/plugins/inputs/systemd_units/README.md
+++ b/plugins/inputs/systemd_units/README.md
@@ -94,6 +94,7 @@ The following *additional* metrics are available with `details = true`:
     - swap_current (uint, current swap usage)
     - swap_peak (uint, peak swap usage)
     - mem_avail (uint, available memory for this unit)
+    - active_enter_timestamp_us (uint, timestamp in us when entered the state)
 
 ### Load
 


### PR DESCRIPTION
## Summary

Add timestamp when a unit entered the current state.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #15944 
