### PR TITLE
chore(sql): Cleanup code

### DIFF
--- a/plugins/inputs/sql/sql.go
+++ b/plugins/inputs/sql/sql.go
@@ -462,12 +462,10 @@ func (q *query) parse(acc telegraf.Accumulator, rows *dbsql.Rows, t time.Time, l
 			if q.fieldFilterInt.Match(name) {
 				v, err := internal.ToInt64(columnData[i])
 				if err != nil {
-					if err != nil {
-						if !errors.Is(err, internal.ErrOutOfRange) {
-							return 0, fmt.Errorf("converting field column %q to int failed: %w", name, err)
-						}
-						logger.Warnf("field column %q: %v", name, err)
+					if !errors.Is(err, internal.ErrOutOfRange) {
+						return 0, fmt.Errorf("converting field column %q to int failed: %w", name, err)
 					}
+					logger.Warnf("field column %q: %v", name, err)
 				}
 				fields[name] = v
 				continue

--- a/plugins/outputs/sql/README.md
+++ b/plugins/outputs/sql/README.md
@@ -84,12 +84,12 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## Database driver
   ## Valid options: mssql (Microsoft SQL Server), mysql (MySQL), pgx (Postgres),
   ##  sqlite (SQLite3), snowflake (snowflake.com) clickhouse (ClickHouse)
-  # driver = ""
+  driver = ""
 
   ## Data source name
   ## The format of the data source name is different for each database driver.
   ## See the plugin readme for details.
-  # data_source_name = ""
+  data_source_name = ""
 
   ## Timestamp column name
   # timestamp_column = "timestamp"

--- a/plugins/outputs/sql/sample.conf
+++ b/plugins/outputs/sql/sample.conf
@@ -3,12 +3,12 @@
   ## Database driver
   ## Valid options: mssql (Microsoft SQL Server), mysql (MySQL), pgx (Postgres),
   ##  sqlite (SQLite3), snowflake (snowflake.com) clickhouse (ClickHouse)
-  # driver = ""
+  driver = ""
 
   ## Data source name
   ## The format of the data source name is different for each database driver.
   ## See the plugin readme for details.
-  # data_source_name = ""
+  data_source_name = ""
 
   ## Timestamp column name
   # timestamp_column = "timestamp"

--- a/plugins/outputs/sql/sql.go
+++ b/plugins/outputs/sql/sql.go
@@ -70,18 +70,29 @@ func (*SQL) SampleConfig() string {
 }
 
 func (p *SQL) Init() error {
+	// Set defaults
 	if p.TableExistsTemplate == "" {
 		p.TableExistsTemplate = "SELECT 1 FROM {TABLE} LIMIT 1"
 	}
+
 	if p.TimestampColumn == "" {
 		p.TimestampColumn = "timestamp"
 	}
+
 	if p.TableTemplate == "" {
 		if p.Driver == "clickhouse" {
 			p.TableTemplate = "CREATE TABLE {TABLE}({COLUMNS}) ORDER BY ({TAG_COLUMN_NAMES}, {TIMESTAMP_COLUMN_NAME})"
 		} else {
 			p.TableTemplate = "CREATE TABLE {TABLE}({COLUMNS})"
 		}
+	}
+
+	// Check for a valid driver
+	switch p.Driver {
+	case "clickhouse", "mssql", "mysql", "pgx", "snowflake", "sqlite":
+		// Do nothing, those are valid
+	default:
+		return fmt.Errorf("unknown driver %q", p.Driver)
 	}
 
 	return nil

--- a/plugins/outputs/sql/sql.go
+++ b/plugins/outputs/sql/sql.go
@@ -104,12 +104,11 @@ func (p *SQL) Init() error {
 func (p *SQL) Connect() error {
 	db, err := gosql.Open(p.Driver, p.DataSourceName)
 	if err != nil {
-		return err
+		return fmt.Errorf("creating database client failed: %w", err)
 	}
 
-	err = db.Ping()
-	if err != nil {
-		return err
+	if err := db.Ping(); err != nil {
+		return fmt.Errorf("pinging database failed: %w", err)
 	}
 
 	db.SetConnMaxIdleTime(time.Duration(p.ConnectionMaxIdleTime))
@@ -118,9 +117,8 @@ func (p *SQL) Connect() error {
 	db.SetMaxOpenConns(p.ConnectionMaxOpen)
 
 	if p.InitSQL != "" {
-		_, err = db.Exec(p.InitSQL)
-		if err != nil {
-			return err
+		if _, err = db.Exec(p.InitSQL); err != nil {
+			return fmt.Errorf("initializing database failed: %w", err)
 		}
 	}
 

--- a/plugins/outputs/sql/sql_test.go
+++ b/plugins/outputs/sql/sql_test.go
@@ -424,8 +424,13 @@ func TestClickHouseDsnConvert(t *testing.T) {
 		},
 	}
 
-	log := testutil.Logger{}
-	for _, test := range tests {
-		require.Equal(t, test.expected, convertClickHouseDsn(test.input, log))
+	for _, tt := range tests {
+		plugin := &SQL{
+			Driver:         "clickhouse",
+			DataSourceName: tt.input,
+			Log:            testutil.Logger{},
+		}
+		require.NoError(t, plugin.Init())
+		require.Equal(t, tt.expected, plugin.DataSourceName)
 	}
 }

--- a/plugins/outputs/sql/sql_test.go
+++ b/plugins/outputs/sql/sql_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"math/rand"
 	"os"
 	"path/filepath"
 	"testing"
@@ -18,36 +17,6 @@ import (
 	"github.com/influxdata/telegraf/metric"
 	"github.com/influxdata/telegraf/testutil"
 )
-
-func TestSqlQuoteIntegration(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping integration test in short mode")
-	}
-}
-
-func TestSqlCreateStatementIntegration(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping integration test in short mode")
-	}
-}
-
-func TestSqlInsertStatementIntegration(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping integration test in short mode")
-	}
-}
-
-func pwgen(n int) string {
-	charset := []byte("abcdedfghijklmnopqrstABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
-
-	nchars := len(charset)
-	buffer := make([]byte, 0, n)
-	for i := 0; i < n; i++ {
-		buffer = append(buffer, charset[rand.Intn(nchars)])
-	}
-
-	return string(buffer)
-}
 
 func stableMetric(
 	name string,
@@ -169,7 +138,7 @@ func TestMysqlIntegration(t *testing.T) {
 	// var. We'll use root to insert and query test data.
 	const username = "root"
 
-	password := pwgen(32)
+	password := testutil.GetRandomString(32)
 	outDir := t.TempDir()
 
 	servicePort := "3306"
@@ -195,11 +164,14 @@ func TestMysqlIntegration(t *testing.T) {
 	address := fmt.Sprintf("%v:%v@tcp(%v:%v)/%v",
 		username, password, container.Address, container.Ports[servicePort], dbname,
 	)
-	p := newSQL()
-	p.Log = testutil.Logger{}
-	p.Driver = "mysql"
-	p.DataSourceName = address
-	p.InitSQL = "SET sql_mode='ANSI_QUOTES';"
+	p := &SQL{
+		Driver:            "mysql",
+		DataSourceName:    address,
+		Convert:           defaultConvert,
+		InitSQL:           "SET sql_mode='ANSI_QUOTES';",
+		ConnectionMaxIdle: 2,
+		Log:               testutil.Logger{},
+	}
 	require.NoError(t, p.Init())
 
 	require.NoError(t, p.Connect())
@@ -249,7 +221,7 @@ func TestPostgresIntegration(t *testing.T) {
 	// default username for postgres is postgres
 	const username = "postgres"
 
-	password := pwgen(32)
+	password := testutil.GetRandomString(32)
 	outDir := t.TempDir()
 
 	servicePort := "5432"
@@ -276,10 +248,13 @@ func TestPostgresIntegration(t *testing.T) {
 	address := fmt.Sprintf("postgres://%v:%v@%v:%v/%v",
 		username, password, container.Address, container.Ports[servicePort], dbname,
 	)
-	p := newSQL()
-	p.Log = testutil.Logger{}
-	p.Driver = "pgx"
-	p.DataSourceName = address
+	p := &SQL{
+		Driver:            "pgx",
+		DataSourceName:    address,
+		Convert:           defaultConvert,
+		ConnectionMaxIdle: 2,
+		Log:               testutil.Logger{},
+	}
 	p.Convert.Real = "double precision"
 	p.Convert.Unsigned = "bigint"
 	p.Convert.ConversionStyle = "literal"
@@ -335,7 +310,7 @@ func TestClickHouseIntegration(t *testing.T) {
 	// username for connecting to clickhouse
 	const username = "clickhouse"
 
-	password := pwgen(32)
+	password := testutil.GetRandomString(32)
 	outDir := t.TempDir()
 
 	servicePort := "9000"
@@ -364,10 +339,13 @@ func TestClickHouseIntegration(t *testing.T) {
 	// host, port, username, password, dbname
 	address := fmt.Sprintf("tcp://%s:%s/%s?username=%s&password=%s",
 		container.Address, container.Ports[servicePort], dbname, username, password)
-	p := newSQL()
-	p.Log = testutil.Logger{}
-	p.Driver = "clickhouse"
-	p.DataSourceName = address
+	p := &SQL{
+		Driver:            "clickhouse",
+		DataSourceName:    address,
+		Convert:           defaultConvert,
+		ConnectionMaxIdle: 2,
+		Log:               testutil.Logger{},
+	}
 	p.Convert.Integer = "Int64"
 	p.Convert.Text = "String"
 	p.Convert.Timestamp = "DateTime"

--- a/plugins/outputs/sql/sqlite_test.go
+++ b/plugins/outputs/sql/sqlite_test.go
@@ -21,10 +21,13 @@ func TestSqlite(t *testing.T) {
 	// Use the plugin to write to the database address :=
 	// fmt.Sprintf("file:%v", dbfile)
 	address := dbfile // accepts a path or a file: URI
-	p := newSQL()
-	p.Log = testutil.Logger{}
-	p.Driver = "sqlite"
-	p.DataSourceName = address
+	p := &SQL{
+		Driver:            "sqlite",
+		DataSourceName:    address,
+		Convert:           defaultConvert,
+		ConnectionMaxIdle: 2,
+		Log:               testutil.Logger{},
+	}
 	require.NoError(t, p.Init())
 
 	require.NoError(t, p.Connect())

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -2,6 +2,7 @@ package testutil
 
 import (
 	"fmt"
+	"math/rand"
 	"net"
 	"net/url"
 	"os"
@@ -40,6 +41,24 @@ func GetLocalHost() string {
 		return host
 	}
 	return localhost
+}
+
+// GetRandomString returns a random alphanumerical string of the given length.
+// Please note, this function is different to `internal.RandomString` as it will
+// not use `crypto.Rand` and will therefore not rely on the entropy-pool of the
+// host which might be drained e.g. in CI pipelines. This is useful to e.g.
+// create random passwords for tests where security is not a concern.
+func GetRandomString(chars int) string {
+	charset := []byte("abcdedfghijklmnopqrstABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
+
+	nchars := len(charset)
+	buffer := make([]byte, 0, chars)
+	for i := 0; i < chars; i++ {
+		//nolint:gosec // Using a weak random number generator on purpose to not drain entropy
+		buffer = append(buffer, charset[rand.Intn(nchars)])
+	}
+
+	return string(buffer)
 }
 
 // MockMetrics returns a mock []telegraf.Metric object for using in unit tests

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -49,13 +49,13 @@ func GetLocalHost() string {
 // host which might be drained e.g. in CI pipelines. This is useful to e.g.
 // create random passwords for tests where security is not a concern.
 func GetRandomString(chars int) string {
-	charset := []byte("abcdedfghijklmnopqrstABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
+	charset := []byte("abcdefghijklmnopqrstABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
 
 	nchars := len(charset)
-	buffer := make([]byte, 0, chars)
-	for i := 0; i < chars; i++ {
+	buffer := make([]byte, chars)
+	for i := range chars {
 		//nolint:gosec // Using a weak random number generator on purpose to not drain entropy
-		buffer = append(buffer, charset[rand.Intn(nchars)])
+		buffer[i] = charset[rand.Intn(nchars)]
 	}
 
 	return string(buffer)


### PR DESCRIPTION
## Summary

This PR uncomments mandatory entries in the configuration,  cleans up initialization in the code a bit and moves the `Init` function to the right spot. Furthermore, the PR unifies random password generation for tests which should not use the `crypto/rand` package to prevent draining the entropy pool as this might kill CI pipelines.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

related to #16621 