### PR TITLE
feat(inputs.cloudwatch): Allow wildcards for namespaces

### DIFF
--- a/plugins/inputs/cloudwatch/README.md
+++ b/plugins/inputs/cloudwatch/README.md
@@ -100,13 +100,13 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## Do not enable if "period" or "delay" is longer than 3 hours, as it will
   ## not return data more than 3 hours old.
   ## See https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_ListMetrics.html
-  #recently_active = "PT3H"
+  # recently_active = "PT3H"
 
   ## Configure the TTL for the internal cache of metrics.
   # cache_ttl = "1h"
 
-  ## Metric Statistic Namespaces (required)
-  namespaces = ["AWS/ELB"]
+  ## Metric Statistic Namespaces, wildcards are allowed
+  # namespaces = ["*"]
 
   ## Metric Format
   ## This determines the format of the produces metrics. 'sparse', the default

--- a/plugins/inputs/cloudwatch/cloudwatch_test.go
+++ b/plugins/inputs/cloudwatch/cloudwatch_test.go
@@ -10,26 +10,482 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 
+	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/filter"
+	"github.com/influxdata/telegraf/metric"
 	common_aws "github.com/influxdata/telegraf/plugins/common/aws"
 	"github.com/influxdata/telegraf/plugins/common/proxy"
 	"github.com/influxdata/telegraf/testutil"
 )
 
-type mockGatherCloudWatchClient struct{}
+func TestSnakeCase(t *testing.T) {
+	require.Equal(t, "cluster_name", snakeCase("Cluster Name"))
+	require.Equal(t, "broker_id", snakeCase("Broker ID"))
+}
 
