### PR TITLE
doc(outputs.mqtt): Add reference to sprig

### DIFF
--- a/plugins/outputs/mqtt/README.md
+++ b/plugins/outputs/mqtt/README.md
@@ -55,8 +55,9 @@ to use them.
   ## {{ .TopicPrefix }}/{{ .Hostname }}/{{ .PluginName }}/{{ .Tag "tag_key" }}
   ## (e.g. prefix/web01.example.com/mem/some_tag_value)
   ## Each path segment accepts either a template placeholder, an environment variable, or a tag key
-  ## of the form `{{.Tag "tag_key_name"}}`. Empty path elements as well as special MQTT characters
-  ## (such as `+` or `#`) are invalid to form the topic name and will lead to an error.
+  ## of the form `{{.Tag "tag_key_name"}}`. All the functions provided by the Sprig library
+  ## (http://masterminds.github.io/sprig/) are available. Empty path elements as well as special MQTT
+  ## characters (such as `+` or `#`) are invalid to form the topic name and will lead to an error.
   ## In case a tag is missing in the metric, that path segment omitted for the final topic.
   topic = "telegraf/{{ .Hostname }}/{{ .PluginName }}"
 

--- a/plugins/outputs/mqtt/sample.conf
+++ b/plugins/outputs/mqtt/sample.conf
@@ -16,8 +16,9 @@
   ## {{ .TopicPrefix }}/{{ .Hostname }}/{{ .PluginName }}/{{ .Tag "tag_key" }}
   ## (e.g. prefix/web01.example.com/mem/some_tag_value)
   ## Each path segment accepts either a template placeholder, an environment variable, or a tag key
-  ## of the form `{{.Tag "tag_key_name"}}`. Empty path elements as well as special MQTT characters
-  ## (such as `+` or `#`) are invalid to form the topic name and will lead to an error.
+  ## of the form `{{.Tag "tag_key_name"}}`. All the functions provided by the Sprig library
+  ## (http://masterminds.github.io/sprig/) are available. Empty path elements as well as special MQTT
+  ## characters (such as `+` or `#`) are invalid to form the topic name and will lead to an error.
   ## In case a tag is missing in the metric, that path segment omitted for the final topic.
   topic = "telegraf/{{ .Hostname }}/{{ .PluginName }}"
 


### PR DESCRIPTION
## Summary
There is no indication that sprig can be used to generate the topic. I only know because I was reading the change log. If there is a better place to put this information let me know.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x ] No AI generated code was used in this PR
