### PR TITLE
chore: updates format of body_form config field in README.txt

### DIFF
--- a/plugins/inputs/http_response/README.md
+++ b/plugins/inputs/http_response/README.md
@@ -58,7 +58,7 @@ to use them.
   ## Key value pairs to encode and set at URL form. Can be used with the POST
   ## method + application/x-www-form-urlencoded content type to replicate the
   ## POSTFORM method.
-  # body_form = { "key": "value" }
+  # body_form = { "key" = ["value"] }
 
   ## Optional name of the field that will contain the body of the response.
   ## By default it is set to an empty String indicating that the body's


### PR DESCRIPTION
BodyForm field is described in HTTPResponse struct as "map[string][]string", so the value of its sub-fields should be an array of strings instead of just strings.

- [x] No AI generated code was used in this PR

resolves #16378
