### PR TITLE
feat(ping): Add option to use start timestamp

### DIFF
--- a/plugins/inputs/ping/ping_notwindows.go
+++ b/plugins/inputs/ping/ping_notwindows.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/influxdata/telegraf"
 )
@@ -30,6 +31,10 @@ type statistics struct {
 }
 
 func (p *Ping) pingToURL(u string, acc telegraf.Accumulator) {
+	startTime := make([]time.Time, 0)
+	if p.UseStartTime {
+		startTime = append(startTime, time.Now())
+	}
 	tags := map[string]string{"url": u}
 	fields := map[string]interface{}{"result_code": 0}
 
@@ -67,7 +72,7 @@ func (p *Ping) pingToURL(u string, acc telegraf.Accumulator) {
 				acc.AddError(fmt.Errorf("host %q: %w", u, err))
 			}
 			fields["result_code"] = 2
-			acc.AddFields("ping", fields, tags)
+			acc.AddFields("ping", fields, tags, startTime...)
 			return
 		}
 	}
@@ -76,7 +81,7 @@ func (p *Ping) pingToURL(u string, acc telegraf.Accumulator) {
 		// fatal error
 		acc.AddError(fmt.Errorf("%q: %w", u, err))
 		fields["result_code"] = 2
-		acc.AddFields("ping", fields, tags)
+		acc.AddFields("ping", fields, tags, startTime...)
 		return
 	}
 
@@ -101,7 +106,7 @@ func (p *Ping) pingToURL(u string, acc telegraf.Accumulator) {
 	if stats.stddev >= 0 {
 		fields["standard_deviation_ms"] = stats.stddev
 	}
-	acc.AddFields("ping", fields, tags)
+	acc.AddFields("ping", fields, tags, startTime...)
 }
 
 // args returns the arguments for the 'ping' executable

--- a/plugins/inputs/ping/ping_windows.go
+++ b/plugins/inputs/ping/ping_windows.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/influxdata/telegraf"
 )
@@ -26,6 +27,10 @@ type statistics struct {
 }
 
 func (p *Ping) pingToURL(host string, acc telegraf.Accumulator) {
+	startTime := make([]time.Time, 0)
+	if p.UseStartTime {
+		startTime = append(startTime, time.Now())
+	}
 	tags := map[string]string{"url": host}
 	fields := map[string]interface{}{"result_code": 0}
 
@@ -53,7 +58,7 @@ func (p *Ping) pingToURL(host string, acc telegraf.Accumulator) {
 
 		fields["result_code"] = 2
 		fields["errors"] = 100.0
-		acc.AddFields("ping", fields, tags)
+		acc.AddFields("ping", fields, tags, startTime...)
 		return
 	}
 	// Calculate packet loss percentage
@@ -74,7 +79,7 @@ func (p *Ping) pingToURL(host string, acc telegraf.Accumulator) {
 	if stats.max >= 0 {
 		fields["maximum_response_ms"] = float64(stats.max)
 	}
-	acc.AddFields("ping", fields, tags)
+	acc.AddFields("ping", fields, tags, startTime...)
 }
 
 // args returns the arguments for the 'ping' executable

--- a/plugins/inputs/ping/sample.conf
+++ b/plugins/inputs/ping/sample.conf
@@ -54,3 +54,7 @@
   ## Number of data bytes to be sent. Corresponds to the "-s"
   ## option of the ping command. This only works with the native method.
   # size = 56
+
+  ## Whether or not to use the timestamp of the ping start instead of finish for the metric
+  ## This is useful for trying to look at things like jitter by allowing strict scheduling
+  # use_start_time = false


### PR DESCRIPTION


## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Since ping can take multiple seconds to finish executing, and it may not be uncommon to set the interval between pings to a second, provide an option to calculate the timestamp for the measurement at the start of the collection, rather than the end.  This may make other comparisons (jitter, etc) easier in downstream TSDBs.
## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #16449
