### PR TITLE
fix(outputs.influxdb_v2): Allow overriding auth and agent headers

### DIFF
--- a/plugins/outputs/influxdb_v2/http.go
+++ b/plugins/outputs/influxdb_v2/http.go
@@ -70,17 +70,21 @@ type httpClient struct {
 }
 
 func (c *httpClient) Init() error {
-	token, err := c.token.Get()
-	if err != nil {
-		return fmt.Errorf("getting token failed: %w", err)
-	}
-
 	if c.headers == nil {
 		c.headers = make(map[string]string, 2)
 	}
-	c.headers["Authorization"] = "Token " + token.String()
-	token.Destroy()
-	c.headers["User-Agent"] = c.userAgent
+
+	if _, ok := c.headers["Authorization"]; !ok {
+		token, err := c.token.Get()
+		if err != nil {
+			return fmt.Errorf("getting token failed: %w", err)
+		}
+		c.headers["Authorization"] = "Token " + token.String()
+		token.Destroy()
+	}
+	if _, ok := c.headers["User-Agent"]; !ok {
+		c.headers["User-Agent"] = c.userAgent
+	}
 
 	var proxy func(*http.Request) (*url.URL, error)
 	if c.proxy != nil {

--- a/plugins/outputs/influxdb_v2/http_test.go
+++ b/plugins/outputs/influxdb_v2/http_test.go
@@ -187,6 +187,22 @@ func TestExponentialBackoffCalculationWithRetryAfter(t *testing.T) {
 	}
 }
 
+func TestHeadersDoNotOverrideConfig(t *testing.T) {
+	testURL, err := url.Parse("https://localhost:8181")
+	require.NoError(t, err)
+	c := &httpClient{
+		headers: map[string]string{
+			"Authorization": "Bearer foo",
+			"User-Agent":    "foo",
+		},
+		// URL to make Init() happy
+		url: testURL,
+	}
+	require.NoError(t, c.Init())
+	require.Equal(t, "Bearer foo", c.headers["Authorization"])
+	require.Equal(t, "foo", c.headers["User-Agent"])
+}
+
 // goos: linux
 // goarch: amd64
 // pkg: github.com/influxdata/telegraf/plugins/outputs/influxdb_v2


### PR DESCRIPTION
## Summary
In #16147, the http header code for the http request was refactored, which led to a changing of the order of header application.

In v1.32.2:
1. "Hard-coded" headers (`Authorization`, `User-Agent`) were added to the headers
2. User-specified headers (config `http_headers`) were added, overwriting the "hard-coded" headers if manually specified

In v1.32.3+:
1. User-specified headers (config `http_headers`) were added to the headers
2. "Hard-coded" headers (`Authorization`, `User-Agent`) were added, overwriting the user-specified headers

In short, if an `Authorization` or `User-Agent` header was specified via the configuration `http_headers` in v1.32.3+, it would be overwritten by the default user agent and the secret store token. This PR reverts this change to be like v1.32.2 and older.

## Checklist
- [X] No AI generated code was used in this PR

## Related issues
resolves #16380
