### PR TITLE
docs(aggregators): Document default settings for period, delay and grace

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -593,14 +593,17 @@ Parameters that can be used with any aggregator plugin:
 - **period**: The period on which to flush & clear each aggregator. All
   metrics that are sent with timestamps outside of this period will be ignored
   by the aggregator.
+  The default period is set to 30 seconds.
 - **delay**: The delay before each aggregator is flushed. This is to control
   how long for aggregators to wait before receiving metrics from input
   plugins, in the case that aggregators are flushing and inputs are gathering
   on the same interval.
+  The default delay is set to 100 ms.
 - **grace**: The duration when the metrics will still be aggregated
   by the plugin, even though they're outside of the aggregation period. This
   is needed in a situation when the agent is expected to receive late metrics
   and it's acceptable to roll them up into next aggregation period.
+  The default grace duration is set to 0 s.
 - **drop_original**: If true, the original metric will be dropped by the
   aggregator and will not get sent to the output plugins.
 - **name_override**: Override the base name of the measurement.  (Default is

--- a/plugins/aggregators/merge/README.md
+++ b/plugins/aggregators/merge/README.md
@@ -24,26 +24,15 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 ```toml @sample.conf
 # Merge metrics into multifield metrics by series key
 [[aggregators.merge]]
+  ## General Aggregator Arguments:
+  ## The period on which to flush & clear the aggregator.
+  # period = "30s"
+
   ## Precision to round the metric timestamp to
   ## This is useful for cases where metrics to merge arrive within a small
   ## interval and thus vary in timestamp. The timestamp of the resulting metric
   ## is also rounded.
   # round_timestamp_to = "1ns"
-
-  ## The period on which to flush & clear each aggregator. 
-  ## All metrics that are sent with timestamps outside of this period will be ignored by the aggregator.
-  # period = "30s"
-
-  ## The delay before each aggregator is flushed. 
-  ## This is to control how long for aggregators to wait before receiving metrics from input plugins, 
-  ## in the case that aggregators are flushing and inputs are gathering on the same interval.
-  # delay = "100ms"
-
-  ## The duration when the metrics will still be aggregated by the plugin, 
-  ## even though they're outside of the aggregation period. 
-  ## This is needed in a situation when the agent is expected to receive late metrics 
-  ## and it's acceptable to roll them up into next aggregation period.  
-  # grace = "0s"
 
   ## If true, the original metric will be dropped by the
   ## aggregator and will not get sent to the output plugins.

--- a/plugins/aggregators/merge/README.md
+++ b/plugins/aggregators/merge/README.md
@@ -30,6 +30,21 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## is also rounded.
   # round_timestamp_to = "1ns"
 
+  ## The period on which to flush & clear each aggregator. 
+  ## All metrics that are sent with timestamps outside of this period will be ignored by the aggregator.
+  # period = "30s"
+
+  ## The delay before each aggregator is flushed. 
+  ## This is to control how long for aggregators to wait before receiving metrics from input plugins, 
+  ## in the case that aggregators are flushing and inputs are gathering on the same interval.
+  # delay = "100ms"
+
+  ## The duration when the metrics will still be aggregated by the plugin, 
+  ## even though they're outside of the aggregation period. 
+  ## This is needed in a situation when the agent is expected to receive late metrics 
+  ## and it's acceptable to roll them up into next aggregation period.  
+  # grace = "0s"
+
   ## If true, the original metric will be dropped by the
   ## aggregator and will not get sent to the output plugins.
   drop_original = true

--- a/plugins/aggregators/merge/sample.conf
+++ b/plugins/aggregators/merge/sample.conf
@@ -6,6 +6,21 @@
   ## is also rounded.
   # round_timestamp_to = "1ns"
 
+  ## The period on which to flush & clear each aggregator. 
+  ## All metrics that are sent with timestamps outside of this period will be ignored by the aggregator.
+  # period = "30s"
+
+  ## The delay before each aggregator is flushed. 
+  ## This is to control how long for aggregators to wait before receiving metrics from input plugins, 
+  ## in the case that aggregators are flushing and inputs are gathering on the same interval.
+  # delay = "100ms"
+
+  ## The duration when the metrics will still be aggregated by the plugin, 
+  ## even though they're outside of the aggregation period. 
+  ## This is needed in a situation when the agent is expected to receive late metrics 
+  ## and it's acceptable to roll them up into next aggregation period.  
+  # grace = "0s"
+
   ## If true, the original metric will be dropped by the
   ## aggregator and will not get sent to the output plugins.
   drop_original = true

--- a/plugins/aggregators/merge/sample.conf
+++ b/plugins/aggregators/merge/sample.conf
@@ -1,25 +1,14 @@
 # Merge metrics into multifield metrics by series key
 [[aggregators.merge]]
+  ## General Aggregator Arguments:
+  ## The period on which to flush & clear the aggregator.
+  # period = "30s"
+
   ## Precision to round the metric timestamp to
   ## This is useful for cases where metrics to merge arrive within a small
   ## interval and thus vary in timestamp. The timestamp of the resulting metric
   ## is also rounded.
   # round_timestamp_to = "1ns"
-
-  ## The period on which to flush & clear each aggregator. 
-  ## All metrics that are sent with timestamps outside of this period will be ignored by the aggregator.
-  # period = "30s"
-
-  ## The delay before each aggregator is flushed. 
-  ## This is to control how long for aggregators to wait before receiving metrics from input plugins, 
-  ## in the case that aggregators are flushing and inputs are gathering on the same interval.
-  # delay = "100ms"
-
-  ## The duration when the metrics will still be aggregated by the plugin, 
-  ## even though they're outside of the aggregation period. 
-  ## This is needed in a situation when the agent is expected to receive late metrics 
-  ## and it's acceptable to roll them up into next aggregation period.  
-  # grace = "0s"
 
   ## If true, the original metric will be dropped by the
   ## aggregator and will not get sent to the output plugins.


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

Adds the default settings for period, delay and grace to the aggregator plugin readme. Additionally, the merge aggregator sample config is extended with an explanation and the default setting for period, delay and grace.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #16181
