### PR TITLE
feat(inputs.chrony): Add probing

### DIFF
--- a/docs/includes/probing.md
+++ b/docs/includes/probing.md
@@ -1,0 +1,5 @@
+This plugin supports probing through the following configuration:
+
+```toml
+startup_error_behavior = "probe"
+```

--- a/plugins/inputs/chrony/README.md
+++ b/plugins/inputs/chrony/README.md
@@ -19,6 +19,14 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 [CONFIGURATION.md]: ../../../docs/CONFIGURATION.md#plugins
 
+## Probing <!-- @/docs/includes/probing.md -->
+
+This plugin supports probing through the following configuration:
+
+```toml
+startup_error_behavior = "probe"
+```
+
 ## Configuration
 
 ```toml @sample.conf
@@ -51,14 +59,6 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## with the following group and permissions.
   # socket_group = "chrony"
   # socket_perms = "0660"
-```
-
-## Probing
-
-This plugin supports probing through the following configuration:
-
-```toml
-startup_error_behavior = "probe"
 ```
 
 ## Local socket permissions

--- a/plugins/inputs/chrony/README.md
+++ b/plugins/inputs/chrony/README.md
@@ -53,6 +53,14 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   # socket_perms = "0660"
 ```
 
+## Probing
+
+This plugin supports probing through the following configuration:
+
+```toml
+startup_error_behavior = "probe"
+```
+
 ## Local socket permissions
 
 To use the unix socket, telegraf must be able to talk to it. Please ensure that

--- a/plugins/inputs/chrony/chrony.go
+++ b/plugins/inputs/chrony/chrony.go
@@ -145,6 +145,15 @@ func (c *Chrony) Start(_ telegraf.Accumulator) error {
 	return nil
 }
 
+func (c *Chrony) Probe() error {
+	sourcesReq := fbchrony.NewSourcesPacket()
+	_, err := c.client.Communicate(sourcesReq)
+	if err != nil {
+		return fmt.Errorf("querying sources failed: %w", err)
+	}
+	return nil
+}
+
 func (c *Chrony) Gather(acc telegraf.Accumulator) error {
 	for _, m := range c.Metrics {
 		switch m {

--- a/plugins/inputs/chrony/chrony_test.go
+++ b/plugins/inputs/chrony/chrony_test.go
@@ -156,6 +156,8 @@ func TestProbeFailure(t *testing.T) {
 
 	// Shutdown the server
 	server.Shutdown()
+
+	// Perform the actual test. Probing should fail here.
 	require.Error(t, plugin.Probe())
 }
 

--- a/plugins/inputs/chrony/chrony_test.go
+++ b/plugins/inputs/chrony/chrony_test.go
@@ -79,9 +79,16 @@ func TestGatherActivity(t *testing.T) {
 }
 
 func TestProbeFailure(t *testing.T) {
+	// We start the server to make sure that the initial dial succeeds to that
+	// Start() does not fail.
+	server := Server{}
+	addr, err := server.Listen(t)
+	require.NoError(t, err)
+	defer server.Shutdown()
+
 	// Setup the plugin
 	plugin := &Chrony{
-		Server:  "",
+		Server:  "udp://" + addr,
 		Metrics: []string{"tracking"},
 		Log:     testutil.Logger{},
 	}
@@ -91,6 +98,8 @@ func TestProbeFailure(t *testing.T) {
 	require.NoError(t, plugin.Start(&acc))
 	defer plugin.Stop()
 
+	// Shutdown the server
+	server.Shutdown()
 	require.Error(t, plugin.Probe())
 }
 

--- a/plugins/inputs/chrony/chrony_test.go
+++ b/plugins/inputs/chrony/chrony_test.go
@@ -79,8 +79,10 @@ func TestGatherActivity(t *testing.T) {
 }
 
 func TestProbeFailure(t *testing.T) {
-	// We start the server to make sure that the initial dial succeeds to that
-	// Start() does not fail.
+	// We start the server to make sure that the initial dial succeeds so that
+	// Start() does not fail. A failure of `Start()` when `startup_error_behavior=probe`
+	// is specified would be treated as an ignore anyway, but that's not what
+	// we're testing here.
 	server := Server{}
 	addr, err := server.Listen(t)
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

This adds the `Probe() error` method to the `inputs.chrony` plugin to allow for startup probing as defined in `/docs/specs/tsd-009-probe-on-startup.md`.

A sanity check was done to ensure this does indeed behave as expected when the chrony daemon is not available:

```
2025-04-22T17:39:14Z I! [agent] Failed to probe inputs.chrony, shutting down plugin: querying sources failed: read udp 127.0.0.1:53811->127.0.0.1:323: read: connection refused
```

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #16860

Documentation updates related to: https://github.com/influxdata/telegraf/pull/16859
