### PR TITLE
fix(inputs.tail): Use correct initial_read_offset persistent offset naming in the code

### DIFF
--- a/plugins/inputs/tail/tail.go
+++ b/plugins/inputs/tail/tail.go
@@ -94,7 +94,7 @@ func (t *Tail) Init() error {
 		if t.FromBeginning {
 			t.InitialReadOffset = "beginning"
 		} else {
-			t.InitialReadOffset = "save-or-end"
+			t.InitialReadOffset = "saved-or-end"
 		}
 	}
 

--- a/plugins/inputs/tail/tail.go
+++ b/plugins/inputs/tail/tail.go
@@ -149,13 +149,13 @@ func (t *Tail) getSeekInfo(file string) (*tail.SeekInfo, error) {
 		return &tail.SeekInfo{Whence: 0, Offset: 0}, nil
 	case "end":
 		return &tail.SeekInfo{Whence: 2, Offset: 0}, nil
-	case "", "save-or-end":
+	case "", "saved-or-end":
 		if offset, ok := t.offsets[file]; ok {
 			t.Log.Debugf("Using offset %d for %q", offset, file)
 			return &tail.SeekInfo{Whence: 0, Offset: offset}, nil
 		}
 		return &tail.SeekInfo{Whence: 2, Offset: 0}, nil
-	case "save-or-beginning":
+	case "saved-or-beginning":
 		if offset, ok := t.offsets[file]; ok {
 			t.Log.Debugf("Using offset %d for %q", offset, file)
 			return &tail.SeekInfo{Whence: 0, Offset: offset}, nil

--- a/plugins/inputs/tail/tail_test.go
+++ b/plugins/inputs/tail/tail_test.go
@@ -830,7 +830,7 @@ func TestGetSeekInfo(t *testing.T) {
 			name:              "Read from end when offset not exists and initial_read_offset set to save-or-end",
 			offsets:           map[string]int64{},
 			file:              "test.log",
-			InitialReadOffset: "save-or-end",
+			InitialReadOffset: "saved-or-end",
 			expected: &tail.SeekInfo{
 				Whence: 2,
 				Offset: 0,
@@ -840,7 +840,7 @@ func TestGetSeekInfo(t *testing.T) {
 			name:              "Read from offset when offset exists and initial_read_offset set to save-or-end",
 			offsets:           map[string]int64{"test.log": 100},
 			file:              "test.log",
-			InitialReadOffset: "save-or-end",
+			InitialReadOffset: "saved-or-end",
 			expected: &tail.SeekInfo{
 				Whence: 0,
 				Offset: 100,
@@ -850,7 +850,7 @@ func TestGetSeekInfo(t *testing.T) {
 			name:              "Read from start when offset not exists and initial_read_offset set to save-offset-or-start",
 			offsets:           map[string]int64{},
 			file:              "test.log",
-			InitialReadOffset: "save-or-beginning",
+			InitialReadOffset: "saved-or-beginning",
 			expected: &tail.SeekInfo{
 				Whence: 0,
 				Offset: 0,
@@ -860,7 +860,7 @@ func TestGetSeekInfo(t *testing.T) {
 			name:              "Read from offset when offset exists and initial_read_offset set to save-or-end",
 			offsets:           map[string]int64{"test.log": 100},
 			file:              "test.log",
-			InitialReadOffset: "save-or-beginning",
+			InitialReadOffset: "saved-or-beginning",
 			expected: &tail.SeekInfo{
 				Whence: 0,
 				Offset: 100,

--- a/plugins/inputs/tail/tail_test.go
+++ b/plugins/inputs/tail/tail_test.go
@@ -827,7 +827,7 @@ func TestGetSeekInfo(t *testing.T) {
 			},
 		},
 		{
-			name:              "Read from end when offset not exists and initial_read_offset set to save-or-end",
+			name:              "Read from end when offset not exists and initial_read_offset set to saved-or-end",
 			offsets:           map[string]int64{},
 			file:              "test.log",
 			InitialReadOffset: "saved-or-end",
@@ -837,7 +837,7 @@ func TestGetSeekInfo(t *testing.T) {
 			},
 		},
 		{
-			name:              "Read from offset when offset exists and initial_read_offset set to save-or-end",
+			name:              "Read from offset when offset exists and initial_read_offset set to saved-or-end",
 			offsets:           map[string]int64{"test.log": 100},
 			file:              "test.log",
 			InitialReadOffset: "saved-or-end",
@@ -857,7 +857,7 @@ func TestGetSeekInfo(t *testing.T) {
 			},
 		},
 		{
-			name:              "Read from offset when offset exists and initial_read_offset set to save-or-end",
+			name:              "Read from offset when offset exists and initial_read_offset set to saved-or-end",
 			offsets:           map[string]int64{"test.log": 100},
 			file:              "test.log",
 			InitialReadOffset: "saved-or-beginning",
@@ -909,8 +909,8 @@ func TestSetInitialValueForInitialReadOffset(t *testing.T) {
 			expected:      "beginning",
 		},
 		{
-			name:     "Set InitialReadOffset to save-or-end when from_beginning set to false and initial_read_offset not set",
-			expected: "save-or-end",
+			name:     "Set InitialReadOffset to saved-or-end when from_beginning set to false and initial_read_offset not set",
+			expected: "saved-or-end",
 		},
 		{
 			name:              "Ignore from_beginning when initial_read_offset is set",


### PR DESCRIPTION
## Summary

Ensure consistency between documentation and actual options in the code.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #16642
