### PR TITLE
docs: Fixed minor typo

### DIFF
--- a/docs/includes/service_input.md
+++ b/docs/includes/service_input.md
@@ -1,5 +1,5 @@
 This plugin is a service input. Normal plugins gather metrics determined by the
-interval setting. Service plugins start a service to listens and waits for
+interval setting. Service plugins start a service to listen and wait for
 metrics or events to occur. Service plugins have two key differences from
 normal plugins:
 

--- a/plugins/inputs/amqp_consumer/README.md
+++ b/plugins/inputs/amqp_consumer/README.md
@@ -22,7 +22,7 @@ For an introduction check the [AMQP concepts page][amqp_concepts] and the
 ## Service Input <!-- @/docs/includes/service_input.md -->
 
 This plugin is a service input. Normal plugins gather metrics determined by the
-interval setting. Service plugins start a service to listens and waits for
+interval setting. Service plugins start a service to listen and wait for
 metrics or events to occur. Service plugins have two key differences from
 normal plugins:
 

--- a/plugins/inputs/cisco_telemetry_mdt/README.md
+++ b/plugins/inputs/cisco_telemetry_mdt/README.md
@@ -19,7 +19,7 @@ later.
 ## Service Input <!-- @/docs/includes/service_input.md -->
 
 This plugin is a service input. Normal plugins gather metrics determined by the
-interval setting. Service plugins start a service to listens and waits for
+interval setting. Service plugins start a service to listen and wait for
 metrics or events to occur. Service plugins have two key differences from
 normal plugins:
 

--- a/plugins/inputs/cloud_pubsub/README.md
+++ b/plugins/inputs/cloud_pubsub/README.md
@@ -13,7 +13,7 @@ and creates metrics using one of the supported [data formats][data_formats].
 ## Service Input <!-- @/docs/includes/service_input.md -->
 
 This plugin is a service input. Normal plugins gather metrics determined by the
-interval setting. Service plugins start a service to listens and waits for
+interval setting. Service plugins start a service to listen and wait for
 metrics or events to occur. Service plugins have two key differences from
 normal plugins:
 

--- a/plugins/inputs/cloud_pubsub_push/README.md
+++ b/plugins/inputs/cloud_pubsub_push/README.md
@@ -22,7 +22,7 @@ in `tls_allowed_cacerts`.
 ## Service Input <!-- @/docs/includes/service_input.md -->
 
 This plugin is a service input. Normal plugins gather metrics determined by the
-interval setting. Service plugins start a service to listens and waits for
+interval setting. Service plugins start a service to listen and wait for
 metrics or events to occur. Service plugins have two key differences from
 normal plugins:
 

--- a/plugins/inputs/cloudwatch_metric_streams/README.md
+++ b/plugins/inputs/cloudwatch_metric_streams/README.md
@@ -19,7 +19,7 @@ This plugin listens for metrics sent via HTTP by
 ## Service Input <!-- @/docs/includes/service_input.md -->
 
 This plugin is a service input. Normal plugins gather metrics determined by the
-interval setting. Service plugins start a service to listens and waits for
+interval setting. Service plugins start a service to listen and wait for
 metrics or events to occur. Service plugins have two key differences from
 normal plugins:
 

--- a/plugins/inputs/eventhub_consumer/README.md
+++ b/plugins/inputs/eventhub_consumer/README.md
@@ -24,7 +24,7 @@ The main focus for development of this plugin is Azure IoT hub:
 ## Service Input <!-- @/docs/includes/service_input.md -->
 
 This plugin is a service input. Normal plugins gather metrics determined by the
-interval setting. Service plugins start a service to listens and waits for
+interval setting. Service plugins start a service to listen and wait for
 metrics or events to occur. Service plugins have two key differences from
 normal plugins:
 

--- a/plugins/inputs/execd/README.md
+++ b/plugins/inputs/execd/README.md
@@ -21,7 +21,7 @@ and the actual message. For example outputting `I! A log message` will create a
 ## Service Input <!-- @/docs/includes/service_input.md -->
 
 This plugin is a service input. Normal plugins gather metrics determined by the
-interval setting. Service plugins start a service to listens and waits for
+interval setting. Service plugins start a service to listen and wait for
 metrics or events to occur. Service plugins have two key differences from
 normal plugins:
 

--- a/plugins/inputs/firehose/README.md
+++ b/plugins/inputs/firehose/README.md
@@ -16,7 +16,7 @@ official [documentation][response_spec].
 ## Service Input <!-- @/docs/includes/service_input.md -->
 
 This plugin is a service input. Normal plugins gather metrics determined by the
-interval setting. Service plugins start a service to listens and waits for
+interval setting. Service plugins start a service to listen and wait for
 metrics or events to occur. Service plugins have two key differences from
 normal plugins:
 

