### PR TITLE
fix(inputs.win_wmi): Restrict threading model to APARTMENTTHREADED

### DIFF
--- a/plugins/inputs/win_wmi/method.go
+++ b/plugins/inputs/win_wmi/method.go
@@ -75,10 +75,10 @@ func (m *method) execute(acc telegraf.Accumulator) error {
 	defer runtime.UnlockOSThread()
 
 	// Init the COM client
-	if err := ole.CoInitializeEx(0, ole.COINIT_MULTITHREADED); err != nil {
+	if err := ole.CoInitializeEx(0, ole.COINIT_APARTMENTTHREADED); err != nil {
 		var oleCode *ole.OleError
-		if errors.As(err, &oleCode) && oleCode.Code() != ole.S_OK && oleCode.Code() != sFalse {
-			return err
+		if !errors.As(err, &oleCode) || (oleCode.Code() != ole.S_OK && oleCode.Code() != sFalse) {
+			return fmt.Errorf("initialization of COM object failed: %w", err)
 		}
 	}
 	defer ole.CoUninitialize()
@@ -86,7 +86,7 @@ func (m *method) execute(acc telegraf.Accumulator) error {
 	// Initialize the WMI service
 	locator, err := oleutil.CreateObject("WbemScripting.SWbemLocator")
 	if err != nil {
-		return err
+		return fmt.Errorf("creation of OLE object failed: %w", err)
 	}
 	if locator == nil {
 		return errors.New("failed to create WbemScripting.SWbemLocator, maybe WMI is broken")


### PR DESCRIPTION
## Summary

This PR is part of the attempt to fix the issues seen in #16179. While I'm not able to reproduce the issues, it seems like restricting the threading model for calling the COM object to a serialized chain for each thread helps. So this PR constraint the threading model in this way.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

related to #16179 
