### PR TITLE
feat(outputs.stackdriver): Ensure quota is charged to configured project

### DIFF
--- a/plugins/outputs/stackdriver/README.md
+++ b/plugins/outputs/stackdriver/README.md
@@ -37,13 +37,11 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   project = "erudite-bloom-151019"
 
   ## Quota Project
-  ## Specifies the Google Cloud project that should be charged for metric ingestion quota.
-  ## If omitted, the quota is charged to the project associated with the service account.
-  ## This is useful when sending metrics to multiple projects using a single service account, 
-  ## ensuring that the target projects are billed instead of the service account's project.
-  ##
-  ## The caller must have the `serviceusage.services.use` permission on the specified quota project.
-  # quota_project = "billing-project"
+  ## Specifies the Google Cloud project that should be billed for metric ingestion.
+  ## If omitted, the quota is charged to the service account’s default project.
+  ## This is useful when sending metrics to multiple projects using a single service account.
+  ## The caller must have the `serviceusage.services.use` permission on the specified project.
+  # quota_project = ""
 
   ## The namespace for the metric descriptor
   ## This is optional and users are encouraged to set the namespace as a

--- a/plugins/outputs/stackdriver/README.md
+++ b/plugins/outputs/stackdriver/README.md
@@ -36,6 +36,15 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## GCP Project
   project = "erudite-bloom-151019"
 
+  ## Quota Project
+  ## Specifies the Google Cloud project that should be charged for metric ingestion quota.
+  ## If omitted, the quota is charged to the project associated with the service account.
+  ## This is useful when sending metrics to multiple projects using a single service account, 
+  ## ensuring that the target projects are billed instead of the service account's project.
+  ##
+  ## The caller must have the `serviceusage.services.use` permission on the specified quota project.
+  # quota_project = "billing-project"
+
   ## The namespace for the metric descriptor
   ## This is optional and users are encouraged to set the namespace as a
   ## resource label instead. If omitted it is not included in the metric name.

--- a/plugins/outputs/stackdriver/README.md
+++ b/plugins/outputs/stackdriver/README.md
@@ -36,6 +36,12 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## GCP Project
   project = "erudite-bloom-151019"
 
+  ## Quota Project
+  ## Specifies the Google Cloud project that should be charged for metric ingestion quota.
+  ## If omitted, the quota is charged to the project associated with the service account.
+  ## This is useful when sending metrics to multiple projects while using a single service account.
+  # quota_project = "billing-project"
+
   ## The namespace for the metric descriptor
   ## This is optional and users are encouraged to set the namespace as a
   ## resource label instead. If omitted it is not included in the metric name.

--- a/plugins/outputs/stackdriver/README.md
+++ b/plugins/outputs/stackdriver/README.md
@@ -39,7 +39,8 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## Quota Project
   ## Specifies the Google Cloud project that should be charged for metric ingestion quota.
   ## If omitted, the quota is charged to the project associated with the service account.
-  ## This is useful when sending metrics to multiple projects while using a single service account.
+  ## This is useful when sending metrics to multiple projects using a single service account, 
+  ## ensuring that the target projects are billed instead of the service account's project.
   # quota_project = "billing-project"
 
   ## The namespace for the metric descriptor

--- a/plugins/outputs/stackdriver/README.md
+++ b/plugins/outputs/stackdriver/README.md
@@ -36,13 +36,6 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## GCP Project
   project = "erudite-bloom-151019"
 
-  ## Quota Project
-  ## Specifies the Google Cloud project that should be charged for metric ingestion quota.
-  ## If omitted, the quota is charged to the project associated with the service account.
-  ## This is useful when sending metrics to multiple projects using a single service account, 
-  ## ensuring that the target projects are billed instead of the service account's project.
-  # quota_project = "billing-project"
-
   ## The namespace for the metric descriptor
   ## This is optional and users are encouraged to set the namespace as a
   ## resource label instead. If omitted it is not included in the metric name.

--- a/plugins/outputs/stackdriver/sample.conf
+++ b/plugins/outputs/stackdriver/sample.conf
@@ -3,6 +3,15 @@
   ## GCP Project
   project = "erudite-bloom-151019"
 
+  ## Quota Project
+  ## Specifies the Google Cloud project that should be charged for metric ingestion quota.
+  ## If omitted, the quota is charged to the project associated with the service account.
+  ## This is useful when sending metrics to multiple projects using a single service account, 
+  ## ensuring that the target projects are billed instead of the service account's project.
+  ##
+  ## The caller must have the `serviceusage.services.use` permission on the specified quota project.
+  # quota_project = "billing-project"
+
   ## The namespace for the metric descriptor
   ## This is optional and users are encouraged to set the namespace as a
   ## resource label instead. If omitted it is not included in the metric name.

--- a/plugins/outputs/stackdriver/sample.conf
+++ b/plugins/outputs/stackdriver/sample.conf
@@ -4,13 +4,11 @@
   project = "erudite-bloom-151019"
 
   ## Quota Project
