### PR TITLE
fix(inputs.syslog): Fix for tests that started failing in 2025

### DIFF
--- a/plugins/inputs/syslog/testcases/rfc3164_best_effort_udp/expected.out
+++ b/plugins/inputs/syslog/testcases/rfc3164_best_effort_udp/expected.out
@@ -1,1 +1,1 @@
-syslog,appname=app,facility=user,hostname=host,severity=notice,source=127.0.0.1 facility_code=1i,message="Test",severity_code=5i,timestamp=1733157063000000000i 0
+syslog,appname=app,facility=user,hostname=host,severity=notice,source=127.0.0.1 facility_code=1i,message="Test",severity_code=5i,timestamp=1764693063000000000i 0

--- a/plugins/inputs/syslog/testcases/rfc3164_strict_udp/expected.out
+++ b/plugins/inputs/syslog/testcases/rfc3164_strict_udp/expected.out
@@ -1,1 +1,1 @@
-syslog,appname=app,facility=user,hostname=host,severity=notice,source=127.0.0.1 facility_code=1i,message="Test",severity_code=5i,timestamp=1733157063000000000i 0
+syslog,appname=app,facility=user,hostname=host,severity=notice,source=127.0.0.1 facility_code=1i,message="Test",severity_code=5i,timestamp=1764693063000000000i 0


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

The RFC 3164 standard does not provide a year for the `TIMESTAMP` field (https://datatracker.ietf.org/doc/html/rfc3164#section-4.1.2), which is why the plugin, when parsing the timestamp, sets the current year.

For both RFC 3164 tests, the timestamp is `Dec 2 16:31:03`.  
In 2024, it parsed to `1733157063000000000`.  
In 2025, it parsed to `1764693063000000000`.

In this PR, I'm updating the expected timeout to 2025. This is just a workaround that will stop working in 2026.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

