### PR TITLE
chore: Fix linter findings for `revive:exported` in `plugins/inputs/system`

### DIFF
--- a/plugins/common/psutil/mock_ps.go
+++ b/plugins/common/psutil/mock_ps.go
@@ -1,40 +1,33 @@
-package system
+package psutil
 
 import (
 	"os"
 
 	"github.com/shirou/gopsutil/v4/cpu"
 	"github.com/shirou/gopsutil/v4/disk"
-	"github.com/shirou/gopsutil/v4/load"
 	"github.com/shirou/gopsutil/v4/mem"
 	"github.com/shirou/gopsutil/v4/net"
-	"github.com/shirou/gopsutil/v4/sensors"
 	"github.com/stretchr/testify/mock"
 )
 
+// MockPS is a mock implementation of the PS interface for testing purposes.
 type MockPS struct {
 	mock.Mock
 	PSDiskDeps
 }
 
+// MockPSDisk is a mock implementation of the PSDiskDeps interface for testing purposes.
 type MockPSDisk struct {
 	*SystemPS
 	*mock.Mock
 }
 
+// MockDiskUsage is a mock implementation for disk usage operations.
 type MockDiskUsage struct {
 	*mock.Mock
 }
 
-func (m *MockPS) LoadAvg() (*load.AvgStat, error) {
-	ret := m.Called()
-
-	r0 := ret.Get(0).(*load.AvgStat)
-	r1 := ret.Error(1)
-
-	return r0, r1
-}
-
+// CPUTimes returns the CPU times statistics.
 func (m *MockPS) CPUTimes(_, _ bool) ([]cpu.TimesStat, error) {
 	ret := m.Called()
 
@@ -44,6 +37,7 @@ func (m *MockPS) CPUTimes(_, _ bool) ([]cpu.TimesStat, error) {
 	return r0, r1
 }
 
+// DiskUsage returns the disk usage statistics.
 func (m *MockPS) DiskUsage(mountPointFilter, mountOptsExclude, fstypeExclude []string) ([]*disk.UsageStat, []*disk.PartitionStat, error) {
 	ret := m.Called(mountPointFilter, mountOptsExclude, fstypeExclude)
 
@@ -54,6 +48,7 @@ func (m *MockPS) DiskUsage(mountPointFilter, mountOptsExclude, fstypeExclude []s
 	return r0, r1, r2
 }
 
+// NetIO returns network I/O statistics for every network interface installed on the system.
 func (m *MockPS) NetIO() ([]net.IOCountersStat, error) {
 	ret := m.Called()
 
@@ -63,6 +58,7 @@ func (m *MockPS) NetIO() ([]net.IOCountersStat, error) {
 	return r0, r1
 }
 
+// NetProto returns network statistics for the entire system.
 func (m *MockPS) NetProto() ([]net.ProtoCountersStat, error) {
 	ret := m.Called()
 
@@ -72,6 +68,7 @@ func (m *MockPS) NetProto() ([]net.ProtoCountersStat, error) {
 	return r0, r1
 }
 
+// DiskIO returns the disk I/O statistics.
 func (m *MockPS) DiskIO(_ []string) (map[string]disk.IOCountersStat, error) {
 	ret := m.Called()
 
@@ -81,6 +78,7 @@ func (m *MockPS) DiskIO(_ []string) (map[string]disk.IOCountersStat, error) {
 	return r0, r1
 }
 
+// VMStat returns the virtual memory statistics.
 func (m *MockPS) VMStat() (*mem.VirtualMemoryStat, error) {
 	ret := m.Called()
 
@@ -90,6 +88,7 @@ func (m *MockPS) VMStat() (*mem.VirtualMemoryStat, error) {
 	return r0, r1
 }
 
+// SwapStat returns the swap memory statistics.
 func (m *MockPS) SwapStat() (*mem.SwapMemoryStat, error) {
 	ret := m.Called()
 
@@ -99,15 +98,7 @@ func (m *MockPS) SwapStat() (*mem.SwapMemoryStat, error) {
 	return r0, r1
 }
 
-func (m *MockPS) Temperature() ([]sensors.TemperatureStat, error) {
-	ret := m.Called()
-
-	r0 := ret.Get(0).([]sensors.TemperatureStat)
-	r1 := ret.Error(1)
-
-	return r0, r1
-}
-
+// NetConnections returns a list of network connections opened.
 func (m *MockPS) NetConnections() ([]net.ConnectionStat, error) {
 	ret := m.Called()
 
@@ -117,6 +108,7 @@ func (m *MockPS) NetConnections() ([]net.ConnectionStat, error) {
 	return r0, r1
 }
 
+// NetConntrack returns more detailed info about the conntrack table.
 func (m *MockPS) NetConntrack(perCPU bool) ([]net.ConntrackStat, error) {
 	ret := m.Called(perCPU)
 
@@ -126,6 +118,7 @@ func (m *MockPS) NetConntrack(perCPU bool) ([]net.ConntrackStat, error) {
 	return r0, r1
 }
 
+// Partitions returns the disk partition statistics.
 func (m *MockDiskUsage) Partitions(all bool) ([]disk.PartitionStat, error) {
 	ret := m.Called(all)
 
@@ -135,11 +128,13 @@ func (m *MockDiskUsage) Partitions(all bool) ([]disk.PartitionStat, error) {
 	return r0, r1
 }
 
+// OSGetenv returns the value of the environment variable named by the key.
 func (m *MockDiskUsage) OSGetenv(key string) string {
 	ret := m.Called(key)
 	return ret.Get(0).(string)
 }
 
+// OSStat returns the FileInfo structure describing the named file.
 func (m *MockDiskUsage) OSStat(name string) (os.FileInfo, error) {
 	ret := m.Called(name)
 
@@ -149,6 +144,7 @@ func (m *MockDiskUsage) OSStat(name string) (os.FileInfo, error) {
 	return r0, r1
 }
 
+// PSDiskUsage returns a file system usage for the specified path.
 func (m *MockDiskUsage) PSDiskUsage(path string) (*disk.UsageStat, error) {
 	ret := m.Called(path)
 

--- a/plugins/inputs/conntrack/conntrack.go
+++ b/plugins/inputs/conntrack/conntrack.go
@@ -14,8 +14,8 @@ import (
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/internal/choice"
+	"github.com/influxdata/telegraf/plugins/common/psutil"
 	"github.com/influxdata/telegraf/plugins/inputs"
-	"github.com/influxdata/telegraf/plugins/inputs/system"
 )
 
 //go:embed sample.conf
@@ -43,7 +43,7 @@ type Conntrack struct {
 	Collect []string `toml:"collect"`
 	Dirs    []string `toml:"dirs"`
 	Files   []string `toml:"files"`
-	ps      system.PS
+	ps      psutil.PS
 }
 
 func (*Conntrack) SampleConfig() string {
@@ -158,7 +158,7 @@ func (c *Conntrack) setDefaults() {
 func init() {
 	inputs.Add(inputName, func() telegraf.Input {
 		return &Conntrack{
-			ps: system.NewSystemPS(),
+			ps: psutil.NewSystemPS(),
 		}
 	})
 }

--- a/plugins/inputs/conntrack/conntrack_test.go
+++ b/plugins/inputs/conntrack/conntrack_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/shirou/gopsutil/v4/net"
 	"github.com/stretchr/testify/require"
 
-	"github.com/influxdata/telegraf/plugins/inputs/system"
+	"github.com/influxdata/telegraf/plugins/common/psutil"
 	"github.com/influxdata/telegraf/testutil"
 )
 
@@ -95,7 +95,7 @@ func TestConfigsUsed(t *testing.T) {
 }
 
 func TestCollectStats(t *testing.T) {
-	var mps system.MockPS
+	var mps psutil.MockPS
 	defer mps.AssertExpectations(t)
 	var acc testutil.Accumulator
 
@@ -163,7 +163,7 @@ func TestCollectStats(t *testing.T) {
 }
 
 func TestCollectStatsPerCpu(t *testing.T) {
-	var mps system.MockPS
+	var mps psutil.MockPS
 	defer mps.AssertExpectations(t)
 	var acc testutil.Accumulator
 
@@ -329,7 +329,7 @@ func TestCollectStatsPerCpu(t *testing.T) {
 func TestCollectPsSystemInit(t *testing.T) {
 	var acc testutil.Accumulator
 	cs := &Conntrack{
-		ps:      system.NewSystemPS(),
+		ps:      psutil.NewSystemPS(),
 		Collect: []string{"all"},
 	}
 	require.NoError(t, cs.Init())

--- a/plugins/inputs/cpu/cpu.go
+++ b/plugins/inputs/cpu/cpu.go
@@ -10,15 +10,15 @@ import (
 	"github.com/shirou/gopsutil/v4/cpu"
 
 	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/plugins/common/psutil"
 	"github.com/influxdata/telegraf/plugins/inputs"
-	"github.com/influxdata/telegraf/plugins/inputs/system"
 )
 
 //go:embed sample.conf
 var sampleConfig string
 
 type CPUStats struct {
-	ps         system.PS
+	ps         psutil.PS
 	lastStats  map[string]cpu.TimesStat
 	cpuInfo    map[string]cpu.InfoStat
 	coreID     bool
@@ -161,7 +161,7 @@ func init() {
 		return &CPUStats{
 			PerCPU:   true,
 			TotalCPU: true,
-			ps:       system.NewSystemPS(),
+			ps:       psutil.NewSystemPS(),
 		}
 	})
 }

--- a/plugins/inputs/cpu/cpu_test.go
+++ b/plugins/inputs/cpu/cpu_test.go
@@ -6,11 +6,11 @@ import (
 	"github.com/shirou/gopsutil/v4/cpu"
 	"github.com/stretchr/testify/require"
 
-	"github.com/influxdata/telegraf/plugins/inputs/system"
+	"github.com/influxdata/telegraf/plugins/common/psutil"
 	"github.com/influxdata/telegraf/testutil"
 )
 
-func newCPUStats(ps system.PS) *CPUStats {
+func newCPUStats(ps psutil.PS) *CPUStats {
 	return &CPUStats{
 		ps:             ps,
 		CollectCPUTime: true,
@@ -19,7 +19,7 @@ func newCPUStats(ps system.PS) *CPUStats {
 }
 
 func TestCPUStats(t *testing.T) {
-	var mps system.MockPS
+	var mps psutil.MockPS
 	defer mps.AssertExpectations(t)
 	var acc testutil.Accumulator
 
@@ -72,7 +72,7 @@ func TestCPUStats(t *testing.T) {
 	assertContainsTaggedFloat(t, &acc, "time_guest", 3.1, 0)
 	assertContainsTaggedFloat(t, &acc, "time_guest_nice", 0.324, 0)
 
-	mps2 := system.MockPS{}
+	mps2 := psutil.MockPS{}
 	mps2.On("CPUTimes").Return([]cpu.TimesStat{cts2}, nil)
 	cs.ps = &mps2
 
@@ -151,8 +151,8 @@ func assertContainsTaggedFloat(
 // TestCPUCountChange tests that no errors are encountered if the number of
 // CPUs increases as reported with LXC.
 func TestCPUCountIncrease(t *testing.T) {
-	var mps system.MockPS
-	var mps2 system.MockPS
+	var mps psutil.MockPS
+	var mps2 psutil.MockPS
 	var acc testutil.Accumulator
 	var err error
 
@@ -186,7 +186,7 @@ func TestCPUCountIncrease(t *testing.T) {
 // TestCPUTimesDecrease tests that telegraf continue to works after
 // CPU times decrease, which seems to occur when Linux system is suspended.
 func TestCPUTimesDecrease(t *testing.T) {
-	var mps system.MockPS
+	var mps psutil.MockPS
 	defer mps.AssertExpectations(t)
 	var acc testutil.Accumulator
 
@@ -224,7 +224,7 @@ func TestCPUTimesDecrease(t *testing.T) {
 	assertContainsTaggedFloat(t, &acc, "time_idle", 80, 0)
 	assertContainsTaggedFloat(t, &acc, "time_iowait", 2, 0)
 
-	mps2 := system.MockPS{}
+	mps2 := psutil.MockPS{}
 	mps2.On("CPUTimes").Return([]cpu.TimesStat{cts2}, nil)
 	cs.ps = &mps2
 
@@ -232,7 +232,7 @@ func TestCPUTimesDecrease(t *testing.T) {
 	err = cs.Gather(&acc)
 	require.Error(t, err)
 
-	mps3 := system.MockPS{}
+	mps3 := psutil.MockPS{}
 	mps3.On("CPUTimes").Return([]cpu.TimesStat{cts3}, nil)
 	cs.ps = &mps3
 

--- a/plugins/inputs/disk/disk.go
+++ b/plugins/inputs/disk/disk.go
@@ -9,8 +9,8 @@ import (
 	"github.com/shirou/gopsutil/v4/disk"
 
 	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/plugins/common/psutil"
 	"github.com/influxdata/telegraf/plugins/inputs"
-	"github.com/influxdata/telegraf/plugins/inputs/system"
 )
 
 //go:embed sample.conf
@@ -22,7 +22,7 @@ type Disk struct {
 	IgnoreMountOpts []string        `toml:"ignore_mount_opts"`
 	Log             telegraf.Logger `toml:"-"`
 
-	ps system.PS
+	ps psutil.PS
 }
 
 func (*Disk) SampleConfig() string {
@@ -30,7 +30,7 @@ func (*Disk) SampleConfig() string {
 }
 
 func (ds *Disk) Init() error {
-	ps := system.NewSystemPS()
+	ps := psutil.NewSystemPS()
 	ps.Log = ds.Log
 	ds.ps = ps
 

--- a/plugins/inputs/disk/disk_test.go
+++ b/plugins/inputs/disk/disk_test.go
@@ -14,13 +14,13 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/influxdata/telegraf"
-	"github.com/influxdata/telegraf/plugins/inputs/system"
+	"github.com/influxdata/telegraf/plugins/common/psutil"
 	"github.com/influxdata/telegraf/testutil"
 )
 
 func TestDiskUsage(t *testing.T) {
 	mck := &mock.Mock{}
-	mps := system.MockPSDisk{SystemPS: &system.SystemPS{PSDiskDeps: &system.MockDiskUsage{Mock: mck}}, Mock: mck}
+	mps := psutil.MockPSDisk{SystemPS: &psutil.SystemPS{PSDiskDeps: &psutil.MockDiskUsage{Mock: mck}}, Mock: mck}
 	defer mps.AssertExpectations(t)
 
 	var acc testutil.Accumulator
@@ -278,7 +278,7 @@ func TestDiskUsageHostMountPrefix(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mck := &mock.Mock{}
-			mps := system.MockPSDisk{SystemPS: &system.SystemPS{PSDiskDeps: &system.MockDiskUsage{Mock: mck}}, Mock: mck}
+			mps := psutil.MockPSDisk{SystemPS: &psutil.SystemPS{PSDiskDeps: &psutil.MockDiskUsage{Mock: mck}}, Mock: mck}
 			defer mps.AssertExpectations(t)
 
 			var acc testutil.Accumulator
@@ -301,7 +301,7 @@ func TestDiskUsageHostMountPrefix(t *testing.T) {
 }
 
 func TestDiskStats(t *testing.T) {
-	var mps system.MockPS
+	var mps psutil.MockPS
 	defer mps.AssertExpectations(t)
 	var acc testutil.Accumulator
 	var err error
@@ -631,7 +631,7 @@ func TestDiskUsageIssues(t *testing.T) {
 
 			// Mock the disk usage
 			mck := &mock.Mock{}
-			mps := system.MockPSDisk{SystemPS: &system.SystemPS{PSDiskDeps: &system.MockDiskUsage{Mock: mck}}, Mock: mck}
+			mps := psutil.MockPSDisk{SystemPS: &psutil.SystemPS{PSDiskDeps: &psutil.MockDiskUsage{Mock: mck}}, Mock: mck}
 			defer mps.AssertExpectations(t)
 
 			mps.On("Partitions", true).Return(partitions, nil)

--- a/plugins/inputs/diskio/diskio.go
+++ b/plugins/inputs/diskio/diskio.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/filter"
+	"github.com/influxdata/telegraf/plugins/common/psutil"
 	"github.com/influxdata/telegraf/plugins/inputs"
-	"github.com/influxdata/telegraf/plugins/inputs/system"
 )
 
 //go:embed sample.conf
@@ -30,7 +30,7 @@ type DiskIO struct {
 	SkipSerialNumber bool            `toml:"skip_serial_number"`
 	Log              telegraf.Logger `toml:"-"`
 
-	ps                system.PS
+	ps                psutil.PS
 	infoCache         map[string]diskInfoCache
 	deviceFilter      filter.Filter
 	warnDiskName      map[string]bool
@@ -218,7 +218,7 @@ func (d *DiskIO) diskTags(devName string) map[string]string {
 }
 
 func init() {
-	ps := system.NewSystemPS()
+	ps := psutil.NewSystemPS()
 	inputs.Add("diskio", func() telegraf.Input {
 		return &DiskIO{ps: ps, SkipSerialNumber: true}
 	})

--- a/plugins/inputs/diskio/diskio_test.go
+++ b/plugins/inputs/diskio/diskio_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/shirou/gopsutil/v4/disk"
 	"github.com/stretchr/testify/require"
 
-	"github.com/influxdata/telegraf/plugins/inputs/system"
+	"github.com/influxdata/telegraf/plugins/common/psutil"
 	"github.com/influxdata/telegraf/testutil"
 )
 
@@ -103,7 +103,7 @@ func TestDiskIO(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var mps system.MockPS
+			var mps psutil.MockPS
 			mps.On("DiskIO").Return(tt.result.stats, tt.result.err)
 
 			var acc testutil.Accumulator
@@ -163,7 +163,7 @@ func TestDiskIOUtil(t *testing.T) {
 	}
 
 	var acc testutil.Accumulator
-	var mps system.MockPS
+	var mps psutil.MockPS
 	mps.On("DiskIO").Return(cts, nil)
 	diskio := &DiskIO{
 		Log:     testutil.Logger{},
@@ -176,7 +176,7 @@ func TestDiskIOUtil(t *testing.T) {
 	// sleep
 	time.Sleep(1 * time.Second)
 	// gather twice
-	mps2 := system.MockPS{}
+	mps2 := psutil.MockPS{}
 	mps2.On("DiskIO").Return(cts2, nil)
 	diskio.ps = &mps2
 

--- a/plugins/inputs/mem/mem.go
+++ b/plugins/inputs/mem/mem.go
@@ -7,15 +7,15 @@ import (
 	"runtime"
 
 	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/plugins/common/psutil"
 	"github.com/influxdata/telegraf/plugins/inputs"
-	"github.com/influxdata/telegraf/plugins/inputs/system"
 )
 
 //go:embed sample.conf
 var sampleConfig string
 
 type Mem struct {
-	ps       system.PS
+	ps       psutil.PS
 	platform string
 }
 
@@ -100,7 +100,7 @@ func (ms *Mem) Gather(acc telegraf.Accumulator) error {
 }
 
 func init() {
-	ps := system.NewSystemPS()
+	ps := psutil.NewSystemPS()
 	inputs.Add("mem", func() telegraf.Input {
 		return &Mem{ps: ps}
 	})

--- a/plugins/inputs/mem/mem_test.go
+++ b/plugins/inputs/mem/mem_test.go
@@ -8,12 +8,12 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/influxdata/telegraf"
-	"github.com/influxdata/telegraf/plugins/inputs/system"
+	"github.com/influxdata/telegraf/plugins/common/psutil"
 	"github.com/influxdata/telegraf/testutil"
 )
 
 func TestMemStats(t *testing.T) {
-	var mps system.MockPS
+	var mps psutil.MockPS
 	var err error
 	defer mps.AssertExpectations(t)
 	var acc testutil.Accumulator

--- a/plugins/inputs/net/net.go
+++ b/plugins/inputs/net/net.go
@@ -14,8 +14,8 @@ import (
 	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/filter"
 	"github.com/influxdata/telegraf/internal"
+	"github.com/influxdata/telegraf/plugins/common/psutil"
 	"github.com/influxdata/telegraf/plugins/inputs"
-	"github.com/influxdata/telegraf/plugins/inputs/system"
 )
 
 //go:embed sample.conf
@@ -26,7 +26,7 @@ type Net struct {
 	IgnoreProtocolStats bool     `toml:"ignore_protocol_stats"`
 
 	filter     filter.Filter
-	ps         system.PS
+	ps         psutil.PS
 	skipChecks bool
 }
 
@@ -158,6 +158,6 @@ func getInterfaceSpeed(ioName string) int64 {
 
 func init() {
 	inputs.Add("net", func() telegraf.Input {
-		return &Net{ps: system.NewSystemPS()}
+		return &Net{ps: psutil.NewSystemPS()}
 	})
 }

--- a/plugins/inputs/net/net_test.go
+++ b/plugins/inputs/net/net_test.go
@@ -10,12 +10,12 @@ import (
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/metric"
-	"github.com/influxdata/telegraf/plugins/inputs/system"
+	"github.com/influxdata/telegraf/plugins/common/psutil"
 	"github.com/influxdata/telegraf/testutil"
 )
 
 func TestNetIOStats(t *testing.T) {
-	var mps system.MockPS
+	var mps psutil.MockPS
 	defer mps.AssertExpectations(t)
 
 	netio := net.IOCountersStat{
@@ -82,7 +82,7 @@ func TestNetIOStats(t *testing.T) {
 }
 
 func TestNetIOStatsSpeedUnsupported(t *testing.T) {
-	var mps system.MockPS
+	var mps psutil.MockPS
 	defer mps.AssertExpectations(t)
 
 	netio := net.IOCountersStat{
@@ -149,7 +149,7 @@ func TestNetIOStatsSpeedUnsupported(t *testing.T) {
 }
 
 func TestNetIOStatsNoSpeedFile(t *testing.T) {
-	var mps system.MockPS
+	var mps psutil.MockPS
 	defer mps.AssertExpectations(t)
 
 	netio := net.IOCountersStat{

--- a/plugins/inputs/netstat/netstat.go
+++ b/plugins/inputs/netstat/netstat.go
@@ -7,15 +7,15 @@ import (
 	"syscall"
 
 	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/plugins/common/psutil"
 	"github.com/influxdata/telegraf/plugins/inputs"
-	"github.com/influxdata/telegraf/plugins/inputs/system"
 )
 
 //go:embed sample.conf
 var sampleConfig string
 
 type NetStat struct {
-	ps system.PS
+	ps psutil.PS
 }
 
 func (*NetStat) SampleConfig() string {
@@ -66,6 +66,6 @@ func (ns *NetStat) Gather(acc telegraf.Accumulator) error {
 
 func init() {
 	inputs.Add("netstat", func() telegraf.Input {
-		return &NetStat{ps: system.NewSystemPS()}
+		return &NetStat{ps: psutil.NewSystemPS()}
 	})
 }

--- a/plugins/inputs/netstat/netstat_test.go
+++ b/plugins/inputs/netstat/netstat_test.go
@@ -10,12 +10,12 @@ import (
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/metric"
-	"github.com/influxdata/telegraf/plugins/inputs/system"
+	"github.com/influxdata/telegraf/plugins/common/psutil"
 	"github.com/influxdata/telegraf/testutil"
 )
 
 func TestNetStats(t *testing.T) {
-	var mps system.MockPS
+	var mps psutil.MockPS
 	defer mps.AssertExpectations(t)
 	mps.On("NetConnections").Return([]net.ConnectionStat{
 		{

--- a/plugins/inputs/swap/swap.go
+++ b/plugins/inputs/swap/swap.go
@@ -6,15 +6,15 @@ import (
 	"fmt"
 
 	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/plugins/common/psutil"
 	"github.com/influxdata/telegraf/plugins/inputs"
-	"github.com/influxdata/telegraf/plugins/inputs/system"
 )
 
 //go:embed sample.conf
 var sampleConfig string
 
 type Swap struct {
-	ps system.PS
+	ps psutil.PS
 }
 
 func (*Swap) SampleConfig() string {
@@ -44,7 +44,7 @@ func (ss *Swap) Gather(acc telegraf.Accumulator) error {
 }
 
 func init() {
-	ps := system.NewSystemPS()
+	ps := psutil.NewSystemPS()
 	inputs.Add("swap", func() telegraf.Input {
 		return &Swap{ps: ps}
 	})

--- a/plugins/inputs/swap/swap_test.go
+++ b/plugins/inputs/swap/swap_test.go
@@ -6,12 +6,12 @@ import (
 	"github.com/shirou/gopsutil/v4/mem"
 	"github.com/stretchr/testify/require"
 
-	"github.com/influxdata/telegraf/plugins/inputs/system"
+	"github.com/influxdata/telegraf/plugins/common/psutil"
 	"github.com/influxdata/telegraf/testutil"
 )
 
 func TestSwapStats(t *testing.T) {
-	var mps system.MockPS
+	var mps psutil.MockPS
 	var err error
 	defer mps.AssertExpectations(t)
 	var acc testutil.Accumulator

--- a/plugins/inputs/system/system.go
+++ b/plugins/inputs/system/system.go
@@ -21,15 +21,15 @@ import (
 //go:embed sample.conf
 var sampleConfig string
 
-type SystemStats struct {
-	Log telegraf.Logger
+type System struct {
+	Log telegraf.Logger `toml:"-"`
 }
 
-func (*SystemStats) SampleConfig() string {
+func (*System) SampleConfig() string {
 	return sampleConfig
 }
 
-func (s *SystemStats) Gather(acc telegraf.Accumulator) error {
+func (s *System) Gather(acc telegraf.Accumulator) error {
 	loadavg, err := load.Avg()
 	if err != nil && !strings.Contains(err.Error(), "not implemented") {
 		return err
@@ -112,6 +112,6 @@ func formatUptime(uptime uint64) string {
 
 func init() {
 	inputs.Add("system", func() telegraf.Input {
-		return &SystemStats{}
+		return &System{}
 	})
 }


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

Address findings for [revive:exported ](https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#exported ) in `plugins/inputs/system`.

As part of this effort for files from `plugins/inputs/system`, the following actions were taken:
- `ps.go` and `mock_PS.go` aren't part of the `system` plugin. They serve as access points to various types of system statistics for other plugins. Therefore, it seems that a better place for these files would be the `plugins/common` package, where I have moved them and properly documented the exported types and functions.
- Type names (`const`, `var`, `struct`, `func`, etc) were changed to unexported, wherever they didn't need to be exported.
- All remaining exported types were given comments in the appropriate form – this does not apply to exported methods that implement "known" plugin interfaces (`Gather|Init|Start|Stop|SampleConfig|Parse|Add|Apply|Serialize|SerializeBatch|SetParser|SetParserFunc|GetState|SetState`).
- The order of methods was organized (exported methods first, then unexported, with `init` at the very end).

It is only part of the bigger work (for issue: https://github.com/influxdata/telegraf/issues/15813).
After all findings of this type in whole project are handled, we can enable `revive:exported` rule in `golangci-lint`.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR