### PR TITLE
chore(outputs.sql): Adapt default templates for ClickHouse

### DIFF
--- a/plugins/outputs/sql/README.md
+++ b/plugins/outputs/sql/README.md
@@ -99,7 +99,11 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ##  {TABLE} - table name as a quoted identifier
   ##  {TABLELITERAL} - table name as a quoted string literal
   ##  {COLUMNS} - column definitions (list of quoted identifiers and types)
+  ##  {TAG_COLUMN_NAMES} - tag column definitions (list of quoted identifiers)
+  ##  {TIMESTAMP_COLUMN_NAME} - the name of the time stamp column, as configured above
   # table_template = "CREATE TABLE {TABLE}({COLUMNS})"
+  ## NOTE: For the clickhouse driver the default is:
+  # table_template = "CREATE TABLE {TABLE}({COLUMNS}) ORDER BY ({TAG_COLUMN_NAMES}, {TIMESTAMP_COLUMN_NAME})"
 
   ## Table existence check template
   ## Available template variables:

--- a/plugins/outputs/sql/sample.conf
+++ b/plugins/outputs/sql/sample.conf
@@ -18,7 +18,11 @@
   ##  {TABLE} - table name as a quoted identifier
   ##  {TABLELITERAL} - table name as a quoted string literal
   ##  {COLUMNS} - column definitions (list of quoted identifiers and types)
+  ##  {TAG_COLUMN_NAMES} - tag column definitions (list of quoted identifiers)
+  ##  {TIMESTAMP_COLUMN_NAME} - the name of the time stamp column, as configured above
   # table_template = "CREATE TABLE {TABLE}({COLUMNS})"
+  ## NOTE: For the clickhouse driver the default is:
+  # table_template = "CREATE TABLE {TABLE}({COLUMNS}) ORDER BY ({TAG_COLUMN_NAMES}, {TIMESTAMP_COLUMN_NAME})"
 
   ## Table existence check template
   ## Available template variables:

--- a/plugins/outputs/sql/sql.go
+++ b/plugins/outputs/sql/sql.go
@@ -153,6 +153,7 @@ func (p *SQL) deriveDatatype(value interface{}) string {
 
 func (p *SQL) generateCreateTable(metric telegraf.Metric) string {
 	columns := make([]string, 0, len(metric.TagList())+len(metric.FieldList())+1)
+	tagColumnNames := make([]string, 0, len(metric.TagList()))
 
 	if p.TimestampColumn != "" {
 		columns = append(columns, fmt.Sprintf("%s %s", quoteIdent(p.TimestampColumn), p.Convert.Timestamp))
@@ -160,6 +161,7 @@ func (p *SQL) generateCreateTable(metric telegraf.Metric) string {
 
 	for _, tag := range metric.TagList() {
 		columns = append(columns, fmt.Sprintf("%s %s", quoteIdent(tag.Key), p.Convert.Text))
+		tagColumnNames = append(tagColumnNames, quoteIdent(tag.Key))
 	}
 
 	var datatype string
@@ -172,6 +174,8 @@ func (p *SQL) generateCreateTable(metric telegraf.Metric) string {
 	query = strings.ReplaceAll(query, "{TABLE}", quoteIdent(metric.Name()))
 	query = strings.ReplaceAll(query, "{TABLELITERAL}", quoteStr(metric.Name()))
 	query = strings.ReplaceAll(query, "{COLUMNS}", strings.Join(columns, ","))
+	query = strings.ReplaceAll(query, "{TAG_COLUMN_NAMES}", strings.Join(tagColumnNames, ","))
+	query = strings.ReplaceAll(query, "{TIMESTAMP_COLUMN_NAME}", quoteIdent(p.TimestampColumn))
 
 	return query
 }
@@ -274,15 +278,30 @@ func (p *SQL) Write(metrics []telegraf.Metric) error {
 	return nil
 }
 
+func (p *SQL) Init() error {
+	if p.TableExistsTemplate == "" {
+		p.TableExistsTemplate = "SELECT 1 FROM {TABLE} LIMIT 1"
+	}
+	if p.TimestampColumn == "" {
+		p.TimestampColumn = "timestamp"
+	}
+	if p.TableTemplate == "" {
+		if p.Driver == "clickhouse" {
+			p.TableTemplate = "CREATE TABLE {TABLE}({COLUMNS}) ORDER BY ({TAG_COLUMN_NAMES}, {TIMESTAMP_COLUMN_NAME})"
+		} else {
+			p.TableTemplate = "CREATE TABLE {TABLE}({COLUMNS})"
+		}
+	}
+
+	return nil
+}
+
 func init() {
 	outputs.Add("sql", func() telegraf.Output { return newSQL() })
 }
 
 func newSQL() *SQL {
 	return &SQL{
-		TableTemplate:       "CREATE TABLE {TABLE}({COLUMNS})",
-		TableExistsTemplate: "SELECT 1 FROM {TABLE} LIMIT 1",
-		TimestampColumn:     "timestamp",
 		Convert: ConvertStruct{
 			Integer:         "INT",
 			Real:            "DOUBLE",

--- a/plugins/outputs/sql/sql_test.go
+++ b/plugins/outputs/sql/sql_test.go
@@ -201,6 +201,7 @@ func TestMysqlIntegration(t *testing.T) {
 	p.Driver = "mysql"
 	p.DataSourceName = address
 	p.InitSQL = "SET sql_mode='ANSI_QUOTES';"
+	require.NoError(t, p.Init())
 
 	require.NoError(t, p.Connect())
 	require.NoError(t, p.Write(
@@ -287,6 +288,7 @@ func TestPostgresIntegration(t *testing.T) {
 	p.Convert.Real = "double precision"
 	p.Convert.Unsigned = "bigint"
 	p.Convert.ConversionStyle = "literal"
+	require.NoError(t, p.Init())
 
 	require.NoError(t, p.Connect())
 	defer p.Close()
@@ -372,7 +374,6 @@ func TestClickHouseIntegration(t *testing.T) {
 	p.Log = testutil.Logger{}
 	p.Driver = "clickhouse"
 	p.DataSourceName = address
-	p.TableTemplate = "CREATE TABLE {TABLE}({COLUMNS}) ENGINE MergeTree() ORDER by timestamp"
 	p.Convert.Integer = "Int64"
 	p.Convert.Text = "String"
 	p.Convert.Timestamp = "DateTime"
@@ -380,6 +381,7 @@ func TestClickHouseIntegration(t *testing.T) {
 	p.Convert.Unsigned = "UInt64"
 	p.Convert.Bool = "UInt8"
 	p.Convert.ConversionStyle = "literal"
+	require.NoError(t, p.Init())
 
 	require.NoError(t, p.Connect())
 	require.NoError(t, p.Write(testMetrics))

--- a/plugins/outputs/sql/sqlite_test.go
+++ b/plugins/outputs/sql/sqlite_test.go
@@ -25,6 +25,7 @@ func TestSqlite(t *testing.T) {
 	p.Log = testutil.Logger{}
 	p.Driver = "sqlite"
 	p.DataSourceName = address
+	require.NoError(t, p.Init())
 
 	require.NoError(t, p.Connect())
 	defer p.Close()


### PR DESCRIPTION
## Summary

The SQL output plugin automatically creates the required table in the target database. For this it uses a default create table template that currently has the value `CREATE TABLE {TABLE}({COLUMNS})` where `{TABLE}` is the metric name and `{COLUMNS}` is a list of column name/type pairs. The plugin has a setting `table_template` to override this template.

ClickHouse requires that in a CREATE TABLE statement a primary key or a sort key is given, thus the default template above does not work with the ClickHouse database.

There is [a section](https://github.com/influxdata/telegraf/blob/51cddd9c94a476604401f48800865e6830d4f7e7/plugins/outputs/sql/README.md#clickhouse) about ClickHouse-specific configuration in the README, but it doesn't mention a mandatory `table_template`.

The integration test solves this issue by hardcoding an override for the template that reads: `CREATE TABLE {TABLE}({COLUMNS}) ENGINE MergeTree() ORDER by timestamp`. In other words, it specifies the timestamp as the sort key.

Specifying only the timestamp as sort key is a valid approach, but it is not recommended in the ClickHouse world because the timestamp has a high cardinality.

This PR makes the following changes:
- Change the default table template from `CREATE TABLE {TABLE}({COLUMNS})` to `CREATE TABLE {TABLE}({COLUMNS}) {SORT_KEY_CLAUSE}`. The placeholder `{SORT_KEY_CLAUSE}` will contain a list of all tag columns when the database is ClickHouse. It will be removed (replaced with an empty string) for any other database.
- Provide another placeholder `{TAG_COLUMNS}` that contains the list of tag columns. You can use this in your `table_template` for example to build a CREATE TABLE statement with extra columns, like this: `CREATE TABLE {TABLE} ({COLUMNS}, my_extra_column int) ORDER BY ({TAG_COLUMNS}, my_extra_column)`
- Remove the hardcoded `table_template` override from the integration test because it is no longer needed to make the test work.

## Checklist

- [X] No AI generated code was used in this PR

## Related issues

resolves #16463
