### PR TITLE
fix(common.ratelimiter): Only grow the buffer but never shrink

### DIFF
--- a/plugins/common/ratelimiter/serializers.go
+++ b/plugins/common/ratelimiter/serializers.go
@@ -51,7 +51,7 @@ func (s *IndividualSerializer) SerializeBatch(metrics []telegraf.Metric, limit i
 	// Grow the buffer so it can hold at least the required size. This will
 	// save us from reallocate often
 	s.buffer.Reset()
-	if limit > 0 && limit < int64(math.MaxInt) {
+	if limit > 0 && limit > int64(s.buffer.Cap()) && limit < int64(math.MaxInt) {
 		s.buffer.Grow(int(limit))
 	}
 


### PR DESCRIPTION
## Summary

We want to reduce the number of allocations so never shrink the buffer but only grow it.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

in preparation of #16741
