### PR TITLE
test(outputs.remotefile): Make test more robust

### DIFF
--- a/plugins/outputs/remotefile/remotefile_test.go
+++ b/plugins/outputs/remotefile/remotefile_test.go
@@ -474,8 +474,12 @@ func TestTrackingMetrics(t *testing.T) {
 	require.NoError(t, plugin.Connect())
 	defer plugin.Close()
 
-	// Write the metrics and wait for the data to settle to disk
+	// Write the input metrics and close the plugin. This is required to
+	// actually flush the data to disk
 	require.NoError(t, plugin.Write(input))
+	plugin.Close()
+
+	// Wait for the data to settle to disk
 	require.Eventually(t, func() bool {
 		ok := true
 		for fn := range expected {


### PR DESCRIPTION
## Summary

This PR tries to prevent the `The process cannot access the file because it is being used by another process` error seen on Windows CI runs by closing the files before testing the outcome.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

