### PR TITLE
fix(inputs.procstat): Resolve remote usernames on Posix systems

### DIFF
--- a/plugins/inputs/procstat/filter.go
+++ b/plugins/inputs/procstat/filter.go
@@ -139,7 +139,7 @@ func (f *filter) applyFilter() ([]processGroup, error) {
 		for _, p := range g.processes {
 			// Users
 			if f.filterUser != nil {
-				if username, err := p.Username(); err != nil || !f.filterUser.Match(username) {
+				if username, err := username(p); err != nil || !f.filterUser.Match(username) {
 					// Errors can happen if we don't have permissions or the process no longer exists
 					continue
 				}

--- a/plugins/inputs/procstat/native_finder.go
+++ b/plugins/inputs/procstat/native_finder.go
@@ -21,7 +21,7 @@ func (*NativeFinder) uid(user string) ([]pid, error) {
 		return dst, err
 	}
 	for _, p := range procs {
-		username, err := p.Username()
+		username, err := username(p)
 		if err != nil {
 			// skip, this can be caused by the pid no longer exists, or you don't have permissions to access it
 			continue

--- a/plugins/inputs/procstat/os_linux.go
+++ b/plugins/inputs/procstat/os_linux.go
@@ -7,6 +7,8 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
+	"os/user"
 	"strconv"
 	"strings"
 	"syscall"
@@ -23,6 +25,31 @@ import (
 
 func processName(p *gopsprocess.Process) (string, error) {
 	return p.Exe()
+}
+
+func username(p *gopsprocess.Process) (string, error) {
+	// Use the local lookup
+	n, err := p.Username()
+	if err == nil {
+		return n, nil
+	}
+
+	// Exit on errors other than unknown user-ID
+	var uerr *user.UnknownUserIdError
+	if !errors.As(err, &uerr) {
+		return "", err
+	}
+
+	// Try to run the `id` command on the UID of the process to resolve remote
+	// users such as LDAP or NIS.
+	uid := strconv.Itoa(int(*uerr))
+	buf, err := exec.Command("id", "-nu", uid).Output()
+	if n := strings.TrimSpace(string(buf)); err == nil && n != "" {
+		return n, nil
+	}
+	// We were either not able to run the command or the user cannot be
+	// resolved so just return the user ID instead.
+	return uid, nil
 }
 
 func queryPidWithWinServiceName(_ string) (uint32, error) {

--- a/plugins/inputs/procstat/os_others.go
+++ b/plugins/inputs/procstat/os_others.go
@@ -4,6 +4,10 @@ package procstat
 
 import (
 	"errors"
+	"os/exec"
+	"os/user"
+	"strconv"
+	"strings"
 	"syscall"
 
 	gopsnet "github.com/shirou/gopsutil/v4/net"
@@ -12,6 +16,31 @@ import (
 
 func processName(p *gopsprocess.Process) (string, error) {
 	return p.Exe()
+}
+
+func username(p *gopsprocess.Process) (string, error) {
+	// Use the local lookup
+	n, err := p.Username()
+	if err == nil {
+		return n, nil
+	}
+
+	// Exit on errors other than unknown user-ID
+	var uerr *user.UnknownUserIdError
+	if !errors.As(err, &uerr) {
+		return "", err
+	}
+
+	// Try to run the `id` command on the UID of the process to resolve remote
+	// users such as LDAP or NIS.
+	uid := strconv.Itoa(int(*uerr))
+	buf, err := exec.Command("id", "-nu", uid).Output()
+	if n := strings.TrimSpace(string(buf)); err == nil && n != "" {
+		return n, nil
+	}
+	// We were either not able to run the command or the user cannot be
+	// resolved so just return the user ID instead.
+	return uid, nil
 }
 
 func queryPidWithWinServiceName(string) (uint32, error) {

--- a/plugins/inputs/procstat/os_windows.go
+++ b/plugins/inputs/procstat/os_windows.go
@@ -18,6 +18,10 @@ func processName(p *gopsprocess.Process) (string, error) {
 	return p.Name()
 }
 
+func username(p *gopsprocess.Process) (string, error) {
+	return p.Username()
+}
+
 func getService(name string) (*mgr.Service, error) {
 	m, err := mgr.Connect()
 	if err != nil {

--- a/plugins/inputs/procstat/process.go
+++ b/plugins/inputs/procstat/process.go
@@ -232,7 +232,7 @@ func (p *proc) metrics(prefix string, cfg *collectionConfig, t time.Time) ([]tel
 		}
 	}
 
-	user, err := p.Username()
+	user, err := username(p.Process)
 	if err == nil {
 		if cfg.tagging["user"] {
 			p.tags["user"] = user


### PR DESCRIPTION
## Summary

The underlying `gopsutil` package relies on the Golang `os/user` package to resolve the process owner on posix systems. However, Golang parses the local user database only, rendering remote users (e.g. LDAP or NIS) unresolvable.
This PR detects the "unresolved UID" case and tries to execute the `id` command for the UID which takes all user-databases into account. 

> [!NOTE]
> The `id` command must be available on the system, in the PATH and executable by Telegraf!

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #16663 
