### PR TITLE
chore: Fix linter findings for `revive:exported` in `plugins/inputs/[w-z]*`

### DIFF
--- a/plugins/inputs/wireguard/wireguard.go
+++ b/plugins/inputs/wireguard/wireguard.go
@@ -16,11 +16,6 @@ import (
 //go:embed sample.conf
 var sampleConfig string
 
-const (
-	measurementDevice = "wireguard_device"
-	measurementPeer   = "wireguard_peer"
-)
-
 var (
 	deviceTypeNames = map[wgtypes.DeviceType]string{
 		wgtypes.Unknown:     "unknown",
@@ -29,8 +24,11 @@ var (
 	}
 )
 
-// Wireguard is an input that enumerates all Wireguard interfaces/devices on
-// the host, and reports gauge metrics for the device itself and its peers.
+const (
+	measurementDevice = "wireguard_device"
+	measurementPeer   = "wireguard_peer"
+)
+
 type Wireguard struct {
 	Devices []string        `toml:"devices"`
 	Log     telegraf.Logger `toml:"-"`
@@ -44,7 +42,6 @@ func (*Wireguard) SampleConfig() string {
 
 func (wg *Wireguard) Init() error {
 	var err error
-
 	wg.client, err = wgctrl.New()
 
 	return err

--- a/plugins/inputs/wireless/wireless.go
+++ b/plugins/inputs/wireless/wireless.go
@@ -11,7 +11,6 @@ import (
 //go:embed sample.conf
 var sampleConfig string
 
-// Wireless is used to store configuration values.
 type Wireless struct {
 	HostProc string          `toml:"host_proc"`
 	Log      telegraf.Logger `toml:"-"`

--- a/plugins/inputs/wireless/wireless_linux.go
+++ b/plugins/inputs/wireless/wireless_linux.go
@@ -14,10 +14,10 @@ import (
 	"github.com/influxdata/telegraf/plugins/inputs"
 )
 
+var newLineByte = []byte("\n")
+
 // length of wireless interface fields
 const interfaceFieldLength = 10
-
-var newLineByte = []byte("\n")
 
 type wirelessInterface struct {
 	Interface string
@@ -33,7 +33,6 @@ type wirelessInterface struct {
 	Beacon    int64
 }
 
-// Gather collects the wireless information.
 func (w *Wireless) Gather(acc telegraf.Accumulator) error {
 	// load proc path, get default value if config value and env variable are empty
 	if w.HostProc == "" {

--- a/plugins/inputs/wireless/wireless_notlinux.go
+++ b/plugins/inputs/wireless/wireless_notlinux.go
@@ -12,7 +12,7 @@ func (w *Wireless) Init() error {
 	return nil
 }
 
-func (*Wireless) Gather(_ telegraf.Accumulator) error {
+func (*Wireless) Gather(telegraf.Accumulator) error {
 	return nil
 }
 

--- a/plugins/inputs/x509_cert/x509_cert.go
+++ b/plugins/inputs/x509_cert/x509_cert.go
@@ -38,7 +38,6 @@ var sampleConfig string
 // Regexp for handling file URIs containing a drive letter and leading slash
 var reDriveLetter = regexp.MustCompile(`^/([a-zA-Z]:/)`)
 
-// X509Cert holds the configuration of the plugin.
 type X509Cert struct {
 	Sources          []string        `toml:"sources"`
 	Timeout          config.Duration `toml:"timeout"`
@@ -93,7 +92,6 @@ func (c *X509Cert) Init() error {
 	return nil
 }
 
-// Gather adds metrics into the accumulator.
 func (c *X509Cert) Gather(acc telegraf.Accumulator) error {
 	now := time.Now()
 

--- a/plugins/inputs/zfs/zfs.go
+++ b/plugins/inputs/zfs/zfs.go
@@ -10,24 +10,23 @@ import (
 //go:embed sample.conf
 var sampleConfig string
 
-type Sysctl func(metric string) ([]string, error)
-type Zpool func() ([]string, error)
-type Zdataset func(properties []string) ([]string, error)
-type Uname func() (string, error)
-
 type Zfs struct {
-	KstatPath      string
-	KstatMetrics   []string
-	PoolMetrics    bool
-	DatasetMetrics bool
+	KstatPath      string          `toml:"kstatPath"`
+	KstatMetrics   []string        `toml:"kstatMetrics"`
+	PoolMetrics    bool            `toml:"poolMetrics"`
+	DatasetMetrics bool            `toml:"datasetMetrics"`
 	Log            telegraf.Logger `toml:"-"`
 
-	sysctl   Sysctl   //nolint:unused // False positive - this var is used for non-default build tag: freebsd
-	zpool    Zpool    //nolint:unused // False positive - this var is used for non-default build tag: freebsd
-	zdataset Zdataset //nolint:unused // False positive - this var is used for non-default build tag: freebsd
-	uname    Uname    //nolint:unused // False positive - this var is used for non-default build tag: freebsd
-	version  int64    //nolint:unused // False positive - this var is used for non-default build tag: freebsd
+	sysctl   sysctlF   //nolint:unused // False positive - this var is used for non-default build tag: freebsd
+	zpool    zpoolF    //nolint:unused // False positive - this var is used for non-default build tag: freebsd
+	zdataset zdatasetF //nolint:unused // False positive - this var is used for non-default build tag: freebsd
+	uname    unameF    //nolint:unused // False positive - this var is used for non-default build tag: freebsd
 }
+
+type sysctlF func(metric string) ([]string, error)
+type zpoolF func() ([]string, error)
+type zdatasetF func(properties []string) ([]string, error)
+type unameF func() (string, error)
 
 func (*Zfs) SampleConfig() string {
 	return sampleConfig

--- a/plugins/inputs/zfs/zfs_freebsd.go
+++ b/plugins/inputs/zfs/zfs_freebsd.go
@@ -22,7 +22,7 @@ func (z *Zfs) Init() error {
 		return fmt.Errorf("determining uname failed: %w", err)
 	}
 	parts := strings.SplitN(release, ".", 2)
-	z.version, err = strconv.ParseInt(parts[0], 10, 64)
+	version, err := strconv.ParseInt(parts[0], 10, 64)
 	if err != nil {
 		return fmt.Errorf("determining version from %q failed: %w", release, err)
 	}
@@ -31,7 +31,7 @@ func (z *Zfs) Init() error {
 	// Please note that starting from FreeBSD 14 the 'vdev_cache_stats' are
 	// no longer available.
 	if len(z.KstatMetrics) == 0 {
-		if z.version < 14 {
+		if version < 14 {
 			z.KstatMetrics = []string{"arcstats", "zfetchstats", "vdev_cache_stats"}
 		} else {
 			z.KstatMetrics = []string{"arcstats", "zfetchstats"}

--- a/plugins/inputs/zfs/zfs_linux.go
+++ b/plugins/inputs/zfs/zfs_linux.go
@@ -14,169 +14,18 @@ import (
 	"github.com/influxdata/telegraf/plugins/inputs"
 )
 
-type metricsVersion uint8
-
 const (
 	unknown metricsVersion = iota
 	v1
 	v2
 )
 
+type metricsVersion uint8
+
 type poolInfo struct {
 	name       string
 	ioFilename string
 	version    metricsVersion
-}
-
-func probeVersion(kstatPath string) (metricsVersion, []string, error) {
-	poolsDirs, err := filepath.Glob(kstatPath + "/*/objset-*")
-
-	// From the docs: the only possible returned error is ErrBadPattern, when pattern is malformed.
-	// Because of this we need to determine how to fallback differently.
-	if err != nil {
-		return unknown, poolsDirs, err
-	}
-
-	if len(poolsDirs) > 0 {
-		return v2, poolsDirs, nil
-	}
-
-	// Fallback to the old kstat in case of an older ZFS version.
-	poolsDirs, err = filepath.Glob(kstatPath + "/*/io")
-	if err != nil {
-		return unknown, poolsDirs, err
-	}
-
-	return v1, poolsDirs, nil
-}
-
-func getPools(kstatPath string) ([]poolInfo, error) {
-	pools := make([]poolInfo, 0)
-	version, poolsDirs, err := probeVersion(kstatPath)
-	if err != nil {
-		return nil, err
-	}
-
-	for _, poolDir := range poolsDirs {
-		poolDirSplit := strings.Split(poolDir, "/")
-		pool := poolDirSplit[len(poolDirSplit)-2]
-		pools = append(pools, poolInfo{name: pool, ioFilename: poolDir, version: version})
-	}
-
-	return pools, nil
-}
-
-func getTags(pools []poolInfo) map[string]string {
-	poolNames := ""
-	knownPools := make(map[string]struct{})
-	for _, entry := range pools {
-		name := entry.name
-		if _, ok := knownPools[name]; !ok {
-			knownPools[name] = struct{}{}
-			if poolNames != "" {
-				poolNames += "::"
-			}
-			poolNames += name
-		}
-	}
-
-	return map[string]string{"pools": poolNames}
-}
-
-func gather(lines []string, fileLines int) (keys, values []string, err error) {
-	if len(lines) < fileLines {
-		return nil, nil, errors.New("expected lines in kstat does not match")
-	}
-
-	keys = strings.Fields(lines[1])
-	values = strings.Fields(lines[2])
-	if len(keys) != len(values) {
-		return nil, nil, fmt.Errorf("key and value count don't match Keys:%v Values:%v", keys, values)
-	}
-
-	return keys, values, nil
-}
-
-func gatherV1(lines []string) (map[string]interface{}, error) {
-	fileLines := 3
-	keys, values, err := gather(lines, fileLines)
-	if err != nil {
-		return nil, err
-	}
-
-	fields := make(map[string]interface{})
-	for i := 0; i < len(keys); i++ {
-		value, err := strconv.ParseInt(values[i], 10, 64)
-		if err != nil {
-			return nil, err
-		}
-
-		fields[keys[i]] = value
-	}
-
-	return fields, nil
-}
-
-// New way of collection. Each objset-* file in ZFS >= 2.1.x has a format looking like this:
-// 36 1 0x01 7 2160 5214787391 73405258558961
-// name                            type data
-// dataset_name                    7    rpool/ROOT/pve-1
-// writes                          4    409570
-// nwritten                        4    2063419969
-// reads                           4    22108699
-// nread                           4    63067280992
-// nunlinks                        4    13849
-// nunlinked                       4    13848
-//
-// For explanation of the first line's values see https://github.com/openzfs/zfs/blob/master/module/os/linux/spl/spl-kstat.c#L61
-func gatherV2(lines []string, tags map[string]string) (map[string]interface{}, error) {
-	fileLines := 9
-	_, _, err := gather(lines, fileLines)
-	if err != nil {
-		return nil, err
-	}
-
-	tags["dataset"] = strings.Fields(lines[2])[2]
-	fields := make(map[string]interface{})
-	for i := 3; i < len(lines); i++ {
-		lineFields := strings.Fields(lines[i])
-		fieldName := lineFields[0]
-		fieldData := lineFields[2]
-		value, err := strconv.ParseInt(fieldData, 10, 64)
-		if err != nil {
-			return nil, err
-		}
-
-		fields[fieldName] = value
-	}
-
-	return fields, nil
-}
-
-func gatherPoolStats(pool poolInfo, acc telegraf.Accumulator) error {
-	lines, err := internal.ReadLines(pool.ioFilename)
-	if err != nil {
-		return err
-	}
-
-	var fields map[string]interface{}
-	var gatherErr error
-	tags := map[string]string{"pool": pool.name}
-	switch pool.version {
-	case v1:
-		fields, gatherErr = gatherV1(lines)
-	case v2:
-		fields, gatherErr = gatherV2(lines, tags)
-	case unknown:
-		return errors.New("unknown metrics version detected")
-	}
-
-	if gatherErr != nil {
-		return gatherErr
-	}
-
-	acc.AddFields("zfs_pool", fields, tags)
-	return nil
 }
 
 func (z *Zfs) Gather(acc telegraf.Accumulator) error {
@@ -234,6 +83,157 @@ func (z *Zfs) Gather(acc telegraf.Accumulator) error {
 	}
 	acc.AddFields("zfs", fields, tags)
 	return nil
+}
+
+func getPools(kstatPath string) ([]poolInfo, error) {
+	pools := make([]poolInfo, 0)
+	version, poolsDirs, err := probeVersion(kstatPath)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, poolDir := range poolsDirs {
+		poolDirSplit := strings.Split(poolDir, "/")
+		pool := poolDirSplit[len(poolDirSplit)-2]
+		pools = append(pools, poolInfo{name: pool, ioFilename: poolDir, version: version})
+	}
+
+	return pools, nil
+}
+
+func probeVersion(kstatPath string) (metricsVersion, []string, error) {
+	poolsDirs, err := filepath.Glob(kstatPath + "/*/objset-*")
+
+	// From the docs: the only possible returned error is ErrBadPattern, when pattern is malformed.
+	// Because of this we need to determine how to fallback differently.
+	if err != nil {
+		return unknown, poolsDirs, err
+	}
+
+	if len(poolsDirs) > 0 {
+		return v2, poolsDirs, nil
+	}
+
+	// Fallback to the old kstat in case of an older ZFS version.
+	poolsDirs, err = filepath.Glob(kstatPath + "/*/io")
+	if err != nil {
+		return unknown, poolsDirs, err
+	}
+
+	return v1, poolsDirs, nil
+}
+
+func getTags(pools []poolInfo) map[string]string {
+	poolNames := ""
+	knownPools := make(map[string]struct{})
+	for _, entry := range pools {
+		name := entry.name
+		if _, ok := knownPools[name]; !ok {
+			knownPools[name] = struct{}{}
+			if poolNames != "" {
+				poolNames += "::"
+			}
+			poolNames += name
+		}
+	}
+
+	return map[string]string{"pools": poolNames}
+}
+
+func gatherPoolStats(pool poolInfo, acc telegraf.Accumulator) error {
+	lines, err := internal.ReadLines(pool.ioFilename)
+	if err != nil {
+		return err
+	}
+
+	var fields map[string]interface{}
+	var gatherErr error
+	tags := map[string]string{"pool": pool.name}
+	switch pool.version {
+	case v1:
+		fields, gatherErr = gatherV1(lines)
+	case v2:
+		fields, gatherErr = gatherV2(lines, tags)
+	case unknown:
+		return errors.New("unknown metrics version detected")
+	}
+
+	if gatherErr != nil {
+		return gatherErr
+	}
+
+	acc.AddFields("zfs_pool", fields, tags)
+	return nil
+}
+
+func gatherV1(lines []string) (map[string]interface{}, error) {
+	fileLines := 3
+	keys, values, err := gather(lines, fileLines)
+	if err != nil {
+		return nil, err
+	}
+
+	fields := make(map[string]interface{})
+	for i := 0; i < len(keys); i++ {
+		value, err := strconv.ParseInt(values[i], 10, 64)
+		if err != nil {
+			return nil, err
+		}
+
+		fields[keys[i]] = value
+	}
+
+	return fields, nil
+}
+
+func gather(lines []string, fileLines int) (keys, values []string, err error) {
+	if len(lines) < fileLines {
+		return nil, nil, errors.New("expected lines in kstat does not match")
+	}
+
+	keys = strings.Fields(lines[1])
+	values = strings.Fields(lines[2])
+	if len(keys) != len(values) {
+		return nil, nil, fmt.Errorf("key and value count don't match Keys:%v Values:%v", keys, values)
+	}
+
+	return keys, values, nil
+}
+
+// New way of collection. Each objset-* file in ZFS >= 2.1.x has a format looking like this:
+// 36 1 0x01 7 2160 5214787391 73405258558961
+// name                            type data
+// dataset_name                    7    rpool/ROOT/pve-1
+// writes                          4    409570
+// nwritten                        4    2063419969
+// reads                           4    22108699
+// nread                           4    63067280992
+// nunlinks                        4    13849
+// nunlinked                       4    13848
+//
+// For explanation of the first line's values see https://github.com/openzfs/zfs/blob/master/module/os/linux/spl/spl-kstat.c#L61
+func gatherV2(lines []string, tags map[string]string) (map[string]interface{}, error) {
+	fileLines := 9
+	_, _, err := gather(lines, fileLines)
+	if err != nil {
+		return nil, err
+	}
+
+	tags["dataset"] = strings.Fields(lines[2])[2]
+	fields := make(map[string]interface{})
+	for i := 3; i < len(lines); i++ {
+		lineFields := strings.Fields(lines[i])
+		fieldName := lineFields[0]
+		fieldData := lineFields[2]
+		value, err := strconv.ParseInt(fieldData, 10, 64)
+		if err != nil {
+			return nil, err
+		}
+
+		fields[fieldName] = value
+	}
+
+	return fields, nil
 }
 
 func init() {

--- a/plugins/inputs/zfs/zfs_other.go
+++ b/plugins/inputs/zfs/zfs_other.go
@@ -7,6 +7,11 @@ import (
 	"github.com/influxdata/telegraf/plugins/inputs"
 )
 
+func (z *Zfs) Init() error {
+	w.Log.Warn("Current platform is not supported")
+	return nil
+}
+
 func (*Zfs) Gather(_ telegraf.Accumulator) error {
 	return nil
 }

--- a/plugins/inputs/zipkin/cmd/stress_test_write/stress_test_write.go
+++ b/plugins/inputs/zipkin/cmd/stress_test_write/stress_test_write.go
@@ -33,29 +33,29 @@ import (
 )
 
 var (
-	BatchSize         int
-	MaxBackLog        int
-	BatchTimeInterval int
-	SpanCount         int
-	ZipkinServerHost  string
+	batchSize         int
+	maxBackLog        int
+	batchTimeInterval int
+	spanCount         int
+	zipkinServerHost  string
 )
 
 func init() {
-	flag.IntVar(&BatchSize, "batch_size", 10000, "")
-	flag.IntVar(&MaxBackLog, "max_backlog", 100000, "")
-	flag.IntVar(&BatchTimeInterval, "batch_interval", 1, "")
-	flag.IntVar(&SpanCount, "span_count", 100000, "")
-	flag.StringVar(&ZipkinServerHost, "zipkin_host", "localhost", "")
+	flag.IntVar(&batchSize, "batch_size", 10000, "")
+	flag.IntVar(&maxBackLog, "max_backlog", 100000, "")
+	flag.IntVar(&batchTimeInterval, "batch_interval", 1, "")
+	flag.IntVar(&spanCount, "span_count", 100000, "")
+	flag.StringVar(&zipkinServerHost, "zipkin_host", "localhost", "")
 }
 
 func main() {
 	flag.Parse()
-	var hostname = fmt.Sprintf("http://%s:9411/api/v1/spans", ZipkinServerHost)
+	var hostname = fmt.Sprintf("http://%s:9411/api/v1/spans", zipkinServerHost)
 	reporter := zipkinhttp.NewReporter(
 		hostname,
-		zipkinhttp.BatchSize(BatchSize),
-		zipkinhttp.MaxBacklog(MaxBackLog),
-		zipkinhttp.BatchInterval(time.Duration(BatchTimeInterval)*time.Second),
+		zipkinhttp.BatchSize(batchSize),
+		zipkinhttp.MaxBacklog(maxBackLog),
+		zipkinhttp.BatchInterval(time.Duration(batchTimeInterval)*time.Second),
 	)
 	defer reporter.Close()
 
@@ -71,8 +71,8 @@ func main() {
 
 	tracer := zipkinot.Wrap(nativeTracer)
 
-	log.Printf("Writing %d spans to zipkin server at %s\n", SpanCount, hostname)
-	for i := 0; i < SpanCount; i++ {
+	log.Printf("Writing %d spans to zipkin server at %s\n", spanCount, hostname)
+	for i := 0; i < spanCount; i++ {
 		parent := tracer.StartSpan("Parent")
 		parent.LogFields(otlog.Message(fmt.Sprintf("Trace%d", i)))
 		parent.Finish()

--- a/plugins/inputs/zipkin/codec/jsonV1/jsonV1.go
+++ b/plugins/inputs/zipkin/codec/jsonV1/jsonV1.go
@@ -24,7 +24,7 @@ func (*JSON) Decode(octets []byte) ([]codec.Span, error) {
 
 	res := make([]codec.Span, 0, len(spans))
 	for i := range spans {
-		if err := spans[i].Validate(); err != nil {
+		if err := spans[i].validate(); err != nil {
 			return nil, err
 		}
 		res = append(res, &spans[i])
@@ -44,7 +44,7 @@ type span struct {
 	BAnno    []binaryAnnotation `json:"binaryAnnotations"`
 }
 
-func (s *span) Validate() error {
+func (s *span) validate() error {
 	var err error
 	check := func(f func() (string, error)) {
 		if err != nil {
@@ -68,21 +68,21 @@ func (s *span) Trace() (string, error) {
 	if s.TraceID == "" {
 		return "", errors.New("trace ID cannot be null")
 	}
-	return TraceIDFromString(s.TraceID)
+	return traceIDFromString(s.TraceID)
 }
 
 func (s *span) SpanID() (string, error) {
 	if s.ID == "" {
 		return "", errors.New("span ID cannot be null")
 	}
-	return IDFromString(s.ID)
+	return idFromString(s.ID)
 }
 
 func (s *span) Parent() (string, error) {
 	if s.ParentID == "" {
 		return "", nil
 	}
-	return IDFromString(s.ParentID)
+	return idFromString(s.ParentID)
 }
 
 func (s *span) Name() string {
@@ -215,8 +215,8 @@ func (e *endpoint) Name() string {
 	return e.ServiceName
 }
 
-// TraceIDFromString creates a TraceID from a hexadecimal string
-func TraceIDFromString(s string) (string, error) {
+// traceIDFromString creates a TraceID from a hexadecimal string
+func traceIDFromString(s string) (string, error) {
 	var hi, lo uint64
 	var err error
 	if len(s) > 32 {
@@ -240,8 +240,8 @@ func TraceIDFromString(s string) (string, error) {
 	return fmt.Sprintf("%x%016x", hi, lo), nil
 }
 
-// IDFromString validates the ID and returns it in hexadecimal format.
-func IDFromString(s string) (string, error) {
+// idFromString validates the ID and returns it in hexadecimal format.
+func idFromString(s string) (string, error) {
 	if len(s) > 16 {
 		return "", fmt.Errorf("length of ID cannot be greater than 16 hex characters: %s", s)
 	}

--- a/plugins/inputs/zipkin/codec/jsonV1/jsonV1_test.go
+++ b/plugins/inputs/zipkin/codec/jsonV1/jsonV1_test.go
@@ -870,13 +870,13 @@ func TestTraceIDFromString(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := TraceIDFromString(tt.s)
+			got, err := traceIDFromString(tt.s)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("TraceIDFromString() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("traceIDFromString() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if got != tt.want {
-				t.Errorf("TraceIDFromString() = %v, want %v", got, tt.want)
+				t.Errorf("traceIDFromString() = %v, want %v", got, tt.want)
 			}
 		})
 	}
@@ -907,13 +907,13 @@ func TestIDFromString(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := IDFromString(tt.s)
+			got, err := idFromString(tt.s)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("IDFromString() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("idFromString() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if got != tt.want {
-				t.Errorf("IDFromString() = %v, want %v", got, tt.want)
+				t.Errorf("idFromString() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/plugins/inputs/zipkin/codec/thrift/thrift_test.go
+++ b/plugins/inputs/zipkin/codec/thrift/thrift_test.go
@@ -198,13 +198,13 @@ func TestUnmarshalThrift(t *testing.T) {
 				t.Fatalf("Could not find file %s\n", tt.filename)
 			}
 
-			got, err := UnmarshalThrift(dat)
+			got, err := unmarshalThrift(dat)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("UnmarshalThrift() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("unmarshalThrift() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if !cmp.Equal(tt.want, got) {
-				t.Errorf("UnmarshalThrift() got(-)/want(+): %s", cmp.Diff(tt.want, got))
+				t.Errorf("unmarshalThrift() got(-)/want(+): %s", cmp.Diff(tt.want, got))
 			}
 		})
 	}

--- a/plugins/inputs/zipkin/convert.go
+++ b/plugins/inputs/zipkin/convert.go
@@ -7,25 +7,22 @@ import (
 	"github.com/influxdata/telegraf/plugins/inputs/zipkin/trace"
 )
 
-// LineProtocolConverter implements the Recorder interface; it is a
-// type meant to encapsulate the storage of zipkin tracing data in
-// telegraf as line protocol.
-type LineProtocolConverter struct {
+// lineProtocolConverter implements the recorder interface;
+// it is a type meant to encapsulate the storage of zipkin tracing data in telegraf as line protocol.
+type lineProtocolConverter struct {
 	acc telegraf.Accumulator
 }
 
-// NewLineProtocolConverter returns an instance of LineProtocolConverter that
-// will add to the given telegraf.Accumulator
-func NewLineProtocolConverter(acc telegraf.Accumulator) *LineProtocolConverter {
-	return &LineProtocolConverter{
+// newLineProtocolConverter returns an instance of lineProtocolConverter that will add to the given telegraf.Accumulator
+func newLineProtocolConverter(acc telegraf.Accumulator) *lineProtocolConverter {
+	return &lineProtocolConverter{
 		acc: acc,
 	}
 }
 
-// Record is LineProtocolConverter's implementation of the Record method of
-// the Recorder interface; it takes a trace as input, and adds it to an internal
-// telegraf.Accumulator.
-func (l *LineProtocolConverter) Record(t trace.Trace) error {
+// record is lineProtocolConverter's implementation of the record method of the recorder interface;
+// it takes a trace as input, and adds it to an internal telegraf.Accumulator.
+func (l *lineProtocolConverter) record(t trace.Trace) error {
 	for _, s := range t {
 		fields := map[string]interface{}{
 			"duration_ns": s.Duration.Nanoseconds(),
@@ -71,12 +68,11 @@ func (l *LineProtocolConverter) Record(t trace.Trace) error {
 	return nil
 }
 
-func (l *LineProtocolConverter) Error(err error) {
+func (l *lineProtocolConverter) error(err error) {
 	l.acc.AddError(err)
 }
 
-// formatName formats name and service name
-// Zipkin forces span and service names to be lowercase:
+// formatName formats name and service name Zipkin forces span and service names to be lowercase:
 // https://github.com/openzipkin/zipkin/pull/805
 func formatName(name string) string {
 	return strings.ToLower(name)

--- a/plugins/inputs/zipkin/convert_test.go
+++ b/plugins/inputs/zipkin/convert_test.go
@@ -328,18 +328,18 @@ func TestLineProtocolConverter_Record(t *testing.T) {
 	for i, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mockAcc.ClearMetrics()
-			l := &LineProtocolConverter{
+			l := &lineProtocolConverter{
 				acc: tt.fields.acc,
 			}
-			if err := l.Record(tt.args.t); (err != nil) != tt.wantErr {
-				t.Errorf("LineProtocolConverter.Record() error = %v, wantErr %v", err, tt.wantErr)
+			if err := l.record(tt.args.t); (err != nil) != tt.wantErr {
+				t.Errorf("lineProtocolConverter.record() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			got := make([]testutil.Metric, 0, len(mockAcc.Metrics))
 			for _, metric := range mockAcc.Metrics {
 				got = append(got, *metric)
 			}
 			if !cmp.Equal(got, tt.want) {
-				t.Errorf("LineProtocolConverter.Record()/%s/%d error = %s ", tt.name, i, cmp.Diff(got, tt.want))
+				t.Errorf("lineProtocolConverter.record()/%s/%d error = %s ", tt.name, i, cmp.Diff(got, tt.want))
 			}
 		})
 	}

--- a/plugins/inputs/zipkin/handler_test.go
+++ b/plugins/inputs/zipkin/handler_test.go
@@ -15,18 +15,18 @@ import (
 	"github.com/influxdata/telegraf/plugins/inputs/zipkin/trace"
 )
 
-type MockRecorder struct {
-	Data trace.Trace
-	Err  error
+type mockRecorder struct {
+	data trace.Trace
+	err  error
 }
 
-func (m *MockRecorder) Record(t trace.Trace) error {
-	m.Data = t
+func (m *mockRecorder) record(t trace.Trace) error {
+	m.data = t
 	return nil
 }
 
-func (m *MockRecorder) Error(err error) {
-	m.Err = err
+func (m *mockRecorder) error(err error) {
+	m.err = err
 }
 
 func TestSpanHandler(t *testing.T) {
@@ -43,16 +43,16 @@ func TestSpanHandler(t *testing.T) {
 			bytes.NewReader(dat)))
 
 	r.Header.Set("Content-Type", "application/x-thrift")
-	handler := NewSpanHandler("/api/v1/spans")
-	mockRecorder := &MockRecorder{}
+	handler := newSpanHandler("/api/v1/spans")
+	mockRecorder := &mockRecorder{}
 	handler.recorder = mockRecorder
 
-	handler.Spans(w, r)
+	handler.spans(w, r)
 	if w.Code != http.StatusNoContent {
 		t.Errorf("MainHandler did not return StatusNoContent %d", w.Code)
 	}
 
-	got := mockRecorder.Data
+	got := mockRecorder.data
 
 	parentID := strconv.FormatInt(22964302721410078, 16)
 	want := trace.Trace{


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

Address findings for [revive:exported ](https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#exported ) in `plugins/inputs/[w-z]*`.

As part of this effort for files from `plugins/inputs/[w-z]*`, the following actions were taken:
- Type names (`const`, `var`, `struct`, `func`, etc) were changed to unexported, wherever they didn't need to be exported.
- All remaining exported types were given comments in the appropriate form – this does not apply to exported methods that implement "known" plugin interfaces (`Gather|Init|Start|Stop|SampleConfig|Parse|Add|Apply|Serialize|SerializeBatch|SetParser|SetParserFunc|GetState|SetState`).
- The order of methods was organized (exported methods first, then unexported, with `init` at the very end).

It is only part of the bigger work (for issue: https://github.com/influxdata/telegraf/issues/15813).
After all findings of this type in whole project are handled, we can enable `revive:exported` rule in `golangci-lint`.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR