### PR TITLE
fix(inputs.win_eventlog): Handle large events to avoid they get dropped silently

### DIFF
--- a/plugins/inputs/win_eventlog/README.md
+++ b/plugins/inputs/win_eventlog/README.md
@@ -121,8 +121,9 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## Globbing supported (e.g. "Level*" matches both "Level" and "LevelText")
   # exclude_empty = ["Task", "Opcode", "*ActivityID", "UserID"]
 
-  ## Maximum size of an event to render. Larger events are not processed and
-  ## will not create a metric.
+  ## Maximum memory size available for an event to render
+  ## Events larger that that are not processed and will not create a metric.
+  ## NOTE: As events are encoded in UTF-16 we need two bytes per character.
   # event_size_limit = "64KB"
 ```
 

--- a/plugins/inputs/win_eventlog/README.md
+++ b/plugins/inputs/win_eventlog/README.md
@@ -123,7 +123,7 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
   ## Maximum size of an event to render. Larger events are not processed and
   ## will not create a metric.
-  # event_size_limit = "16KB"
+  # event_size_limit = "64KB"
 ```
 
 ### Filtering

--- a/plugins/inputs/win_eventlog/README.md
+++ b/plugins/inputs/win_eventlog/README.md
@@ -120,6 +120,10 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## The values below are included by default.
   ## Globbing supported (e.g. "Level*" matches both "Level" and "LevelText")
   # exclude_empty = ["Task", "Opcode", "*ActivityID", "UserID"]
+
+  ## Maximum size of an event to render. Larger events are not processed and
+  ## will not create a metric.
+  # event_size_limit = "16KB"
 ```
 
 ### Filtering

--- a/plugins/inputs/win_eventlog/sample.conf
+++ b/plugins/inputs/win_eventlog/sample.conf
@@ -98,4 +98,4 @@
 
   ## Maximum size of an event to render. Larger events are not processed and
   ## will not create a metric.
-  # event_size_limit = "16KB"
+  # event_size_limit = "64KB"

--- a/plugins/inputs/win_eventlog/sample.conf
+++ b/plugins/inputs/win_eventlog/sample.conf
@@ -96,6 +96,7 @@
   ## Globbing supported (e.g. "Level*" matches both "Level" and "LevelText")
   # exclude_empty = ["Task", "Opcode", "*ActivityID", "UserID"]
 
-  ## Maximum size of an event to render. Larger events are not processed and
-  ## will not create a metric.
+  ## Maximum memory size available for an event to render
+  ## Events larger that that are not processed and will not create a metric.
+  ## NOTE: As events are encoded in UTF-16 we need two bytes per character.
   # event_size_limit = "64KB"

--- a/plugins/inputs/win_eventlog/sample.conf
+++ b/plugins/inputs/win_eventlog/sample.conf
@@ -95,3 +95,7 @@
   ## The values below are included by default.
   ## Globbing supported (e.g. "Level*" matches both "Level" and "LevelText")
   # exclude_empty = ["Task", "Opcode", "*ActivityID", "UserID"]
+
+  ## Maximum size of an event to render. Larger events are not processed and
+  ## will not create a metric.
+  # event_size_limit = "16KB"

--- a/plugins/inputs/win_eventlog/zsyscall_windows.go
+++ b/plugins/inputs/win_eventlog/zsyscall_windows.go
@@ -103,25 +103,22 @@ func evtSubscribe(
 	return handle, err
 }
 
-//nolint:revive //argument-limit conditionally more arguments allowed
 func evtRender(
-	context evtHandle,
 	fragment evtHandle,
 	flags evtRenderFlag,
 	bufferSize uint32,
 	buffer *byte,
 	bufferUsed *uint32,
-	propertyCount *uint32,
 ) error {
 	r1, _, e1 := syscall.SyscallN(
 		procEvtRender.Addr(),
-		uintptr(context),
+		uintptr(0), // context
 		uintptr(fragment),
 		uintptr(flags),
 		uintptr(bufferSize),
-		uintptr(unsafe.Pointer(buffer)),        //nolint:gosec // G103: Valid use of unsafe call to pass buffer
-		uintptr(unsafe.Pointer(bufferUsed)),    //nolint:gosec // G103: Valid use of unsafe call to pass bufferUsed
-		uintptr(unsafe.Pointer(propertyCount)), //nolint:gosec // G103: Valid use of unsafe call to pass propertyCount
+		uintptr(unsafe.Pointer(buffer)),     //nolint:gosec // G103: Valid use of unsafe call to pass buffer
+		uintptr(unsafe.Pointer(bufferUsed)), //nolint:gosec // G103: Valid use of unsafe call to pass bufferUsed
+		uintptr(unsafe.Pointer(nil)),        //nolint:gosec // G103: Valid use of unsafe call to pass propertyCount
 	)
 
 	var err error


### PR DESCRIPTION
## Summary

This PR allows to handle arbitrarily large events but introduces a `event_size_limit` to prevent denial-of-service situations when _really_ large events occur. Furthermore, now an error message is logged if the message is too large so that there is at least a trace in the logs.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #16381 
