### PR TITLE
feat(inputs.prometheus): Add HTTP service discovery support

### DIFF
--- a/plugins/inputs/prometheus/README.md
+++ b/plugins/inputs/prometheus/README.md
@@ -3,6 +3,10 @@
 The prometheus input plugin gathers metrics from HTTP servers exposing metrics
 in Prometheus format.
 
+⭐ Telegraf v0.1.5
+🏷️ applications, server
+💻 all
+
 ## Global configuration options <!-- @/docs/includes/plugin_config.md -->
 
 In addition to the plugin-specific configuration settings, plugins support
@@ -186,6 +190,12 @@ and `bearer_token_string` option. See the
   #     [inputs.prometheus.consul.query.tags]
   #       host = "{{.Node}}"
 
+  ## Scrape Hosts available with http service discovery
+  # [inputs.prometheus.http_service_discovery]
+  #   enabled = false
+  #   url = "http://localhost:9000/service-discovery"
+  #   query_interval = "5m"
+
   ## Control pod scraping based on pod namespace annotations
   ## Pass and drop here act like tagpass and tagdrop, but instead
   ## of filtering metrics they filters pod candidates for scraping
@@ -342,6 +352,17 @@ The following example fields can be used in url or tag templates:
 
 For full list of available fields and their type see struct CatalogService in
 <https://github.com/hashicorp/consul/blob/master/api/catalog.go>
+
+### HTTP Service Discovery
+
+Enabling this option and configuring `url` will allow the plugin to
+query a given http service discovery endpoint for available hosts. Using
+`query_interval` the plugin will periodically query the endpoint for services
+and refresh the list of scraped urls.  It can use the information from the
+response to build the scraped url and additional tags.
+
+More information on the format of http service discovery is found
+[here](https://prometheus.io/docs/prometheus/latest/http_sd/).
 
 ### Bearer Token
 

--- a/plugins/inputs/prometheus/http_service_discovery.go
+++ b/plugins/inputs/prometheus/http_service_discovery.go
@@ -109,7 +109,7 @@ func (p *Prometheus) refreshHTTPServices(sdURL string, client *http.Client) erro
 			targetURL, err := url.Parse(targetValue)
 			if err != nil {
 				p.Log.Warnf("Failed to parse target %q", targetValue)
-				break
+				continue
 			}
 			service := urlAndAddress{
 				url:         targetURL,

--- a/plugins/inputs/prometheus/http_service_discovery.go
+++ b/plugins/inputs/prometheus/http_service_discovery.go
@@ -96,14 +96,14 @@ func (p *Prometheus) refreshHTTPServices(sdURL string, client *http.Client) erro
 	}
 
 	var result []httpSDOutput
-        if err := json.Unmarshal(body, &result); err != nil {
-            return fmt.Errorf("unmarshalling JSON failed: %w", err)
-        }
-        
-        // Validate the response
-        if len(result) == 0 {
-            p.Log.Warnf("Service discovery returned no results")
-        }
+	if err := json.Unmarshal(body, &result); err != nil {
+		return fmt.Errorf("unmarshalling JSON failed: %w", err)
+	}
+
+	// Validate the response
+	if len(result) == 0 {
+		p.Log.Warnf("Service discovery returned no results")
+	}
 
 	for _, sdOutputItem := range result {
 		for _, targetValue := range sdOutputItem.Targets {

--- a/plugins/inputs/prometheus/http_service_discovery.go
+++ b/plugins/inputs/prometheus/http_service_discovery.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/influxdata/telegraf/config"
@@ -101,8 +102,9 @@ func (p *Prometheus) refreshHTTPServices(sdURL string, client *http.Client) erro
 
 	for _, sdOutputItem := range result {
 		for _, targetValue := range sdOutputItem.Targets {
-			// http service discovery returns <host>:<port> pairs so we default to appending http to all hosts
-			targetValue = "http://" + targetValue
+			if !strings.HasPrefix(targetValue, "http://") && !strings.HasPrefix(targetValue, "https://") {
+				targetValue = "http://" + targetValue
+			}
 
 			targetURL, err := url.Parse(targetValue)
 			if err != nil {

--- a/plugins/inputs/prometheus/http_service_discovery.go
+++ b/plugins/inputs/prometheus/http_service_discovery.go
@@ -91,7 +91,7 @@ func (p *Prometheus) refreshHTTPServices(sdURL string, client *http.Client) erro
 	var body []byte
 	body, err = io.ReadAll(resp.Body)
 	if err != nil {
-		return err
+		return fmt.Errorf("reading response body failed: %w", err)
 	}
 
 	var result []httpSDOutput

--- a/plugins/inputs/prometheus/http_service_discovery.go
+++ b/plugins/inputs/prometheus/http_service_discovery.go
@@ -96,9 +96,14 @@ func (p *Prometheus) refreshHTTPServices(sdURL string, client *http.Client) erro
 	}
 
 	var result []httpSDOutput
-	if err := json.Unmarshal(body, &result); err != nil {
-		return fmt.Errorf("unmarshalling JSON failed: %w", err)
-	}
+        if err := json.Unmarshal(body, &result); err != nil {
+            return fmt.Errorf("unmarshalling JSON failed: %w", err)
+        }
+        
+        // Validate the response
+        if len(result) == 0 {
+            p.Log.Warnf("Service discovery returned no results")
+        }
 
 	for _, sdOutputItem := range result {
 		for _, targetValue := range sdOutputItem.Targets {

--- a/plugins/inputs/prometheus/http_service_discovery.go
+++ b/plugins/inputs/prometheus/http_service_discovery.go
@@ -1,0 +1,127 @@
+package prometheus
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/influxdata/telegraf/config"
+)
+
+type HTTPSDConfig struct {
+	Enabled       bool            `toml:"enabled"`
+	URL           string          `toml:"url"`
+	QueryInterval config.Duration `toml:"query_interval"`
+}
+
+// standard output for http service discovery is here https://prometheus.io/docs/prometheus/latest/http_sd/#http_sd-format
+type httpSDOutput struct {
+	Targets []string          `json:"targets"`
+	Labels  map[string]string `json:"labels"`
+}
+
+func (p *Prometheus) startHTTPSD(ctx context.Context) error {
+	// default settings
+	var queryInterval time.Duration
+	if p.HTTPSDConfig.QueryInterval == 0 {
+		queryInterval = time.Duration(5) * time.Minute
+	} else {
+		queryInterval = time.Duration(p.HTTPSDConfig.QueryInterval)
+	}
+
+	if p.HTTPSDConfig.URL == "" {
+		p.HTTPSDConfig.URL = "http://localhost:9000/service-discovery"
+	}
+
+	tlsCfg, err := p.HTTPClientConfig.TLSConfig()
+	if err != nil {
+		return err
+	}
+
+	p.wg.Add(1)
+	go func() {
+		defer p.wg.Done()
+		client := &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig:   tlsCfg,
+				DisableKeepAlives: true,
+			},
+		}
+		defer client.CloseIdleConnections()
+		if err := p.refreshHTTPServices(p.HTTPSDConfig.URL, client); err != nil {
+			p.Log.Errorf("Unable to refresh HTTP scraped services: %v", err)
+		}
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(queryInterval):
+				err := p.refreshHTTPServices(p.HTTPSDConfig.URL, client)
+				if err != nil {
+					p.Log.Errorf("Unable to refresh HTTP scraped services: %v", err)
+				}
+			}
+		}
+	}()
+
+	return nil
+}
+
+func (p *Prometheus) refreshHTTPServices(sdURL string, client *http.Client) error {
+	services := make(map[string]urlAndAddress)
+	req, err := http.NewRequest("GET", sdURL, nil)
+	if err != nil {
+		return fmt.Errorf("creating request failed: %w", err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("discovery failed with status %q", resp.Status)
+	}
+
+	var body []byte
+	body, err = io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	var result []httpSDOutput
+	if err := json.Unmarshal(body, &result); err != nil {
+		return fmt.Errorf("unmarshalling JSON failed: %w", err)
+	}
+
+	for _, sdOutputItem := range result {
+		for _, targetValue := range sdOutputItem.Targets {
+			// http service discovery returns <host>:<port> pairs so we default to appending http to all hosts
+			targetValue = "http://" + targetValue
+
+			targetURL, err := url.Parse(targetValue)
+			if err != nil {
+				p.Log.Warnf("Failed to parse target %q", targetValue)
+				break
+			}
+			service := urlAndAddress{
+				url:         targetURL,
+				originalURL: targetURL,
+				// in this case target labels should just be added to the tags
+				tags: sdOutputItem.Labels,
+			}
+			services[service.url.String()] = service
+		}
+	}
+
+	p.lock.Lock()
+	p.httpServices = services
+	p.lock.Unlock()
+
+	return nil
+}

--- a/plugins/inputs/prometheus/http_service_discovery_test.go
+++ b/plugins/inputs/prometheus/http_service_discovery_test.go
@@ -1,0 +1,53 @@
+package prometheus
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/influxdata/telegraf/config"
+)
+
+func TestHttpSD(t *testing.T) {
+	testcasePath := filepath.Join("testcases", "service_discovery")
+	configFilename := filepath.Join(testcasePath, "telegraf.conf")
+	expectedResult := filepath.Join(testcasePath, "http-services.json")
+
+	// read expected result
+	result, err := os.ReadFile(expectedResult)
+	require.NoError(t, err)
+
+	// Create a fake API server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if _, err := w.Write(result); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Error(err)
+			return
+		}
+	}))
+	defer server.Close()
+
+	// Load the configuration
+	cfg := config.NewConfig()
+	require.NoError(t, cfg.LoadConfig(configFilename))
+	require.Len(t, cfg.Inputs, 1)
+
+	// Setup and start the plugin
+	plugin := cfg.Inputs[0].Input.(*Prometheus)
+	plugin.HTTPSDConfig.URL = server.URL
+	require.NoError(t, plugin.Init())
+
+	// refresh http services
+	client := &http.Client{}
+	defer client.CloseIdleConnections()
+	require.NoError(t, plugin.refreshHTTPServices(server.URL, client))
+
+	plugin.lock.Lock()
+	// check we have 2 http services
+	require.Len(t, plugin.httpServices, 2)
+	plugin.lock.Unlock()
+}