--- a/plugins/inputs/gnmi/README.md
+++ b/plugins/inputs/gnmi/README.md
@@ -17,7 +17,7 @@ Cisco IOS XE 16.12 and later.
 ## Service Input <!-- @/docs/includes/service_input.md -->
 
 This plugin is a service input. Normal plugins gather metrics determined by the
-interval setting. Service plugins start a service to listens and waits for
+interval setting. Service plugins start a service to listen and wait for
 metrics or events to occur. Service plugins have two key differences from
 normal plugins:
 

--- a/plugins/inputs/http_listener_v2/README.md
+++ b/plugins/inputs/http_listener_v2/README.md
@@ -20,7 +20,7 @@ This plugin listens for metrics sent via HTTP in any of the supported
 ## Service Input <!-- @/docs/includes/service_input.md -->
 
 This plugin is a service input. Normal plugins gather metrics determined by the
-interval setting. Service plugins start a service to listens and waits for
+interval setting. Service plugins start a service to listen and wait for
 metrics or events to occur. Service plugins have two key differences from
 normal plugins:
 

--- a/plugins/inputs/influxdb_listener/README.md
+++ b/plugins/inputs/influxdb_listener/README.md
@@ -29,7 +29,7 @@ defer to the output plugins configuration.
 ## Service Input <!-- @/docs/includes/service_input.md -->
 
 This plugin is a service input. Normal plugins gather metrics determined by the
-interval setting. Service plugins start a service to listens and waits for
+interval setting. Service plugins start a service to listen and wait for
 metrics or events to occur. Service plugins have two key differences from
 normal plugins:
 

--- a/plugins/inputs/influxdb_v2_listener/README.md
+++ b/plugins/inputs/influxdb_v2_listener/README.md
@@ -17,7 +17,7 @@ to the output plugins configuration.
 ## Service Input <!-- @/docs/includes/service_input.md -->
 
 This plugin is a service input. Normal plugins gather metrics determined by the
-interval setting. Service plugins start a service to listens and waits for
+interval setting. Service plugins start a service to listen and wait for
 metrics or events to occur. Service plugins have two key differences from
 normal plugins:
 

--- a/plugins/inputs/intel_rdt/README.md
+++ b/plugins/inputs/intel_rdt/README.md
@@ -46,7 +46,7 @@ how to configure the tool visit the [wiki][wiki] and read the
 ## Service Input <!-- @/docs/includes/service_input.md -->
 
 This plugin is a service input. Normal plugins gather metrics determined by the
-interval setting. Service plugins start a service to listens and waits for
+interval setting. Service plugins start a service to listen and wait for
 metrics or events to occur. Service plugins have two key differences from
 normal plugins:
 

--- a/plugins/inputs/jti_openconfig_telemetry/README.md
+++ b/plugins/inputs/jti_openconfig_telemetry/README.md
@@ -13,7 +13,7 @@ This service plugin reads [OpenConfig][openconfig] telemetry data via the
 ## Service Input <!-- @/docs/includes/service_input.md -->
 
 This plugin is a service input. Normal plugins gather metrics determined by the
-interval setting. Service plugins start a service to listens and waits for
+interval setting. Service plugins start a service to listen and wait for
 metrics or events to occur. Service plugins have two key differences from
 normal plugins:
 

--- a/plugins/inputs/kafka_consumer/README.md
+++ b/plugins/inputs/kafka_consumer/README.md
@@ -16,7 +16,7 @@ instances of Telegraf can consume messages from the same topic in parallel.
 ## Service Input <!-- @/docs/includes/service_input.md -->
 
 This plugin is a service input. Normal plugins gather metrics determined by the
-interval setting. Service plugins start a service to listens and waits for
+interval setting. Service plugins start a service to listen and wait for
 metrics or events to occur. Service plugins have two key differences from
 normal plugins:
 

--- a/plugins/inputs/kinesis_consumer/README.md
+++ b/plugins/inputs/kinesis_consumer/README.md
@@ -13,7 +13,7 @@ stream in one of the supported [data formats][data_formats].
 ## Service Input <!-- @/docs/includes/service_input.md -->
 
 This plugin is a service input. Normal plugins gather metrics determined by the
-interval setting. Service plugins start a service to listens and waits for
+interval setting. Service plugins start a service to listen and wait for
 metrics or events to occur. Service plugins have two key differences from
 normal plugins:
 

--- a/plugins/inputs/knx_listener/README.md
+++ b/plugins/inputs/knx_listener/README.md
@@ -14,7 +14,7 @@ datapoint-types can be found at the underlying [`knx-go` project][knxgo].
 ## Service Input <!-- @/docs/includes/service_input.md -->
 
 This plugin is a service input. Normal plugins gather metrics determined by the
