### PR TITLE
feat(outputs.nats): Allow asynchronous publishing for Jetstream

### DIFF
--- a/plugins/outputs/nats/README.md
+++ b/plugins/outputs/nats/README.md
@@ -78,6 +78,7 @@ to use them.
     # async_publish = false
 
     ## Timeout for wating on acknowledgement on asynchronous publishing
+    ## String with valid units "ns", "us" (or "µs"), "ms", "s", "m", "h".
     # async_ack_timeout = "5s"
 
     ## Full jetstream create stream config, refer: https://docs.nats.io/nats-concepts/jetstream/streams

--- a/plugins/outputs/nats/README.md
+++ b/plugins/outputs/nats/README.md
@@ -74,6 +74,9 @@ to use them.
     # name = ""
     # subjects = []
 
+    ## Use asynchronous publishing for higher throughput, but note that it does not guarantee order within batches.
+    # async_publish = false
+
     ## Full jetstream create stream config, refer: https://docs.nats.io/nats-concepts/jetstream/streams
     # retention = "limits"
     # max_consumers = -1

--- a/plugins/outputs/nats/README.md
+++ b/plugins/outputs/nats/README.md
@@ -77,6 +77,10 @@ to use them.
     ## Use asynchronous publishing for higher throughput, but note that it does not guarantee order within batches.
     # async_publish = false
 
+    ## Timeout for wating on acknowledgement on asynchronous publishing
+    ## String with valid units "ns", "us" (or "µs"), "ms", "s", "m", "h".
+    # async_ack_timeout = "5s"
+
     ## Full jetstream create stream config, refer: https://docs.nats.io/nats-concepts/jetstream/streams
     # retention = "limits"
     # max_consumers = -1

--- a/plugins/outputs/nats/README.md
+++ b/plugins/outputs/nats/README.md
@@ -78,7 +78,6 @@ to use them.
     # async_publish = false
 
     ## Timeout for wating on acknowledgement on asynchronous publishing
-    ## String with valid units "ns", "us" (or "µs"), "ms", "s", "m", "h".
     # async_ack_timeout = "5s"
 
     ## Full jetstream create stream config, refer: https://docs.nats.io/nats-concepts/jetstream/streams

--- a/plugins/outputs/nats/nats.go
+++ b/plugins/outputs/nats/nats.go
@@ -309,7 +309,6 @@ func init() {
 	outputs.Add("nats", func() telegraf.Output {
 		return &NATS{
 			Jetstream: &StreamConfig{
-				// Default to 5s timeout
 				AsyncAckTimeout: config.Duration(time.Second * 5),
 			},
 		}

--- a/plugins/outputs/nats/nats.go
+++ b/plugins/outputs/nats/nats.go
@@ -299,7 +299,7 @@ func (n *NATS) Write(metrics []telegraf.Metric) error {
 				}
 			}
 		case <-time.After(time.Duration(n.Jetstream.AsyncAckTimeout)):
-			return fmt.Errorf("jetstream PubAsync ack timeout (pending=%d)", n.jetstreamClient.PublishAsyncPending())
+			return fmt.Errorf("waiting for acknowledgement timed out, %d messages pending", n.jetstreamClient.PublishAsyncPending())
 		}
 	}
 	return nil

--- a/plugins/outputs/nats/nats_test.go
+++ b/plugins/outputs/nats/nats_test.go
@@ -156,6 +156,7 @@ func TestConfigParsing(t *testing.T) {
 		{name: "Valid Default", path: filepath.Join("testcases", "no-js.conf")},
 		{name: "Valid JS", path: filepath.Join("testcases", "js-default.conf")},
 		{name: "Valid JS Config", path: filepath.Join("testcases", "js-config.conf")},
+		{name: "Valid JS Async Publish", path: filepath.Join("testcases", "js-async-pub.conf")},
 		{name: "Subjects warning", path: filepath.Join("testcases", "js-subjects.conf")},
 		{name: "Invalid JS", path: filepath.Join("testcases", "js-no-stream.conf"), wantErr: true},
 	}

--- a/plugins/outputs/nats/sample.conf
+++ b/plugins/outputs/nats/sample.conf
@@ -44,6 +44,10 @@
     ## Use asynchronous publishing for higher throughput, but note that it does not guarantee order within batches.
     # async_publish = false
 
+    ## Timeout for wating on acknowledgement on asynchronous publishing
+    ## String with valid units "ns", "us" (or "µs"), "ms", "s", "m", "h".
+    # async_ack_timeout = "5s"
+
     ## Full jetstream create stream config, refer: https://docs.nats.io/nats-concepts/jetstream/streams
     # retention = "limits"
     # max_consumers = -1

--- a/plugins/outputs/nats/sample.conf
+++ b/plugins/outputs/nats/sample.conf
@@ -41,6 +41,9 @@
     # name = ""
     # subjects = []
 
+    ## Use asynchronous publishing for higher throughput, but note that it does not guarantee order within batches.
+    # async_publish = false
+
     ## Full jetstream create stream config, refer: https://docs.nats.io/nats-concepts/jetstream/streams
     # retention = "limits"
     # max_consumers = -1

--- a/plugins/outputs/nats/testcases/js-async-pub.conf
+++ b/plugins/outputs/nats/testcases/js-async-pub.conf
@@ -8,3 +8,4 @@
     name = "my-stream"
     subjects = ["not", "here"]
     async_publish = true
+    async_ack_timeout = "5s"

--- a/plugins/outputs/nats/testcases/js-async-pub.conf
+++ b/plugins/outputs/nats/testcases/js-async-pub.conf
@@ -1,0 +1,10 @@
+## NATS output with async jetstream publish
+[[outputs.nats]]
+  ## URLs of NATS servers
+  servers = ["nats://localhost:4222"]
+  subject = "telegraf-subject"
+  data_format = "influx"
+  [outputs.nats.jetstream]
+    name = "my-stream"
+    subjects = ["not", "here"]
+    async_publish = true


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Solves #16581 by adding option to use async jetstream publish.  "Make" up for loose of performance when changing to sync jetstream publisher vs core. 

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #16581
based on #16570 
