### PR TITLE
chore(deps): Bump tj-actions/changed-files from v45 to v46.0.1

### DIFF
--- a/.github/workflows/readme-linter.yml
+++ b/.github/workflows/readme-linter.yml
@@ -17,7 +17,7 @@ jobs:
           fetch-depth: 0
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v45
+        uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32 # v46.0.1
         with:
           base_sha: ${{ github.event.pull_request.base.sha }}
           files: ./plugins/**/README.md


### PR DESCRIPTION
## Summary

This PR bumps the changed-file-detection action to a new version and hash-tags this version to avoid issues with manipulated tags.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #16649