### PR TITLE
chore: Increase dependabot open PRs limit to 25

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 25
     labels:
       - "dependencies"
   - package-ecosystem: "gomod"


### PR DESCRIPTION
## Summary
Increases the dependabot open PRs limit from 10 to 25 to try and catch up on our backlog of dependency updates gradually

## Checklist
- [x] No AI generated code was used in this PR

## Related issues
resolves #
