### PR TITLE
refactor(statsd receiver): rename Statsd.UDPlistener => UDPConn

### DIFF
--- a/plugins/inputs/statsd/statsd.go
+++ b/plugins/inputs/statsd/statsd.go
@@ -130,7 +130,7 @@ type Statsd struct {
 	distributions []cacheddistributions
 
 	// Protocol listeners
-	UDPlistener *net.UDPConn
+	UDPConn     *net.UDPConn
 	TCPlistener *net.TCPListener
 
 	// track current connections so we can close them in Stop()
@@ -296,7 +296,7 @@ func (s *Statsd) Start(ac telegraf.Accumulator) error {
 		}
 
 		s.Log.Infof("UDP listening on %q", conn.LocalAddr().String())
-		s.UDPlistener = conn
+		s.UDPConn = conn
 
 		s.wg.Add(1)
 		go func() {
@@ -450,8 +450,8 @@ func (s *Statsd) Stop() {
 	s.Log.Infof("Stopping the statsd service")
 	close(s.done)
 	if s.isUDP() {
-		if s.UDPlistener != nil {
-			s.UDPlistener.Close()
+		if s.UDPConn != nil {
+			s.UDPConn.Close()
 		}
 	} else {
 		if s.TCPlistener != nil {
@@ -530,7 +530,7 @@ func (s *Statsd) tcpListen(listener *net.TCPListener) error {
 // udpListen starts listening for UDP packets on the configured port.
 func (s *Statsd) udpListen(conn *net.UDPConn) error {
 	if s.ReadBufferSize > 0 {
-		if err := s.UDPlistener.SetReadBuffer(s.ReadBufferSize); err != nil {
+		if err := s.UDPConn.SetReadBuffer(s.ReadBufferSize); err != nil {
 			return err
 		}
 	}

--- a/plugins/inputs/statsd/statsd_test.go
+++ b/plugins/inputs/statsd/statsd_test.go
@@ -2168,7 +2168,7 @@ func TestUdpFillQueue(t *testing.T) {
 	var acc testutil.Accumulator
 	require.NoError(t, plugin.Start(&acc))
 
-	conn, err := net.Dial("udp", plugin.UDPlistener.LocalAddr().String())
+	conn, err := net.Dial("udp", plugin.UDPConn.LocalAddr().String())
 	require.NoError(t, err)
 	numberToSend := plugin.AllowedPendingMessages
 	for i := 0; i < numberToSend; i++ {

--- a/plugins/inputs/statsd/statsd_test.go
+++ b/plugins/inputs/statsd/statsd_test.go
@@ -2177,7 +2177,7 @@ func TestUdpFillQueue(t *testing.T) {
 	require.NoError(t, conn.Close())
 
 	require.Eventually(t, func() bool {
-		return plugin.UDPPacketsRecv.Get() >= int64(numberToSend)
+		return plugin.Stats.UDPPacketsRecv.Get() >= int64(numberToSend)
 	}, 1*time.Second, 100*time.Millisecond)
 	defer plugin.Stop()
 


### PR DESCRIPTION

Summary:

Later in this stack of diffs, I rename `TCPlistener` to `Listener` because it becomes a generic listener for all networks supported by `net.Listen`. That makes `UDPlistener`'s naming stand out because:

- It isn't a listener. It's a `*net.UDPConn`.
- It isn't the UDP counterpart to `Listener`.

This diff renames it to `UDPConn` to improve clarity.

Test Plan:

Unit tests pass.
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/influxdata/telegraf/pull/16420).
* #16421
* __->__ #16420
* #16419