### PR TITLE
chore(linters): Enable `ST1005`, `ST1013`, `ST1016`, `ST1017`, `QF1002` checks for `staticcheck`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -381,18 +381,6 @@ linters:
         # Poorly chosen identifier.
         # https://staticcheck.dev/docs/checks/#ST1003
         - -ST1003
-        # Incorrectly formatted error string.
-        # https://staticcheck.dev/docs/checks/#ST1005
-        - -ST1005
-        # Should use constants for HTTP error codes, not magic numbers.
-        # https://staticcheck.dev/docs/checks/#ST1013
-        - -ST1013
-        # Use consistent method receiver names.
-        # https://staticcheck.dev/docs/checks/#ST1016
-        - -ST1016
-        # Don't use Yoda conditions.
-        # https://staticcheck.dev/docs/checks/#ST1017
-        - -ST1017
         # The documentation of an exported function should start with the function's name.
         # https://staticcheck.dev/docs/checks/#ST1020
         - -ST1020
@@ -405,9 +393,6 @@ linters:
         # Apply De Morgan's law.
         # https://staticcheck.dev/docs/checks/#QF1001
         - -QF1001
-        # Convert untagged switch to tagged switch.
-        # https://staticcheck.dev/docs/checks/#QF1002
-        - -QF1002
         # Convert if/else-if chain to tagged switch.
         # https://staticcheck.dev/docs/checks/#QF1003
         - -QF1003

--- a/config/config.go
+++ b/config/config.go
@@ -662,8 +662,8 @@ func (c *Config) LoadConfigData(data []byte, path string) error {
 
 	if len(c.UnusedFields) > 0 {
 		return fmt.Errorf(
-			"line %d: configuration specified the fields %q, but they were not used. "+
-				"This is either a typo or this config option does not exist in this version.",
+			"line %d: configuration specified the fields %q, but they were not used; "+
+				"this is either a typo or this config option does not exist in this version",
 			tbl.Line, keys(c.UnusedFields))
 	}
 
@@ -700,8 +700,8 @@ func (c *Config) LoadConfigData(data []byte, path string) error {
 				}
 				if len(c.UnusedFields) > 0 {
 					return fmt.Errorf(
-						"plugin %s.%s: line %d: configuration specified the fields %q, but they were not used. "+
-							"This is either a typo or this config option does not exist in this version.",
+						"plugin %s.%s: line %d: configuration specified the fields %q, but they were not used; "+
+							"this is either a typo or this config option does not exist in this version",
 						name, pluginName, subTable.Line, keys(c.UnusedFields))
 				}
 			}
@@ -725,8 +725,8 @@ func (c *Config) LoadConfigData(data []byte, path string) error {
 				}
 				if len(c.UnusedFields) > 0 {
 					return fmt.Errorf(
-						"plugin %s.%s: line %d: configuration specified the fields %q, but they were not used. "+
-							"This is either a typo or this config option does not exist in this version.",
+						"plugin %s.%s: line %d: configuration specified the fields %q, but they were not used; "+
+							"this is either a typo or this config option does not exist in this version",
 						name, pluginName, subTable.Line, keys(c.UnusedFields))
 				}
 			}
@@ -745,8 +745,8 @@ func (c *Config) LoadConfigData(data []byte, path string) error {
 				}
 				if len(c.UnusedFields) > 0 {
 					return fmt.Errorf(
-						"plugin %s.%s: line %d: configuration specified the fields %q, but they were not used. "+
-							"This is either a typo or this config option does not exist in this version.",
+						"plugin %s.%s: line %d: configuration specified the fields %q, but they were not used; "+
+							"this is either a typo or this config option does not exist in this version",
 						name,
 						pluginName,
 						subTable.Line,
@@ -769,8 +769,8 @@ func (c *Config) LoadConfigData(data []byte, path string) error {
 				}
 				if len(c.UnusedFields) > 0 {
 					return fmt.Errorf(
-						"plugin %s.%s: line %d: configuration specified the fields %q, but they were not used. "+
-							"This is either a typo or this config option does not exist in this version.",
+						"plugin %s.%s: line %d: configuration specified the fields %q, but they were not used; "+
+							"this is either a typo or this config option does not exist in this version",
 						name, pluginName, subTable.Line, keys(c.UnusedFields))
 				}
 			}
@@ -787,8 +787,8 @@ func (c *Config) LoadConfigData(data []byte, path string) error {
 					return fmt.Errorf("unsupported config format: %s", pluginName)
 				}
 				if len(c.UnusedFields) > 0 {
-					msg := "plugin %s.%s: line %d: configuration specified the fields %q, but they were not used. " +
-						"This is either a typo or this config option does not exist in this version."
+					msg := "plugin %s.%s: line %d: configuration specified the fields %q, but they were not used; " +
+						"this is either a typo or this config option does not exist in this version"
 					return fmt.Errorf(msg, name, pluginName, subTable.Line, keys(c.UnusedFields))
 				}
 			}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -387,62 +387,62 @@ func TestConfig_FieldNotDefined(t *testing.T) {
 		{
 			name:     "in input plugin without parser",
 			filename: "./testdata/invalid_field.toml",
-			expected: "line 1: configuration specified the fields [\"not_a_field\"], but they were not used. " +
-				"This is either a typo or this config option does not exist in this version.",
+			expected: "line 1: configuration specified the fields [\"not_a_field\"], but they were not used; " +
+				"this is either a typo or this config option does not exist in this version",
 		},
 		{
 			name:     "in input plugin with parser",
 			filename: "./testdata/invalid_field_with_parser.toml",
-			expected: "line 1: configuration specified the fields [\"not_a_field\"], but they were not used. " +
-				"This is either a typo or this config option does not exist in this version.",
+			expected: "line 1: configuration specified the fields [\"not_a_field\"], but they were not used; " +
+				"this is either a typo or this config option does not exist in this version",
 		},
 		{
 			name:     "in input plugin with parser func",
 			filename: "./testdata/invalid_field_with_parserfunc.toml",
-			expected: "line 1: configuration specified the fields [\"not_a_field\"], but they were not used. " +
-				"This is either a typo or this config option does not exist in this version.",
+			expected: "line 1: configuration specified the fields [\"not_a_field\"], but they were not used; " +
+				"this is either a typo or this config option does not exist in this version",
 		},
 		{
 			name:     "in parser of input plugin",
 			filename: "./testdata/invalid_field_in_parser_table.toml",
-			expected: "line 1: configuration specified the fields [\"not_a_field\"], but they were not used. " +
-				"This is either a typo or this config option does not exist in this version.",
+			expected: "line 1: configuration specified the fields [\"not_a_field\"], but they were not used; " +
+				"this is either a typo or this config option does not exist in this version",
 		},
 		{
 			name:     "in parser of input plugin with parser-func",
 			filename: "./testdata/invalid_field_in_parserfunc_table.toml",
-			expected: "line 1: configuration specified the fields [\"not_a_field\"], but they were not used. " +
-				"This is either a typo or this config option does not exist in this version.",
+			expected: "line 1: configuration specified the fields [\"not_a_field\"], but they were not used; " +
+				"this is either a typo or this config option does not exist in this version",
 		},
 		{
 			name:     "in processor plugin without parser",
 			filename: "./testdata/invalid_field_processor.toml",
-			expected: "line 1: configuration specified the fields [\"not_a_field\"], but they were not used. " +
-				"This is either a typo or this config option does not exist in this version.",
+			expected: "line 1: configuration specified the fields [\"not_a_field\"], but they were not used; " +
+				"this is either a typo or this config option does not exist in this version",
 		},
 		{
 			name:     "in processor plugin with parser",
 			filename: "./testdata/invalid_field_processor_with_parser.toml",
-			expected: "line 1: configuration specified the fields [\"not_a_field\"], but they were not used. " +
-				"This is either a typo or this config option does not exist in this version.",
+			expected: "line 1: configuration specified the fields [\"not_a_field\"], but they were not used; " +
+				"this is either a typo or this config option does not exist in this version",
 		},
 		{
 			name:     "in processor plugin with parser func",
 			filename: "./testdata/invalid_field_processor_with_parserfunc.toml",
-			expected: "line 1: configuration specified the fields [\"not_a_field\"], but they were not used. " +
-				"This is either a typo or this config option does not exist in this version.",
+			expected: "line 1: configuration specified the fields [\"not_a_field\"], but they were not used; " +
+				"this is either a typo or this config option does not exist in this version",
 		},
 		{
 			name:     "in parser of processor plugin",
 			filename: "./testdata/invalid_field_processor_in_parser_table.toml",
-			expected: "line 1: configuration specified the fields [\"not_a_field\"], but they were not used. " +
-				"This is either a typo or this config option does not exist in this version.",
+			expected: "line 1: configuration specified the fields [\"not_a_field\"], but they were not used; " +
+				"this is either a typo or this config option does not exist in this version",
 		},
 		{
 			name:     "in parser of processor plugin with parser-func",
 			filename: "./testdata/invalid_field_processor_in_parserfunc_table.toml",
-			expected: "line 1: configuration specified the fields [\"not_a_field\"], but they were not used. " +
-				"This is either a typo or this config option does not exist in this version.",
+			expected: "line 1: configuration specified the fields [\"not_a_field\"], but they were not used; " +
+				"this is either a typo or this config option does not exist in this version",
 		},
 	}
 

--- a/plugins/inputs/burrow/burrow_test.go
+++ b/plugins/inputs/burrow/burrow_test.go
@@ -51,12 +51,12 @@ func getHTTPServerBasicAuth() *httptest.Server {
 
 		username, password, authOK := r.BasicAuth()
 		if !authOK {
-			http.Error(w, "Not authorized", 401)
+			http.Error(w, "Not authorized", http.StatusUnauthorized)
 			return
 		}
 
 		if username != "test" && password != "test" {
-			http.Error(w, "Not authorized", 401)
+			http.Error(w, "Not authorized", http.StatusUnauthorized)
 			return
 		}
 

--- a/plugins/inputs/monit/monit_test.go
+++ b/plugins/inputs/monit/monit_test.go
@@ -587,7 +587,7 @@ func TestConnection(t *testing.T) {
 func TestInvalidUsernameOrPassword(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !checkAuth(r, "testing", "testing") {
-			http.Error(w, "Unauthorized.", 401)
+			http.Error(w, "Unauthorized.", http.StatusUnauthorized)
 			return
 		}
 
@@ -618,7 +618,7 @@ func TestInvalidUsernameOrPassword(t *testing.T) {
 func TestNoUsernameOrPasswordConfiguration(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !checkAuth(r, "testing", "testing") {
-			http.Error(w, "Unauthorized.", 401)
+			http.Error(w, "Unauthorized.", http.StatusUnauthorized)
 			return
 		}
 

--- a/plugins/inputs/phpfpm/fcgi_client.go
+++ b/plugins/inputs/phpfpm/fcgi_client.go
@@ -84,12 +84,12 @@ READ_LOOP:
 			break
 		}
 
-		switch {
-		case rec.h.Type == typeStdout:
+		switch rec.h.Type {
+		case typeStdout:
 			retout = append(retout, rec.content()...)
-		case rec.h.Type == typeStderr:
+		case typeStderr:
 			reterr = append(reterr, rec.content()...)
-		case rec.h.Type == typeEndRequest:
+		case typeEndRequest:
 			fallthrough
 		default:
 			break READ_LOOP

--- a/plugins/inputs/redfish/redfish_test.go
+++ b/plugins/inputs/redfish/redfish_test.go
@@ -18,7 +18,7 @@ import (
 func TestDellApis(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !checkAuth(r, "test", "test") {
-			http.Error(w, "Unauthorized.", 401)
+			http.Error(w, "Unauthorized.", http.StatusUnauthorized)
 			return
 		}
 
@@ -441,7 +441,7 @@ func TestDellApis(t *testing.T) {
 func TestHPApis(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !checkAuth(r, "test", "test") {
-			http.Error(w, "Unauthorized.", 401)
+			http.Error(w, "Unauthorized.", http.StatusUnauthorized)
 			return
 		}
 
@@ -620,7 +620,7 @@ func TestHPApis(t *testing.T) {
 func TestHPilo4Apis(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !checkAuth(r, "test", "test") {
-			http.Error(w, "Unauthorized.", 401)
+			http.Error(w, "Unauthorized.", http.StatusUnauthorized)
 			return
 		}
 
@@ -725,7 +725,7 @@ func checkAuth(r *http.Request, username, password string) bool {
 func TestInvalidUsernameorPassword(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !checkAuth(r, "testing", "testing") {
-			http.Error(w, "Unauthorized.", 401)
+			http.Error(w, "Unauthorized.", http.StatusUnauthorized)
 			return
 		}
 
@@ -756,7 +756,7 @@ func TestInvalidUsernameorPassword(t *testing.T) {
 func TestNoUsernameorPasswordConfiguration(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !checkAuth(r, "testing", "testing") {
-			http.Error(w, "Unauthorized.", 401)
+			http.Error(w, "Unauthorized.", http.StatusUnauthorized)
 			return
 		}
 
@@ -821,7 +821,7 @@ func TestInvalidDellJSON(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if !checkAuth(r, "test", "test") {
-					http.Error(w, "Unauthorized.", 401)
+					http.Error(w, "Unauthorized.", http.StatusUnauthorized)
 					return
 				}
 
@@ -892,7 +892,7 @@ func TestInvalidHPJSON(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if !checkAuth(r, "test", "test") {
-					http.Error(w, "Unauthorized.", 401)
+					http.Error(w, "Unauthorized.", http.StatusUnauthorized)
 					return
 				}
 
@@ -932,7 +932,7 @@ func TestInvalidHPJSON(t *testing.T) {
 func TestIncludeTagSetsConfiguration(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !checkAuth(r, "test", "test") {
-			http.Error(w, "Unauthorized.", 401)
+			http.Error(w, "Unauthorized.", http.StatusUnauthorized)
 			return
 		}
 

--- a/plugins/outputs/bigquery/bigquery.go
+++ b/plugins/outputs/bigquery/bigquery.go
@@ -50,34 +50,34 @@ func (*BigQuery) SampleConfig() string {
 	return sampleConfig
 }
 
-func (s *BigQuery) Init() error {
-	if s.Project == "" {
-		s.Project = bigquery.DetectProjectID
+func (b *BigQuery) Init() error {
+	if b.Project == "" {
+		b.Project = bigquery.DetectProjectID
 	}
 
-	if s.Dataset == "" {
+	if b.Dataset == "" {
 		return errors.New(`"dataset" is required`)
 	}
 
-	s.warnedOnHyphens = make(map[string]bool)
+	b.warnedOnHyphens = make(map[string]bool)
 
 	return nil
 }
 
-func (s *BigQuery) Connect() error {
-	if s.client == nil {
-		if err := s.setUpDefaultClient(); err != nil {
+func (b *BigQuery) Connect() error {
+	if b.client == nil {
+		if err := b.setUpDefaultClient(); err != nil {
 			return err
 		}
 	}
 
-	if s.CompactTable != "" {
+	if b.CompactTable != "" {
 		ctx := context.Background()
-		ctx, cancel := context.WithTimeout(ctx, time.Duration(s.Timeout))
+		ctx, cancel := context.WithTimeout(ctx, time.Duration(b.Timeout))
 		defer cancel()
 
 		// Check if the compact table exists
-		_, err := s.client.Dataset(s.Dataset).Table(s.CompactTable).Metadata(ctx)
+		_, err := b.client.Dataset(b.Dataset).Table(b.CompactTable).Metadata(ctx)
 		if err != nil {
 			return fmt.Errorf("compact table: %w", err)
 		}
@@ -85,15 +85,15 @@ func (s *BigQuery) Connect() error {
 	return nil
 }
 
-func (s *BigQuery) setUpDefaultClient() error {
+func (b *BigQuery) setUpDefaultClient() error {
 	var credentialsOption option.ClientOption
 
 	// https://cloud.google.com/go/docs/reference/cloud.google.com/go/0.94.1#hdr-Timeouts_and_Cancellation
 	// Do not attempt to add timeout to this context for the bigquery client.
 	ctx := context.Background()
 
-	if s.CredentialsFile != "" {
-		credentialsOption = option.WithCredentialsFile(s.CredentialsFile)
+	if b.CredentialsFile != "" {
+		credentialsOption = option.WithCredentialsFile(b.CredentialsFile)
 	} else {
 		creds, err := google.FindDefaultCredentials(ctx, bigquery.Scope)
 		if err != nil {
@@ -104,18 +104,18 @@ func (s *BigQuery) setUpDefaultClient() error {
 		credentialsOption = option.WithCredentials(creds)
 	}
 
-	client, err := bigquery.NewClient(ctx, s.Project,
+	client, err := bigquery.NewClient(ctx, b.Project,
 		credentialsOption,
 		option.WithUserAgent(internal.ProductToken()),
 	)
-	s.client = client
+	b.client = client
 	return err
 }
 
 // Write the metrics to Google Cloud BigQuery.
-func (s *BigQuery) Write(metrics []telegraf.Metric) error {
-	if s.CompactTable != "" {
-		return s.writeCompact(metrics)
+func (b *BigQuery) Write(metrics []telegraf.Metric) error {
+	if b.CompactTable != "" {
+		return b.writeCompact(metrics)
 	}
 
 	groupedMetrics := groupByMetricName(metrics)
@@ -126,7 +126,7 @@ func (s *BigQuery) Write(metrics []telegraf.Metric) error {
 		wg.Add(1)
 		go func(k string, v []bigquery.ValueSaver) {
 			defer wg.Done()
-			s.insertToTable(k, v)
+			b.insertToTable(k, v)
 		}(k, v)
 	}
 
@@ -135,19 +135,19 @@ func (s *BigQuery) Write(metrics []telegraf.Metric) error {
 	return nil
 }
 
-func (s *BigQuery) writeCompact(metrics []telegraf.Metric) error {
+func (b *BigQuery) writeCompact(metrics []telegraf.Metric) error {
 	ctx := context.Background()
-	ctx, cancel := context.WithTimeout(ctx, time.Duration(s.Timeout))
+	ctx, cancel := context.WithTimeout(ctx, time.Duration(b.Timeout))
 	defer cancel()
 
 	// Always returns an instance, even if table doesn't exist (anymore).
-	inserter := s.client.Dataset(s.Dataset).Table(s.CompactTable).Inserter()
+	inserter := b.client.Dataset(b.Dataset).Table(b.CompactTable).Inserter()
 
 	var compactValues []*bigquery.ValuesSaver
 	for _, m := range metrics {
-		valueSaver, err := s.newCompactValuesSaver(m)
+		valueSaver, err := b.newCompactValuesSaver(m)
 		if err != nil {
-			s.Log.Warnf("could not prepare metric as compact value: %v", err)
+			b.Log.Warnf("could not prepare metric as compact value: %v", err)
 		} else {
 			compactValues = append(compactValues, valueSaver)
 		}
@@ -182,7 +182,7 @@ func newValuesSaver(m telegraf.Metric) *bigquery.ValuesSaver {
 	}
 }
 
-func (s *BigQuery) newCompactValuesSaver(m telegraf.Metric) (*bigquery.ValuesSaver, error) {
+func (b *BigQuery) newCompactValuesSaver(m telegraf.Metric) (*bigquery.ValuesSaver, error) {
 	tags, err := json.Marshal(m.Tags())
 	if err != nil {
 		return nil, fmt.Errorf("serializing tags: %w", err)
@@ -193,7 +193,7 @@ func (s *BigQuery) newCompactValuesSaver(m telegraf.Metric) (*bigquery.ValuesSav
 		if fv, ok := field.Value.(float64); ok {
 			// JSON does not support these special values
 			if math.IsNaN(fv) || math.IsInf(fv, 0) {
-				s.Log.Debugf("Ignoring unsupported field %s with value %q for metric %s", field.Key, field.Value, m.Name())
+				b.Log.Debugf("Ignoring unsupported field %s with value %q for metric %s", field.Key, field.Value, m.Name())
 				continue
 			}
 		}
@@ -279,38 +279,38 @@ func valueToBqType(v interface{}) bigquery.FieldType {
 	}
 }
 
-func (s *BigQuery) insertToTable(metricName string, metrics []bigquery.ValueSaver) {
+func (b *BigQuery) insertToTable(metricName string, metrics []bigquery.ValueSaver) {
 	ctx := context.Background()
-	ctx, cancel := context.WithTimeout(ctx, time.Duration(s.Timeout))
+	ctx, cancel := context.WithTimeout(ctx, time.Duration(b.Timeout))
 	defer cancel()
 
-	tableName := s.metricToTable(metricName)
-	table := s.client.Dataset(s.Dataset).Table(tableName)
+	tableName := b.metricToTable(metricName)
+	table := b.client.Dataset(b.Dataset).Table(tableName)
 	inserter := table.Inserter()
 
 	if err := inserter.Put(ctx, metrics); err != nil {
-		s.Log.Errorf("inserting metric %q failed: %v", metricName, err)
+		b.Log.Errorf("inserting metric %q failed: %v", metricName, err)
 	}
 }
 
-func (s *BigQuery) metricToTable(metricName string) string {
+func (b *BigQuery) metricToTable(metricName string) string {
 	if !strings.Contains(metricName, "-") {
 		return metricName
 	}
 
-	dhm := strings.ReplaceAll(metricName, "-", s.ReplaceHyphenTo)
+	dhm := strings.ReplaceAll(metricName, "-", b.ReplaceHyphenTo)
 
-	if warned := s.warnedOnHyphens[metricName]; !warned {
-		s.Log.Warnf("Metric %q contains hyphens please consider using the rename processor plugin, falling back to %q", metricName, dhm)
-		s.warnedOnHyphens[metricName] = true
+	if warned := b.warnedOnHyphens[metricName]; !warned {
+		b.Log.Warnf("Metric %q contains hyphens please consider using the rename processor plugin, falling back to %q", metricName, dhm)
+		b.warnedOnHyphens[metricName] = true
 	}
 
 	return dhm
 }
 
 // Close will terminate the session to the backend, returning error if an issue arises.
-func (s *BigQuery) Close() error {
-	return s.client.Close()
+func (b *BigQuery) Close() error {
+	return b.client.Close()
 }
 
 func init() {

--- a/plugins/outputs/sumologic/sumologic_test.go
+++ b/plugins/outputs/sumologic/sumologic_test.go
@@ -348,7 +348,7 @@ func TestContentEncodingGzip(t *testing.T) {
 					t.Error(err)
 					return
 				}
-				if "metric=cpu field=value  42 0\n" != string(payload) {
+				if string(payload) != "metric=cpu field=value  42 0\n" {
 					w.WriteHeader(http.StatusInternalServerError)
 					t.Errorf("Not equal, expected: %q, actual: %q", "metric=cpu field=value  42 0\n", string(payload))
 					return

--- a/plugins/serializers/prometheus/convert.go
+++ b/plugins/serializers/prometheus/convert.go
@@ -63,8 +63,8 @@ func sanitize(name string, table Table) (string, bool) {
 	var b strings.Builder
 
 	for i, r := range name {
-		switch {
-		case i == 0:
+		switch i {
+		case 0:
 			if unicode.In(r, table.First) {
 				b.WriteRune(r)
 			}

--- a/tools/update_goversion/main.go
+++ b/tools/update_goversion/main.go
@@ -73,7 +73,7 @@ func findHashes(body io.Reader, version string) (map[string]string, error) {
 		if tokenType == html.StartTagToken {
 			// get the token
 			token := htmlTokens.Token()
-			if "table" == token.Data && len(token.Attr) == 1 && token.Attr[0].Val == "downloadtable" {
+			if token.Data == "table" && len(token.Attr) == 1 && token.Attr[0].Val == "downloadtable" {
 				insideDownloadTable = true
 			}
 


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

Fixes following findings:
```
config/config.go:664:10                            staticcheck  ST1005: error strings should not end with punctuation or newlines
config/config.go:702:13                            staticcheck  ST1005: error strings should not end with punctuation or newlines
config/config.go:727:13                            staticcheck  ST1005: error strings should not end with punctuation or newlines
config/config.go:747:13                            staticcheck  ST1005: error strings should not end with punctuation or newlines
config/config.go:771:13                            staticcheck  ST1005: error strings should not end with punctuation or newlines
config/config.go:792:13                            staticcheck  ST1005: error strings should not end with punctuation or newlines
plugins/inputs/burrow/burrow_test.go:54:36         staticcheck  ST1013: should use constant http.StatusUnauthorized instead of numeric literal 401
plugins/inputs/burrow/burrow_test.go:59:36         staticcheck  ST1013: should use constant http.StatusUnauthorized instead of numeric literal 401
plugins/inputs/cgroup/cgroup_linux.go:20:18        staticcheck  ST1016: methods on the same type should have the same receiver name (seen 1x "cg", 4x "g")
plugins/inputs/monit/monit_test.go:590:35          staticcheck  ST1013: should use constant http.StatusUnauthorized instead of numeric literal 401
plugins/inputs/monit/monit_test.go:621:35          staticcheck  ST1013: should use constant http.StatusUnauthorized instead of numeric literal 401
plugins/inputs/phpfpm/fcgi_client.go:87:3          staticcheck  QF1002: could use tagged switch on rec.h.Type
plugins/inputs/redfish/redfish_test.go:21:35       staticcheck  ST1013: should use constant http.StatusUnauthorized instead of numeric literal 401
plugins/inputs/redfish/redfish_test.go:444:35      staticcheck  ST1013: should use constant http.StatusUnauthorized instead of numeric literal 401
plugins/inputs/redfish/redfish_test.go:623:35      staticcheck  ST1013: should use constant http.StatusUnauthorized instead of numeric literal 401
plugins/inputs/redfish/redfish_test.go:728:35      staticcheck  ST1013: should use constant http.StatusUnauthorized instead of numeric literal 401
plugins/inputs/redfish/redfish_test.go:759:35      staticcheck  ST1013: should use constant http.StatusUnauthorized instead of numeric literal 401
plugins/inputs/redfish/redfish_test.go:824:37      staticcheck  ST1013: should use constant http.StatusUnauthorized instead of numeric literal 401
plugins/inputs/redfish/redfish_test.go:895:37      staticcheck  ST1013: should use constant http.StatusUnauthorized instead of numeric literal 401
plugins/inputs/redfish/redfish_test.go:935:35      staticcheck  ST1013: should use constant http.StatusUnauthorized instead of numeric literal 401
plugins/outputs/bigquery/bigquery.go:312:20        staticcheck  ST1016: methods on the same type should have the same receiver name (seen 2x "b", 9x "s")
plugins/outputs/sumologic/sumologic_test.go:351:8  staticcheck  ST1017: don't use Yoda conditions
plugins/serializers/prometheus/convert.go:66:3     staticcheck  QF1002: could use tagged switch on i
tools/update_goversion/main.go:76:7                staticcheck  ST1017: don't use Yoda conditions
```

And enables [`ST1005`](https://staticcheck.dev/docs/checks/#ST1005), [`ST1013`](https://staticcheck.dev/docs/checks/#ST1013), [`ST1016`](https://staticcheck.dev/docs/checks/#ST1016), [`ST1017`](https://staticcheck.dev/docs/checks/#ST1017), [`QF1002`](https://staticcheck.dev/docs/checks/#QF1002) checks for `staticcheck`.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #16818
resolves #16819
resolves #16820
resolves #16821
resolves #16825
