### PR TITLE
chore(licenses): Fix link and whitelist package

### DIFF
--- a/docs/LICENSE_OF_DEPENDENCIES.md
+++ b/docs/LICENSE_OF_DEPENDENCIES.md
@@ -316,7 +316,7 @@ following works:
 - github.com/opentracing/opentracing-go [Apache License 2.0](https://github.com/opentracing/opentracing-go/blob/master/LICENSE)
 - github.com/p4lang/p4runtime [Apache License 2.0](https://github.com/p4lang/p4runtime/blob/main/LICENSE)
 - github.com/paulmach/orb [MIT License](https://github.com/paulmach/orb/blob/master/LICENSE.md)
-- github.com/pavlo-v-chernykh/keystore-go [MIT License](https://github.com/pavlo-v-chernykh/keystore-go/blob/main/LICENSE)
+- github.com/pavlo-v-chernykh/keystore-go [MIT License](https://github.com/pavlo-v-chernykh/keystore-go/blob/master/LICENSE)
 - github.com/pborman/ansi [BSD 3-Clause "New" or "Revised" License](https://github.com/pborman/ansi/blob/master/LICENSE)
 - github.com/pcolladosoto/goslurm [MIT License](https://github.com/pcolladosoto/goslurm/blob/main/LICENSE)
 - github.com/peterbourgon/unixtransport [Apache License 2.0](https://github.com/peterbourgon/unixtransport/blob/main/LICENSE)

--- a/tools/license_checker/data/whitelist
+++ b/tools/license_checker/data/whitelist
@@ -1,3 +1,2 @@
-<github.com/ClickHouse/clickhouse-go@v2.0.0 MIT
 <github.com/couchbase/goutils@v0.1.2 Apache-2.0
-<=github.com/gorilla/websocket@v1.5.0 BSD-2-Clause
+<=github.com/segmentio/asm@v1.2.0 MIT


### PR DESCRIPTION
## Summary

This PR fixes the link to the `https://github.com/pavlo-v-chernykh/keystore-go` license and whitelists the `github.com/segmentio/asm` package for versions `<=v1.2.0` as the latest master has a license change to `MIT-0` but released versions are still `MIT`.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues
