### PR TITLE
fix(agent): Set `godebug x509negativeserial=1` as a workaround

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/influxdata/telegraf
 
 go 1.23.0
 
+godebug x509negativeserial=1
+
 require (
 	cloud.google.com/go/bigquery v1.65.0
 	cloud.google.com/go/monitoring v1.22.0


### PR DESCRIPTION
## Summary
Works around an issue with negative and oversize x509 certificate serial numbers to restore behavior from before Go 1.23. Long term I am communicating with the Go team to see if there is a better solution

## Checklist
- [x] No AI generated code was used in this PR

## Related issues
Related to #16309
