### PR TITLE
fix(serializers.prometheus): Use legacy validation for metric name

### DIFF
--- a/plugins/serializers/prometheus/convert.go
+++ b/plugins/serializers/prometheus/convert.go
@@ -88,7 +88,7 @@ func sanitize(name string, table Table) (string, bool) {
 // not, it attempts to replaces invalid runes with an underscore to create a
 // valid name.
 func SanitizeMetricName(name string) (string, bool) {
-	if model.IsValidMetricName(model.LabelValue(name)) {
+	if model.IsValidLegacyMetricName(name) {
 		return name, true
 	}
 	return sanitize(name, MetricNameTable)

--- a/plugins/serializers/prometheusremotewrite/prometheusremotewrite.go
+++ b/plugins/serializers/prometheusremotewrite/prometheusremotewrite.go
@@ -46,10 +46,12 @@ func (s *Serializer) SerializeBatch(metrics []telegraf.Metric) ([]byte, error) {
 		var metrickey MetricKey
 		var promts prompb.TimeSeries
 		for _, field := range metric.FieldList() {
-			metricName := prometheus.MetricName(metric.Name(), field.Key, metric.Type())
-			metricName, ok := prometheus.SanitizeMetricName(metricName)
+			rawName := prometheus.MetricName(metric.Name(), field.Key, metric.Type())
+			fmt.Println("raw:", rawName)
+			metricName, ok := prometheus.SanitizeMetricName(rawName)
+			fmt.Println("sanitized:", metricName)
 			if !ok {
-				traceAndKeepErr("failed to parse metric name %q", metricName)
+				traceAndKeepErr("failed to parse metric name %q", rawName)
 				continue
 			}
 

--- a/plugins/serializers/prometheusremotewrite/prometheusremotewrite.go
+++ b/plugins/serializers/prometheusremotewrite/prometheusremotewrite.go
@@ -47,9 +47,7 @@ func (s *Serializer) SerializeBatch(metrics []telegraf.Metric) ([]byte, error) {
 		var promts prompb.TimeSeries
 		for _, field := range metric.FieldList() {
 			rawName := prometheus.MetricName(metric.Name(), field.Key, metric.Type())
-			fmt.Println("raw:", rawName)
 			metricName, ok := prometheus.SanitizeMetricName(rawName)
-			fmt.Println("sanitized:", metricName)
 			if !ok {
 				traceAndKeepErr("failed to parse metric name %q", rawName)
 				continue

--- a/plugins/serializers/prometheusremotewrite/prometheusremotewrite_test.go
+++ b/plugins/serializers/prometheusremotewrite/prometheusremotewrite_test.go
@@ -220,7 +220,7 @@ func TestRemoteWriteSerializeNegative(t *testing.T) {
 
 	m := testutil.MustMetric("@@!!", nil, map[string]interface{}{"!!": "@@"}, time.Unix(0, 0))
 	_, err := s.Serialize(m)
-	assert("failed to parse \"@@!!_!!\"", err)
+	assert("failed to parse metric name \"@@!!_!!\"", err)
 
 	m = testutil.MustMetric("prometheus", nil,
 		map[string]interface{}{


### PR DESCRIPTION
## Summary

With PR #16453  we bumped the prometheus package which in turn changed the validation scheme for metric-names and labels to only being UTF-8 conform. However, while changing the label validation scheme back to "legacy" the metric name validation was not. This PR fixes the metric name validation and reverts the check to "legacy". This PR is also relevant for the `prometheusremotewrite` serializer as it reuses the sanitization code.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #16550 
