### PR TITLE
fix(inputs.cloudwatch): Handle metric includes/excludes correctly to prevent panic

### DIFF
--- a/plugins/inputs/cloudwatch/cloudwatch.go
+++ b/plugins/inputs/cloudwatch/cloudwatch.go
@@ -300,7 +300,14 @@ func (c *CloudWatch) getFilteredMetrics() ([]filteredMetric, error) {
 			if cm.StatisticInclude == nil && cm.StatisticExclude == nil {
 				entry.statFilter = c.statFilter
 			} else {
-				f, err := filter.NewIncludeExcludeFilter(*cm.StatisticInclude, *cm.StatisticExclude)
+				var includeStats, excludeStats []string
+				if cm.StatisticInclude != nil {
+					includeStats = *cm.StatisticInclude
+				}
+				if cm.StatisticExclude != nil {
+					excludeStats = *cm.StatisticExclude
+				}
+				f, err := filter.NewIncludeExcludeFilter(includeStats, excludeStats)
 				if err != nil {
 					return nil, fmt.Errorf("creating statistics filter for metric %d failed: %w", idx+1, err)
 				}


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
This change ensures safe handling when only one of StatisticInclude or StatisticExclude is non-nil, preventing a nil pointer dereference that was causing a panic.

Background
The bug stemmed from not accounting for all possible nil combinations of these two pointers. The existing if condition only handled the case where both were nil, but the else block did not properly handle scenarios where only one was set. This fix explicitly checks each pointer before dereferencing.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #16779
