### PR TITLE
chore: Fix linter findings for `revive:unused-receiver` in `plugins/inputs/[l-r]`

### DIFF
--- a/plugins/inputs/lanz/lanz.go
+++ b/plugins/inputs/lanz/lanz.go
@@ -58,7 +58,7 @@ func (l *Lanz) Start(acc telegraf.Accumulator) error {
 	return nil
 }
 
-func (l *Lanz) Gather(_ telegraf.Accumulator) error {
+func (*Lanz) Gather(telegraf.Accumulator) error {
 	return nil
 }
 

--- a/plugins/inputs/leofs/leofs.go
+++ b/plugins/inputs/leofs/leofs.go
@@ -159,7 +159,7 @@ func (*LeoFS) SampleConfig() string {
 
 func (l *LeoFS) Gather(acc telegraf.Accumulator) error {
 	if len(l.Servers) == 0 {
-		return l.gatherServer(defaultEndpoint, serverTypeManagerMaster, acc)
+		return gatherServer(defaultEndpoint, serverTypeManagerMaster, acc)
 	}
 	var wg sync.WaitGroup
 	for _, endpoint := range l.Servers {
@@ -185,14 +185,14 @@ func (l *LeoFS) Gather(acc telegraf.Accumulator) error {
 		wg.Add(1)
 		go func(endpoint string, st serverType) {
 			defer wg.Done()
-			acc.AddError(l.gatherServer(endpoint, st, acc))
+			acc.AddError(gatherServer(endpoint, st, acc))
 		}(endpoint, st)
 	}
 	wg.Wait()
 	return nil
 }
 
-func (l *LeoFS) gatherServer(endpoint string, serverType serverType, acc telegraf.Accumulator) error {
+func gatherServer(endpoint string, serverType serverType, acc telegraf.Accumulator) error {
 	cmd := exec.Command("snmpwalk", "-v2c", "-cpublic", "-On", endpoint, oid)
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {

--- a/plugins/inputs/libvirt/libvirt.go
+++ b/plugins/inputs/libvirt/libvirt.go
@@ -47,7 +47,7 @@ type Libvirt struct {
 	domainsMap         map[string]struct{}
 }
 
-func (l *Libvirt) SampleConfig() string {
+func (*Libvirt) SampleConfig() string {
 	return sampleConfig
 }
 

--- a/plugins/inputs/libvirt/libvirt_metric_format.go
+++ b/plugins/inputs/libvirt/libvirt_metric_format.go
@@ -17,31 +17,31 @@ var (
 )
 
 func (l *Libvirt) addMetrics(stats []golibvirt.DomainStatsRecord, vcpuInfos map[string][]vcpuAffinity, acc telegraf.Accumulator) {
-	domainsMetrics := l.translateMetrics(stats)
+	domainsMetrics := translateMetrics(stats)
 
 	for domainName, metrics := range domainsMetrics {
 		for metricType, values := range metrics {
 			switch metricType {
 			case "state":
-				l.addStateMetrics(values, domainName, acc)
+				addStateMetrics(values, domainName, acc)
 			case "cpu":
-				l.addCPUMetrics(values, domainName, acc)
+				addCPUMetrics(values, domainName, acc)
 			case "balloon":
-				l.addBalloonMetrics(values, domainName, acc)
+				addBalloonMetrics(values, domainName, acc)
 			case "vcpu":
 				l.addVcpuMetrics(values, domainName, vcpuInfos[domainName], acc)
 			case "net":
-				l.addInterfaceMetrics(values, domainName, acc)
+				addInterfaceMetrics(values, domainName, acc)
 			case "perf":
-				l.addPerfMetrics(values, domainName, acc)
+				addPerfMetrics(values, domainName, acc)
 			case "block":
-				l.addBlockMetrics(values, domainName, acc)
+				addBlockMetrics(values, domainName, acc)
 			case "iothread":
-				l.addIothreadMetrics(values, domainName, acc)
+				addIothreadMetrics(values, domainName, acc)
 			case "memory":
-				l.addMemoryMetrics(values, domainName, acc)
+				addMemoryMetrics(values, domainName, acc)
 			case "dirtyrate":
-				l.addDirtyrateMetrics(values, domainName, acc)
+				addDirtyrateMetrics(values, domainName, acc)
 			}
 		}
 	}
@@ -61,7 +61,7 @@ func (l *Libvirt) addMetrics(stats []golibvirt.DomainStatsRecord, vcpuInfos map[
 	}
 }
 
-func (l *Libvirt) translateMetrics(stats []golibvirt.DomainStatsRecord) map[string]map[string]map[string]golibvirt.TypedParamValue {
+func translateMetrics(stats []golibvirt.DomainStatsRecord) map[string]map[string]map[string]golibvirt.TypedParamValue {
 	metrics := make(map[string]map[string]map[string]golibvirt.TypedParamValue)
 	for _, stat := range stats {
 		if stat.Params != nil {
@@ -83,7 +83,7 @@ func (l *Libvirt) translateMetrics(stats []golibvirt.DomainStatsRecord) map[stri
 	return metrics
 }
 
-func (l *Libvirt) addStateMetrics(metrics map[string]golibvirt.TypedParamValue, domainName string, acc telegraf.Accumulator) {
+func addStateMetrics(metrics map[string]golibvirt.TypedParamValue, domainName string, acc telegraf.Accumulator) {
 	var stateFields = make(map[string]interface{})
 	var stateTags = map[string]string{
 		"domain_name": domainName,
@@ -101,7 +101,7 @@ func (l *Libvirt) addStateMetrics(metrics map[string]golibvirt.TypedParamValue, 
 	}
 }
 
-func (l *Libvirt) addCPUMetrics(metrics map[string]golibvirt.TypedParamValue, domainName string, acc telegraf.Accumulator) {
+func addCPUMetrics(metrics map[string]golibvirt.TypedParamValue, domainName string, acc telegraf.Accumulator) {
 	var cpuFields = make(map[string]interface{})
 	var cpuCacheMonitorTotalFields = make(map[string]interface{})
 
@@ -188,7 +188,7 @@ func (l *Libvirt) addCPUMetrics(metrics map[string]golibvirt.TypedParamValue, do
 	}
 }
 
-func (l *Libvirt) addBalloonMetrics(metrics map[string]golibvirt.TypedParamValue, domainName string, acc telegraf.Accumulator) {
+func addBalloonMetrics(metrics map[string]golibvirt.TypedParamValue, domainName string, acc telegraf.Accumulator) {
 	var balloonFields = make(map[string]interface{})
 	var balloonTags = map[string]string{
 		"domain_name": domainName,
@@ -283,7 +283,7 @@ func (l *Libvirt) getCurrentPCPUForVCPU(vcpuID string, vcpuInfos []vcpuAffinity)
 	return -1
 }
 
-func (l *Libvirt) addInterfaceMetrics(metrics map[string]golibvirt.TypedParamValue, domainName string, acc telegraf.Accumulator) {
+func addInterfaceMetrics(metrics map[string]golibvirt.TypedParamValue, domainName string, acc telegraf.Accumulator) {
 	var netTotalFields = make(map[string]interface{})
 	var netData = make(map[string]map[string]interface{})
 
@@ -330,7 +330,7 @@ func (l *Libvirt) addInterfaceMetrics(metrics map[string]golibvirt.TypedParamVal
 	}
 }
 
-func (l *Libvirt) addPerfMetrics(metrics map[string]golibvirt.TypedParamValue, domainName string, acc telegraf.Accumulator) {
+func addPerfMetrics(metrics map[string]golibvirt.TypedParamValue, domainName string, acc telegraf.Accumulator) {
 	var perfFields = make(map[string]interface{})
 	var perfTags = map[string]string{
 		"domain_name": domainName,
@@ -351,7 +351,7 @@ func (l *Libvirt) addPerfMetrics(metrics map[string]golibvirt.TypedParamValue, d
 	}
 }
 
-func (l *Libvirt) addBlockMetrics(metrics map[string]golibvirt.TypedParamValue, domainName string, acc telegraf.Accumulator) {
+func addBlockMetrics(metrics map[string]golibvirt.TypedParamValue, domainName string, acc telegraf.Accumulator) {
 	var blockTotalFields = make(map[string]interface{})
 	var blockData = make(map[string]map[string]interface{})
 
@@ -399,7 +399,7 @@ func (l *Libvirt) addBlockMetrics(metrics map[string]golibvirt.TypedParamValue, 
 	}
 }
 
-func (l *Libvirt) addIothreadMetrics(metrics map[string]golibvirt.TypedParamValue, domainName string, acc telegraf.Accumulator) {
+func addIothreadMetrics(metrics map[string]golibvirt.TypedParamValue, domainName string, acc telegraf.Accumulator) {
 	var iothreadTotalFields = make(map[string]interface{})
 	var iothreadData = make(map[string]map[string]interface{})
 
@@ -446,7 +446,7 @@ func (l *Libvirt) addIothreadMetrics(metrics map[string]golibvirt.TypedParamValu
 	}
 }
 
-func (l *Libvirt) addMemoryMetrics(metrics map[string]golibvirt.TypedParamValue, domainName string, acc telegraf.Accumulator) {
+func addMemoryMetrics(metrics map[string]golibvirt.TypedParamValue, domainName string, acc telegraf.Accumulator) {
 	var memoryBandwidthMonitorTotalFields = make(map[string]interface{})
 
 	var memoryBandwidthMonitorData = make(map[string]map[string]interface{})
@@ -528,7 +528,7 @@ func (l *Libvirt) addMemoryMetrics(metrics map[string]golibvirt.TypedParamValue,
 	}
 }
 
-func (l *Libvirt) addDirtyrateMetrics(metrics map[string]golibvirt.TypedParamValue, domainName string, acc telegraf.Accumulator) {
+func addDirtyrateMetrics(metrics map[string]golibvirt.TypedParamValue, domainName string, acc telegraf.Accumulator) {
 	var dirtyrateFields = make(map[string]interface{})
 	var dirtyrateVcpuData = make(map[string]map[string]interface{})
 

--- a/plugins/inputs/linux_cpu/linux_cpu.go
+++ b/plugins/inputs/linux_cpu/linux_cpu.go
@@ -47,7 +47,7 @@ type prop struct {
 	optional bool
 }
 
-func (g *LinuxCPU) SampleConfig() string {
+func (*LinuxCPU) SampleConfig() string {
 	return sampleConfig
 }
 

--- a/plugins/inputs/logstash/logstash.go
+++ b/plugins/inputs/logstash/logstash.go
@@ -283,12 +283,7 @@ func (logstash *Logstash) gatherProcessStats(address string, accumulator telegra
 }
 
 // gatherPluginsStats go through a list of plugins and add their metrics to the accumulator
-func (logstash *Logstash) gatherPluginsStats(
-	plugins []plugin,
-	pluginType string,
-	tags map[string]string,
-	accumulator telegraf.Accumulator,
-) error {
+func gatherPluginsStats(plugins []plugin, pluginType string, tags map[string]string, accumulator telegraf.Accumulator) error {
 	for _, plugin := range plugins {
 		pluginTags := map[string]string{
 			"plugin_name": plugin.Name,
@@ -370,7 +365,7 @@ func (logstash *Logstash) gatherPluginsStats(
 	return nil
 }
 
-func (logstash *Logstash) gatherQueueStats(queue pipelineQueue, tags map[string]string, acc telegraf.Accumulator) error {
+func gatherQueueStats(queue pipelineQueue, tags map[string]string, acc telegraf.Accumulator) error {
 	queueTags := map[string]string{
 		"queue_type": queue.Type,
 	}
@@ -438,20 +433,20 @@ func (logstash *Logstash) gatherPipelineStats(address string, accumulator telegr
 	}
 	accumulator.AddFields("logstash_events", flattener.Fields, tags)
 
-	err = logstash.gatherPluginsStats(pipelineStats.Pipeline.Plugins.Inputs, "input", tags, accumulator)
+	err = gatherPluginsStats(pipelineStats.Pipeline.Plugins.Inputs, "input", tags, accumulator)
 	if err != nil {
 		return err
 	}
-	err = logstash.gatherPluginsStats(pipelineStats.Pipeline.Plugins.Filters, "filter", tags, accumulator)
+	err = gatherPluginsStats(pipelineStats.Pipeline.Plugins.Filters, "filter", tags, accumulator)
 	if err != nil {
 		return err
 	}
-	err = logstash.gatherPluginsStats(pipelineStats.Pipeline.Plugins.Outputs, "output", tags, accumulator)
+	err = gatherPluginsStats(pipelineStats.Pipeline.Plugins.Outputs, "output", tags, accumulator)
 	if err != nil {
 		return err
 	}
 
-	err = logstash.gatherQueueStats(pipelineStats.Pipeline.Queue, tags, accumulator)
+	err = gatherQueueStats(pipelineStats.Pipeline.Queue, tags, accumulator)
 	if err != nil {
 		return err
 	}
@@ -484,20 +479,20 @@ func (logstash *Logstash) gatherPipelinesStats(address string, accumulator teleg
 		}
 		accumulator.AddFields("logstash_events", flattener.Fields, tags)
 
-		err = logstash.gatherPluginsStats(pipeline.Plugins.Inputs, "input", tags, accumulator)
+		err = gatherPluginsStats(pipeline.Plugins.Inputs, "input", tags, accumulator)
 		if err != nil {
 			return err
 		}
-		err = logstash.gatherPluginsStats(pipeline.Plugins.Filters, "filter", tags, accumulator)
+		err = gatherPluginsStats(pipeline.Plugins.Filters, "filter", tags, accumulator)
 		if err != nil {
 			return err
 		}
-		err = logstash.gatherPluginsStats(pipeline.Plugins.Outputs, "output", tags, accumulator)
+		err = gatherPluginsStats(pipeline.Plugins.Outputs, "output", tags, accumulator)
 		if err != nil {
 			return err
 		}
 
-		err = logstash.gatherQueueStats(pipeline.Queue, tags, accumulator)
+		err = gatherQueueStats(pipeline.Queue, tags, accumulator)
 		if err != nil {
 			return err
 		}

--- a/plugins/inputs/lvm/lvm.go
+++ b/plugins/inputs/lvm/lvm.go
@@ -33,10 +33,6 @@ func (*LVM) SampleConfig() string {
 	return sampleConfig
 }
 
-func (*LVM) Init() error {
-	return nil
-}
-
 func (lvm *LVM) Gather(acc telegraf.Accumulator) error {
 	if err := lvm.gatherPhysicalVolumes(acc); err != nil {
 		return err

--- a/plugins/inputs/lvm/lvm.go
+++ b/plugins/inputs/lvm/lvm.go
@@ -33,7 +33,7 @@ func (*LVM) SampleConfig() string {
 	return sampleConfig
 }
 
-func (lvm *LVM) Init() error {
+func (*LVM) Init() error {
 	return nil
 }
 

--- a/plugins/inputs/mcrouter/mcrouter.go
+++ b/plugins/inputs/mcrouter/mcrouter.go
@@ -128,14 +128,14 @@ func (m *Mcrouter) Gather(acc telegraf.Accumulator) error {
 	}
 
 	for _, serverAddress := range m.Servers {
-		acc.AddError(m.gatherServer(ctx, serverAddress, acc))
+		acc.AddError(gatherServer(ctx, serverAddress, acc))
 	}
 
 	return nil
 }
 
 // parseAddress parses an address string into 'host:port' and 'protocol' parts
-func (m *Mcrouter) parseAddress(address string) (parsedAddress, protocol string, err error) {
+func parseAddress(address string) (parsedAddress, protocol string, err error) {
 	var host string
 	var port string
 
@@ -181,13 +181,13 @@ func (m *Mcrouter) parseAddress(address string) (parsedAddress, protocol string,
 	return parsedAddress, protocol, nil
 }
 
-func (m *Mcrouter) gatherServer(ctx context.Context, address string, acc telegraf.Accumulator) error {
+func gatherServer(ctx context.Context, address string, acc telegraf.Accumulator) error {
 	var conn net.Conn
 	var err error
 	var protocol string
 	var dialer net.Dialer
 
-	address, protocol, err = m.parseAddress(address)
+	address, protocol, err = parseAddress(address)
 	if err != nil {
 		return err
 	}

--- a/plugins/inputs/mcrouter/mcrouter_test.go
+++ b/plugins/inputs/mcrouter/mcrouter_test.go
@@ -15,10 +15,6 @@ import (
 )
 
 func TestAddressParsing(t *testing.T) {
-	m := &Mcrouter{
-		Servers: []string{"tcp://" + testutil.GetLocalHost()},
-	}
-
 	var acceptTests = [][3]string{
 		{"tcp://localhost:8086", "localhost:8086", "tcp"},
 		{"tcp://localhost", "localhost:" + defaultServerURL.Port(), "tcp"},
@@ -32,7 +28,7 @@ func TestAddressParsing(t *testing.T) {
 	}
 
 	for _, args := range acceptTests {
-		address, protocol, err := m.parseAddress(args[0])
+		address, protocol, err := parseAddress(args[0])
 
 		require.NoError(t, err, args[0])
 		require.Equal(t, args[1], address, args[0])
@@ -40,7 +36,7 @@ func TestAddressParsing(t *testing.T) {
 	}
 
 	for _, addr := range rejectTests {
-		address, protocol, err := m.parseAddress(addr)
+		address, protocol, err := parseAddress(addr)
 
 		require.Error(t, err, addr)
 		require.Empty(t, address, addr)

--- a/plugins/inputs/modbus/configuration_metric.go
+++ b/plugins/inputs/modbus/configuration_metric.go
@@ -42,7 +42,7 @@ type configurationPerMetric struct {
 	logger              telegraf.Logger
 }
 
-func (c *configurationPerMetric) sampleConfigPart() string {
+func (*configurationPerMetric) sampleConfigPart() string {
 	return sampleConfigPartPerMetric
 }
 
@@ -366,7 +366,7 @@ func (c *configurationPerMetric) fieldID(seed maphash.Seed, def metricDefinition
 	return mh.Sum64()
 }
 
-func (c *configurationPerMetric) determineOutputDatatype(input string) (string, error) {
+func (*configurationPerMetric) determineOutputDatatype(input string) (string, error) {
 	// Handle our special types
 	switch input {
 	case "INT8L", "INT8H", "INT16", "INT32", "INT64":
@@ -381,7 +381,7 @@ func (c *configurationPerMetric) determineOutputDatatype(input string) (string, 
 	return "unknown", fmt.Errorf("invalid input datatype %q for determining output", input)
 }
 
-func (c *configurationPerMetric) determineFieldLength(input string, length uint16) (uint16, error) {
+func (*configurationPerMetric) determineFieldLength(input string, length uint16) (uint16, error) {
 	// Handle our special types
 	switch input {
 	case "BIT", "INT8L", "INT8H", "UINT8L", "UINT8H":

--- a/plugins/inputs/modbus/configuration_register.go
+++ b/plugins/inputs/modbus/configuration_register.go
@@ -31,7 +31,7 @@ type configurationOriginal struct {
 	logger           telegraf.Logger
 }
 
-func (c *configurationOriginal) sampleConfigPart() string {
+func (*configurationOriginal) sampleConfigPart() string {
 	return sampleConfigPartPerRegister
 }
 
@@ -43,19 +43,19 @@ func (c *configurationOriginal) check() error {
 		return fmt.Errorf("invalid 'string_register_location' %q", c.workarounds.StringRegisterLocation)
 	}
 
-	if err := c.validateFieldDefinitions(c.DiscreteInputs, cDiscreteInputs); err != nil {
+	if err := validateFieldDefinitions(c.DiscreteInputs, cDiscreteInputs); err != nil {
 		return err
 	}
 
-	if err := c.validateFieldDefinitions(c.Coils, cCoils); err != nil {
+	if err := validateFieldDefinitions(c.Coils, cCoils); err != nil {
 		return err
 	}
 
-	if err := c.validateFieldDefinitions(c.HoldingRegisters, cHoldingRegisters); err != nil {
+	if err := validateFieldDefinitions(c.HoldingRegisters, cHoldingRegisters); err != nil {
 		return err
 	}
 
-	return c.validateFieldDefinitions(c.InputRegisters, cInputRegisters)
+	return validateFieldDefinitions(c.InputRegisters, cInputRegisters)
 }
 
 func (c *configurationOriginal) process() (map[byte]requestSet, error) {
@@ -182,7 +182,7 @@ func (c *configurationOriginal) newFieldFromDefinition(def fieldDefinition, type
 	return f, nil
 }
 
-func (c *configurationOriginal) validateFieldDefinitions(fieldDefs []fieldDefinition, registerType string) error {
+func validateFieldDefinitions(fieldDefs []fieldDefinition, registerType string) error {
 	nameEncountered := make(map[string]bool, len(fieldDefs))
 	for _, item := range fieldDefs {
 		// check empty name
@@ -276,7 +276,7 @@ func (c *configurationOriginal) validateFieldDefinitions(fieldDefs []fieldDefini
 	return nil
 }
 
-func (c *configurationOriginal) normalizeInputDatatype(dataType string, words int) (string, error) {
+func (*configurationOriginal) normalizeInputDatatype(dataType string, words int) (string, error) {
 	if dataType == "FLOAT32" {
 		config.PrintOptionValueDeprecationNotice("input.modbus", "data_type", "FLOAT32", telegraf.DeprecationInfo{
 			Since:     "1.16.0",
@@ -323,7 +323,7 @@ func (c *configurationOriginal) normalizeInputDatatype(dataType string, words in
 	return normalizeInputDatatype(dataType)
 }
 
-func (c *configurationOriginal) normalizeOutputDatatype(dataType string) (string, error) {
+func (*configurationOriginal) normalizeOutputDatatype(dataType string) (string, error) {
 	// Handle our special types
 	switch dataType {
 	case "FIXED", "FLOAT32", "UFIXED":
@@ -332,7 +332,7 @@ func (c *configurationOriginal) normalizeOutputDatatype(dataType string) (string
 	return normalizeOutputDatatype("native")
 }
 
-func (c *configurationOriginal) normalizeByteOrder(byteOrder string) (string, error) {
+func (*configurationOriginal) normalizeByteOrder(byteOrder string) (string, error) {
 	// Handle our special types
 	switch byteOrder {
 	case "AB", "ABCDEFGH":

--- a/plugins/inputs/modbus/configuration_request.go
+++ b/plugins/inputs/modbus/configuration_request.go
@@ -45,7 +45,7 @@ type configurationPerRequest struct {
 	logger              telegraf.Logger
 }
 
-func (c *configurationPerRequest) sampleConfigPart() string {
+func (*configurationPerRequest) sampleConfigPart() string {
 	return sampleConfigPartPerRequest
 }
 
@@ -300,7 +300,7 @@ func (c *configurationPerRequest) newFieldFromDefinition(def requestFieldDefinit
 
 	fieldLength := uint16(1)
 	if typed {
-		if fieldLength, err = c.determineFieldLength(def.InputType, def.Length); err != nil {
+		if fieldLength, err = determineFieldLength(def.InputType, def.Length); err != nil {
 			return field{}, err
 		}
 	}
@@ -338,7 +338,7 @@ func (c *configurationPerRequest) newFieldFromDefinition(def requestFieldDefinit
 			// For non-scaling cases we should choose the output corresponding to the input class
 			// i.e. INT64 for INT*, UINT64 for UINT* etc.
 			var err error
-			if def.OutputType, err = c.determineOutputDatatype(def.InputType); err != nil {
+			if def.OutputType, err = determineOutputDatatype(def.InputType); err != nil {
 				return field{}, err
 			}
 		} else {
@@ -406,7 +406,7 @@ func (c *configurationPerRequest) fieldID(seed maphash.Seed, def requestDefiniti
 	return mh.Sum64()
 }
 
-func (c *configurationPerRequest) determineOutputDatatype(input string) (string, error) {
+func determineOutputDatatype(input string) (string, error) {
 	// Handle our special types
 	switch input {
 	case "INT8L", "INT8H", "INT16", "INT32", "INT64":
@@ -421,7 +421,7 @@ func (c *configurationPerRequest) determineOutputDatatype(input string) (string,
 	return "unknown", fmt.Errorf("invalid input datatype %q for determining output", input)
 }
 
-func (c *configurationPerRequest) determineFieldLength(input string, length uint16) (uint16, error) {
+func determineFieldLength(input string, length uint16) (uint16, error) {
 	// Handle our special types
 	switch input {
 	case "BIT", "INT8L", "INT8H", "UINT8L", "UINT8H":

--- a/plugins/inputs/modbus/modbus.go
+++ b/plugins/inputs/modbus/modbus.go
@@ -251,22 +251,22 @@ func (m *Modbus) Gather(acc telegraf.Accumulator) error {
 		if !m.ExcludeRegisterTypeTag {
 			tags["type"] = cCoils
 		}
-		m.collectFields(grouper, timestamp, tags, requests.coil)
+		collectFields(grouper, timestamp, tags, requests.coil)
 
 		if !m.ExcludeRegisterTypeTag {
 			tags["type"] = cDiscreteInputs
 		}
-		m.collectFields(grouper, timestamp, tags, requests.discrete)
+		collectFields(grouper, timestamp, tags, requests.discrete)
 
 		if !m.ExcludeRegisterTypeTag {
 			tags["type"] = cHoldingRegisters
 		}
-		m.collectFields(grouper, timestamp, tags, requests.holding)
+		collectFields(grouper, timestamp, tags, requests.holding)
 
 		if !m.ExcludeRegisterTypeTag {
 			tags["type"] = cInputRegisters
 		}
-		m.collectFields(grouper, timestamp, tags, requests.input)
+		collectFields(grouper, timestamp, tags, requests.input)
 
 		// Add the metrics grouped by series to the accumulator
 		for _, x := range grouper.Metrics() {
@@ -532,7 +532,7 @@ func (m *Modbus) gatherRequestsInput(requests []request) error {
 	return nil
 }
 
-func (m *Modbus) collectFields(grouper *metric.SeriesGrouper, timestamp time.Time, tags map[string]string, requests []request) {
+func collectFields(grouper *metric.SeriesGrouper, timestamp time.Time, tags map[string]string, requests []request) {
 	for _, request := range requests {
 		for _, field := range request.fields {
 			// Collect tags from global and per-request

--- a/plugins/inputs/monit/monit_test.go
+++ b/plugins/inputs/monit/monit_test.go
@@ -17,8 +17,8 @@ import (
 type transportMock struct {
 }
 
-func (*transportMock) RoundTrip(_ *http.Request) (*http.Response, error) {
-	errorString := "Get http://127.0.0.1:2812/_status?format=xml: " +
+func (*transportMock) RoundTrip(*http.Request) (*http.Response, error) {
+	errorString := "get http://127.0.0.1:2812/_status?format=xml: " +
 		"read tcp 192.168.10.2:55610->127.0.0.1:2812: " +
 		"read: connection reset by peer"
 	return nil, errors.New(errorString)

--- a/plugins/inputs/monit/monit_test.go
+++ b/plugins/inputs/monit/monit_test.go
@@ -17,7 +17,7 @@ import (
 type transportMock struct {
 }
 
-func (t *transportMock) RoundTrip(_ *http.Request) (*http.Response, error) {
+func (*transportMock) RoundTrip(_ *http.Request) (*http.Response, error) {
 	errorString := "Get http://127.0.0.1:2812/_status?format=xml: " +
 		"read tcp 192.168.10.2:55610->127.0.0.1:2812: " +
 		"read: connection reset by peer"

--- a/plugins/inputs/mqtt_consumer/mqtt_consumer_test.go
+++ b/plugins/inputs/mqtt_consumer/mqtt_consumer_test.go
@@ -64,15 +64,15 @@ type fakeParser struct{}
 // fakeParser satisfies telegraf.Parser
 var _ telegraf.Parser = &fakeParser{}
 
-func (p *fakeParser) Parse(_ []byte) ([]telegraf.Metric, error) {
+func (*fakeParser) Parse(_ []byte) ([]telegraf.Metric, error) {
 	panic("not implemented")
 }
 
-func (p *fakeParser) ParseLine(_ string) (telegraf.Metric, error) {
+func (*fakeParser) ParseLine(_ string) (telegraf.Metric, error) {
 	panic("not implemented")
 }
 
-func (p *fakeParser) SetDefaultTags(_ map[string]string) {
+func (*fakeParser) SetDefaultTags(_ map[string]string) {
 	panic("not implemented")
 }
 
@@ -84,15 +84,15 @@ type fakeToken struct {
 // fakeToken satisfies mqtt.Token
 var _ mqtt.Token = &fakeToken{}
 
-func (t *fakeToken) Wait() bool {
+func (*fakeToken) Wait() bool {
 	return true
 }
 
-func (t *fakeToken) WaitTimeout(time.Duration) bool {
+func (*fakeToken) WaitTimeout(time.Duration) bool {
 	return true
 }
 
-func (t *fakeToken) Error() error {
+func (*fakeToken) Error() error {
 	return nil
 }
 
@@ -166,7 +166,7 @@ type message struct {
 	qos   byte
 }
 
-func (m *message) Duplicate() bool {
+func (*message) Duplicate() bool {
 	panic("not implemented")
 }
 
@@ -174,7 +174,7 @@ func (m *message) Qos() byte {
 	return m.qos
 }
 
-func (m *message) Retained() bool {
+func (*message) Retained() bool {
 	panic("not implemented")
 }
 
@@ -182,15 +182,15 @@ func (m *message) Topic() string {
 	return m.topic
 }
 
-func (m *message) MessageID() uint16 {
+func (*message) MessageID() uint16 {
 	panic("not implemented")
 }
 
-func (m *message) Payload() []byte {
+func (*message) Payload() []byte {
 	return []byte("cpu time_idle=42i")
 }
 
-func (m *message) Ack() {
+func (*message) Ack() {
 	panic("not implemented")
 }
 

--- a/plugins/inputs/mqtt_consumer/mqtt_consumer_test.go
+++ b/plugins/inputs/mqtt_consumer/mqtt_consumer_test.go
@@ -64,15 +64,15 @@ type fakeParser struct{}
 // fakeParser satisfies telegraf.Parser
 var _ telegraf.Parser = &fakeParser{}
 
-func (*fakeParser) Parse(_ []byte) ([]telegraf.Metric, error) {
+func (*fakeParser) Parse([]byte) ([]telegraf.Metric, error) {
 	panic("not implemented")
 }
 
-func (*fakeParser) ParseLine(_ string) (telegraf.Metric, error) {
+func (*fakeParser) ParseLine(string) (telegraf.Metric, error) {
 	panic("not implemented")
 }
 
-func (*fakeParser) SetDefaultTags(_ map[string]string) {
+func (*fakeParser) SetDefaultTags(map[string]string) {
 	panic("not implemented")
 }
 

--- a/plugins/inputs/mysql/mysql.go
+++ b/plugins/inputs/mysql/mysql.go
@@ -461,7 +461,7 @@ func (m *Mysql) gatherServer(server *config.Secret, acc telegraf.Accumulator) er
 	}
 
 	if m.GatherBinaryLogs {
-		err = m.gatherBinaryLogs(db, servtag, acc)
+		err = gatherBinaryLogs(db, servtag, acc)
 		if err != nil {
 			return err
 		}
@@ -510,35 +510,35 @@ func (m *Mysql) gatherServer(server *config.Secret, acc telegraf.Accumulator) er
 	}
 
 	if m.GatherTableIOWaits {
-		err = m.gatherPerfTableIOWaits(db, servtag, acc)
+		err = gatherPerfTableIOWaits(db, servtag, acc)
 		if err != nil {
 			return err
 		}
 	}
 
 	if m.GatherIndexIOWaits {
-		err = m.gatherPerfIndexIOWaits(db, servtag, acc)
+		err = gatherPerfIndexIOWaits(db, servtag, acc)
 		if err != nil {
 			return err
 		}
 	}
 
 	if m.GatherTableLockWaits {
-		err = m.gatherPerfTableLockWaits(db, servtag, acc)
+		err = gatherPerfTableLockWaits(db, servtag, acc)
 		if err != nil {
 			return err
 		}
 	}
 
 	if m.GatherEventWaits {
-		err = m.gatherPerfEventWaits(db, servtag, acc)
+		err = gatherPerfEventWaits(db, servtag, acc)
 		if err != nil {
 			return err
 		}
 	}
 
 	if m.GatherFileEventsStats {
-		err = m.gatherPerfFileEventsStatuses(db, servtag, acc)
+		err = gatherPerfFileEventsStatuses(db, servtag, acc)
 		if err != nil {
 			return err
 		}
@@ -712,7 +712,7 @@ func (m *Mysql) gatherSlaveStatuses(db *sql.DB, servtag string, acc telegraf.Acc
 
 // gatherBinaryLogs can be used to collect size and count of all binary files
 // binlogs metric requires the MySQL server to turn it on in configuration
-func (m *Mysql) gatherBinaryLogs(db *sql.DB, servtag string, acc telegraf.Accumulator) error {
+func gatherBinaryLogs(db *sql.DB, servtag string, acc telegraf.Accumulator) error {
 	// run query
 	rows, err := db.Query(binaryLogsQuery)
 	if err != nil {
@@ -1174,9 +1174,8 @@ func getColSlice(rows *sql.Rows) ([]interface{}, error) {
 	return nil, fmt.Errorf("not Supported - %d columns", l)
 }
 
-// gatherPerfTableIOWaits can be used to get total count and time
-// of I/O wait event for each table and process
-func (m *Mysql) gatherPerfTableIOWaits(db *sql.DB, servtag string, acc telegraf.Accumulator) error {
+// gatherPerfTableIOWaits can be used to get total count and time of I/O wait event for each table and process
+func gatherPerfTableIOWaits(db *sql.DB, servtag string, acc telegraf.Accumulator) error {
 	rows, err := db.Query(perfTableIOWaitsQuery)
 	if err != nil {
 		return err
@@ -1221,9 +1220,8 @@ func (m *Mysql) gatherPerfTableIOWaits(db *sql.DB, servtag string, acc telegraf.
 	return nil
 }
 
-// gatherPerfIndexIOWaits can be used to get total count and time
-// of I/O wait event for each index and process
-func (m *Mysql) gatherPerfIndexIOWaits(db *sql.DB, servtag string, acc telegraf.Accumulator) error {
+// gatherPerfIndexIOWaits can be used to get total count and time of I/O wait event for each index and process
+func gatherPerfIndexIOWaits(db *sql.DB, servtag string, acc telegraf.Accumulator) error {
 	rows, err := db.Query(perfIndexIOWaitsQuery)
 	if err != nil {
 		return err
@@ -1500,7 +1498,7 @@ func (m *Mysql) gatherPerfSummaryPerAccountPerEvent(db *sql.DB, servtag string, 
 // the total number and time for SQL and external lock wait events
 // for each table and operation
 // requires the MySQL server to be enabled to save this metric
-func (m *Mysql) gatherPerfTableLockWaits(db *sql.DB, servtag string, acc telegraf.Accumulator) error {
+func gatherPerfTableLockWaits(db *sql.DB, servtag string, acc telegraf.Accumulator) error {
 	// check if table exists,
 	// if performance_schema is not enabled, tables do not exist
 	// then there is no need to scan them
@@ -1627,7 +1625,7 @@ func (m *Mysql) gatherPerfTableLockWaits(db *sql.DB, servtag string, acc telegra
 }
 
 // gatherPerfEventWaits can be used to get total time and number of event waits
-func (m *Mysql) gatherPerfEventWaits(db *sql.DB, servtag string, acc telegraf.Accumulator) error {
+func gatherPerfEventWaits(db *sql.DB, servtag string, acc telegraf.Accumulator) error {
 	rows, err := db.Query(perfEventWaitsQuery)
 	if err != nil {
 		return err
@@ -1658,7 +1656,7 @@ func (m *Mysql) gatherPerfEventWaits(db *sql.DB, servtag string, acc telegraf.Ac
 }
 
 // gatherPerfFileEvents can be used to get stats on file events
-func (m *Mysql) gatherPerfFileEventsStatuses(db *sql.DB, servtag string, acc telegraf.Accumulator) error {
+func gatherPerfFileEventsStatuses(db *sql.DB, servtag string, acc telegraf.Accumulator) error {
 	rows, err := db.Query(perfFileEventsQuery)
 	if err != nil {
 		return err

--- a/plugins/inputs/nats_consumer/nats_consumer.go
+++ b/plugins/inputs/nats_consumer/nats_consumer.go
@@ -186,7 +186,7 @@ func (n *NatsConsumer) Start(acc telegraf.Accumulator) error {
 	return nil
 }
 
-func (n *NatsConsumer) Gather(_ telegraf.Accumulator) error {
+func (*NatsConsumer) Gather(telegraf.Accumulator) error {
 	return nil
 }
 

--- a/plugins/inputs/neptune_apex/neptune_apex.go
+++ b/plugins/inputs/neptune_apex/neptune_apex.go
@@ -83,12 +83,12 @@ func (n *NeptuneApex) gatherServer(
 	if err != nil {
 		return err
 	}
-	return n.parseXML(acc, resp)
+	return parseXML(acc, resp)
 }
 
 // parseXML is strict on the input and does not do best-effort parsing.
 // This is because of the life-support nature of the Neptune Apex.
-func (n *NeptuneApex) parseXML(acc telegraf.Accumulator, data []byte) error {
+func parseXML(acc telegraf.Accumulator, data []byte) error {
 	r := xmlReply{}
 	err := xml.Unmarshal(data, &r)
 	if err != nil {

--- a/plugins/inputs/neptune_apex/neptune_apex_test.go
+++ b/plugins/inputs/neptune_apex/neptune_apex_test.go
@@ -57,9 +57,7 @@ func TestGather(t *testing.T) {
 }
 
 func TestParseXML(t *testing.T) {
-	n := &NeptuneApex{}
-	goodTime := time.Date(2018, 12, 22, 21, 55, 37, 0,
-		time.FixedZone("PST", 3600*-8))
+	goodTime := time.Date(2018, 12, 22, 21, 55, 37, 0, time.FixedZone("PST", 3600*-8))
 	tests := []struct {
 		name        string
 		xmlResponse []byte
@@ -363,7 +361,7 @@ func TestParseXML(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			var acc testutil.Accumulator
-			err := n.parseXML(&acc, test.xmlResponse)
+			err := parseXML(&acc, test.xmlResponse)
 			if test.wantErr {
 				require.Error(t, err, "expected error but got <nil>")
 				return

--- a/plugins/inputs/netflow/netflow.go
+++ b/plugins/inputs/netflow/netflow.go
@@ -114,7 +114,7 @@ func (n *NetFlow) Start(acc telegraf.Accumulator) error {
 	return nil
 }
 
-func (n *NetFlow) Gather(_ telegraf.Accumulator) error {
+func (*NetFlow) Gather(telegraf.Accumulator) error {
 	return nil
 }
 

--- a/plugins/inputs/netflow/netflow_v5.go
+++ b/plugins/inputs/netflow/netflow_v5.go
@@ -15,14 +15,14 @@ import (
 // Decoder structure
 type netflowv5Decoder struct{}
 
-func (d *netflowv5Decoder) init() error {
+func (*netflowv5Decoder) init() error {
 	if err := initL4ProtoMapping(); err != nil {
 		return fmt.Errorf("initializing layer 4 protocol mapping failed: %w", err)
 	}
 	return nil
 }
 
-func (d *netflowv5Decoder) decode(srcIP net.IP, payload []byte) ([]telegraf.Metric, error) {
+func (*netflowv5Decoder) decode(srcIP net.IP, payload []byte) ([]telegraf.Metric, error) {
 	src := srcIP.String()
 
 	// Decode the message

--- a/plugins/inputs/nginx_upstream_check/nginx_upstream_check.go
+++ b/plugins/inputs/nginx_upstream_check/nginx_upstream_check.go
@@ -160,7 +160,7 @@ func (check *NginxUpstreamCheck) gatherStatusData(address string, accumulator te
 
 		fields := map[string]interface{}{
 			"status":      server.Status,
-			"status_code": check.getStatusCode(server.Status),
+			"status_code": getStatusCode(server.Status),
 			"rise":        server.Rise,
 			"fall":        server.Fall,
 		}
@@ -171,7 +171,7 @@ func (check *NginxUpstreamCheck) gatherStatusData(address string, accumulator te
 	return nil
 }
 
-func (check *NginxUpstreamCheck) getStatusCode(status string) uint8 {
+func getStatusCode(status string) uint8 {
 	switch status {
 	case "up":
 		return 1

--- a/plugins/inputs/nsq_consumer/nsq_consumer.go
+++ b/plugins/inputs/nsq_consumer/nsq_consumer.go
@@ -138,7 +138,7 @@ func (n *NSQConsumer) Start(ac telegraf.Accumulator) error {
 	return nil
 }
 
-func (n *NSQConsumer) Gather(_ telegraf.Accumulator) error {
+func (*NSQConsumer) Gather(telegraf.Accumulator) error {
 	return nil
 }
 

--- a/plugins/inputs/nvidia_smi/nvidia_smi.go
+++ b/plugins/inputs/nvidia_smi/nvidia_smi.go
@@ -51,7 +51,7 @@ func (smi *NvidiaSMI) Start(telegraf.Accumulator) error {
 	return nil
 }
 
-func (smi *NvidiaSMI) Stop() {}
+func (*NvidiaSMI) Stop() {}
 
 // Gather implements the telegraf interface
 func (smi *NvidiaSMI) Gather(acc telegraf.Accumulator) error {

--- a/plugins/inputs/opentelemetry/writer.go
+++ b/plugins/inputs/opentelemetry/writer.go
@@ -49,6 +49,6 @@ func (w *writeToAccumulator) EnqueuePoint(
 	return nil
 }
 
-func (w *writeToAccumulator) WriteBatch(_ context.Context) error {
+func (*writeToAccumulator) WriteBatch(context.Context) error {
 	return nil
 }

--- a/plugins/inputs/pf/pf.go
+++ b/plugins/inputs/pf/pf.go
@@ -104,7 +104,7 @@ func (pf *PF) Gather(acc telegraf.Accumulator) error {
 		return nil
 	}
 
-	if perr := pf.parsePfctlOutput(o, acc); perr != nil {
+	if perr := parsePfctlOutput(o, acc); perr != nil {
 		acc.AddError(perr)
 	}
 	return nil
@@ -114,7 +114,7 @@ func errMissingData(tag string) error {
 	return fmt.Errorf("struct data for tag %q not found in %s output", tag, pfctlCommand)
 }
 
-func (pf *PF) parsePfctlOutput(pfoutput string, acc telegraf.Accumulator) error {
+func parsePfctlOutput(pfoutput string, acc telegraf.Accumulator) error {
 	fields := make(map[string]interface{})
 	scanner := bufio.NewScanner(strings.NewReader(pfoutput))
 	for scanner.Scan() {

--- a/plugins/inputs/phpfpm/fcgi_test.go
+++ b/plugins/inputs/phpfpm/fcgi_test.go
@@ -125,7 +125,7 @@ func (c *writeOnlyConn) Write(p []byte) (int, error) {
 	return len(p), nil
 }
 
-func (*writeOnlyConn) Read(_ []byte) (int, error) {
+func (*writeOnlyConn) Read([]byte) (int, error) {
 	return 0, errors.New("conn is write-only")
 }
 

--- a/plugins/inputs/phpfpm/fcgi_test.go
+++ b/plugins/inputs/phpfpm/fcgi_test.go
@@ -72,7 +72,7 @@ type nilCloser struct {
 	io.ReadWriter
 }
 
-func (c *nilCloser) Close() error { return nil }
+func (*nilCloser) Close() error { return nil }
 
 func TestStreams(t *testing.T) {
 	var rec record
@@ -125,11 +125,11 @@ func (c *writeOnlyConn) Write(p []byte) (int, error) {
 	return len(p), nil
 }
 
-func (c *writeOnlyConn) Read(_ []byte) (int, error) {
+func (*writeOnlyConn) Read(_ []byte) (int, error) {
 	return 0, errors.New("conn is write-only")
 }
 
-func (c *writeOnlyConn) Close() error {
+func (*writeOnlyConn) Close() error {
 	return nil
 }
 

--- a/plugins/inputs/phpfpm/phpfpm_test.go
+++ b/plugins/inputs/phpfpm/phpfpm_test.go
@@ -31,7 +31,7 @@ import (
 type statServer struct{}
 
 // We create a fake server to return test data
-func (s statServer) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
+func (statServer) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "text/plain")
 	w.Header().Set("Content-Length", strconv.Itoa(len(outputSample)))
 	fmt.Fprint(w, outputSample)

--- a/plugins/inputs/powerdns/powerdns_linux_test.go
+++ b/plugins/inputs/powerdns/powerdns_linux_test.go
@@ -13,9 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type statServer struct{}
-
-func (s statServer) serverSocket(l net.Listener) {
+func serverSocket(l net.Listener) {
 	for {
 		conn, err := l.Accept()
 		if err != nil {
@@ -46,8 +44,7 @@ func TestPowerdnsGeneratesMetrics(t *testing.T) {
 
 	defer socket.Close()
 
-	s := statServer{}
-	go s.serverSocket(socket)
+	go serverSocket(socket)
 
 	p := &Powerdns{
 		UnixSockets: []string{sockname},

--- a/plugins/inputs/powerdns_recursor/powerdns_recursor.go
+++ b/plugins/inputs/powerdns_recursor/powerdns_recursor.go
@@ -53,7 +53,7 @@ func (p *PowerdnsRecursor) Init() error {
 	case 2:
 		p.gatherFromServer = p.gatherFromV2Server
 	case 3:
-		p.gatherFromServer = p.gatherFromV3Server
+		p.gatherFromServer = gatherFromV3Server
 	default:
 		return fmt.Errorf("unknown control protocol version '%d', allowed values are 1, 2, 3", p.ControlProtocolVersion)
 	}

--- a/plugins/inputs/powerdns_recursor/protocol_v3.go
+++ b/plugins/inputs/powerdns_recursor/protocol_v3.go
@@ -16,7 +16,7 @@ import (
 // status: uint32
 // dataLength: size_t
 // data: byte[dataLength]
-func (p *PowerdnsRecursor) gatherFromV3Server(address string, acc telegraf.Accumulator) error {
+func gatherFromV3Server(address string, acc telegraf.Accumulator) error {
 	conn, err := net.Dial("unix", address)
 	if err != nil {
 		return err

--- a/plugins/inputs/procstat/native_finder.go
+++ b/plugins/inputs/procstat/native_finder.go
@@ -14,7 +14,7 @@ import (
 type NativeFinder struct{}
 
 // Uid will return all pids for the given user
-func (pg *NativeFinder) uid(user string) ([]pid, error) {
+func (*NativeFinder) uid(user string) ([]pid, error) {
 	var dst []pid
 	procs, err := gopsprocess.Processes()
 	if err != nil {
@@ -34,7 +34,7 @@ func (pg *NativeFinder) uid(user string) ([]pid, error) {
 }
 
 // PidFile returns the pid from the pid file given.
-func (pg *NativeFinder) pidFile(path string) ([]pid, error) {
+func (*NativeFinder) pidFile(path string) ([]pid, error) {
 	var pids []pid
 	pidString, err := os.ReadFile(path)
 	if err != nil {
@@ -49,13 +49,13 @@ func (pg *NativeFinder) pidFile(path string) ([]pid, error) {
 }
 
 // FullPattern matches on the command line when the process was executed
-func (pg *NativeFinder) fullPattern(pattern string) ([]pid, error) {
+func (*NativeFinder) fullPattern(pattern string) ([]pid, error) {
 	var pids []pid
 	regxPattern, err := regexp.Compile(pattern)
 	if err != nil {
 		return pids, err
 	}
-	procs, err := pg.fastProcessList()
+	procs, err := fastProcessList()
 	if err != nil {
 		return pids, err
 	}
@@ -73,7 +73,7 @@ func (pg *NativeFinder) fullPattern(pattern string) ([]pid, error) {
 }
 
 // Children matches children pids on the command line when the process was executed
-func (pg *NativeFinder) children(processID pid) ([]pid, error) {
+func (*NativeFinder) children(processID pid) ([]pid, error) {
 	// Get all running processes
 	p, err := gopsprocess.NewProcess(int32(processID))
 	if err != nil {
@@ -93,7 +93,7 @@ func (pg *NativeFinder) children(processID pid) ([]pid, error) {
 	return pids, err
 }
 
-func (pg *NativeFinder) fastProcessList() ([]*gopsprocess.Process, error) {
+func fastProcessList() ([]*gopsprocess.Process, error) {
 	pids, err := gopsprocess.Pids()
 	if err != nil {
 		return nil, err
@@ -107,13 +107,13 @@ func (pg *NativeFinder) fastProcessList() ([]*gopsprocess.Process, error) {
 }
 
 // Pattern matches on the process name
-func (pg *NativeFinder) pattern(pattern string) ([]pid, error) {
+func (*NativeFinder) pattern(pattern string) ([]pid, error) {
 	var pids []pid
 	regxPattern, err := regexp.Compile(pattern)
 	if err != nil {
 		return pids, err
 	}
-	procs, err := pg.fastProcessList()
+	procs, err := fastProcessList()
 	if err != nil {
 		return pids, err
 	}

--- a/plugins/inputs/procstat/pgrep.go
+++ b/plugins/inputs/procstat/pgrep.go
@@ -23,7 +23,7 @@ func newPgrepFinder() (pidFinder, error) {
 	return &pgrep{path}, nil
 }
 
-func (pg *pgrep) pidFile(path string) ([]pid, error) {
+func (*pgrep) pidFile(path string) ([]pid, error) {
 	var pids []pid
 	pidString, err := os.ReadFile(path)
 	if err != nil {

--- a/plugins/inputs/procstat/procstat.go
+++ b/plugins/inputs/procstat/procstat.go
@@ -617,7 +617,7 @@ func (p *Procstat) cgroupPIDs() ([]pidsTags, error) {
 
 	pidTags := make([]pidsTags, 0, len(items))
 	for _, item := range items {
-		pids, err := p.singleCgroupPIDs(item)
+		pids, err := singleCgroupPIDs(item)
 		if err != nil {
 			return nil, err
 		}
@@ -628,7 +628,7 @@ func (p *Procstat) cgroupPIDs() ([]pidsTags, error) {
 	return pidTags, nil
 }
 
-func (p *Procstat) singleCgroupPIDs(path string) ([]pid, error) {
+func singleCgroupPIDs(path string) ([]pid, error) {
 	ok, err := isDir(path)
 	if err != nil {
 		return nil, err

--- a/plugins/inputs/procstat/procstat_test.go
+++ b/plugins/inputs/procstat/procstat_test.go
@@ -126,7 +126,7 @@ func (p *testProc) pid() pid {
 	return p.procID
 }
 
-func (p *testProc) Name() (string, error) {
+func (*testProc) Name() (string, error) {
 	return "test_proc", nil
 }
 
@@ -134,7 +134,7 @@ func (p *testProc) setTag(k, v string) {
 	p.tags[k] = v
 }
 
-func (p *testProc) MemoryMaps(bool) (*[]gopsprocess.MemoryMapsStat, error) {
+func (*testProc) MemoryMaps(bool) (*[]gopsprocess.MemoryMapsStat, error) {
 	stats := make([]gopsprocess.MemoryMapsStat, 0)
 	return &stats, nil
 }

--- a/plugins/inputs/prometheus/kubernetes.go
+++ b/plugins/inputs/prometheus/kubernetes.go
@@ -419,7 +419,7 @@ func registerPod(pod *corev1.Pod, p *Prometheus) {
 			tags[k] = v
 		}
 	}
-	podURL := p.addressToURL(targetURL, targetURL.Hostname())
+	podURL := addressToURL(targetURL, targetURL.Hostname())
 
 	// Locks earlier if using cAdvisor calls - makes a new list each time
 	// rather than updating and removing from the same list

--- a/plugins/inputs/prometheus/prometheus.go
+++ b/plugins/inputs/prometheus/prometheus.go
@@ -338,7 +338,7 @@ func (p *Prometheus) initFilters() error {
 	return nil
 }
 
-func (p *Prometheus) addressToURL(u *url.URL, address string) *url.URL {
+func addressToURL(u *url.URL, address string) *url.URL {
 	host := address
 	if u.Port() != "" {
 		host = address + ":" + u.Port()
@@ -393,7 +393,7 @@ func (p *Prometheus) getAllURLs() (map[string]urlAndAddress, error) {
 			continue
 		}
 		for _, resolved := range resolvedAddresses {
-			serviceURL := p.addressToURL(address, resolved)
+			serviceURL := addressToURL(address, resolved)
 			allURLs[serviceURL.String()] = urlAndAddress{
 				url:         serviceURL,
 				address:     resolved,

--- a/plugins/inputs/radius/radius.go
+++ b/plugins/inputs/radius/radius.go
@@ -32,7 +32,7 @@ type Radius struct {
 //go:embed sample.conf
 var sampleConfig string
 
-func (r *Radius) SampleConfig() string {
+func (*Radius) SampleConfig() string {
 	return sampleConfig
 }
 

--- a/plugins/inputs/raindrops/raindrops.go
+++ b/plugins/inputs/raindrops/raindrops.go
@@ -89,7 +89,7 @@ func (r *Raindrops) gatherURL(addr *url.URL, acc telegraf.Accumulator) error {
 	if err != nil {
 		return err
 	}
-	tags := r.getTags(addr)
+	tags := getTags(addr)
 	fields := map[string]interface{}{
 		"calling": calling,
 		"writing": writing,
@@ -153,7 +153,7 @@ func (r *Raindrops) gatherURL(addr *url.URL, acc telegraf.Accumulator) error {
 }
 
 // Get tag(s) for the raindrops calling/writing plugin
-func (r *Raindrops) getTags(addr *url.URL) map[string]string {
+func getTags(addr *url.URL) map[string]string {
 	h := addr.Host
 	host, port, err := net.SplitHostPort(h)
 	if err != nil {

--- a/plugins/inputs/raindrops/raindrops_test.go
+++ b/plugins/inputs/raindrops/raindrops_test.go
@@ -35,11 +35,10 @@ writing: 200
 // Verify that raindrops tags are properly parsed based on the server
 func TestRaindropsTags(t *testing.T) {
 	urls := []string{"http://localhost/_raindrops", "http://localhost:80/_raindrops"}
-	r := &Raindrops{}
 	for _, url1 := range urls {
 		addr, err := url.Parse(url1)
 		require.NoError(t, err)
-		tagMap := r.getTags(addr)
+		tagMap := getTags(addr)
 		require.Contains(t, tagMap["server"], "localhost")
 	}
 }

--- a/plugins/inputs/redis/redis.go
+++ b/plugins/inputs/redis/redis.go
@@ -315,7 +315,7 @@ func (r *Redis) Gather(acc telegraf.Accumulator) error {
 		wg.Add(1)
 		go func(client Client) {
 			defer wg.Done()
-			acc.AddError(r.gatherServer(client, acc))
+			acc.AddError(gatherServer(client, acc))
 			acc.AddError(r.gatherCommandValues(client, acc))
 		}(client)
 	}
@@ -344,7 +344,7 @@ func (r *Redis) gatherCommandValues(client Client, acc telegraf.Accumulator) err
 	return nil
 }
 
-func (r *Redis) gatherServer(client Client, acc telegraf.Accumulator) error {
+func gatherServer(client Client, acc telegraf.Accumulator) error {
 	info, err := client.Info().Result()
 	if err != nil {
 		return err
@@ -774,7 +774,7 @@ func coerceType(value interface{}, typ reflect.Type) reflect.Value {
 	return reflect.ValueOf(value)
 }
 
-func (r *Redis) Start(telegraf.Accumulator) error {
+func (*Redis) Start(telegraf.Accumulator) error {
 	return nil
 }
 

--- a/plugins/inputs/redis/redis_test.go
+++ b/plugins/inputs/redis/redis_test.go
@@ -17,19 +17,19 @@ import (
 
 type testClient struct{}
 
-func (t *testClient) BaseTags() map[string]string {
+func (*testClient) BaseTags() map[string]string {
 	return map[string]string{"host": "redis.net"}
 }
 
-func (t *testClient) Info() *redis.StringCmd {
+func (*testClient) Info() *redis.StringCmd {
 	return nil
 }
 
-func (t *testClient) Do(_ string, _ ...interface{}) (interface{}, error) {
+func (*testClient) Do(_ string, _ ...interface{}) (interface{}, error) {
 	return 2, nil
 }
 
-func (t *testClient) Close() error {
+func (*testClient) Close() error {
 	return nil
 }
 

--- a/plugins/inputs/redis/redis_test.go
+++ b/plugins/inputs/redis/redis_test.go
@@ -25,7 +25,7 @@ func (*testClient) Info() *redis.StringCmd {
 	return nil
 }
 
-func (*testClient) Do(_ string, _ ...interface{}) (interface{}, error) {
+func (*testClient) Do(string, ...interface{}) (interface{}, error) {
 	return 2, nil
 }
 

--- a/plugins/inputs/rethinkdb/rethinkdb.go
+++ b/plugins/inputs/rethinkdb/rethinkdb.go
@@ -30,7 +30,7 @@ func (*RethinkDB) SampleConfig() string {
 // Returns one of the errors encountered while gather stats (if any).
 func (r *RethinkDB) Gather(acc telegraf.Accumulator) error {
 	if len(r.Servers) == 0 {
-		return r.gatherServer(localhost, acc)
+		return gatherServer(localhost, acc)
 	}
 
 	var wg sync.WaitGroup
@@ -47,7 +47,7 @@ func (r *RethinkDB) Gather(acc telegraf.Accumulator) error {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			acc.AddError(r.gatherServer(&Server{URL: u}, acc))
+			acc.AddError(gatherServer(&Server{URL: u}, acc))
 		}()
 	}
 
@@ -56,7 +56,7 @@ func (r *RethinkDB) Gather(acc telegraf.Accumulator) error {
 	return nil
 }
 
-func (r *RethinkDB) gatherServer(server *Server, acc telegraf.Accumulator) error {
+func gatherServer(server *Server, acc telegraf.Accumulator) error {
 	var err error
 	connectOpts := gorethink.ConnectOpts{
 		Address:       server.URL.Host,

--- a/plugins/inputs/riemann_listener/riemann_listener.go
+++ b/plugins/inputs/riemann_listener/riemann_listener.go
@@ -275,7 +275,7 @@ func (*RiemannSocketListener) SampleConfig() string {
 	return sampleConfig
 }
 
-func (rsl *RiemannSocketListener) Gather(_ telegraf.Accumulator) error {
+func (*RiemannSocketListener) Gather(telegraf.Accumulator) error {
 	return nil
 }
 


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

Address findings for [revive:unused-receiver](https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unused-receiver) in `plugins/inputs/[l-r]*`.

It is only part of the bigger work for https://github.com/influxdata/telegraf/issues/16190.
After all findings of this type in whole project are handled, we can enable `revive:unused-receiver` rule in `golangci-lint`.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