--- a/plugins/inputs/prometheus/http_service_discovery_test.go
+++ b/plugins/inputs/prometheus/http_service_discovery_test.go
@@ -47,7 +47,7 @@ func TestHttpSD(t *testing.T) {
 	require.NoError(t, plugin.refreshHTTPServices(server.URL, client))
 
 	plugin.lock.Lock()
-	// check we have 2 http services
-	require.Len(t, plugin.httpServices, 2)
-	plugin.lock.Unlock()
+	defer plugin.lock.Unlock()
+	// check we have 8 http services
+	require.Len(t, plugin.httpServices, 8)
 }

--- a/plugins/inputs/prometheus/http_service_discovery_test.go
+++ b/plugins/inputs/prometheus/http_service_discovery_test.go
@@ -22,13 +22,19 @@ func TestHttpSD(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create a fake API server
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		if _, err := w.Write(result); err != nil {
-			w.WriteHeader(http.StatusInternalServerError)
-			t.Error(err)
-			return
-		}
-	}))
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+    // Verify it's a GET request
+    if r.Method != http.MethodGET {
+        w.WriteHeader(http.StatusMethodNotAllowed)
+        return
+    }
+    
+    w.Header().Set("Content-Type", "application/json")
+    if _, err := w.Write(result); err != nil {
+        t.Errorf("Failed to write response: %v", err)
+        return
+    }
+}))
 	defer server.Close()
 
 	// Load the configuration