-  ## Specifies the Google Cloud project that should be charged for metric ingestion quota.
-  ## If omitted, the quota is charged to the project associated with the service account.
-  ## This is useful when sending metrics to multiple projects using a single service account, 
-  ## ensuring that the target projects are billed instead of the service account's project.
-  ##
-  ## The caller must have the `serviceusage.services.use` permission on the specified quota project.
-  # quota_project = "billing-project"
+  ## Specifies the Google Cloud project that should be billed for metric ingestion.
+  ## If omitted, the quota is charged to the service account’s default project.
+  ## This is useful when sending metrics to multiple projects using a single service account.
+  ## The caller must have the `serviceusage.services.use` permission on the specified project.
+  # quota_project = ""
 
   ## The namespace for the metric descriptor
   ## This is optional and users are encouraged to set the namespace as a

--- a/plugins/outputs/stackdriver/stackdriver.go
+++ b/plugins/outputs/stackdriver/stackdriver.go
@@ -142,15 +142,14 @@ func (s *Stackdriver) Connect() error {
 		option.WithUserAgent(internal.ProductToken()),
 	}
 
-
-        if s.QuotaProject != "" {
-                options = append(options, option.WithQuotaProject(s.QuotaProject))
-                s.Log.Infof("Using QuotaProject %s for quota attribution", s.QuotaProject)
-        }
+	if s.QuotaProject != "" {
+		options = append(options, option.WithQuotaProject(s.QuotaProject))
+		s.Log.Infof("Using QuotaProject %s for quota attribution", s.QuotaProject)
+	}
 
 	if s.client == nil {
 		ctx := context.Background()
-		client, err := monitoring.NewMetricClient(ctx, options...) 
+		client, err := monitoring.NewMetricClient(ctx, options...)
 		if err != nil {
 			return err
 		}

--- a/plugins/outputs/stackdriver/stackdriver.go
+++ b/plugins/outputs/stackdriver/stackdriver.go
@@ -136,9 +136,19 @@ func (s *Stackdriver) Connect() error {
 
 	s.ResourceLabels["project_id"] = s.Project
 
+	// Define client options, starting with the user agent
+	options := []option.ClientOption{
+		option.WithUserAgent(internal.ProductToken()), // This ensures ProductToken is included
+	}
+
+	// Ensure quota attribution follows the configured project
+	if s.Project != "" {
+		options = append(options, option.WithQuotaProject(s.Project))
+	}
+
 	if s.client == nil {
 		ctx := context.Background()
-		client, err := monitoring.NewMetricClient(ctx, option.WithUserAgent(internal.ProductToken()))
+		client, err := monitoring.NewMetricClient(ctx, options...) // Pass the options array
 		if err != nil {
 			return err
 		}

--- a/plugins/outputs/stackdriver/stackdriver.go
+++ b/plugins/outputs/stackdriver/stackdriver.go
@@ -139,10 +139,10 @@ func (s *Stackdriver) Connect() error {
 
 	// Define client options, starting with the user agent
 	options := []option.ClientOption{
-		option.WithUserAgent(internal.ProductToken()), // This ensures ProductToken is included
+		option.WithUserAgent(internal.ProductToken()),
 	}
 
-	// Ensure quota attribution follows the configured project
+
         if s.QuotaProject != "" {
                 options = append(options, option.WithQuotaProject(s.QuotaProject))
                 s.Log.Infof("Using QuotaProject %s for quota attribution", s.QuotaProject)
@@ -150,7 +150,7 @@ func (s *Stackdriver) Connect() error {
 
 	if s.client == nil {
 		ctx := context.Background()
-		client, err := monitoring.NewMetricClient(ctx, options...) // Pass the options array
+		client, err := monitoring.NewMetricClient(ctx, options...) 
 		if err != nil {
 			return err
 		}

--- a/plugins/outputs/stackdriver/stackdriver.go
+++ b/plugins/outputs/stackdriver/stackdriver.go
@@ -33,6 +33,7 @@ var sampleConfig string
 // Stackdriver is the Google Stackdriver config info.
 type Stackdriver struct {
 	Project              string            `toml:"project"`
+	QuotaProject         string            `toml:"quota_project"`
 	Namespace            string            `toml:"namespace"`
 	ResourceType         string            `toml:"resource_type"`
 	ResourceLabels       map[string]string `toml:"resource_labels"`
@@ -142,9 +143,10 @@ func (s *Stackdriver) Connect() error {
 	}
 
 	// Ensure quota attribution follows the configured project
-	if s.Project != "" {
-		options = append(options, option.WithQuotaProject(s.Project))
-	}
+        if s.QuotaProject != "" {
+                options = append(options, option.WithQuotaProject(s.QuotaProject))
+                s.Log.Infof("Using QuotaProject %s for quota attribution", s.QuotaProject)
+        }
 
 	if s.client == nil {
 		ctx := context.Background()


### PR DESCRIPTION
- Updated Stackdriver output plugin to use the `project` field from the Telegraf configuration for quota attribution via `option.WithQuotaProject(s.Project)`.
- Ensures that metric ingestion quota is billed to the destination project rather than the service account’s project.
- This allows sending metrics to multiple projects while ensuring that each project is responsible for its own quota, instead of charging all usage to the service account’s project.
- Preserves existing behavior while improving clarity and correctness in quota handling.

## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [X] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves https://github.com/influxdata/telegraf/issues/16584
