### PR TITLE
feat(outputs.health): Add max time between metrics check

### DIFF
--- a/plugins/outputs/health/README.md
+++ b/plugins/outputs/health/README.md
@@ -46,6 +46,12 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   # tls_cert = "/etc/telegraf/cert.pem"
   # tls_key = "/etc/telegraf/key.pem"
 
+  ## Maximum expected time between metrics being written
+  ## Enforces an unhealthy state if there was no new metric seen for at least
+  ## the specified time. The check is disabled by default and only used if a
+  ## positive time is specified.
+  # max_time_between_metrics = "0s"
+
   ## NOTE: Due to the way TOML is parsed, tables must be at the END of the
   ## plugin definition, otherwise additional config options are read as part of
   ## the table
@@ -66,6 +72,19 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## [[outputs.health.contains]]
   ##   field = "buffer_size"
 ```
+
+### Maximum time between metrics
+
+The health plugin can assert that metrics are being delivered to it at an
+expected rate when setting `max_time_between_metrics` to a positive number.
+The check measures the time between consecutive writes to the plugin and
+compares it to the defined `max_time_between_metrics`. When the time
+elapsed between writes is greater than the configured maximum time, the plugin
+will report an unhealthy status. As soon as metrics are written again to the
+plugin, the health status will reset to healthy.
+
+Note that the metric timestamps are not taken into account, rather the time they
+are written to the plugin.
 
 ### compares
 

--- a/plugins/outputs/health/sample.conf
+++ b/plugins/outputs/health/sample.conf
@@ -21,6 +21,12 @@
   # tls_cert = "/etc/telegraf/cert.pem"
   # tls_key = "/etc/telegraf/key.pem"
 
+  ## Maximum expected time between metrics being written
+  ## Enforces an unhealthy state if there was no new metric seen for at least
+  ## the specified time. The check is disabled by default and only used if a
+  ## positive time is specified.
+  # max_time_between_metrics = "0s"
+
   ## NOTE: Due to the way TOML is parsed, tables must be at the END of the
   ## plugin definition, otherwise additional config options are read as part of
   ## the table


### PR DESCRIPTION
## Summary
This adds a new check to the `health` output plugin that can detect moments when no metrics are flowing through `telegraf`. For example, when impacted by issues like https://github.com/influxdata/telegraf/issues/16070

This is disabled by default, and can be enabled using the new configuration options:

```
[[outputs.health]]
  service_address = "http://:8080"
  max_time_between_metrics = "1s"
  unhealthy_if_metrics_are_delayed = true
```

Besides the included unittests, this change was validated running `telegraf` with the following configuration:

```
[[inputs.internal]]
  interval = "20s"

[[outputs.health]]
  service_address = "http://:8080"
  max_time_between_metrics = "1s"
  unhealthy_if_metrics_are_delayed = true
```

And querying the health status using: 
```
while true; do curl -X GET localhost:8080; sleep 0.01; done
```

1. Telegraf starts healthy.
2. Once 1s passes after the first internal metrics are written, the status changes to unhealthy
3. After that, every 20s, it reports OK for 1s and then goes back to unhealthy.

This PR replaces the previous implementation attempt done in https://github.com/influxdata/telegraf/pull/16212
For more context, refer to [this slack thread](https://influxcommunity.slack.com/archives/CH99HUH8V/p1736782025589019?thread_ts=1731947234.950749&cid=CH99HUH8V)

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->
resolves https://github.com/influxdata/telegraf/issues/16645
