### PR TITLE
fix(outputs.opensearch): Use correct pipeline name while creating bulk-indexers

### DIFF
--- a/plugins/outputs/opensearch/opensearch.go
+++ b/plugins/outputs/opensearch/opensearch.go
@@ -324,7 +324,7 @@ func getTargetIndexers(metrics []telegraf.Metric, osInst *Opensearch) map[string
 
 			if pipelineName != "" {
 				// BulkIndexer supports pipeline at config level not metric level
-				if _, ok := indexers[osInst.pipelineName]; ok {
+				if _, ok := indexers[pipelineName]; ok {
 					continue
 				}
 				bulkIndxr, err := createBulkIndexer(osInst, pipelineName)

--- a/plugins/outputs/opensearch/opensearch.go
+++ b/plugins/outputs/opensearch/opensearch.go
@@ -52,7 +52,6 @@ type Opensearch struct {
 	Log                 telegraf.Logger `toml:"-"`
 	tls.ClientConfig
 
-	pipelineName string
 	indexTmpl    *template.Template
 	pipelineTmpl *template.Template
 	onSucc       func(context.Context, opensearchutil.BulkIndexerItem, opensearchutil.BulkIndexerResponseItem)


### PR DESCRIPTION
## Summary
We are performing an incorrect check when verifying the existence of an `opensearchutil.BulkIndexer`, leading to the creation of multiple instances. This excessive instantiation results in a memory leak.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #16295
