### PR TITLE
feat(inputs.whois): Support IDN domains

### DIFF
--- a/plugins/inputs/whois/testcases/invalid_domain/expected.err
+++ b/plugins/inputs/whois/testcases/invalid_domain/expected.err
@@ -1,0 +1,2 @@
+invalid domain format: "*.example.com"
+invalid domain format: "no-tld"

--- a/plugins/inputs/whois/testcases/invalid_domain/telegraf.conf
+++ b/plugins/inputs/whois/testcases/invalid_domain/telegraf.conf
@@ -1,3 +1,3 @@
 [[inputs.whois]]
-  domains = ["invalid-domain.xyz"]
+  domains = ["invalid-domain.xyz", "*.example.com", "no-tld"]
   timeout = "5s"

--- a/plugins/inputs/whois/testcases/valid_idn_domain/expected.out
+++ b/plugins/inputs/whois/testcases/valid_idn_domain/expected.out
@@ -1,1 +1,2 @@
 whois,domain=münchen.de,status=unknown registrant="not set",registrar="DENIC eG (the German domain registry)",name_servers="ns01e.muenchen.de,ns02e.muenchen.de",dnssec_enabled=false,creation_timestamp=808358400i,expiration_timestamp=1912896000i,updated_timestamp=1704067200i,expiry=172283583i
+whois,domain=xn--mnchn-kva.de,status=unknown registrant="not set",registrar="DENIC eG",name_servers="ns01e.muenchen.de,ns02e.muenchen.de",dnssec_enabled=false,creation_timestamp=808358400i,expiration_timestamp=1912896000i,updated_timestamp=1704067200i,expiry=172283583i

--- a/plugins/inputs/whois/testcases/valid_idn_domain/expected.out
+++ b/plugins/inputs/whois/testcases/valid_idn_domain/expected.out
@@ -1,0 +1,1 @@
+whois,domain=münchen.de,status=unknown registrant="not set",registrar="DENIC eG (the German domain registry)",name_servers="ns01e.muenchen.de,ns02e.muenchen.de",dnssec_enabled=false,creation_timestamp=808358400i,expiration_timestamp=1912896000i,updated_timestamp=1704067200i,expiry=172283583i

--- a/plugins/inputs/whois/testcases/valid_idn_domain/input_münchen.de.txt
+++ b/plugins/inputs/whois/testcases/valid_idn_domain/input_münchen.de.txt
@@ -1,0 +1,7 @@
+Domain Name: münchen.de
+Registrar: DENIC eG (the German domain registry)
+Updated Date: 2024-01-01T00:00:00Z
+Creation Date: 1995-08-14T00:00:00Z
+Registry Expiry Date: 2030-08-14T00:00:00Z
+Name Server: ns01e.muenchen.de
+Name Server: ns02e.muenchen.de

--- a/plugins/inputs/whois/testcases/valid_idn_domain/input_xn--mnchn-kva.de.txt
+++ b/plugins/inputs/whois/testcases/valid_idn_domain/input_xn--mnchn-kva.de.txt
@@ -1,0 +1,7 @@
+Domain Name: xn--mnchn-kva.de
+Registrar: DENIC eG
+Updated Date: 2024-01-01T00:00:00Z
+Creation Date: 1995-08-14T00:00:00Z
+Registry Expiry Date: 2030-08-14T00:00:00Z
+Name Server: ns01e.muenchen.de
+Name Server: ns02e.muenchen.de

--- a/plugins/inputs/whois/testcases/valid_idn_domain/telegraf.conf
+++ b/plugins/inputs/whois/testcases/valid_idn_domain/telegraf.conf
@@ -1,0 +1,3 @@
+[[inputs.whois]]
+  domains = ["münchen.de"]
+  timeout = "5s"

--- a/plugins/inputs/whois/testcases/valid_idn_domain/telegraf.conf
+++ b/plugins/inputs/whois/testcases/valid_idn_domain/telegraf.conf
@@ -1,3 +1,3 @@
 [[inputs.whois]]
-  domains = ["münchen.de"]
+  domains = ["münchen.de", "xn--mnchn-kva.de"]
   timeout = "5s"

--- a/plugins/inputs/whois/whois.go
+++ b/plugins/inputs/whois/whois.go
@@ -58,12 +58,7 @@ func (w *Whois) Init() error {
 	return nil
 }
 
-var (
-	// For ASCII domains
-	asciiDomainRegex = regexp.MustCompile(`^([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,63}$`)
-	// For Punycode domains
-	punycodeRegex = regexp.MustCompile(`^(xn--[a-zA-Z0-9-]{1,59}\.)+[a-zA-Z]{2,63}$`)
-)
+var asciiDomainRegex = regexp.MustCompile(`^([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,63}$`)
 
 func isValidDomain(domain string) bool {
 	if len(domain) > maxDomainLength {
@@ -82,8 +77,7 @@ func isValidDomain(domain string) bool {
 		return false
 	}
 
-	// Either match ASCII pattern or punycode pattern
-	return asciiDomainRegex.MatchString(punycodeVersion) || punycodeRegex.MatchString(punycodeVersion)
+	return asciiDomainRegex.MatchString(punycodeVersion)
 }
 
 func (w *Whois) Gather(acc telegraf.Accumulator) error {

--- a/plugins/inputs/whois/whois.go
+++ b/plugins/inputs/whois/whois.go
@@ -10,12 +10,13 @@ import (
 	"strings"
 	"time"
 
-	"github.com/influxdata/telegraf"
-	"github.com/influxdata/telegraf/config"
-	"github.com/influxdata/telegraf/plugins/inputs"
 	"github.com/likexian/whois"
 	"github.com/likexian/whois-parser"
 	"golang.org/x/net/idna"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/config"
+	"github.com/influxdata/telegraf/plugins/inputs"
 )
 
 //go:embed sample.conf

--- a/plugins/inputs/whois/whois.go
+++ b/plugins/inputs/whois/whois.go
@@ -21,9 +21,7 @@ import (
 //go:embed sample.conf
 var sampleConfig string
 
-const (
-	maxDomainLength = 253
-)
+const maxDomainLength = 253
 
 type Whois struct {
 	Domains            []string        `toml:"domains"`

--- a/plugins/inputs/whois/whois.go
+++ b/plugins/inputs/whois/whois.go
@@ -6,17 +6,16 @@ import (
 	_ "embed"
 	"errors"
 	"fmt"
-	"golang.org/x/net/idna"
 	"regexp"
 	"strings"
 	"time"
 
-	"github.com/likexian/whois"
-	"github.com/likexian/whois-parser"
-
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/plugins/inputs"
+	"github.com/likexian/whois"
+	"github.com/likexian/whois-parser"
+	"golang.org/x/net/idna"
 )
 
 //go:embed sample.conf


### PR DESCRIPTION
## Summary
**Add IDN Support to Whois Plugin**  

Enhances domain validation for Internationalized Domain Name (IDN) support by handling punycode conversion.  

**Implementation:**  
- Validate as a standard ASCII domain first.  
- Convert non-ASCII domains to punycode with strict validation.  
- Ensure the converted domain matches ASCII or punycode patterns.  

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues

related to: #16509
