### PR TITLE
fix(system.uptime_format): Remove the "uptime_format" metric (#16358)

### DIFF
--- a/plugins/inputs/system/system.go
+++ b/plugins/inputs/system/system.go
@@ -2,10 +2,7 @@
 package system
 
 import (
-	"bufio"
-	"bytes"
 	_ "embed"
-	"fmt"
 	"os"
 	"strings"
 	"time"
@@ -68,9 +65,6 @@ func (s *SystemStats) Gather(acc telegraf.Accumulator) error {
 	acc.AddCounter("system", map[string]interface{}{
 		"uptime": uptime,
 	}, nil, now)
-	acc.AddFields("system", map[string]interface{}{
-		"uptime_format": formatUptime(uptime),
-	}, nil, now)
 
 	return nil
 }
@@ -84,30 +78,6 @@ func findUniqueUsers(userStats []host.UserStat) int {
 	}
 
 	return len(uniqueUsers)
-}
-
-func formatUptime(uptime uint64) string {
-	buf := new(bytes.Buffer)
-	w := bufio.NewWriter(buf)
-
-	days := uptime / (60 * 60 * 24)
-
-	if days != 0 {
-		s := ""
-		if days > 1 {
-			s = "s"
-		}
-		fmt.Fprintf(w, "%d day%s, ", days, s)
-	}
-
-	minutes := uptime / 60
-	hours := minutes / 60
-	hours %= 24
-	minutes %= 60
-
-	fmt.Fprintf(w, "%2d:%02d", hours, minutes)
-	w.Flush()
-	return buf.String()
 }
 
 func init() {


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

Issue https://github.com/influxdata/telegraf/issues/16358 contains evidence of errors in the prometheusremotewrite serializer, caused by the metric "system.uptime_format". This PR removes this metric from the "system" plugin, because the alternative metric "uptime" already contains the relevant values, and because the "uptime_format" metric has been deprecated since v1.10.

After removing this metric, the errors mentioned in #16358 no longer appear in telegraf's log.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #16358
