### PR TITLE
chore(deps): Bump golangci-lint from v1.62.2 to v1.63.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,7 +106,7 @@ jobs:
       - run: 'make check-deps'
       - run:
           name: "Install golangci-lint"
-          command: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.63.0
+          command: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.63.1
       - run:
           name: "golangci-lint/Linux"
           # There are only 4 vCPUs available for this executor, so use only 4 instead of the default number
@@ -120,7 +120,7 @@ jobs:
       - check-changed-files-or-halt
       - run:
           name: "Install golangci-lint"
-          command: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.63.0
+          command: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.63.1
       - run:
           name: "golangci-lint/macOS"
           # There are only 4 vCPUs available for this executor, so use only 4 instead of the default number
@@ -134,7 +134,7 @@ jobs:
       - check-changed-files-or-halt
       - run:
           name: "Install golangci-lint"
-          command: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.63.0
+          command: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.63.1
       - run:
           name: "golangci-lint/Windows"
           # There are only 4 vCPUs available for this executor, so use only 4 instead of the default number

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,7 +106,7 @@ jobs:
       - run: 'make check-deps'
       - run:
           name: "Install golangci-lint"
-          command: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.62.2
+          command: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.63.0
       - run:
           name: "golangci-lint/Linux"
           # There are only 4 vCPUs available for this executor, so use only 4 instead of the default number
@@ -120,7 +120,7 @@ jobs:
       - check-changed-files-or-halt
       - run:
           name: "Install golangci-lint"
-          command: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.62.2
+          command: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.63.0
       - run:
           name: "golangci-lint/macOS"
           # There are only 4 vCPUs available for this executor, so use only 4 instead of the default number
@@ -134,7 +134,7 @@ jobs:
       - check-changed-files-or-halt
       - run:
           name: "Install golangci-lint"
-          command: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.62.2
+          command: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.63.0
       - run:
           name: "golangci-lint/Windows"
           # There are only 4 vCPUs available for this executor, so use only 4 instead of the default number

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,7 +106,7 @@ jobs:
       - run: 'make check-deps'
       - run:
           name: "Install golangci-lint"
-          command: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.63.3
+          command: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.63.4
       - run:
           name: "golangci-lint/Linux"
           # There are only 4 vCPUs available for this executor, so use only 4 instead of the default number
@@ -120,7 +120,7 @@ jobs:
       - check-changed-files-or-halt
       - run:
           name: "Install golangci-lint"
-          command: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.63.3
+          command: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.63.4
       - run:
           name: "golangci-lint/macOS"
           # There are only 4 vCPUs available for this executor, so use only 4 instead of the default number
@@ -134,7 +134,7 @@ jobs:
       - check-changed-files-or-halt
       - run:
           name: "Install golangci-lint"
-          command: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.63.3
+          command: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.63.4
       - run:
           name: "golangci-lint/Windows"
           # There are only 4 vCPUs available for this executor, so use only 4 instead of the default number

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,7 +106,7 @@ jobs:
       - run: 'make check-deps'
       - run:
           name: "Install golangci-lint"
-          command: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.63.1
+          command: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.63.3
       - run:
           name: "golangci-lint/Linux"
           # There are only 4 vCPUs available for this executor, so use only 4 instead of the default number
@@ -120,7 +120,7 @@ jobs:
       - check-changed-files-or-halt
       - run:
           name: "Install golangci-lint"
-          command: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.63.1
+          command: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.63.3
       - run:
           name: "golangci-lint/macOS"
           # There are only 4 vCPUs available for this executor, so use only 4 instead of the default number
@@ -134,7 +134,7 @@ jobs:
       - check-changed-files-or-halt
       - run:
           name: "Install golangci-lint"
-          command: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.63.1
+          command: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.63.3
       - run:
           name: "golangci-lint/Windows"
           # There are only 4 vCPUs available for this executor, so use only 4 instead of the default number

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -84,7 +84,7 @@ linters-settings:
     # Default: false
     disable-all: true
     # Which checks should be enabled in addition to default checks; can't be combined with 'disabled-checks'.
-    # By default, list of stable checks is used (https://go-critic.github.io/overview#checks-overview).
+    # By default, list of stable checks is used (https://go-critic.com/overview#checks-overview).
     # To see which checks are enabled run `GL_DEBUG=gocritic golangci-lint run --enable=gocritic`.
     enabled-checks:
       # diagnostic
@@ -143,7 +143,7 @@ linters-settings:
 
     # Settings passed to gocritic.
     # The settings key is the name of a supported gocritic checker.
-    # The list of supported checkers can be find in https://go-critic.github.io/overview.
+    # The list of supported checkers can be find in https://go-critic.com/overview.
     settings:
       hugeParam:
         # Size in bytes that makes the warning trigger.
@@ -159,38 +159,38 @@ linters-settings:
     # Available rules: https://github.com/securego/gosec#available-rules
     # Default: [] - means include all rules
     includes:
