### PR TITLE
chore(inputs.statsd): Refactor internal stats into their own struct

### DIFF
--- a/plugins/inputs/statsd/statsd_test.go
+++ b/plugins/inputs/statsd/statsd_test.go
@@ -2177,7 +2177,7 @@ func TestUdpFillQueue(t *testing.T) {
 	require.NoError(t, conn.Close())
 
 	require.Eventually(t, func() bool {
-		return plugin.UDPPacketsRecv.Get() >= int64(numberToSend)
+		return plugin.Stats.UDPPacketsRecv.Get() >= int64(numberToSend)
 	}, 1*time.Second, 100*time.Millisecond)
 	defer plugin.Stop()
 


### PR DESCRIPTION

Summary:

Later in this stack of diffs, I add a field named `MaxConnections` to `Statsd` because it controls the max number of connections for all listener types, not just TCP listeners. That creates a naming collision with the existing field named `MaxConnections`, which is an internal stat tracker. This diff eliminates that name collision by encapsulating all of `Statsd`'s internal stat trackers in a struct.

Test Plan:

Existing unit tests pass.
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/influxdata/telegraf/pull/16419).
* #16421
* #16420
* __->__ #16419