### PR TITLE
chore: Increase dependabot PR limit for Go dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 25
     ignore:
       # Dependabot isn't able to update this packages that do not match the
       # source, so anything with a version


### PR DESCRIPTION
## Summary
Sets this option in the gomod package ecosystem instead of just the github actions one

## Checklist
- [x] No AI generated code was used in this PR

## Related issues
resolves #
