### PR TITLE
fix(inputs.proxmox): Allow search domain to be empty

### DIFF
--- a/plugins/inputs/proxmox/README.md
+++ b/plugins/inputs/proxmox/README.md
@@ -25,9 +25,7 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   api_token = "USER@REALM!TOKENID=UUID"
 
   ## Node name, defaults to OS hostname
-  ## Unless Telegraf is on the same host as Proxmox, setting this is required
-  ## for Telegraf to successfully connect to Proxmox. If not on the same host,
-  ## leaving this empty will often lead to a "search domain is not set" error.
+  ## Unless Telegraf is on the same host as Proxmox, setting this is required.
   # node_name = ""
 
   ## Additional tags of the VM stats data to add as a tag

--- a/plugins/inputs/proxmox/sample.conf
+++ b/plugins/inputs/proxmox/sample.conf
@@ -6,9 +6,7 @@
   api_token = "USER@REALM!TOKENID=UUID"
 
   ## Node name, defaults to OS hostname
-  ## Unless Telegraf is on the same host as Proxmox, setting this is required
-  ## for Telegraf to successfully connect to Proxmox. If not on the same host,
-  ## leaving this empty will often lead to a "search domain is not set" error.
+  ## Unless Telegraf is on the same host as Proxmox, setting this is required.
   # node_name = ""
 
   ## Additional tags of the VM stats data to add as a tag


### PR DESCRIPTION
## Summary

Currently, Telegraf errors out if no search domain is configured for the proxmox node. However, the search domain is only used for outputting the FQDN for the node (and VM). This PR prevents Telegraf from erroring out at the cost of not getting the FQDN of the node.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #16475 
