### PR TITLE
feat(inputs.nsdp): Make inputs.nsdp an internal plugin

### DIFF
--- a/EXTERNAL_PLUGINS.md
+++ b/EXTERNAL_PLUGINS.md
@@ -31,7 +31,6 @@ Pull requests welcome.
 - [fritzbox](https://github.com/hdecarne-github/fritzbox-telegraf-plugin) - Gather statistics from [FRITZ!Box](https://avm.de/produkte/fritzbox/) router and repeater
 - [linux-psi-telegraf-plugin](https://github.com/gridscale/linux-psi-telegraf-plugin) - Gather pressure stall information ([PSI](https://facebookmicrosites.github.io/psi/)) from the Linux Kernel
 - [huebridge](https://github.com/hdecarne-github/huebridge-telegraf-plugin) - Gather smart home statistics from [Hue Bridge](https://www.philips-hue.com/) devices
-- [nsdp](https://github.com/hdecarne-github/nsdp-telegraf-plugin) - Gather switch network statistics via [Netgear Switch Discovery Protocol](https://en.wikipedia.org/wiki/Netgear_Switch_Discovery_Protocol)
 - [hwinfo](https://github.com/zachstence/hwinfo-telegraf-plugin) - Gather Windows system hardware information from [HWiNFO](https://www.hwinfo.com/)
 - [libvirt](https://gitlab.com/warrenio/tools/telegraf-input-libvirt) - Gather libvirt domain stats, based on a historical Telegraf implementation [libvirt](https://libvirt.org/)
 - [bacnet](https://github.com/JurajMarcin/telegraf-bacnet) - Gather statistics from BACnet devices, with support for device discovery and Change of Value subscriptions

--- a/docs/LICENSE_OF_DEPENDENCIES.md
+++ b/docs/LICENSE_OF_DEPENDENCIES.md
@@ -362,6 +362,7 @@ following works:
 - github.com/stoewer/go-strcase [MIT License](https://github.com/stoewer/go-strcase/blob/master/LICENSE)
 - github.com/stretchr/objx [MIT License](https://github.com/stretchr/objx/blob/master/LICENSE)
 - github.com/stretchr/testify [MIT License](https://github.com/stretchr/testify/blob/master/LICENSE)
+- github.com/tdrn-org/go-nsdp [MIT License](https://github.com/tdrn-org/go-nsdp/blob/main/LICENSE)
 - github.com/testcontainers/testcontainers-go [MIT License](https://github.com/testcontainers/testcontainers-go/blob/main/LICENSE)
 - github.com/thomasklein94/packer-plugin-libvirt [Mozilla Public License 2.0](https://github.com/thomasklein94/packer-plugin-libvirt/blob/main/LICENSE)
 - github.com/tidwall/gjson [MIT License](https://github.com/tidwall/gjson/blob/master/LICENSE)

--- a/go.mod
+++ b/go.mod
@@ -471,6 +471,7 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stoewer/go-strcase v1.3.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
+	github.com/tdrn-org/go-nsdp v0.4.0
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect
 	github.com/tidwall/tinylru v1.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2321,6 +2321,8 @@ github.com/t3rm1n4l/go-mega v0.0.0-20240219080617-d494b6a8ace7 h1:Jtcrb09q0AVWe3
 github.com/t3rm1n4l/go-mega v0.0.0-20240219080617-d494b6a8ace7/go.mod h1:suDIky6yrK07NnaBadCB4sS0CqFOvUK91lH7CR+JlDA=
 github.com/tbrandon/mbserver v0.0.0-20170611213546-993e1772cc62 h1:Oj2e7Sae4XrOsk3ij21QjjEgAcVSeo9nkp0dI//cD2o=
 github.com/tbrandon/mbserver v0.0.0-20170611213546-993e1772cc62/go.mod h1:qUzPVlSj2UgxJkVbH0ZwuuiR46U8RBMDT5KLY78Ifpw=
+github.com/tdrn-org/go-nsdp v0.4.0 h1:fAEHYgxvocRl6MjXPqELXuXUSAWVuMCwA0YCY1JAtqY=
+github.com/tdrn-org/go-nsdp v0.4.0/go.mod h1:zp7CxiCPcyXHo+s6tn+wrNBr1qQe1G/hOh/FybM5xiM=
 github.com/tedsuo/ifrit v0.0.0-20180802180643-bea94bb476cc/go.mod h1:eyZnKCc955uh98WQvzOm0dgAeLnf2O0Rz0LPoC5ze+0=
 github.com/testcontainers/testcontainers-go v0.34.0 h1:5fbgF0vIN5u+nD3IWabQwRybuB4GY8G2HHgCkbMzMHo=
 github.com/testcontainers/testcontainers-go v0.34.0/go.mod h1:6P/kMkQe8yqPHfPWNulFGdFHTD8HB2vLq/231xY2iPQ=

--- a/plugins/inputs/all/nsdp.go
+++ b/plugins/inputs/all/nsdp.go
@@ -1,0 +1,5 @@
+//go:build !custom || inputs || inputs.nsdp
+
+package all
+
+import _ "github.com/influxdata/telegraf/plugins/inputs/nsdp" // register plugin

--- a/plugins/inputs/nsdp/README.md
+++ b/plugins/inputs/nsdp/README.md
@@ -1,0 +1,74 @@
+# NSDP (Netgear Switch Discovery Protocol) Input Plugin
+
+This input plugin gathers status from NSDP
+([Netgear Switch Discovery Protocol][1]) capable devices.
+
+[1]: https://en.wikipedia.org/wiki/Netgear_Switch_Discovery_Protocol
+
+Retrieved status are:
+
+- Bytes (sent and received)
+- Total amount of packates processed
+- Total amount of broadcasts processed
+- Total amount of multicast processed
+- Total amount of errors occurred
+
+Each per switch and port.
+
+## Global configuration options <!-- @/docs/includes/plugin_config.md -->
+
+In addition to the plugin-specific configuration settings, plugins support
+additional global and plugin configuration settings. These settings are used to
+modify metrics, tags, and field or create aliases and configure ordering, etc.
+See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
+
+[CONFIGURATION.md]: ../../../docs/CONFIGURATION.md#plugins
+
+## Configuration
+
+```toml @sample.conf
+# Gather NSDP (Netgear Switch Discovery Protocol) status
+[[inputs.nsdp]]
+  ## The target address to use for NSDP gathering the status.
+  # target = "255.255.255.255:63322"
+
+  ## The maximum number of device responses to wait for. 0 means no limit.
+  ## NSDP works asynchronously. Without a limit (0) the plugin always waits
+  ## the amount given in timeout for possible responses. By setting this
+  ## option to the known number of the devices, the plugin completes
+  ## processing as soon as the last device has answered.
+  # device_limit = 0
+
+  ## The maximum duration to wait for device responses.
+  # timeout = "2s"
+
+  ## Enable debug output
+  # debug = false
+```
+
+## Metrics
+
+- `nsdp_device_port`
+  - tags
+    - `nsdp_device` - The device identifier (MAC/HW address)
+    - `nsdp_device_ip` - The device's IP address
+    - `nsdp_device_name` - The device's name
+    - `nsdp_device_model` - The device's model
+    - `nsdp_device_port` - The port id the fields are referring to
+  - fields
+    - `bytes_sent` (uint) - Number of bytes sent via this port
+    - `bytes_recv` (uint) - Number of bytes received via this port
+    - `packets_total` (uint) - Total number of packets processed on this port
+    - `broadcasts_total` (uint) - Total number of broadcasts processed on this port
+    - `multicasts_total` (uint) - Total number of multicasts processed on this port
+    - `errors_total` (uint) - Total number of errors encountered on this port
+
+## Example Output
+
+<!-- markdownlint-disable MD013 -->
+
+```text
+nsdp_device_port,nsdp_device_model=GS108Ev3,nsdp_device_port=4,nsdp_device=cb:a9:87:65:43:21,nsdp_device_ip=10.1.0.3,nsdp_device_name=switch1 multicasts_total=0,errors_total=0,bytes_sent=47027386,bytes_recv=4310867,packets_total=0,broadcasts_total=0 1736590886
+```
+
+<!-- markdownlint-enable MD013 -->.

--- a/plugins/inputs/nsdp/nsdp.go
+++ b/plugins/inputs/nsdp/nsdp.go
@@ -1,0 +1,166 @@
+//go:generate ../../../tools/readme_config_includer/generator
+package nsdp
+
+import (
+	_ "embed"
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/config"
+	"github.com/influxdata/telegraf/logger"
+	"github.com/influxdata/telegraf/plugins/inputs"
+	"github.com/tdrn-org/go-nsdp"
+)
+
+//go:embed sample.conf
+var sampleConfig string
+
+const pluginName = "nsdp"
+
+const defaultTimeout = config.Duration(2 * time.Second)
+
+type NSDP struct {
+	Target      string          `toml:"target"`
+	DeviceLimit uint            `toml:"device_limit"`
+	Timeout     config.Duration `toml:"timeout"`
+	Debug       bool            `toml:"debug"`
+
+	Log telegraf.Logger `toml:"-"`
+}
+
+func defaultNSDP() *NSDP {
+	return &NSDP{
+		Target:  nsdp.IPv4BroadcastTarget,
+		Timeout: defaultTimeout,
+	}
+}
+
+func (*NSDP) SampleConfig() string {
+	return sampleConfig
+}
+
+func (plugin *NSDP) Init() error {
+	if plugin.Log == nil {
+		plugin.Log = logger.New("inputs", pluginName, "")
+	}
+	return nil
+}
+
+func (plugin *NSDP) Gather(acc telegraf.Accumulator) error {
+	start := time.Now()
+	if plugin.Debug {
+		plugin.Log.Infof("Querying %s", plugin.Target)
+	}
+	conn, request, err := plugin.prepareGatherRequest()
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+	responses, err := conn.SendReceiveMessage(request)
+	if err != nil {
+		return err
+	}
+	for device, response := range responses {
+		if plugin.Debug {
+			plugin.Log.Infof("Processing device: %s", device)
+		}
+		plugin.gatherDevice(acc, device, response)
+	}
+	if plugin.Debug {
+		elapsed := time.Since(start)
+		plugin.Log.Info("took: ", elapsed)
+	}
+	return nil
+}
+
+func (plugin *NSDP) prepareGatherRequest() (*nsdp.Conn, *nsdp.Message, error) {
+	conn, err := nsdp.NewConn(plugin.Target, plugin.Debug)
+	if err != nil {
+		return nil, nil, err
+	}
+	conn.ReceiveDeviceLimit = plugin.DeviceLimit
+	conn.ReceiveTimeout = time.Duration(plugin.Timeout)
+	request := nsdp.NewMessage(nsdp.ReadRequest)
+	request.AppendTLV(nsdp.EmptyDeviceModel())
+	request.AppendTLV(nsdp.EmptyDeviceName())
+	request.AppendTLV(nsdp.EmptyDeviceIP())
+	request.AppendTLV(nsdp.EmptyPortStatistic())
+	return conn, request, nil
+}
+
+func (plugin *NSDP) gatherDevice(acc telegraf.Accumulator, device string, response *nsdp.Message) {
+	var deviceModel string
+	var deviceName string
+	var deviceIP net.IP
+	portStatistics := make(map[uint8]*nsdp.PortStatistic, 0)
+	for _, tlv := range response.Body {
+		switch tlv.Type() {
+		case nsdp.TypeDeviceModel:
+			deviceModel = tlv.(*nsdp.DeviceModel).Model
+		case nsdp.TypeDeviceName:
+			deviceName = tlv.(*nsdp.DeviceName).Name
+		case nsdp.TypeDeviceIP:
+			deviceIP = tlv.(*nsdp.DeviceIP).IP
+		case nsdp.TypePortStatistic:
+			portStatistic := tlv.(*nsdp.PortStatistic)
+			portStatistics[portStatistic.Port] = portStatistic
+		}
+	}
+	for port, statistic := range portStatistics {
+		if statistic.Received != 0 || statistic.Sent != 0 {
+			tags := make(map[string]string)
+			tags["nsdp_device"] = device
+			tags["nsdp_device_ip"] = deviceIP.String()
+			tags["nsdp_device_name"] = deviceName
+			tags["nsdp_device_model"] = deviceModel
+			tags["nsdp_device_port"] = strconv.FormatUint(uint64(port), 10)
+			fields := make(map[string]interface{})
+			fields["bytes_sent"] = statistic.Sent
+			fields["bytes_recv"] = statistic.Received
+			fields["packets_total"] = statistic.Packets
+			fields["broadcasts_total"] = statistic.Broadcasts
+			fields["multicasts_total"] = statistic.Multicasts
+			fields["errors_total"] = statistic.Errors
+			acc.AddCounter("nsdp_device_port", fields, tags)
+			if plugin.Debug {
+				plugin.logMetric("nsdp_device_port", tags, fields)
+			}
+		}
+	}
+}
+
+func (plugin *NSDP) logMetric(name string, tags map[string]string, fields map[string]interface{}) {
+	buffer := strings.Builder{}
+	buffer.WriteString(name)
+	for tagKey, tagValue := range tags {
+		buffer.WriteRune(',')
+		buffer.WriteString(tagKey)
+		buffer.WriteRune('=')
+		buffer.WriteString(fmt.Sprint(tagValue))
+	}
+	writeSpace := true
+	for fieldKey, fieldValue := range fields {
+		if writeSpace {
+			buffer.WriteRune(' ')
+			writeSpace = false
+		} else {
+			buffer.WriteRune(',')
+		}
+		buffer.WriteString(fieldKey)
+		buffer.WriteRune('=')
+		buffer.WriteString(fmt.Sprint(fieldValue))
+	}
+	buffer.WriteRune(' ')
+	buffer.WriteString(fmt.Sprint(time.Now().Unix()))
+	plugin.Log.Info(buffer.String())
+}
+
+func init() {
+	inputs.Add(pluginName, func() telegraf.Input {
+		return defaultNSDP()
+	})
+}

--- a/plugins/inputs/nsdp/nsdp_test.go
+++ b/plugins/inputs/nsdp/nsdp_test.go
@@ -1,0 +1,71 @@
+package nsdp
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/BurntSushi/toml"
+	"github.com/influxdata/telegraf/config"
+	"github.com/influxdata/telegraf/testutil"
+	"github.com/stretchr/testify/require"
+	"github.com/tdrn-org/go-nsdp"
+)
+
+func TestInitDefaults(t *testing.T) {
+	plugin := defaultNSDP()
+	err := plugin.Init()
+	require.NoError(t, err)
+	require.Equal(t, nsdp.IPv4BroadcastTarget, plugin.Target)
+	require.Equal(t, uint(0), plugin.DeviceLimit)
+	require.Equal(t, defaultTimeout, plugin.Timeout)
+	require.False(t, plugin.Debug)
+	require.NotNil(t, plugin.Log)
+}
+
+func TestConfig(t *testing.T) {
+	conf, err := os.ReadFile("testdata/nsdp.conf")
+	require.NoError(t, err)
+	var plugin = defaultNSDP()
+	err = toml.Unmarshal(conf, plugin)
+	require.NoError(t, err)
+	err = plugin.Init()
+	require.NoError(t, err)
+	require.Equal(t, pluginTestResponderTarget, plugin.Target)
+	require.Equal(t, uint(1), plugin.DeviceLimit)
+	require.Equal(t, config.Duration(5*time.Second), plugin.Timeout)
+	require.True(t, plugin.Debug)
+}
+
+const pluginTestResponderTarget = "127.0.0.1:63322"
+
+func TestGather(t *testing.T) {
+	responder, err := nsdp.NewTestResponder(pluginTestResponderTarget)
+	require.Nil(t, err)
+	defer responder.Stop()
+	responder.AddResponses(
+		"0102000000000000bcd07432b8dc123456789abc000037b94e534450000000000001000847533130384576330003000773776974636832000600040a010004100000310100000000e73b5f1a000000001e31523c0000000000000000000000000000000000000000000000000000000000000000100000310200000000152d5eae0000000052ea11ea0000000000000000000000000000000000000000000000000000000000000000100000310300000000068561aa00000000bcc8cb35000000000000000000000000000000000000000000000000000000000000000010000031040000000002d5fe00000000002b37dad900000000000000000000000000000000000000000000000000000000000000001000003105000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000100000310600000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010000031070000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000003108000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffff0000",
+		"0102000000000000bcd07432b8dccba987654321000037b94e534450000000000001000847533130384576330003000773776974636831000600040a0100031000003101000000059a9d833200000000303e8eb5000000000000000000000000000000000000000000000000000000000000000010000031020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000003103000000000d9a35e4000000026523c66600000000000000000000000000000000000000000000000000000000000000001000003104000000000041c7530000000002cd94ba000000000000000000000000000000000000000000000000000000000000000010000031050000000021b9ca41000000031a9bff610000000000000000000000000000000000000000000000000000000000000000100000310600000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010000031070000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000003108000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffff0000")
+	err = responder.Start()
+	require.Nil(t, err)
+	plugin := defaultNSDP()
+	plugin.Target = pluginTestResponderTarget
+	plugin.DeviceLimit = 2
+	plugin.Debug = true
+	err = plugin.Init()
+	require.Nil(t, err)
+	acc := &testutil.Accumulator{}
+	err = acc.GatherError(plugin.Gather)
+	require.NoError(t, err)
+	testMeasurement(t, acc, "nsdp_device_port", []string{"nsdp_device", "nsdp_device_ip", "nsdp_device_name", "nsdp_device_model", "nsdp_device_port"}, []string{"bytes_sent", "bytes_recv", "packets_total", "broadcasts_total", "multicasts_total", "errors_total"})
+}
+
+func testMeasurement(t *testing.T, acc *testutil.Accumulator, measurement string, tags []string, fields []string) {
+	require.Truef(t, acc.HasMeasurement(measurement), "measurement: %s", measurement)
+	for _, tag := range tags {
+		require.Truef(t, acc.HasTag(measurement, tag), "measurement: %s tag: %s", measurement, tag)
+	}
+	for _, field := range fields {
+		require.True(t, acc.HasField(measurement, field), "measurement: %s field: %s", measurement, field)
+	}
+}

--- a/plugins/inputs/nsdp/sample.conf
+++ b/plugins/inputs/nsdp/sample.conf
@@ -1,0 +1,17 @@
+# Gather NSDP (Netgear Switch Discovery Protocol) status
+[[inputs.nsdp]]
+  ## The target address to use for NSDP gathering the status.
+  # target = "255.255.255.255:63322"
+
+  ## The maximum number of device responses to wait for. 0 means no limit.
+  ## NSDP works asynchronously. Without a limit (0) the plugin always waits
+  ## the amount given in timeout for possible responses. By setting this
+  ## option to the known number of the devices, the plugin completes
+  ## processing as soon as the last device has answered.
+  # device_limit = 0
+
+  ## The maximum duration to wait for device responses.
+  # timeout = "2s"
+
+  ## Enable debug output
+  # debug = false

--- a/plugins/inputs/nsdp/testdata/nsdp.conf
+++ b/plugins/inputs/nsdp/testdata/nsdp.conf
@@ -1,0 +1,15 @@
+  ## The target address to use for NSDP gathering the status.
+  target = "127.0.0.1:63322"
+
+  ## The maximum number of device responses to wait for. 0 means no limit.
+  ## NSDP works asynchronously. Without a limit (0) the plugin always waits
+  ## the amount given in timeout for possible responses. By setting this
+  ## option to the known number of the devices, the plugin completes
+  ## processing as soon as the last device has answered.
+  device_limit = 1
+
+  ## The maximum duration to wait for device responses.
+  timeout = "5s"
+
+  ## Enable debug output
+  debug = true


### PR DESCRIPTION
## Summary
This PR provides the inputs.nsdp plugin for collecting statistics from from NSDP
([Netgear Switch Discovery Protocol][1]) capable devices.

I previously contributed this plugin as an [external one](https://github.com/hdecarne-github/nsdp-telegraf-plugin). As part of the latest reworks I also converted it into an internal one.

[1]: https://en.wikipedia.org/wiki/Netgear_Switch_Discovery_Protocol

## Checklist
- [X] No AI generated code was used in this PR

## Related issues
resolves #16391
