### PR TITLE
docs(parsers.openmetrics): Update link to specification

### DIFF
--- a/plugins/parsers/openmetrics/README.md
+++ b/plugins/parsers/openmetrics/README.md
@@ -8,7 +8,7 @@ but can also be used by e.g.
 The plugin allows to output different metric formats as described in the
 [Metric Formats section](#metric-formats).
 
-[OpenMetrics Text Format]: https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md
+[OpenMetrics Text Format]: https://github.com/prometheus/OpenMetrics/blob/v1.0.0/specification/OpenMetrics.md
 
 ## Configuration
 


### PR DESCRIPTION
Related to https://github.com/prometheus/OpenMetrics/issues/287

The OM 2.0 effort is kicked off, and will start developing on main. This updates the links to OpenMetrics to reference the 1.0 release. The OM project has also been moved into the prometheus github org.