### PR TITLE
chore(serializers.prometheusremotewrite): Changed log level for dropped series to warning

### DIFF
--- a/plugins/serializers/prometheusremotewrite/prometheusremotewrite.go
+++ b/plugins/serializers/prometheusremotewrite/prometheusremotewrite.go
@@ -199,7 +199,7 @@ func (s *Serializer) SerializeBatch(metrics []telegraf.Metric) ([]byte, error) {
 	if lastErr != nil {
 		// log only the last recorded error in the batch, as it could have many errors and logging each one
 		// could be too verbose. The following log line still provides enough info for user to act on.
-		s.Log.Errorf("some series were dropped, %d series left to send; last recorded error: %v", len(entries), lastErr)
+		s.Log.Warnf("some series were dropped, %d series left to send; last recorded error: %v", len(entries), lastErr)
 	}
 
 	var promTS = make([]prompb.TimeSeries, len(entries))

--- a/plugins/serializers/prometheusremotewrite/prometheusremotewrite_test.go
+++ b/plugins/serializers/prometheusremotewrite/prometheusremotewrite_test.go
@@ -210,8 +210,9 @@ func TestRemoteWriteSerializeNegative(t *testing.T) {
 		t.Helper()
 		require.NoError(t, err)
 
-		lastMsg := clog.LastWarning()
-		require.NotEmpty(t, lastMsg, "expected non-empty last message")
+		warnings := clog.Warnings()
+		require.NotEmpty(t, warnings, "expected non-empty last message")
+		lastMsg := warnings[len(warnings)-1]
 		require.Contains(t, lastMsg, msg, "unexpected log message")
 
 		// reset logger so it can be reused again

--- a/plugins/serializers/prometheusremotewrite/prometheusremotewrite_test.go
+++ b/plugins/serializers/prometheusremotewrite/prometheusremotewrite_test.go
@@ -210,7 +210,7 @@ func TestRemoteWriteSerializeNegative(t *testing.T) {
 		t.Helper()
 		require.NoError(t, err)
 
-		lastMsg := clog.LastError()
+		lastMsg := clog.LastWarning()
 		require.NotEmpty(t, lastMsg, "expected non-empty last message")
 		require.Contains(t, lastMsg, msg, "unexpected log message")
 

--- a/testutil/capturelog.go
+++ b/testutil/capturelog.go
@@ -131,6 +131,17 @@ func (l *CaptureLogger) Warnings() []string {
 	return l.filter(LevelWarn)
 }
 
+func (l *CaptureLogger) LastWarning() string {
+	l.Lock()
+	defer l.Unlock()
+	for i := len(l.messages) - 1; i >= 0; i-- {
+		if l.messages[i].Level == LevelWarn {
+			return l.messages[i].String()
+		}
+	}
+	return ""
+}
+
 func (l *CaptureLogger) LastError() string {
 	l.Lock()
 	defer l.Unlock()

--- a/testutil/capturelog.go
+++ b/testutil/capturelog.go
@@ -131,17 +131,6 @@ func (l *CaptureLogger) Warnings() []string {
 	return l.filter(LevelWarn)
 }
 
-func (l *CaptureLogger) LastWarning() string {
-	l.Lock()
-	defer l.Unlock()
-	for i := len(l.messages) - 1; i >= 0; i-- {
-		if l.messages[i].Level == LevelWarn {
-			return l.messages[i].String()
-		}
-	}
-	return ""
-}
-
 func (l *CaptureLogger) LastError() string {
 	l.Lock()
 	defer l.Unlock()


### PR DESCRIPTION
## Summary
Current log level for dropped series are now error. It's better to adjust it to warning since there are much more severe errors that can happen and dropped series are very noisy. This make it possible to example adjust log_level to error while incorrect metrics is fixed to stop logs from all the spam. 

## Checklist
- [x] No AI generated code was used in this PR

## Related issues
resolves #16864
