### PR TITLE
chore(inputs.vsphere): Improve metric collection error logging

### DIFF
--- a/plugins/inputs/vsphere/endpoint.go
+++ b/plugins/inputs/vsphere/endpoint.go
@@ -1156,7 +1156,7 @@ func (e *endpoint) collectResource(ctx context.Context, resourceType string, acc
 			n, localLatest, err := e.collectChunk(ctx, chunk, res, acc, estInterval)
 			e.log.Debugf("CollectChunk for %s returned %d metrics", resourceType, n)
 			if err != nil {
-				acc.AddError(errors.New("while collecting " + res.name + ": " + err.Error()))
+				acc.AddError(errors.New("while collecting " + res.name + " for vcenter " + e.url.Host + ": " + err.Error()))
 				return
 			}
 			e.parent.Log.Debugf("CollectChunk for %s returned %d metrics", resourceType, n)


### PR DESCRIPTION
## Summary
Includes the vcenter name in error logging when an accumulator error is added 

## Checklist
- [x] No AI generated code was used in this PR

## Related issues
resolves #16567