### PR TITLE
chore(agent): Add "disk_write_through" alias to disk buffer strategy config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -297,7 +297,7 @@ type AgentConfig struct {
 	BufferStrategy string `toml:"buffer_strategy"`
 
 	// BufferDirectory is the directory to store buffer files for serialized
-	// to disk metrics when using the "disk" buffer strategy.
+	// to disk metrics when using the "disk_write_through" buffer strategy.
 	BufferDirectory string `toml:"buffer_directory"`
 }
 
@@ -1654,8 +1654,8 @@ func (c *Config) buildOutput(name, source string, tbl *ast.Table) (*models.Outpu
 	}
 
 	bufferStrategy := c.Agent.BufferStrategy
-	if bufferStrategy == "disk_write_through" {
-		bufferStrategy = "disk"
+	if bufferStrategy == "disk" {
+		bufferStrategy = "disk_write_through"
 	}
 	oc := &models.OutputConfig{
 		Name:            name,
@@ -1682,7 +1682,7 @@ func (c *Config) buildOutput(name, source string, tbl *ast.Table) (*models.Outpu
 		return nil, c.firstErr()
 	}
 
-	if oc.BufferStrategy == "disk" {
+	if oc.BufferStrategy == "disk_write_through" {
 		log.Printf("W! Using disk-write-through buffer strategy for plugin outputs.%s, this is an experimental feature", name)
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -293,7 +293,7 @@ type AgentConfig struct {
 	ConfigURLRetryAttempts int `toml:"config_url_retry_attempts"`
 
 	// BufferStrategy is the metric buffer type to use for a given output plugin.
-	// Supported types currently are "memory" and "disk".
+	// Supported types currently are "memory" and "disk_write_through" (alias: "disk").
 	BufferStrategy string `toml:"buffer_strategy"`
 
 	// BufferDirectory is the directory to store buffer files for serialized
@@ -1652,11 +1652,16 @@ func (c *Config) buildOutput(name, source string, tbl *ast.Table) (*models.Outpu
 	if err != nil {
 		return nil, err
 	}
+
+	bufferStrategy := c.Agent.BufferStrategy
+	if bufferStrategy == "disk_write_through" {
+		bufferStrategy = "disk"
+	}
 	oc := &models.OutputConfig{
 		Name:            name,
 		Source:          source,
 		Filter:          filter,
-		BufferStrategy:  c.Agent.BufferStrategy,
+		BufferStrategy:  bufferStrategy,
 		BufferDirectory: c.Agent.BufferDirectory,
 	}
 
@@ -1678,7 +1683,7 @@ func (c *Config) buildOutput(name, source string, tbl *ast.Table) (*models.Outpu
 	}
 
 	if oc.BufferStrategy == "disk" {
-		log.Printf("W! Using disk buffer strategy for plugin outputs.%s, this is an experimental feature", name)
+		log.Printf("W! Using disk-write-through buffer strategy for plugin outputs.%s, this is an experimental feature", name)
 	}
 
 	// Generate an ID for the plugin

--- a/docs/specs/tsd-005-output-buffer-strategy.md
+++ b/docs/specs/tsd-005-output-buffer-strategy.md
@@ -22,7 +22,7 @@ output plugins, agent configuration, persist to disk
 The configuration is at the agent-level, with options for:
 
 - **Memory**, the current implementation, with no persistence to disk
-- **Write-through**, all metrics are also written to disk using a
+- **Disk-write-through**, all metrics are also written to disk using a
   Write Ahead Log (WAL) file
 - **Disk-overflow**, when the memory buffer fills, metrics are flushed to a
   WAL file to avoid dropping overflow metrics

--- a/models/buffer.go
+++ b/models/buffer.go
@@ -103,7 +103,7 @@ func NewBuffer(name, id, alias string, capacity int, strategy, path string) (Buf
 	switch strategy {
 	case "", "memory":
 		return NewMemoryBuffer(capacity, bs)
-	case "disk":
+	case "disk_write_through":
 		return NewDiskBuffer(name, id, path, bs)
 	}
 	return nil, fmt.Errorf("invalid buffer strategy %q", strategy)

--- a/models/buffer_disk_test.go
+++ b/models/buffer_disk_test.go
@@ -19,7 +19,7 @@ func TestDiskBufferRetainsTrackingInformation(t *testing.T) {
 	var delivered int
 	mm, _ := metric.WithTracking(m, func(telegraf.DeliveryInfo) { delivered++ })
 
-	buf, err := NewBuffer("test", "123", "", 0, "disk", t.TempDir())
+	buf, err := NewBuffer("test", "123", "", 0, "disk_write_through", t.TempDir())
 	require.NoError(t, err)
 	buf.Stats().MetricsAdded.Set(0)
 	buf.Stats().MetricsWritten.Set(0)
@@ -78,7 +78,7 @@ func TestDiskBufferTrackingDroppedFromOldWal(t *testing.T) {
 	walfile.Close()
 
 	// Create a buffer
-	buf, err := NewBuffer("123", "123", "", 0, "disk", path)
+	buf, err := NewBuffer("123", "123", "", 0, "disk_write_through", path)
 	require.NoError(t, err)
 	buf.Stats().MetricsAdded.Set(0)
 	buf.Stats().MetricsWritten.Set(0)
@@ -98,7 +98,7 @@ func TestDiskBufferTrackingDroppedFromOldWal(t *testing.T) {
 // https://github.com/influxdata/telegraf/issues/16696
 func TestDiskBufferTruncate(t *testing.T) {
 	// Create a disk buffer
-	buf, err := NewBuffer("test", "id123", "", 0, "disk", t.TempDir())
+	buf, err := NewBuffer("test", "id123", "", 0, "disk_write_through", t.TempDir())
 	require.NoError(t, err)
 	defer buf.Close()
 	diskBuf, ok := buf.(*DiskBuffer)

--- a/models/buffer_suite_test.go
+++ b/models/buffer_suite_test.go
@@ -24,7 +24,7 @@ func (s *BufferSuiteTest) SetupTest() {
 	switch s.bufferType {
 	case "", "memory":
 		s.hasMaxCapacity = true
-	case "disk":
+	case "disk_write_through":
 		path, err := os.MkdirTemp("", "*-buffer-test")
 		s.Require().NoError(err)
 		s.bufferPath = path
@@ -44,7 +44,7 @@ func TestMemoryBufferSuite(t *testing.T) {
 }
 
 func TestDiskBufferSuite(t *testing.T) {
-	suite.Run(t, &BufferSuiteTest{bufferType: "disk"})
+	suite.Run(t, &BufferSuiteTest{bufferType: "disk_write_through"})
 }
 
 func (s *BufferSuiteTest) newTestBuffer(capacity int) Buffer {

--- a/models/running_output.go
+++ b/models/running_output.go
@@ -385,7 +385,7 @@ func (*RunningOutput) updateTransaction(tx *Transaction, err error) {
 
 func (r *RunningOutput) LogBufferStatus() {
 	nBuffer := r.buffer.Len()
-	if r.Config.BufferStrategy == "disk" {
+	if r.Config.BufferStrategy == "disk_write_through" {
 		r.log.Debugf("Buffer fullness: %d metrics", nBuffer)
 	} else {
 		r.log.Debugf("Buffer fullness: %d / %d metrics", nBuffer, r.MetricBufferLimit)


### PR DESCRIPTION
## Summary
Clarifies the option name without breaking existing configurations. Also took the time to clean up the strategy checking code to avoid hardcoding the option names in multiple places

## Checklist
- [x] No AI generated code was used in this PR

## Related issues
resolves #
