### PR TITLE
fix(agent): Skip initialization of second processor state if requested

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -231,10 +231,12 @@ func (a *Agent) InitPlugins() error {
 			return fmt.Errorf("could not initialize aggregator %s: %w", aggregator.LogName(), err)
 		}
 	}
-	for _, processor := range a.Config.AggProcessors {
-		err := processor.Init()
-		if err != nil {
-			return fmt.Errorf("could not initialize processor %s: %w", processor.LogName(), err)
+	if !a.Config.Agent.SkipProcessorsAfterAggregators {
+		for _, processor := range a.Config.AggProcessors {
+			err := processor.Init()
+			if err != nil {
+				return fmt.Errorf("could not initialize processor %s: %w", processor.LogName(), err)
+			}
 		}
 	}
 	for _, output := range a.Config.Outputs {


### PR DESCRIPTION
## Summary

Currently, the telegraf agent does initialize the processors in the processor stage after the aggregators even if `skip_processors_after_aggregators` is set to `true`. While the processors are not executed, initializing them is confusing and unnecessary.

This PR skips the initialization of the second processor stage if the user intends to skip them anyway.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #16143 
