### PR TITLE
chore: Update go to 1.24.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
     working_directory: '/go/src/github.com/influxdata/telegraf'
     resource_class: large
     docker:
-      - image: 'quay.io/influxdb/telegraf-ci:1.24.1'
+      - image: 'quay.io/influxdb/telegraf-ci:1.24.2'
     environment:
       GOFLAGS: -p=4
   mac:

--- a/.github/workflows/readme-linter.yml
+++ b/.github/workflows/readme-linter.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.24.1'
+          go-version: '1.24.2'
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0

--- a/Makefile
+++ b/Makefile
@@ -257,8 +257,8 @@ plugins/parsers/influx/machine.go: plugins/parsers/influx/machine.go.rl
 
 .PHONY: ci
 ci:
-	docker build -t quay.io/influxdb/telegraf-ci:1.24.1 - < scripts/ci.docker
-	docker push quay.io/influxdb/telegraf-ci:1.24.1
+	docker build -t quay.io/influxdb/telegraf-ci:1.24.2 - < scripts/ci.docker
+	docker push quay.io/influxdb/telegraf-ci:1.24.2
 
 .PHONY: install
 install: $(buildbin)

--- a/scripts/ci.docker
+++ b/scripts/ci.docker
@@ -1,4 +1,4 @@
-FROM golang:1.24.1
+FROM golang:1.24.2
 
 RUN chmod -R 755 "$GOPATH"
 

--- a/scripts/installgo_linux.sh
+++ b/scripts/installgo_linux.sh
@@ -2,15 +2,15 @@
 
 set -eux
 
-GO_VERSION="1.24.1"
+GO_VERSION="1.24.2"
 GO_ARCH="linux-amd64"
 # from https://go.dev/dl
-GO_VERSION_SHA="cb2396bae64183cdccf81a9a6df0aea3bce9511fc21469fb89a0c00470088073"
+GO_VERSION_SHA="68097bd680839cbc9d464a0edce4f7c333975e27a90246890e9f1078c7e702ad"
 
 # Download Go and verify Go tarball
 setup_go () {
     echo "installing go"
-    curl -L https://golang.org/dl/go${GO_VERSION}.${GO_ARCH}.tar.gz --output go${GO_VERSION}.${GO_ARCH}.tar.gz
+    curl -L https://go.dev/dl/go${GO_VERSION}.${GO_ARCH}.tar.gz --output go${GO_VERSION}.${GO_ARCH}.tar.gz
     if ! echo "${GO_VERSION_SHA}  go${GO_VERSION}.${GO_ARCH}.tar.gz" | shasum --algorithm 256 --check -; then
         echo "Checksum failed" >&2
         exit 1

--- a/scripts/installgo_mac.sh
+++ b/scripts/installgo_mac.sh
@@ -3,9 +3,9 @@
 set -eux
 
 ARCH=$(uname -m)
-GO_VERSION="1.24.1"
-GO_VERSION_SHA_arm64="295581b5619acc92f5106e5bcb05c51869337eb19742fdfa6c8346c18e78ff88" # from https://go.dev/dl
-GO_VERSION_SHA_amd64="addbfce2056744962e2d7436313ab93486660cf7a2e066d171b9d6f2da7c7abe" # from https://go.dev/dl
+GO_VERSION="1.24.2"
+GO_VERSION_SHA_arm64="b70f8b3c5b4ccb0ad4ffa5ee91cd38075df20fdbd953a1daedd47f50fbcff47a" # from https://go.dev/dl
+GO_VERSION_SHA_amd64="238d9c065d09ff6af229d2e3b8b5e85e688318d69f4006fb85a96e41c216ea83" # from https://go.dev/dl
 
 if [ "$ARCH" = 'arm64' ]; then
     GO_ARCH="darwin-arm64"
@@ -23,7 +23,7 @@ sudo mkdir -p ${path}
 # it is slow to update and we can't pull specific minor versions.)
 setup_go () {
     echo "installing go"
-    curl -L "https://golang.org/dl/go${GO_VERSION}.${GO_ARCH}.tar.gz" --output "go${GO_VERSION}.${GO_ARCH}.tar.gz"
+    curl -L "https://go.dev/dl/go${GO_VERSION}.${GO_ARCH}.tar.gz" --output "go${GO_VERSION}.${GO_ARCH}.tar.gz"
     if ! echo "${GO_VERSION_SHA}  go${GO_VERSION}.${GO_ARCH}.tar.gz" | shasum --algorithm 256 --check -; then
         echo "Checksum failed" >&2
         exit 1

--- a/scripts/installgo_windows.sh
+++ b/scripts/installgo_windows.sh
@@ -2,7 +2,7 @@
 
 set -eux
 
-GO_VERSION="1.24.1"
+GO_VERSION="1.24.2"
 
 setup_go () {
     choco upgrade golang --allow-downgrade --version=${GO_VERSION}


### PR DESCRIPTION
## Summary
Updates go to 1.24.2. Also adjusts the go downloads website url to the new one.

I'm still having issues with publishing the CI container to quay, so that has not been done yet

## Checklist
- [x] No AI generated code was used in this PR

## Related issues
resolves #16728 

