### PR TITLE
fix(inputs.win_wmi): Replace hard-coded class-name with correct config setting

### DIFF
--- a/plugins/inputs/win_wmi/method.go
+++ b/plugins/inputs/win_wmi/method.go
@@ -149,7 +149,7 @@ func (m *method) execute(acc telegraf.Accumulator) error {
 	defer outputParamsRaw.Clear()
 
 	// Execute the method
-	outputRaw, err := service.CallMethod("ExecMethod", "StdRegProv", m.Method, inputParamsRaw)
+	outputRaw, err := service.CallMethod("ExecMethod", m.ClassName, m.Method, inputParamsRaw)
 	if err != nil {
 		return fmt.Errorf("failed to execute method %s: %w", m.Method, err)
 	}


### PR DESCRIPTION
## Summary

Replace the hard-coded left-over when calling the given method. Thanks @skartikey for spotting this!

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

related to #16699 
