### PR TITLE
fix(inputs.win_wmi): Free resources to avoid leaks

### DIFF
--- a/plugins/inputs/win_wmi/method.go
+++ b/plugins/inputs/win_wmi/method.go
@@ -248,6 +248,7 @@ func (m *method) extractData(prop *ole.VARIANT, output *ole.IDispatch) (map[stri
 		return tags, fields, nil
 	}
 	if array := property.ToArray(); array != nil {
+		defer array.Release()
 		if m.tagFilter != nil && m.tagFilter.Match(name) {
 			for i, v := range array.ToValueArray() {
 				if s, err := internal.ToString(v); err == nil && s != "" {

--- a/plugins/inputs/win_wmi/method.go
+++ b/plugins/inputs/win_wmi/method.go
@@ -164,65 +164,83 @@ func (m *method) execute(acc telegraf.Accumulator) error {
 	defer outputPropertiesRaw.Clear()
 
 	// Convert the results to fields and tags
-	tags, fields := make(map[string]string), make(map[string]interface{})
+	tags := make(map[string]string)
+	fields := make(map[string]interface{})
 
 	// Add a source tag if we use remote queries
 	if m.host != "" {
 		tags["source"] = m.host
 	}
 
-	err = oleutil.ForEach(outputProperties, func(p *ole.VARIANT) error {
-		// Name of the returned result item
-		nameProperty, err := p.ToIDispatch().GetProperty("Name")
+	if err := oleutil.ForEach(outputProperties, func(p *ole.VARIANT) error {
+		propTags, propFields, err := m.extractData(p, output)
 		if err != nil {
-			return errors.New("cannot get output property name")
+			return err
 		}
-		name := nameProperty.ToString()
-		defer nameProperty.Clear()
-
-		// Value of the returned result item
-		property, err := output.GetProperty(name)
-		if err != nil {
-			return fmt.Errorf("failed to get value for output property %s: %w", name, err)
+		for k, v := range propTags {
+			tags[k] = v
 		}
-
-		// Map the fieldname if provided
-		if n, found := m.FieldMapping[name]; found {
-			name = n
+		for k, v := range propFields {
+			fields[k] = v
 		}
-
-		// We might get either scalar values or an array of values...
-		if value := property.Value(); value != nil {
-			if m.tagFilter != nil && m.tagFilter.Match(name) {
-				if s, err := internal.ToString(value); err == nil && s != "" {
-					tags[name] = s
-				}
-			} else {
-				fields[name] = value
-			}
-			return nil
-		}
-		if array := property.ToArray(); array != nil {
-			if m.tagFilter != nil && m.tagFilter.Match(name) {
-				for i, v := range array.ToValueArray() {
-					if s, err := internal.ToString(v); err == nil && s != "" {
-						tags[fmt.Sprintf("%s_%d", name, i)] = s
-					}
-				}
-			} else {
-				for i, v := range array.ToValueArray() {
-					fields[fmt.Sprintf("%s_%d", name, i)] = v
-				}
-			}
-			return nil
-		}
-		return fmt.Errorf("cannot handle property %q with value %v", name, property)
-	})
-	if err != nil {
+		return nil
+	}); err != nil {
 		return fmt.Errorf("cannot iterate the output properties: %w", err)
 	}
 
 	acc.AddFields(m.ClassName, fields, tags)
 
 	return nil
+}
+
+func (m *method) extractData(prop *ole.VARIANT, output *ole.IDispatch) (map[string]string, map[string]interface{}, error) {
+	// Name of the returned result item
+	nameProperty, err := prop.ToIDispatch().GetProperty("Name")
+	if err != nil {
+		return nil, nil, errors.New("cannot get output property name")
+	}
+	raw := nameProperty.ToString()
+	defer nameProperty.Clear()
+
+	// Map the fieldname if provided
+	name := raw
+	if n, found := m.FieldMapping[name]; found {
+		name = n
+	}
+
+	// Value of the returned result item
+	property, err := output.GetProperty(raw)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get value for output property %s: %w", raw, err)
+	}
+	defer property.Clear()
+
+	// We might get either scalar values or an array of values...
+	tags := make(map[string]string)
+	fields := make(map[string]interface{})
+	if value := property.Value(); value != nil {
+		if m.tagFilter != nil && m.tagFilter.Match(name) {
+			if s, err := internal.ToString(value); err == nil && s != "" {
+				tags[name] = s
+			}
+		} else {
+			fields[name] = value
+		}
+		return tags, fields, nil
+	}
+	if array := property.ToArray(); array != nil {
+		if m.tagFilter != nil && m.tagFilter.Match(name) {
+			for i, v := range array.ToValueArray() {
+				if s, err := internal.ToString(v); err == nil && s != "" {
+					tags[fmt.Sprintf("%s_%d", name, i)] = s
+				}
+			}
+		} else {
+			for i, v := range array.ToValueArray() {
+				fields[fmt.Sprintf("%s_%d", name, i)] = v
+			}
+		}
+		return tags, fields, nil
+	}
+	return nil, nil, fmt.Errorf("cannot handle property %q with value %v", name, property)
 }

--- a/plugins/inputs/win_wmi/method.go
+++ b/plugins/inputs/win_wmi/method.go
@@ -133,7 +133,6 @@ func (m *method) execute(acc telegraf.Accumulator) error {
 	if err != nil {
 		return fmt.Errorf("failed to get input parameters for %s: %w", m.Method, err)
 	}
-	defer inputParamsRaw.Clear()
 	inputParams := inputParamsRaw.ToIDispatch()
 	defer inputParams.Release()
 	inputProps := make([]*ole.VARIANT, 0, len(m.Arguments))
@@ -155,7 +154,6 @@ func (m *method) execute(acc telegraf.Accumulator) error {
 	if err != nil {
 		return fmt.Errorf("failed to get output parameters for %s: %w", m.Method, err)
 	}
-	defer outputParamsRaw.Clear()
 	outputParams := outputParamsRaw.ToIDispatch()
 	defer outputParams.Release()
 
@@ -164,7 +162,6 @@ func (m *method) execute(acc telegraf.Accumulator) error {
 	if err != nil {
 		return fmt.Errorf("failed to execute method %s: %w", m.Method, err)
 	}
-	defer outputRaw.Clear()
 	output := outputRaw.ToIDispatch()
 	defer output.Release()
 
@@ -172,7 +169,6 @@ func (m *method) execute(acc telegraf.Accumulator) error {
 	if err != nil {
 		return fmt.Errorf("failed to get output properties for method %s: %w", m.Method, err)
 	}
-	defer outputPropertiesRaw.Clear()
 	outputProperties := outputPropertiesRaw.ToIDispatch()
 	defer outputProperties.Release()
 

--- a/plugins/inputs/win_wmi/method.go
+++ b/plugins/inputs/win_wmi/method.go
@@ -111,7 +111,6 @@ func (m *method) execute(acc telegraf.Accumulator) error {
 	if err != nil {
 		return fmt.Errorf("failed to get class %s: %w", m.ClassName, err)
 	}
-	defer classRaw.Clear()
 	class := classRaw.ToIDispatch()
 	defer class.Release()
 
@@ -119,7 +118,6 @@ func (m *method) execute(acc telegraf.Accumulator) error {
 	if err != nil {
 		return fmt.Errorf("failed to call method %s: %w", m.Method, err)
 	}
-	defer classMethodsRaw.Clear()
 	classMethods := classMethodsRaw.ToIDispatch()
 	defer classMethods.Release()
 
@@ -127,7 +125,6 @@ func (m *method) execute(acc telegraf.Accumulator) error {
 	if err != nil {
 		return fmt.Errorf("failed to call method %s: %w", m.Method, err)
 	}
-	defer methodRaw.Clear()
 	method := methodRaw.ToIDispatch()
 	defer method.Release()
 

--- a/plugins/inputs/win_wmi/method.go
+++ b/plugins/inputs/win_wmi/method.go
@@ -99,16 +99,15 @@ func (m *method) execute(acc telegraf.Accumulator) error {
 	}
 	defer wmi.Release()
 
-	serviceRaw, err := oleutil.CallMethod(wmi, "ConnectServer", m.connectionParams...)
+	serviceRaw, err := wmi.CallMethod("ConnectServer", m.connectionParams...)
 	if err != nil {
 		return fmt.Errorf("failed calling method ConnectServer: %w", err)
 	}
-	defer serviceRaw.Clear()
 	service := serviceRaw.ToIDispatch()
 	defer service.Release()
 
 	// Get the specified class-method
-	classRaw, err := oleutil.CallMethod(service, "Get", m.ClassName)
+	classRaw, err := service.CallMethod("Get", m.ClassName)
 	if err != nil {
 		return fmt.Errorf("failed to get class %s: %w", m.ClassName, err)
 	}
@@ -133,7 +132,7 @@ func (m *method) execute(acc telegraf.Accumulator) error {
 	defer method.Release()
 
 	// Fill the input parameters of the method
-	inputParamsRaw, err := oleutil.GetProperty(method, "InParameters")
+	inputParamsRaw, err := method.GetProperty("InParameters")
 	if err != nil {
 		return fmt.Errorf("failed to get input parameters for %s: %w", m.Method, err)
 	}
@@ -155,7 +154,7 @@ func (m *method) execute(acc telegraf.Accumulator) error {
 	}
 
 	// Get the output parameters of the method
-	outputParamsRaw, err := oleutil.GetProperty(method, "OutParameters")
+	outputParamsRaw, err := method.GetProperty("OutParameters")
 	if err != nil {
 		return fmt.Errorf("failed to get output parameters for %s: %w", m.Method, err)
 	}
@@ -172,7 +171,7 @@ func (m *method) execute(acc telegraf.Accumulator) error {
 	output := outputRaw.ToIDispatch()
 	defer output.Release()
 
-	outputPropertiesRaw, err := oleutil.GetProperty(outputParams, "Properties_")
+	outputPropertiesRaw, err := outputParams.GetProperty("Properties_")
 	if err != nil {
 		return fmt.Errorf("failed to get output properties for method %s: %w", m.Method, err)
 	}


### PR DESCRIPTION
## Summary

This PR attempts to fix the issues seen in #16179. While I'm not able to reproduce the issues, it seems like restricting the threading model for calling the COM object more to a serialized chain for each thread. Furthermore, the PR adds error prefixes to better localize the error and makes error handling more strict. Additionally, the PR frees the `property` resource properly which could otherwise lead to a memory leak.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

based on #16781 
resolves #16179 
