### PR TITLE
feat(migrations): Add migration for outputs.amqp

### DIFF
--- a/migrations/all/outputs_amqp.go
+++ b/migrations/all/outputs_amqp.go
@@ -1,0 +1,5 @@
+//go:build !custom || (migrations && (outputs || outputs.amqp))
+
+package all
+
+import _ "github.com/influxdata/telegraf/migrations/outputs_amqp" // register migration

--- a/migrations/outputs_amqp/migration.go
+++ b/migrations/outputs_amqp/migration.go
@@ -1,0 +1,94 @@
+package outputs_amqp
+
+import (
+	"github.com/influxdata/toml"
+	"github.com/influxdata/toml/ast"
+
+	"github.com/influxdata/telegraf/migrations"
+)
+
+type amqp struct {
+	Headers         map[string]string `toml:"headers"`
+	Database        string            `toml:"database"`
+	RetentionPolicy string            `toml:"retention_policy"`
+
+	Precision string `toml:"precision"`
+
+	Brokers []string `toml:"brokers"`
+	URL     string   `toml:"url"`
+}
+
+func migrate(tbl *ast.Table) ([]byte, string, error) {
+	var old amqp
+	var plugin map[string]interface{}
+	if err := migrations.UnmarshalTableSkipMissing(tbl, &old); err != nil {
+		return nil, "", err
+	}
+	if err := toml.UnmarshalTable(tbl, &plugin); err != nil {
+		return nil, "", err
+	}
+
+	var applied bool
+
+	// Only apply these fields if the headers array is empty, as was the previous behavior.
+	// However, still remove these fields from the toml if they exist
+	doHeaders := len(old.Headers) == 0
+	if old.Database != "" {
+		applied = true
+
+		if doHeaders {
+			if old.Headers == nil {
+				old.Headers = make(map[string]string, 1)
+			}
+			old.Headers["database"] = old.Database
+			plugin["headers"] = old.Headers
+		}
+
+		delete(plugin, "database")
+	}
+
+	if old.RetentionPolicy != "" {
+		applied = true
+
+		if doHeaders {
+			if old.Headers == nil {
+				old.Headers = make(map[string]string, 1)
+			}
+			old.Headers["retention_policy"] = old.RetentionPolicy
+			plugin["headers"] = old.Headers
+		}
+
+		delete(plugin, "retention_policy")
+	}
+
+	if old.Precision != "" {
+		applied = true
+		delete(plugin, "precision")
+	}
+
+	if old.URL != "" {
+		applied = true
+		// Retains old behavior after this option was deprecated
+		if len(old.Brokers) == 0 {
+			plugin["brokers"] = []string{old.URL}
+		}
+		delete(plugin, "url")
+	}
+
+	// No options migrated so we can exit early
+	if !applied {
+		return nil, "", migrations.ErrNotApplicable
+	}
+
+	// Create the corresponding plugin configurations
+	cfg := migrations.CreateTOMLStruct("outputs", "amqp")
+	cfg.Add("outputs", "amqp", plugin)
+
+	output, err := toml.Marshal(cfg)
+	return output, "", err
+}
+
+// Register the migration function for the plugin type
+func init() {
+	migrations.AddPluginMigration("outputs.amqp", migrate)
+}

--- a/migrations/outputs_amqp/migration.go
+++ b/migrations/outputs_amqp/migration.go
@@ -9,17 +9,6 @@ import (
 
 const messagePrefix = "could not migrate one or more options from the 'outputs.amqp' plugin:"
 
-type amqp struct {
-	Headers         map[string]string `toml:"headers"`
-	Database        string            `toml:"database"`
-	RetentionPolicy string            `toml:"retention_policy"`
-
-	Precision string `toml:"precision"`
-
-	Brokers []string `toml:"brokers"`
-	URL     string   `toml:"url"`
-}
-
 func migrate(tbl *ast.Table) ([]byte, string, error) {
 	var plugin map[string]interface{}
 	if err := toml.UnmarshalTable(tbl, &plugin); err != nil {

--- a/migrations/outputs_amqp/migration_test.go
+++ b/migrations/outputs_amqp/migration_test.go
@@ -1,0 +1,62 @@
+package outputs_amqp_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/influxdata/telegraf/config"
+	_ "github.com/influxdata/telegraf/migrations/outputs_amqp" // register migration
+	_ "github.com/influxdata/telegraf/plugins/outputs/amqp"    // register plugin
+	_ "github.com/influxdata/telegraf/plugins/serializers/all" // register serializers
+)
+
+func TestCases(t *testing.T) {
+	// Get all directories in testdata
+	folders, err := os.ReadDir("testcases")
+	require.NoError(t, err)
+
+	for _, f := range folders {
+		// Only handle folders
+		if !f.IsDir() {
+			continue
+		}
+
+		t.Run(f.Name(), func(t *testing.T) {
+			testcasePath := filepath.Join("testcases", f.Name())
+			inputFile := filepath.Join(testcasePath, "telegraf.conf")
+			expectedFile := filepath.Join(testcasePath, "expected.conf")
+
+			// Read the expected output
+			expected := config.NewConfig()
+			require.NoError(t, expected.LoadConfig(expectedFile))
+			require.NotEmpty(t, expected.Outputs)
+
+			// Read the input data
+			input, remote, err := config.LoadConfigFile(inputFile)
+			require.NoError(t, err)
+			require.False(t, remote)
+			require.NotEmpty(t, input)
+
+			// Migrate
+			output, n, err := config.ApplyMigrations(input)
+			require.NoError(t, err)
+			require.NotEmpty(t, output)
+			require.GreaterOrEqual(t, n, uint64(1))
+			actual := config.NewConfig()
+			require.NoError(t, actual.LoadConfigData(output, config.EmptySourcePath))
+
+			// Test the output
+			require.Len(t, actual.Outputs, len(expected.Outputs))
+			actualIDs := make([]string, 0, len(expected.Outputs))
+			expectedIDs := make([]string, 0, len(expected.Outputs))
+			for i := range actual.Outputs {
+				actualIDs = append(actualIDs, actual.Outputs[i].ID())
+				expectedIDs = append(expectedIDs, expected.Outputs[i].ID())
+			}
+			require.ElementsMatchf(t, expectedIDs, actualIDs, "generated config: %s", string(output))
+		})
+	}
+}

--- a/migrations/outputs_amqp/testcases/minimal/expected.conf
+++ b/migrations/outputs_amqp/testcases/minimal/expected.conf
@@ -1,0 +1,11 @@
+# Publishes metrics to an AMQP broker
+[[outputs.amqp]]
+  ## Brokers to publish to.  If multiple brokers are specified a random broker
+  ## will be selected anytime a connection is established.  This can be
+  ## helpful for load balancing when not using a dedicated load balancer.
+  brokers = ["amqp://localhost:5672/influxdb"]
+
+  headers = {"database" = "db", "retention_policy" = "rp"}
+
+  ## Exchange to declare and publish to.
+  exchange = "telegraf"

--- a/migrations/outputs_amqp/testcases/minimal/telegraf.conf
+++ b/migrations/outputs_amqp/testcases/minimal/telegraf.conf
@@ -1,0 +1,16 @@
+# Publishes metrics to an AMQP broker
+[[outputs.amqp]]
+  ## Brokers to publish to.  If multiple brokers are specified a random broker
+  ## will be selected anytime a connection is established.  This can be
+  ## helpful for load balancing when not using a dedicated load balancer.
+  brokers = []
+
+  url = "amqp://localhost:5672/influxdb"
+
+  precision = "something"
+
+  database = "db"
+  retention_policy = "rp"
+
+  ## Exchange to declare and publish to.
+  exchange = "telegraf"

--- a/migrations/utils.go
+++ b/migrations/utils.go
@@ -1,12 +1,6 @@
 package migrations
 
-import (
-	"fmt"
-	"reflect"
-
-	"github.com/influxdata/toml"
-	"github.com/influxdata/toml/ast"
-)
+import "fmt"
 
 type pluginTOMLStruct map[string]map[string][]interface{}
 
@@ -38,16 +32,4 @@ func AsStringSlice(raw interface{}) ([]string, error) {
 		converted = append(converted, el)
 	}
 	return converted, nil
-}
-
-// UnmarshalTableSkipMissing unmarshals a TOML table into a struct, skipping any missing fields.
-// This is useful for migration purposes where we want to ignore valid fields in the existing
-// configuration that have no effect on migrations.
-func UnmarshalTableSkipMissing(tbl *ast.Table, v interface{}) error {
-	config := toml.DefaultConfig
-	config.MissingField = func(_ reflect.Type, _ string) error {
-		return nil
-	}
-
-	return config.UnmarshalTable(tbl, v)
 }

--- a/migrations/utils.go
+++ b/migrations/utils.go
@@ -2,6 +2,10 @@ package migrations
 
 import (
 	"fmt"
+	"reflect"
+
+	"github.com/influxdata/toml"
+	"github.com/influxdata/toml/ast"
 )
 
 type pluginTOMLStruct map[string]map[string][]interface{}
@@ -34,4 +38,16 @@ func AsStringSlice(raw interface{}) ([]string, error) {
 		converted = append(converted, el)
 	}
 	return converted, nil
+}
+
+// UnmarshalTableSkipMissing unmarshals a TOML table into a struct, skipping any missing fields.
+// This is useful for migration purposes where we want to ignore valid fields in the existing
+// configuration that have no effect on migrations.
+func UnmarshalTableSkipMissing(tbl *ast.Table, v interface{}) error {
+	config := toml.DefaultConfig
+	config.MissingField = func(_ reflect.Type, _ string) error {
+		return nil
+	}
+
+	return config.UnmarshalTable(tbl, v)
 }

