### PR TITLE
docs: Document `probe` as an option for the startup-error-behavior

### DIFF
--- a/docs/includes/startup_error_behavior.md
+++ b/docs/includes/startup_error_behavior.md
@@ -9,6 +9,6 @@ using the `startup_error_behavior` setting. Available values are:
 - `retry`:  Telegraf will try to startup the plugin in every gather or write
             cycle in case of startup errors. The plugin is disabled until
             the startup succeeds.
-- `probe`:  Telegraf will probe the plugin's function (if possible) and disables the plugin 
+- `probe`:  Telegraf will probe the plugin's function (if possible) and disables the plugin
             in case probing fails. If the plugin does not support probing, Telegraf will
             behave as if `ignore` was set instead.

--- a/docs/includes/startup_error_behavior.md
+++ b/docs/includes/startup_error_behavior.md
@@ -9,3 +9,6 @@ using the `startup_error_behavior` setting. Available values are:
 - `retry`:  Telegraf will try to startup the plugin in every gather or write
             cycle in case of startup errors. The plugin is disabled until
             the startup succeeds.
+- `probe`:  Telegraf will call the `Probe() error` method, if available. If the
+            method returns an error, Telegraf disables the plugin but continues
+            processing for all other plugins.

--- a/docs/includes/startup_error_behavior.md
+++ b/docs/includes/startup_error_behavior.md
@@ -9,6 +9,6 @@ using the `startup_error_behavior` setting. Available values are:
 - `retry`:  Telegraf will try to startup the plugin in every gather or write
             cycle in case of startup errors. The plugin is disabled until
             the startup succeeds.
-- `probe`:  Telegraf will call the `Probe() error` method, if available. If the
-            method returns an error, Telegraf disables the plugin but continues
-            processing for all other plugins.
+- `probe`:  Telegraf will probe the plugin's function (if possible) and disables the plugin 
+            in case probing fails. If the plugin does not support probing, Telegraf will
+            behave as if `ignore` was set instead.

--- a/plugins/inputs/amqp_consumer/README.md
+++ b/plugins/inputs/amqp_consumer/README.md
@@ -52,9 +52,9 @@ using the `startup_error_behavior` setting. Available values are:
 - `retry`:  Telegraf will try to startup the plugin in every gather or write
             cycle in case of startup errors. The plugin is disabled until
             the startup succeeds.
-- `probe`:  Telegraf will call the `Probe() error` method, if available. If the
-            method returns an error, Telegraf disables the plugin but continues
-            processing for all other plugins.
+- `probe`:  Telegraf will probe the plugin's function (if possible) and disables the plugin 
+            in case probing fails. If the plugin does not support probing, Telegraf will
+            behave as if `ignore` was set instead.
 
 ## Secret-store support
 

--- a/plugins/inputs/amqp_consumer/README.md
+++ b/plugins/inputs/amqp_consumer/README.md
@@ -52,6 +52,9 @@ using the `startup_error_behavior` setting. Available values are:
 - `retry`:  Telegraf will try to startup the plugin in every gather or write
             cycle in case of startup errors. The plugin is disabled until
             the startup succeeds.
+- `probe`:  Telegraf will call the `Probe() error` method, if available. If the
+            method returns an error, Telegraf disables the plugin but continues
+            processing for all other plugins.
 
 ## Secret-store support
 

--- a/plugins/inputs/amqp_consumer/README.md
+++ b/plugins/inputs/amqp_consumer/README.md
@@ -52,7 +52,7 @@ using the `startup_error_behavior` setting. Available values are:
 - `retry`:  Telegraf will try to startup the plugin in every gather or write
             cycle in case of startup errors. The plugin is disabled until
             the startup succeeds.
-- `probe`:  Telegraf will probe the plugin's function (if possible) and disables the plugin 
+- `probe`:  Telegraf will probe the plugin's function (if possible) and disables the plugin
             in case probing fails. If the plugin does not support probing, Telegraf will
             behave as if `ignore` was set instead.
 

--- a/plugins/inputs/kafka_consumer/README.md
+++ b/plugins/inputs/kafka_consumer/README.md
@@ -46,9 +46,9 @@ using the `startup_error_behavior` setting. Available values are:
 - `retry`:  Telegraf will try to startup the plugin in every gather or write
             cycle in case of startup errors. The plugin is disabled until
             the startup succeeds.
-- `probe`:  Telegraf will call the `Probe() error` method, if available. If the
-            method returns an error, Telegraf disables the plugin but continues
-            processing for all other plugins.
+- `probe`:  Telegraf will probe the plugin's function (if possible) and disables the plugin 
+            in case probing fails. If the plugin does not support probing, Telegraf will
+            behave as if `ignore` was set instead.
 
 ## Secret-store support
 

--- a/plugins/inputs/kafka_consumer/README.md
+++ b/plugins/inputs/kafka_consumer/README.md
@@ -46,7 +46,7 @@ using the `startup_error_behavior` setting. Available values are:
 - `retry`:  Telegraf will try to startup the plugin in every gather or write
             cycle in case of startup errors. The plugin is disabled until
             the startup succeeds.
-- `probe`:  Telegraf will probe the plugin's function (if possible) and disables the plugin 
+- `probe`:  Telegraf will probe the plugin's function (if possible) and disables the plugin
             in case probing fails. If the plugin does not support probing, Telegraf will
             behave as if `ignore` was set instead.
 

--- a/plugins/inputs/kafka_consumer/README.md
+++ b/plugins/inputs/kafka_consumer/README.md
@@ -46,6 +46,9 @@ using the `startup_error_behavior` setting. Available values are:
 - `retry`:  Telegraf will try to startup the plugin in every gather or write
             cycle in case of startup errors. The plugin is disabled until
             the startup succeeds.
+- `probe`:  Telegraf will call the `Probe() error` method, if available. If the
+            method returns an error, Telegraf disables the plugin but continues
+            processing for all other plugins.
 
 ## Secret-store support
 

--- a/plugins/inputs/mqtt_consumer/README.md
+++ b/plugins/inputs/mqtt_consumer/README.md
@@ -43,7 +43,7 @@ using the `startup_error_behavior` setting. Available values are:
 - `retry`:  Telegraf will try to startup the plugin in every gather or write
             cycle in case of startup errors. The plugin is disabled until
             the startup succeeds.
-- `probe`:  Telegraf will probe the plugin's function (if possible) and disables the plugin 
+- `probe`:  Telegraf will probe the plugin's function (if possible) and disables the plugin
             in case probing fails. If the plugin does not support probing, Telegraf will
             behave as if `ignore` was set instead.
 

--- a/plugins/inputs/mqtt_consumer/README.md
+++ b/plugins/inputs/mqtt_consumer/README.md
@@ -43,6 +43,9 @@ using the `startup_error_behavior` setting. Available values are:
 - `retry`:  Telegraf will try to startup the plugin in every gather or write
             cycle in case of startup errors. The plugin is disabled until
             the startup succeeds.
+- `probe`:  Telegraf will call the `Probe() error` method, if available. If the
+            method returns an error, Telegraf disables the plugin but continues
+            processing for all other plugins.
 
 ## Secret-store support
 

--- a/plugins/inputs/mqtt_consumer/README.md
+++ b/plugins/inputs/mqtt_consumer/README.md
@@ -43,9 +43,9 @@ using the `startup_error_behavior` setting. Available values are:
 - `retry`:  Telegraf will try to startup the plugin in every gather or write
             cycle in case of startup errors. The plugin is disabled until
             the startup succeeds.
-- `probe`:  Telegraf will call the `Probe() error` method, if available. If the
-            method returns an error, Telegraf disables the plugin but continues
-            processing for all other plugins.
+- `probe`:  Telegraf will probe the plugin's function (if possible) and disables the plugin 
+            in case probing fails. If the plugin does not support probing, Telegraf will
+            behave as if `ignore` was set instead.
 
 ## Secret-store support
 

--- a/plugins/inputs/nvidia_smi/README.md
+++ b/plugins/inputs/nvidia_smi/README.md
@@ -23,7 +23,7 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 [CONFIGURATION.md]: ../../../docs/CONFIGURATION.md#plugins
 
-## Startup error behavior options 
+## Startup error behavior options
 
 In addition to the plugin-specific and global configuration settings the plugin
 supports options for specifying the behavior when experiencing startup errors

--- a/plugins/inputs/nvidia_smi/README.md
+++ b/plugins/inputs/nvidia_smi/README.md
@@ -23,7 +23,7 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 [CONFIGURATION.md]: ../../../docs/CONFIGURATION.md#plugins
 
-## Startup error behavior options
+## Startup error behavior options 
 
 In addition to the plugin-specific and global configuration settings the plugin
 supports options for specifying the behavior when experiencing startup errors
@@ -34,6 +34,9 @@ using the `startup_error_behavior` setting. Available values are:
 - `ignore`: Telegraf will ignore startup errors for this plugin and disables it
             but continues processing for all other plugins.
 - `retry`:  NOT AVAILABLE
+- `probe`:  Telegraf will call the `Probe() error` method, if available. If the
+            method returns an error, Telegraf disables the plugin but continues
+            processing for all other plugins.
 
 ## Configuration
 

--- a/plugins/inputs/s7comm/README.md
+++ b/plugins/inputs/s7comm/README.md
@@ -28,9 +28,9 @@ using the `startup_error_behavior` setting. Available values are:
 - `retry`:  Telegraf will try to startup the plugin in every gather or write
             cycle in case of startup errors. The plugin is disabled until
             the startup succeeds.
-- `probe`:  Telegraf will call the `Probe() error` method, if available. If the
-            method returns an error, Telegraf disables the plugin but continues
-            processing for all other plugins.
+- `probe`:  Telegraf will probe the plugin's function (if possible) and disables the plugin 
+            in case probing fails. If the plugin does not support probing, Telegraf will
+            behave as if `ignore` was set instead.
 
 ## Configuration
 

--- a/plugins/inputs/s7comm/README.md
+++ b/plugins/inputs/s7comm/README.md
@@ -24,6 +24,9 @@ using the `startup_error_behavior` setting. Available values are:
 - `retry`:  Telegraf will try to startup the plugin in every gather or write
             cycle in case of startup errors. The plugin is disabled until
             the startup succeeds.
+- `probe`:  Telegraf will call the `Probe() error` method, if available. If the
+            method returns an error, Telegraf disables the plugin but continues
+            processing for all other plugins.
 
 ## Configuration
 

--- a/plugins/inputs/s7comm/README.md
+++ b/plugins/inputs/s7comm/README.md
@@ -2,6 +2,10 @@
 
 This plugin reads metrics from Siemens PLCs via the S7 protocol.
 
+⭐ Telegraf v1.28.0
+🏷️ hardware
+💻 all
+
 ## Global configuration options <!-- @/docs/includes/plugin_config.md -->
 
 In addition to the plugin-specific configuration settings, plugins support

--- a/plugins/inputs/s7comm/README.md
+++ b/plugins/inputs/s7comm/README.md
@@ -28,7 +28,7 @@ using the `startup_error_behavior` setting. Available values are:
 - `retry`:  Telegraf will try to startup the plugin in every gather or write
             cycle in case of startup errors. The plugin is disabled until
             the startup succeeds.
-- `probe`:  Telegraf will probe the plugin's function (if possible) and disables the plugin 
+- `probe`:  Telegraf will probe the plugin's function (if possible) and disables the plugin
             in case probing fails. If the plugin does not support probing, Telegraf will
             behave as if `ignore` was set instead.
 

--- a/plugins/outputs/cratedb/README.md
+++ b/plugins/outputs/cratedb/README.md
@@ -51,7 +51,7 @@ using the `startup_error_behavior` setting. Available values are:
 - `retry`:  Telegraf will try to startup the plugin in every gather or write
             cycle in case of startup errors. The plugin is disabled until
             the startup succeeds.
