### PR TITLE
docs(processors.filter): Correct tag specification in rule example

### DIFF
--- a/plugins/processors/filter/README.md
+++ b/plugins/processors/filter/README.md
@@ -79,5 +79,5 @@ Alternatively, you can "black-list" the `OK` value via
   namepass = ["machine"]
 
   [[processors.filter.rule]]
-    tags = {"status" = "OK"}
+    tags = {"status" = ["OK"]}
 ```


### PR DESCRIPTION
## Summary
There's an error in the example configuration, which causes Telegraf 1.33 to fail with the error
```
unmarshalling failed: line 73: cannot unmarshal TOML string into []string
```

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #16433
