### PR TITLE
Introducing Telegraf Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Docker pulls](https://img.shields.io/docker/pulls/library/telegraf.svg)](https://hub.docker.com/_/telegraf/)
 [![Go Report Card](https://goreportcard.com/badge/github.com/influxdata/telegraf)](https://goreportcard.com/report/github.com/influxdata/telegraf)
 [![Circle CI](https://circleci.com/gh/influxdata/telegraf.svg?style=svg)](https://circleci.com/gh/influxdata/telegraf)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Telegraf%20Guru-006BFF)](https://gurubase.io/g/telegraf)
 
 Telegraf is an agent for collecting, processing, aggregating, and writing
 metrics, logs, and other arbitrary data.


### PR DESCRIPTION
Hello Team,

This PR is a friendly notification that the [Telegraf Guru](https://gurubase.io/g/telegraf) has been added to Gurubase. The Telegraf Guru uses data from this repository and the [documentation](https://docs.influxdata.com/telegraf/v1/) to answer questions by leveraging the LLM.

Gurubase is a centralized, RAG-based learning and troubleshooting assistant platform. Each "Guru" is equipped with custom knowledge to answer user questions based on data collected for that tool. More information can be found in [this repo](https://github.com/getanteon/gurubase).

This PR updates the README to indicate that Telegraf users can now ask questions to Telegraf Guru. As shown in the [Used By](https://github.com/getanteon/gurubase?tab=readme-ov-file#used-by) section, over 100 open-source repositories currently showcase their Guru in their README.md.

By default, there are three possible actions:
1. If you dislike it, we can immediately disable Telegraf Guru in Gurubase and remove this PR.
2. If you like it but don’t want to add it to the README, we can remove this PR or include it in another place you prefer.
3. If you’re happy with it, we can keep it as is and merge the PR.

Although this PR is created by the Gurubase Notifier account, the team monitors it and will answer any questions you may have.

**Note:** If you consider this PR a time-waster, apologize for the inconvenience. Developers often request us to create a Guru for the tools they use. Once we create it, we notify the maintainers to inform them and seek their approval.