-      - G101
-      - G102
-      - G103
-      - G106
-      - G107
-      - G108
-      - G109
-      - G110
-      - G111
-      - G112
-      - G114
-      - G201
-      - G202
-      - G203
-      - G301
-      - G302
-      - G303
-      - G305
-      - G306
-      - G401
-      - G403
-      - G404
-      - G405
-      - G406
-      - G501
-      - G502
-      - G503
-      - G505
-      - G506
-      - G507
-      - G601
-      - G602
+      - G101 # Look for hard coded credentials
+      - G102 # Bind to all interfaces
+      - G103 # Audit the use of unsafe block
+      - G106 # Audit the use of ssh.InsecureIgnoreHostKey
+      - G107 # Url provided to HTTP request as taint input
+      - G108 # Profiling endpoint automatically exposed on /debug/pprof
+      - G109 # Potential Integer overflow made by strconv.Atoi result conversion to int16/32
+      - G110 # Potential DoS vulnerability via decompression bomb
+      - G111 # Potential directory traversal
+      - G112 # Potential slowloris attack
+      - G114 # Use of net/http serve function that has no support for setting timeouts
+      - G201 # SQL query construction using format string
+      - G202 # SQL query construction using string concatenation
+      - G203 # Use of unescaped data in HTML templates
+      - G301 # Poor file permissions used when creating a directory
+      - G302 # Poor file permissions used with chmod
+      - G303 # Creating tempfile using a predictable path
+      - G305 # File traversal when extracting zip/tar archive
+      - G306 # Poor file permissions used when writing to a new file
+      - G401 # Detect the usage of MD5 or SHA1
+      - G403 # Ensure minimum RSA key length of 2048 bits
+      - G404 # Insecure random number source (rand)
+      - G405 # Detect the usage of DES or RC4
+      - G406 # Detect the usage of MD4 or RIPEMD160
+      - G501 # Import blocklist: crypto/md5
+      - G502 # Import blocklist: crypto/des
+      - G503 # Import blocklist: crypto/rc4
+      - G505 # Import blocklist: crypto/sha1
+      - G506 # Import blocklist: golang.org/x/crypto/md4
+      - G507 # Import blocklist: golang.org/x/crypto/ripemd160
+      - G601 # Implicit memory aliasing of items from a range statement
+      - G602 # Slice access out of bounds
       # G104, G105, G113, G204, G304, G307, G402, G504 were not enabled intentionally
       # TODO: review G115 when reporting false positives is fixed (https://github.com/securego/gosec/issues/1212)
     # To specify the configuration of rules.
@@ -432,6 +432,10 @@ issues:
   # Default: 3
   max-same-issues: 0
 
+  # Make issues output unique by line.
+  # Default: true
+  uniq-by-line: false
+
 # output configuration options
 output:
   # The formats used to render issues.
@@ -464,10 +468,6 @@ output:
     - format: tab
       path: stdout
 
-  # Make issues output unique by line.
-  # Default: true
-  uniq-by-line: false
-
   # Sort results by the order defined in `sort-order`.
   # Default: false
   sort-results: true
@@ -476,7 +476,9 @@ output:
   # Default: false
   show-stats: true
 
+# Options for analysis running.
 run:
   # Timeout for analysis, e.g. 30s, 5m.
+  # If the value is lower or equal to 0, the timeout is disabled.
   # Default: 1m
   timeout: 10m

--- a/Makefile
+++ b/Makefile
@@ -180,7 +180,7 @@ vet:
 .PHONY: lint-install
 lint-install:
 	@echo "Installing golangci-lint"
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.62.2
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.63.0
 
 	@echo "Installing markdownlint"
 	npm install -g markdownlint-cli

--- a/Makefile
+++ b/Makefile
@@ -180,7 +180,7 @@ vet:
 .PHONY: lint-install
 lint-install:
 	@echo "Installing golangci-lint"
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.63.1
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.63.3
 
 	@echo "Installing markdownlint"
 	npm install -g markdownlint-cli

--- a/Makefile
+++ b/Makefile
@@ -180,7 +180,7 @@ vet:
 .PHONY: lint-install
 lint-install:
 	@echo "Installing golangci-lint"
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.63.0
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.63.1
 
 	@echo "Installing markdownlint"
 	npm install -g markdownlint-cli

--- a/Makefile
+++ b/Makefile
@@ -180,7 +180,7 @@ vet:
 .PHONY: lint-install
 lint-install:
 	@echo "Installing golangci-lint"
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.63.3
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.63.4
 
 	@echo "Installing markdownlint"
 	npm install -g markdownlint-cli

--- a/plugins/inputs/prometheus/prometheus.go
+++ b/plugins/inputs/prometheus/prometheus.go
@@ -497,11 +497,9 @@ func (p *Prometheus) gatherURL(u urlAndAddress, acc telegraf.Accumulator) (map[s
 	var start time.Time
 	if u.url.Scheme != "unix" {
 		start = time.Now()
-		//nolint:bodyclose // False positive (because of if-else) - body will be closed in `defer`
 		resp, err = p.client.Do(req)
 	} else {
 		start = time.Now()
-		//nolint:bodyclose // False positive (because of if-else) - body will be closed in `defer`
 		resp, err = uClient.Do(req)
 	}
 	end := time.Since(start).Seconds()


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

- `golangci-lint` bumped to `v1.63.4`
- Matching the configuration file to the example from https://github.com/golangci/golangci-lint/blob/master/.golangci.reference.yml.

- New findings addressed:
```
plugins/inputs/prometheus/prometheus.go:500:3  nolintlint  directive `//nolint:bodyclose // False positive (because of if-else) - body will be closed in `defer`` is unused for linter "bodyclose"
plugins/inputs/prometheus/prometheus.go:504:3  nolintlint  directive `//nolint:bodyclose // False positive (because of if-else) - body will be closed in `defer`` is unused for linter "bodyclose"
```

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR
