### PR TITLE
chore: Fix linter findings for `revive:exported` in `plugins/inputs/webhooks/*`

### DIFF
--- a/plugins/inputs/webhooks/artifactory/artifactory_webhook_mock_json_test.go
+++ b/plugins/inputs/webhooks/artifactory/artifactory_webhook_mock_json_test.go
@@ -1,6 +1,6 @@
 package artifactory
 
-func UnsupportedEventJSON() string {
+func unsupportedEventJSON() string {
 	return `
 	{
 		"domain": "not_supported",
@@ -15,7 +15,7 @@ func UnsupportedEventJSON() string {
 	}`
 }
 
-func ArtifactDeployedEventJSON() string {
+func artifactDeployedEventJSON() string {
 	return `
 	{
 		"domain": "artifact",
@@ -30,7 +30,7 @@ func ArtifactDeployedEventJSON() string {
 	}`
 }
 
-func ArtifactDeletedEventJSON() string {
+func artifactDeletedEventJSON() string {
 	return `
 	{
 		"domain": "artifact",
@@ -45,7 +45,7 @@ func ArtifactDeletedEventJSON() string {
 	}`
 }
 
-func ArtifactMovedEventJSON() string {
+func artifactMovedEventJSON() string {
 	return `
 	{
 		"domain": "artifact",
@@ -62,7 +62,7 @@ func ArtifactMovedEventJSON() string {
 	}`
 }
 
-func ArtifactCopiedEventJSON() string {
+func artifactCopiedEventJSON() string {
 	return `
 	{
 		"domain": "artifact",
@@ -79,7 +79,7 @@ func ArtifactCopiedEventJSON() string {
 	}`
 }
 
-func ArtifactPropertiesAddedEventJSON() string {
+func artifactPropertiesAddedEventJSON() string {
 	return `
 	{
 		"domain": "artifact_property",
@@ -98,7 +98,7 @@ func ArtifactPropertiesAddedEventJSON() string {
 	}`
 }
 
-func ArtifactPropertiesDeletedEventJSON() string {
+func artifactPropertiesDeletedEventJSON() string {
 	return `
 	{
 		"domain": "artifact_property",
@@ -117,7 +117,7 @@ func ArtifactPropertiesDeletedEventJSON() string {
 	}`
 }
 
-func DockerPushedEventJSON() string {
+func dockerPushedEventJSON() string {
 	return `
 	{
 		"domain": "docker",
@@ -140,7 +140,7 @@ func DockerPushedEventJSON() string {
 	}`
 }
 
-func DockerDeletedEventJSON() string {
+func dockerDeletedEventJSON() string {
 	return `
 	{
 		"domain": "docker",
@@ -163,7 +163,7 @@ func DockerDeletedEventJSON() string {
 	}`
 }
 
-func DockerPromotedEventJSON() string {
+func dockerPromotedEventJSON() string {
 	return `
 	{
 		"domain": "docker",
@@ -186,7 +186,7 @@ func DockerPromotedEventJSON() string {
 	}`
 }
 
-func BuildUploadedEventJSON() string {
+func buildUploadedEventJSON() string {
 	return `
 	{
 		"domain": "build",
@@ -199,7 +199,7 @@ func BuildUploadedEventJSON() string {
 	}`
 }
 
-func BuildDeletedEventJSON() string {
+func buildDeletedEventJSON() string {
 	return `
 	{
 		"domain": "build",
@@ -212,7 +212,7 @@ func BuildDeletedEventJSON() string {
 	}`
 }
 
-func BuildPromotedEventJSON() string {
+func buildPromotedEventJSON() string {
 	return `
 	{
 		"domain": "build",
@@ -225,7 +225,7 @@ func BuildPromotedEventJSON() string {
 	}`
 }
 
-func ReleaseBundleCreatedEventJSON() string {
+func releaseBundleCreatedEventJSON() string {
 	return `
 	{
 		"domain": "release_bundle",
@@ -240,7 +240,7 @@ func ReleaseBundleCreatedEventJSON() string {
 	}`
 }
 
-func ReleaseBundleSignedEventJSON() string {
+func releaseBundleSignedEventJSON() string {
 	return `
 	{
 		"domain": "release_bundle",
@@ -255,7 +255,7 @@ func ReleaseBundleSignedEventJSON() string {
 	}`
 }
 
-func ReleaseBundleDeletedEventJSON() string {
+func releaseBundleDeletedEventJSON() string {
 	return `
 	{
 		"domain": "release_bundle",
@@ -270,7 +270,7 @@ func ReleaseBundleDeletedEventJSON() string {
 	}`
 }
 
-func DistributionStartedEventJSON() string {
+func distributionStartedEventJSON() string {
 	return `
 	{
 		"domain": "distribution",
@@ -297,7 +297,7 @@ func DistributionStartedEventJSON() string {
 	  }`
 }
 
-func DistributionCompletedEventJSON() string {
+func distributionCompletedEventJSON() string {
 	return `
 	{
 		"domain": "distribution",
@@ -324,7 +324,7 @@ func DistributionCompletedEventJSON() string {
 	  }`
 }
 
-func DistributionAbortedEventJSON() string {
+func distributionAbortedEventJSON() string {
 	return `
 	{
 		"domain": "distribution",
@@ -351,7 +351,7 @@ func DistributionAbortedEventJSON() string {
 	  }`
 }
 
-func DistributionFailedEventJSON() string {
+func distributionFailedEventJSON() string {
 	return `
 	{
 		"domain": "distribution",
@@ -378,7 +378,7 @@ func DistributionFailedEventJSON() string {
 	}`
 }
 
-func DestinationReceivedEventJSON() string {
+func destinationReceivedEventJSON() string {
 	return `
 	{
 		"domain": "destination",
@@ -393,7 +393,7 @@ func DestinationReceivedEventJSON() string {
 	}`
 }
 
-func DestinationDeleteStartedEventJSON() string {
+func destinationDeleteStartedEventJSON() string {
 	return `
 	{
 		"domain": "destination",
@@ -408,7 +408,7 @@ func DestinationDeleteStartedEventJSON() string {
 	}`
 }
 
-func DestinationDeleteCompletedEventJSON() string {
+func destinationDeleteCompletedEventJSON() string {
 	return `
 	{
 		"domain": "destination",
@@ -423,7 +423,7 @@ func DestinationDeleteCompletedEventJSON() string {
 	}`
 }
 
-func DestinationDeleteFailedEventJSON() string {
+func destinationDeleteFailedEventJSON() string {
 	return `
 	{
 		"domain": "destination",

--- a/plugins/inputs/webhooks/artifactory/artifactory_webhook_models.go
+++ b/plugins/inputs/webhooks/artifactory/artifactory_webhook_models.go
@@ -11,7 +11,7 @@ import (
 const meas = "artifactory_webhooks"
 
 type event interface {
-	NewMetric() telegraf.Metric
+	newMetric() telegraf.Metric
 }
 
 type artifactDeploymentOrDeletedEvent struct {
@@ -26,7 +26,7 @@ type artifactDeploymentOrDeletedEvent struct {
 	} `json:"data"`
 }
 
-func (e artifactDeploymentOrDeletedEvent) NewMetric() telegraf.Metric {
+func (e artifactDeploymentOrDeletedEvent) newMetric() telegraf.Metric {
 	t := map[string]string{
 		"domain":     e.Domain,
 		"event_type": e.Event,
@@ -55,7 +55,7 @@ type artifactMovedOrCopiedEvent struct {
 	} `json:"data"`
 }
 
-func (e artifactMovedOrCopiedEvent) NewMetric() telegraf.Metric {
+func (e artifactMovedOrCopiedEvent) newMetric() telegraf.Metric {
 	t := map[string]string{
 		"domain":     e.Domain,
 		"event_type": e.Event,
@@ -85,7 +85,7 @@ type artifactPropertiesEvent struct {
 	}
 }
 
-func (e artifactPropertiesEvent) NewMetric() telegraf.Metric {
+func (e artifactPropertiesEvent) newMetric() telegraf.Metric {
 	t := map[string]string{
 		"domain":     e.Domain,
 		"event_type": e.Event,
@@ -120,7 +120,7 @@ type dockerEvent struct {
 	} `json:"data"`
 }
 
-func (e dockerEvent) NewMetric() telegraf.Metric {
+func (e dockerEvent) newMetric() telegraf.Metric {
 	t := map[string]string{
 		"domain":     e.Domain,
 		"event_type": e.Event,
@@ -149,7 +149,7 @@ type buildEvent struct {
 	} `json:"data"`
 }
 
-func (e buildEvent) NewMetric() telegraf.Metric {
+func (e buildEvent) newMetric() telegraf.Metric {
 	t := map[string]string{
 		"domain":     e.Domain,
 		"event_type": e.Event,
@@ -175,7 +175,7 @@ type releaseBundleEvent struct {
 	JpdOrigin string `json:"jpd_origin"`
 }
 
-func (e releaseBundleEvent) NewMetric() telegraf.Metric {
+func (e releaseBundleEvent) newMetric() telegraf.Metric {
 	t := map[string]string{
 		"domain":              e.Domain,
 		"event_type":          e.Event,
@@ -209,7 +209,7 @@ type distributionEvent struct {
 	OriginURL string `json:"jpd_origin"`
 }
 
-func (e distributionEvent) NewMetric() telegraf.Metric {
+func (e distributionEvent) newMetric() telegraf.Metric {
 	t := map[string]string{
 		"domain":              e.Domain,
 		"event_type":          e.Event,
@@ -239,7 +239,7 @@ type destinationEvent struct {
 	OriginURL string `json:"jpd_origin"`
 }
 
-func (e destinationEvent) NewMetric() telegraf.Metric {
+func (e destinationEvent) newMetric() telegraf.Metric {
 	t := map[string]string{
 		"domain":              e.Domain,
 		"event_type":          e.Event,

--- a/plugins/inputs/webhooks/artifactory/artifactory_webhook_test.go
+++ b/plugins/inputs/webhooks/artifactory/artifactory_webhook_test.go
@@ -11,9 +11,9 @@ import (
 	"github.com/influxdata/telegraf/testutil"
 )
 
-func ArtifactoryWebhookRequest(t *testing.T, domain, event, jsonString string) {
+func artifactoryWebhookRequest(t *testing.T, domain, event, jsonString string) {
 	var acc testutil.Accumulator
-	awh := &ArtifactoryWebhook{Path: "/artifactory", acc: &acc, log: testutil.Logger{}}
+	awh := &Webhook{Path: "/artifactory", acc: &acc, log: testutil.Logger{}}
 	req, err := http.NewRequest("POST", "/artifactory", strings.NewReader(jsonString))
 	require.NoError(t, err)
 	w := httptest.NewRecorder()
@@ -23,9 +23,9 @@ func ArtifactoryWebhookRequest(t *testing.T, domain, event, jsonString string) {
 	}
 }
 
-func ArtifactoryWebhookRequestWithSignature(t *testing.T, event, jsonString, signature string, expectedStatus int) {
+func artifactoryWebhookRequestWithSignature(t *testing.T, event, jsonString, signature string, expectedStatus int) {
 	var acc testutil.Accumulator
-	awh := &ArtifactoryWebhook{Path: "/artifactory", acc: &acc, log: testutil.Logger{}}
+	awh := &Webhook{Path: "/artifactory", acc: &acc, log: testutil.Logger{}}
 	req, err := http.NewRequest("POST", "/artifactory", strings.NewReader(jsonString))
 	require.NoError(t, err)
 	req.Header.Add("x-jfrog-event-auth", signature)
@@ -38,8 +38,8 @@ func ArtifactoryWebhookRequestWithSignature(t *testing.T, event, jsonString, sig
 
 func TestUnsupportedEvent(t *testing.T) {
 	var acc testutil.Accumulator
-	awh := &ArtifactoryWebhook{Path: "/artifactory", acc: &acc, log: testutil.Logger{}}
-	req, err := http.NewRequest("POST", "/artifactory", strings.NewReader(UnsupportedEventJSON()))
+	awh := &Webhook{Path: "/artifactory", acc: &acc, log: testutil.Logger{}}
+	req, err := http.NewRequest("POST", "/artifactory", strings.NewReader(unsupportedEventJSON()))
 	require.NoError(t, err)
 	w := httptest.NewRecorder()
 	awh.eventHandler(w, req)
@@ -49,103 +49,103 @@ func TestUnsupportedEvent(t *testing.T) {
 }
 
 func TestArtifactDeployedEvent(t *testing.T) {
-	ArtifactoryWebhookRequest(t, "artifact", "deployed", ArtifactDeployedEventJSON())
+	artifactoryWebhookRequest(t, "artifact", "deployed", artifactDeployedEventJSON())
 }
 
 func TestArtifactDeleted(t *testing.T) {
-	ArtifactoryWebhookRequest(t, "artifact", "deleted", ArtifactDeletedEventJSON())
+	artifactoryWebhookRequest(t, "artifact", "deleted", artifactDeletedEventJSON())
 }
 
 func TestArtifactMovedEvent(t *testing.T) {
-	ArtifactoryWebhookRequest(t, "artifact", "moved", ArtifactMovedEventJSON())
+	artifactoryWebhookRequest(t, "artifact", "moved", artifactMovedEventJSON())
 }
 
 func TestArtifactCopiedEvent(t *testing.T) {
-	ArtifactoryWebhookRequest(t, "artifact", "copied", ArtifactCopiedEventJSON())
+	artifactoryWebhookRequest(t, "artifact", "copied", artifactCopiedEventJSON())
 }
 
 func TestArtifactPropertiesAddedEvent(t *testing.T) {
-	ArtifactoryWebhookRequest(t, "artifact_property", "added", ArtifactPropertiesAddedEventJSON())
+	artifactoryWebhookRequest(t, "artifact_property", "added", artifactPropertiesAddedEventJSON())
 }
 
 func TestArtifactPropertiesDeletedEvent(t *testing.T) {
-	ArtifactoryWebhookRequest(t, "artifact_property", "deleted", ArtifactPropertiesDeletedEventJSON())
+	artifactoryWebhookRequest(t, "artifact_property", "deleted", artifactPropertiesDeletedEventJSON())
 }
 
 func TestDockerPushedEvent(t *testing.T) {
-	ArtifactoryWebhookRequest(t, "docker", "pushed", DockerPushedEventJSON())
+	artifactoryWebhookRequest(t, "docker", "pushed", dockerPushedEventJSON())
 }
 
 func TestDockerDeletedEvent(t *testing.T) {
-	ArtifactoryWebhookRequest(t, "docker", "deleted", DockerDeletedEventJSON())
+	artifactoryWebhookRequest(t, "docker", "deleted", dockerDeletedEventJSON())
 }
 
 func TestDockerPromotedEvent(t *testing.T) {
-	ArtifactoryWebhookRequest(t, "docker", "promoted", DockerPromotedEventJSON())
+	artifactoryWebhookRequest(t, "docker", "promoted", dockerPromotedEventJSON())
 }
 
 func TestBuildUploadedEvent(t *testing.T) {
-	ArtifactoryWebhookRequest(t, "build", "uploaded", BuildUploadedEventJSON())
+	artifactoryWebhookRequest(t, "build", "uploaded", buildUploadedEventJSON())
 }
 
 func TestBuildDeletedEvent(t *testing.T) {
-	ArtifactoryWebhookRequest(t, "build", "deleted", BuildDeletedEventJSON())
+	artifactoryWebhookRequest(t, "build", "deleted", buildDeletedEventJSON())
 }
 
 func TestBuildPromotedEvent(t *testing.T) {
-	ArtifactoryWebhookRequest(t, "build", "promoted", BuildPromotedEventJSON())
+	artifactoryWebhookRequest(t, "build", "promoted", buildPromotedEventJSON())
 }
 
 func TestReleaseBundleCreatedEvent(t *testing.T) {
-	ArtifactoryWebhookRequest(t, "release_bundle", "created", ReleaseBundleCreatedEventJSON())
+	artifactoryWebhookRequest(t, "release_bundle", "created", releaseBundleCreatedEventJSON())
 }
 
 func TestReleaseBundleSignedEvent(t *testing.T) {
-	ArtifactoryWebhookRequest(t, "release_bundle", "signed", ReleaseBundleSignedEventJSON())
+	artifactoryWebhookRequest(t, "release_bundle", "signed", releaseBundleSignedEventJSON())
 }
 
 func TestReleaseBundleDeletedEvent(t *testing.T) {
-	ArtifactoryWebhookRequest(t, "release_bundle", "deleted", ReleaseBundleDeletedEventJSON())
+	artifactoryWebhookRequest(t, "release_bundle", "deleted", releaseBundleDeletedEventJSON())
 }
 
 func TestDistributionStartedEvent(t *testing.T) {
-	ArtifactoryWebhookRequest(t, "distribution", "distribute_started", DistributionStartedEventJSON())
+	artifactoryWebhookRequest(t, "distribution", "distribute_started", distributionStartedEventJSON())
 }
 
 func TestDistributionCompletedEvent(t *testing.T) {
-	ArtifactoryWebhookRequest(t, "distribution", "distribute_started", DistributionCompletedEventJSON())
+	artifactoryWebhookRequest(t, "distribution", "distribute_started", distributionCompletedEventJSON())
 }
 
 func TestDistributionAbortedEvent(t *testing.T) {
-	ArtifactoryWebhookRequest(t, "distribution", "distribute_aborted", DistributionAbortedEventJSON())
+	artifactoryWebhookRequest(t, "distribution", "distribute_aborted", distributionAbortedEventJSON())
 }
 
 func TestDistributionFailedEvent(t *testing.T) {
-	ArtifactoryWebhookRequest(t, "distribution", "distribute_failed", DistributionFailedEventJSON())
+	artifactoryWebhookRequest(t, "distribution", "distribute_failed", distributionFailedEventJSON())
 }
 
 func TestDestinationReceivedEvent(t *testing.T) {
-	ArtifactoryWebhookRequest(t, "destination", "received", DestinationReceivedEventJSON())
+	artifactoryWebhookRequest(t, "destination", "received", destinationReceivedEventJSON())
 }
 
 func TestDestinationDeletedStartedEvent(t *testing.T) {
-	ArtifactoryWebhookRequest(t, "destination", "delete_started", DestinationDeleteStartedEventJSON())
+	artifactoryWebhookRequest(t, "destination", "delete_started", destinationDeleteStartedEventJSON())
 }
 
 func TestDestinationDeletedCompletedEvent(t *testing.T) {
-	ArtifactoryWebhookRequest(t, "destination", "delete_completed", DestinationDeleteCompletedEventJSON())
+	artifactoryWebhookRequest(t, "destination", "delete_completed", destinationDeleteCompletedEventJSON())
 }
 
 func TestDestinationDeleteFailedEvent(t *testing.T) {
-	ArtifactoryWebhookRequest(t, "destination", "delete_failed", DestinationDeleteFailedEventJSON())
+	artifactoryWebhookRequest(t, "destination", "delete_failed", destinationDeleteFailedEventJSON())
 }
 
 func TestEventWithSignatureSuccess(t *testing.T) {
-	ArtifactoryWebhookRequestWithSignature(
+	artifactoryWebhookRequestWithSignature(
 		t,
 		"watch",
-		ArtifactDeployedEventJSON(),
-		generateSignature("signature", []byte(ArtifactDeployedEventJSON())),
+		artifactDeployedEventJSON(),
+		generateSignature("signature", []byte(artifactDeployedEventJSON())),
 		http.StatusOK,
 	)
 }

--- a/plugins/inputs/webhooks/filestack/filestack_webhooks_events.go
+++ b/plugins/inputs/webhooks/filestack/filestack_webhooks_events.go
@@ -2,19 +2,19 @@ package filestack
 
 import "strconv"
 
-type FilestackEvent struct {
+type filestackEvent struct {
 	Action    string `json:"action"`
 	TimeStamp int64  `json:"timestamp"`
 	ID        int    `json:"id"`
 }
 
-func (fe *FilestackEvent) Tags() map[string]string {
+func (fe *filestackEvent) tags() map[string]string {
 	return map[string]string{
 		"action": fe.Action,
 	}
 }
 
-func (fe *FilestackEvent) Fields() map[string]interface{} {
+func (fe *filestackEvent) fields() map[string]interface{} {
 	return map[string]interface{}{
 		"id": strconv.Itoa(fe.ID),
 	}

--- a/plugins/inputs/webhooks/filestack/filestack_webhooks_test.go
+++ b/plugins/inputs/webhooks/filestack/filestack_webhooks_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/influxdata/telegraf/testutil"
 )
 
-func postWebhooks(t *testing.T, md *FilestackWebhook, eventBodyFile io.Reader) *httptest.ResponseRecorder {
+func postWebhooks(t *testing.T, md *Webhook, eventBodyFile io.Reader) *httptest.ResponseRecorder {
 	req, err := http.NewRequest("POST", "/filestack", eventBodyFile)
 	require.NoError(t, err)
 	w := httptest.NewRecorder()
@@ -25,7 +25,7 @@ func postWebhooks(t *testing.T, md *FilestackWebhook, eventBodyFile io.Reader) *
 
 func TestDialogEvent(t *testing.T) {
 	var acc testutil.Accumulator
-	fs := &FilestackWebhook{Path: "/filestack", acc: &acc}
+	fs := &Webhook{Path: "/filestack", acc: &acc}
 	resp := postWebhooks(t, fs, getFile(t, "testdata/dialog_open.json"))
 	if resp.Code != http.StatusOK {
 		t.Errorf("POST returned HTTP status code %v.\nExpected %v", resp.Code, http.StatusOK)
@@ -43,7 +43,7 @@ func TestDialogEvent(t *testing.T) {
 }
 
 func TestParseError(t *testing.T) {
-	fs := &FilestackWebhook{Path: "/filestack"}
+	fs := &Webhook{Path: "/filestack"}
 	resp := postWebhooks(t, fs, strings.NewReader(""))
 	if resp.Code != http.StatusBadRequest {
 		t.Errorf("POST returned HTTP status code %v.\nExpected %v", resp.Code, http.StatusBadRequest)
@@ -52,7 +52,7 @@ func TestParseError(t *testing.T) {
 
 func TestUploadEvent(t *testing.T) {
 	var acc testutil.Accumulator
-	fs := &FilestackWebhook{Path: "/filestack", acc: &acc}
+	fs := &Webhook{Path: "/filestack", acc: &acc}
 	resp := postWebhooks(t, fs, getFile(t, "testdata/upload.json"))
 	if resp.Code != http.StatusOK {
 		t.Errorf("POST returned HTTP status code %v.\nExpected %v", resp.Code, http.StatusOK)
@@ -71,7 +71,7 @@ func TestUploadEvent(t *testing.T) {
 
 func TestVideoConversionEvent(t *testing.T) {
 	var acc testutil.Accumulator
-	fs := &FilestackWebhook{Path: "/filestack", acc: &acc}
+	fs := &Webhook{Path: "/filestack", acc: &acc}
 	resp := postWebhooks(t, fs, getFile(t, "testdata/video_conversion.json"))
 	if resp.Code != http.StatusBadRequest {
 		t.Errorf("POST returned HTTP status code %v.\nExpected %v", resp.Code, http.StatusBadRequest)

--- a/plugins/inputs/webhooks/github/github_webhooks.go
+++ b/plugins/inputs/webhooks/github/github_webhooks.go
@@ -14,15 +14,16 @@ import (
 	"github.com/influxdata/telegraf/plugins/common/auth"
 )
 
-type GithubWebhook struct {
+type Webhook struct {
 	Path   string
-	Secret string
+	secret string
 	acc    telegraf.Accumulator
 	log    telegraf.Logger
 	auth.BasicAuth
 }
 
-func (gh *GithubWebhook) Register(router *mux.Router, acc telegraf.Accumulator, log telegraf.Logger) {
+// Register registers the webhook with the provided router
+func (gh *Webhook) Register(router *mux.Router, acc telegraf.Accumulator, log telegraf.Logger) {
 	router.HandleFunc(gh.Path, gh.eventHandler).Methods("POST")
 
 	gh.log = log
@@ -30,7 +31,7 @@ func (gh *GithubWebhook) Register(router *mux.Router, acc telegraf.Accumulator, 
 	gh.acc = acc
 }
 
-func (gh *GithubWebhook) eventHandler(w http.ResponseWriter, r *http.Request) {
+func (gh *Webhook) eventHandler(w http.ResponseWriter, r *http.Request) {
 	defer r.Body.Close()
 
 	if !gh.Verify(r) {
@@ -45,19 +46,19 @@ func (gh *GithubWebhook) eventHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if gh.Secret != "" && !checkSignature(gh.Secret, data, r.Header.Get("X-Hub-Signature")) {
+	if gh.secret != "" && !checkSignature(gh.secret, data, r.Header.Get("X-Hub-Signature")) {
 		gh.log.Error("Fail to check the github webhook signature")
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
 
-	e, err := gh.NewEvent(data, eventType)
+	e, err := gh.newEvent(data, eventType)
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
 	if e != nil {
-		p := e.NewMetric()
+		p := e.newMetric()
 		gh.acc.AddFields("github_webhooks", p.Fields(), p.Tags(), p.Time())
 	}
 
@@ -80,7 +81,7 @@ func (e *newEventError) Error() string {
 	return e.s
 }
 
-func (gh *GithubWebhook) NewEvent(data []byte, name string) (event, error) {
+func (gh *Webhook) newEvent(data []byte, name string) (event, error) {
 	gh.log.Debugf("New %v event received", name)
 	switch name {
 	case "commit_comment":

--- a/plugins/inputs/webhooks/github/github_webhooks_mock_json_test.go
+++ b/plugins/inputs/webhooks/github/github_webhooks_mock_json_test.go
@@ -1,6 +1,6 @@
 package github
 
-func CommitCommentEventJSON() string {
+func commitCommentEventJSON() string {
 	return `{
   "action": "created",
   "comment": {
@@ -143,123 +143,7 @@ func CommitCommentEventJSON() string {
 }`
 }
 
-func CreateEventJSON() string {
-	return `{
-  "ref": "0.0.1",
-  "ref_type": "tag",
-  "master_branch": "master",
-  "description": "",
-  "pusher_type": "user",
-  "repository": {
-    "id": 35129377,
-    "name": "public-repo",
-    "full_name": "baxterthehacker/public-repo",
-    "owner": {
-      "login": "baxterthehacker",
-      "id": 6752317,
-      "avatar_url": "https://avatars.githubusercontent.com/u/6752317?v=3",
-      "gravatar_id": "",
-      "url": "https://api.github.com/users/baxterthehacker",
-      "html_url": "https://github.com/baxterthehacker",
-      "followers_url": "https://api.github.com/users/baxterthehacker/followers",
-      "following_url": "https://api.github.com/users/baxterthehacker/following{/other_user}",
-      "gists_url": "https://api.github.com/users/baxterthehacker/gists{/gist_id}",
-      "starred_url": "https://api.github.com/users/baxterthehacker/starred{/owner}{/repo}",
-      "subscriptions_url": "https://api.github.com/users/baxterthehacker/subscriptions",
-      "organizations_url": "https://api.github.com/users/baxterthehacker/orgs",
-      "repos_url": "https://api.github.com/users/baxterthehacker/repos",
-      "events_url": "https://api.github.com/users/baxterthehacker/events{/privacy}",
-      "received_events_url": "https://api.github.com/users/baxterthehacker/received_events",
-      "type": "User",
-      "site_admin": false
-    },
-    "private": false,
-    "html_url": "https://github.com/baxterthehacker/public-repo",
-    "description": "",
-    "fork": false,
-    "url": "https://api.github.com/repos/baxterthehacker/public-repo",
-    "forks_url": "https://api.github.com/repos/baxterthehacker/public-repo/forks",
-    "keys_url": "https://api.github.com/repos/baxterthehacker/public-repo/keys{/key_id}",
-    "collaborators_url": "https://api.github.com/repos/baxterthehacker/public-repo/collaborators{/collaborator}",
-    "teams_url": "https://api.github.com/repos/baxterthehacker/public-repo/teams",
-    "hooks_url": "https://api.github.com/repos/baxterthehacker/public-repo/hooks",
-    "issue_events_url": "https://api.github.com/repos/baxterthehacker/public-repo/issues/events{/number}",
-    "events_url": "https://api.github.com/repos/baxterthehacker/public-repo/events",
-    "assignees_url": "https://api.github.com/repos/baxterthehacker/public-repo/assignees{/user}",
-    "branches_url": "https://api.github.com/repos/baxterthehacker/public-repo/branches{/branch}",
-    "tags_url": "https://api.github.com/repos/baxterthehacker/public-repo/tags",
-    "blobs_url": "https://api.github.com/repos/baxterthehacker/public-repo/git/blobs{/sha}",
-    "git_tags_url": "https://api.github.com/repos/baxterthehacker/public-repo/git/tags{/sha}",
-    "git_refs_url": "https://api.github.com/repos/baxterthehacker/public-repo/git/refs{/sha}",
-    "trees_url": "https://api.github.com/repos/baxterthehacker/public-repo/git/trees{/sha}",
-    "statuses_url": "https://api.github.com/repos/baxterthehacker/public-repo/statuses/{sha}",
-    "languages_url": "https://api.github.com/repos/baxterthehacker/public-repo/languages",
-    "stargazers_url": "https://api.github.com/repos/baxterthehacker/public-repo/stargazers",
-    "contributors_url": "https://api.github.com/repos/baxterthehacker/public-repo/contributors",
-    "subscribers_url": "https://api.github.com/repos/baxterthehacker/public-repo/subscribers",
-    "subscription_url": "https://api.github.com/repos/baxterthehacker/public-repo/subscription",
-    "commits_url": "https://api.github.com/repos/baxterthehacker/public-repo/commits{/sha}",
-    "git_commits_url": "https://api.github.com/repos/baxterthehacker/public-repo/git/commits{/sha}",
-    "comments_url": "https://api.github.com/repos/baxterthehacker/public-repo/comments{/number}",
-    "issue_comment_url": "https://api.github.com/repos/baxterthehacker/public-repo/issues/comments{/number}",
-    "contents_url": "https://api.github.com/repos/baxterthehacker/public-repo/contents/{+path}",
-    "compare_url": "https://api.github.com/repos/baxterthehacker/public-repo/compare/{base}...{head}",
-    "merges_url": "https://api.github.com/repos/baxterthehacker/public-repo/merges",
-    "archive_url": "https://api.github.com/repos/baxterthehacker/public-repo/{archive_format}{/ref}",
-    "downloads_url": "https://api.github.com/repos/baxterthehacker/public-repo/downloads",
-    "issues_url": "https://api.github.com/repos/baxterthehacker/public-repo/issues{/number}",
-    "pulls_url": "https://api.github.com/repos/baxterthehacker/public-repo/pulls{/number}",
-    "milestones_url": "https://api.github.com/repos/baxterthehacker/public-repo/milestones{/number}",
-    "notifications_url": "https://api.github.com/repos/baxterthehacker/public-repo/notifications{?since,all,participating}",
-    "labels_url": "https://api.github.com/repos/baxterthehacker/public-repo/labels{/name}",
-    "releases_url": "https://api.github.com/repos/baxterthehacker/public-repo/releases{/id}",
-    "created_at": "2015-05-05T23:40:12Z",
-    "updated_at": "2015-05-05T23:40:30Z",
-    "pushed_at": "2015-05-05T23:40:38Z",
-    "git_url": "git://github.com/baxterthehacker/public-repo.git",
-    "ssh_url": "git@github.com:baxterthehacker/public-repo.git",
-    "clone_url": "https://github.com/baxterthehacker/public-repo.git",
-    "svn_url": "https://github.com/baxterthehacker/public-repo",
-    "homepage": null,
-    "size": 0,
-    "stargazers_count": 0,
-    "watchers_count": 0,
-    "language": null,
-    "has_issues": true,
-    "has_downloads": true,
-    "has_wiki": true,
-    "has_pages": true,
-    "forks_count": 0,
-    "mirror_url": null,
-    "open_issues_count": 2,
-    "forks": 0,
-    "open_issues": 2,
-    "watchers": 0,
-    "default_branch": "master"
-  },
-  "sender": {
-    "login": "baxterthehacker",
-    "id": 6752317,
-    "avatar_url": "https://avatars.githubusercontent.com/u/6752317?v=3",
-    "gravatar_id": "",
-    "url": "https://api.github.com/users/baxterthehacker",
-    "html_url": "https://github.com/baxterthehacker",
-    "followers_url": "https://api.github.com/users/baxterthehacker/followers",
-    "following_url": "https://api.github.com/users/baxterthehacker/following{/other_user}",
-    "gists_url": "https://api.github.com/users/baxterthehacker/gists{/gist_id}",
-    "starred_url": "https://api.github.com/users/baxterthehacker/starred{/owner}{/repo}",
-    "subscriptions_url": "https://api.github.com/users/baxterthehacker/subscriptions",
-    "organizations_url": "https://api.github.com/users/baxterthehacker/orgs",
-    "repos_url": "https://api.github.com/users/baxterthehacker/repos",
-    "events_url": "https://api.github.com/users/baxterthehacker/events{/privacy}",
-    "received_events_url": "https://api.github.com/users/baxterthehacker/received_events",
-    "type": "User",
-    "site_admin": false
-  }
-}`
-}
-
-func DeleteEventJSON() string {
+func deleteEventJSON() string {
 	return `{
   "ref": "simple-tag",
   "ref_type": "tag",
@@ -373,7 +257,7 @@ func DeleteEventJSON() string {
 }`
 }
 
-func DeploymentEventJSON() string {
+func deploymentEventJSON() string {
 	return `{
   "deployment": {
     "url": "https://api.github.com/repos/baxterthehacker/public-repo/deployments/710692",
@@ -518,7 +402,7 @@ func DeploymentEventJSON() string {
 }`
 }
 
-func DeploymentStatusEventJSON() string {
+func deploymentStatusEventJSON() string {
 	return `{
   "deployment": {
     "url": "https://api.github.com/repos/baxterthehacker/public-repo/deployments/710692",
@@ -694,7 +578,7 @@ func DeploymentStatusEventJSON() string {
 `
 }
 
-func ForkEventJSON() string {
+func forkEventJSON() string {
 	return `{
   "forkee": {
     "id": 35129393,
@@ -893,7 +777,7 @@ func ForkEventJSON() string {
 }`
 }
 
-func GollumEventJSON() string {
+func gollumEventJSON() string {
 	return `{
   "pages": [
     {
@@ -1014,7 +898,7 @@ func GollumEventJSON() string {
 }`
 }
 
-func IssueCommentEventJSON() string {
+func issueCommentEventJSON() string {
 	return `{
   "action": "created",
   "issue": {
@@ -1199,7 +1083,7 @@ func IssueCommentEventJSON() string {
 }`
 }
 
-func IssuesEventJSON() string {
+func issuesEventJSON() string {
 	return `{
   "action": "opened",
   "issue": {
@@ -1356,7 +1240,7 @@ func IssuesEventJSON() string {
 }`
 }
 
-func MemberEventJSON() string {
+func memberEventJSON() string {
 	return `{
   "action": "added",
   "member": {
@@ -1487,7 +1371,7 @@ func MemberEventJSON() string {
 }`
 }
 
-func MembershipEventJSON() string {
+func membershipEventJSON() string {
 	return `{
   "action": "added",
   "scope": "team",
@@ -1551,7 +1435,7 @@ func MembershipEventJSON() string {
 }`
 }
 
-func PageBuildEventJSON() string {
+func pageBuildEventJSON() string {
 	return `{
   "id": 15995382,
   "build": {
@@ -1693,7 +1577,7 @@ func PageBuildEventJSON() string {
 }`
 }
 
-func PublicEventJSON() string {
+func publicEventJSON() string {
 	return `{
   "repository": {
     "id": 35129377,
@@ -1804,7 +1688,7 @@ func PublicEventJSON() string {
 }`
 }
 
-func PullRequestReviewCommentEventJSON() string {
+func pullRequestReviewCommentEventJSON() string {
 	return `{
   "action": "created",
   "comment": {
@@ -2253,422 +2137,7 @@ func PullRequestReviewCommentEventJSON() string {
 }`
 }
 
-func PullRequestEventJSON() string {
-	return `{
-  "action": "opened",
-  "number": 1,
-  "pull_request": {
-    "url": "https://api.github.com/repos/baxterthehacker/public-repo/pulls/1",
-    "id": 34778301,
-    "html_url": "https://github.com/baxterthehacker/public-repo/pull/1",
-    "diff_url": "https://github.com/baxterthehacker/public-repo/pull/1.diff",
-    "patch_url": "https://github.com/baxterthehacker/public-repo/pull/1.patch",
-    "issue_url": "https://api.github.com/repos/baxterthehacker/public-repo/issues/1",
-    "number": 1,
-    "state": "open",
-    "locked": false,
-    "title": "Update the README with new information",
-    "user": {
-      "login": "baxterthehacker",
-      "id": 6752317,
-      "avatar_url": "https://avatars.githubusercontent.com/u/6752317?v=3",
-      "gravatar_id": "",
-      "url": "https://api.github.com/users/baxterthehacker",
-      "html_url": "https://github.com/baxterthehacker",
-      "followers_url": "https://api.github.com/users/baxterthehacker/followers",
-      "following_url": "https://api.github.com/users/baxterthehacker/following{/other_user}",
-      "gists_url": "https://api.github.com/users/baxterthehacker/gists{/gist_id}",
-      "starred_url": "https://api.github.com/users/baxterthehacker/starred{/owner}{/repo}",
-      "subscriptions_url": "https://api.github.com/users/baxterthehacker/subscriptions",
-      "organizations_url": "https://api.github.com/users/baxterthehacker/orgs",
-      "repos_url": "https://api.github.com/users/baxterthehacker/repos",
-      "events_url": "https://api.github.com/users/baxterthehacker/events{/privacy}",
-      "received_events_url": "https://api.github.com/users/baxterthehacker/received_events",
-      "type": "User",
-      "site_admin": false
-    },
-    "body": "This is a pretty simple change that we need to pull into master.",
-    "created_at": "2015-05-05T23:40:27Z",
-    "updated_at": "2015-05-05T23:40:27Z",
-    "closed_at": null,
-    "merged_at": null,
-    "merge_commit_sha": null,
-    "assignee": null,
-    "milestone": null,
-    "commits_url": "https://api.github.com/repos/baxterthehacker/public-repo/pulls/1/commits",
-    "review_comments_url": "https://api.github.com/repos/baxterthehacker/public-repo/pulls/1/comments",
-    "review_comment_url": "https://api.github.com/repos/baxterthehacker/public-repo/pulls/comments{/number}",
-    "comments_url": "https://api.github.com/repos/baxterthehacker/public-repo/issues/1/comments",
-    "statuses_url": "https://api.github.com/repos/baxterthehacker/public-repo/statuses/0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c",
-    "head": {
-      "label": "baxterthehacker:changes",
-      "ref": "changes",
-      "sha": "0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c",
-      "user": {
-        "login": "baxterthehacker",
-        "id": 6752317,
-        "avatar_url": "https://avatars.githubusercontent.com/u/6752317?v=3",
-        "gravatar_id": "",
-        "url": "https://api.github.com/users/baxterthehacker",
-        "html_url": "https://github.com/baxterthehacker",
-        "followers_url": "https://api.github.com/users/baxterthehacker/followers",
-        "following_url": "https://api.github.com/users/baxterthehacker/following{/other_user}",
-        "gists_url": "https://api.github.com/users/baxterthehacker/gists{/gist_id}",
-        "starred_url": "https://api.github.com/users/baxterthehacker/starred{/owner}{/repo}",
-        "subscriptions_url": "https://api.github.com/users/baxterthehacker/subscriptions",
-        "organizations_url": "https://api.github.com/users/baxterthehacker/orgs",
-        "repos_url": "https://api.github.com/users/baxterthehacker/repos",
-        "events_url": "https://api.github.com/users/baxterthehacker/events{/privacy}",
-        "received_events_url": "https://api.github.com/users/baxterthehacker/received_events",
-        "type": "User",
-        "site_admin": false
-      },
-      "repo": {
-        "id": 35129377,
-        "name": "public-repo",
-        "full_name": "baxterthehacker/public-repo",
-        "owner": {
-          "login": "baxterthehacker",
-          "id": 6752317,
-          "avatar_url": "https://avatars.githubusercontent.com/u/6752317?v=3",
-          "gravatar_id": "",
-          "url": "https://api.github.com/users/baxterthehacker",
-          "html_url": "https://github.com/baxterthehacker",
-          "followers_url": "https://api.github.com/users/baxterthehacker/followers",
-          "following_url": "https://api.github.com/users/baxterthehacker/following{/other_user}",
-          "gists_url": "https://api.github.com/users/baxterthehacker/gists{/gist_id}",
-          "starred_url": "https://api.github.com/users/baxterthehacker/starred{/owner}{/repo}",
-          "subscriptions_url": "https://api.github.com/users/baxterthehacker/subscriptions",
-          "organizations_url": "https://api.github.com/users/baxterthehacker/orgs",
-          "repos_url": "https://api.github.com/users/baxterthehacker/repos",
-          "events_url": "https://api.github.com/users/baxterthehacker/events{/privacy}",
-          "received_events_url": "https://api.github.com/users/baxterthehacker/received_events",
-          "type": "User",
-          "site_admin": false
-        },
-        "private": false,
-        "html_url": "https://github.com/baxterthehacker/public-repo",
-        "description": "",
-        "fork": false,
-        "url": "https://api.github.com/repos/baxterthehacker/public-repo",
-        "forks_url": "https://api.github.com/repos/baxterthehacker/public-repo/forks",
-        "keys_url": "https://api.github.com/repos/baxterthehacker/public-repo/keys{/key_id}",
-        "collaborators_url": "https://api.github.com/repos/baxterthehacker/public-repo/collaborators{/collaborator}",
-        "teams_url": "https://api.github.com/repos/baxterthehacker/public-repo/teams",
-        "hooks_url": "https://api.github.com/repos/baxterthehacker/public-repo/hooks",
-        "issue_events_url": "https://api.github.com/repos/baxterthehacker/public-repo/issues/events{/number}",
-        "events_url": "https://api.github.com/repos/baxterthehacker/public-repo/events",
-        "assignees_url": "https://api.github.com/repos/baxterthehacker/public-repo/assignees{/user}",
-        "branches_url": "https://api.github.com/repos/baxterthehacker/public-repo/branches{/branch}",
-        "tags_url": "https://api.github.com/repos/baxterthehacker/public-repo/tags",
-        "blobs_url": "https://api.github.com/repos/baxterthehacker/public-repo/git/blobs{/sha}",
-        "git_tags_url": "https://api.github.com/repos/baxterthehacker/public-repo/git/tags{/sha}",
-        "git_refs_url": "https://api.github.com/repos/baxterthehacker/public-repo/git/refs{/sha}",
-        "trees_url": "https://api.github.com/repos/baxterthehacker/public-repo/git/trees{/sha}",
-        "statuses_url": "https://api.github.com/repos/baxterthehacker/public-repo/statuses/{sha}",
-        "languages_url": "https://api.github.com/repos/baxterthehacker/public-repo/languages",
-        "stargazers_url": "https://api.github.com/repos/baxterthehacker/public-repo/stargazers",
-        "contributors_url": "https://api.github.com/repos/baxterthehacker/public-repo/contributors",
-        "subscribers_url": "https://api.github.com/repos/baxterthehacker/public-repo/subscribers",
-        "subscription_url": "https://api.github.com/repos/baxterthehacker/public-repo/subscription",
-        "commits_url": "https://api.github.com/repos/baxterthehacker/public-repo/commits{/sha}",
-        "git_commits_url": "https://api.github.com/repos/baxterthehacker/public-repo/git/commits{/sha}",
-        "comments_url": "https://api.github.com/repos/baxterthehacker/public-repo/comments{/number}",
-        "issue_comment_url": "https://api.github.com/repos/baxterthehacker/public-repo/issues/comments{/number}",
-        "contents_url": "https://api.github.com/repos/baxterthehacker/public-repo/contents/{+path}",
-        "compare_url": "https://api.github.com/repos/baxterthehacker/public-repo/compare/{base}...{head}",
-        "merges_url": "https://api.github.com/repos/baxterthehacker/public-repo/merges",
-        "archive_url": "https://api.github.com/repos/baxterthehacker/public-repo/{archive_format}{/ref}",
-        "downloads_url": "https://api.github.com/repos/baxterthehacker/public-repo/downloads",
-        "issues_url": "https://api.github.com/repos/baxterthehacker/public-repo/issues{/number}",
-        "pulls_url": "https://api.github.com/repos/baxterthehacker/public-repo/pulls{/number}",
-        "milestones_url": "https://api.github.com/repos/baxterthehacker/public-repo/milestones{/number}",
-        "notifications_url": "https://api.github.com/repos/baxterthehacker/public-repo/notifications{?since,all,participating}",
-        "labels_url": "https://api.github.com/repos/baxterthehacker/public-repo/labels{/name}",
-        "releases_url": "https://api.github.com/repos/baxterthehacker/public-repo/releases{/id}",
-        "created_at": "2015-05-05T23:40:12Z",
-        "updated_at": "2015-05-05T23:40:12Z",
-        "pushed_at": "2015-05-05T23:40:26Z",
-        "git_url": "git://github.com/baxterthehacker/public-repo.git",
-        "ssh_url": "git@github.com:baxterthehacker/public-repo.git",
-        "clone_url": "https://github.com/baxterthehacker/public-repo.git",
-        "svn_url": "https://github.com/baxterthehacker/public-repo",
-        "homepage": null,
-        "size": 0,
-        "stargazers_count": 0,
-        "watchers_count": 0,
-        "language": null,
-        "has_issues": true,
-        "has_downloads": true,
-        "has_wiki": true,
-        "has_pages": true,
-        "forks_count": 0,
-        "mirror_url": null,
-        "open_issues_count": 1,
-        "forks": 0,
-        "open_issues": 1,
-        "watchers": 0,
-        "default_branch": "master"
-      }
-    },
-    "base": {
-      "label": "baxterthehacker:master",
-      "ref": "master",
-      "sha": "9049f1265b7d61be4a8904a9a27120d2064dab3b",
-      "user": {
-        "login": "baxterthehacker",
-        "id": 6752317,
-        "avatar_url": "https://avatars.githubusercontent.com/u/6752317?v=3",
-        "gravatar_id": "",
-        "url": "https://api.github.com/users/baxterthehacker",
-        "html_url": "https://github.com/baxterthehacker",
-        "followers_url": "https://api.github.com/users/baxterthehacker/followers",
-        "following_url": "https://api.github.com/users/baxterthehacker/following{/other_user}",
-        "gists_url": "https://api.github.com/users/baxterthehacker/gists{/gist_id}",
-        "starred_url": "https://api.github.com/users/baxterthehacker/starred{/owner}{/repo}",
-        "subscriptions_url": "https://api.github.com/users/baxterthehacker/subscriptions",
-        "organizations_url": "https://api.github.com/users/baxterthehacker/orgs",
-        "repos_url": "https://api.github.com/users/baxterthehacker/repos",
-        "events_url": "https://api.github.com/users/baxterthehacker/events{/privacy}",
-        "received_events_url": "https://api.github.com/users/baxterthehacker/received_events",
-        "type": "User",
-        "site_admin": false
-      },
-      "repo": {
-        "id": 35129377,
-        "name": "public-repo",
-        "full_name": "baxterthehacker/public-repo",
-        "owner": {
-          "login": "baxterthehacker",
-          "id": 6752317,
-          "avatar_url": "https://avatars.githubusercontent.com/u/6752317?v=3",
-          "gravatar_id": "",
-          "url": "https://api.github.com/users/baxterthehacker",
-          "html_url": "https://github.com/baxterthehacker",
-          "followers_url": "https://api.github.com/users/baxterthehacker/followers",
-          "following_url": "https://api.github.com/users/baxterthehacker/following{/other_user}",
-          "gists_url": "https://api.github.com/users/baxterthehacker/gists{/gist_id}",
-          "starred_url": "https://api.github.com/users/baxterthehacker/starred{/owner}{/repo}",
-          "subscriptions_url": "https://api.github.com/users/baxterthehacker/subscriptions",
-          "organizations_url": "https://api.github.com/users/baxterthehacker/orgs",
-          "repos_url": "https://api.github.com/users/baxterthehacker/repos",
-          "events_url": "https://api.github.com/users/baxterthehacker/events{/privacy}",
-          "received_events_url": "https://api.github.com/users/baxterthehacker/received_events",
-          "type": "User",
-          "site_admin": false
-        },
-        "private": false,
-        "html_url": "https://github.com/baxterthehacker/public-repo",
-        "description": "",
-        "fork": false,
-        "url": "https://api.github.com/repos/baxterthehacker/public-repo",
-        "forks_url": "https://api.github.com/repos/baxterthehacker/public-repo/forks",
-        "keys_url": "https://api.github.com/repos/baxterthehacker/public-repo/keys{/key_id}",
-        "collaborators_url": "https://api.github.com/repos/baxterthehacker/public-repo/collaborators{/collaborator}",
-        "teams_url": "https://api.github.com/repos/baxterthehacker/public-repo/teams",
-        "hooks_url": "https://api.github.com/repos/baxterthehacker/public-repo/hooks",
-        "issue_events_url": "https://api.github.com/repos/baxterthehacker/public-repo/issues/events{/number}",
-        "events_url": "https://api.github.com/repos/baxterthehacker/public-repo/events",
-        "assignees_url": "https://api.github.com/repos/baxterthehacker/public-repo/assignees{/user}",
-        "branches_url": "https://api.github.com/repos/baxterthehacker/public-repo/branches{/branch}",
-        "tags_url": "https://api.github.com/repos/baxterthehacker/public-repo/tags",
-        "blobs_url": "https://api.github.com/repos/baxterthehacker/public-repo/git/blobs{/sha}",
-        "git_tags_url": "https://api.github.com/repos/baxterthehacker/public-repo/git/tags{/sha}",
-        "git_refs_url": "https://api.github.com/repos/baxterthehacker/public-repo/git/refs{/sha}",
-        "trees_url": "https://api.github.com/repos/baxterthehacker/public-repo/git/trees{/sha}",
-        "statuses_url": "https://api.github.com/repos/baxterthehacker/public-repo/statuses/{sha}",
-        "languages_url": "https://api.github.com/repos/baxterthehacker/public-repo/languages",
-        "stargazers_url": "https://api.github.com/repos/baxterthehacker/public-repo/stargazers",
-        "contributors_url": "https://api.github.com/repos/baxterthehacker/public-repo/contributors",
-        "subscribers_url": "https://api.github.com/repos/baxterthehacker/public-repo/subscribers",
-        "subscription_url": "https://api.github.com/repos/baxterthehacker/public-repo/subscription",
-        "commits_url": "https://api.github.com/repos/baxterthehacker/public-repo/commits{/sha}",
-        "git_commits_url": "https://api.github.com/repos/baxterthehacker/public-repo/git/commits{/sha}",
-        "comments_url": "https://api.github.com/repos/baxterthehacker/public-repo/comments{/number}",
-        "issue_comment_url": "https://api.github.com/repos/baxterthehacker/public-repo/issues/comments{/number}",
-        "contents_url": "https://api.github.com/repos/baxterthehacker/public-repo/contents/{+path}",
-        "compare_url": "https://api.github.com/repos/baxterthehacker/public-repo/compare/{base}...{head}",
-        "merges_url": "https://api.github.com/repos/baxterthehacker/public-repo/merges",
-        "archive_url": "https://api.github.com/repos/baxterthehacker/public-repo/{archive_format}{/ref}",
-        "downloads_url": "https://api.github.com/repos/baxterthehacker/public-repo/downloads",
-        "issues_url": "https://api.github.com/repos/baxterthehacker/public-repo/issues{/number}",
-        "pulls_url": "https://api.github.com/repos/baxterthehacker/public-repo/pulls{/number}",
-        "milestones_url": "https://api.github.com/repos/baxterthehacker/public-repo/milestones{/number}",
-        "notifications_url": "https://api.github.com/repos/baxterthehacker/public-repo/notifications{?since,all,participating}",
-        "labels_url": "https://api.github.com/repos/baxterthehacker/public-repo/labels{/name}",
-        "releases_url": "https://api.github.com/repos/baxterthehacker/public-repo/releases{/id}",
-        "created_at": "2015-05-05T23:40:12Z",
-        "updated_at": "2015-05-05T23:40:12Z",
-        "pushed_at": "2015-05-05T23:40:26Z",
-        "git_url": "git://github.com/baxterthehacker/public-repo.git",
-        "ssh_url": "git@github.com:baxterthehacker/public-repo.git",
-        "clone_url": "https://github.com/baxterthehacker/public-repo.git",
-        "svn_url": "https://github.com/baxterthehacker/public-repo",
-        "homepage": null,
-        "size": 0,
-        "stargazers_count": 0,
-        "watchers_count": 0,
-        "language": null,
-        "has_issues": true,
-        "has_downloads": true,
-        "has_wiki": true,
-        "has_pages": true,
-        "forks_count": 0,
-        "mirror_url": null,
-        "open_issues_count": 1,
-        "forks": 0,
-        "open_issues": 1,
-        "watchers": 0,
-        "default_branch": "master"
-      }
-    },
-    "_links": {
-      "self": {
-        "href": "https://api.github.com/repos/baxterthehacker/public-repo/pulls/1"
-      },
-      "html": {
-        "href": "https://github.com/baxterthehacker/public-repo/pull/1"
-      },
-      "issue": {
-        "href": "https://api.github.com/repos/baxterthehacker/public-repo/issues/1"
-      },
-      "comments": {
-        "href": "https://api.github.com/repos/baxterthehacker/public-repo/issues/1/comments"
-      },
-      "review_comments": {
-        "href": "https://api.github.com/repos/baxterthehacker/public-repo/pulls/1/comments"
-      },
-      "review_comment": {
-        "href": "https://api.github.com/repos/baxterthehacker/public-repo/pulls/comments{/number}"
-      },
-      "commits": {
-        "href": "https://api.github.com/repos/baxterthehacker/public-repo/pulls/1/commits"
-      },
-      "statuses": {
-        "href": "https://api.github.com/repos/baxterthehacker/public-repo/statuses/0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c"
-      }
-    },
-    "merged": false,
-    "mergeable": null,
-    "mergeable_state": "unknown",
-    "merged_by": null,
-    "comments": 0,
-    "review_comments": 0,
-    "commits": 1,
-    "additions": 1,
-    "deletions": 1,
-    "changed_files": 1
-  },
-  "repository": {
-    "id": 35129377,
-    "name": "public-repo",
-    "full_name": "baxterthehacker/public-repo",
-    "owner": {
-      "login": "baxterthehacker",
-      "id": 6752317,
-      "avatar_url": "https://avatars.githubusercontent.com/u/6752317?v=3",
-      "gravatar_id": "",
-      "url": "https://api.github.com/users/baxterthehacker",
-      "html_url": "https://github.com/baxterthehacker",
-      "followers_url": "https://api.github.com/users/baxterthehacker/followers",
-      "following_url": "https://api.github.com/users/baxterthehacker/following{/other_user}",
-      "gists_url": "https://api.github.com/users/baxterthehacker/gists{/gist_id}",
-      "starred_url": "https://api.github.com/users/baxterthehacker/starred{/owner}{/repo}",
-      "subscriptions_url": "https://api.github.com/users/baxterthehacker/subscriptions",
-      "organizations_url": "https://api.github.com/users/baxterthehacker/orgs",
-      "repos_url": "https://api.github.com/users/baxterthehacker/repos",
-      "events_url": "https://api.github.com/users/baxterthehacker/events{/privacy}",
-      "received_events_url": "https://api.github.com/users/baxterthehacker/received_events",
-      "type": "User",
-      "site_admin": false
-    },
-    "private": false,
-    "html_url": "https://github.com/baxterthehacker/public-repo",
-    "description": "",
-    "fork": false,
-    "url": "https://api.github.com/repos/baxterthehacker/public-repo",
-    "forks_url": "https://api.github.com/repos/baxterthehacker/public-repo/forks",
-    "keys_url": "https://api.github.com/repos/baxterthehacker/public-repo/keys{/key_id}",
-    "collaborators_url": "https://api.github.com/repos/baxterthehacker/public-repo/collaborators{/collaborator}",
-    "teams_url": "https://api.github.com/repos/baxterthehacker/public-repo/teams",
-    "hooks_url": "https://api.github.com/repos/baxterthehacker/public-repo/hooks",
-    "issue_events_url": "https://api.github.com/repos/baxterthehacker/public-repo/issues/events{/number}",
-    "events_url": "https://api.github.com/repos/baxterthehacker/public-repo/events",
-    "assignees_url": "https://api.github.com/repos/baxterthehacker/public-repo/assignees{/user}",
-    "branches_url": "https://api.github.com/repos/baxterthehacker/public-repo/branches{/branch}",
-    "tags_url": "https://api.github.com/repos/baxterthehacker/public-repo/tags",
-    "blobs_url": "https://api.github.com/repos/baxterthehacker/public-repo/git/blobs{/sha}",
-    "git_tags_url": "https://api.github.com/repos/baxterthehacker/public-repo/git/tags{/sha}",
-    "git_refs_url": "https://api.github.com/repos/baxterthehacker/public-repo/git/refs{/sha}",
-    "trees_url": "https://api.github.com/repos/baxterthehacker/public-repo/git/trees{/sha}",
-    "statuses_url": "https://api.github.com/repos/baxterthehacker/public-repo/statuses/{sha}",
-    "languages_url": "https://api.github.com/repos/baxterthehacker/public-repo/languages",
-    "stargazers_url": "https://api.github.com/repos/baxterthehacker/public-repo/stargazers",
-    "contributors_url": "https://api.github.com/repos/baxterthehacker/public-repo/contributors",
-    "subscribers_url": "https://api.github.com/repos/baxterthehacker/public-repo/subscribers",
-    "subscription_url": "https://api.github.com/repos/baxterthehacker/public-repo/subscription",
-    "commits_url": "https://api.github.com/repos/baxterthehacker/public-repo/commits{/sha}",
-    "git_commits_url": "https://api.github.com/repos/baxterthehacker/public-repo/git/commits{/sha}",
-    "comments_url": "https://api.github.com/repos/baxterthehacker/public-repo/comments{/number}",
-    "issue_comment_url": "https://api.github.com/repos/baxterthehacker/public-repo/issues/comments{/number}",
-    "contents_url": "https://api.github.com/repos/baxterthehacker/public-repo/contents/{+path}",
-    "compare_url": "https://api.github.com/repos/baxterthehacker/public-repo/compare/{base}...{head}",
-    "merges_url": "https://api.github.com/repos/baxterthehacker/public-repo/merges",
-    "archive_url": "https://api.github.com/repos/baxterthehacker/public-repo/{archive_format}{/ref}",
-    "downloads_url": "https://api.github.com/repos/baxterthehacker/public-repo/downloads",
-    "issues_url": "https://api.github.com/repos/baxterthehacker/public-repo/issues{/number}",
-    "pulls_url": "https://api.github.com/repos/baxterthehacker/public-repo/pulls{/number}",
-    "milestones_url": "https://api.github.com/repos/baxterthehacker/public-repo/milestones{/number}",
-    "notifications_url": "https://api.github.com/repos/baxterthehacker/public-repo/notifications{?since,all,participating}",
-    "labels_url": "https://api.github.com/repos/baxterthehacker/public-repo/labels{/name}",
-    "releases_url": "https://api.github.com/repos/baxterthehacker/public-repo/releases{/id}",
-    "created_at": "2015-05-05T23:40:12Z",
-    "updated_at": "2015-05-05T23:40:12Z",
-    "pushed_at": "2015-05-05T23:40:26Z",
-    "git_url": "git://github.com/baxterthehacker/public-repo.git",
-    "ssh_url": "git@github.com:baxterthehacker/public-repo.git",
-    "clone_url": "https://github.com/baxterthehacker/public-repo.git",
-    "svn_url": "https://github.com/baxterthehacker/public-repo",
-    "homepage": null,
-    "size": 0,
-    "stargazers_count": 0,
-    "watchers_count": 0,
-    "language": null,
-    "has_issues": true,
-    "has_downloads": true,
-    "has_wiki": true,
-    "has_pages": true,
-    "forks_count": 0,
-    "mirror_url": null,
-    "open_issues_count": 1,
-    "forks": 0,
-    "open_issues": 1,
-    "watchers": 0,
-    "default_branch": "master"
-  },
-  "sender": {
-    "login": "baxterthehacker",
-    "id": 6752317,
-    "avatar_url": "https://avatars.githubusercontent.com/u/6752317?v=3",
-    "gravatar_id": "",
-    "url": "https://api.github.com/users/baxterthehacker",
-    "html_url": "https://github.com/baxterthehacker",
-    "followers_url": "https://api.github.com/users/baxterthehacker/followers",
-    "following_url": "https://api.github.com/users/baxterthehacker/following{/other_user}",
-    "gists_url": "https://api.github.com/users/baxterthehacker/gists{/gist_id}",
-    "starred_url": "https://api.github.com/users/baxterthehacker/starred{/owner}{/repo}",
-    "subscriptions_url": "https://api.github.com/users/baxterthehacker/subscriptions",
-    "organizations_url": "https://api.github.com/users/baxterthehacker/orgs",
-    "repos_url": "https://api.github.com/users/baxterthehacker/repos",
-    "events_url": "https://api.github.com/users/baxterthehacker/events{/privacy}",
-    "received_events_url": "https://api.github.com/users/baxterthehacker/received_events",
-    "type": "User",
-    "site_admin": false
-  }
-}`
-}
-
-func PushEventJSON() string {
+func pushEventJSON() string {
 	return `{
   "ref": "refs/heads/changes",
   "before": "9049f1265b7d61be4a8904a9a27120d2064dab3b",
@@ -2832,7 +2301,7 @@ func PushEventJSON() string {
 }`
 }
 
-func RepositoryEventJSON() string {
+func repositoryEventJSON() string {
 	return `{
   "action": "created",
   "repository": {
@@ -2954,7 +2423,7 @@ func RepositoryEventJSON() string {
 }`
 }
 
-func ReleaseEventJSON() string {
+func releaseEventJSON() string {
 	return `{
   "action": "published",
   "release": {
@@ -3105,7 +2574,7 @@ func ReleaseEventJSON() string {
 }`
 }
 
-func StatusEventJSON() string {
+func statusEventJSON() string {
 	return `{
   "id": 214015194,
   "sha": "9049f1265b7d61be4a8904a9a27120d2064dab3b",
@@ -3314,7 +2783,7 @@ func StatusEventJSON() string {
 }`
 }
 
-func TeamAddEventJSON() string {
+func teamAddEventJSON() string {
 	return `{
   "team": {
     "name": "github",
@@ -3446,7 +2915,7 @@ func TeamAddEventJSON() string {
 }`
 }
 
-func WatchEventJSON() string {
+func watchEventJSON() string {
 	return `{
   "action": "started",
   "repository": {

--- a/plugins/inputs/webhooks/github/github_webhooks_models.go
+++ b/plugins/inputs/webhooks/github/github_webhooks_models.go
@@ -11,7 +11,7 @@ import (
 const meas = "github_webhooks"
 
 type event interface {
-	NewMetric() telegraf.Metric
+	newMetric() telegraf.Metric
 }
 
 type repository struct {
@@ -90,7 +90,7 @@ type commitCommentEvent struct {
 	Sender     sender        `json:"sender"`
 }
 
-func (s commitCommentEvent) NewMetric() telegraf.Metric {
+func (s commitCommentEvent) newMetric() telegraf.Metric {
 	event := "commit_comment"
 	t := map[string]string{
 		"event":      event,
@@ -117,7 +117,7 @@ type createEvent struct {
 	Sender     sender     `json:"sender"`
 }
 
-func (s createEvent) NewMetric() telegraf.Metric {
+func (s createEvent) newMetric() telegraf.Metric {
 	event := "create"
 	t := map[string]string{
 		"event":      event,
@@ -144,7 +144,7 @@ type deleteEvent struct {
 	Sender     sender     `json:"sender"`
 }
 
-func (s deleteEvent) NewMetric() telegraf.Metric {
+func (s deleteEvent) newMetric() telegraf.Metric {
 	event := "delete"
 	t := map[string]string{
 		"event":      event,
@@ -170,7 +170,7 @@ type deploymentEvent struct {
 	Sender     sender     `json:"sender"`
 }
 
-func (s deploymentEvent) NewMetric() telegraf.Metric {
+func (s deploymentEvent) newMetric() telegraf.Metric {
 	event := "deployment"
 	t := map[string]string{
 		"event":      event,
@@ -199,7 +199,7 @@ type deploymentStatusEvent struct {
 	Sender           sender           `json:"sender"`
 }
 
-func (s deploymentStatusEvent) NewMetric() telegraf.Metric {
+func (s deploymentStatusEvent) newMetric() telegraf.Metric {
 	event := "delete"
 	t := map[string]string{
 		"event":      event,
@@ -229,7 +229,7 @@ type forkEvent struct {
 	Sender     sender     `json:"sender"`
 }
 
-func (s forkEvent) NewMetric() telegraf.Metric {
+func (s forkEvent) newMetric() telegraf.Metric {
 	event := "fork"
 	t := map[string]string{
 		"event":      event,
@@ -255,7 +255,7 @@ type gollumEvent struct {
 }
 
 // REVIEW: Going to be lazy and not deal with the pages.
-func (s gollumEvent) NewMetric() telegraf.Metric {
+func (s gollumEvent) newMetric() telegraf.Metric {
 	event := "gollum"
 	t := map[string]string{
 		"event":      event,
@@ -280,7 +280,7 @@ type issueCommentEvent struct {
 	Sender     sender       `json:"sender"`
 }
 
-func (s issueCommentEvent) NewMetric() telegraf.Metric {
+func (s issueCommentEvent) newMetric() telegraf.Metric {
 	event := "issue_comment"
 	t := map[string]string{
 		"event":      event,
@@ -309,7 +309,7 @@ type issuesEvent struct {
 	Sender     sender     `json:"sender"`
 }
 
-func (s issuesEvent) NewMetric() telegraf.Metric {
+func (s issuesEvent) newMetric() telegraf.Metric {
 	event := "issue"
 	t := map[string]string{
 		"event":      event,
@@ -337,7 +337,7 @@ type memberEvent struct {
 	Sender     sender     `json:"sender"`
 }
 
-func (s memberEvent) NewMetric() telegraf.Metric {
+func (s memberEvent) newMetric() telegraf.Metric {
 	event := "member"
 	t := map[string]string{
 		"event":      event,
@@ -364,7 +364,7 @@ type membershipEvent struct {
 	Team   team   `json:"team"`
 }
 
-func (s membershipEvent) NewMetric() telegraf.Metric {
+func (s membershipEvent) newMetric() telegraf.Metric {
 	event := "membership"
 	t := map[string]string{
 		"event":  event,
@@ -385,7 +385,7 @@ type pageBuildEvent struct {
 	Sender     sender     `json:"sender"`
 }
 
-func (s pageBuildEvent) NewMetric() telegraf.Metric {
+func (s pageBuildEvent) newMetric() telegraf.Metric {
 	event := "page_build"
 	t := map[string]string{
 		"event":      event,
@@ -408,7 +408,7 @@ type publicEvent struct {
 	Sender     sender     `json:"sender"`
 }
 
-func (s publicEvent) NewMetric() telegraf.Metric {
+func (s publicEvent) newMetric() telegraf.Metric {
 	event := "public"
 	t := map[string]string{
 		"event":      event,
@@ -433,7 +433,7 @@ type pullRequestEvent struct {
 	Sender      sender      `json:"sender"`
 }
 
-func (s pullRequestEvent) NewMetric() telegraf.Metric {
+func (s pullRequestEvent) newMetric() telegraf.Metric {
 	event := "pull_request"
 	t := map[string]string{
 		"event":      event,
@@ -467,7 +467,7 @@ type pullRequestReviewCommentEvent struct {
 	Sender      sender                   `json:"sender"`
 }
 
-func (s pullRequestReviewCommentEvent) NewMetric() telegraf.Metric {
+func (s pullRequestReviewCommentEvent) newMetric() telegraf.Metric {
 	event := "pull_request_review_comment"
 	t := map[string]string{
 		"event":      event,
@@ -503,7 +503,7 @@ type pushEvent struct {
 	Sender     sender     `json:"sender"`
 }
 
-func (s pushEvent) NewMetric() telegraf.Metric {
+func (s pushEvent) newMetric() telegraf.Metric {
 	event := "push"
 	t := map[string]string{
 		"event":      event,
@@ -530,7 +530,7 @@ type releaseEvent struct {
 	Sender     sender     `json:"sender"`
 }
 
-func (s releaseEvent) NewMetric() telegraf.Metric {
+func (s releaseEvent) newMetric() telegraf.Metric {
 	event := "release"
 	t := map[string]string{
 		"event":      event,
@@ -554,7 +554,7 @@ type repositoryEvent struct {
 	Sender     sender     `json:"sender"`
 }
 
-func (s repositoryEvent) NewMetric() telegraf.Metric {
+func (s repositoryEvent) newMetric() telegraf.Metric {
 	event := "repository"
 	t := map[string]string{
 		"event":      event,
@@ -579,7 +579,7 @@ type statusEvent struct {
 	Sender     sender     `json:"sender"`
 }
 
-func (s statusEvent) NewMetric() telegraf.Metric {
+func (s statusEvent) newMetric() telegraf.Metric {
 	event := "status"
 	t := map[string]string{
 		"event":      event,
@@ -605,7 +605,7 @@ type teamAddEvent struct {
 	Sender     sender     `json:"sender"`
 }
 
-func (s teamAddEvent) NewMetric() telegraf.Metric {
+func (s teamAddEvent) newMetric() telegraf.Metric {
 	event := "team_add"
 	t := map[string]string{
 		"event":      event,
@@ -629,7 +629,7 @@ type watchEvent struct {
 	Sender     sender     `json:"sender"`
 }
 
-func (s watchEvent) NewMetric() telegraf.Metric {
+func (s watchEvent) newMetric() telegraf.Metric {
 	event := "delete"
 	t := map[string]string{
 		"event":      event,

--- a/plugins/inputs/webhooks/github/github_webhooks_test.go
+++ b/plugins/inputs/webhooks/github/github_webhooks_test.go
@@ -11,9 +11,9 @@ import (
 	"github.com/influxdata/telegraf/testutil"
 )
 
-func GithubWebhookRequest(t *testing.T, event, jsonString string) {
+func githubWebhookRequest(t *testing.T, event, jsonString string) {
 	var acc testutil.Accumulator
-	gh := &GithubWebhook{Path: "/github", acc: &acc, log: testutil.Logger{}}
+	gh := &Webhook{Path: "/github", acc: &acc, log: testutil.Logger{}}
 	req, err := http.NewRequest("POST", "/github", strings.NewReader(jsonString))
 	require.NoError(t, err)
 	req.Header.Add("X-Github-Event", event)
@@ -24,9 +24,9 @@ func GithubWebhookRequest(t *testing.T, event, jsonString string) {
 	}
 }
 
-func GithubWebhookRequestWithSignature(t *testing.T, event, jsonString, signature string, expectedStatus int) {
+func githubWebhookRequestWithSignature(t *testing.T, event, jsonString, signature string, expectedStatus int) {
 	var acc testutil.Accumulator
-	gh := &GithubWebhook{Path: "/github", Secret: "signature", acc: &acc, log: testutil.Logger{}}
+	gh := &Webhook{Path: "/github", secret: "signature", acc: &acc, log: testutil.Logger{}}
 	req, err := http.NewRequest("POST", "/github", strings.NewReader(jsonString))
 	require.NoError(t, err)
 	req.Header.Add("X-Github-Event", event)
@@ -39,91 +39,91 @@ func GithubWebhookRequestWithSignature(t *testing.T, event, jsonString, signatur
 }
 
 func TestCommitCommentEvent(t *testing.T) {
-	GithubWebhookRequest(t, "commit_comment", CommitCommentEventJSON())
+	githubWebhookRequest(t, "commit_comment", commitCommentEventJSON())
 }
 
 func TestPingEvent(t *testing.T) {
-	GithubWebhookRequest(t, "ping", "")
+	githubWebhookRequest(t, "ping", "")
 }
 
 func TestDeleteEvent(t *testing.T) {
-	GithubWebhookRequest(t, "delete", DeleteEventJSON())
+	githubWebhookRequest(t, "delete", deleteEventJSON())
 }
 
 func TestDeploymentEvent(t *testing.T) {
-	GithubWebhookRequest(t, "deployment", DeploymentEventJSON())
+	githubWebhookRequest(t, "deployment", deploymentEventJSON())
 }
 
 func TestDeploymentStatusEvent(t *testing.T) {
-	GithubWebhookRequest(t, "deployment_status", DeploymentStatusEventJSON())
+	githubWebhookRequest(t, "deployment_status", deploymentStatusEventJSON())
 }
 
 func TestForkEvent(t *testing.T) {
-	GithubWebhookRequest(t, "fork", ForkEventJSON())
+	githubWebhookRequest(t, "fork", forkEventJSON())
 }
 
 func TestGollumEvent(t *testing.T) {
-	GithubWebhookRequest(t, "gollum", GollumEventJSON())
+	githubWebhookRequest(t, "gollum", gollumEventJSON())
 }
 
 func TestIssueCommentEvent(t *testing.T) {
-	GithubWebhookRequest(t, "issue_comment", IssueCommentEventJSON())
+	githubWebhookRequest(t, "issue_comment", issueCommentEventJSON())
 }
 
 func TestIssuesEvent(t *testing.T) {
-	GithubWebhookRequest(t, "issues", IssuesEventJSON())
+	githubWebhookRequest(t, "issues", issuesEventJSON())
 }
 
 func TestMemberEvent(t *testing.T) {
-	GithubWebhookRequest(t, "member", MemberEventJSON())
+	githubWebhookRequest(t, "member", memberEventJSON())
 }
 
 func TestMembershipEvent(t *testing.T) {
-	GithubWebhookRequest(t, "membership", MembershipEventJSON())
+	githubWebhookRequest(t, "membership", membershipEventJSON())
 }
 
 func TestPageBuildEvent(t *testing.T) {
-	GithubWebhookRequest(t, "page_build", PageBuildEventJSON())
+	githubWebhookRequest(t, "page_build", pageBuildEventJSON())
 }
 
 func TestPublicEvent(t *testing.T) {
-	GithubWebhookRequest(t, "public", PublicEventJSON())
+	githubWebhookRequest(t, "public", publicEventJSON())
 }
 
 func TestPullRequestReviewCommentEvent(t *testing.T) {
-	GithubWebhookRequest(t, "pull_request_review_comment", PullRequestReviewCommentEventJSON())
+	githubWebhookRequest(t, "pull_request_review_comment", pullRequestReviewCommentEventJSON())
 }
 
 func TestPushEvent(t *testing.T) {
-	GithubWebhookRequest(t, "push", PushEventJSON())
+	githubWebhookRequest(t, "push", pushEventJSON())
 }
 
 func TestReleaseEvent(t *testing.T) {
-	GithubWebhookRequest(t, "release", ReleaseEventJSON())
+	githubWebhookRequest(t, "release", releaseEventJSON())
 }
 
 func TestRepositoryEvent(t *testing.T) {
-	GithubWebhookRequest(t, "repository", RepositoryEventJSON())
+	githubWebhookRequest(t, "repository", repositoryEventJSON())
 }
 
 func TestStatusEvent(t *testing.T) {
-	GithubWebhookRequest(t, "status", StatusEventJSON())
+	githubWebhookRequest(t, "status", statusEventJSON())
 }
 
 func TestTeamAddEvent(t *testing.T) {
-	GithubWebhookRequest(t, "team_add", TeamAddEventJSON())
+	githubWebhookRequest(t, "team_add", teamAddEventJSON())
 }
 
 func TestWatchEvent(t *testing.T) {
-	GithubWebhookRequest(t, "watch", WatchEventJSON())
+	githubWebhookRequest(t, "watch", watchEventJSON())
 }
 
 func TestEventWithSignatureFail(t *testing.T) {
-	GithubWebhookRequestWithSignature(t, "watch", WatchEventJSON(), "signature", http.StatusBadRequest)
+	githubWebhookRequestWithSignature(t, "watch", watchEventJSON(), "signature", http.StatusBadRequest)
 }
 
 func TestEventWithSignatureSuccess(t *testing.T) {
-	GithubWebhookRequestWithSignature(t, "watch", WatchEventJSON(), generateSignature("signature", []byte(WatchEventJSON())), http.StatusOK)
+	githubWebhookRequestWithSignature(t, "watch", watchEventJSON(), generateSignature("signature", []byte(watchEventJSON())), http.StatusOK)
 }
 
 func TestCheckSignatureSuccess(t *testing.T) {

--- a/plugins/inputs/webhooks/mandrill/mandrill_webhooks_events.go
+++ b/plugins/inputs/webhooks/mandrill/mandrill_webhooks_events.go
@@ -1,23 +1,18 @@
 package mandrill
 
-type Event interface {
-	Tags() map[string]string
-	Fields() map[string]interface{}
-}
-
-type MandrillEvent struct {
+type mandrillEvent struct {
 	EventName string `json:"event"`
 	TimeStamp int64  `json:"ts"`
 	ID        string `json:"_id"`
 }
 
-func (me *MandrillEvent) Tags() map[string]string {
+func (me *mandrillEvent) tags() map[string]string {
 	return map[string]string{
 		"event": me.EventName,
 	}
 }
 
-func (me *MandrillEvent) Fields() map[string]interface{} {
+func (me *mandrillEvent) fields() map[string]interface{} {
 	return map[string]interface{}{
 		"id": me.ID,
 	}

--- a/plugins/inputs/webhooks/mandrill/mandrill_webhooks_test.go
+++ b/plugins/inputs/webhooks/mandrill/mandrill_webhooks_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/influxdata/telegraf/testutil"
 )
 
-func postWebhooks(t *testing.T, md *MandrillWebhook, eventBody string) *httptest.ResponseRecorder {
+func postWebhooks(t *testing.T, md *Webhook, eventBody string) *httptest.ResponseRecorder {
 	body := url.Values{}
 	body.Set("mandrill_events", eventBody)
 	req, err := http.NewRequest("POST", "/mandrill", strings.NewReader(body.Encode()))
@@ -44,7 +44,7 @@ func TestHead(t *testing.T) {
 
 func TestSendEvent(t *testing.T) {
 	var acc testutil.Accumulator
-	md := &MandrillWebhook{Path: "/mandrill", acc: &acc}
+	md := &Webhook{Path: "/mandrill", acc: &acc}
 	resp := postWebhooks(t, md, "["+readFile(t, "testdata/send_event.json")+"]")
 	if resp.Code != http.StatusOK {
 		t.Errorf("POST send returned HTTP status code %v.\nExpected %v", resp.Code, http.StatusOK)
@@ -63,7 +63,7 @@ func TestSendEvent(t *testing.T) {
 
 func TestMultipleEvents(t *testing.T) {
 	var acc testutil.Accumulator
-	md := &MandrillWebhook{Path: "/mandrill", acc: &acc}
+	md := &Webhook{Path: "/mandrill", acc: &acc}
 	resp := postWebhooks(t, md, "["+readFile(t, "testdata/send_event.json")+","+readFile(t, "testdata/hard_bounce_event.json")+"]")
 	if resp.Code != http.StatusOK {
 		t.Errorf("POST send returned HTTP status code %v.\nExpected %v", resp.Code, http.StatusOK)

--- a/plugins/inputs/webhooks/papertrail/papertrail_test.go
+++ b/plugins/inputs/webhooks/papertrail/papertrail_test.go
@@ -15,7 +15,7 @@ const (
 	contentType = "application/x-www-form-urlencoded"
 )
 
-func post(t *testing.T, pt *PapertrailWebhook, contentType, body string) *httptest.ResponseRecorder {
+func post(t *testing.T, pt *Webhook, contentType, body string) *httptest.ResponseRecorder {
 	req, err := http.NewRequest("POST", "/", strings.NewReader(body))
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", contentType)
@@ -26,7 +26,7 @@ func post(t *testing.T, pt *PapertrailWebhook, contentType, body string) *httpte
 
 func TestWrongContentType(t *testing.T) {
 	var acc testutil.Accumulator
-	pt := &PapertrailWebhook{Path: "/papertrail", acc: &acc}
+	pt := &Webhook{Path: "/papertrail", acc: &acc}
 	form := url.Values{}
 	form.Set("payload", sampleEventPayload)
 	data := form.Encode()
@@ -37,7 +37,7 @@ func TestWrongContentType(t *testing.T) {
 
 func TestMissingPayload(t *testing.T) {
 	var acc testutil.Accumulator
-	pt := &PapertrailWebhook{Path: "/papertrail", acc: &acc}
+	pt := &Webhook{Path: "/papertrail", acc: &acc}
 
 	resp := post(t, pt, contentType, "")
 	require.Equal(t, http.StatusBadRequest, resp.Code)
@@ -45,7 +45,7 @@ func TestMissingPayload(t *testing.T) {
 
 func TestPayloadNotJSON(t *testing.T) {
 	var acc testutil.Accumulator
-	pt := &PapertrailWebhook{Path: "/papertrail", acc: &acc}
+	pt := &Webhook{Path: "/papertrail", acc: &acc}
 
 	resp := post(t, pt, contentType, "payload={asdf]")
 	require.Equal(t, http.StatusBadRequest, resp.Code)
@@ -53,7 +53,7 @@ func TestPayloadNotJSON(t *testing.T) {
 
 func TestPayloadInvalidJSON(t *testing.T) {
 	var acc testutil.Accumulator
-	pt := &PapertrailWebhook{Path: "/papertrail", acc: &acc}
+	pt := &Webhook{Path: "/papertrail", acc: &acc}
 
 	resp := post(t, pt, contentType, `payload={"value": 42}`)
 	require.Equal(t, http.StatusBadRequest, resp.Code)
@@ -61,7 +61,7 @@ func TestPayloadInvalidJSON(t *testing.T) {
 
 func TestEventPayload(t *testing.T) {
 	var acc testutil.Accumulator
-	pt := &PapertrailWebhook{Path: "/papertrail", acc: &acc}
+	pt := &Webhook{Path: "/papertrail", acc: &acc}
 
 	form := url.Values{}
 	form.Set("payload", sampleEventPayload)
@@ -111,7 +111,7 @@ func TestEventPayload(t *testing.T) {
 
 func TestCountPayload(t *testing.T) {
 	var acc testutil.Accumulator
-	pt := &PapertrailWebhook{Path: "/papertrail", acc: &acc}
+	pt := &Webhook{Path: "/papertrail", acc: &acc}
 	form := url.Values{}
 	form.Set("payload", sampleCountPayload)
 	resp := post(t, pt, contentType, form.Encode())

--- a/plugins/inputs/webhooks/papertrail/papertrail_webhooks.go
+++ b/plugins/inputs/webhooks/papertrail/papertrail_webhooks.go
@@ -12,21 +12,22 @@ import (
 	"github.com/influxdata/telegraf/plugins/common/auth"
 )
 
-type PapertrailWebhook struct {
+type Webhook struct {
 	Path string
 	acc  telegraf.Accumulator
 	log  telegraf.Logger
 	auth.BasicAuth
 }
 
-func (pt *PapertrailWebhook) Register(router *mux.Router, acc telegraf.Accumulator, log telegraf.Logger) {
+// Register registers the webhook with the provided router
+func (pt *Webhook) Register(router *mux.Router, acc telegraf.Accumulator, log telegraf.Logger) {
 	router.HandleFunc(pt.Path, pt.eventHandler).Methods("POST")
 	pt.log = log
 	pt.log.Infof("Started the papertrail_webhook on %s", pt.Path)
 	pt.acc = acc
 }
 
-func (pt *PapertrailWebhook) eventHandler(w http.ResponseWriter, r *http.Request) {
+func (pt *Webhook) eventHandler(w http.ResponseWriter, r *http.Request) {
 	if r.Header.Get("Content-Type") != "application/x-www-form-urlencoded" {
 		http.Error(w, "Unsupported Media Type", http.StatusUnsupportedMediaType)
 		return
@@ -43,7 +44,7 @@ func (pt *PapertrailWebhook) eventHandler(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	var payload Payload
+	var payload payload
 	err := json.Unmarshal([]byte(data), &payload)
 	if err != nil {
 		http.Error(w, "Bad Request", http.StatusBadRequest)

--- a/plugins/inputs/webhooks/papertrail/papertrail_webhooks_models.go
+++ b/plugins/inputs/webhooks/papertrail/papertrail_webhooks_models.go
@@ -4,7 +4,7 @@ import (
 	"time"
 )
 
-type Event struct {
+type event struct {
 	ID                int64     `json:"id"`
 	ReceivedAt        time.Time `json:"received_at"`
 	DisplayReceivedAt string    `json:"display_received_at"`
@@ -18,13 +18,13 @@ type Event struct {
 	Message           string    `json:"message"`
 }
 
-type Count struct {
+type count struct {
 	SourceName string            `json:"source_name"`
 	SourceID   int64             `json:"source_id"`
 	TimeSeries *map[int64]uint64 `json:"timeseries"`
 }
 
-type SavedSearch struct {
+type savedSearch struct {
 	ID        int64  `json:"id"`
 	Name      string `json:"name"`
 	Query     string `json:"query"`
@@ -32,10 +32,10 @@ type SavedSearch struct {
 	SearchURL string `json:"html_search_url"`
 }
 
-type Payload struct {
-	Events      []*Event     `json:"events"`
-	Counts      []*Count     `json:"counts"`
-	SavedSearch *SavedSearch `json:"saved_search"`
+type payload struct {
+	Events      []*event     `json:"events"`
+	Counts      []*count     `json:"counts"`
+	SavedSearch *savedSearch `json:"saved_search"`
 	MaxID       string       `json:"max_id"`
 	MinID       string       `json:"min_id"`
 }

--- a/plugins/inputs/webhooks/particle/particle_webhooks.go
+++ b/plugins/inputs/webhooks/particle/particle_webhooks.go
@@ -33,25 +33,26 @@ func newEvent() *event {
 	}
 }
 
-func (e *event) Time() (time.Time, error) {
+func (e *event) time() (time.Time, error) {
 	return time.Parse("2006-01-02T15:04:05Z", e.PublishedAt)
 }
 
-type ParticleWebhook struct {
+type Webhook struct {
 	Path string
 	acc  telegraf.Accumulator
 	log  telegraf.Logger
 	auth.BasicAuth
 }
 
-func (rb *ParticleWebhook) Register(router *mux.Router, acc telegraf.Accumulator, log telegraf.Logger) {
+// Register registers the webhook with the provided router
+func (rb *Webhook) Register(router *mux.Router, acc telegraf.Accumulator, log telegraf.Logger) {
 	router.HandleFunc(rb.Path, rb.eventHandler).Methods("POST")
 	rb.log = log
 	rb.log.Infof("Started the webhooks_particle on %s", rb.Path)
 	rb.acc = acc
 }
 
-func (rb *ParticleWebhook) eventHandler(w http.ResponseWriter, r *http.Request) {
+func (rb *Webhook) eventHandler(w http.ResponseWriter, r *http.Request) {
 	defer r.Body.Close()
 
 	if !rb.Verify(r) {
@@ -66,7 +67,7 @@ func (rb *ParticleWebhook) eventHandler(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	pTime, err := e.Time()
+	pTime, err := e.time()
 	if err != nil {
 		pTime = time.Now()
 	}

--- a/plugins/inputs/webhooks/particle/particle_webhooks_test.go
+++ b/plugins/inputs/webhooks/particle/particle_webhooks_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/influxdata/telegraf/testutil"
 )
 
-func postWebhooks(t *testing.T, rb *ParticleWebhook, eventBody string) *httptest.ResponseRecorder {
+func postWebhooks(t *testing.T, rb *Webhook, eventBody string) *httptest.ResponseRecorder {
 	req, err := http.NewRequest("POST", "/", strings.NewReader(eventBody))
 	require.NoError(t, err)
 	w := httptest.NewRecorder()
@@ -25,8 +25,8 @@ func postWebhooks(t *testing.T, rb *ParticleWebhook, eventBody string) *httptest
 func TestNewItem(t *testing.T) {
 	t.Parallel()
 	var acc testutil.Accumulator
-	rb := &ParticleWebhook{Path: "/particle", acc: &acc}
-	resp := postWebhooks(t, rb, NewItemJSON())
+	rb := &Webhook{Path: "/particle", acc: &acc}
+	resp := postWebhooks(t, rb, newItemJSON())
 	if resp.Code != http.StatusOK {
 		t.Errorf("POST new_item returned HTTP status code %v.\nExpected %v", resp.Code, http.StatusOK)
 	}
@@ -53,8 +53,8 @@ func TestNewItem(t *testing.T) {
 func TestUnknowItem(t *testing.T) {
 	t.Parallel()
 	var acc testutil.Accumulator
-	rb := &ParticleWebhook{Path: "/particle", acc: &acc}
-	resp := postWebhooks(t, rb, UnknowJSON())
+	rb := &Webhook{Path: "/particle", acc: &acc}
+	resp := postWebhooks(t, rb, unknownJSON())
 	if resp.Code != http.StatusOK {
 		t.Errorf("POST unknown returned HTTP status code %v.\nExpected %v", resp.Code, http.StatusOK)
 	}
@@ -63,8 +63,8 @@ func TestUnknowItem(t *testing.T) {
 func TestDefaultMeasurementName(t *testing.T) {
 	t.Parallel()
 	var acc testutil.Accumulator
-	rb := &ParticleWebhook{Path: "/particle", acc: &acc}
-	resp := postWebhooks(t, rb, BlankMeasurementJSON())
+	rb := &Webhook{Path: "/particle", acc: &acc}
+	resp := postWebhooks(t, rb, blankMeasurementJSON())
 	if resp.Code != http.StatusOK {
 		t.Errorf("POST new_item returned HTTP status code %v.\nExpected %v", resp.Code, http.StatusOK)
 	}
@@ -80,7 +80,7 @@ func TestDefaultMeasurementName(t *testing.T) {
 	acc.AssertContainsTaggedFields(t, "eventName", fields, tags)
 }
 
-func BlankMeasurementJSON() string {
+func blankMeasurementJSON() string {
 	return `
 	{
 	  "event": "eventName",
@@ -104,7 +104,7 @@ func BlankMeasurementJSON() string {
   }`
 }
 
-func NewItemJSON() string {
+func newItemJSON() string {
 	return `
 	{
 	  "event": "temperature",
@@ -136,7 +136,7 @@ func NewItemJSON() string {
   }`
 }
 
-func UnknowJSON() string {
+func unknownJSON() string {
 	return `
     {
       "event": "roger"

--- a/plugins/inputs/webhooks/rollbar/rollbar_webhooks_events.go
+++ b/plugins/inputs/webhooks/rollbar/rollbar_webhooks_events.go
@@ -3,8 +3,8 @@ package rollbar
 import "strconv"
 
 type event interface {
-	Tags() map[string]string
-	Fields() map[string]interface{}
+	tags() map[string]string
+	fields() map[string]interface{}
 }
 
 type dummyEvent struct {
@@ -32,7 +32,7 @@ type newItem struct {
 	Data      newItemData `json:"data"`
 }
 
-func (ni *newItem) Tags() map[string]string {
+func (ni *newItem) tags() map[string]string {
 	return map[string]string{
 		"event":       ni.EventName,
 		"environment": ni.Data.Item.Environment,
@@ -42,7 +42,7 @@ func (ni *newItem) Tags() map[string]string {
 	}
 }
 
-func (ni *newItem) Fields() map[string]interface{} {
+func (ni *newItem) fields() map[string]interface{} {
 	return map[string]interface{}{
 		"id": ni.Data.Item.ID,
 	}
@@ -69,7 +69,7 @@ type occurrence struct {
 	Data      occurrenceData `json:"data"`
 }
 
-func (o *occurrence) Tags() map[string]string {
+func (o *occurrence) tags() map[string]string {
 	return map[string]string{
 		"event":       o.EventName,
 		"environment": o.Data.Item.Environment,
@@ -79,7 +79,7 @@ func (o *occurrence) Tags() map[string]string {
 	}
 }
 
-func (o *occurrence) Fields() map[string]interface{} {
+func (o *occurrence) fields() map[string]interface{} {
 	return map[string]interface{}{
 		"id": o.Data.Item.ID,
 	}
@@ -100,7 +100,7 @@ type deploy struct {
 	Data      deployData `json:"data"`
 }
 
-func (ni *deploy) Tags() map[string]string {
+func (ni *deploy) tags() map[string]string {
 	return map[string]string{
 		"event":       ni.EventName,
 		"environment": ni.Data.Deploy.Environment,
@@ -108,7 +108,7 @@ func (ni *deploy) Tags() map[string]string {
 	}
 }
 
-func (ni *deploy) Fields() map[string]interface{} {
+func (ni *deploy) fields() map[string]interface{} {
 	return map[string]interface{}{
 		"id": ni.Data.Deploy.ID,
 	}

--- a/plugins/inputs/webhooks/rollbar/rollbar_webhooks_events_json_test.go
+++ b/plugins/inputs/webhooks/rollbar/rollbar_webhooks_events_json_test.go
@@ -1,6 +1,6 @@
 package rollbar
 
-func NewItemJSON() string {
+func newItemJSON() string {
 	return `
 	{
 	  "event_name": "new_item",
@@ -68,7 +68,7 @@ func NewItemJSON() string {
 	}`
 }
 
-func OccurrenceJSON() string {
+func occurrenceJSON() string {
 	return `
 	{
 	  "event_name": "occurrence",
@@ -132,7 +132,7 @@ func OccurrenceJSON() string {
 	}`
 }
 
-func DeployJSON() string {
+func deployJSON() string {
 	return `
     {
       "event_name": "deploy",
@@ -152,7 +152,7 @@ func DeployJSON() string {
     }`
 }
 
-func UnknowJSON() string {
+func unknownJSON() string {
 	return `
     {
       "event_name": "roger"

--- a/plugins/inputs/webhooks/rollbar/rollbar_webhooks_test.go
+++ b/plugins/inputs/webhooks/rollbar/rollbar_webhooks_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/influxdata/telegraf/testutil"
 )
 
-func postWebhooks(t *testing.T, rb *RollbarWebhook, eventBody string) *httptest.ResponseRecorder {
+func postWebhooks(t *testing.T, rb *Webhook, eventBody string) *httptest.ResponseRecorder {
 	req, err := http.NewRequest("POST", "/", strings.NewReader(eventBody))
 	require.NoError(t, err)
 	w := httptest.NewRecorder()
@@ -24,8 +24,8 @@ func postWebhooks(t *testing.T, rb *RollbarWebhook, eventBody string) *httptest.
 
 func TestNewItem(t *testing.T) {
 	var acc testutil.Accumulator
-	rb := &RollbarWebhook{Path: "/rollbar", acc: &acc}
-	resp := postWebhooks(t, rb, NewItemJSON())
+	rb := &Webhook{Path: "/rollbar", acc: &acc}
+	resp := postWebhooks(t, rb, newItemJSON())
 	if resp.Code != http.StatusOK {
 		t.Errorf("POST new_item returned HTTP status code %v.\nExpected %v", resp.Code, http.StatusOK)
 	}
@@ -47,8 +47,8 @@ func TestNewItem(t *testing.T) {
 
 func TestOccurrence(t *testing.T) {
 	var acc testutil.Accumulator
-	rb := &RollbarWebhook{Path: "/rollbar", acc: &acc}
-	resp := postWebhooks(t, rb, OccurrenceJSON())
+	rb := &Webhook{Path: "/rollbar", acc: &acc}
+	resp := postWebhooks(t, rb, occurrenceJSON())
 	if resp.Code != http.StatusOK {
 		t.Errorf("POST occurrence returned HTTP status code %v.\nExpected %v", resp.Code, http.StatusOK)
 	}
@@ -70,8 +70,8 @@ func TestOccurrence(t *testing.T) {
 
 func TestDeploy(t *testing.T) {
 	var acc testutil.Accumulator
-	rb := &RollbarWebhook{Path: "/rollbar", acc: &acc}
-	resp := postWebhooks(t, rb, DeployJSON())
+	rb := &Webhook{Path: "/rollbar", acc: &acc}
+	resp := postWebhooks(t, rb, deployJSON())
 	if resp.Code != http.StatusOK {
 		t.Errorf("POST deploy returned HTTP status code %v.\nExpected %v", resp.Code, http.StatusOK)
 	}
@@ -90,8 +90,8 @@ func TestDeploy(t *testing.T) {
 }
 
 func TestUnknowItem(t *testing.T) {
-	rb := &RollbarWebhook{Path: "/rollbar"}
-	resp := postWebhooks(t, rb, UnknowJSON())
+	rb := &Webhook{Path: "/rollbar"}
+	resp := postWebhooks(t, rb, unknownJSON())
 	if resp.Code != http.StatusOK {
 		t.Errorf("POST unknow returned HTTP status code %v.\nExpected %v", resp.Code, http.StatusOK)
 	}

--- a/plugins/inputs/webhooks/webhooks.go
+++ b/plugins/inputs/webhooks/webhooks.go
@@ -31,63 +31,32 @@ const (
 	defaultWriteTimeout = 10 * time.Second
 )
 
-type Webhook interface {
-	Register(router *mux.Router, acc telegraf.Accumulator, log telegraf.Logger)
-}
-
-func init() {
-	inputs.Add("webhooks", func() telegraf.Input { return NewWebhooks() })
-}
-
 type Webhooks struct {
 	ServiceAddress string          `toml:"service_address"`
 	ReadTimeout    config.Duration `toml:"read_timeout"`
 	WriteTimeout   config.Duration `toml:"write_timeout"`
 
-	Github      *github.GithubWebhook           `toml:"github"`
-	Filestack   *filestack.FilestackWebhook     `toml:"filestack"`
-	Mandrill    *mandrill.MandrillWebhook       `toml:"mandrill"`
-	Rollbar     *rollbar.RollbarWebhook         `toml:"rollbar"`
-	Papertrail  *papertrail.PapertrailWebhook   `toml:"papertrail"`
-	Particle    *particle.ParticleWebhook       `toml:"particle"`
-	Artifactory *artifactory.ArtifactoryWebhook `toml:"artifactory"`
+	Artifactory *artifactory.Webhook `toml:"artifactory"`
+	Filestack   *filestack.Webhook   `toml:"filestack"`
+	Github      *github.Webhook      `toml:"github"`
+	Mandrill    *mandrill.Webhook    `toml:"mandrill"`
+	Papertrail  *papertrail.Webhook  `toml:"papertrail"`
+	Particle    *particle.Webhook    `toml:"particle"`
+	Rollbar     *rollbar.Webhook     `toml:"rollbar"`
 
 	Log telegraf.Logger `toml:"-"`
 
 	srv *http.Server
 }
 
-func NewWebhooks() *Webhooks {
-	return &Webhooks{}
+// Webhook is an interface that all webhooks must implement
+type Webhook interface {
+	// Register registers the webhook with the provided router
+	Register(router *mux.Router, acc telegraf.Accumulator, log telegraf.Logger)
 }
 
 func (*Webhooks) SampleConfig() string {
 	return sampleConfig
-}
-
-func (*Webhooks) Gather(telegraf.Accumulator) error {
-	return nil
-}
-
-// AvailableWebhooks Looks for fields which implement Webhook interface
-func (wb *Webhooks) AvailableWebhooks() []Webhook {
-	webhooks := make([]Webhook, 0)
-	s := reflect.ValueOf(wb).Elem()
-	for i := 0; i < s.NumField(); i++ {
-		f := s.Field(i)
-
-		if !f.CanInterface() {
-			continue
-		}
-
-		if wbPlugin, ok := f.Interface().(Webhook); ok {
-			if !reflect.ValueOf(wbPlugin).IsNil() {
-				webhooks = append(webhooks, wbPlugin)
-			}
-		}
-	}
-
-	return webhooks
 }
 
 func (wb *Webhooks) Start(acc telegraf.Accumulator) error {
@@ -100,7 +69,7 @@ func (wb *Webhooks) Start(acc telegraf.Accumulator) error {
 
 	r := mux.NewRouter()
 
-	for _, webhook := range wb.AvailableWebhooks() {
+	for _, webhook := range wb.availableWebhooks() {
 		webhook.Register(r, acc, wb.Log)
 	}
 
@@ -128,7 +97,40 @@ func (wb *Webhooks) Start(acc telegraf.Accumulator) error {
 	return nil
 }
 
+func (*Webhooks) Gather(telegraf.Accumulator) error {
+	return nil
+}
+
 func (wb *Webhooks) Stop() {
 	wb.srv.Close()
 	wb.Log.Infof("Stopping the Webhooks service")
+}
+
+// availableWebhooks Looks for fields which implement Webhook interface
+func (wb *Webhooks) availableWebhooks() []Webhook {
+	webhooks := make([]Webhook, 0)
+	s := reflect.ValueOf(wb).Elem()
+	for i := 0; i < s.NumField(); i++ {
+		f := s.Field(i)
+
+		if !f.CanInterface() {
+			continue
+		}
+
+		if wbPlugin, ok := f.Interface().(Webhook); ok {
+			if !reflect.ValueOf(wbPlugin).IsNil() {
+				webhooks = append(webhooks, wbPlugin)
+			}
+		}
+	}
+
+	return webhooks
+}
+
+func newWebhooks() *Webhooks {
+	return &Webhooks{}
+}
+
+func init() {
+	inputs.Add("webhooks", func() telegraf.Input { return newWebhooks() })
 }

--- a/plugins/inputs/webhooks/webhooks_test.go
+++ b/plugins/inputs/webhooks/webhooks_test.go
@@ -5,46 +5,60 @@ import (
 	"testing"
 
 	"github.com/influxdata/telegraf/plugins/inputs/webhooks/artifactory"
+	"github.com/influxdata/telegraf/plugins/inputs/webhooks/filestack"
 	"github.com/influxdata/telegraf/plugins/inputs/webhooks/github"
+	"github.com/influxdata/telegraf/plugins/inputs/webhooks/mandrill"
 	"github.com/influxdata/telegraf/plugins/inputs/webhooks/papertrail"
 	"github.com/influxdata/telegraf/plugins/inputs/webhooks/particle"
 	"github.com/influxdata/telegraf/plugins/inputs/webhooks/rollbar"
 )
 
 func TestAvailableWebhooks(t *testing.T) {
-	wb := NewWebhooks()
+	wb := newWebhooks()
 	expected := make([]Webhook, 0)
-	if !reflect.DeepEqual(wb.AvailableWebhooks(), expected) {
-		t.Errorf("expected to %v.\nGot %v", expected, wb.AvailableWebhooks())
+	if !reflect.DeepEqual(wb.availableWebhooks(), expected) {
+		t.Errorf("expected to %v.\nGot %v", expected, wb.availableWebhooks())
 	}
 
-	wb.Github = &github.GithubWebhook{Path: "/github"}
-	expected = append(expected, wb.Github)
-	if !reflect.DeepEqual(wb.AvailableWebhooks(), expected) {
-		t.Errorf("expected to be %v.\nGot %v", expected, wb.AvailableWebhooks())
-	}
-
-	wb.Rollbar = &rollbar.RollbarWebhook{Path: "/rollbar"}
-	expected = append(expected, wb.Rollbar)
-	if !reflect.DeepEqual(wb.AvailableWebhooks(), expected) {
-		t.Errorf("expected to be %v.\nGot %v", expected, wb.AvailableWebhooks())
-	}
-
-	wb.Papertrail = &papertrail.PapertrailWebhook{Path: "/papertrail"}
-	expected = append(expected, wb.Papertrail)
-	if !reflect.DeepEqual(wb.AvailableWebhooks(), expected) {
-		t.Errorf("expected to be %v.\nGot %v", expected, wb.AvailableWebhooks())
-	}
-
-	wb.Particle = &particle.ParticleWebhook{Path: "/particle"}
-	expected = append(expected, wb.Particle)
-	if !reflect.DeepEqual(wb.AvailableWebhooks(), expected) {
-		t.Errorf("expected to be %v.\nGot %v", expected, wb.AvailableWebhooks())
-	}
-
-	wb.Artifactory = &artifactory.ArtifactoryWebhook{Path: "/artifactory"}
+	wb.Artifactory = &artifactory.Webhook{Path: "/artifactory"}
 	expected = append(expected, wb.Artifactory)
-	if !reflect.DeepEqual(wb.AvailableWebhooks(), expected) {
-		t.Errorf("expected to be %v.\nGot %v", expected, wb.AvailableWebhooks())
+	if !reflect.DeepEqual(wb.availableWebhooks(), expected) {
+		t.Errorf("expected to be %v.\nGot %v", expected, wb.availableWebhooks())
+	}
+
+	wb.Filestack = &filestack.Webhook{Path: "/filestack"}
+	expected = append(expected, wb.Filestack)
+	if !reflect.DeepEqual(wb.availableWebhooks(), expected) {
+		t.Errorf("expected to be %v.\nGot %v", expected, wb.availableWebhooks())
+	}
+
+	wb.Github = &github.Webhook{Path: "/github"}
+	expected = append(expected, wb.Github)
+	if !reflect.DeepEqual(wb.availableWebhooks(), expected) {
+		t.Errorf("expected to be %v.\nGot %v", expected, wb.availableWebhooks())
+	}
+
+	wb.Mandrill = &mandrill.Webhook{Path: "/mandrill"}
+	expected = append(expected, wb.Mandrill)
+	if !reflect.DeepEqual(wb.availableWebhooks(), expected) {
+		t.Errorf("expected to be %v.\nGot %v", expected, wb.availableWebhooks())
+	}
+
+	wb.Papertrail = &papertrail.Webhook{Path: "/papertrail"}
+	expected = append(expected, wb.Papertrail)
+	if !reflect.DeepEqual(wb.availableWebhooks(), expected) {
+		t.Errorf("expected to be %v.\nGot %v", expected, wb.availableWebhooks())
+	}
+
+	wb.Particle = &particle.Webhook{Path: "/particle"}
+	expected = append(expected, wb.Particle)
+	if !reflect.DeepEqual(wb.availableWebhooks(), expected) {
+		t.Errorf("expected to be %v.\nGot %v", expected, wb.availableWebhooks())
+	}
+
+	wb.Rollbar = &rollbar.Webhook{Path: "/rollbar"}
+	expected = append(expected, wb.Rollbar)
+	if !reflect.DeepEqual(wb.availableWebhooks(), expected) {
+		t.Errorf("expected to be %v.\nGot %v", expected, wb.availableWebhooks())
 	}
 }


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

Address findings for [revive:exported ](https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#exported ) in `plugins/inputs/webhooks`.

As part of this effort for files from `plugins/inputs/webhooks`, the following actions were taken:
- Type names (`const`, `var`, `struct`, `func`, etc) were changed to unexported, wherever they didn't need to be exported.
- All remaining exported types were given comments in the appropriate form – this does not apply to exported methods that implement "known" plugin interfaces (`Gather|Init|Start|Stop|SampleConfig|Parse|Add|Apply|Serialize|SerializeBatch|SetParser|SetParserFunc|GetState|SetState`).
- The order of methods was organized (exported methods first, then unexported, with `init` at the very end).

It is only part of the bigger work (for issue: https://github.com/influxdata/telegraf/issues/15813).
After all findings of this type in whole project are handled, we can enable `revive:exported` rule in `golangci-lint`.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR