### PR TITLE
feat(outputs.cloudwatch): Set namespace with a template

### DIFF
--- a/plugins/outputs/cloudwatch/README.md
+++ b/plugins/outputs/cloudwatch/README.md
@@ -79,7 +79,9 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   # use_system_proxy = false
   # http_proxy_url = "http://localhost:8888"
 
-  ## Namespace for the CloudWatch MetricDatums
+  ## Namespace for the CloudWatch MetricDatums. A Go template can be used to
+  ## specify the namespace based on a tag `{{.Tag "namespace"}}`. All functions
+  ## of the Sprig library (http://masterminds.github.io/sprig/) are available.
   namespace = "InfluxData/Telegraf"
 
   ## If you have a large amount of metrics, you should consider to send

--- a/plugins/outputs/cloudwatch/cloudwatch.go
+++ b/plugins/outputs/cloudwatch/cloudwatch.go
@@ -201,7 +201,7 @@ func (c *CloudWatch) Write(metrics []telegraf.Metric) error {
 	const maxDatumsPerCall = 1000
 
 	for _, partition := range PartitionDatums(maxDatumsPerCall, datums) {
-		err := c.WriteToCloudWatch(partition)
+		err := c.WriteToCloudWatch(c.Namespace, partition)
 		if err != nil {
 			return err
 		}
@@ -210,10 +210,10 @@ func (c *CloudWatch) Write(metrics []telegraf.Metric) error {
 	return nil
 }
 
-func (c *CloudWatch) WriteToCloudWatch(datums []types.MetricDatum) error {
+func (c *CloudWatch) WriteToCloudWatch(namespace string, datums []types.MetricDatum) error {
 	params := &cloudwatch.PutMetricDataInput{
 		MetricData: datums,
-		Namespace:  aws.String(c.Namespace),
+		Namespace:  aws.String(namespace),
 	}
 
 	_, err := c.svc.PutMetricData(context.Background(), params)

--- a/plugins/outputs/cloudwatch/namespace_generator.go
+++ b/plugins/outputs/cloudwatch/namespace_generator.go
@@ -23,7 +23,7 @@ func NewNamespaceGenerator(namespace string) (*NamespaceGenerator, error) {
 
 func (t *NamespaceGenerator) Generate(m telegraf.Metric) (string, error) {
 	var b strings.Builder
-	err := t.template.Execute(&b, t)
+	err := t.template.Execute(&b, m)
 	if err != nil {
 		return "", err
 	}

--- a/plugins/outputs/cloudwatch/namespace_generator.go
+++ b/plugins/outputs/cloudwatch/namespace_generator.go
@@ -1,0 +1,32 @@
+package cloudwatch
+
+import (
+	"strings"
+	"text/template"
+
+	"github.com/Masterminds/sprig/v3"
+	"github.com/influxdata/telegraf"
+)
+
+type NamespaceGenerator struct {
+	metric   telegraf.Metric
+	template *template.Template
+}
+
+func NewNamespaceGenerator(namespace string) (*NamespaceGenerator, error) {
+	nt, err := template.New("namespace").Funcs(sprig.TxtFuncMap()).Parse(namespace)
+	if err != nil {
+		return nil, err
+	}
+	return &NamespaceGenerator{template: nt}, nil
+}
+
+func (t *NamespaceGenerator) Generate(m telegraf.Metric) (string, error) {
+	var b strings.Builder
+	err := t.template.Execute(&b, t)
+	if err != nil {
+		return "", err
+	}
+
+	return b.String(), nil
+}

--- a/plugins/outputs/cloudwatch/sample.conf
+++ b/plugins/outputs/cloudwatch/sample.conf
@@ -32,7 +32,9 @@
   # use_system_proxy = false
   # http_proxy_url = "http://localhost:8888"
 
-  ## Namespace for the CloudWatch MetricDatums
+  ## Namespace for the CloudWatch MetricDatums. A Go template can be used to
+  ## specify the namespace based on a tag `{{.Tag "namespace"}}`. All functions
+  ## of the Sprig library (http://masterminds.github.io/sprig/) are available.
   namespace = "InfluxData/Telegraf"
 
   ## If you have a large amount of metrics, you should consider to send


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
This allows metrics that need to be sent to different cloudwatch namespaces to use tags to route the metrics appropriately, instead of having to specify a different cloudwatch output for each namespace.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #16499
