### PR TITLE
fix(inputs.lustre2): getLustreProcStats skips empty files

### DIFF
--- a/plugins/inputs/lustre2/lustre2.go
+++ b/plugins/inputs/lustre2/lustre2.go
@@ -242,6 +242,11 @@ func (l *Lustre2) getLustreProcStats(fileglob string, wantedFields []*mapping) e
 		if err != nil {
 			return err
 		}
+		if len(wholeFile) == 0 {
+			l.Log.Debugf("Skipping empty file %s", file)
+			continue
+		}
+
 		jobs := strings.Split(string(wholeFile), "- ")
 		for _, job := range jobs {
 			lines := strings.Split(job, "\n")


### PR DESCRIPTION
## Summary
From Lustre2.16 some stats files (e.g. /proc/fs/lustre/mdt/*/job_stats) can be completely empty, whereas in previous versions there were always at least some characters at the beginning of the file (e.g. "job_stats: ") 

`getLustreProcStats` generates an "index out of range" crash when trying to "figure out if the data should be tagged with job_id" if the file is completely empty.

This fix enables to skip empty files as there is nothing to report anyway.

## Checklist
- [x ] No AI generated code was used in this PR

## Related issues
resolves #16631