-func (*mockGatherCloudWatchClient) ListMetrics(
-	_ context.Context,
-	params *cloudwatch.ListMetricsInput,
-	_ ...func(*cloudwatch.Options),
-) (*cloudwatch.ListMetricsOutput, error) {
-	response := &cloudwatch.ListMetricsOutput{
-		Metrics: []types.Metric{
+func TestGather(t *testing.T) {
+	plugin := &CloudWatch{
+		CredentialConfig: common_aws.CredentialConfig{
+			Region: "us-east-1",
+		},
+		Namespace: "AWS/ELB",
+		Delay:     config.Duration(1 * time.Minute),
+		Period:    config.Duration(1 * time.Minute),
+		RateLimit: 200,
+		BatchSize: 500,
+		Log:       testutil.Logger{},
+	}
+	require.NoError(t, plugin.Init())
+	plugin.client = defaultMockClient("AWS/ELB")
+
+	var acc testutil.Accumulator
+	require.NoError(t, acc.GatherError(plugin.Gather))
+
+	expected := []telegraf.Metric{
+		metric.New(
+			"cloudwatch_aws_elb",
+			map[string]string{
+				"region":             "us-east-1",
+				"load_balancer_name": "p-example1",
+			},
+			map[string]interface{}{
+				"latency_minimum":      0.1,
+				"latency_maximum":      0.3,
+				"latency_average":      0.2,
+				"latency_sum":          123.0,
+				"latency_sample_count": 100.0,
+			},
+			time.Unix(0, 0),
+		),
+		metric.New(
+			"cloudwatch_aws_elb",
+			map[string]string{
+				"region":             "us-east-1",
+				"load_balancer_name": "p-example2",
+			},
+			map[string]interface{}{
+				"latency_minimum":      0.1,
+				"latency_maximum":      0.3,
+				"latency_average":      0.2,
+				"latency_sum":          124.0,
+				"latency_sample_count": 100.0,
+			},
+			time.Unix(0, 0),
+		),
+	}
+
+	testutil.RequireMetricsEqual(t, expected, acc.GetTelegrafMetrics(), testutil.IgnoreTime())
+}
+
+func TestGatherDenseMetric(t *testing.T) {
+	plugin := &CloudWatch{
+		CredentialConfig: common_aws.CredentialConfig{
+			Region: "us-east-1",
+		},
+		Namespace:    "AWS/ELB",
+		Delay:        config.Duration(1 * time.Minute),
+		Period:       config.Duration(1 * time.Minute),
+		RateLimit:    200,
+		BatchSize:    500,
+		MetricFormat: "dense",
+		Log:          testutil.Logger{},
+	}
+	require.NoError(t, plugin.Init())
+	plugin.client = defaultMockClient("AWS/ELB")
+
+	var acc testutil.Accumulator
+	require.NoError(t, acc.GatherError(plugin.Gather))
+
+	expected := []telegraf.Metric{
+		metric.New(
+			"cloudwatch_aws_elb",
+			map[string]string{
+				"region":             "us-east-1",
+				"load_balancer_name": "p-example1",
+				"metric_name":        "latency",
+			},
+			map[string]interface{}{
+				"minimum":      0.1,
+				"maximum":      0.3,
+				"average":      0.2,
+				"sum":          123.0,
+				"sample_count": 100.0,
+			},
+			time.Unix(0, 0),
+		),
+		metric.New(
+			"cloudwatch_aws_elb",
+			map[string]string{
+				"region":             "us-east-1",
+				"load_balancer_name": "p-example2",
+				"metric_name":        "latency",
+			},
+			map[string]interface{}{
+				"minimum":      0.1,
+				"maximum":      0.3,
+				"average":      0.2,
+				"sum":          124.0,
+				"sample_count": 100.0,
+			},
+			time.Unix(0, 0),
+		),
+	}
+
+	testutil.RequireMetricsEqual(t, expected, acc.GetTelegrafMetrics(), testutil.IgnoreTime())
+}
+
+func TestMultiAccountGather(t *testing.T) {
+	plugin := &CloudWatch{
+		CredentialConfig: common_aws.CredentialConfig{
+			Region: "us-east-1",
+		},
+		Namespace:             "AWS/ELB",
+		Delay:                 config.Duration(1 * time.Minute),
+		Period:                config.Duration(1 * time.Minute),
+		RateLimit:             200,
+		BatchSize:             500,
+		Log:                   testutil.Logger{},
+		IncludeLinkedAccounts: true,
+	}
+	require.NoError(t, plugin.Init())
+	plugin.client = defaultMockClient("AWS/ELB")
+
+	var acc testutil.Accumulator
+	require.NoError(t, acc.GatherError(plugin.Gather))
+
+	expected := []telegraf.Metric{
+		metric.New(
+			"cloudwatch_aws_elb",
+			map[string]string{
+				"region":             "us-east-1",
+				"load_balancer_name": "p-example1",
+				"account":            "123456789012",
+			},
+			map[string]interface{}{
+				"latency_minimum":      0.1,
+				"latency_maximum":      0.3,
+				"latency_average":      0.2,
+				"latency_sum":          123.0,
+				"latency_sample_count": 100.0,
+			},
+			time.Unix(0, 0),
+		),
+		metric.New(
+			"cloudwatch_aws_elb",
+			map[string]string{
+				"region":             "us-east-1",
+				"load_balancer_name": "p-example2",
+				"account":            "923456789017",
+			},
+			map[string]interface{}{
+				"latency_minimum":      0.1,
+				"latency_maximum":      0.3,
+				"latency_average":      0.2,
+				"latency_sum":          124.0,
+				"latency_sample_count": 100.0,
+			},
+			time.Unix(0, 0),
+		),
+	}
+
+	testutil.RequireMetricsEqual(t, expected, acc.GetTelegrafMetrics(), testutil.IgnoreTime())
+}
+
+func TestGatherMultipleNamespaces(t *testing.T) {
+	plugin := &CloudWatch{
+		CredentialConfig: common_aws.CredentialConfig{
+			Region: "us-east-1",
+		},
+		Namespaces: []string{"AWS/ELB", "AWS/EC2"},
+		Delay:      config.Duration(1 * time.Minute),
+		Period:     config.Duration(1 * time.Minute),
+		RateLimit:  200,
+		BatchSize:  500,
+		Log:        testutil.Logger{},
+	}
+	require.NoError(t, plugin.Init())
+	plugin.client = defaultMockClient("AWS/ELB", "AWS/EC2")
+
+	var acc testutil.Accumulator
+	require.NoError(t, acc.GatherError(plugin.Gather))
+
+	expected := []telegraf.Metric{
+		metric.New(
+			"cloudwatch_aws_elb",
+			map[string]string{
+				"region":             "us-east-1",
+				"load_balancer_name": "p-example1",
+			},
+			map[string]interface{}{
+				"latency_minimum":      0.1,
+				"latency_maximum":      0.3,
+				"latency_average":      0.2,
+				"latency_sum":          123.0,
+				"latency_sample_count": 100.0,
+			},
+			time.Unix(0, 0),
+		),
+		metric.New(
+			"cloudwatch_aws_elb",
+			map[string]string{
+				"region":             "us-east-1",
+				"load_balancer_name": "p-example2",
+			},
+			map[string]interface{}{
+				"latency_minimum":      0.1,
+				"latency_maximum":      0.3,
+				"latency_average":      0.2,
+				"latency_sum":          124.0,
+				"latency_sample_count": 100.0,
+			},
+			time.Unix(0, 0),
+		),
+		metric.New(
+			"cloudwatch_aws_ec2",
+			map[string]string{
+				"region":             "us-east-1",
+				"load_balancer_name": "p-example1",
+			},
+			map[string]interface{}{
+				"latency_minimum":      0.1,
+				"latency_maximum":      0.3,
+				"latency_average":      0.2,
+				"latency_sum":          123.0,
+				"latency_sample_count": 100.0,
+			},
+			time.Unix(0, 0),
+		),
+		metric.New(
+			"cloudwatch_aws_ec2",
+			map[string]string{
+				"region":             "us-east-1",
+				"load_balancer_name": "p-example2",
+			},
+			map[string]interface{}{
+				"latency_minimum":      0.1,
+				"latency_maximum":      0.3,
+				"latency_average":      0.2,
+				"latency_sum":          124.0,
+				"latency_sample_count": 100.0,
+			},
+			time.Unix(0, 0),
+		),
+	}
+
+	option := []cmp.Option{
+		testutil.IgnoreTime(),
+		testutil.SortMetrics(),
+	}
+
+	testutil.RequireMetricsEqual(t, expected, acc.GetTelegrafMetrics(), option...)
+}
+
+func TestSelectMetrics(t *testing.T) {
+	plugin := &CloudWatch{
+		CredentialConfig: common_aws.CredentialConfig{
+			Region: "us-east-1",
+		},
+		Namespace: "AWS/ELB",
+		Delay:     config.Duration(1 * time.Minute),
+		Period:    config.Duration(1 * time.Minute),
+		RateLimit: 200,
+		BatchSize: 500,
+		Metrics: []*cloudwatchMetric{
 			{
-				Namespace:  params.Namespace,
+				MetricNames: []string{"Latency", "RequestCount"},
+				Dimensions: []*dimension{
+					{
+						Name:  "LoadBalancerName",
+						Value: "lb*",
+					},
+					{
+						Name:  "AvailabilityZone",
+						Value: "us-east*",
+					},
+				},
+			},
+		},
+		Log: testutil.Logger{},
+	}
+	require.NoError(t, plugin.Init())
+	plugin.client = selectedMockClient()
+	filtered, err := plugin.getFilteredMetrics()
+	// We've asked for 2 (out of 4) metrics, over all 3 load balancers in all 2
+	// AZs. We should get 12 metrics.
+	require.Len(t, filtered[0].metrics, 12)
+	require.NoError(t, err)
+}
+
+func TestGenerateStatisticsInputParams(t *testing.T) {
+	d := types.Dimension{
+		Name:  aws.String("LoadBalancerName"),
+		Value: aws.String("p-example"),
+	}
+
+	namespace := "AWS/ELB"
+	m := types.Metric{
+		MetricName: aws.String("Latency"),
+		Dimensions: []types.Dimension{d},
+		Namespace:  aws.String(namespace),
+	}
+
+	plugin := &CloudWatch{
+		Namespaces: []string{namespace},
+		Delay:      config.Duration(1 * time.Minute),
+		Period:     config.Duration(1 * time.Minute),
+		BatchSize:  500,
+		Log:        testutil.Logger{},
+	}
+	require.NoError(t, plugin.Init())
+
+	now := time.Now()
+
+	plugin.updateWindow(now)
+
+	statFilter, err := filter.NewIncludeExcludeFilter(nil, nil)
+	require.NoError(t, err)
+	queries := plugin.getDataQueries([]filteredMetric{{metrics: []types.Metric{m}, statFilter: statFilter}})
+	params := &cloudwatch.GetMetricDataInput{
+		StartTime:         aws.Time(plugin.windowStart),
+		EndTime:           aws.Time(plugin.windowEnd),
+		MetricDataQueries: queries[namespace],
+	}
+
+	require.EqualValues(t, *params.EndTime, now.Add(-time.Duration(plugin.Delay)))
+	require.EqualValues(t, *params.StartTime, now.Add(-time.Duration(plugin.Period)).Add(-time.Duration(plugin.Delay)))
+	require.Len(t, params.MetricDataQueries, 5)
+	require.Len(t, params.MetricDataQueries[0].MetricStat.Metric.Dimensions, 1)
+	require.EqualValues(t, 60, *params.MetricDataQueries[0].MetricStat.Period)
+}
+
+func TestGenerateStatisticsInputParamsFiltered(t *testing.T) {
+	d := types.Dimension{
+		Name:  aws.String("LoadBalancerName"),
+		Value: aws.String("p-example"),
+	}
+
+	namespace := "AWS/ELB"
+	m := types.Metric{
+		MetricName: aws.String("Latency"),
+		Dimensions: []types.Dimension{d},
+		Namespace:  aws.String(namespace),
+	}
+
+	plugin := &CloudWatch{
+		Namespaces: []string{namespace},
+		Delay:      config.Duration(1 * time.Minute),
+		Period:     config.Duration(1 * time.Minute),
+		BatchSize:  500,
+		Log:        testutil.Logger{},
+	}
+	require.NoError(t, plugin.Init())
+
+	now := time.Now()
+
+	plugin.updateWindow(now)
+
+	statFilter, err := filter.NewIncludeExcludeFilter([]string{"average", "sample_count"}, nil)
+	require.NoError(t, err)
+	queries := plugin.getDataQueries([]filteredMetric{{metrics: []types.Metric{m}, statFilter: statFilter}})
+	params := &cloudwatch.GetMetricDataInput{
+		StartTime:         aws.Time(plugin.windowStart),
+		EndTime:           aws.Time(plugin.windowEnd),
+		MetricDataQueries: queries[namespace],
+	}
+
+	require.EqualValues(t, *params.EndTime, now.Add(-time.Duration(plugin.Delay)))
+	require.EqualValues(t, *params.StartTime, now.Add(-time.Duration(plugin.Period)).Add(-time.Duration(plugin.Delay)))
+	require.Len(t, params.MetricDataQueries, 2)
+	require.Len(t, params.MetricDataQueries[0].MetricStat.Metric.Dimensions, 1)
+	require.EqualValues(t, 60, *params.MetricDataQueries[0].MetricStat.Period)
+}
+
+func TestMetricsCacheTimeout(t *testing.T) {
+	cache := &metricCache{
+		metrics: make([]filteredMetric, 0),
+		built:   time.Now(),
+		ttl:     time.Minute,
+	}
+
+	require.True(t, cache.metrics != nil && time.Since(cache.built) < cache.ttl)
+	cache.built = time.Now().Add(-time.Minute)
+	require.False(t, cache.metrics != nil && time.Since(cache.built) < cache.ttl)
+}
+
+func TestUpdateWindow(t *testing.T) {
+	plugin := &CloudWatch{
+		Namespace: "AWS/ELB",
+		Delay:     config.Duration(1 * time.Minute),
+		Period:    config.Duration(1 * time.Minute),
+		BatchSize: 500,
+		Log:       testutil.Logger{},
+	}
+
+	now := time.Now()
+
+	require.True(t, plugin.windowEnd.IsZero())
+	require.True(t, plugin.windowStart.IsZero())
+
+	plugin.updateWindow(now)
+
+	newStartTime := plugin.windowEnd
+
+	// initial window just has a single period
+	require.EqualValues(t, plugin.windowEnd, now.Add(-time.Duration(plugin.Delay)))
+	require.EqualValues(t, plugin.windowStart, now.Add(-time.Duration(plugin.Delay)).Add(-time.Duration(plugin.Period)))
+
+	now = time.Now()
+	plugin.updateWindow(now)
+
+	// subsequent window uses previous end time as start time
+	require.EqualValues(t, plugin.windowEnd, now.Add(-time.Duration(plugin.Delay)))
+	require.EqualValues(t, plugin.windowStart, newStartTime)
+}
+
+func TestProxyFunction(t *testing.T) {
+	proxyCfg := proxy.HTTPProxy{HTTPProxyURL: "http://www.penguins.com"}
+
+	proxyFunction, err := proxyCfg.Proxy()
+	require.NoError(t, err)
+
+	u, err := url.Parse("https://monitoring.us-west-1.amazonaws.com/")
+	require.NoError(t, err)
+
+	proxyResult, err := proxyFunction(&http.Request{URL: u})
+	require.NoError(t, err)
+	require.Equal(t, "www.penguins.com", proxyResult.Host)
+}
+
+func TestCombineNamespaces(t *testing.T) {
+	plugin := &CloudWatch{
+		Namespace:  "AWS/ELB",
+		Namespaces: []string{"AWS/EC2", "AWS/Billing"},
+		BatchSize:  500,
+		Log:        testutil.Logger{},
+	}
+
+	require.NoError(t, plugin.Init())
+	require.Equal(t, []string{"AWS/EC2", "AWS/Billing", "AWS/ELB"}, plugin.Namespaces)
+}
+
+// INTERNAL mock client implementation
+type mockClient struct {
+	metrics []types.Metric
+}
+
+func defaultMockClient(namespaces ...string) *mockClient {
+	c := &mockClient{
+		metrics: make([]types.Metric, 0, len(namespaces)),
+	}
+
+	for _, namespace := range namespaces {
+		c.metrics = append(c.metrics,
+			types.Metric{
+				Namespace:  aws.String(namespace),
 				MetricName: aws.String("Latency"),
 				Dimensions: []types.Dimension{
 					{
@@ -38,8 +494,8 @@ func (*mockGatherCloudWatchClient) ListMetrics(
 					},
 				},
 			},
-			{
-				Namespace:  params.Namespace,
+			types.Metric{
+				Namespace:  aws.String(namespace),
 				MetricName: aws.String("Latency"),
 				Dimensions: []types.Dimension{
 					{
@@ -47,16 +503,68 @@ func (*mockGatherCloudWatchClient) ListMetrics(
 						Value: aws.String("p-example2"),
 					},
 				},
-			},
-		},
+			})
 	}
+	return c
+}
+
+func selectedMockClient() *mockClient {
+	c := &mockClient{
+		metrics: make([]types.Metric, 0, 4*3*2),
+	}
+	// 4 metrics for 3 ELBs  in 2 AZs
+	for _, m := range []string{"Latency", "RequestCount", "HealthyHostCount", "UnHealthyHostCount"} {
+		for _, lb := range []string{"lb-1", "lb-2", "lb-3"} {
+			// For each metric/ELB pair, we get an aggregate value across all AZs.
+			c.metrics = append(c.metrics, types.Metric{
+				Namespace:  aws.String("AWS/ELB"),
+				MetricName: aws.String(m),
+				Dimensions: []types.Dimension{
+					{
+						Name:  aws.String("LoadBalancerName"),
+						Value: aws.String(lb),
+					},
+				},
+			})
+			for _, az := range []string{"us-east-1a", "us-east-1b"} {
+				// We get a metric for each metric/ELB/AZ triplet.
+				c.metrics = append(c.metrics, types.Metric{
+					Namespace:  aws.String("AWS/ELB"),
+					MetricName: aws.String(m),
+					Dimensions: []types.Dimension{
+						{
+							Name:  aws.String("LoadBalancerName"),
+							Value: aws.String(lb),
+						},
+						{
+							Name:  aws.String("AvailabilityZone"),
+							Value: aws.String(az),
+						},
+					},
+				})
+			}
+		}
+	}
+
+	return c
+}
+
+func (c *mockClient) ListMetrics(
+	_ context.Context,
+	params *cloudwatch.ListMetricsInput,
+	_ ...func(*cloudwatch.Options),
+) (*cloudwatch.ListMetricsOutput, error) {
+	response := &cloudwatch.ListMetricsOutput{
+		Metrics: c.metrics,
+	}
+
 	if params.IncludeLinkedAccounts != nil && *params.IncludeLinkedAccounts {
-		(*response).OwningAccounts = []string{"123456789012", "923456789017"}
+		response.OwningAccounts = []string{"123456789012", "923456789017"}
 	}
 	return response, nil
 }
 
-func (*mockGatherCloudWatchClient) GetMetricData(
+func (*mockClient) GetMetricData(
 	_ context.Context,
 	params *cloudwatch.GetMetricDataInput,
 	_ ...func(*cloudwatch.Options),
@@ -155,416 +663,4 @@ func (*mockGatherCloudWatchClient) GetMetricData(
 			},
 		},
 	}, nil
-}
-
-func TestSnakeCase(t *testing.T) {
-	require.Equal(t, "cluster_name", snakeCase("Cluster Name"))
-	require.Equal(t, "broker_id", snakeCase("Broker ID"))
-}
-
-func TestGather(t *testing.T) {
-	duration, err := time.ParseDuration("1m")
-	require.NoError(t, err)
-	internalDuration := config.Duration(duration)
-	c := &CloudWatch{
-		CredentialConfig: common_aws.CredentialConfig{
-			Region: "us-east-1",
-		},
-		Namespace: "AWS/ELB",
-		Delay:     internalDuration,
-		Period:    internalDuration,
-		RateLimit: 200,
-		BatchSize: 500,
-		Log:       testutil.Logger{},
-	}
-
-	var acc testutil.Accumulator
-
-	require.NoError(t, c.Init())
-	c.client = &mockGatherCloudWatchClient{}
-	require.NoError(t, acc.GatherError(c.Gather))
-
-	fields := map[string]interface{}{}
-	fields["latency_minimum"] = 0.1
-	fields["latency_maximum"] = 0.3
-	fields["latency_average"] = 0.2
-	fields["latency_sum"] = 123.0
-	fields["latency_sample_count"] = 100.0
-
-	tags := map[string]string{}
-	tags["region"] = "us-east-1"
-	tags["load_balancer_name"] = "p-example1"
-
-	require.True(t, acc.HasMeasurement("cloudwatch_aws_elb"))
-	acc.AssertContainsTaggedFields(t, "cloudwatch_aws_elb", fields, tags)
-}
-
-func TestGatherDenseMetric(t *testing.T) {
-	duration, err := time.ParseDuration("1m")
-	require.NoError(t, err)
-	internalDuration := config.Duration(duration)
-	c := &CloudWatch{
-		CredentialConfig: common_aws.CredentialConfig{
-			Region: "us-east-1",
-		},
-		Namespace:    "AWS/ELB",
-		Delay:        internalDuration,
-		Period:       internalDuration,
-		RateLimit:    200,
-		BatchSize:    500,
-		MetricFormat: "dense",
-		Log:          testutil.Logger{},
-	}
-
-	var acc testutil.Accumulator
-
-	require.NoError(t, c.Init())
-	c.client = &mockGatherCloudWatchClient{}
-	require.NoError(t, acc.GatherError(c.Gather))
-
-	fields := map[string]interface{}{}
-	fields["minimum"] = 0.1
-	fields["maximum"] = 0.3
-	fields["average"] = 0.2
-	fields["sum"] = 123.0
-	fields["sample_count"] = 100.0
-
-	tags := map[string]string{}
-	tags["region"] = "us-east-1"
-	tags["load_balancer_name"] = "p-example1"
-	tags["metric_name"] = "latency"
-
-	require.True(t, acc.HasMeasurement("cloudwatch_aws_elb"))
-	acc.AssertContainsTaggedFields(t, "cloudwatch_aws_elb", fields, tags)
-}
-
-func TestMultiAccountGather(t *testing.T) {
-	duration, err := time.ParseDuration("1m")
-	require.NoError(t, err)
-	internalDuration := config.Duration(duration)
-	c := &CloudWatch{
-		CredentialConfig: common_aws.CredentialConfig{
-			Region: "us-east-1",
-		},
-		Namespace:             "AWS/ELB",
-		Delay:                 internalDuration,
-		Period:                internalDuration,
-		RateLimit:             200,
-		BatchSize:             500,
-		Log:                   testutil.Logger{},
-		IncludeLinkedAccounts: true,
-	}
-
-	var acc testutil.Accumulator
-
-	require.NoError(t, c.Init())
-	c.client = &mockGatherCloudWatchClient{}
-	require.NoError(t, acc.GatherError(c.Gather))
-
-	fields := map[string]interface{}{}
-	fields["latency_minimum"] = 0.1
-	fields["latency_maximum"] = 0.3
-	fields["latency_average"] = 0.2
-	fields["latency_sum"] = 123.0
-	fields["latency_sample_count"] = 100.0
-
-	tags := map[string]string{}
-	tags["region"] = "us-east-1"
-	tags["load_balancer_name"] = "p-example1"
-	tags["account"] = "123456789012"
-
-	require.True(t, acc.HasMeasurement("cloudwatch_aws_elb"))
-	acc.AssertContainsTaggedFields(t, "cloudwatch_aws_elb", fields, tags)
-
-	tags["load_balancer_name"] = "p-example2"
-	tags["account"] = "923456789017"
-	fields["latency_sum"] = 124.0
-	acc.AssertContainsTaggedFields(t, "cloudwatch_aws_elb", fields, tags)
-}
-
-func TestGather_MultipleNamespaces(t *testing.T) {
-	duration, err := time.ParseDuration("1m")
-	require.NoError(t, err)
-	internalDuration := config.Duration(duration)
-	c := &CloudWatch{
-		Namespaces: []string{"AWS/ELB", "AWS/EC2"},
-		Delay:      internalDuration,
-		Period:     internalDuration,
-		RateLimit:  200,
-		BatchSize:  500,
-		Log:        testutil.Logger{},
-	}
-
-	var acc testutil.Accumulator
-
-	require.NoError(t, c.Init())
-	c.client = &mockGatherCloudWatchClient{}
-	require.NoError(t, acc.GatherError(c.Gather))
-
-	require.True(t, acc.HasMeasurement("cloudwatch_aws_elb"))
-	require.True(t, acc.HasMeasurement("cloudwatch_aws_ec2"))
-}
-
-type mockSelectMetricsCloudWatchClient struct{}
-
-func (*mockSelectMetricsCloudWatchClient) ListMetrics(
-	context.Context,
-	*cloudwatch.ListMetricsInput,
-	...func(*cloudwatch.Options),
-) (*cloudwatch.ListMetricsOutput, error) {
-	metrics := make([]types.Metric, 0)
-	// 4 metrics are available
-	metricNames := []string{"Latency", "RequestCount", "HealthyHostCount", "UnHealthyHostCount"}
-	// for 3 ELBs
-	loadBalancers := []string{"lb-1", "lb-2", "lb-3"}
-	// in 2 AZs
-	availabilityZones := []string{"us-east-1a", "us-east-1b"}
-	for _, m := range metricNames {
-		for _, lb := range loadBalancers {
-			// For each metric/ELB pair, we get an aggregate value across all AZs.
-			metrics = append(metrics, types.Metric{
-				Namespace:  aws.String("AWS/ELB"),
-				MetricName: aws.String(m),
-				Dimensions: []types.Dimension{
-					{
-						Name:  aws.String("LoadBalancerName"),
-						Value: aws.String(lb),
-					},
-				},
-			})
-			for _, az := range availabilityZones {
-				// We get a metric for each metric/ELB/AZ triplet.
-				metrics = append(metrics, types.Metric{
-					Namespace:  aws.String("AWS/ELB"),
-					MetricName: aws.String(m),
-					Dimensions: []types.Dimension{
-						{
-							Name:  aws.String("LoadBalancerName"),
-							Value: aws.String(lb),
-						},
-						{
-							Name:  aws.String("AvailabilityZone"),
-							Value: aws.String(az),
-						},
-					},
-				})
-			}
-		}
-	}
-
-	result := &cloudwatch.ListMetricsOutput{
-		Metrics: metrics,
-	}
-	return result, nil
-}
-
-func (*mockSelectMetricsCloudWatchClient) GetMetricData(
-	context.Context,
-	*cloudwatch.GetMetricDataInput,
-	...func(*cloudwatch.Options),
-) (*cloudwatch.GetMetricDataOutput, error) {
-	return nil, nil
-}
-
-func TestSelectMetrics(t *testing.T) {
-	duration, err := time.ParseDuration("1m")
-	require.NoError(t, err)
-	internalDuration := config.Duration(duration)
-	c := &CloudWatch{
-		CredentialConfig: common_aws.CredentialConfig{
-			Region: "us-east-1",
-		},
-		Namespace: "AWS/ELB",
-		Delay:     internalDuration,
-		Period:    internalDuration,
-		RateLimit: 200,
-		BatchSize: 500,
-		Metrics: []*cloudwatchMetric{
-			{
-				MetricNames: []string{"Latency", "RequestCount"},
-				Dimensions: []*dimension{
-					{
-						Name:  "LoadBalancerName",
-						Value: "lb*",
-					},
-					{
-						Name:  "AvailabilityZone",
-						Value: "us-east*",
-					},
-				},
-			},
-		},
-		Log: testutil.Logger{},
-	}
-	require.NoError(t, c.Init())
-	c.client = &mockSelectMetricsCloudWatchClient{}
-	filtered, err := getFilteredMetrics(c)
-	// We've asked for 2 (out of 4) metrics, over all 3 load balancers in all 2
-	// AZs. We should get 12 metrics.
-	require.Len(t, filtered[0].metrics, 12)
-	require.NoError(t, err)
-}
-
-func TestGenerateStatisticsInputParams(t *testing.T) {
-	d := types.Dimension{
-		Name:  aws.String("LoadBalancerName"),
-		Value: aws.String("p-example"),
-	}
-
-	namespace := "AWS/ELB"
-	m := types.Metric{
-		MetricName: aws.String("Latency"),
-		Dimensions: []types.Dimension{d},
-		Namespace:  aws.String(namespace),
-	}
-
-	duration, err := time.ParseDuration("1m")
-	require.NoError(t, err)
-	internalDuration := config.Duration(duration)
-
-	c := &CloudWatch{
-		Namespaces: []string{namespace},
-		Delay:      internalDuration,
-		Period:     internalDuration,
-		BatchSize:  500,
-		Log:        testutil.Logger{},
-	}
-
-	require.NoError(t, c.initializeCloudWatch())
-
-	now := time.Now()
-
-	c.updateWindow(now)
-
-	statFilter, err := filter.NewIncludeExcludeFilter(nil, nil)
-	require.NoError(t, err)
-	queries := c.getDataQueries([]filteredMetric{{metrics: []types.Metric{m}, statFilter: statFilter}})
-	params := c.getDataInputs(queries[namespace])
-
-	require.EqualValues(t, *params.EndTime, now.Add(-time.Duration(c.Delay)))
-	require.EqualValues(t, *params.StartTime, now.Add(-time.Duration(c.Period)).Add(-time.Duration(c.Delay)))
-	require.Len(t, params.MetricDataQueries, 5)
-	require.Len(t, params.MetricDataQueries[0].MetricStat.Metric.Dimensions, 1)
-	require.EqualValues(t, 60, *params.MetricDataQueries[0].MetricStat.Period)
-}
-
-func TestGenerateStatisticsInputParamsFiltered(t *testing.T) {
-	d := types.Dimension{
-		Name:  aws.String("LoadBalancerName"),
-		Value: aws.String("p-example"),
-	}
-
-	namespace := "AWS/ELB"
-	m := types.Metric{
-		MetricName: aws.String("Latency"),
-		Dimensions: []types.Dimension{d},
-		Namespace:  aws.String(namespace),
-	}
-
-	duration, err := time.ParseDuration("1m")
-	require.NoError(t, err)
-	internalDuration := config.Duration(duration)
-
-	c := &CloudWatch{
-		Namespaces: []string{namespace},
-		Delay:      internalDuration,
-		Period:     internalDuration,
-		BatchSize:  500,
-		Log:        testutil.Logger{},
-	}
-
-	require.NoError(t, c.initializeCloudWatch())
-
-	now := time.Now()
-
-	c.updateWindow(now)
-
-	statFilter, err := filter.NewIncludeExcludeFilter([]string{"average", "sample_count"}, nil)
-	require.NoError(t, err)
-	queries := c.getDataQueries([]filteredMetric{{metrics: []types.Metric{m}, statFilter: statFilter}})
-	params := c.getDataInputs(queries[namespace])
-
-	require.EqualValues(t, *params.EndTime, now.Add(-time.Duration(c.Delay)))
-	require.EqualValues(t, *params.StartTime, now.Add(-time.Duration(c.Period)).Add(-time.Duration(c.Delay)))
-	require.Len(t, params.MetricDataQueries, 2)
-	require.Len(t, params.MetricDataQueries[0].MetricStat.Metric.Dimensions, 1)
-	require.EqualValues(t, 60, *params.MetricDataQueries[0].MetricStat.Period)
-}
-
-func TestMetricsCacheTimeout(t *testing.T) {
-	cache := &metricCache{
-		metrics: make([]filteredMetric, 0),
-		built:   time.Now(),
-		ttl:     time.Minute,
-	}
-
-	require.True(t, cache.isValid())
-	cache.built = time.Now().Add(-time.Minute)
-	require.False(t, cache.isValid())
-}
-
-func TestUpdateWindow(t *testing.T) {
-	duration, err := time.ParseDuration("1m")
-	require.NoError(t, err)
-	internalDuration := config.Duration(duration)
-
-	c := &CloudWatch{
-		Namespace: "AWS/ELB",
-		Delay:     internalDuration,
-		Period:    internalDuration,
-		BatchSize: 500,
-		Log:       testutil.Logger{},
-	}
-
-	now := time.Now()
-
-	require.True(t, c.windowEnd.IsZero())
-	require.True(t, c.windowStart.IsZero())
-
-	c.updateWindow(now)
-
-	newStartTime := c.windowEnd
-
-	// initial window just has a single period
-	require.EqualValues(t, c.windowEnd, now.Add(-time.Duration(c.Delay)))
-	require.EqualValues(t, c.windowStart, now.Add(-time.Duration(c.Delay)).Add(-time.Duration(c.Period)))
-
-	now = time.Now()
-	c.updateWindow(now)
-
-	// subsequent window uses previous end time as start time
-	require.EqualValues(t, c.windowEnd, now.Add(-time.Duration(c.Delay)))
-	require.EqualValues(t, c.windowStart, newStartTime)
-}
-
-func TestProxyFunction(t *testing.T) {
-	c := &CloudWatch{
-		HTTPProxy: proxy.HTTPProxy{
-			HTTPProxyURL: "http://www.penguins.com",
-		},
-		BatchSize: 500,
-		Log:       testutil.Logger{},
-	}
-
-	proxyFunction, err := c.HTTPProxy.Proxy()
-	require.NoError(t, err)
-
-	u, err := url.Parse("https://monitoring.us-west-1.amazonaws.com/")
-	require.NoError(t, err)
-
-	proxyResult, err := proxyFunction(&http.Request{URL: u})
-	require.NoError(t, err)
-	require.Equal(t, "www.penguins.com", proxyResult.Host)
-}
-
-func TestCombineNamespaces(t *testing.T) {
-	c := &CloudWatch{
-		Namespace:  "AWS/ELB",
-		Namespaces: []string{"AWS/EC2", "AWS/Billing"},
-		BatchSize:  500,
-		Log:        testutil.Logger{},
-	}
-
-	require.NoError(t, c.Init())
-	require.Equal(t, []string{"AWS/EC2", "AWS/Billing", "AWS/ELB"}, c.Namespaces)
 }

--- a/plugins/inputs/cloudwatch/sample.conf
+++ b/plugins/inputs/cloudwatch/sample.conf
@@ -65,13 +65,13 @@
   ## Do not enable if "period" or "delay" is longer than 3 hours, as it will
   ## not return data more than 3 hours old.
   ## See https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_ListMetrics.html
-  #recently_active = "PT3H"
+  # recently_active = "PT3H"
 
   ## Configure the TTL for the internal cache of metrics.
   # cache_ttl = "1h"
 
-  ## Metric Statistic Namespaces (required)
-  namespaces = ["AWS/ELB"]
+  ## Metric Statistic Namespaces, wildcards are allowed
+  # namespaces = ["*"]
 
   ## Metric Format
   ## This determines the format of the produces metrics. 'sparse', the default

--- a/plugins/inputs/cloudwatch/utils.go
+++ b/plugins/inputs/cloudwatch/utils.go
@@ -1,0 +1,53 @@
+package cloudwatch
+
+import (
+	"slices"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
+	"github.com/influxdata/telegraf/internal"
+)
+
+func dimensionsMatch(ref []*dimension, values []types.Dimension) bool {
+	for _, rd := range ref {
+		var found bool
+		for _, vd := range values {
+			if rd.Name == *vd.Name && (rd.valueMatcher == nil || rd.valueMatcher.Match(*vd.Value)) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}
+
+func metricMatch(cm *cloudwatchMetric, m types.Metric) bool {
+	if !slices.Contains(cm.MetricNames, *m.MetricName) {
+		return false
+	}
+	return dimensionsMatch(cm.Dimensions, m.Dimensions)
+}
+
+func sanitizeMeasurement(namespace string) string {
+	namespace = strings.ReplaceAll(namespace, "/", "_")
+	namespace = snakeCase(namespace)
+	return "cloudwatch_" + namespace
+}
+
+func snakeCase(s string) string {
+	s = internal.SnakeCase(s)
+	s = strings.ReplaceAll(s, " ", "_")
+	s = strings.ReplaceAll(s, "__", "_")
+	return s
+}
+
+func ctod(cDimensions []types.Dimension) *map[string]string {
+	dimensions := make(map[string]string, len(cDimensions))
+	for i := range cDimensions {
+		dimensions[snakeCase(*cDimensions[i].Name)] = *cDimensions[i].Value
+	}
+	return &dimensions
+}


### PR DESCRIPTION
## Summary

This PR reworks the cloudwatch plugin to support wildcards for the namespaces configuration option.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #16208 
