### PR TITLE
chore(inputs.syslog): Fix testcase timestamp hardcoding 2024

### DIFF
--- a/plugins/inputs/syslog/testcases/rfc3164_best_effort_udp/expected.out
+++ b/plugins/inputs/syslog/testcases/rfc3164_best_effort_udp/expected.out
@@ -1,1 +1,1 @@
-syslog,appname=app,facility=user,hostname=host,severity=notice,source=127.0.0.1 facility_code=1i,message="Test",severity_code=5i,timestamp=1733157063000000000i 0
+syslog,appname=app,facility=user,hostname=host,severity=notice,source=127.0.0.1 facility_code=1i,message="Test",severity_code=5i,timestamp=1764693063000000000i 0

--- a/plugins/inputs/syslog/testcases/rfc3164_strict_udp/expected.out
+++ b/plugins/inputs/syslog/testcases/rfc3164_strict_udp/expected.out
@@ -1,1 +1,1 @@
-syslog,appname=app,facility=user,hostname=host,severity=notice,source=127.0.0.1 facility_code=1i,message="Test",severity_code=5i,timestamp=1733157063000000000i 0
+syslog,appname=app,facility=user,hostname=host,severity=notice,source=127.0.0.1 facility_code=1i,message="Test",severity_code=5i,timestamp=1764693063000000000i 0


### PR DESCRIPTION
## Summary
Timestamp for RFC3164 hardcoding 2024 in the timestamp expected output

## Checklist
- [X] No AI generated code was used in this PR

## Related issues
resolves #
