### PR TITLE
fix(internal): Fix plural acronyms in SnakeCase function

### DIFF
--- a/internal/internal.go
+++ b/internal/internal.go
@@ -112,8 +112,15 @@ func SnakeCase(in string) string {
 
 	var out []rune
 	for i := 0; i < length; i++ {
-		if i > 0 && unicode.IsUpper(runes[i]) && ((i+1 < length && unicode.IsLower(runes[i+1])) || unicode.IsLower(runes[i-1])) {
-			out = append(out, '_')
+		if i > 0 && unicode.IsUpper(runes[i]) {
+			prevLower := unicode.IsLower(runes[i-1])
+			nextLower := i+1 < length && unicode.IsLower(runes[i+1])
+			// Special case for plural acronyms
+			nextPlural := i+1 < length && runes[i+1] == 's'
+
+			if prevLower || (nextLower && !nextPlural) {
+				out = append(out, '_')
+			}
 		}
 		out = append(out, unicode.ToLower(runes[i]))
 	}

--- a/internal/internal_test.go
+++ b/internal/internal_test.go
@@ -34,6 +34,7 @@ var tests = []SnakeTest{
 	{"LinuxMOTD", "linux_motd"},
 	{"OMGWTFBBQ", "omgwtfbbq"},
 	{"omg_wtf_bbq", "omg_wtf_bbq"},
+	{"ConsumedLCUs", "consumed_lcus"},
 }
 
 func TestSnakeCase(t *testing.T) {


### PR DESCRIPTION
## Summary
Fixes plural acronyms being split up into "separate words" for snake case. Example:
- `SnakeIDGoogle` gets split into `snake_id_google`
- `ConsumedLCUs` would get split into `consumed_lc_us`, since it assumes that `Us` is the "next word

Now will return `consumed_lcus`, having a special case for acronyms like `LCUs` (ending in 's')

## Checklist
- [X] No AI generated code was used in this PR

## Related issues
resolves #16496
