### PR TITLE
feat(outputs.mqtt): Add sprig for topic name generator for homie layout

### DIFF
--- a/plugins/outputs/mqtt/README.md
+++ b/plugins/outputs/mqtt/README.md
@@ -200,7 +200,7 @@ while `homie_node_id` will provide a template for the `node-id` part of the
 topic. Both options can contain [Go templates][GoTemplates] similar to `topic`
 with `{{ .PluginName }}` referencing the metric name and `{{ .Tag "key"}}`
 referencing the tag with the name `key`.
-[Sprig](http://masterminds.github.io/sprig/) helper functions are also available.
+[Sprig](http://masterminds.github.io/sprig/) helper functions are available.
 
 For example writing the metrics
 

--- a/plugins/outputs/mqtt/README.md
+++ b/plugins/outputs/mqtt/README.md
@@ -199,7 +199,7 @@ used to specify the `device-id` path. The __mandatory__ options
 while `homie_node_id` will provide a template for the `node-id` part of the
 topic. Both options can contain [Go templates][GoTemplates] similar to `topic`
 with `{{ .PluginName }}` referencing the metric name and `{{ .Tag "key"}}`
-referencing the tag with the name `key`.
+referencing the tag with the name `key`. [Sprig](http://masterminds.github.io/sprig/) helper functions are also available.
 
 For example writing the metrics
 

--- a/plugins/outputs/mqtt/README.md
+++ b/plugins/outputs/mqtt/README.md
@@ -199,7 +199,8 @@ used to specify the `device-id` path. The __mandatory__ options
 while `homie_node_id` will provide a template for the `node-id` part of the
 topic. Both options can contain [Go templates][GoTemplates] similar to `topic`
 with `{{ .PluginName }}` referencing the metric name and `{{ .Tag "key"}}`
-referencing the tag with the name `key`. [Sprig](http://masterminds.github.io/sprig/) helper functions are also available.
+referencing the tag with the name `key`.
+[Sprig](http://masterminds.github.io/sprig/) helper functions are also available.
 
 For example writing the metrics
 

--- a/plugins/outputs/mqtt/homie.go
+++ b/plugins/outputs/mqtt/homie.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/Masterminds/sprig/v3"
+
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/internal"
 )
@@ -102,7 +104,7 @@ type HomieGenerator struct {
 }
 
 func NewHomieGenerator(tmpl string) (*HomieGenerator, error) {
-	tt, err := template.New("topic_name").Parse(tmpl)
+	tt, err := template.New("topic_name").Funcs(sprig.TxtFuncMap()).Parse(tmpl)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
This is to make the homie `topic_name` consistent with the normal mqtt `topic_name` templating.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR
