### PR TITLE
docs(outputs.influxdb_v2): Use correct unit for rate_limit example

### DIFF
--- a/plugins/outputs/influxdb_v2/README.md
+++ b/plugins/outputs/influxdb_v2/README.md
@@ -103,7 +103,7 @@ more details on how to use them.
   # insecure_skip_verify = false
 
   ## Rate limits for sending data (disabled by default)
-  ## Available, uncompressed payload size e.g. "5Mb"
+  ## Available, uncompressed payload size e.g. "5MB"
   # rate_limit = "unlimited"
   ## Fixed time-window for the available payload size e.g. "5m"
   # rate_limit_period = "0s"

--- a/plugins/outputs/influxdb_v2/sample.conf
+++ b/plugins/outputs/influxdb_v2/sample.conf
@@ -73,7 +73,7 @@
   # insecure_skip_verify = false
 
   ## Rate limits for sending data (disabled by default)
-  ## Available, uncompressed payload size e.g. "5Mb"
+  ## Available, uncompressed payload size e.g. "5MB"
   # rate_limit = "unlimited"
   ## Fixed time-window for the available payload size e.g. "5m"
   # rate_limit_period = "0s"


### PR DESCRIPTION
## Summary

Fix the unit to be valid.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues
