### PR TITLE
fix(outputs.sql): Fix insert into ClickHouse

### DIFF
--- a/plugins/outputs/sql/sql.go
+++ b/plugins/outputs/sql/sql.go
@@ -187,7 +187,7 @@ func (p *SQL) generateInsert(tablename string, columns []string) string {
 		}
 	}
 
-	return fmt.Sprintf("INSERT INTO %s(%s) VALUES(%s)",
+	return fmt.Sprintf("INSERT INTO %s (%s) VALUES(%s)",
 		quoteIdent(tablename),
 		strings.Join(quotedColumns, ","),
 		strings.Join(placeholders, ","))


### PR DESCRIPTION
## Summary

The clickhouse-go database driver does not like an INSERT without a space after the table name. (https://github.com/ClickHouse/clickhouse-go/issues/1485) This works around that issue by inserting a space there, which is completely valid SQL as well.

## Checklist

- [X] No AI generated code was used in this PR

## Related issues

resolves #16471
