### PR TITLE
test: Update fedora image for nightly test

### DIFF
--- a/tools/package_incus_test/main.go
+++ b/tools/package_incus_test/main.go
@@ -10,8 +10,8 @@ import (
 )
 
 var imagesRPM = []string{
+	"fedora/41",
 	"fedora/40",
-	"fedora/39",
 	"centos/9-Stream",
 }
 


### PR DESCRIPTION
## Summary

This bumps the fedora image for the nightly smoke test as Fedora 39 is no longer available as an Incus image.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues
