### PR TITLE
chore: Fix linter findings for `revive:unused-receiver` in `agent`, `cmd`, `config`, `internal`, `metric`, `migrations`, `models`, `testutils` and `tools`

### DIFF
--- a/agent/accumulator_test.go
+++ b/agent/accumulator_test.go
@@ -143,7 +143,7 @@ func TestAddTrackingMetricGroupEmpty(t *testing.T) {
 type TestMetricMaker struct {
 }
 
-func (tm *TestMetricMaker) Name() string {
+func (*TestMetricMaker) Name() string {
 	return "TestPlugin"
 }
 
@@ -151,10 +151,10 @@ func (tm *TestMetricMaker) LogName() string {
 	return tm.Name()
 }
 
-func (tm *TestMetricMaker) MakeMetric(metric telegraf.Metric) telegraf.Metric {
+func (*TestMetricMaker) MakeMetric(metric telegraf.Metric) telegraf.Metric {
 	return metric
 }
 
-func (tm *TestMetricMaker) Log() telegraf.Logger {
+func (*TestMetricMaker) Log() telegraf.Logger {
 	return logger.New("TestPlugin", "test", "")
 }

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -340,10 +340,7 @@ func (a *Agent) initPersister() error {
 	return nil
 }
 
-func (a *Agent) startInputs(
-	dst chan<- telegraf.Metric,
-	inputs []*models.RunningInput,
-) (*inputUnit, error) {
+func (*Agent) startInputs(dst chan<- telegraf.Metric, inputs []*models.RunningInput) (*inputUnit, error) {
 	log.Printf("D! [agent] Starting service inputs")
 
 	unit := &inputUnit{
@@ -447,13 +444,9 @@ func (a *Agent) runInputs(
 	log.Printf("D! [agent] Input channel closed")
 }
 
-// testStartInputs is a variation of startInputs for use in --test and --once
-// mode. It differs by logging Start errors and returning only plugins
-// successfully started.
-func (a *Agent) testStartInputs(
-	dst chan<- telegraf.Metric,
-	inputs []*models.RunningInput,
-) *inputUnit {
+// testStartInputs is a variation of startInputs for use in --test and --once mode.
+// It differs by logging Start errors and returning only plugins successfully started.
+func (*Agent) testStartInputs(dst chan<- telegraf.Metric, inputs []*models.RunningInput) *inputUnit {
 	log.Printf("D! [agent] Starting service inputs")
 
 	unit := &inputUnit{
@@ -582,14 +575,8 @@ func (a *Agent) gatherLoop(
 	}
 }
 
-// gatherOnce runs the input's Gather function once, logging a warning each
-// interval it fails to complete before.
-func (a *Agent) gatherOnce(
-	acc telegraf.Accumulator,
-	input *models.RunningInput,
-	ticker Ticker,
-	interval time.Duration,
-) error {
+// gatherOnce runs the input's Gather function once, logging a warning each interval it fails to complete before.
+func (*Agent) gatherOnce(acc telegraf.Accumulator, input *models.RunningInput, ticker Ticker, interval time.Duration) error {
 	done := make(chan error)
 	go func() {
 		defer panicRecover(input)
@@ -617,12 +604,8 @@ func (a *Agent) gatherOnce(
 	}
 }
 
-// startProcessors sets up the processor chain and calls Start on all
-// processors.  If an error occurs any started processors are Stopped.
-func (a *Agent) startProcessors(
-	dst chan<- telegraf.Metric,
-	runningProcessors models.RunningProcessors,
-) (chan<- telegraf.Metric, []*processorUnit, error) {
+// startProcessors sets up the processor chain and calls Start on all processors.  If an error occurs any started processors are Stopped.
+func (*Agent) startProcessors(dst chan<- telegraf.Metric, runningProcessors models.RunningProcessors) (chan<- telegraf.Metric, []*processorUnit, error) {
 	var src chan telegraf.Metric
 	units := make([]*processorUnit, 0, len(runningProcessors))
 	// The processor chain is constructed from the output side starting from
@@ -657,11 +640,8 @@ func (a *Agent) startProcessors(
 	return src, units, nil
 }
 
-// runProcessors begins processing metrics and runs until the source channel is
-// closed and all metrics have been written.
-func (a *Agent) runProcessors(
-	units []*processorUnit,
-) {
+// runProcessors begins processing metrics and runs until the source channel is closed and all metrics have been written.
+func (*Agent) runProcessors(units []*processorUnit) {
 	var wg sync.WaitGroup
 	for _, unit := range units {
 		wg.Add(1)
@@ -684,7 +664,7 @@ func (a *Agent) runProcessors(
 }
 
 // startAggregators sets up the aggregator unit and returns the source channel.
-func (a *Agent) startAggregators(aggC, outputC chan<- telegraf.Metric, aggregators []*models.RunningAggregator) (chan<- telegraf.Metric, *aggregatorUnit) {
+func (*Agent) startAggregators(aggC, outputC chan<- telegraf.Metric, aggregators []*models.RunningAggregator) (chan<- telegraf.Metric, *aggregatorUnit) {
 	src := make(chan telegraf.Metric, 100)
 	unit := &aggregatorUnit{
 		src:         src,
@@ -771,11 +751,7 @@ func updateWindow(start time.Time, roundInterval bool, period time.Duration) (ti
 }
 
 // push runs the push for a single aggregator every period.
-func (a *Agent) push(
-	ctx context.Context,
-	aggregator *models.RunningAggregator,
-	acc telegraf.Accumulator,
-) {
+func (*Agent) push(ctx context.Context, aggregator *models.RunningAggregator, acc telegraf.Accumulator) {
 	for {
 		// Ensures that Push will be called for each period, even if it has
 		// already elapsed before this function is called.  This is guaranteed
@@ -824,7 +800,7 @@ func (a *Agent) startOutputs(
 }
 
 // connectOutput connects to all outputs.
-func (a *Agent) connectOutput(ctx context.Context, output *models.RunningOutput) error {
+func (*Agent) connectOutput(ctx context.Context, output *models.RunningOutput) error {
 	log.Printf("D! [agent] Attempting connection to [%s]", output.LogName())
 	if err := output.Connect(); err != nil {
 		log.Printf("E! [agent] Failed to connect to [%s], retrying in 15s, error was %q", output.LogName(), err)
@@ -938,13 +914,8 @@ func (a *Agent) flushLoop(
 	}
 }
 
-// flushOnce runs the output's Write function once, logging a warning each
-// interval it fails to complete before the flush interval elapses.
-func (a *Agent) flushOnce(
-	output *models.RunningOutput,
-	ticker Ticker,
-	writeFunc func() error,
-) error {
+// flushOnce runs the output's Write function once, logging a warning each interval it fails to complete before the flush interval elapses.
+func (*Agent) flushOnce(output *models.RunningOutput, ticker Ticker, writeFunc func() error) error {
 	done := make(chan error)
 	go func() {
 		done <- writeFunc()
@@ -963,12 +934,8 @@ func (a *Agent) flushOnce(
 	}
 }
 
-// flushBatch runs the output's Write function once Unlike flushOnce the
-// interval elapsing is not considered during these flushes.
-func (a *Agent) flushBatch(
-	output *models.RunningOutput,
-	writeFunc func() error,
-) error {
+// flushBatch runs the output's Write function once Unlike flushOnce the interval elapsing is not considered during these flushes.
+func (*Agent) flushBatch(output *models.RunningOutput, writeFunc func() error) error {
 	err := writeFunc()
 	output.LogBufferStatus()
 	return err

--- a/cmd/telegraf/main_test.go
+++ b/cmd/telegraf/main_test.go
@@ -53,11 +53,11 @@ func (m *MockTelegraf) Init(_ <-chan error, _ Filters, g GlobalFlags, w WindowFl
 	m.WindowFlags = w
 }
 
-func (m *MockTelegraf) Run() error {
+func (*MockTelegraf) Run() error {
 	return nil
 }
 
-func (m *MockTelegraf) ListSecretStores() ([]string, error) {
+func (*MockTelegraf) ListSecretStores() ([]string, error) {
 	ids := make([]string, 0, len(secrets))
 	for k := range secrets {
 		ids = append(ids, k)
@@ -65,7 +65,7 @@ func (m *MockTelegraf) ListSecretStores() ([]string, error) {
 	return ids, nil
 }
 
-func (m *MockTelegraf) GetSecretStore(id string) (telegraf.SecretStore, error) {
+func (*MockTelegraf) GetSecretStore(id string) (telegraf.SecretStore, error) {
 	v, found := secrets[id]
 	if !found {
 		return nil, errors.New("unknown secret store")
@@ -78,11 +78,11 @@ type MockSecretStore struct {
 	Secrets map[string][]byte
 }
 
-func (s *MockSecretStore) Init() error {
+func (*MockSecretStore) Init() error {
 	return nil
 }
 
-func (s *MockSecretStore) SampleConfig() string {
+func (*MockSecretStore) SampleConfig() string {
 	return "I'm just a dummy"
 }
 
@@ -149,7 +149,7 @@ func (m *MockServer) Start(_ string) {
 	m.Address = "localhost:6060"
 }
 
-func (m *MockServer) ErrChan() <-chan error {
+func (*MockServer) ErrChan() <-chan error {
 	return nil
 }
 

--- a/cmd/telegraf/telegraf.go
+++ b/cmd/telegraf/telegraf.go
@@ -254,7 +254,7 @@ func (t *Telegraf) watchLocalConfig(ctx context.Context, signals chan os.Signal,
 	signals <- syscall.SIGHUP
 }
 
-func (t *Telegraf) watchRemoteConfigs(ctx context.Context, signals chan os.Signal, interval time.Duration, remoteConfigs []string) {
+func (*Telegraf) watchRemoteConfigs(ctx context.Context, signals chan os.Signal, interval time.Duration, remoteConfigs []string) {
 	configs := strings.Join(remoteConfigs, ", ")
 	log.Printf("I! Remote config watcher started for: %s\n", configs)
 

--- a/config/config.go
+++ b/config/config.go
@@ -1659,7 +1659,7 @@ func (c *Config) resetMissingTomlFieldTracker() {
 	c.toml.MissingField = c.missingTomlField
 }
 
-func (c *Config) getFieldString(tbl *ast.Table, fieldName string) string {
+func (*Config) getFieldString(tbl *ast.Table, fieldName string) string {
 	if node, ok := tbl.Fields[fieldName]; ok {
 		if kv, ok := node.(*ast.KeyValue); ok {
 			if str, ok := kv.Value.(*ast.String); ok {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1198,10 +1198,10 @@ type MockupInputPluginParserNew struct {
 	ParserFunc telegraf.ParserFunc
 }
 
-func (m *MockupInputPluginParserNew) SampleConfig() string {
+func (*MockupInputPluginParserNew) SampleConfig() string {
 	return "Mockup old parser test plugin"
 }
-func (m *MockupInputPluginParserNew) Gather(_ telegraf.Accumulator) error {
+func (*MockupInputPluginParserNew) Gather(telegraf.Accumulator) error {
 	return nil
 }
 func (m *MockupInputPluginParserNew) SetParser(parser telegraf.Parser) {
@@ -1231,10 +1231,10 @@ type MockupInputPlugin struct {
 	parser telegraf.Parser
 }
 
-func (m *MockupInputPlugin) SampleConfig() string {
+func (*MockupInputPlugin) SampleConfig() string {
 	return "Mockup test input plugin"
 }
-func (m *MockupInputPlugin) Gather(_ telegraf.Accumulator) error {
+func (*MockupInputPlugin) Gather(telegraf.Accumulator) error {
 	return nil
 }
 func (m *MockupInputPlugin) SetParser(parser telegraf.Parser) {
@@ -1246,10 +1246,10 @@ type MockupInputPluginParserFunc struct {
 	parserFunc telegraf.ParserFunc
 }
 
-func (m *MockupInputPluginParserFunc) SampleConfig() string {
+func (*MockupInputPluginParserFunc) SampleConfig() string {
 	return "Mockup test input plugin"
 }
-func (m *MockupInputPluginParserFunc) Gather(_ telegraf.Accumulator) error {
+func (*MockupInputPluginParserFunc) Gather(telegraf.Accumulator) error {
 	return nil
 }
 func (m *MockupInputPluginParserFunc) SetParserFunc(pf telegraf.ParserFunc) {
@@ -1261,10 +1261,10 @@ type MockupInputPluginParserOnly struct {
 	parser telegraf.Parser
 }
 
-func (m *MockupInputPluginParserOnly) SampleConfig() string {
+func (*MockupInputPluginParserOnly) SampleConfig() string {
 	return "Mockup test input plugin"
 }
-func (m *MockupInputPluginParserOnly) Gather(_ telegraf.Accumulator) error {
+func (*MockupInputPluginParserOnly) Gather(telegraf.Accumulator) error {
 	return nil
 }
 func (m *MockupInputPluginParserOnly) SetParser(p telegraf.Parser) {
@@ -1277,18 +1277,18 @@ type MockupProcessorPluginParser struct {
 	ParserFunc telegraf.ParserFunc
 }
 
-func (m *MockupProcessorPluginParser) Start(_ telegraf.Accumulator) error {
+func (*MockupProcessorPluginParser) Start(telegraf.Accumulator) error {
 	return nil
 }
-func (m *MockupProcessorPluginParser) Stop() {
+func (*MockupProcessorPluginParser) Stop() {
 }
-func (m *MockupProcessorPluginParser) SampleConfig() string {
+func (*MockupProcessorPluginParser) SampleConfig() string {
 	return "Mockup test processor plugin with parser"
 }
-func (m *MockupProcessorPluginParser) Apply(_ ...telegraf.Metric) []telegraf.Metric {
+func (*MockupProcessorPluginParser) Apply(...telegraf.Metric) []telegraf.Metric {
 	return nil
 }
-func (m *MockupProcessorPluginParser) Add(_ telegraf.Metric, _ telegraf.Accumulator) error {
+func (*MockupProcessorPluginParser) Add(telegraf.Metric, telegraf.Accumulator) error {
 	return nil
 }
 func (m *MockupProcessorPluginParser) SetParser(parser telegraf.Parser) {
@@ -1304,15 +1304,10 @@ type MockupProcessorPlugin struct {
 	state  []uint64
 }
 
-func (m *MockupProcessorPlugin) Start(_ telegraf.Accumulator) error {
-	return nil
-}
-func (m *MockupProcessorPlugin) Stop() {
-}
-func (m *MockupProcessorPlugin) SampleConfig() string {
+func (*MockupProcessorPlugin) SampleConfig() string {
 	return "Mockup test processor plugin with parser"
 }
-func (m *MockupProcessorPlugin) Apply(in ...telegraf.Metric) []telegraf.Metric {
+func (*MockupProcessorPlugin) Apply(in ...telegraf.Metric) []telegraf.Metric {
 	out := make([]telegraf.Metric, 0, len(in))
 	for _, m := range in {
 		m.AddTag("processed", "yes")
@@ -1338,18 +1333,18 @@ type MockupProcessorPluginParserOnly struct {
 	Parser telegraf.Parser
 }
 
-func (m *MockupProcessorPluginParserOnly) Start(_ telegraf.Accumulator) error {
+func (*MockupProcessorPluginParserOnly) Start(telegraf.Accumulator) error {
 	return nil
 }
-func (m *MockupProcessorPluginParserOnly) Stop() {
+func (*MockupProcessorPluginParserOnly) Stop() {
 }
-func (m *MockupProcessorPluginParserOnly) SampleConfig() string {
+func (*MockupProcessorPluginParserOnly) SampleConfig() string {
 	return "Mockup test processor plugin with parser"
 }
-func (m *MockupProcessorPluginParserOnly) Apply(_ ...telegraf.Metric) []telegraf.Metric {
+func (*MockupProcessorPluginParserOnly) Apply(...telegraf.Metric) []telegraf.Metric {
 	return nil
 }
-func (m *MockupProcessorPluginParserOnly) Add(_ telegraf.Metric, _ telegraf.Accumulator) error {
+func (*MockupProcessorPluginParserOnly) Add(telegraf.Metric, telegraf.Accumulator) error {
 	return nil
 }
 func (m *MockupProcessorPluginParserOnly) SetParser(parser telegraf.Parser) {
@@ -1361,18 +1356,18 @@ type MockupProcessorPluginParserFunc struct {
 	Parser telegraf.ParserFunc
 }
 
-func (m *MockupProcessorPluginParserFunc) Start(_ telegraf.Accumulator) error {
+func (*MockupProcessorPluginParserFunc) Start(telegraf.Accumulator) error {
 	return nil
 }
-func (m *MockupProcessorPluginParserFunc) Stop() {
+func (*MockupProcessorPluginParserFunc) Stop() {
 }
-func (m *MockupProcessorPluginParserFunc) SampleConfig() string {
+func (*MockupProcessorPluginParserFunc) SampleConfig() string {
 	return "Mockup test processor plugin with parser"
 }
-func (m *MockupProcessorPluginParserFunc) Apply(_ ...telegraf.Metric) []telegraf.Metric {
+func (*MockupProcessorPluginParserFunc) Apply(...telegraf.Metric) []telegraf.Metric {
 	return nil
 }
-func (m *MockupProcessorPluginParserFunc) Add(_ telegraf.Metric, _ telegraf.Accumulator) error {
+func (*MockupProcessorPluginParserFunc) Add(telegraf.Metric, telegraf.Accumulator) error {
 	return nil
 }
 func (m *MockupProcessorPluginParserFunc) SetParserFunc(pf telegraf.ParserFunc) {
@@ -1389,16 +1384,16 @@ type MockupOutputPlugin struct {
 	tls.ClientConfig
 }
 
-func (m *MockupOutputPlugin) Connect() error {
+func (*MockupOutputPlugin) Connect() error {
 	return nil
 }
-func (m *MockupOutputPlugin) Close() error {
+func (*MockupOutputPlugin) Close() error {
 	return nil
 }
-func (m *MockupOutputPlugin) SampleConfig() string {
+func (*MockupOutputPlugin) SampleConfig() string {
 	return "Mockup test output plugin"
 }
-func (m *MockupOutputPlugin) Write(_ []telegraf.Metric) error {
+func (*MockupOutputPlugin) Write([]telegraf.Metric) error {
 	return nil
 }
 
@@ -1474,11 +1469,11 @@ func (m *MockupStatePlugin) SetState(state interface{}) error {
 	return nil
 }
 
-func (m *MockupStatePlugin) SampleConfig() string {
+func (*MockupStatePlugin) SampleConfig() string {
 	return "Mockup test plugin"
 }
 
-func (m *MockupStatePlugin) Gather(_ telegraf.Accumulator) error {
+func (*MockupStatePlugin) Gather(telegraf.Accumulator) error {
 	return nil
 }
 

--- a/config/deprecation.go
+++ b/config/deprecation.go
@@ -252,7 +252,7 @@ func (c *Config) CollectDeprecationInfos(inFilter, outFilter, aggFilter, procFil
 	return infos
 }
 
-func (c *Config) PrintDeprecationList(plugins []PluginDeprecationInfo) {
+func (*Config) PrintDeprecationList(plugins []PluginDeprecationInfo) {
 	sort.Slice(plugins, func(i, j int) bool { return plugins[i].Name < plugins[j].Name })
 
 	for _, plugin := range plugins {

--- a/config/secret_protected.go
+++ b/config/secret_protected.go
@@ -122,7 +122,7 @@ func (c *protectedSecretContainer) Buffer() (SecretBuffer, error) {
 	return &lockedBuffer{lockbuf}, nil
 }
 
-func (c *protectedSecretContainer) AsBuffer(secret []byte) SecretBuffer {
+func (*protectedSecretContainer) AsBuffer(secret []byte) SecretBuffer {
 	return &lockedBuffer{memguard.NewBufferFromBytes(secret)}
 }
 

--- a/config/secret_test.go
+++ b/config/secret_test.go
@@ -801,7 +801,7 @@ type MockupSecretStore struct {
 	Dynamic bool
 }
 
-func (s *MockupSecretStore) Init() error {
+func (*MockupSecretStore) Init() error {
 	return nil
 }
 func (*MockupSecretStore) SampleConfig() string {

--- a/config/secret_unprotected.go
+++ b/config/secret_unprotected.go
@@ -33,7 +33,7 @@ func (lb *unlockedBuffer) Size() int {
 	return len(lb.content)
 }
 
-func (lb *unlockedBuffer) Grow(_ int) {
+func (*unlockedBuffer) Grow(int) {
 	// The underlying byte-buffer will grow dynamically
 }
 
@@ -85,7 +85,7 @@ func (c *unprotectedSecretContainer) Buffer() (SecretBuffer, error) {
 	return newUnlockedBuffer(c.buf.content), nil
 }
 
-func (c *unprotectedSecretContainer) AsBuffer(secret []byte) SecretBuffer {
+func (*unprotectedSecretContainer) AsBuffer(secret []byte) SecretBuffer {
 	return &unlockedBuffer{secret}
 }
 

--- a/internal/snmp/translator_gosmi.go
+++ b/internal/snmp/translator_gosmi.go
@@ -55,7 +55,7 @@ func (g *gosmiTranslator) SnmpTable(oid string) (
 	return mibName, oidNum, oidText, fields, nil
 }
 
-func (g *gosmiTranslator) SnmpFormatEnum(oid string, value interface{}, full bool) (string, error) {
+func (*gosmiTranslator) SnmpFormatEnum(oid string, value interface{}, full bool) (string, error) {
 	if value == nil {
 		return "", nil
 	}
@@ -80,7 +80,7 @@ func (g *gosmiTranslator) SnmpFormatEnum(oid string, value interface{}, full boo
 	return v.String(), nil
 }
 
-func (g *gosmiTranslator) SnmpFormatDisplayHint(oid string, value interface{}) (string, error) {
+func (*gosmiTranslator) SnmpFormatDisplayHint(oid string, value interface{}) (string, error) {
 	if value == nil {
 		return "", nil
 	}

--- a/internal/snmp/translator_netsnmp.go
+++ b/internal/snmp/translator_netsnmp.go
@@ -263,10 +263,10 @@ func (n *netsnmpTranslator) snmpTranslateCall(oid string) (mibName string, oidNu
 	return mibName, oidNum, oidText, conversion, nil
 }
 
-func (n *netsnmpTranslator) SnmpFormatEnum(_ string, _ interface{}, _ bool) (string, error) {
+func (*netsnmpTranslator) SnmpFormatEnum(string, interface{}, bool) (string, error) {
 	return "", errors.New("not implemented in netsnmp translator")
 }
 
-func (n *netsnmpTranslator) SnmpFormatDisplayHint(_ string, _ interface{}) (string, error) {
+func (*netsnmpTranslator) SnmpFormatDisplayHint(string, interface{}) (string, error) {
 	return "", errors.New("not implemented in netsnmp translator")
 }

--- a/internal/snmp/wrapper_test.go
+++ b/internal/snmp/wrapper_test.go
@@ -42,7 +42,7 @@ func (tsc *testSNMPConnection) Walk(oid string, wf gosnmp.WalkFunc) error {
 	}
 	return nil
 }
-func (tsc *testSNMPConnection) Reconnect() error {
+func (*testSNMPConnection) Reconnect() error {
 	return nil
 }
 

--- a/metric/metric.go
+++ b/metric/metric.go
@@ -278,13 +278,13 @@ func (m *metric) HashID() uint64 {
 	return h.Sum64()
 }
 
-func (m *metric) Accept() {
+func (*metric) Accept() {
 }
 
-func (m *metric) Reject() {
+func (*metric) Reject() {
 }
 
-func (m *metric) Drop() {
+func (*metric) Drop() {
 }
 
 // Convert field to a supported type or nil if inconvertible

--- a/migrations/general_metricfilter/migration_test.go
+++ b/migrations/general_metricfilter/migration_test.go
@@ -88,9 +88,9 @@ type MockupInputPlugin struct {
 	Timeout config.Duration `toml:"timeout"`
 }
 
-func (m *MockupInputPlugin) SampleConfig() string {
+func (*MockupInputPlugin) SampleConfig() string {
 	return "Mockup test input plugin"
 }
-func (m *MockupInputPlugin) Gather(_ telegraf.Accumulator) error {
+func (*MockupInputPlugin) Gather(telegraf.Accumulator) error {
 	return nil
 }

--- a/models/buffer.go
+++ b/models/buffer.go
@@ -41,7 +41,7 @@ func (tx *Transaction) AcceptAll() {
 	}
 }
 
-func (tx *Transaction) KeepAll() {}
+func (*Transaction) KeepAll() {}
 
 func (tx *Transaction) InferKeep() []int {
 	used := make([]bool, len(tx.Batch))

--- a/models/buffer_mem.go
+++ b/models/buffer_mem.go
@@ -119,7 +119,7 @@ func (b *MemoryBuffer) EndTransaction(tx *Transaction) {
 	b.BufferSize.Set(int64(b.length()))
 }
 
-func (b *MemoryBuffer) Close() error {
+func (*MemoryBuffer) Close() error {
 	return nil
 }
 

--- a/models/running_aggregator_test.go
+++ b/models/running_aggregator_test.go
@@ -243,7 +243,7 @@ type mockAggregator struct {
 	sum int64
 }
 
-func (t *mockAggregator) SampleConfig() string {
+func (*mockAggregator) SampleConfig() string {
 	return ""
 }
 

--- a/models/running_input.go
+++ b/models/running_input.go
@@ -102,7 +102,7 @@ type InputConfig struct {
 	AlwaysIncludeGlobalTags bool
 }
 
-func (r *RunningInput) metricFiltered(metric telegraf.Metric) {
+func (*RunningInput) metricFiltered(metric telegraf.Metric) {
 	metric.Drop()
 }
 

--- a/models/running_input_test.go
+++ b/models/running_input_test.go
@@ -489,10 +489,10 @@ func TestRunningInputMakeMetricWithGatherEndTimeSource(t *testing.T) {
 
 type mockInput struct{}
 
-func (t *mockInput) SampleConfig() string {
+func (*mockInput) SampleConfig() string {
 	return ""
 }
 
-func (t *mockInput) Gather(_ telegraf.Accumulator) error {
+func (*mockInput) Gather(telegraf.Accumulator) error {
 	return nil
 }

--- a/models/running_output.go
+++ b/models/running_output.go
@@ -362,7 +362,7 @@ func (r *RunningOutput) writeMetrics(metrics []telegraf.Metric) error {
 	return err
 }
 
-func (r *RunningOutput) updateTransaction(tx *Transaction, err error) {
+func (*RunningOutput) updateTransaction(tx *Transaction, err error) {
 	// No error indicates all metrics were written successfully
 	if err == nil {
 		tx.AcceptAll()

--- a/models/running_processor.go
+++ b/models/running_processor.go
@@ -54,7 +54,7 @@ func NewRunningProcessor(processor telegraf.StreamingProcessor, config *Processo
 	}
 }
 
-func (rp *RunningProcessor) metricFiltered(metric telegraf.Metric) {
+func (*RunningProcessor) metricFiltered(metric telegraf.Metric) {
 	metric.Drop()
 }
 
@@ -83,7 +83,7 @@ func (rp *RunningProcessor) LogName() string {
 	return logName("processors", rp.Config.Name, rp.Config.Alias)
 }
 
-func (rp *RunningProcessor) MakeMetric(metric telegraf.Metric) telegraf.Metric {
+func (*RunningProcessor) MakeMetric(metric telegraf.Metric) telegraf.Metric {
 	return metric
 }
 

--- a/models/running_processor_test.go
+++ b/models/running_processor_test.go
@@ -212,7 +212,7 @@ type mockProcessor struct {
 	hasBeenInit bool
 }
 
-func (p *mockProcessor) SampleConfig() string {
+func (*mockProcessor) SampleConfig() string {
 	return ""
 }
 

--- a/testutil/accumulator.go
+++ b/testutil/accumulator.go
@@ -265,10 +265,10 @@ func (a *Accumulator) AddError(err error) {
 	a.Unlock()
 }
 
-func (a *Accumulator) SetPrecision(_ time.Duration) {
+func (*Accumulator) SetPrecision(time.Duration) {
 }
 
-func (a *Accumulator) DisablePrecision() {
+func (*Accumulator) DisablePrecision() {
 }
 
 func (a *Accumulator) Debug() bool {
@@ -756,17 +756,17 @@ func (a *Accumulator) BoolField(measurement, field string) (v, ok bool) {
 // telegraf accumulator machinery.
 type NopAccumulator struct{}
 
-func (n *NopAccumulator) AddFields(_ string, _ map[string]interface{}, _ map[string]string, _ ...time.Time) {
+func (*NopAccumulator) AddFields(string, map[string]interface{}, map[string]string, ...time.Time) {
 }
-func (n *NopAccumulator) AddGauge(_ string, _ map[string]interface{}, _ map[string]string, _ ...time.Time) {
+func (*NopAccumulator) AddGauge(string, map[string]interface{}, map[string]string, ...time.Time) {
 }
-func (n *NopAccumulator) AddCounter(_ string, _ map[string]interface{}, _ map[string]string, _ ...time.Time) {
+func (*NopAccumulator) AddCounter(string, map[string]interface{}, map[string]string, ...time.Time) {
 }
-func (n *NopAccumulator) AddSummary(_ string, _ map[string]interface{}, _ map[string]string, _ ...time.Time) {
+func (*NopAccumulator) AddSummary(string, map[string]interface{}, map[string]string, ...time.Time) {
 }
-func (n *NopAccumulator) AddHistogram(_ string, _ map[string]interface{}, _ map[string]string, _ ...time.Time) {
+func (*NopAccumulator) AddHistogram(string, map[string]interface{}, map[string]string, ...time.Time) {
 }
-func (n *NopAccumulator) AddMetric(telegraf.Metric)                       {}
-func (n *NopAccumulator) SetPrecision(_ time.Duration)                    {}
-func (n *NopAccumulator) AddError(_ error)                                {}
-func (n *NopAccumulator) WithTracking(_ int) telegraf.TrackingAccumulator { return nil }
+func (*NopAccumulator) AddMetric(telegraf.Metric)                     {}
+func (*NopAccumulator) SetPrecision(time.Duration)                    {}
+func (*NopAccumulator) AddError(error)                                {}
+func (*NopAccumulator) WithTracking(int) telegraf.TrackingAccumulator { return nil }

--- a/testutil/capturelog.go
+++ b/testutil/capturelog.go
@@ -50,7 +50,7 @@ func (l *CaptureLogger) loga(level byte, args ...any) {
 	l.print(Entry{level, l.Name, fmt.Sprint(args...)})
 }
 
-func (l *CaptureLogger) Level() telegraf.LogLevel {
+func (*CaptureLogger) Level() telegraf.LogLevel {
 	return telegraf.Trace
 }
 

--- a/testutil/tls.go
+++ b/testutil/tls.go
@@ -52,15 +52,15 @@ func (p *pki) CACertPath() string {
 	return path.Join(p.keyPath, "cacert.pem")
 }
 
-func (p *pki) CipherSuite() string {
+func (*pki) CipherSuite() string {
 	return "TLS_RSA_WITH_3DES_EDE_CBC_SHA"
 }
 
-func (p *pki) TLSMinVersion() string {
+func (*pki) TLSMinVersion() string {
 	return "TLS11"
 }
 
-func (p *pki) TLSMaxVersion() string {
+func (*pki) TLSMaxVersion() string {
 	return "TLS13"
 }
 

--- a/tools/package_incus_test/incus.go
+++ b/tools/package_incus_test/incus.go
@@ -21,7 +21,7 @@ type BytesBuffer struct {
 	*bytes.Buffer
 }
 
-func (b *BytesBuffer) Close() error {
+func (*BytesBuffer) Close() error {
 	return nil
 }
 


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

Address findings for [revive:unused-receiver](https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unused-receiver) in `agent`, `cmd`, `config`, `internal`, `metric`, `migrations`, `models`, `testutils` and `tools`.

It is only part of the bigger work for https://github.com/influxdata/telegraf/issues/16190.
After all findings of this type in whole project are handled, we can enable `revive:unused-receiver` rule in `golangci-lint`.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

