### PR TITLE
feat(processors.template): Add sprig function for templates

### DIFF
--- a/plugins/processors/template/README.md
+++ b/plugins/processors/template/README.md
@@ -7,6 +7,7 @@ routing option.
 
 The template has access to each metric's measurement name, tags, fields, and
 timestamp using the [interface in `/template_metric.go`](template_metric.go).
+[Sprig](http://masterminds.github.io/sprig/) helper functions are available.
 
 Read the full [Go Template Documentation][].
 

--- a/plugins/processors/template/template.go
+++ b/plugins/processors/template/template.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/Masterminds/sprig/v3"
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/plugins/processors"
 )
@@ -64,12 +65,12 @@ func (r *TemplateProcessor) Apply(in ...telegraf.Metric) []telegraf.Metric {
 func (r *TemplateProcessor) Init() error {
 	var err error
 
-	r.tmplTag, err = template.New("tag template").Parse(r.Tag)
+	r.tmplTag, err = template.New("tag template").Funcs(sprig.TxtFuncMap()).Parse(r.Tag)
 	if err != nil {
 		return fmt.Errorf("creating tag name template failed: %w", err)
 	}
 
-	r.tmplValue, err = template.New("value template").Parse(r.Template)
+	r.tmplValue, err = template.New("value template").Funcs(sprig.TxtFuncMap()).Parse(r.Template)
 	if err != nil {
 		return fmt.Errorf("creating value template failed: %w", err)
 	}


### PR DESCRIPTION
## Summary
This enables the use of sprig functions in the template processor

## Checklist

- [x] No AI generated code was used in this PR