### PR TITLE
chore(outputs.sql): Update ClickHouse Docker image for integration test

### DIFF
--- a/plugins/outputs/sql/testdata/clickhouse/enable_stdout_log.xml
+++ b/plugins/outputs/sql/testdata/clickhouse/enable_stdout_log.xml
@@ -1,0 +1,5 @@
+<clickhouse>
+	<logger>
+		<console>1</console>
+	</logger>
+</clickhouse>


### PR DESCRIPTION
## Summary
The Docker image `yandex/clickhouse-server` that has been used for the integration test hasn't been updated in 3 years. ClickHouse has moved to the Docker image that is called `clickhouse`.

This uses the new image for the integration test.

The log messages have changed, so that is taken into account when waiting for the test container to spin up. Technically waiting for the open port would be enough but for good measure we also wait for a corresponding log output. To get the log output, a config file is included.

## Checklist

- [X] No AI generated code was used in this PR

## Related issues

resolves #16461