--- a/migrations/utils.go
+++ b/migrations/utils.go
@@ -1,6 +1,8 @@
 package migrations
 
-import "fmt"
+import (
+	"fmt"
+)
 
 type pluginTOMLStruct map[string]map[string][]interface{}
 

--- a/plugins/outputs/amqp/amqp.go
+++ b/plugins/outputs/amqp/amqp.go
@@ -41,7 +41,6 @@ func (*externalAuth) Response() string {
 }
 
 type AMQP struct {
-	URL                string            `toml:"url" deprecated:"1.7.0;1.35.0;use 'brokers' instead"`
 	Brokers            []string          `toml:"brokers"`
 	Exchange           string            `toml:"exchange"`
 	ExchangeType       string            `toml:"exchange_type"`
@@ -55,9 +54,6 @@ type AMQP struct {
 	RoutingTag         string            `toml:"routing_tag"`
 	RoutingKey         string            `toml:"routing_key"`
 	DeliveryMode       string            `toml:"delivery_mode"`
-	Database           string            `toml:"database" deprecated:"1.7.0;1.35.0;use 'headers' instead"`
-	RetentionPolicy    string            `toml:"retention_policy" deprecated:"1.7.0;1.35.0;use 'headers' instead"`
-	Precision          string            `toml:"precision" deprecated:"1.2.0;1.35.0;option is ignored"`
 	Headers            map[string]string `toml:"headers"`
 	Timeout            config.Duration   `toml:"timeout"`
 	UseBatchFormat     bool              `toml:"use_batch_format"`
@@ -242,9 +238,6 @@ func (q *AMQP) makeClientConfig() (*ClientConfig, error) {
 	}
 
 	clientConfig.brokers = q.Brokers
-	if len(clientConfig.brokers) == 0 {
-		clientConfig.brokers = []string{q.URL}
-	}
 
 	switch q.DeliveryMode {
 	case "transient":
@@ -259,12 +252,6 @@ func (q *AMQP) makeClientConfig() (*ClientConfig, error) {
 		clientConfig.headers = make(amqp.Table, len(q.Headers))
 		for k, v := range q.Headers {
 			clientConfig.headers[k] = v
-		}
-	} else {
-		// Copy deprecated fields into message header
-		clientConfig.headers = amqp.Table{
-			"database":         q.Database,
-			"retention_policy": q.RetentionPolicy,
 		}
 	}
 

--- a/plugins/outputs/amqp/amqp_test.go
+++ b/plugins/outputs/amqp/amqp_test.go
@@ -116,7 +116,7 @@ func TestConnect(t *testing.T) {
 		{
 			name: "username password",
 			output: &AMQP{
-				URL:      "amqp://foo:bar@localhost",
+				Brokers:  []string{"amqp://foo:bar@localhost"},
 				Username: config.NewSecret([]byte("telegraf")),
 				Password: config.NewSecret([]byte("pa$$word")),
 				connect: func(_ *ClientConfig) (Client, error) {
@@ -138,7 +138,7 @@ func TestConnect(t *testing.T) {
 		{
 			name: "url support",
 			output: &AMQP{
-				URL: DefaultURL,
+				Brokers: []string{DefaultURL},
 				connect: func(_ *ClientConfig) (Client, error) {
 					return NewMockClient(), nil
 				},


### PR DESCRIPTION
## Summary
Removes the deprecated options `database`, `retention_policy`, `url`, and `precision`, providing migrations for these fields

## Checklist
- [X] No AI generated code was used in this PR

## Related issues
resolves #16936
