### PR TITLE
chore(linter): Address findings for `staticcheck->QF1001` - Apply De Morgan’s law

### DIFF
--- a/cmd/telegraf/telegraf.go
+++ b/cmd/telegraf/telegraf.go
@@ -361,7 +361,7 @@ func (t *Telegraf) runAgent(ctx context.Context, reloadConfig bool) error {
 		}
 	}
 
-	if !(t.test || t.testWait != 0) && len(c.Outputs) == 0 {
+	if !t.test && t.testWait == 0 && len(c.Outputs) == 0 {
 		return errors.New("no outputs found, probably invalid config file provided")
 	}
 	if t.plugindDir == "" && len(c.Inputs) == 0 {

--- a/plugins/common/adx/adx.go
+++ b/plugins/common/adx/adx.go
@@ -62,7 +62,7 @@ func (cfg *Config) NewClient(app string, log telegraf.Logger) (*Client, error) {
 		cfg.MetricsGrouping = TablePerMetric
 	}
 
-	if !(cfg.MetricsGrouping == SingleTable || cfg.MetricsGrouping == TablePerMetric) {
+	if cfg.MetricsGrouping != SingleTable && cfg.MetricsGrouping != TablePerMetric {
 		return nil, errors.New("metrics grouping type is not valid")
 	}
 

--- a/plugins/inputs/fluentd/fluentd.go
+++ b/plugins/inputs/fluentd/fluentd.go
@@ -175,20 +175,20 @@ func (h *Fluentd) Gather(acc telegraf.Accumulator) error {
 				tmpFields["buffer_available_buffer_space_ratios"] = *p.AvailBufferSpaceRatios
 			}
 
-			if !((p.BufferQueueLength == nil) &&
-				(p.RetryCount == nil) &&
-				(p.BufferTotalQueuedSize == nil) &&
-				(p.EmitCount == nil) &&
-				(p.EmitRecords == nil) &&
-				(p.EmitSize == nil) &&
-				(p.WriteCount == nil) &&
-				(p.FlushTimeCount == nil) &&
-				(p.SlowFlushCount == nil) &&
-				(p.RollbackCount == nil) &&
-				(p.BufferStageLength == nil) &&
-				(p.BufferStageByteSize == nil) &&
-				(p.BufferQueueByteSize == nil) &&
-				(p.AvailBufferSpaceRatios == nil)) {
+			if p.BufferQueueLength != nil ||
+				p.RetryCount != nil ||
+				p.BufferTotalQueuedSize != nil ||
+				p.EmitCount != nil ||
+				p.EmitRecords != nil ||
+				p.EmitSize != nil ||
+				p.WriteCount != nil ||
+				p.FlushTimeCount != nil ||
+				p.SlowFlushCount != nil ||
+				p.RollbackCount != nil ||
+				p.BufferStageLength != nil ||
+				p.BufferStageByteSize != nil ||
+				p.BufferQueueByteSize != nil ||
+				p.AvailBufferSpaceRatios != nil {
 				acc.AddFields(measurement, tmpFields, tmpTags)
 			}
 		}

--- a/plugins/inputs/ipset/ipset.go
+++ b/plugins/inputs/ipset/ipset.go
@@ -65,8 +65,7 @@ func (i *Ipset) Gather(acc telegraf.Accumulator) error {
 
 		// Ignore sets created without the "counters" option
 		nocomment := strings.Split(line, "\"")[0]
-		if !(strings.Contains(nocomment, "packets") &&
-			strings.Contains(nocomment, "bytes")) {
+		if !strings.Contains(nocomment, "packets") || !strings.Contains(nocomment, "bytes") {
 			continue
 		}
 

--- a/plugins/inputs/opensearch_query/aggregation.response.go
+++ b/plugins/inputs/opensearch_query/aggregation.response.go
@@ -102,7 +102,7 @@ func (a *aggregateValue) UnmarshalJSON(bytes []byte) error {
 }
 
 func (a *aggregateValue) isAggregation() bool {
-	return !(a.buckets == nil)
+	return a.buckets != nil
 }
 
 func (b *bucketData) UnmarshalJSON(bytes []byte) error {

--- a/plugins/inputs/vsphere/endpoint.go
+++ b/plugins/inputs/vsphere/endpoint.go
@@ -817,8 +817,8 @@ func getVMs(ctx context.Context, e *endpoint, rf *resourceFilter) (objectMap, er
 			for _, ip := range net.IpConfig.IpAddress {
 				addr := ip.IpAddress
 				for _, ipType := range e.parent.IPAddresses {
-					if !(ipType == "ipv4" && isIPv4.MatchString(addr) ||
-						ipType == "ipv6" && isIPv6.MatchString(addr)) {
+					if (ipType != "ipv4" || !isIPv4.MatchString(addr)) &&
+						(ipType != "ipv6" || !isIPv6.MatchString(addr)) {
 						continue
 					}
 

--- a/plugins/outputs/graphite/graphite.go
+++ b/plugins/outputs/graphite/graphite.go
@@ -200,7 +200,7 @@ func (g *Graphite) checkEOF(conn net.Conn) error {
 	}
 	// Log non-timeout errors and close.
 	var netErr net.Error
-	if !(errors.As(err, &netErr) && netErr.Timeout()) {
+	if !errors.As(err, &netErr) || !netErr.Timeout() {
 		g.Log.Debugf("conn %s checkEOF .conn.Read returned err != EOF, which is unexpected.  closing conn. error: %s", conn, err)
 		err = conn.Close()
 		g.Log.Debugf("Failed to close the connection: %v", err)

--- a/plugins/outputs/signalfx/signalfx_test.go
+++ b/plugins/outputs/signalfx/signalfx_test.go
@@ -593,7 +593,7 @@ func TestSignalFx_Errors(t *testing.T) {
 				err := s.Write([]telegraf.Metric{m})
 				require.Error(t, err)
 			}
-			for !(len(s.client.(*errorsink).datapoints) == len(tt.want.datapoints) && len(s.client.(*errorsink).events) == len(tt.want.events)) {
+			for len(s.client.(*errorsink).datapoints) != len(tt.want.datapoints) || len(s.client.(*errorsink).events) != len(tt.want.events) {
 				time.Sleep(1 * time.Second)
 			}
 			if !reflect.DeepEqual(s.client.(*errorsink).datapoints, tt.want.datapoints) {

--- a/plugins/parsers/xpath/parser.go
+++ b/plugins/parsers/xpath/parser.go
@@ -629,7 +629,7 @@ func (p *Parser) constructFieldName(root, node dataNode, name string, expand boo
 }
 
 func (p *Parser) debugEmptyQuery(operation string, root dataNode, initialquery string) {
-	if p.Log == nil || !(p.Log.Level().Includes(telegraf.Trace) || p.Trace) { // for backward compatibility
+	if p.Log == nil || (!p.Log.Level().Includes(telegraf.Trace) && !p.Trace) { // for backward compatibility
 		return
 	}
 

--- a/tools/license_checker/whitelist.go
+++ b/tools/license_checker/whitelist.go
@@ -106,7 +106,7 @@ func (w *whitelist) Check(pkg, version, spdx string) (ok, found bool) {
 		case "<=":
 			match = pkgver.LessThan(*entry.Version) || pkgver.Equal(*entry.Version)
 		case ">":
-			match = !(pkgver.LessThan(*entry.Version) || pkgver.Equal(*entry.Version))
+			match = !pkgver.LessThan(*entry.Version) && !pkgver.Equal(*entry.Version)
 		case ">=":
 			match = !pkgver.LessThan(*entry.Version)
 		}


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

In this PR, I address findings for: `staticcheck->QF1001` - Apply De Morgan’s law.  
However, as agreed in https://github.com/influxdata/telegraf/issues/16826, I am not enabling this rule.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #16826
