### PR TITLE
fix(inputs.net): Skip checks in containerized environments

### DIFF
--- a/plugins/inputs/net/net.go
+++ b/plugins/inputs/net/net.go
@@ -45,6 +45,11 @@ func (n *Net) Init() error {
 		)
 	}
 
+	// So not use the interface list of the system if the HOST_PROC variable is
+	// set as the interfaces are determined by a syscall and therefore might
+	// differ especially in container environments.
+	n.skipChecks = os.Getenv("HOST_PROC") != ""
+
 	return nil
 }
 


### PR DESCRIPTION
## Summary

When running in containerized environments existing interface checks fail for cases where `procfs` is not mounted in `/proc` because the `net.Interfaces()` function will perform a syscall not taking the `HOST_PROC` environment variable into account. Therefore, this PR will _disable_ the checks in cases where the `HOST_PROC` environment variable is set.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #16564 
