### PR TITLE
feat(inputs.nvidia_smi): Implement probing

### DIFF
--- a/plugins/inputs/nvidia_smi/nvidia_smi.go
+++ b/plugins/inputs/nvidia_smi/nvidia_smi.go
@@ -31,8 +31,9 @@ type NvidiaSMI struct {
 	Timeout config.Duration `toml:"timeout"`
 	Log     telegraf.Logger `toml:"-"`
 
-	ignorePlugin bool
-	once         sync.Once
+	nvidiaSMIArgs []string
+	ignorePlugin  bool
+	once          sync.Once
 }
 
 func (*NvidiaSMI) SampleConfig() string {
@@ -53,6 +54,15 @@ func (smi *NvidiaSMI) Start(telegraf.Accumulator) error {
 
 func (*NvidiaSMI) Stop() {}
 
+func (smi *NvidiaSMI) Probe() error {
+	// Construct and execute metrics query
+	_, err := internal.CombinedOutputTimeout(exec.Command(smi.BinPath, smi.nvidiaSMIArgs...), time.Duration(smi.Timeout))
+	if err != nil {
+		return fmt.Errorf("calling %q failed: %w", smi.BinPath, err)
+	}
+	return nil
+}
+
 // Gather implements the telegraf interface
 func (smi *NvidiaSMI) Gather(acc telegraf.Accumulator) error {
 	if smi.ignorePlugin {
@@ -60,7 +70,7 @@ func (smi *NvidiaSMI) Gather(acc telegraf.Accumulator) error {
 	}
 
 	// Construct and execute metrics query
-	data, err := internal.CombinedOutputTimeout(exec.Command(smi.BinPath, "-q", "-x"), time.Duration(smi.Timeout))
+	data, err := internal.CombinedOutputTimeout(exec.Command(smi.BinPath, smi.nvidiaSMIArgs...), time.Duration(smi.Timeout))
 	if err != nil {
 		return fmt.Errorf("calling %q failed: %w", smi.BinPath, err)
 	}
@@ -119,8 +129,9 @@ func (smi *NvidiaSMI) parse(acc telegraf.Accumulator, data []byte) error {
 func init() {
 	inputs.Add("nvidia_smi", func() telegraf.Input {
 		return &NvidiaSMI{
-			BinPath: "/usr/bin/nvidia-smi",
-			Timeout: config.Duration(5 * time.Second),
+			BinPath:       "/usr/bin/nvidia-smi",
+			Timeout:       config.Duration(5 * time.Second),
+			nvidiaSMIArgs: []string{"-q", "-x"},
 		}
 	})
 }


### PR DESCRIPTION
## Summary

This PR implements [tsd-009](https://github.com/influxdata/telegraf/blob/master/docs/specs/tsd-009-probe-on-startup.md) for the `inputs.nvidia_smi` plugin. This is achieved by running nvidia-smi once and checking the return code for a successful run.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues

- https://github.com/influxdata/telegraf/issues/15915
- https://github.com/influxdata/telegraf/issues/16028

