### PR TITLE
fix(inputs.cloudwatch): Restore filtering to match all dimensions

### DIFF
--- a/plugins/inputs/cloudwatch/cloudwatch.go
+++ b/plugins/inputs/cloudwatch/cloudwatch.go
@@ -146,8 +146,12 @@ func (c *CloudWatch) Init() error {
 		}
 	})
 
-	// Initialize filter for metric dimensions to include
 	for _, m := range c.Metrics {
+		// Sort the metrics for efficient comparison later
+		slices.SortStableFunc(m.Dimensions, func(a, b *dimension) int {
+			return strings.Compare(a.Name, b.Name)
+		})
+		// Initialize filter for metric dimensions to include
 		for _, dimension := range m.Dimensions {
 			matcher, err := filter.NewIncludeExcludeFilter([]string{dimension.Value}, nil)
 			if err != nil {


### PR DESCRIPTION
## Summary

PR #16337 changed the dimension filtering and by doing so accidentally changed the filter behavior to accept all "unconfigured" dimensions. This however, leads to the artifact that users are no longer able to exclude dimension to e.g. query data accumulated over availability zones.

This PR restores the pre-v1.34.0 behavior and will only accept metrics that match _all_ configured dimensions i.e. excluding metrics with dimensions not configured by the user.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #17001 
