### PR TITLE
fix(outputs.azure_monitor): Prevent infinite send loop for outdated metrics

### DIFF
--- a/plugins/outputs/azure_monitor/sample.conf
+++ b/plugins/outputs/azure_monitor/sample.conf
@@ -27,3 +27,11 @@
   ## cloud environment, set the appropriate REST endpoint for receiving
   ## metrics. (Note: region may be unused in this context)
   # endpoint_url = "https://monitoring.core.usgovcloudapi.net"
+
+  ## Time limitations of metric to send
+  ## Documentation can be found here:
+  ##   https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-store-custom-rest-api?tabs=rest#timestamp
+  ## However, the returned (400) error message might document more strict or
+  ## relaxed settings. By default, only past metrics witin the limit are sent.
+  # timestamp_limit_past = "30m"
+  # timestamp_limit_future = "-1m"

--- a/plugins/outputs/azure_monitor/types.go
+++ b/plugins/outputs/azure_monitor/types.go
@@ -6,8 +6,9 @@ import (
 )
 
 type azureMonitorMetric struct {
-	Time time.Time         `json:"time"`
-	Data *azureMonitorData `json:"data"`
+	Time  time.Time         `json:"time"`
+	Data  *azureMonitorData `json:"data"`
+	index int
 }
 
 type azureMonitorData struct {


### PR DESCRIPTION
## Summary

The Azure Monitor service has limitations on the time-range of accepted metrics. Metrics older than 30 minutes and more than 4 minutes into the future (or 20 min in the past and 5 min in the future according to documentation) are not accepted and the service responds with a `400` HTTP error code. The current code propagates this error up into the model and the model code then assumes it must reschedule the batch or metrics due to a retryable error. Usually metrics are filtered according to those limits but due to latency during transmission etc. the error might still be triggered.

This PR handles the `400` HTTP error code as a non-retryable error and fixes other non-retryable errors paths on the way.
It furthermore introduces two new configuration settings to better control the accepted metric timeframe allowing a more robust limit for filtering the metrics. Please note: The default values of the parameters (30 min into the past until 1 minute into the past) are representing the previous behavior, where the upper limit is in the past (contrary to 4 min into the future) to allow aggregation of metrics to happen before sending those aggregates.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #15908 
