### PR TITLE
feat(outputs.nats): Use Jetstream publisher when using Jetstream

### DIFF
--- a/plugins/outputs/nats/nats.go
+++ b/plugins/outputs/nats/nats.go
@@ -264,8 +264,11 @@ func (n *NATS) Write(metrics []telegraf.Metric) error {
 			n.Log.Debugf("Could not serialize metric: %v", err)
 			continue
 		}
-		// use the same Publish API for nats core and jetstream
-		err = n.conn.Publish(n.Subject, buf)
+		if n.Jetstream != nil {
+			_, err = n.jetstreamClient.Publish(context.Background(), n.Subject, buf, jetstream.WithExpectStream(n.Jetstream.Name))
+		} else {
+			err = n.conn.Publish(n.Subject, buf)
+		}
 		if err != nil {
 			return fmt.Errorf("failed to send NATS message: %w", err)
 		}


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
The NATS output plugin use the NATS Core publisher both for Core and Jetstream. This can be problematic when publishing many messages to a Jetsteam, you do not have `pack` and can overload the server. This PR change publisher to use Jetstream publisher insted of Core when publishing to Jetstream. 

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #16571
