### PR TITLE
feat(inputs.ipset): add filter to ignore ipsets by configurable regex

### DIFF
--- a/plugins/inputs/ipset/ipset_entries_test.go
+++ b/plugins/inputs/ipset/ipset_entries_test.go
@@ -10,6 +10,10 @@ import (
 	"github.com/influxdata/telegraf/testutil"
 )
 
+func filterNoopFn(_ string) bool {
+	return false
+}
+
 func TestIpsetEntries(t *testing.T) {
 	var acc testutil.Accumulator
 
@@ -22,7 +26,7 @@ func TestIpsetEntries(t *testing.T) {
 
 	entries := ipsetEntries{}
 	for _, line := range lines {
-		require.NoError(t, entries.addLine(line, &acc))
+		require.NoError(t, entries.addLine(line, filterNoopFn, &acc))
 	}
 	entries.commit(&acc)
 
@@ -49,20 +53,20 @@ func TestIpsetEntriesCidr(t *testing.T) {
 
 	lines := []string{
 		"create mylist0 hash:net family inet hashsize 16384 maxelem 131072 timeout 300 bucketsize 12 initval 0x4effa9ad",
-		"add mylist0 89.101.238.143 timeout 161558",
-		"add mylist0 122.224.5.0/24 timeout 186758",
-		"add mylist0 47.128.40.145 timeout 431559",
+		"add mylist0 89.101.238.143",
+		"add mylist0 122.224.5.0/24",
+		"add mylist0 47.128.40.145",
 
 		"create mylist1 hash:net family inet hashsize 16384 maxelem 131072 timeout 300 bucketsize 12 initval 0x4effa9ad",
-		"add mylist1 90.101.238.143 timeout 161558",
-		"add mylist1 44.128.40.145 timeout 431559",
-		"add mylist1 122.224.5.0/8 timeout 186758",
-		"add mylist1 45.128.40.145 timeout 431560",
+		"add mylist1 90.101.238.143",
+		"add mylist1 44.128.40.145",
+		"add mylist1 122.224.5.0/8",
+		"add mylist1 45.128.40.145",
 	}
 
 	entries := ipsetEntries{}
 	for _, line := range lines {
-		require.NoError(t, entries.addLine(line, &acc))
+		require.NoError(t, entries.addLine(line, filterNoopFn, &acc))
 	}
 	entries.commit(&acc)
 
@@ -87,6 +91,64 @@ func TestIpsetEntriesCidr(t *testing.T) {
 			map[string]interface{}{
 				"entries": 4,
 				"ips":     16777217,
+			},
+			time.Unix(0, 0),
+			telegraf.Gauge,
+		),
+	}
+
+	testutil.RequireMetricsEqual(t, expected, acc.GetTelegrafMetrics(), testutil.IgnoreTime())
+}
+
+func TestIpsetEntriesExclude(t *testing.T) {
+	var acc testutil.Accumulator
+
+	lines := []string{
+		"create mylist hash:net family inet hashsize 16384 maxelem 131072 timeout 300 bucketsize 12 initval 0x4effa9ad",
+		"add mylist 89.101.238.143 timeout 161558",
+		"add mylist 122.224.15.166 timeout 186758",
+		"add mylist 47.128.40.145 timeout 431559",
+		"create mylist2 hash:net family inet hashsize 16384 maxelem 131072 timeout 300 bucketsize 12 initval 0x4effa9ad",
+		"add mylist 89.101.238.143 timeout 161558",
+		"add mylist 122.224.15.166 timeout 186758",
+		"add mylist 47.128.40.145 timeout 431559",
+		"create mylist3 hash:net family inet hashsize 16384 maxelem 131072 timeout 300 bucketsize 12 initval 0x4effa9ad",
+		"add mylist 89.101.238.143 timeout 161558",
+		"add mylist 122.224.15.166 timeout 186758",
+		"add mylist 47.128.40.145 timeout 431559",
+	}
+
+	excludeFn := func(setName string) bool {
+		return setName == "mylist2"
+	}
+
+	entries := ipsetEntries{}
+	for _, line := range lines {
+		require.NoError(t, entries.addLine(line, excludeFn, &acc))
+	}
+	entries.commit(&acc)
+
+	expected := []telegraf.Metric{
+		testutil.MustMetric(
+			"ipset",
+			map[string]string{
+				"set": "mylist",
+			},
+			map[string]interface{}{
+				"entries": 3,
+				"ips":     3,
+			},
+			time.Unix(0, 0),
+			telegraf.Gauge,
+		),
+		testutil.MustMetric(
+			"ipset",
+			map[string]string{
+				"set": "mylist3",
+			},
+			map[string]interface{}{
+				"entries": 3,
+				"ips":     3,
 			},
 			time.Unix(0, 0),
 			telegraf.Gauge,


### PR DESCRIPTION
## Summary
Some tools that are managing ipsets are creating short-term temporary ipsets (e.g. firehol).

Desired behavior would be that telegraf can be configured to ignore those ipsets because it is of no use to create metrics for them.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves [#16618](https://github.com/influxdata/telegraf/issues/16618)

## Notes
To be able to test the regex mechanism, the compiled regex is injected here in the test code because the `Init` function does not seem to be called in the test runs (which would set up the regex when running outside of the tests):
```
			if tt.ignoreSetRegex != "" {
				ips.ignoreSetsRegexC = regexp.MustCompile(tt.ignoreSetRegex)
			}
```
Please check if this approach is ok.