### PR TITLE
fix(agent): Correctly truncate the disk buffer

### DIFF
--- a/models/buffer_disk.go
+++ b/models/buffer_disk.go
@@ -246,7 +246,7 @@ func (b *DiskBuffer) EndTransaction(tx *Transaction) {
 			panic(err)
 		}
 	} else {
-		if err := b.file.TruncateFront(b.batchFirst + uint64(removeIdx+1)); err != nil {
+		if err := b.file.TruncateFront(b.batchFirst + uint64(removeIdx)); err != nil {
 			log.Printf("E! batch length: %d, first: %d, size: %d", len(tx.Batch), b.batchFirst, b.batchSize)
 			panic(err)
 		}

--- a/models/buffer_disk.go
+++ b/models/buffer_disk.go
@@ -241,7 +241,7 @@ func (b *DiskBuffer) EndTransaction(tx *Transaction) {
 	if b.isEmpty {
 		// WAL files cannot be fully empty but need to contain at least one
 		// item to not throw an error
-		if err := b.file.TruncateFront(b.writeIndex()-1); err != nil {
+		if err := b.file.TruncateFront(b.writeIndex() - 1); err != nil {
 			log.Printf("E! batch length: %d, first: %d, size: %d", len(tx.Batch), b.batchFirst, b.batchSize)
 			panic(err)
 		}

--- a/models/buffer_disk.go
+++ b/models/buffer_disk.go
@@ -253,7 +253,7 @@ func (b *DiskBuffer) EndTransaction(tx *Transaction) {
 	}
 
 	// Truncate the mask and update the relative offsets
-	b.mask = b.mask[:removeIdx]
+	b.mask = b.mask[removeIdx:]
 	for i := range b.mask {
 		b.mask[i] -= removeIdx
 	}

--- a/models/buffer_disk.go
+++ b/models/buffer_disk.go
@@ -146,12 +146,12 @@ func (b *DiskBuffer) BeginTransaction(batchSize int) *Transaction {
 	offsets := make([]int, 0, batchSize)
 	readIndex := b.batchFirst
 	endIndex := b.writeIndex()
-	offset := 0
-	for ; batchSize > 0 && readIndex < endIndex; readIndex, offset = readIndex+1, offset+1 {
+	for offset := 0; batchSize > 0 && readIndex < endIndex; offset++ {
 		data, err := b.file.Read(readIndex)
 		if err != nil {
 			panic(err)
 		}
+		readIndex++
 
 		if slices.Contains(b.mask, offset) {
 			// Metric is masked by a previous write and is scheduled for removal

--- a/models/buffer_disk.go
+++ b/models/buffer_disk.go
@@ -233,11 +233,11 @@ func (b *DiskBuffer) EndTransaction(tx *Transaction) {
 		if offset != i {
 			break
 		}
-		removeIdx = offset
+		removeIdx = offset + 1
 	}
 
 	// Remove the metrics in front from the WAL file
-	b.isEmpty = b.entries()-removeIdx-1 <= 0
+	b.isEmpty = b.entries()-removeIdx <= 0
 	if b.isEmpty {
 		// WAL files cannot be fully empty but need to contain at least one
 		// item to not throw an error

--- a/models/buffer_suite_test.go
+++ b/models/buffer_suite_test.go
@@ -585,8 +585,7 @@ func (s *BufferSuiteTest) TestBufferAcceptRemovesBatch() {
 	buf.EndTransaction(tx)
 	s.Equal(1, buf.Len())
 
-	switch buf := buf.(type) {
-	case *DiskBuffer:
+	if buf, ok := buf.(*DiskBuffer); ok {
 		s.Equal(1, buf.entries())
 	}
 }

--- a/models/buffer_suite_test.go
+++ b/models/buffer_suite_test.go
@@ -584,10 +584,6 @@ func (s *BufferSuiteTest) TestBufferAcceptRemovesBatch() {
 	tx.AcceptAll()
 	buf.EndTransaction(tx)
 	s.Equal(1, buf.Len())
-
-	if buf, ok := buf.(*DiskBuffer); ok {
-		s.Equal(1, buf.entries())
-	}
 }
 
 func (s *BufferSuiteTest) TestBufferRejectLeavesBatch() {

--- a/models/buffer_suite_test.go
+++ b/models/buffer_suite_test.go
@@ -584,6 +584,11 @@ func (s *BufferSuiteTest) TestBufferAcceptRemovesBatch() {
 	tx.AcceptAll()
 	buf.EndTransaction(tx)
 	s.Equal(1, buf.Len())
+
+	switch buf := buf.(type) {
+	case *DiskBuffer:
+		s.Equal(1, buf.entries())
+	}
 }
 
 func (s *BufferSuiteTest) TestBufferRejectLeavesBatch() {


### PR DESCRIPTION
## Summary

The disk buffer grows and never shrinks, as documented [here](https://github.com/influxdata/telegraf/issues/16696).

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #16314
resolves #16500
resolves #16615
resolves #16696
