### PR TITLE
fix(inputs.intel_powerstat): Fix option removal version

### DIFF
--- a/plugins/inputs/intel_powerstat/intel_powerstat.go
+++ b/plugins/inputs/intel_powerstat/intel_powerstat.go
@@ -237,7 +237,7 @@ func (p *PowerStat) parseCPUMetrics() error {
 	if slices.Contains(p.CPUMetrics, cpuBusyCycles) {
 		config.PrintOptionValueDeprecationNotice("inputs.intel_powerstat", "cpu_metrics", cpuBusyCycles, telegraf.DeprecationInfo{
 			Since:     "1.23.0",
-			RemovalIn: "1.35.0;",
+			RemovalIn: "1.35.0",
 			Notice:    "'cpu_c0_state_residency' metric name should be used instead.",
 		})
 	}


### PR DESCRIPTION
## Summary
Telegraf fails when parsing RemovalIn value from DeprecationInfo. It is defined as  "1.35.0;"  but should be  "1.35.0".

## Checklist

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #16376