-interval setting. Service plugins start a service to listens and waits for
+interval setting. Service plugins start a service to listen and wait for
 metrics or events to occur. Service plugins have two key differences from
 normal plugins:
 

--- a/plugins/inputs/lanz/README.md
+++ b/plugins/inputs/lanz/README.md
@@ -18,7 +18,7 @@ on TCP (usually through port 50001) on the switch's management IP.
 ## Service Input <!-- @/docs/includes/service_input.md -->
 
 This plugin is a service input. Normal plugins gather metrics determined by the
-interval setting. Service plugins start a service to listens and waits for
+interval setting. Service plugins start a service to listen and wait for
 metrics or events to occur. Service plugins have two key differences from
 normal plugins:
 

--- a/plugins/inputs/logparser/README.md
+++ b/plugins/inputs/logparser/README.md
@@ -52,7 +52,7 @@ Here an example for replacing the existing instance:
 ## Service Input <!-- @/docs/includes/service_input.md -->
 
 This plugin is a service input. Normal plugins gather metrics determined by the
-interval setting. Service plugins start a service to listens and waits for
+interval setting. Service plugins start a service to listen and wait for
 metrics or events to occur. Service plugins have two key differences from
 normal plugins:
 

--- a/plugins/inputs/mqtt_consumer/README.md
+++ b/plugins/inputs/mqtt_consumer/README.md
@@ -13,7 +13,7 @@ configured topics in one of the supported [data formats][data_formats].
 ## Service Input <!-- @/docs/includes/service_input.md -->
 
 This plugin is a service input. Normal plugins gather metrics determined by the
-interval setting. Service plugins start a service to listens and waits for
+interval setting. Service plugins start a service to listen and wait for
 metrics or events to occur. Service plugins have two key differences from
 normal plugins:
 

--- a/plugins/inputs/nats_consumer/README.md
+++ b/plugins/inputs/nats_consumer/README.md
@@ -21,7 +21,7 @@ The plugin supports authenticating via [username/password][userpass], a
 ## Service Input <!-- @/docs/includes/service_input.md -->
 
 This plugin is a service input. Normal plugins gather metrics determined by the
-interval setting. Service plugins start a service to listens and waits for
+interval setting. Service plugins start a service to listen and wait for
 metrics or events to occur. Service plugins have two key differences from
 normal plugins:
 

--- a/plugins/inputs/netflow/README.md
+++ b/plugins/inputs/netflow/README.md
@@ -22,7 +22,7 @@ Definitions for IPFIX are according to [IANA assignment document][IPFIX doc].
 ## Service Input <!-- @/docs/includes/service_input.md -->
 
 This plugin is a service input. Normal plugins gather metrics determined by the
-interval setting. Service plugins start a service to listens and waits for
+interval setting. Service plugins start a service to listen and wait for
 metrics or events to occur. Service plugins have two key differences from
 normal plugins:
 

--- a/plugins/inputs/nsq_consumer/README.md
+++ b/plugins/inputs/nsq_consumer/README.md
@@ -13,7 +13,7 @@ messaging platform brokers in one of the supported [data formats][data_formats].
 ## Service Input <!-- @/docs/includes/service_input.md -->
 
 This plugin is a service input. Normal plugins gather metrics determined by the
-interval setting. Service plugins start a service to listens and waits for
+interval setting. Service plugins start a service to listen and wait for
 metrics or events to occur. Service plugins have two key differences from
 normal plugins:
 

--- a/plugins/inputs/opcua_listener/README.md
+++ b/plugins/inputs/opcua_listener/README.md
@@ -12,7 +12,7 @@ erver.
 ## Service Input <!-- @/docs/includes/service_input.md -->
 
 This plugin is a service input. Normal plugins gather metrics determined by the
-interval setting. Service plugins start a service to listens and waits for
+interval setting. Service plugins start a service to listen and wait for
 metrics or events to occur. Service plugins have two key differences from
 normal plugins:
 

--- a/plugins/inputs/opentelemetry/README.md
+++ b/plugins/inputs/opentelemetry/README.md
@@ -6,7 +6,7 @@ This plugin receives traces, metrics and logs from
 ## Service Input <!-- @/docs/includes/service_input.md -->
 
 This plugin is a service input. Normal plugins gather metrics determined by the
-interval setting. Service plugins start a service to listens and waits for
+interval setting. Service plugins start a service to listen and wait for
 metrics or events to occur. Service plugins have two key differences from
 normal plugins:
 

