### PR TITLE
chore: Fix linter findings that were accidentally pushed to master branch

### DIFF
--- a/models/running_input_test.go
+++ b/models/running_input_test.go
@@ -547,11 +547,11 @@ type mockProbingInput struct {
 	probeReturn error
 }
 
-func (m *mockProbingInput) SampleConfig() string {
+func (*mockProbingInput) SampleConfig() string {
 	return ""
 }
 
-func (m *mockProbingInput) Gather(_ telegraf.Accumulator) error {
+func (*mockProbingInput) Gather(telegraf.Accumulator) error {
 	return nil
 }
 


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

```
models/running_input_test.go:550:7  revive  unused-receiver: method receiver 'm' is not referenced in method's body, consider removing or renaming it as _
models/running_input_test.go:554:7  revive  unused-receiver: method receiver 'm' is not referenced in method's body, consider removing or renaming it as _
```

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR
