### PR TITLE
fix(outputs.sql): Allow to disable timestamp column

### DIFF
--- a/plugins/outputs/sql/README.md
+++ b/plugins/outputs/sql/README.md
@@ -91,7 +91,7 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## See the plugin readme for details.
   data_source_name = ""
 
-  ## Timestamp column name
+  ## Timestamp column name, set to empty to ignore the timestamp
   # timestamp_column = "timestamp"
 
   ## Table creation template

--- a/plugins/outputs/sql/sample.conf
+++ b/plugins/outputs/sql/sample.conf
@@ -10,7 +10,7 @@
   ## See the plugin readme for details.
   data_source_name = ""
 
-  ## Timestamp column name
+  ## Timestamp column name, set to empty to ignore the timestamp
   # timestamp_column = "timestamp"
 
   ## Table creation template

--- a/plugins/outputs/sql/sql.go
+++ b/plugins/outputs/sql/sql.go
@@ -75,10 +75,6 @@ func (p *SQL) Init() error {
 		p.TableExistsTemplate = "SELECT 1 FROM {TABLE} LIMIT 1"
 	}
 
-	if p.TimestampColumn == "" {
-		p.TimestampColumn = "timestamp"
-	}
-
 	if p.TableTemplate == "" {
 		if p.Driver == "clickhouse" {
 			p.TableTemplate = "CREATE TABLE {TABLE}({COLUMNS}) ORDER BY ({TAG_COLUMN_NAMES}, {TIMESTAMP_COLUMN_NAME})"
@@ -362,6 +358,9 @@ func init() {
 	outputs.Add("sql", func() telegraf.Output {
 		return &SQL{
 			Convert: defaultConvert,
+
+			// Allow overriding the timestamp column to empty by the user
+			TimestampColumn: "timestamp",
 
 			// Defaults for the connection settings (ConnectionMaxIdleTime,
 			// ConnectionMaxLifetime, ConnectionMaxIdle, and ConnectionMaxOpen)

--- a/plugins/outputs/sql/sqlite_test.go
+++ b/plugins/outputs/sql/sqlite_test.go
@@ -25,6 +25,7 @@ func TestSqlite(t *testing.T) {
 		Driver:            "sqlite",
 		DataSourceName:    address,
 		Convert:           defaultConvert,
+		TimestampColumn:   "timestamp",
 		ConnectionMaxIdle: 2,
 		Log:               testutil.Logger{},
 	}

--- a/plugins/outputs/sql/testdata/mariadb_no_timestamp/expected_metric_one.sql
+++ b/plugins/outputs/sql/testdata/mariadb_no_timestamp/expected_metric_one.sql
@@ -1,0 +1,13 @@
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `metric_one` (
+  `tag_one` text DEFAULT NULL,
+  `tag_two` text DEFAULT NULL,
+  `int64_one` int(11) DEFAULT NULL,
+  `int64_two` int(11) DEFAULT NULL,
+  `bool_one` tinyint(1) DEFAULT NULL,
+  `bool_two` tinyint(1) DEFAULT NULL,
+  `uint64_one` int(10) unsigned DEFAULT NULL,
+  `float64_one` double DEFAULT NULL
+);
+/*!40101 SET character_set_client = @saved_cs_client */;
+INSERT INTO `metric_one` VALUES ('tag1','tag2',1234,2345,1,0,1000000000,3.1415);

--- a/plugins/outputs/sql/testdata/mariadb_no_timestamp/expected_metric_three.sql
+++ b/plugins/outputs/sql/testdata/mariadb_no_timestamp/expected_metric_three.sql
@@ -1,0 +1,7 @@
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `metric three` (
+  `tag four` text DEFAULT NULL,
+  `string two` text DEFAULT NULL
+);
+/*!40101 SET character_set_client = @saved_cs_client */;
+INSERT INTO `metric three` VALUES ('tag4','string2');

--- a/plugins/outputs/sql/testdata/mariadb_no_timestamp/expected_metric_two.sql
+++ b/plugins/outputs/sql/testdata/mariadb_no_timestamp/expected_metric_two.sql
@@ -1,0 +1,7 @@
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `metric_two` (
+  `tag_three` text DEFAULT NULL,
+  `string_one` text DEFAULT NULL
+);
+/*!40101 SET character_set_client = @saved_cs_client */;
+INSERT INTO `metric_two` VALUES ('tag3','string1');

--- a/plugins/outputs/sql/testdata/mariadb_no_timestamp/initdb/script.sql
+++ b/plugins/outputs/sql/testdata/mariadb_no_timestamp/initdb/script.sql
@@ -1,0 +1,4 @@
+create database foo;
+use foo;
+create table bar (baz int);
+insert into bar (baz) values (1);


### PR DESCRIPTION
## Summary

This PR allows to set the timestamp column to empty to not insert the timestamp column.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #16621 
based on #16624
superseeds #16623