--- a/plugins/inputs/riemann_listener/README.md
+++ b/plugins/inputs/riemann_listener/README.md
@@ -6,7 +6,7 @@ client that use riemann clients using riemann-protobuff format.
 ## Service Input <!-- @/docs/includes/service_input.md -->
 
 This plugin is a service input. Normal plugins gather metrics determined by the
-interval setting. Service plugins start a service to listens and waits for
+interval setting. Service plugins start a service to listen and wait for
 metrics or events to occur. Service plugins have two key differences from
 normal plugins:
 

--- a/plugins/inputs/sflow/README.md
+++ b/plugins/inputs/sflow/README.md
@@ -21,7 +21,7 @@ avoid cardinality issues:
 ## Service Input <!-- @/docs/includes/service_input.md -->
 
 This plugin is a service input. Normal plugins gather metrics determined by the
-interval setting. Service plugins start a service to listens and waits for
+interval setting. Service plugins start a service to listen and wait for
 metrics or events to occur. Service plugins have two key differences from
 normal plugins:
 

--- a/plugins/inputs/socket_listener/README.md
+++ b/plugins/inputs/socket_listener/README.md
@@ -9,7 +9,7 @@ Formats](../../../docs/DATA_FORMATS_INPUT.md).
 ## Service Input <!-- @/docs/includes/service_input.md -->
 
 This plugin is a service input. Normal plugins gather metrics determined by the
-interval setting. Service plugins start a service to listens and waits for
+interval setting. Service plugins start a service to listen and wait for
 metrics or events to occur. Service plugins have two key differences from
 normal plugins:
 

--- a/plugins/inputs/statsd/README.md
+++ b/plugins/inputs/statsd/README.md
@@ -5,7 +5,7 @@ The StatsD input plugin gathers metrics from a Statsd server.
 ## Service Input <!-- @/docs/includes/service_input.md -->
 
 This plugin is a service input. Normal plugins gather metrics determined by the
-interval setting. Service plugins start a service to listens and waits for
+interval setting. Service plugins start a service to listen and wait for
 metrics or events to occur. Service plugins have two key differences from
 normal plugins:
 

--- a/plugins/inputs/suricata/README.md
+++ b/plugins/inputs/suricata/README.md
@@ -9,7 +9,7 @@ It can also report for triggered Suricata IDS/IPS alerts.
 ## Service Input <!-- @/docs/includes/service_input.md -->
 
 This plugin is a service input. Normal plugins gather metrics determined by the
-interval setting. Service plugins start a service to listens and waits for
+interval setting. Service plugins start a service to listen and wait for
 metrics or events to occur. Service plugins have two key differences from
 normal plugins:
 

--- a/plugins/inputs/syslog/README.md
+++ b/plugins/inputs/syslog/README.md
@@ -13,7 +13,7 @@ Syslog messages should be formatted according to
 ## Service Input <!-- @/docs/includes/service_input.md -->
 
 This plugin is a service input. Normal plugins gather metrics determined by the
-interval setting. Service plugins start a service to listens and waits for
+interval setting. Service plugins start a service to listen and wait for
 metrics or events to occur. Service plugins have two key differences from
 normal plugins:
 

--- a/plugins/inputs/tail/README.md
+++ b/plugins/inputs/tail/README.md
@@ -22,7 +22,7 @@ Formats](../../../docs/DATA_FORMATS_INPUT.md).
 ## Service Input <!-- @/docs/includes/service_input.md -->
 
 This plugin is a service input. Normal plugins gather metrics determined by the
-interval setting. Service plugins start a service to listens and waits for
+interval setting. Service plugins start a service to listen and wait for
 metrics or events to occur. Service plugins have two key differences from
 normal plugins:
 

--- a/plugins/inputs/webhooks/README.md
+++ b/plugins/inputs/webhooks/README.md
@@ -18,7 +18,7 @@ sudo service telegraf start
 ## Service Input <!-- @/docs/includes/service_input.md -->
 
 This plugin is a service input. Normal plugins gather metrics determined by the
-interval setting. Service plugins start a service to listens and waits for
+interval setting. Service plugins start a service to listen and wait for
 metrics or events to occur. Service plugins have two key differences from
 normal plugins:
 

--- a/plugins/inputs/zipkin/README.md
+++ b/plugins/inputs/zipkin/README.md
@@ -14,7 +14,7 @@ standard.
 ## Service Input <!-- @/docs/includes/service_input.md -->
 
 This plugin is a service input. Normal plugins gather metrics determined by the
-interval setting. Service plugins start a service to listens and waits for
+interval setting. Service plugins start a service to listen and wait for
 metrics or events to occur. Service plugins have two key differences from
 normal plugins:
 


### PR DESCRIPTION
## Summary

This PR fixes a minor typo in the docs of service input plugins.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #16983
