### PR TITLE
feat(opcua_listener.event_streaming_input)

### DIFF
--- a/plugins/inputs/opcua_listener/README.md
+++ b/plugins/inputs/opcua_listener/README.md
@@ -1,6 +1,6 @@
 # OPC UA Client Listener Input Plugin
 
-The `opcua_listener` plugin subscribes to data from OPC UA Server devices.
+The `opcua_listener` plugin subscribes to data & events from OPC UA Server devices.
 
 Telegraf minimum version: Telegraf 1.25
 Plugin minimum tested version: 1.25
@@ -258,6 +258,15 @@ to use them.
   # [inputs.opcua_listener.request_workarounds]
     ## Use unregistered reads instead of registered reads
     # use_unregistered_reads = false
+
+
+  ##Event Streaming
+  # [inputs.opcua_listener.event_streaming_input]
+    # streaming_interval = "10s"
+    # streaming_event_type = "ns=0;i=2041"
+    # streaming_node_ids = ["ns=2;s=0:East/Blue"]
+    # streaming_fields = ["Severity", "Message", "Time"]
+    # streaming_source_names = ["SourceName1", "SourceName2"]
 ```
 
 ## Node Configuration
@@ -342,16 +351,44 @@ This example group configuration has three groups with two nodes each:
     ]
 ```
 
+## Event Streaming Configuration
+
+This plugin furthermore enables monitoring of
+OPC UA events by subscribing to specific node IDs and filtering events based on
+event_type and source_name.
+Once configured, Telegraf subscribes to the specified event_type’s Node-ID,
+and collects events that meet the defined criteria.
+The `node_ids` parameter specifies the nodes to monitor for
+events (monitored items).
+However, the actual subscription is based on the `event_type`,
+which determines the events that are capture.
+
+## Event Streaming Configuration Parameters
+
+- `streaming_interval` Polling interval for data collection, e.g., 10s.
+- `streaming_node_ids` A list of OPC UA node identifiers (NodeIds) specifying the nodes to monitor for event notifications, which are associated with the defined event type.
+- `streaming_event_type` Defines the type or level of events to capture from the monitored nodes.
+- `streaming_fields` Specifies the fields to capture from event notifications.
+- `streaming_source_names` Specifies OPCUA Event source_names to filter on (optional)
+
 ## Connection Service
 
 This plugin subscribes to the specified nodes to receive data from
 the OPC server. The updates are received at most as fast as the
-`subscription_interval`.
+`subscription_interval`. Events are received within intervalls defined in `streaming_interval`
 
 ## Metrics
 
 The metrics collected by this input plugin will depend on the
 configured `nodes` and `group`.
+
+## Metrics (Event Streaming)
+
+Measurement names are based on the OPC UA fields selected in the
+telegraf config.
+All the fields are added to the Output `fields`.
+All metrics receive the node_id & opcua_host `tags` indicating
+the related NodeID and OPCUA Server where the event is coming from.
 
 ## Example Output
 
@@ -360,4 +397,24 @@ group1_metric_name,group1_tag=val1,id=ns\=3;i\=1001,node1_tag=val2 name=0,Qualit
 group1_metric_name,group1_tag=val1,id=ns\=3;i\=1002,node1_tag=val3 name=-1.389117,Quality="OK (0x0)" 1606893246000000000
 group2_metric_name,group2_tag=val3,id=ns\=3;i\=1003,node2_tag=val4 Quality="OK (0x0)",saw=-1.6 1606893246000000000
 group2_metric_name,group2_tag=val3,id=ns\=3;i\=1004 sin=1.902113,Quality="OK (0x0)" 1606893246000000000
+```
+
+## Example Output (Event Streaming)
+
+```text
+{
+    "fields": {
+        "EventType": "i=10751",
+        "Message": "The alarm severity has increased.",
+        "SourceName": "SouthMotor",
+        "Time": "2024-12-09 07:46:48.8492578 +0000 UTC"
+    },
+    "name": "opcua_event_subscription",
+    "tags": {
+        "host": "myHost",
+        "node_id": "ns=2;s=0:East/Blue",
+        "opcua_host": "opc.tcp://opcua.demo-this.com:62544/Quickstarts/AlarmConditionServer"
+    },
+    "timestamp": 1733730411
+}
 ```

--- a/plugins/inputs/opcua_listener/opcua_listener.go
+++ b/plugins/inputs/opcua_listener/opcua_listener.go
@@ -64,19 +64,43 @@ func (o *OpcUaListener) Stop() {
 
 func (o *OpcUaListener) connect(acc telegraf.Accumulator) error {
 	ctx := context.Background()
+
+	err := o.client.connect()
+	if err != nil {
+		switch o.client.Config.ConnectFailBehavior {
+		case "retry":
+			o.Log.Warnf("Failed to connect to OPC UA server %s. Will attempt to connect again at the next interval: %s", o.client.Config.Endpoint, err)
+		case "ignore":
+			o.Log.Errorf("Failed to connect to OPC UA server %s. Will not retry: %s", o.client.Config.Endpoint, err)
+		}
+		return err
+	}
 	ch, err := o.client.startStreamValues(ctx)
+	if err != nil {
+		return err
+	}
+
+	chEvents, err := o.client.startStreamEvents(ctx)
 	if err != nil {
 		return err
 	}
 
 	go func() {
 		for {
-			m, ok := <-ch
-			if !ok {
-				o.Log.Debug("Metric collection stopped due to closed channel")
-				return
+			select {
+			case m, ok := <-ch:
+				if !ok {
+					o.Log.Debug("Metric collection stopped due to closed channel")
+					return
+				}
+				acc.AddMetric(m)
+			case m, ok := <-chEvents:
+				if !ok {
+					o.Log.Debug("Event collection stopped due to closed channel")
+					return
+				}
+				acc.AddMetric(m)
 			}
-			acc.AddMetric(m)
 		}
 	}()
 

--- a/plugins/inputs/opcua_listener/sample.conf
+++ b/plugins/inputs/opcua_listener/sample.conf
@@ -219,3 +219,12 @@
   # [inputs.opcua_listener.request_workarounds]
     ## Use unregistered reads instead of registered reads
     # use_unregistered_reads = false
+
+
+  ##Event Streaming
+  # [inputs.opcua_listener.event_streaming_input]
+    # streaming_interval = "10s"
+    # streaming_event_type = "ns=0;i=2041"
+    # streaming_node_ids = ["ns=2;s=0:East/Blue"]
+    # streaming_source_names = ["SourceName1", "SourceName2"]
+    # streaming_fields = ["Severity", "Message", "Time"]


### PR DESCRIPTION
## Summary
This new feature in opcua_listener is useful to subscribe to OPC UA node ids to receive upcoming events on the subscribed nodes.



## Checklist
- [x ] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
resolves https://github.com/influxdata/telegraf/issues/16275
replaces https://github.com/influxdata/telegraf/pull/16300