-- `probe`:  Telegraf will probe the plugin's function (if possible) and disables the plugin 
+- `probe`:  Telegraf will probe the plugin's function (if possible) and disables the plugin
             in case probing fails. If the plugin does not support probing, Telegraf will
             behave as if `ignore` was set instead.
 

--- a/plugins/outputs/cratedb/README.md
+++ b/plugins/outputs/cratedb/README.md
@@ -51,9 +51,9 @@ using the `startup_error_behavior` setting. Available values are:
 - `retry`:  Telegraf will try to startup the plugin in every gather or write
             cycle in case of startup errors. The plugin is disabled until
             the startup succeeds.
-- `probe`:  Telegraf will call the `Probe() error` method, if available. If the
-            method returns an error, Telegraf disables the plugin but continues
-            processing for all other plugins.
+- `probe`:  Telegraf will probe the plugin's function (if possible) and disables the plugin 
+            in case probing fails. If the plugin does not support probing, Telegraf will
+            behave as if `ignore` was set instead.
 
 ## Configuration
 

--- a/plugins/outputs/cratedb/README.md
+++ b/plugins/outputs/cratedb/README.md
@@ -51,6 +51,9 @@ using the `startup_error_behavior` setting. Available values are:
 - `retry`:  Telegraf will try to startup the plugin in every gather or write
             cycle in case of startup errors. The plugin is disabled until
             the startup succeeds.
+- `probe`:  Telegraf will call the `Probe() error` method, if available. If the
+            method returns an error, Telegraf disables the plugin but continues
+            processing for all other plugins.
 
 ## Configuration
 

--- a/plugins/outputs/kafka/README.md
+++ b/plugins/outputs/kafka/README.md
@@ -30,7 +30,7 @@ using the `startup_error_behavior` setting. Available values are:
 - `retry`:  Telegraf will try to startup the plugin in every gather or write
             cycle in case of startup errors. The plugin is disabled until
             the startup succeeds.
-- `probe`:  Telegraf will probe the plugin's function (if possible) and disables the plugin 
+- `probe`:  Telegraf will probe the plugin's function (if possible) and disables the plugin
             in case probing fails. If the plugin does not support probing, Telegraf will
             behave as if `ignore` was set instead.
 

--- a/plugins/outputs/kafka/README.md
+++ b/plugins/outputs/kafka/README.md
@@ -30,9 +30,9 @@ using the `startup_error_behavior` setting. Available values are:
 - `retry`:  Telegraf will try to startup the plugin in every gather or write
             cycle in case of startup errors. The plugin is disabled until
             the startup succeeds.
-- `probe`:  Telegraf will call the `Probe() error` method, if available. If the
-            method returns an error, Telegraf disables the plugin but continues
-            processing for all other plugins.
+- `probe`:  Telegraf will probe the plugin's function (if possible) and disables the plugin 
+            in case probing fails. If the plugin does not support probing, Telegraf will
+            behave as if `ignore` was set instead.
 
 ## Secret-store support
 

--- a/plugins/outputs/kafka/README.md
+++ b/plugins/outputs/kafka/README.md
@@ -30,6 +30,9 @@ using the `startup_error_behavior` setting. Available values are:
 - `retry`:  Telegraf will try to startup the plugin in every gather or write
             cycle in case of startup errors. The plugin is disabled until
             the startup succeeds.
+- `probe`:  Telegraf will call the `Probe() error` method, if available. If the
+            method returns an error, Telegraf disables the plugin but continues
+            processing for all other plugins.
 
 ## Secret-store support
 

--- a/plugins/outputs/postgresql/README.md
+++ b/plugins/outputs/postgresql/README.md
@@ -31,7 +31,7 @@ using the `startup_error_behavior` setting. Available values are:
 - `retry`:  Telegraf will try to startup the plugin in every gather or write
             cycle in case of startup errors. The plugin is disabled until
             the startup succeeds.
-- `probe`:  Telegraf will probe the plugin's function (if possible) and disables the plugin 
+- `probe`:  Telegraf will probe the plugin's function (if possible) and disables the plugin
             in case probing fails. If the plugin does not support probing, Telegraf will
             behave as if `ignore` was set instead.
 

