### PR TITLE
feat(inputs.docker): Support swarm jobs

### DIFF
--- a/plugins/inputs/docker/docker.go
+++ b/plugins/inputs/docker/docker.go
@@ -309,6 +309,18 @@ func (d *Docker) gatherSwarmInfo(acc telegraf.Accumulator) error {
 				tags["service_mode"] = "global"
 				fields["tasks_running"] = running[service.ID]
 				fields["tasks_desired"] = tasksNoShutdown[service.ID]
+			} else if service.Spec.Mode.ReplicatedJob != nil {
+				tags["service_mode"] = "replicated_job"
+				fields["tasks_running"] = running[service.ID]
+				if service.Spec.Mode.ReplicatedJob.MaxConcurrent != nil {
+					fields["max_concurrent"] = *service.Spec.Mode.ReplicatedJob.MaxConcurrent
+				}
+				if service.Spec.Mode.ReplicatedJob.TotalCompletions != nil {
+					fields["total_completions"] = *service.Spec.Mode.ReplicatedJob.TotalCompletions
+				}
+			} else if service.Spec.Mode.GlobalJob != nil {
+				tags["service_mode"] = "global_job"
+				fields["tasks_running"] = running[service.ID]
 			} else {
 				d.Log.Error("Unknown replica mode")
 			}

--- a/plugins/inputs/docker/docker_test.go
+++ b/plugins/inputs/docker/docker_test.go
@@ -1102,6 +1102,32 @@ func TestDockerGatherSwarmInfo(t *testing.T) {
 			"service_mode": "global",
 		},
 	)
+
+	acc.AssertContainsTaggedFields(t,
+		"docker_swarm",
+		map[string]interface{}{
+			"tasks_running":     int(0),
+			"max_concurrent":    uint64(2),
+			"total_completions": uint64(2),
+		},
+		map[string]string{
+			"service_id":   "rfmqydhe8cluzl9hayyrhw5ga",
+			"service_name": "test3",
+			"service_mode": "replicated_job",
+		},
+	)
+
+	acc.AssertContainsTaggedFields(t,
+		"docker_swarm",
+		map[string]interface{}{
+			"tasks_running": int(0),
+		},
+		map[string]string{
+			"service_id":   "mp50lo68vqgkory4e26ts8f9d",
+			"service_name": "test4",
+			"service_mode": "global_job",
+		},
+	)
 }
 
 func TestContainerStateFilter(t *testing.T) {

--- a/plugins/inputs/docker/docker_testdata.go
+++ b/plugins/inputs/docker/docker_testdata.go
@@ -196,6 +196,31 @@ var serviceList = []swarm.Service{
 			},
 		},
 	},
+	{
+		ID: "rfmqydhe8cluzl9hayyrhw5ga",
+		Spec: swarm.ServiceSpec{
+			Annotations: swarm.Annotations{
+				Name: "test3",
+			},
+			Mode: swarm.ServiceMode{
+				ReplicatedJob: &swarm.ReplicatedJob{
+					MaxConcurrent:    &two,
+					TotalCompletions: &two,
+				},
+			},
+		},
+	},
+	{
+		ID: "mp50lo68vqgkory4e26ts8f9d",
+		Spec: swarm.ServiceSpec{
+			Annotations: swarm.Annotations{
+				Name: "test4",
+			},
+			Mode: swarm.ServiceMode{
+				GlobalJob: &swarm.GlobalJob{},
+			},
+		},
+	},
 }
 
 var taskList = []swarm.Task{


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Gather info about [swarm jobs](https://github.com/moby/moby/commit/30d9fe30b1c1bf52f15a41e0b106a1542a167e04) like for normal swarm services and don't flood logs with errors about "unsupported replica mode"

relevant test configs

telegraf.conf
```toml
[[outputs.file]]
  files = ["stdout"]

[[inputs.docker]]
  endpoint = "unix:///var/run/docker.sock"
  gather_services = true
```

compose.yml
```yaml
services:
  long:
    image: alpine
    command: sleep 20
    deploy:
      mode: global-job

  short:
    image: hello-world
    deploy:
      mode: replicated-job
      replicas: 1

  daemon:
    image: jmalloc/echo-server
    deploy:
      mode: replicated
      replicas: 1
```

output sample
```
docker_swarm,host=testst.int,service_id=mp50lo68vqgkory4e26ts8f9d,service_mode=global_job,service_name=jobs_long tasks_running=0i 1733841760000000000
docker_swarm,host=testst.int,service_id=rfmqydhe8cluzl9hayyrhw5ga,service_mode=replicated_job,service_name=jobs_short tasks_running=0i,max_concurrent=1i,total_completions=1i 1733841760000000000
docker_swarm,host=testst.int,service_id=wb11cftte0u6cc4bn1l96dnxr,service_mode=replicated,service_name=jobs_daemon tasks_running=1i,tasks_desired=1i 1733841760000000000
```

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #16291
