### PR TITLE
fix(inputs.mongodb): SIGSEGV when gatherDBStats fails and returns nil pointer causing subsequent dereference failure

### DIFF
--- a/plugins/inputs/mongodb/mongodb_server.go
+++ b/plugins/inputs/mongodb/mongodb_server.go
@@ -327,7 +327,8 @@ func (s *server) gatherData(acc telegraf.Accumulator, gatherClusterStatus, gathe
 		for _, name := range names {
 			db, err := s.gatherDBStats(name)
 			if err != nil {
-				s.log.Debugf("Error getting db stats from %q: %s", name, err.Error())
+				s.log.Errorf("Error getting db stats from %q: %s", name, err.Error())
+				continue
 			}
 			dbStats.Dbs = append(dbStats.Dbs, *db)
 		}


### PR DESCRIPTION
## Summary
Occasionally happens on our clusters, like every 2-4 weeks. The error message has never been seen as it gets logged at Debug level, which has also been changed to Error in this commit. Please let me know if the log level update is not an issue as I can see some errors are only logged at Debug level.

## Checklist
- [x] No AI generated code was used in this PR

## Related issues