--- a/plugins/outputs/postgresql/README.md
+++ b/plugins/outputs/postgresql/README.md
@@ -31,9 +31,9 @@ using the `startup_error_behavior` setting. Available values are:
 - `retry`:  Telegraf will try to startup the plugin in every gather or write
             cycle in case of startup errors. The plugin is disabled until
             the startup succeeds.
-- `probe`:  Telegraf will call the `Probe() error` method, if available. If the
-            method returns an error, Telegraf disables the plugin but continues
-            processing for all other plugins.
+- `probe`:  Telegraf will probe the plugin's function (if possible) and disables the plugin 
+            in case probing fails. If the plugin does not support probing, Telegraf will
+            behave as if `ignore` was set instead.
 
 ## Secret-store support
 

--- a/plugins/outputs/postgresql/README.md
+++ b/plugins/outputs/postgresql/README.md
@@ -31,6 +31,9 @@ using the `startup_error_behavior` setting. Available values are:
 - `retry`:  Telegraf will try to startup the plugin in every gather or write
             cycle in case of startup errors. The plugin is disabled until
             the startup succeeds.
+- `probe`:  Telegraf will call the `Probe() error` method, if available. If the
+            method returns an error, Telegraf disables the plugin but continues
+            processing for all other plugins.
 
 ## Secret-store support
 

--- a/plugins/outputs/syslog/README.md
+++ b/plugins/outputs/syslog/README.md
@@ -42,9 +42,9 @@ using the `startup_error_behavior` setting. Available values are:
 - `retry`:  Telegraf will try to startup the plugin in every gather or write
             cycle in case of startup errors. The plugin is disabled until
             the startup succeeds.
-- `probe`:  Telegraf will call the `Probe() error` method, if available. If the
-            method returns an error, Telegraf disables the plugin but continues
-            processing for all other plugins.
+- `probe`:  Telegraf will probe the plugin's function (if possible) and disables the plugin 
+            in case probing fails. If the plugin does not support probing, Telegraf will
+            behave as if `ignore` was set instead.
 
 ## Configuration
 

--- a/plugins/outputs/syslog/README.md
+++ b/plugins/outputs/syslog/README.md
@@ -42,6 +42,9 @@ using the `startup_error_behavior` setting. Available values are:
 - `retry`:  Telegraf will try to startup the plugin in every gather or write
             cycle in case of startup errors. The plugin is disabled until
             the startup succeeds.
+- `probe`:  Telegraf will call the `Probe() error` method, if available. If the
+            method returns an error, Telegraf disables the plugin but continues
+            processing for all other plugins.
 
 ## Configuration
 

--- a/plugins/outputs/syslog/README.md
+++ b/plugins/outputs/syslog/README.md
@@ -42,7 +42,7 @@ using the `startup_error_behavior` setting. Available values are:
 - `retry`:  Telegraf will try to startup the plugin in every gather or write
             cycle in case of startup errors. The plugin is disabled until
             the startup succeeds.
-- `probe`:  Telegraf will probe the plugin's function (if possible) and disables the plugin 
+- `probe`:  Telegraf will probe the plugin's function (if possible) and disables the plugin
             in case probing fails. If the plugin does not support probing, Telegraf will
             behave as if `ignore` was set instead.
 


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

The docs should make more explicit mention of the probe config option for `startup_error_behavior`. This adds mention of it in the `docs/includes/startup_error_behavior.md`.

I'm looking for thoughts/opinions on the right way to do this. If exposing this in the plugin documentation for plugins that don't actually support probing is inappropriate, I'm happy to rethink this PR.

NOTE: The `inputs.nvidia_smi` plugin does not include the `docs/includes/startup_error_behavior.md` file, which is perhaps a historic leftover. Should We modify this to include the doc and make explicit mention of the fact that this plugin supports probing?

https://github.com/influxdata/telegraf/blob/master/plugins/inputs/nvidia_smi/README.md#startup-error-behavior-options

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #16858
