### PR TITLE
feat(inputs.gnmi): Add support for "depth" extension

### DIFF
--- a/plugins/inputs/gnmi/README.md
+++ b/plugins/inputs/gnmi/README.md
@@ -75,11 +75,18 @@ details on how to use them.
   ## gRPC Maximum Message Size
   # max_msg_size = "4MB"
 
+  ## Subtree depth for depth extension (disables if < 1)
+  ## see https://github.com/openconfig/reference/blob/master/rpc/gnmi/gnmi-depth.md
+  # depth = 0
+
   ## Enable to get the canonical path as field-name
   # canonical_field_names = false
 
   ## Remove leading slashes and dots in field-name
   # trim_field_names = false
+
+  ## Only receive updates for the state, also suppresses receiving the initial state
+  # updates_only = false
 
   ## Guess the path-tag if an update does not contain a prefix-path
   ## Supported values are

--- a/plugins/inputs/gnmi/sample.conf
+++ b/plugins/inputs/gnmi/sample.conf
@@ -28,11 +28,18 @@
   ## gRPC Maximum Message Size
   # max_msg_size = "4MB"
 
+  ## Subtree depth for depth extension (disables if < 1)
+  ## see https://github.com/openconfig/reference/blob/master/rpc/gnmi/gnmi-depth.md
+  # depth = 0
+
   ## Enable to get the canonical path as field-name
   # canonical_field_names = false
 
   ## Remove leading slashes and dots in field-name
   # trim_field_names = false
+
+  ## Only receive updates for the state, also suppresses receiving the initial state
+  # updates_only = false
 
   ## Guess the path-tag if an update does not contain a prefix-path
   ## Supported values are

--- a/plugins/inputs/gnmi/sample.conf.in
+++ b/plugins/inputs/gnmi/sample.conf.in
@@ -28,11 +28,18 @@
   ## gRPC Maximum Message Size
   # max_msg_size = "4MB"
 
+  ## Subtree depth for depth extension (disables if < 1)
+  ## see https://github.com/openconfig/reference/blob/master/rpc/gnmi/gnmi-depth.md
+  # depth = 0
+
   ## Enable to get the canonical path as field-name
   # canonical_field_names = false
 
   ## Remove leading slashes and dots in field-name
   # trim_field_names = false
+
+  ## Only receive updates for the state, also suppresses receiving the initial state
+  # updates_only = false
 
   ## Guess the path-tag if an update does not contain a prefix-path
   ## Supported values are


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Adds support for gNMI depth extension to control the depth of the recursion when the server evaluates a group of paths. 

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #16432
