### PR TITLE
feat(agent): Add support for input probing

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -379,8 +379,7 @@ func (a *Agent) startInputs(
 			return nil, fmt.Errorf("starting input %s: %w", input.LogName(), err)
 		}
 		if err := input.Probe(); err != nil {
-			// Probe failures are not fatal to Telegraf itself, so simply skip
-			// adding the input.
+			// Probe failures are none-fatal to the agent but should only remove the plugin
 			log.Printf("I! [agent] Failed to probe %s, shutting down plugin: %s", input.LogName(), err)
 			input.Stop()
 			continue

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -378,6 +378,12 @@ func (a *Agent) startInputs(
 
 			return nil, fmt.Errorf("starting input %s: %w", input.LogName(), err)
 		}
+		if err := input.Probe(); err != nil {
+			// Probe failures are not fatal to Telegraf itself, so simply skip
+			// adding the input.
+			log.Printf("I! [agent] Failed to probe %s, shutting down plugin: %s", input.LogName(), err)
+			continue
+		}
 		unit.inputs = append(unit.inputs, input)
 	}
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -379,7 +379,7 @@ func (a *Agent) startInputs(
 			return nil, fmt.Errorf("starting input %s: %w", input.LogName(), err)
 		}
 		if err := input.Probe(); err != nil {
-			// Probe failures are none-fatal to the agent but should only remove the plugin
+			// Probe failures are non-fatal to the agent but should only remove the plugin
 			log.Printf("I! [agent] Failed to probe %s, shutting down plugin: %s", input.LogName(), err)
 			input.Stop()
 			continue

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -382,6 +382,7 @@ func (a *Agent) startInputs(
 			// Probe failures are not fatal to Telegraf itself, so simply skip
 			// adding the input.
 			log.Printf("I! [agent] Failed to probe %s, shutting down plugin: %s", input.LogName(), err)
+			input.Stop()
 			continue
 		}
 		unit.inputs = append(unit.inputs, input)

--- a/models/running_input.go
+++ b/models/running_input.go
@@ -173,10 +173,8 @@ func (r *RunningInput) Start(acc telegraf.Accumulator) error {
 func (r *RunningInput) Probe() error {
 	p, ok := r.Input.(telegraf.ProbePlugin)
 	if !ok || r.Config.StartupErrorBehavior != "probe" {
-		r.log.Debug("Not probing plugin")
 		return nil
 	}
-	r.log.Debug("Probing plugin")
 	return p.Probe()
 }
 

--- a/models/running_input.go
+++ b/models/running_input.go
@@ -112,7 +112,7 @@ func (r *RunningInput) LogName() string {
 
 func (r *RunningInput) Init() error {
 	switch r.Config.StartupErrorBehavior {
-	case "", "error", "retry", "ignore":
+	case "", "error", "retry", "ignore", "probe":
 	default:
 		return fmt.Errorf("invalid 'startup_error_behavior' setting %q", r.Config.StartupErrorBehavior)
 	}
@@ -161,13 +161,23 @@ func (r *RunningInput) Start(acc telegraf.Accumulator) error {
 		}
 		r.log.Infof("Startup failed: %v; retrying...", err)
 		return nil
-	case "ignore":
+	case "ignore", "probe":
 		return &internal.FatalError{Err: serr}
 	default:
 		r.log.Errorf("Invalid 'startup_error_behavior' setting %q", r.Config.StartupErrorBehavior)
 	}
 
 	return err
+}
+
+func (r *RunningInput) Probe() error {
+	p, ok := r.Input.(telegraf.ProbePlugin)
+	if !ok || r.Config.StartupErrorBehavior != "probe" {
+		r.log.Debug("Not probing plugin")
+		return nil
+	}
+	r.log.Debug("Probing plugin")
+	return p.Probe()
 }
 
 func (r *RunningInput) Stop() {

--- a/models/running_input_test.go
+++ b/models/running_input_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/zeebo/assert"
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/metric"

--- a/plugin.go
+++ b/plugin.go
@@ -58,7 +58,7 @@ type StatefulPlugin interface {
 }
 
 // ProbePlugin is an interface that all input/output plugins need to
-// implement in order to support the `probe` value of `startup_error_behavior`.
+// implement in order to support the `probe` value of `startup_error_behavior`
 type ProbePlugin interface {
 	Probe() error
 }

--- a/plugin.go
+++ b/plugin.go
@@ -56,3 +56,9 @@ type StatefulPlugin interface {
 	// initialization (after Init() function).
 	SetState(state interface{}) error
 }
+
+// ProbePlugin is an interface that all input/output plugins need to
+// implement in order to support the `probe` value of `startup_error_behavior`.
+type ProbePlugin interface {
+	Probe() error
+}


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

This PR adds support in `RunningInput` and the `Agent` to call an input plugin's `Probe` method if it exists and if the plugin has been configured for probing.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues

- Spec: #16052
- #15915
- #16028
- #16305
