### PR TITLE
fix(secrets): Make "insufficient lockable memory" warning work on BSDs

### DIFF
--- a/cmd/telegraf/telegraf_posix.go
+++ b/cmd/telegraf/telegraf_posix.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"log"
+	"runtime"
 	"syscall"
 )
 
@@ -20,8 +21,16 @@ func (t *Telegraf) Run() error {
 }
 
 func getLockedMemoryLimit() uint64 {
-	// From https://elixir.bootlin.com/linux/latest/source/include/uapi/asm-generic/resource.h#L35
-	const rLimitMemlock = 8
+	var rLimitMemlock int
+
+	switch runtime.GOOS {
+	case "dragonfly", "freebsd", "netbsd", "openbsd":
+		// From https://cgit.freebsd.org/src/tree/sys/sys/resource.h#n107
+		rLimitMemlock = 6
+	default:
+		// From https://elixir.bootlin.com/linux/latest/source/include/uapi/asm-generic/resource.h#L35
+		rLimitMemlock = 8
+	}
 
 	var limit syscall.Rlimit
 	if err := syscall.Getrlimit(rLimitMemlock, &limit); err != nil {


### PR DESCRIPTION
## Summary

On BSDs (OpenBSD/FreeBSD/NetBSD/Dragonfly/Others?), telegraf had a bug in its detection of the lockable memory:
the respective value of the resource constant **`RLIMIT_MEMLOCK`**,  used as `getrlimit(2)` parameter, deviates from the Linux one.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #16681
