### PR TITLE
fix: log if an error is returned from upstream

### DIFF
--- a/plugins/outputs/influxdb_v2/http.go
+++ b/plugins/outputs/influxdb_v2/http.go
@@ -330,6 +330,12 @@ func (c *httpClient) writeBatch(ctx context.Context, bucket string, metrics []te
 		for i := range len(metrics) {
 			rejected = append(rejected, i)
 		}
+
+		if (!strings.HasPrefix(writeResp.Code, "invalid")){
+				// This isn't a partial write, some form of error is being reported
+				c.log.Warnf("failed to write metric to %s (will be dropped: %s)", bucket, resp.Status)
+		}
+
 		return &internal.PartialWriteError{
 			Err:           fmt.Errorf("failed to write metric to %s (will be dropped: %s): %s", bucket, resp.Status, desc),
 			MetricsReject: rejected,
@@ -355,6 +361,7 @@ func (c *httpClient) writeBatch(ctx context.Context, bucket string, metrics []te
 		for i := range len(metrics) {
 			rejected = append(rejected, i)
 		}
+		c.log.Warnf("failed to write metric to %s (will be dropped: %s): %s", bucket, resp.Status, desc)
 		return &internal.PartialWriteError{
 			Err:           fmt.Errorf("failed to write metric to %s (will be dropped: %s): %s", bucket, resp.Status, desc),
 			MetricsReject: rejected,


### PR DESCRIPTION
## Summary
Raising to try and address https://github.com/influxdata/telegraf/issues/16386

Because of the partial writes handling, the influxdb_v2 output plugin doesn't complain if it receives a 400. This can mask configuration issues and make it look like data is being written when it isn't.

This PR adjusts the handling to ensure that a `400` matches the partial writes behaviour (i.e. includes a message which begins with `invalid`) and generates a logline if that's not the case.

Note: it doesn't change behaviour beyond that - we likely still want the metrics to be discarded so they don't block the buffer. But, this also means that, as written, Telegraf will print both a failure and a success message:


```text
2025-01-09T12:18:27Z W! [outputs.influxdb_v2] failed to write metric to testingdb (will be dropped: 400 Bad Request)
2025-01-09T12:18:27Z D! [outputs.influxdb_v2] Wrote batch of 13 metrics in 3.996059ms
```



## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