--- a/plugins/inputs/prometheus/http_service_discovery_test.go
+++ b/plugins/inputs/prometheus/http_service_discovery_test.go
@@ -23,18 +23,18 @@ func TestHttpSD(t *testing.T) {
 
 	// Create a fake API server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-    // Verify it's a GET request
-    if r.Method != http.MethodGET {
-        w.WriteHeader(http.StatusMethodNotAllowed)
-        return
-    }
-    
-    w.Header().Set("Content-Type", "application/json")
-    if _, err := w.Write(result); err != nil {
-        t.Errorf("Failed to write response: %v", err)
-        return
-    }
-}))
+		// Verify it's a GET request
+		if r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := w.Write(result); err != nil {
+			t.Errorf("Failed to write response: %v", err)
+			return
+		}
+	}))
 	defer server.Close()
 
 	// Load the configuration

--- a/plugins/inputs/prometheus/sample.conf
+++ b/plugins/inputs/prometheus/sample.conf
@@ -161,6 +161,12 @@
   #     [inputs.prometheus.consul.query.tags]
   #       host = "{{.Node}}"
 
+  ## Scrape Hosts available with http service discovery
+  # [inputs.prometheus.http_service_discovery]
+  #   enabled = false
+  #   url = "http://localhost:9000/service-discovery"
+  #   query_interval = "5m"
+
   ## Control pod scraping based on pod namespace annotations
   ## Pass and drop here act like tagpass and tagdrop, but instead
   ## of filtering metrics they filters pod candidates for scraping

--- a/plugins/inputs/prometheus/testcases/service_discovery/http-services.json
+++ b/plugins/inputs/prometheus/testcases/service_discovery/http-services.json
@@ -1,0 +1,20 @@
+[
+  {
+    "targets": [
+      "localhost:9090"
+    ],
+    "labels": {
+      "host": "localhost",
+      "port": "9090"
+    }
+  },
+  {
+    "targets": [
+      "localhost:9091"
+    ],
+    "labels": {
+      "host": "localhost",
+      "port": "9091"
+    }
+  }
+]

--- a/plugins/inputs/prometheus/testcases/service_discovery/http-services.json
+++ b/plugins/inputs/prometheus/testcases/service_discovery/http-services.json
@@ -1,20 +1,23 @@
 [
   {
-    "targets": [
-      "localhost:9090"
-    ],
+    "targets": ["10.0.10.2:9100", "10.0.10.3:9100", "10.0.10.4:9100", "10.0.10.5:9100"],
     "labels": {
-      "host": "localhost",
-      "port": "9090"
+      "__meta_datacenter": "london",
+      "__meta_prometheus_job": "node"
     }
   },
   {
-    "targets": [
-      "localhost:9091"
-    ],
+    "targets": ["10.0.40.2:9100", "10.0.40.3:9100"],
     "labels": {
-      "host": "localhost",
-      "port": "9091"
+      "__meta_datacenter": "london",
+      "__meta_prometheus_job": "alertmanager"
+    }
+  },
+  {
+    "targets": ["10.0.40.2:9093", "10.0.40.3:9093"],
+    "labels": {
+      "__meta_datacenter": "newyork",
+      "__meta_prometheus_job": "alertmanager"
     }
   }
 ]

--- a/plugins/inputs/prometheus/testcases/service_discovery/telegraf.conf
+++ b/plugins/inputs/prometheus/testcases/service_discovery/telegraf.conf
@@ -1,0 +1,4 @@
+[[inputs.prometheus]]
+  [inputs.prometheus.http_service_discovery]
+     enabled = true
+     url = "dummy"


### PR DESCRIPTION
## Summary
This is a basic implementation to support HTTP service discovery. There are many use cases where something like this could be useful such as when hosts change and a developer might need to write their own http service discovery service. I tested this with a basic implementation of http service discovery I wrote here https://github.com/djbarajas/http-prometheus-sd/tree/main.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves https://github.com/influxdata/telegraf/issues/16695.
