### PR TITLE
feat(processors.cumulative_sum): Add plugin

### DIFF
--- a/plugins/processors/all/cumulative_sum.go
+++ b/plugins/processors/all/cumulative_sum.go
@@ -1,0 +1,5 @@
+//go:build !custom || processors || processors.cumulative_sum
+
+package all
+
+import _ "github.com/influxdata/telegraf/plugins/processors/cumulative_sum" // register plugin

--- a/plugins/processors/cumulative_sum/README.md
+++ b/plugins/processors/cumulative_sum/README.md
@@ -1,11 +1,11 @@
 # Cumulative Sum Processor Plugin
 
-This plugin accumulates field values per-metric over time and emit metrics with 
-cumulative sums whenever a metric is updated. This is useful when using outputs 
+This plugin accumulates field values per-metric over time and emit metrics with
+cumulative sums whenever a metric is updated. This is useful when using outputs
 relying on monotonically increasing values
 
 > [!NOTE]
-> Metrics within a series are accumulated in the **order of arrival** and not in 
+> Metrics within a series are accumulated in the **order of arrival** and not in
 > order of their timestamps!
 
 ## Global configuration options <!-- @/docs/includes/plugin_config.md -->

--- a/plugins/processors/cumulative_sum/README.md
+++ b/plugins/processors/cumulative_sum/README.md
@@ -37,5 +37,7 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 - net,host=server01 bytes_sent=1000,bytes_received=500
 - net,host=server01 bytes_sent=2500,bytes_received=1500
 - net,host=server01 bytes_sent=3000,bytes_received=2500
++ net,host=server01 bytes_sent_sum=1000,bytes_received_sum=500
++ net,host=server01 bytes_sent_sum=3500,bytes_received_sum=2000
 + net,host=server01 bytes_sent_sum=6500,bytes_received_sum=4500
 ```

--- a/plugins/processors/cumulative_sum/README.md
+++ b/plugins/processors/cumulative_sum/README.md
@@ -16,19 +16,14 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 ## Configuration
 
 ```toml @sample.conf
-# Accumulate field metrics if it's a numerical and add new field with summed values
+# Compute the cumulative sum of the given fields
 [[processors.cumulative_sum]]
-  ## If true, the original field will be dropped by the
-  ## processor and will be removed from original metric.
-  ## Defaults to true.
-  # drop_original_field = true
+  ## Numerical fields to be processed (accepting wildcards)
+  # fields = ["*"]
 
-  ## Fields to be processed (all if empty)
-  # fields = []
-
-  ## Maximum time to save accumulated value without update.original
-  ## Default = 10m
-  # clean_up_interval = "600s"
+  ## Interval after which the sum value is reset to zero
+  ## If zero or unset the sum is never reset.
+  # expiry_interval = "0s"
 ```
 
 ## Example
@@ -37,7 +32,7 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 - net,host=server01 bytes_sent=1000,bytes_received=500
 - net,host=server01 bytes_sent=2500,bytes_received=1500
 - net,host=server01 bytes_sent=3000,bytes_received=2500
-+ net,host=server01 bytes_sent_sum=1000,bytes_received_sum=500
-+ net,host=server01 bytes_sent_sum=3500,bytes_received_sum=2000
-+ net,host=server01 bytes_sent_sum=6500,bytes_received_sum=4500
++ net,host=server01 bytes_sent=1000,bytes_sent_sum=1000,bytes_received=500,bytes_received_sum=500
++ net,host=server01 bytes_sent=2500,bytes_sent_sum=3500,bytes_received=1500,bytes_received_sum=2000
++ net,host=server01 bytes_sent=3000,bytes_sent_sum=6500,bytes_received=2500,bytes_received_sum=4500
 ```

--- a/plugins/processors/cumulative_sum/README.md
+++ b/plugins/processors/cumulative_sum/README.md
@@ -1,8 +1,8 @@
 # Cumulative Sum Processor Plugin
 
-Accumulate field values over time and emit metrics with cumulative sums.
-This processor is useful when you use prometheus output to have monotonic
-increasing and use increase function.
+This plugin accumulates field values per-metric over time and emit metrics with 
+cumulative sums whenever a metric is updated. This is useful when using outputs 
+relying on monotonically increasing values
 
 ## Global configuration options <!-- @/docs/includes/plugin_config.md -->
 

--- a/plugins/processors/cumulative_sum/README.md
+++ b/plugins/processors/cumulative_sum/README.md
@@ -4,6 +4,10 @@ This plugin accumulates field values per-metric over time and emit metrics with
 cumulative sums whenever a metric is updated. This is useful when using outputs 
 relying on monotonically increasing values
 
+> [!NOTE]
+> Metrics within a series are accumulated in the **order of arrival** and not in 
+> order of their timestamps!
+
 ## Global configuration options <!-- @/docs/includes/plugin_config.md -->
 
 In addition to the plugin-specific configuration settings, plugins support
@@ -21,8 +25,11 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## Numerical fields to be processed (accepting wildcards)
   # fields = ["*"]
 
-  ## Interval after which the sum value is reset to zero
-  ## If zero or unset the sum is never reset.
+  ## Interval after which metrics are evicted from the cache and the
+  ## sum values are reset to zero. A zero or unset value will keep the
+  ## metric forever.
+  ## It is strongly recommended to set an expiry interval to avoid
+  ## growing memory usage when varying metric series are processed.
   # expiry_interval = "0s"
 ```
 

--- a/plugins/processors/cumulative_sum/README.md
+++ b/plugins/processors/cumulative_sum/README.md
@@ -1,0 +1,41 @@
+# Cumulative Sum Processor Plugin
+
+Accumulate field values over time and emit metrics with cumulative sums.
+This processor is useful when you use prometheus output to have monotonic
+increasing and use increase function.
+
+## Global configuration options <!-- @/docs/includes/plugin_config.md -->
+
+In addition to the plugin-specific configuration settings, plugins support
+additional global and plugin configuration settings. These settings are used to
+modify metrics, tags, and field or create aliases and configure ordering, etc.
+See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
+
+[CONFIGURATION.md]: ../../../docs/CONFIGURATION.md#plugins
+
+## Configuration
+
+```toml @sample.conf
+# Accumulate field metrics if it's a numerical and add new field with summed values
+[[processors.cumulative_sum]]
+  ## If true, the original field will be dropped by the
+  ## processor and will be removed from original metric.
+  ## Defaults to true.
+  # drop_original_field = true
+
+  ## Fields to be processed (all if empty)
+  # fields = []
+
+  ## Maximum time to save accumulated value without update.original
+  ## Default = 10m
+  # clean_up_interval = "600s"
+```
+
+## Example
+
+```diff
+- net,host=server01 bytes_sent=1000,bytes_received=500
+- net,host=server01 bytes_sent=2500,bytes_received=1500
+- net,host=server01 bytes_sent=3000,bytes_received=2500
++ net,host=server01 bytes_sent_sum=6500,bytes_received_sum=4500
+```

--- a/plugins/processors/cumulative_sum/cumulative_sum.go
+++ b/plugins/processors/cumulative_sum/cumulative_sum.go
@@ -72,7 +72,7 @@ func (c *CumulativeSum) Apply(in ...telegraf.Metric) []telegraf.Metric {
 			// Ignore all fields not convertible to float
 			fv, err := internal.ToFloat64(field.Value)
 			if err != nil {
-				c.Log.Errorf("Failed to sum field %s, with value %s: %v", field.Key, field.Value, err)
+				c.Log.Tracef("Skipping field %q with value %v (%T) as it is not convertible to string: %v", field.Key, field.Value, field.Value, err)
 				continue
 			}
 

--- a/plugins/processors/cumulative_sum/cumulative_sum.go
+++ b/plugins/processors/cumulative_sum/cumulative_sum.go
@@ -20,7 +20,7 @@ var sampleConfig string
 type CumulativeSum struct {
 	Fields            []string        `toml:"fields"`
 	KeepOriginalField bool            `toml:"keep_original_field"`
-	ResetInterval     config.Duration `toml:"reset_interval"`
+	ExpiryInterval    config.Duration `toml:"expiry_interval"`
 	Log               telegraf.Logger `toml:"-"`
 	accept            filter.Filter
 	cache             map[uint64]*entry
@@ -54,8 +54,8 @@ func (c *CumulativeSum) Apply(in ...telegraf.Metric) []telegraf.Metric {
 	now := time.Now()
 
 	// Cleanup cache entries that are too old
-	if c.ResetInterval > 0 {
-		threshold := now.Add(-time.Duration(c.ResetInterval))
+	if c.ExpiryInterval > 0 {
+		threshold := now.Add(-time.Duration(c.ExpiryInterval))
 		maps.DeleteFunc(c.cache, func(_ uint64, e *entry) bool {
 			return e.seen.Before(threshold)
 		})

--- a/plugins/processors/cumulative_sum/cumulative_sum.go
+++ b/plugins/processors/cumulative_sum/cumulative_sum.go
@@ -72,7 +72,7 @@ func (c *CumulativeSum) Apply(in ...telegraf.Metric) []telegraf.Metric {
 			// Ignore all fields not convertible to float
 			fv, err := internal.ToFloat64(field.Value)
 			if err != nil {
-				c.Log.Tracef("Skipping field %q with value %v (%T) as it is not convertible to string: %v", field.Key, field.Value, field.Value, err)
+				c.Log.Tracef("Skipping field %q with value %v (%T) as it is not convertible to float: %v", field.Key, field.Value, field.Value, err)
 				continue
 			}
 

--- a/plugins/processors/cumulative_sum/cumulative_sum.go
+++ b/plugins/processors/cumulative_sum/cumulative_sum.go
@@ -18,12 +18,11 @@ import (
 var sampleConfig string
 
 type CumulativeSum struct {
-	Fields            []string        `toml:"fields"`
-	KeepOriginalField bool            `toml:"keep_original_field"`
-	ExpiryInterval    config.Duration `toml:"expiry_interval"`
-	Log               telegraf.Logger `toml:"-"`
-	accept            filter.Filter
-	cache             map[uint64]*entry
+	Fields         []string        `toml:"fields"`
+	ExpiryInterval config.Duration `toml:"expiry_interval"`
+	Log            telegraf.Logger `toml:"-"`
+	accept         filter.Filter
+	cache          map[uint64]*entry
 }
 
 type entry struct {
@@ -86,9 +85,6 @@ func (c *CumulativeSum) Apply(in ...telegraf.Metric) []telegraf.Metric {
 			// Compute the sum and create the new field
 			sum := stored.sums[field.Key] + fv
 			m.AddField(field.Key+"_sum", sum)
-			if !c.KeepOriginalField {
-				m.RemoveField(field.Key)
-			}
 			stored.sums[field.Key] = sum
 		}
 		stored.seen = now
@@ -103,8 +99,6 @@ func (c *CumulativeSum) Apply(in ...telegraf.Metric) []telegraf.Metric {
 
 func init() {
 	processors.Add("cumulative_sum", func() telegraf.Processor {
-		return &CumulativeSum{
-			KeepOriginalField: true,
-		}
+		return &CumulativeSum{}
 	})
 }

--- a/plugins/processors/cumulative_sum/cumulative_sum.go
+++ b/plugins/processors/cumulative_sum/cumulative_sum.go
@@ -1,0 +1,146 @@
+//go:generate ../../../tools/readme_config_includer/generator
+package cumulative_sum
+
+import (
+	_ "embed"
+	"time"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/config"
+	"github.com/influxdata/telegraf/plugins/processors"
+)
+
+//go:embed sample.conf
+var sampleConfig string
+
+type CumulativeSum struct {
+	Log               telegraf.Logger
+	Fields            []string        `toml:"fields"`
+	DropOriginalField bool            `toml:"drop_original_field"`
+	CleanUpInterval   config.Duration `toml:"clean_up_interval"`
+
+	fieldMap    map[string]bool
+	cache       map[uint64]aggregate
+	nextCleanUp time.Time
+}
+
+type aggregate struct {
+	name       string
+	tags       map[string]string
+	fields     map[string]float64
+	expireTime time.Time
+}
+
+var timeNow = time.Now
+
+func NewCumulativeSum() *CumulativeSum {
+	return &CumulativeSum{
+		DropOriginalField: true,
+		CleanUpInterval:   config.Duration(10 * time.Minute),
+		cache:             make(map[uint64]aggregate),
+	}
+}
+
+func (*CumulativeSum) SampleConfig() string {
+	return sampleConfig
+}
+
+func (c *CumulativeSum) Apply(in ...telegraf.Metric) []telegraf.Metric {
+	c.cleanup()
+	for _, original := range in {
+		id := original.HashID()
+		if _, ok := c.cache[id]; !ok {
+			a := aggregate{
+				name:       original.Name(),
+				tags:       original.Tags(),
+				fields:     make(map[string]float64),
+				expireTime: timeNow().Add(time.Duration(c.CleanUpInterval)),
+			}
+			for _, field := range original.FieldList() {
+				if c.fieldMap != nil {
+					if _, ok := c.fieldMap[field.Key]; !ok {
+						continue
+					}
+				}
+				if fv, ok := convert(field.Value); ok {
+					a.fields[field.Key] = fv
+					original.AddField(field.Key+"_sum", fv)
+					if c.DropOriginalField {
+						original.RemoveField(field.Key)
+					}
+				}
+			}
+			c.cache[id] = a
+		} else {
+			for _, field := range original.FieldList() {
+				if c.fieldMap != nil {
+					if _, ok := c.fieldMap[field.Key]; !ok {
+						continue
+					}
+				}
+				if fv, ok := convert(field.Value); ok {
+					a := c.cache[id]
+					if _, ok := a.fields[field.Key]; !ok {
+						// hit an uncached field of a cached metric
+						a.fields[field.Key] = fv
+					} else {
+						a.fields[field.Key] = a.fields[field.Key] + fv
+					}
+					original.AddField(field.Key+"_sum", a.fields[field.Key])
+					if c.DropOriginalField {
+						original.RemoveField(field.Key)
+					}
+					a.expireTime = timeNow().Add(time.Duration(c.CleanUpInterval))
+					c.cache[id] = a
+				}
+			}
+		}
+	}
+	return in
+}
+
+// Remove expired items from cache
+func (c *CumulativeSum) cleanup() {
+	now := timeNow()
+	if c.nextCleanUp.After(now) {
+		return
+	}
+	c.nextCleanUp = now.Add(time.Duration(c.CleanUpInterval))
+	keep := make(map[uint64]aggregate)
+	for id, a := range c.cache {
+		if a.expireTime.After(now) {
+			keep[id] = a
+		}
+	}
+	c.cache = keep
+}
+
+func convert(in interface{}) (float64, bool) {
+	switch v := in.(type) {
+	case float64:
+		return v, true
+	case int64:
+		return float64(v), true
+	case uint64:
+		return float64(v), true
+	default:
+		return 0, false
+	}
+}
+
+func (c *CumulativeSum) Init() error {
+	c.nextCleanUp = timeNow().Add(time.Duration(c.CleanUpInterval))
+	if c.Fields != nil {
+		c.fieldMap = make(map[string]bool, len(c.Fields))
+		for _, field := range c.Fields {
+			c.fieldMap[field] = true
+		}
+	}
+	return nil
+}
+
+func init() {
+	processors.Add("cumulative_sum", func() telegraf.Processor {
+		return NewCumulativeSum()
+	})
+}

--- a/plugins/processors/cumulative_sum/cumulative_sum.go
+++ b/plugins/processors/cumulative_sum/cumulative_sum.go
@@ -103,6 +103,8 @@ func (c *CumulativeSum) Apply(in ...telegraf.Metric) []telegraf.Metric {
 
 func init() {
 	processors.Add("cumulative_sum", func() telegraf.Processor {
-		return &CumulativeSum{}
+		return &CumulativeSum{
+			KeepOriginalField: true,
+		}
 	})
 }

--- a/plugins/processors/cumulative_sum/cumulative_sum_test.go
+++ b/plugins/processors/cumulative_sum/cumulative_sum_test.go
@@ -29,7 +29,7 @@ func TestCumulativeSum(t *testing.T) {
 		),
 	}
 
-	plugin := NewCumulativeSum()
+	plugin := &CumulativeSum{}
 	require.NoError(t, plugin.Init())
 
 	actual := plugin.Apply(
@@ -48,7 +48,7 @@ func TestCumulativeSum(t *testing.T) {
 }
 
 // TestCumulativeSum perform sum of two metrics and left original field
-func TestCumulativeSumDropOriginalFalse(t *testing.T) {
+func TestCumulativeSumKeepOriginalFieldTrue(t *testing.T) {
 	expected := []telegraf.Metric{
 		metric.New(
 			"m1",
@@ -64,8 +64,9 @@ func TestCumulativeSumDropOriginalFalse(t *testing.T) {
 		),
 	}
 
-	plugin := NewCumulativeSum()
-	plugin.DropOriginalField = false
+	plugin := &CumulativeSum{
+		KeepOriginalField: true,
+	}
 	require.NoError(t, plugin.Init())
 
 	actual := plugin.Apply(
@@ -100,7 +101,7 @@ func TestCumulativeSumStringField(t *testing.T) {
 		),
 	}
 
-	plugin := NewCumulativeSum()
+	plugin := &CumulativeSum{}
 	require.NoError(t, plugin.Init())
 
 	actual := plugin.Apply(
@@ -135,7 +136,7 @@ func TestCumulativeFieldFilteredOut(t *testing.T) {
 		),
 	}
 
-	plugin := NewCumulativeSum()
+	plugin := &CumulativeSum{}
 	plugin.Fields = []string{"another_name"}
 	require.NoError(t, plugin.Init())
 
@@ -173,7 +174,7 @@ func TestCumulativeFieldMatch(t *testing.T) {
 		),
 	}
 
-	plugin := NewCumulativeSum()
+	plugin := &CumulativeSum{}
 	plugin.Fields = []string{"value"}
 	require.NoError(t, plugin.Init())
 
@@ -204,8 +205,8 @@ func TestCumulativeSumCleanedAccumulatorAfterCleanupInterval(t *testing.T) {
 		timeNow = time.Now
 	})
 
-	plugin := NewCumulativeSum()
-	plugin.CleanUpInterval = config.Duration(60 * time.Second)
+	plugin := &CumulativeSum{}
+	plugin.ResetInterval = config.Duration(60 * time.Second)
 	require.NoError(t, plugin.Init())
 
 	plugin.Apply(

--- a/plugins/processors/cumulative_sum/cumulative_sum_test.go
+++ b/plugins/processors/cumulative_sum/cumulative_sum_test.go
@@ -1,10 +1,10 @@
 package cumulative_sum
 
 import (
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/require"
 
 	"github.com/influxdata/telegraf"

--- a/plugins/processors/cumulative_sum/cumulative_sum_test.go
+++ b/plugins/processors/cumulative_sum/cumulative_sum_test.go
@@ -234,6 +234,9 @@ func TestCumulativeSumCleanedAccumulatorAfterCleanupInterval(t *testing.T) {
 
 	currentTime = time.Unix(70, 0)
 
+	// force clean up
+	plugin.Apply()
+
 	expected := []telegraf.Metric{
 		metric.New(
 			"m1",

--- a/plugins/processors/cumulative_sum/cumulative_sum_test.go
+++ b/plugins/processors/cumulative_sum/cumulative_sum_test.go
@@ -1,0 +1,267 @@
+package cumulative_sum
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/config"
+	"github.com/influxdata/telegraf/metric"
+	"github.com/influxdata/telegraf/testutil"
+)
+
+// TestCumulativeSum perform sum of two metrics
+func TestCumulativeSum(t *testing.T) {
+	expected := []telegraf.Metric{
+		metric.New(
+			"m1",
+			map[string]string{"metric_tag": "from_metric"},
+			map[string]interface{}{"value_sum": float64(1)},
+			time.Unix(0, 0),
+		),
+		metric.New(
+			"m1",
+			map[string]string{"metric_tag": "from_metric"},
+			map[string]interface{}{"value_sum": float64(4)},
+			time.Unix(0, 0),
+		),
+	}
+
+	plugin := NewCumulativeSum()
+	require.NoError(t, plugin.Init())
+
+	actual := plugin.Apply(
+		metric.New(
+			"m1",
+			map[string]string{"metric_tag": "from_metric"},
+			map[string]interface{}{"value": 1},
+			time.Unix(0, 0),
+		), metric.New(
+			"m1",
+			map[string]string{"metric_tag": "from_metric"},
+			map[string]interface{}{"value": 3},
+			time.Unix(0, 0),
+		))
+	testutil.RequireMetricsEqual(t, expected, actual)
+}
+
+// TestCumulativeSum perform sum of two metrics and left original field
+func TestCumulativeSumDropOriginalFalse(t *testing.T) {
+	expected := []telegraf.Metric{
+		metric.New(
+			"m1",
+			map[string]string{"metric_tag": "from_metric"},
+			map[string]interface{}{"value": int64(1), "value_sum": float64(1)},
+			time.Unix(0, 0),
+		),
+		metric.New(
+			"m1",
+			map[string]string{"metric_tag": "from_metric"},
+			map[string]interface{}{"value": int64(3), "value_sum": float64(4)},
+			time.Unix(0, 0),
+		),
+	}
+
+	plugin := NewCumulativeSum()
+	plugin.DropOriginalField = false
+	require.NoError(t, plugin.Init())
+
+	actual := plugin.Apply(
+		metric.New(
+			"m1",
+			map[string]string{"metric_tag": "from_metric"},
+			map[string]interface{}{"value": 1},
+			time.Unix(0, 0),
+		), metric.New(
+			"m1",
+			map[string]string{"metric_tag": "from_metric"},
+			map[string]interface{}{"value": 3},
+			time.Unix(0, 0),
+		))
+	testutil.RequireMetricsEqual(t, expected, actual)
+}
+
+// TestCumulativeSum perform sum of two metrics and don't touch string field
+func TestCumulativeSumStringField(t *testing.T) {
+	expected := []telegraf.Metric{
+		metric.New(
+			"m1",
+			map[string]string{"metric_tag": "from_metric"},
+			map[string]interface{}{"value_name": "name", "value_sum": float64(1)},
+			time.Unix(0, 0),
+		),
+		metric.New(
+			"m1",
+			map[string]string{"metric_tag": "from_metric"},
+			map[string]interface{}{"value_name": "name", "value_sum": float64(4)},
+			time.Unix(0, 0),
+		),
+	}
+
+	plugin := NewCumulativeSum()
+	require.NoError(t, plugin.Init())
+
+	actual := plugin.Apply(
+		metric.New(
+			"m1",
+			map[string]string{"metric_tag": "from_metric"},
+			map[string]interface{}{"value_name": "name", "value": float64(1)},
+			time.Unix(0, 0),
+		), metric.New(
+			"m1",
+			map[string]string{"metric_tag": "from_metric"},
+			map[string]interface{}{"value_name": "name", "value": float64(3)},
+			time.Unix(0, 0),
+		))
+	testutil.RequireMetricsEqual(t, expected, actual)
+}
+
+// TestCumulativeSum don't perform sum of two metrics with filtered out fields
+func TestCumulativeFieldFilteredOut(t *testing.T) {
+	expected := []telegraf.Metric{
+		metric.New(
+			"m1",
+			map[string]string{"metric_tag": "from_metric"},
+			map[string]interface{}{"value_name": "name", "value": float64(1)},
+			time.Unix(0, 0),
+		),
+		metric.New(
+			"m1",
+			map[string]string{"metric_tag": "from_metric"},
+			map[string]interface{}{"value_name": "name", "value": float64(3)},
+			time.Unix(0, 0),
+		),
+	}
+
+	plugin := NewCumulativeSum()
+	plugin.Fields = []string{"another_name"}
+	require.NoError(t, plugin.Init())
+
+	// same as expected
+	actual := plugin.Apply(
+		metric.New(
+			"m1",
+			map[string]string{"metric_tag": "from_metric"},
+			map[string]interface{}{"value_name": "name", "value": float64(1)},
+			time.Unix(0, 0),
+		),
+		metric.New(
+			"m1",
+			map[string]string{"metric_tag": "from_metric"},
+			map[string]interface{}{"value_name": "name", "value": float64(3)},
+			time.Unix(0, 0),
+		))
+	testutil.RequireMetricsEqual(t, expected, actual)
+}
+
+// TestCumulativeSum perform sum of two metrics when field name match config
+func TestCumulativeFieldMatch(t *testing.T) {
+	expected := []telegraf.Metric{
+		metric.New(
+			"m1",
+			map[string]string{"metric_tag": "from_metric"},
+			map[string]interface{}{"value_name": "name", "value_sum": float64(1)},
+			time.Unix(0, 0),
+		),
+		metric.New(
+			"m1",
+			map[string]string{"metric_tag": "from_metric"},
+			map[string]interface{}{"value_name": "name", "value_sum": float64(4)},
+			time.Unix(0, 0),
+		),
+	}
+
+	plugin := NewCumulativeSum()
+	plugin.Fields = []string{"value"}
+	require.NoError(t, plugin.Init())
+
+	actual := plugin.Apply(
+		metric.New(
+			"m1",
+			map[string]string{"metric_tag": "from_metric"},
+			map[string]interface{}{"value_name": "name", "value_sum": float64(1)},
+			time.Unix(0, 0),
+		),
+		metric.New(
+			"m1",
+			map[string]string{"metric_tag": "from_metric"},
+			map[string]interface{}{"value_name": "name", "value_sum": float64(4)},
+			time.Unix(0, 0),
+		))
+	testutil.RequireMetricsEqual(t, expected, actual)
+}
+
+// TestCumulativeSum clean up internal interval for metric fields that wasn't updated too long
+func TestCumulativeSumCleanedAccumulatorAfterCleanupInterval(t *testing.T) {
+	currentTime := time.Unix(5, 0)
+
+	timeNow = func() time.Time {
+		return currentTime
+	}
+	t.Cleanup(func() {
+		timeNow = time.Now
+	})
+
+	plugin := NewCumulativeSum()
+	plugin.CleanUpInterval = config.Duration(60 * time.Second)
+	require.NoError(t, plugin.Init())
+
+	plugin.Apply(
+		metric.New(
+			"m1",
+			map[string]string{"metric_tag": "from_metric"},
+			map[string]interface{}{"value": 1},
+			time.Unix(0, 0),
+		), metric.New(
+			"m2",
+			map[string]string{"metric_tag": "from_metric"},
+			map[string]interface{}{"value": 7},
+			time.Unix(0, 0),
+		))
+
+	currentTime = time.Unix(30, 0)
+
+	plugin.Apply(
+		metric.New(
+			"m1",
+			map[string]string{"metric_tag": "from_metric"},
+			map[string]interface{}{"value": 1},
+			time.Unix(0, 0),
+		))
+
+	currentTime = time.Unix(70, 0)
+
+	expected := []telegraf.Metric{
+		metric.New(
+			"m1",
+			map[string]string{"metric_tag": "from_metric"},
+			map[string]interface{}{"value_sum": float64(3)},
+			time.Unix(0, 0),
+		),
+		metric.New(
+			"m2",
+			map[string]string{"metric_tag": "from_metric"},
+			map[string]interface{}{"value_sum": float64(7)},
+			time.Unix(0, 0),
+		),
+	}
+
+	actual := plugin.Apply(
+		metric.New(
+			"m1",
+			map[string]string{"metric_tag": "from_metric"},
+			map[string]interface{}{"value": 1},
+			time.Unix(0, 0),
+		),
+		metric.New(
+			"m2",
+			map[string]string{"metric_tag": "from_metric"},
+			map[string]interface{}{"value": 7},
+			time.Unix(0, 0),
+		),
+	)
+
+	testutil.RequireMetricsEqual(t, expected, actual)
+}

--- a/plugins/processors/cumulative_sum/cumulative_sum_test.go
+++ b/plugins/processors/cumulative_sum/cumulative_sum_test.go
@@ -28,7 +28,7 @@ func TestApply(t *testing.T) {
 					"foo",
 					map[string]string{"tag": "some tag"},
 					map[string]interface{}{
-						"healty":        false,
+						"healthy":       false,
 						"value":         float64(1.1),
 						"error_counter": int64(10),
 						"error":         "machine broken",
@@ -39,8 +39,8 @@ func TestApply(t *testing.T) {
 					"bar",
 					map[string]string{"tag": "another tag"},
 					map[string]interface{}{
-						"healty": true,
-						"value":  float64(4.4),
+						"healthy": true,
+						"value":   float64(4.4),
 					},
 					now,
 				),
@@ -50,8 +50,8 @@ func TestApply(t *testing.T) {
 					"foo",
 					map[string]string{"tag": "some tag"},
 					map[string]interface{}{
-						"healty":            false,
-						"healty_sum":        float64(0),
+						"healthy":           false,
+						"healthy_sum":       float64(0),
 						"value":             float64(1.1),
 						"value_sum":         float64(1.1),
 						"error_counter":     int64(10),
@@ -64,10 +64,10 @@ func TestApply(t *testing.T) {
 					"bar",
 					map[string]string{"tag": "another tag"},
 					map[string]interface{}{
-						"healty":     true,
-						"healty_sum": float64(1),
-						"value":      float64(4.4),
-						"value_sum":  float64(4.4),
+						"healthy":     true,
+						"healthy_sum": float64(1),
+						"value":       float64(4.4),
+						"value_sum":   float64(4.4),
 					},
 					now,
 				),
@@ -81,7 +81,7 @@ func TestApply(t *testing.T) {
 					"foo",
 					map[string]string{"tag": "some tag"},
 					map[string]interface{}{
-						"healty":        false,
+						"healthy":       false,
 						"value":         float64(1.1),
 						"error_counter": int64(10),
 						"error":         "machine broken",
@@ -92,8 +92,8 @@ func TestApply(t *testing.T) {
 					"bar",
 					map[string]string{"tag": "another tag"},
 					map[string]interface{}{
-						"healty": true,
-						"value":  float64(4.4),
+						"healthy": true,
+						"value":   float64(4.4),
 					},
 					now,
 				),
@@ -103,7 +103,7 @@ func TestApply(t *testing.T) {
 					"foo",
 					map[string]string{"tag": "some tag"},
 					map[string]interface{}{
-						"healty":        false,
+						"healthy":       false,
 						"value":         float64(1.1),
 						"value_sum":     float64(1.1),
 						"error_counter": int64(10),
@@ -115,7 +115,7 @@ func TestApply(t *testing.T) {
 					"bar",
 					map[string]string{"tag": "another tag"},
 					map[string]interface{}{
-						"healty":    true,
+						"healthy":   true,
 						"value":     float64(4.4),
 						"value_sum": float64(4.4),
 					},

--- a/plugins/processors/cumulative_sum/sample.conf
+++ b/plugins/processors/cumulative_sum/sample.conf
@@ -3,9 +3,6 @@
   ## Numerical fields to be processed (accepting wildcards)
   # fields = ["*"]
 
-  ## If true, the original field will be dropped from the output metric
-  # drop_original_field = true
-
   ## Interval after which the sum value is reset to zero
   ## If zero or unset the sum is never reset.
   # expiry_interval = "0s"

--- a/plugins/processors/cumulative_sum/sample.conf
+++ b/plugins/processors/cumulative_sum/sample.conf
@@ -1,0 +1,13 @@
+# Accumulate field metrics if it's a numerical and add new field with summed values
+[[processors.cumulative_sum]]
+  ## If true, the original field will be dropped by the
+  ## processor and will be removed from original metric.
+  ## Defaults to true.
+  # drop_original_field = true
+
+  ## Fields to be processed (all if empty)
+  # fields = []
+
+  ## Maximum time to save accumulated value without update.original
+  ## Default = 10m
+  # clean_up_interval = "600s"

--- a/plugins/processors/cumulative_sum/sample.conf
+++ b/plugins/processors/cumulative_sum/sample.conf
@@ -8,4 +8,4 @@
 
   ## Interval after which the sum value is reset to zero
   ## If zero or unset the sum is never reset.
-  # reset_interval = "0s"
+  # expiry_interval = "0s"

--- a/plugins/processors/cumulative_sum/sample.conf
+++ b/plugins/processors/cumulative_sum/sample.conf
@@ -1,13 +1,9 @@
-# Accumulate field metrics if it's a numerical and add new field with summed values
+# Compute the cumulative sum of the given fields
 [[processors.cumulative_sum]]
-  ## If true, the original field will be dropped by the
-  ## processor and will be removed from original metric.
-  ## Defaults to true.
+  ## Numerical fields to be processed (accepting wildcards)
+  # fields = ["*"]
+  ## If true, the original field will be dropped from the output metric
   # drop_original_field = true
-
-  ## Fields to be processed (all if empty)
-  # fields = []
-
-  ## Maximum time to save accumulated value without update.original
-  ## Default = 10m
-  # clean_up_interval = "600s"
+  ## Interval after which the sum value is reset to zero
+  ## If zero or unset the sum is never reset.
+  # reset_interval = "0s"

--- a/plugins/processors/cumulative_sum/sample.conf
+++ b/plugins/processors/cumulative_sum/sample.conf
@@ -2,8 +2,10 @@
 [[processors.cumulative_sum]]
   ## Numerical fields to be processed (accepting wildcards)
   # fields = ["*"]
+
   ## If true, the original field will be dropped from the output metric
   # drop_original_field = true
+
   ## Interval after which the sum value is reset to zero
   ## If zero or unset the sum is never reset.
   # reset_interval = "0s"

--- a/plugins/processors/cumulative_sum/sample.conf
+++ b/plugins/processors/cumulative_sum/sample.conf
@@ -3,6 +3,9 @@
   ## Numerical fields to be processed (accepting wildcards)
   # fields = ["*"]
 
-  ## Interval after which the sum value is reset to zero
-  ## If zero or unset the sum is never reset.
+  ## Interval after which metrics are evicted from the cache and the
+  ## sum values are reset to zero. A zero or unset value will keep the
+  ## metric forever.
+  ## It is strongly recommended to set an expiry interval to avoid
+  ## growing memory usage when varying metric series are processed.
   # expiry_interval = "0s"


### PR DESCRIPTION
## Summary
We collect metrics from a large amount of mobile devices and scrape aggregated data with Prometheus. We don't have [a monotonic increasing](https://prometheus.io/docs/concepts/metric_types/#counter) without cumulative effect (like for histogram aggregator). Sum is reset based on period settings, which prevents us from building graphs with different time intervals.

This MR add a new config property to allow accumulate data for a long period of time even between resets.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves [#16591](https://github.com/influxdata/telegraf/issues/16591)
