### PR TITLE
feat(outputs.prometheus_client): Allow adding custom headers

### DIFF
--- a/plugins/outputs/prometheus_client/README.md
+++ b/plugins/outputs/prometheus_client/README.md
@@ -81,6 +81,9 @@ to use them.
   ## Export metric collection time.
   # export_timestamp = false
 
+  ## Set custom headers for HTTP responses.
+  # http_headers = {"X-Special-Header" = "Special-Value"}
+
   ## Specify the metric type explicitly.
   ## This overrides the metric-type of the Telegraf metric. Globbing is allowed.
   # [outputs.prometheus_client.metric_types]

--- a/plugins/outputs/prometheus_client/sample.conf
+++ b/plugins/outputs/prometheus_client/sample.conf
@@ -49,6 +49,9 @@
   ## Export metric collection time.
   # export_timestamp = false
 
+  ## Set custom headers for HTTP responses.
+  # http_headers = {"X-Special-Header" = "Special-Value"}
+
   ## Specify the metric type explicitly.
   ## This overrides the metric-type of the Telegraf metric. Globbing is allowed.
   # [outputs.prometheus_client.metric_types]


### PR DESCRIPTION
## Summary
Allow simple setting of custom headers in prometheus_client's HTTP response, in this case to meet security requirements, but also just as a generally useful feature.

## Checklist
- [x] No AI generated code was used in this PR

## Related issues
resolves #16565
