### PR TITLE
fix(outputs.quix): Allow empty certificate for new cloud managed instances

### DIFF
--- a/plugins/outputs/quix/quix.go
+++ b/plugins/outputs/quix/quix.go
@@ -111,7 +111,8 @@ func (q *Quix) Connect() error {
 
 		cfg.Net.TLS.Enable = true
 		
-        	// Certificate (optional)
+        	// Add the CA certificate sent by the server if there is any. Newer cloud
+        	// instances do not need this and we can go with the system certificates.
 		if len(quixConfig.cert) > 0 {
 			certPool := x509.NewCertPool()
 			if !certPool.AppendCertsFromPEM(quixConfig.cert) {

--- a/plugins/outputs/quix/quix.go
+++ b/plugins/outputs/quix/quix.go
@@ -109,17 +109,15 @@ func (q *Quix) Connect() error {
 			return fmt.Errorf("unsupported SASL mechanism: %s", quixConfig.SaslMechanism)
 		}
 
-		// Certificate (optional)
+		cfg.Net.TLS.Enable = true
+		
+        	// Certificate (optional)
 		if len(quixConfig.cert) > 0 {
 			certPool := x509.NewCertPool()
 			if !certPool.AppendCertsFromPEM(quixConfig.cert) {
 				return errors.New("appending CA cert to pool failed")
 			}
-			cfg.Net.TLS.Enable = true
 			cfg.Net.TLS.Config = &tls.Config{RootCAs: certPool}
-		} else {
-			cfg.Net.TLS.Enable = true
-			cfg.Net.TLS.Config = &tls.Config{InsecureSkipVerify: true}
 		}
 	case "PLAINTEXT":
 		// No additional configuration required for plaintext communication

--- a/plugins/outputs/quix/quix.go
+++ b/plugins/outputs/quix/quix.go
@@ -109,13 +109,18 @@ func (q *Quix) Connect() error {
 			return fmt.Errorf("unsupported SASL mechanism: %s", quixConfig.SaslMechanism)
 		}
 
-		// Certificate
-		certPool := x509.NewCertPool()
-		if !certPool.AppendCertsFromPEM(quixConfig.cert) {
-			return errors.New("appending CA cert to pool failed")
+		// Certificate (optional)
+		if len(quixConfig.cert) > 0 {
+			certPool := x509.NewCertPool()
+			if !certPool.AppendCertsFromPEM(quixConfig.cert) {
+				return errors.New("appending CA cert to pool failed")
+			}
+			cfg.Net.TLS.Enable = true
+			cfg.Net.TLS.Config = &tls.Config{RootCAs: certPool}
+		} else {
+			cfg.Net.TLS.Enable = true
+			cfg.Net.TLS.Config = &tls.Config{InsecureSkipVerify: true}
 		}
-		cfg.Net.TLS.Enable = true
-		cfg.Net.TLS.Config = &tls.Config{RootCAs: certPool}
 	case "PLAINTEXT":
 		// No additional configuration required for plaintext communication
 	default:

--- a/plugins/outputs/quix/quix.go
+++ b/plugins/outputs/quix/quix.go
@@ -110,9 +110,9 @@ func (q *Quix) Connect() error {
 		}
 
 		cfg.Net.TLS.Enable = true
-		
-        	// Add the CA certificate sent by the server if there is any. Newer cloud
-        	// instances do not need this and we can go with the system certificates.
+
+		// Add the CA certificate sent by the server if there is any. Newer cloud
+		// instances do not need this and we can go with the system certificates.
 		if len(quixConfig.cert) > 0 {
 			certPool := x509.NewCertPool()
 			if !certPool.AppendCertsFromPEM(quixConfig.cert) {


### PR DESCRIPTION
## Summary
New Quix Cloud managed broker don't require certificate and current Quix plugin implementation will fail in such a scenario.


## Checklist
- [x] No AI generated code was used in this PR

## Related issues

resolves #16856
