### PR TITLE
chore: Fix linter findings for `revive:exported` in `plugins/serializers`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -343,7 +343,6 @@ linters:
             - "**/plugins/parsers/**"
             - "**/plugins/processors/**"
             - "**/plugins/secretstores/**"
-            - "**/plugins/serializers/**"
             - "**/selfstat/**"
             - "**/serializer.go"
             - "**/testutil/**"
@@ -524,7 +523,7 @@ linters:
 
       # revive:exported
       - path: (.+)\.go$
-        text: exported method .*\.(Init |SampleConfig |Gather |Start |Stop |GetState |SetState |SetParser |SetParserFunc |SetTranslator |Probe )should have comment or be unexported
+        text: exported method .*\.(Init |SampleConfig |Gather |Start |Stop |GetState |SetState |SetParser |SetParserFunc |SetTranslator |Probe |Serialize |SerializeBatch )should have comment or be unexported
 
       # EXC0001 errcheck: Almost all programs ignore errors on these functions, and in most cases it's ok
       - path: (.+)\.go$

--- a/plugins/outputs/graphite/graphite.go
+++ b/plugins/outputs/graphite/graphite.go
@@ -47,7 +47,7 @@ type Graphite struct {
 	common_tls.ClientConfig
 
 	connections []connection
-	serializer  *graphite.GraphiteSerializer
+	serializer  *graphite.Serializer
 }
 
 func (*Graphite) SampleConfig() string {
@@ -55,7 +55,7 @@ func (*Graphite) SampleConfig() string {
 }
 
 func (g *Graphite) Init() error {
-	s := &graphite.GraphiteSerializer{
+	s := &graphite.Serializer{
 		Prefix:          g.Prefix,
 		Template:        g.Template,
 		StrictRegex:     g.GraphiteStrictRegex,

--- a/plugins/outputs/instrumental/instrumental.go
+++ b/plugins/outputs/instrumental/instrumental.go
@@ -40,7 +40,7 @@ type Instrumental struct {
 	Log telegraf.Logger `toml:"-"`
 
 	conn       net.Conn
-	serializer *graphite.GraphiteSerializer
+	serializer *graphite.Serializer
 }
 
 const (
@@ -56,7 +56,7 @@ func (*Instrumental) SampleConfig() string {
 }
 
 func (i *Instrumental) Init() error {
-	s := &graphite.GraphiteSerializer{
+	s := &graphite.Serializer{
 		Prefix:          i.Prefix,
 		Template:        i.Template,
 		TagSanitizeMode: "strict",

--- a/plugins/outputs/sumologic/sumologic.go
+++ b/plugins/outputs/sumologic/sumologic.go
@@ -91,7 +91,7 @@ func (s *SumoLogic) Connect() error {
 	switch serializer.(type) {
 	case *carbon2.Serializer:
 		s.headers[contentTypeHeader] = carbon2ContentType
-	case *graphite.GraphiteSerializer:
+	case *graphite.Serializer:
 		s.headers[contentTypeHeader] = graphiteContentType
 	case *prometheus.Serializer:
 		s.headers[contentTypeHeader] = prometheusContentType

--- a/plugins/outputs/sumologic/sumologic_test.go
+++ b/plugins/outputs/sumologic/sumologic_test.go
@@ -237,7 +237,7 @@ func TestContentType(t *testing.T) {
 				s.headers = map[string]string{
 					contentTypeHeader: graphiteContentType,
 				}
-				serializer := &graphite.GraphiteSerializer{}
+				serializer := &graphite.Serializer{}
 				require.NoError(t, serializer.Init())
 				s.SetSerializer(serializer)
 				return s

--- a/plugins/serializers/binary/entry.go
+++ b/plugins/serializers/binary/entry.go
@@ -11,6 +11,7 @@ import (
 
 type converterFunc func(value interface{}, order binary.ByteOrder) ([]byte, error)
 
+// Entry defines a single entry in the binary serializer configuration.
 type Entry struct {
 	ReadFrom         string `toml:"read_from"`         // field, tag, time, name
 	Name             string `toml:"name"`              // name of entry

--- a/plugins/serializers/cloudevents/cloudevents.go
+++ b/plugins/serializers/cloudevents/cloudevents.go
@@ -15,8 +15,8 @@ import (
 )
 
 const (
-	EventTypeSingle = "com.influxdata.telegraf.metric"
-	EventTypeBatch  = "com.influxdata.telegraf.metrics"
+	eventTypeSingle = "com.influxdata.telegraf.metric"
+	eventTypeBatch  = "com.influxdata.telegraf.metrics"
 )
 
 type Serializer struct {
@@ -86,7 +86,7 @@ func (s *Serializer) SerializeBatch(metrics []telegraf.Metric) ([]byte, error) {
 
 func (s *Serializer) batchMetrics(metrics []telegraf.Metric) ([]byte, error) {
 	// Determine the necessary information
-	eventType := EventTypeBatch
+	eventType := eventTypeBatch
 	if s.EventType != "" {
 		eventType = s.EventType
 	}
@@ -155,7 +155,7 @@ func (s *Serializer) createEvent(m telegraf.Metric) (*cloudevents.Event, error) 
 			source = v
 		}
 	}
-	eventType := EventTypeSingle
+	eventType := eventTypeSingle
 	if s.EventType != "" {
 		eventType = s.EventType
 	}

--- a/plugins/serializers/cloudevents/cloudevents_test.go
+++ b/plugins/serializers/cloudevents/cloudevents_test.go
@@ -36,7 +36,7 @@ func TestCases(t *testing.T) {
 
 	// Set up for file inputs
 	outputs.Add("dummy", func() telegraf.Output {
-		return &OutputDummy{}
+		return &outputDummy{}
 	})
 
 	for _, f := range folders {
@@ -68,7 +68,7 @@ func TestCases(t *testing.T) {
 			cfg := config.NewConfig()
 			require.NoError(t, cfg.LoadConfig(configFilename))
 			require.Len(t, cfg.Outputs, 1, "wrong number of outputs")
-			plugin, ok := cfg.Outputs[0].Output.(*OutputDummy)
+			plugin, ok := cfg.Outputs[0].Output.(*outputDummy)
 			require.True(t, ok)
 			serializer, ok := plugin.serializer.(*models.RunningSerializer).Serializer.(*Serializer)
 			require.True(t, ok)
@@ -159,26 +159,26 @@ func checkEvents(messages [][]byte) error {
 }
 
 /* Dummy output to allow full config parsing loop */
-type OutputDummy struct {
+type outputDummy struct {
 	Batch      bool `toml:"batch"`
 	serializer telegraf.Serializer
 	output     [][]byte
 }
 
-func (*OutputDummy) SampleConfig() string {
+func (*outputDummy) SampleConfig() string {
 	return "dummy"
 }
 
-func (o *OutputDummy) Connect() error {
+func (o *outputDummy) Connect() error {
 	o.output = make([][]byte, 0)
 	return nil
 }
 
-func (*OutputDummy) Close() error {
+func (*outputDummy) Close() error {
 	return nil
 }
 
-func (o *OutputDummy) Write(metrics []telegraf.Metric) error {
+func (o *outputDummy) Write(metrics []telegraf.Metric) error {
 	if o.Batch {
 		buf, err := o.serializer.SerializeBatch(metrics)
 		if err != nil {
@@ -198,7 +198,7 @@ func (o *OutputDummy) Write(metrics []telegraf.Metric) error {
 	return nil
 }
 
-func (o *OutputDummy) SetSerializer(s telegraf.Serializer) {
+func (o *outputDummy) SetSerializer(s telegraf.Serializer) {
 	o.serializer = s
 }
 

--- a/plugins/serializers/csv/csv_test.go
+++ b/plugins/serializers/csv/csv_test.go
@@ -213,9 +213,9 @@ func TestSerializeTransformationBatch(t *testing.T) {
 	}
 }
 
-type Config Serializer
+type config Serializer
 
-func loadTestConfiguration(filename string) (*Config, []string, error) {
+func loadTestConfiguration(filename string) (*config, []string, error) {
 	buf, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, nil, err
@@ -228,7 +228,7 @@ func loadTestConfiguration(filename string) (*Config, []string, error) {
 			header = append(header, line)
 		}
 	}
-	var cfg Config
+	var cfg config
 	err = toml.Unmarshal(buf, &cfg)
 	return &cfg, header, err
 }

--- a/plugins/serializers/graphite/graphite.go
+++ b/plugins/serializers/graphite/graphite.go
@@ -14,6 +14,7 @@ import (
 	"github.com/influxdata/telegraf/plugins/serializers"
 )
 
+// DefaultTemplate is the default template used for graphite serialization.
 const DefaultTemplate = "host.tags.measurement.field"
 
 var (
@@ -33,12 +34,7 @@ var (
 	fieldDeleter = strings.NewReplacer(".FIELDNAME", "", "FIELDNAME.", "")
 )
 
-type GraphiteTemplate struct {
-	Filter filter.Filter
-	Value  string
-}
-
-type GraphiteSerializer struct {
+type Serializer struct {
 	Prefix          string   `toml:"prefix"`
 	Template        string   `toml:"template"`
 	StrictRegex     string   `toml:"graphite_strict_sanitize_regex"`
@@ -47,12 +43,17 @@ type GraphiteSerializer struct {
 	Separator       string   `toml:"graphite_separator"`
 	Templates       []string `toml:"templates"`
 
-	tmplts             []*GraphiteTemplate
+	tmplts             []*template
 	strictAllowedChars *regexp.Regexp
 }
 
-func (s *GraphiteSerializer) Init() error {
-	graphiteTemplates, defaultTemplate, err := InitGraphiteTemplates(s.Templates)
+type template struct {
+	filter filter.Filter
+	value  string
+}
+
+func (s *Serializer) Init() error {
+	graphiteTemplates, defaultTemplate, err := initGraphiteTemplates(s.Templates)
 	if err != nil {
 		return err
 	}
@@ -83,7 +84,7 @@ func (s *GraphiteSerializer) Init() error {
 	return nil
 }
 
-func (s *GraphiteSerializer) Serialize(metric telegraf.Metric) ([]byte, error) {
+func (s *Serializer) Serialize(metric telegraf.Metric) ([]byte, error) {
 	var out []byte
 
 	// Convert UnixNano to Unix timestamps
@@ -96,7 +97,7 @@ func (s *GraphiteSerializer) Serialize(metric telegraf.Metric) ([]byte, error) {
 			if fieldValue == "" {
 				continue
 			}
-			bucket := s.SerializeBucketNameWithTags(metric.Name(), metric.Tags(), s.Prefix, s.Separator, fieldName, s.TagSanitizeMode)
+			bucket := s.serializeBucketNameWithTags(metric.Name(), metric.Tags(), s.Prefix, s.Separator, fieldName, s.TagSanitizeMode)
 			metricString := fmt.Sprintf("%s %s %d\n",
 				// insert "field" section of template
 				bucket,
@@ -109,8 +110,8 @@ func (s *GraphiteSerializer) Serialize(metric telegraf.Metric) ([]byte, error) {
 	default:
 		template := s.Template
 		for _, graphiteTemplate := range s.tmplts {
-			if graphiteTemplate.Filter.Match(metric.Name()) {
-				template = graphiteTemplate.Value
+			if graphiteTemplate.filter.Match(metric.Name()) {
+				template = graphiteTemplate.value
 				break
 			}
 		}
@@ -137,7 +138,7 @@ func (s *GraphiteSerializer) Serialize(metric telegraf.Metric) ([]byte, error) {
 	return out, nil
 }
 
-func (s *GraphiteSerializer) SerializeBatch(metrics []telegraf.Metric) ([]byte, error) {
+func (s *Serializer) SerializeBatch(metrics []telegraf.Metric) ([]byte, error) {
 	var batch bytes.Buffer
 	for _, m := range metrics {
 		buf, err := s.Serialize(m)
@@ -149,41 +150,14 @@ func (s *GraphiteSerializer) SerializeBatch(metrics []telegraf.Metric) ([]byte, 
 	return batch.Bytes(), nil
 }
 
-func formatValue(value interface{}) string {
-	switch v := value.(type) {
-	case string:
-		return ""
-	case bool:
-		if v {
-			return "1"
-		}
-		return "0"
-	case uint64:
-		return strconv.FormatUint(v, 10)
-	case int64:
-		return strconv.FormatInt(v, 10)
-	case float64:
-		if math.IsNaN(v) {
-			return ""
-		}
-
-		if math.IsInf(v, 0) {
-			return ""
-		}
-		return strconv.FormatFloat(v, 'f', -1, 64)
-	}
-
-	return ""
-}
-
 // SerializeBucketName will take the given measurement name and tags and
-// produce a graphite bucket. It will use the GraphiteSerializer.Template
+// produce a graphite bucket. It will use the Serializer.Template
 // to generate this, or DefaultTemplate.
 //
 // NOTE: SerializeBucketName replaces the "field" portion of the template with
 // FIELDNAME. It is up to the user to replace this. This is so that
 // SerializeBucketName can be called just once per measurement, rather than
-// once per field. See GraphiteSerializer.InsertField() function.
+// once per field. See Serializer.InsertField() function.
 func SerializeBucketName(measurement string, tags map[string]string, template, prefix string) string {
 	if template == "" {
 		template = DefaultTemplate
@@ -232,9 +206,46 @@ func SerializeBucketName(measurement string, tags map[string]string, template, p
 	return prefix + "." + strings.Join(out, ".")
 }
 
-func InitGraphiteTemplates(templates []string) ([]*GraphiteTemplate, string, error) {
+// InsertField takes the bucket string from SerializeBucketName and replaces the FIELDNAME portion.
+// If fieldName == "value", it will simply delete the FIELDNAME portion.
+func InsertField(bucket, fieldName string) string {
+	// if the field name is "value", then dont use it
+	if fieldName == "value" {
+		return fieldDeleter.Replace(bucket)
+	}
+	return strings.Replace(bucket, "FIELDNAME", fieldName, 1)
+}
+
+func formatValue(value interface{}) string {
+	switch v := value.(type) {
+	case string:
+		return ""
+	case bool:
+		if v {
+			return "1"
+		}
+		return "0"
+	case uint64:
+		return strconv.FormatUint(v, 10)
+	case int64:
+		return strconv.FormatInt(v, 10)
+	case float64:
+		if math.IsNaN(v) {
+			return ""
+		}
+
+		if math.IsInf(v, 0) {
+			return ""
+		}
+		return strconv.FormatFloat(v, 'f', -1, 64)
+	}
+
+	return ""
+}
+
+func initGraphiteTemplates(templates []string) ([]*template, string, error) {
 	defaultTemplate := ""
-	graphiteTemplates := make([]*GraphiteTemplate, 0, len(templates))
+	graphiteTemplates := make([]*template, 0, len(templates))
 	for i, t := range templates {
 		parts := strings.Fields(t)
 
@@ -261,19 +272,19 @@ func InitGraphiteTemplates(templates []string) ([]*GraphiteTemplate, string, err
 			return nil, "", err
 		}
 
-		graphiteTemplates = append(graphiteTemplates, &GraphiteTemplate{
-			Filter: tFilter,
-			Value:  parts[1],
+		graphiteTemplates = append(graphiteTemplates, &template{
+			filter: tFilter,
+			value:  parts[1],
 		})
 	}
 
 	return graphiteTemplates, defaultTemplate, nil
 }
 
-// SerializeBucketNameWithTags will take the given measurement name and tags and
+// serializeBucketNameWithTags will take the given measurement name and tags and
 // produce a graphite bucket. It will use the Graphite11Serializer.
 // http://graphite.readthedocs.io/en/latest/tags.html
-func (s *GraphiteSerializer) SerializeBucketNameWithTags(measurement string, tags map[string]string, prefix, separator, field, tagSanitizeMode string) string {
+func (s *Serializer) serializeBucketNameWithTags(measurement string, tags map[string]string, prefix, separator, field, tagSanitizeMode string) string {
 	var out string
 	var tagsCopy []string
 	for k, v := range tags {
@@ -307,17 +318,6 @@ func (s *GraphiteSerializer) SerializeBucketNameWithTags(measurement string, tag
 	return out
 }
 
-// InsertField takes the bucket string from SerializeBucketName and replaces the
-// FIELDNAME portion. If fieldName == "value", it will simply delete the
-// FIELDNAME portion.
-func InsertField(bucket, fieldName string) string {
-	// if the field name is "value", then dont use it
-	if fieldName == "value" {
-		return fieldDeleter.Replace(bucket)
-	}
-	return strings.Replace(bucket, "FIELDNAME", fieldName, 1)
-}
-
 func buildTags(tags map[string]string) string {
 	keys := make([]string, 0, len(tags))
 	for k := range tags {
@@ -337,7 +337,7 @@ func buildTags(tags map[string]string) string {
 	return tagStr
 }
 
-func (s *GraphiteSerializer) strictSanitize(value string) string {
+func (s *Serializer) strictSanitize(value string) string {
 	// Apply special hyphenation rules to preserve backwards compatibility
 	value = hyphenChars.Replace(value)
 	// Apply rule to drop some chars to preserve backwards compatibility
@@ -356,7 +356,7 @@ func compatibleSanitize(name, value string) string {
 func init() {
 	serializers.Add("graphite",
 		func() telegraf.Serializer {
-			return &GraphiteSerializer{}
+			return &Serializer{}
 		},
 	)
 }

--- a/plugins/serializers/graphite/graphite_test.go
+++ b/plugins/serializers/graphite/graphite_test.go
@@ -72,7 +72,7 @@ func TestSerializeMetricNoHost(t *testing.T) {
 	}
 	m := metric.New("cpu", tags, fields, now)
 
-	s := GraphiteSerializer{}
+	s := Serializer{}
 	require.NoError(t, s.Init())
 	buf, err := s.Serialize(m)
 	require.NoError(t, err)
@@ -99,7 +99,7 @@ func TestSerializeMetricNoHostWithTagSupport(t *testing.T) {
 	}
 	m := metric.New("cpu", tags, fields, now)
 
-	s := GraphiteSerializer{
+	s := Serializer{
 		TagSupport: true,
 		Separator:  ".",
 	}
@@ -130,7 +130,7 @@ func TestSerializeMetricHost(t *testing.T) {
 	}
 	m := metric.New("cpu", tags, fields, now)
 
-	s := GraphiteSerializer{}
+	s := Serializer{}
 	require.NoError(t, s.Init())
 	buf, err := s.Serialize(m)
 	require.NoError(t, err)
@@ -160,7 +160,7 @@ func TestSerializeMetricHostWithMultipleTemplates(t *testing.T) {
 	m1 := metric.New("cpu", tags, fields, now)
 	m2 := metric.New("new_cpu", tags, fields, now)
 
-	s := GraphiteSerializer{
+	s := Serializer{
 		Templates: []string{
 			"cp* tags.measurement.host.field",
 			"new_cpu tags.host.measurement.field",
@@ -203,7 +203,7 @@ func TestSerializeMetricHostWithMultipleTemplatesWithDefault(t *testing.T) {
 	m1 := metric.New("cpu", tags, fields, now)
 	m2 := metric.New("new_cpu", tags, fields, now)
 
-	s := GraphiteSerializer{
+	s := Serializer{
 		Templates: []string{
 			"cp* tags.measurement.host.field",
 			"tags.host.measurement.field",
@@ -245,7 +245,7 @@ func TestSerializeMetricHostWithTagSupport(t *testing.T) {
 	}
 	m := metric.New("cpu", tags, fields, now)
 
-	s := GraphiteSerializer{
+	s := Serializer{
 		TagSupport: true,
 		Separator:  ".",
 	}
@@ -277,7 +277,7 @@ func TestSerializeValueField(t *testing.T) {
 	}
 	m := metric.New("cpu", tags, fields, now)
 
-	s := GraphiteSerializer{}
+	s := Serializer{}
 	require.NoError(t, s.Init())
 
 	buf, err := s.Serialize(m)
@@ -302,7 +302,7 @@ func TestSerializeValueFieldWithTagSupport(t *testing.T) {
 	}
 	m := metric.New("cpu", tags, fields, now)
 
-	s := GraphiteSerializer{
+	s := Serializer{
 		TagSupport: true,
 		Separator:  ".",
 	}
@@ -331,7 +331,7 @@ func TestSerializeValueField2(t *testing.T) {
 	}
 	m := metric.New("cpu", tags, fields, now)
 
-	s := GraphiteSerializer{
+	s := Serializer{
 		Template: "host.field.tags.measurement",
 	}
 	require.NoError(t, s.Init())
@@ -358,7 +358,7 @@ func TestSerializeValueString(t *testing.T) {
 	}
 	m := metric.New("cpu", tags, fields, now)
 
-	s := GraphiteSerializer{
+	s := Serializer{
 		Template: "host.field.tags.measurement",
 	}
 	require.NoError(t, s.Init())
@@ -381,7 +381,7 @@ func TestSerializeValueStringWithTagSupport(t *testing.T) {
 	}
 	m := metric.New("cpu", tags, fields, now)
 
-	s := GraphiteSerializer{
+	s := Serializer{
 		TagSupport: true,
 		Separator:  ".",
 	}
@@ -406,7 +406,7 @@ func TestSerializeValueBoolean(t *testing.T) {
 	}
 	m := metric.New("cpu", tags, fields, now)
 
-	s := GraphiteSerializer{
+	s := Serializer{
 		Template: "host.field.tags.measurement",
 	}
 	require.NoError(t, s.Init())
@@ -437,7 +437,7 @@ func TestSerializeValueBooleanWithTagSupport(t *testing.T) {
 	}
 	m := metric.New("cpu", tags, fields, now)
 
-	s := GraphiteSerializer{
+	s := Serializer{
 		TagSupport: true,
 		Separator:  ".",
 	}
@@ -464,7 +464,7 @@ func TestSerializeValueUnsigned(t *testing.T) {
 	}
 	m := metric.New("mem", tags, fields, now)
 
-	s := GraphiteSerializer{}
+	s := Serializer{}
 	require.NoError(t, s.Init())
 
 	buf, err := s.Serialize(m)
@@ -486,7 +486,7 @@ func TestSerializeFieldWithSpaces(t *testing.T) {
 	}
 	m := metric.New("cpu", tags, fields, now)
 
-	s := GraphiteSerializer{
+	s := Serializer{
 		Template: "host.tags.measurement.field",
 	}
 	require.NoError(t, s.Init())
@@ -513,7 +513,7 @@ func TestSerializeFieldWithSpacesWithTagSupport(t *testing.T) {
 	}
 	m := metric.New("cpu", tags, fields, now)
 
-	s := GraphiteSerializer{
+	s := Serializer{
 		TagSupport: true,
 		Separator:  ".",
 	}
@@ -542,7 +542,7 @@ func TestSerializeTagWithSpaces(t *testing.T) {
 	}
 	m := metric.New("cpu", tags, fields, now)
 
-	s := GraphiteSerializer{
+	s := Serializer{
 		Template: "host.tags.measurement.field",
 	}
 	require.NoError(t, s.Init())
@@ -569,7 +569,7 @@ func TestSerializeTagWithSpacesWithTagSupport(t *testing.T) {
 	}
 	m := metric.New("cpu", tags, fields, now)
 
-	s := GraphiteSerializer{
+	s := Serializer{
 		TagSupport: true,
 		Separator:  ".",
 	}
@@ -597,7 +597,7 @@ func TestSerializeTagWithSpacesWithTagSupportCompatibleSanitize(t *testing.T) {
 	}
 	m := metric.New("cpu", tags, fields, now)
 
-	s := GraphiteSerializer{
+	s := Serializer{
 		TagSupport:      true,
 		TagSanitizeMode: "compatible",
 		Separator:       ".",
@@ -627,7 +627,7 @@ func TestSerializeValueField3(t *testing.T) {
 	}
 	m := metric.New("cpu", tags, fields, now)
 
-	s := GraphiteSerializer{
+	s := Serializer{
 		Template: "field.host.tags.measurement",
 	}
 	require.NoError(t, s.Init())
@@ -655,7 +655,7 @@ func TestSerializeValueField5(t *testing.T) {
 	}
 	m := metric.New("cpu", tags, fields, now)
 
-	s := GraphiteSerializer{
+	s := Serializer{
 		Template: template5,
 	}
 	require.NoError(t, s.Init())
@@ -683,7 +683,7 @@ func TestSerializeMetricPrefix(t *testing.T) {
 	}
 	m := metric.New("cpu", tags, fields, now)
 
-	s := GraphiteSerializer{Prefix: "prefix"}
+	s := Serializer{Prefix: "prefix"}
 	require.NoError(t, s.Init())
 
 	buf, err := s.Serialize(m)
@@ -712,7 +712,7 @@ func TestSerializeMetricPrefixWithTagSupport(t *testing.T) {
 	}
 	m := metric.New("cpu", tags, fields, now)
 
-	s := GraphiteSerializer{
+	s := Serializer{
 		Prefix:     "prefix",
 		TagSupport: true,
 		Separator:  ".",
@@ -745,7 +745,7 @@ func TestSerializeCustomRegex(t *testing.T) {
 	}
 	m := metric.New("cpu", tags, fields, now)
 
-	s := GraphiteSerializer{
+	s := Serializer{
 		StrictRegex: `[^a-zA-Z0-9-:._=|\p{L}]`,
 	}
 	require.NoError(t, s.Init())
@@ -951,7 +951,7 @@ func TestClean(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := GraphiteSerializer{}
+			s := Serializer{}
 			require.NoError(t, s.Init())
 
 			m := metric.New(tt.metricName, tt.tags, tt.fields, now)
@@ -1045,7 +1045,7 @@ func TestCleanWithTagsSupport(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := GraphiteSerializer{
+			s := Serializer{
 				TagSupport: true,
 				Separator:  ".",
 			}
@@ -1142,7 +1142,7 @@ func TestCleanWithTagsSupportCompatibleSanitize(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := GraphiteSerializer{
+			s := Serializer{
 				TagSupport:      true,
 				TagSanitizeMode: "compatible",
 				Separator:       ".",
@@ -1177,7 +1177,7 @@ func TestSerializeBatch(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := GraphiteSerializer{}
+			s := Serializer{}
 			require.NoError(t, s.Init())
 
 			m := metric.New(tt.metricName, tt.tags, tt.fields, now)
@@ -1208,7 +1208,7 @@ func TestSerializeBatchWithTagsSupport(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := GraphiteSerializer{
+			s := Serializer{
 				TagSupport: true,
 				Separator:  ".",
 			}
@@ -1223,7 +1223,7 @@ func TestSerializeBatchWithTagsSupport(t *testing.T) {
 }
 
 func BenchmarkSerialize(b *testing.B) {
-	s := &GraphiteSerializer{}
+	s := &Serializer{}
 	require.NoError(b, s.Init())
 	metrics := serializers.BenchmarkMetrics(b)
 	b.ResetTimer()
@@ -1234,7 +1234,7 @@ func BenchmarkSerialize(b *testing.B) {
 }
 
 func BenchmarkSerializeBatch(b *testing.B) {
-	s := &GraphiteSerializer{}
+	s := &Serializer{}
 	require.NoError(b, s.Init())
 	m := serializers.BenchmarkMetrics(b)
 	metrics := m[:]

--- a/plugins/serializers/influx/influx.go
+++ b/plugins/serializers/influx/influx.go
@@ -16,35 +16,12 @@ import (
 )
 
 const (
-	MaxInt64      = int64(^uint64(0) >> 1)
-	NeedMoreSpace = "need more space"
-	InvalidName   = "invalid name"
-	NoFields      = "no serializable fields"
+	maxInt64      = int64(^uint64(0) >> 1)
+	needMoreSpace = "need more space"
+	invalidName   = "invalid name"
+	noFields      = "no serializable fields"
 )
 
-// MetricError is an error causing an entire metric to be unserializable.
-type MetricError struct {
-	series string
-	reason string
-}
-
-func (e MetricError) Error() string {
-	if e.series != "" {
-		return fmt.Sprintf("%q: %s", e.series, e.reason)
-	}
-	return e.reason
-}
-
-// FieldError is an error causing a field to be unserializable.
-type FieldError struct {
-	reason string
-}
-
-func (e FieldError) Error() string {
-	return e.reason
-}
-
-// Serializer is a serializer for line protocol.
 type Serializer struct {
 	MaxLineBytes  int  `toml:"influx_max_line_bytes"`
 	SortFields    bool `toml:"influx_sort_fields"`
@@ -59,6 +36,28 @@ type Serializer struct {
 	pair   []byte
 }
 
+// metricError is an error causing an entire metric to be unserializable.
+type metricError struct {
+	series string
+	reason string
+}
+
+func (e metricError) Error() string {
+	if e.series != "" {
+		return fmt.Sprintf("%q: %s", e.series, e.reason)
+	}
+	return e.reason
+}
+
+// fieldError is an error causing a field to be unserializable.
+type fieldError struct {
+	reason string
+}
+
+func (e fieldError) Error() string {
+	return e.reason
+}
+
 func (s *Serializer) Init() error {
 	s.header = make([]byte, 0, 50)
 	s.footer = make([]byte, 0, 21)
@@ -67,9 +66,6 @@ func (s *Serializer) Init() error {
 	return nil
 }
 
-// Serialize writes the telegraf.Metric to a byte slice.  May produce multiple
-// lines of output if longer than maximum line length.  Lines are terminated
-// with a newline (LF) char.
 func (s *Serializer) Serialize(m telegraf.Metric) ([]byte, error) {
 	s.buf.Reset()
 	err := s.writeMetric(&s.buf, m)
@@ -81,14 +77,12 @@ func (s *Serializer) Serialize(m telegraf.Metric) ([]byte, error) {
 	return append(out, s.buf.Bytes()...), nil
 }
 
-// SerializeBatch writes the slice of metrics and returns a byte slice of the
-// results.  The returned byte slice may contain multiple lines of data.
 func (s *Serializer) SerializeBatch(metrics []telegraf.Metric) ([]byte, error) {
 	s.buf.Reset()
 	for _, m := range metrics {
-		err := s.Write(&s.buf, m)
+		err := s.write(&s.buf, m)
 		if err != nil {
-			var mErr *MetricError
+			var mErr *metricError
 			if errors.As(err, &mErr) {
 				continue
 			}
@@ -98,7 +92,8 @@ func (s *Serializer) SerializeBatch(metrics []telegraf.Metric) ([]byte, error) {
 	out := make([]byte, 0, s.buf.Len())
 	return append(out, s.buf.Bytes()...), nil
 }
-func (s *Serializer) Write(w io.Writer, m telegraf.Metric) error {
+
+func (s *Serializer) write(w io.Writer, m telegraf.Metric) error {
 	return s.writeMetric(w, m)
 }
 
@@ -119,7 +114,7 @@ func (s *Serializer) buildHeader(m telegraf.Metric) error {
 
 	name := nameEscape(m.Name())
 	if name == "" {
-		return s.newMetricError(InvalidName)
+		return s.newMetricError(invalidName)
 	}
 
 	s.header = append(s.header, name...)
@@ -168,7 +163,7 @@ func (s *Serializer) buildFieldPair(key string, value interface{}) error {
 	// Some keys are not encodeable as line protocol, such as those with a
 	// trailing '\' or empty strings.
 	if key == "" {
-		return &FieldError{"invalid field key"}
+		return &fieldError{"invalid field key"}
 	}
 
 	s.pair = append(s.pair, key...)
@@ -219,7 +214,7 @@ func (s *Serializer) writeMetric(w io.Writer, m telegraf.Metric) error {
 			// Need at least one field per line, this metric cannot be fit
 			// into the max line bytes.
 			if firstField {
-				return s.newMetricError(NeedMoreSpace)
+				return s.newMetricError(needMoreSpace)
 			}
 
 			err = s.writeBytes(w, s.footer)
@@ -232,7 +227,7 @@ func (s *Serializer) writeMetric(w io.Writer, m telegraf.Metric) error {
 			bytesNeeded = len(s.header) + len(s.pair) + len(s.footer)
 
 			if bytesNeeded > s.MaxLineBytes {
-				return s.newMetricError(NeedMoreSpace)
+				return s.newMetricError(needMoreSpace)
 			}
 		}
 
@@ -258,18 +253,18 @@ func (s *Serializer) writeMetric(w io.Writer, m telegraf.Metric) error {
 	}
 
 	if firstField {
-		return s.newMetricError(NoFields)
+		return s.newMetricError(noFields)
 	}
 
 	return s.writeBytes(w, s.footer)
 }
 
-func (s *Serializer) newMetricError(reason string) *MetricError {
+func (s *Serializer) newMetricError(reason string) *metricError {
 	if len(s.header) != 0 {
 		series := bytes.TrimRight(s.header, " ")
-		return &MetricError{series: string(series), reason: reason}
+		return &metricError{series: string(series), reason: reason}
 	}
-	return &MetricError{reason: reason}
+	return &metricError{reason: reason}
 }
 
 func (s *Serializer) appendFieldValue(buf []byte, value interface{}) ([]byte, error) {
@@ -278,19 +273,19 @@ func (s *Serializer) appendFieldValue(buf []byte, value interface{}) ([]byte, er
 		if s.UintSupport {
 			return appendUintField(buf, v), nil
 		}
-		if v <= uint64(MaxInt64) {
+		if v <= uint64(maxInt64) {
 			return appendIntField(buf, int64(v)), nil
 		}
-		return appendIntField(buf, MaxInt64), nil
+		return appendIntField(buf, maxInt64), nil
 	case int64:
 		return appendIntField(buf, v), nil
 	case float64:
 		if math.IsNaN(v) {
-			return nil, &FieldError{"is NaN"}
+			return nil, &fieldError{"is NaN"}
 		}
 
 		if math.IsInf(v, 0) {
-			return nil, &FieldError{"is Inf"}
+			return nil, &fieldError{"is Inf"}
 		}
 
 		return appendFloatField(buf, v), nil
@@ -299,7 +294,7 @@ func (s *Serializer) appendFieldValue(buf []byte, value interface{}) ([]byte, er
 	case bool:
 		return appendBoolField(buf, v), nil
 	default:
-		return buf, &FieldError{fmt.Sprintf("invalid value type: %T", v)}
+		return buf, &fieldError{fmt.Sprintf("invalid value type: %T", v)}
 	}
 }
 

--- a/plugins/serializers/influx/influx_test.go
+++ b/plugins/serializers/influx/influx_test.go
@@ -83,7 +83,7 @@ var tests = []struct {
 			},
 			time.Unix(0, 0),
 		),
-		errReason: NoFields,
+		errReason: noFields,
 	},
 	{
 		name: "float Inf",
@@ -387,7 +387,7 @@ var tests = []struct {
 			time.Unix(1519194109, 42),
 		),
 		output:    nil,
-		errReason: NeedMoreSpace,
+		errReason: needMoreSpace,
 	},
 	{
 		name: "no fields",
@@ -397,7 +397,7 @@ var tests = []struct {
 			map[string]interface{}{},
 			time.Unix(0, 0),
 		),
-		errReason: NoFields,
+		errReason: noFields,
 	},
 	{
 		name: "procstat",

--- a/plugins/serializers/influx/reader.go
+++ b/plugins/serializers/influx/reader.go
@@ -50,11 +50,11 @@ func (r *reader) Read(p []byte) (int, error) {
 	}
 
 	for _, metric := range r.metrics[r.offset:] {
-		err := r.serializer.Write(r.buf, metric)
+		err := r.serializer.write(r.buf, metric)
 		r.offset++
 		if err != nil {
 			r.buf.Reset()
-			var mErr *MetricError
+			var mErr *metricError
 			if errors.As(err, &mErr) {
 				continue
 			}

--- a/plugins/serializers/json/json.go
+++ b/plugins/serializers/json/json.go
@@ -22,7 +22,7 @@ type Serializer struct {
 	NestedFieldsInclude []string        `toml:"json_nested_fields_include"`
 	NestedFieldsExclude []string        `toml:"json_nested_fields_exclude"`
 
-	nestedfields filter.Filter
+	nestedFields filter.Filter
 }
 
 func (s *Serializer) Init() error {
@@ -48,7 +48,7 @@ func (s *Serializer) Init() error {
 		if err != nil {
 			return err
 		}
-		s.nestedfields = f
+		s.nestedFields = f
 	}
 
 	return nil
@@ -128,7 +128,7 @@ func (s *Serializer) createObject(metric telegraf.Metric) map[string]interface{}
 			}
 		case string:
 			// Check for nested fields if any
-			if s.nestedfields != nil && s.nestedfields.Match(field.Key) {
+			if s.nestedFields != nil && s.nestedFields.Match(field.Key) {
 				bv := []byte(fv)
 				if json.Valid(bv) {
 					var nested interface{}

--- a/plugins/serializers/msgpack/msgpack.go
+++ b/plugins/serializers/msgpack/msgpack.go
@@ -5,26 +5,11 @@ import (
 	"github.com/influxdata/telegraf/plugins/serializers"
 )
 
-// Serializer encodes metrics in MessagePack format
 type Serializer struct{}
 
-func marshalMetric(buf []byte, metric telegraf.Metric) ([]byte, error) {
-	return (&Metric{
-		Name:   metric.Name(),
-		Time:   MessagePackTime{time: metric.Time()},
-		Tags:   metric.Tags(),
-		Fields: metric.Fields(),
-	}).MarshalMsg(buf)
-}
-
-// Serialize implements serializers.Serializer.Serialize
-// github.com/influxdata/telegraf/plugins/serializers/Serializer
 func (*Serializer) Serialize(metric telegraf.Metric) ([]byte, error) {
 	return marshalMetric(nil, metric)
 }
-
-// SerializeBatch implements serializers.Serializer.SerializeBatch
-// github.com/influxdata/telegraf/plugins/serializers/Serializer
 func (*Serializer) SerializeBatch(metrics []telegraf.Metric) ([]byte, error) {
 	buf := make([]byte, 0)
 	for _, m := range metrics {
@@ -36,6 +21,15 @@ func (*Serializer) SerializeBatch(metrics []telegraf.Metric) ([]byte, error) {
 		}
 	}
 	return buf, nil
+}
+
+func marshalMetric(buf []byte, metric telegraf.Metric) ([]byte, error) {
+	return (&Metric{
+		Name:   metric.Name(),
+		Time:   MessagePackTime{time: metric.Time()},
+		Tags:   metric.Tags(),
+		Fields: metric.Fields(),
+	}).MarshalMsg(buf)
 }
 
 func init() {

--- a/plugins/serializers/nowmetric/nowmetric.go
+++ b/plugins/serializers/nowmetric/nowmetric.go
@@ -13,7 +13,7 @@ type Serializer struct {
 	Format string `toml:"nowmetric_format"`
 }
 
-type OIMetric struct {
+type oiMetric struct {
 	Metric    string            `json:"metric_type"`
 	Resource  string            `json:"resource"`
 	Node      string            `json:"node"`
@@ -23,9 +23,10 @@ type OIMetric struct {
 	Source    string            `json:"source"`
 }
 
-type OIMetrics []OIMetric
-type OIMetricsObj struct {
-	Records []OIMetric `json:"records"`
+type oiMetrics []oiMetric
+
+type oiMetricsObj struct {
+	Records []oiMetric `json:"records"`
 }
 
 func (s *Serializer) Init() error {
@@ -44,27 +45,27 @@ func (s *Serializer) Serialize(metric telegraf.Metric) (out []byte, err error) {
 	m := createObject(metric)
 
 	if s.Format == "jsonv2" {
-		obj := OIMetricsObj{Records: m}
+		obj := oiMetricsObj{Records: m}
 		return json.Marshal(obj)
 	}
 	return json.Marshal(m)
 }
 
 func (s *Serializer) SerializeBatch(metrics []telegraf.Metric) (out []byte, err error) {
-	objects := make([]OIMetric, 0)
+	objects := make([]oiMetric, 0)
 	for _, metric := range metrics {
 		objects = append(objects, createObject(metric)...)
 	}
 
 	if s.Format == "jsonv2" {
-		obj := OIMetricsObj{Records: objects}
+		obj := oiMetricsObj{Records: objects}
 		return json.Marshal(obj)
 	}
 
 	return json.Marshal(objects)
 }
 
-func createObject(metric telegraf.Metric) OIMetrics {
+func createObject(metric telegraf.Metric) oiMetrics {
 	/*  ServiceNow Operational Intelligence supports an array of JSON objects.
 	** Following elements accepted in the request body:
 		 ** metric_type: 	The name of the metric
@@ -76,8 +77,8 @@ func createObject(metric telegraf.Metric) OIMetrics {
 		 ** ci2metric_id:	List of key-value pairs to identify the CI.
 		 ** source:			Data source monitoring the metric type
 	*/
-	var allmetrics OIMetrics //nolint:prealloc // Pre-allocating may change format of marshaled JSON
-	var oimetric OIMetric
+	var allmetrics oiMetrics //nolint:prealloc // Pre-allocating may change format of marshaled JSON
+	var oimetric oiMetric
 	oimetric.Source = "Telegraf"
 
 	// Process Tags to extract node & resource name info

--- a/plugins/serializers/prometheus/collection_test.go
+++ b/plugins/serializers/prometheus/collection_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/influxdata/telegraf/testutil"
 )
 
-type Input struct {
+type input struct {
 	metric  telegraf.Metric
 	addtime time.Time
 }
@@ -23,14 +23,14 @@ func TestCollectionExpire(t *testing.T) {
 		name     string
 		now      time.Time
 		age      time.Duration
-		input    []Input
+		input    []input
 		expected []*dto.MetricFamily
 	}{
 		{
 			name: "not expired",
 			now:  time.Unix(1, 0),
 			age:  10 * time.Second,
-			input: []Input{
+			input: []input{
 				{
 					metric: testutil.MustMetric(
 						"cpu",
@@ -61,7 +61,7 @@ func TestCollectionExpire(t *testing.T) {
 			name: "update metric expiration",
 			now:  time.Unix(20, 0),
 			age:  10 * time.Second,
-			input: []Input{
+			input: []input{
 				{
 					metric: testutil.MustMetric(
 						"cpu",
@@ -103,7 +103,7 @@ func TestCollectionExpire(t *testing.T) {
 			name: "update metric expiration descending order",
 			now:  time.Unix(20, 0),
 			age:  10 * time.Second,
-			input: []Input{
+			input: []input{
 				{
 					metric: testutil.MustMetric(
 						"cpu",
@@ -144,7 +144,7 @@ func TestCollectionExpire(t *testing.T) {
 			name: "expired single metric in metric family",
 			now:  time.Unix(20, 0),
 			age:  10 * time.Second,
-			input: []Input{
+			input: []input{
 				{
 					metric: testutil.MustMetric(
 						"cpu",
@@ -163,7 +163,7 @@ func TestCollectionExpire(t *testing.T) {
 			name: "expired one metric in metric family",
 			now:  time.Unix(20, 0),
 			age:  10 * time.Second,
-			input: []Input{
+			input: []input{
 				{
 					metric: testutil.MustMetric(
 						"cpu",
@@ -204,7 +204,7 @@ func TestCollectionExpire(t *testing.T) {
 			name: "histogram bucket updates",
 			now:  time.Unix(0, 0),
 			age:  10 * time.Second,
-			input: []Input{
+			input: []input{
 				{
 					metric: testutil.MustMetric(
 						"prometheus",
@@ -307,7 +307,7 @@ func TestCollectionExpire(t *testing.T) {
 			name: "entire histogram expires",
 			now:  time.Unix(20, 0),
 			age:  10 * time.Second,
-			input: []Input{
+			input: []input{
 				{
 					metric: testutil.MustMetric(
 						"prometheus",
@@ -350,7 +350,7 @@ func TestCollectionExpire(t *testing.T) {
 			name: "histogram does not expire because of addtime from bucket",
 			now:  time.Unix(20, 0),
 			age:  10 * time.Second,
-			input: []Input{
+			input: []input{
 				{
 					metric: testutil.MustMetric(
 						"prometheus",
@@ -418,7 +418,7 @@ func TestCollectionExpire(t *testing.T) {
 			name: "summary quantile updates",
 			now:  time.Unix(0, 0),
 			age:  10 * time.Second,
-			input: []Input{
+			input: []input{
 				{
 					metric: testutil.MustMetric(
 						"prometheus",
@@ -495,7 +495,7 @@ func TestCollectionExpire(t *testing.T) {
 			name: "Entire summary expires",
 			now:  time.Unix(20, 0),
 			age:  10 * time.Second,
-			input: []Input{
+			input: []input{
 				{
 					metric: testutil.MustMetric(
 						"prometheus",
@@ -527,7 +527,7 @@ func TestCollectionExpire(t *testing.T) {
 			name: "summary does not expire because of quantile addtime",
 			now:  time.Unix(20, 0),
 			age:  10 * time.Second,
-			input: []Input{
+			input: []input{
 				{
 					metric: testutil.MustMetric(
 						"prometheus",
@@ -595,7 +595,7 @@ func TestCollectionExpire(t *testing.T) {
 			name: "expire based on add time",
 			now:  time.Unix(20, 0),
 			age:  10 * time.Second,
-			input: []Input{
+			input: []input{
 				{
 					metric: testutil.MustMetric(
 						"cpu",
@@ -643,14 +643,14 @@ func TestExportTimestamps(t *testing.T) {
 		name     string
 		now      time.Time
 		age      time.Duration
-		input    []Input
+		input    []input
 		expected []*dto.MetricFamily
 	}{
 		{
 			name: "histogram bucket updates",
 			now:  time.Unix(23, 0),
 			age:  10 * time.Second,
-			input: []Input{
+			input: []input{
 				{
 					metric: testutil.MustMetric(
 						"prometheus",
@@ -754,7 +754,7 @@ func TestExportTimestamps(t *testing.T) {
 			name: "summary quantile updates",
 			now:  time.Unix(23, 0),
 			age:  10 * time.Second,
-			input: []Input{
+			input: []input{
 				{
 					metric: testutil.MustMetric(
 						"prometheus",

--- a/plugins/serializers/prometheus/convert.go
+++ b/plugins/serializers/prometheus/convert.go
@@ -10,13 +10,13 @@ import (
 	"github.com/influxdata/telegraf"
 )
 
-type Table struct {
-	First *unicode.RangeTable
-	Rest  *unicode.RangeTable
+type table struct {
+	first *unicode.RangeTable
+	rest  *unicode.RangeTable
 }
 
-var MetricNameTable = Table{
-	First: &unicode.RangeTable{
+var metricNameTable = table{
+	first: &unicode.RangeTable{
 		R16: []unicode.Range16{
 			{0x003A, 0x003A, 1}, // :
 			{0x0041, 0x005A, 1}, // A-Z
@@ -25,7 +25,7 @@ var MetricNameTable = Table{
 		},
 		LatinOffset: 4,
 	},
-	Rest: &unicode.RangeTable{
+	rest: &unicode.RangeTable{
 		R16: []unicode.Range16{
 			{0x0030, 0x003A, 1}, // 0-:
 			{0x0041, 0x005A, 1}, // A-Z
@@ -36,8 +36,8 @@ var MetricNameTable = Table{
 	},
 }
 
-var LabelNameTable = Table{
-	First: &unicode.RangeTable{
+var labelNameTable = table{
+	first: &unicode.RangeTable{
 		R16: []unicode.Range16{
 			{0x0041, 0x005A, 1}, // A-Z
 			{0x005F, 0x005F, 1}, // _
@@ -45,7 +45,7 @@ var LabelNameTable = Table{
 		},
 		LatinOffset: 3,
 	},
-	Rest: &unicode.RangeTable{
+	rest: &unicode.RangeTable{
 		R16: []unicode.Range16{
 			{0x0030, 0x0039, 1}, // 0-9
 			{0x0041, 0x005A, 1}, // A-Z
@@ -56,20 +56,19 @@ var LabelNameTable = Table{
 	},
 }
 
-// Sanitize checks if the name is valid according to the table.  If not, it
-// attempts to replaces invalid runes with an underscore to create a valid
-// name.
-func sanitize(name string, table Table) (string, bool) {
+// sanitize checks if the name is valid, according to the table.
+// If not, it attempts to replace invalid runes with an underscore to create a valid name.
+func sanitize(name string, table table) (string, bool) {
 	var b strings.Builder
 
 	for i, r := range name {
 		switch i {
 		case 0:
-			if unicode.In(r, table.First) {
+			if unicode.In(r, table.first) {
 				b.WriteRune(r)
 			}
 		default:
-			if unicode.In(r, table.Rest) {
+			if unicode.In(r, table.rest) {
 				b.WriteRune(r)
 			} else {
 				b.WriteString("_")
@@ -84,24 +83,22 @@ func sanitize(name string, table Table) (string, bool) {
 	return name, true
 }
 
-// SanitizeMetricName checks if the name is a valid Prometheus metric name.  If
-// not, it attempts to replaces invalid runes with an underscore to create a
-// valid name.
+// SanitizeMetricName checks if the name is a valid Prometheus metric name.
+// If not, it attempts to replace invalid runes with an underscore to create a valid name.
 func SanitizeMetricName(name string) (string, bool) {
 	if model.IsValidLegacyMetricName(name) {
 		return name, true
 	}
-	return sanitize(name, MetricNameTable)
+	return sanitize(name, metricNameTable)
 }
 
-// SanitizeLabelName checks if the name is a valid Prometheus label name.  If
-// not, it attempts to replaces invalid runes with an underscore to create a
-// valid name.
+// SanitizeLabelName checks if the name is a valid Prometheus label name.
+// If not, it attempts to replace invalid runes with an underscore to create a valid name.
 func SanitizeLabelName(name string) (string, bool) {
 	if model.LabelName(name).IsValidLegacy() {
 		return name, true
 	}
-	return sanitize(name, LabelNameTable)
+	return sanitize(name, labelNameTable)
 }
 
 // MetricName returns the Prometheus metric name.
@@ -124,7 +121,7 @@ func MetricName(measurement, fieldKey string, valueType telegraf.ValueType) stri
 	return measurement + "_" + fieldKey
 }
 
-func MetricType(valueType telegraf.ValueType) *dto.MetricType {
+func metricType(valueType telegraf.ValueType) *dto.MetricType {
 	switch valueType {
 	case telegraf.Counter:
 		return dto.MetricType_COUNTER.Enum()

--- a/plugins/serializers/prometheus/prometheus.go
+++ b/plugins/serializers/prometheus/prometheus.go
@@ -12,6 +12,23 @@ import (
 	"github.com/influxdata/telegraf/plugins/serializers"
 )
 
+type Serializer struct {
+	FormatConfig
+}
+
+// FormatConfig contains the configuration for the Prometheus serializer.
+type FormatConfig struct {
+	ExportTimestamp bool `toml:"prometheus_export_timestamp"`
+	SortMetrics     bool `toml:"prometheus_sort_metrics"`
+	StringAsLabel   bool `toml:"prometheus_string_as_label"`
+	// CompactEncoding defines whether to include
+	// HELP metadata in Prometheus payload. Setting to true
+	// helps to reduce payload size.
+	CompactEncoding bool        `toml:"prometheus_compact_encoding"`
+	TypeMappings    MetricTypes `toml:"prometheus_metric_types"`
+}
+
+// MetricTypes defines the mapping of metric names to their types.
 type MetricTypes struct {
 	Counter []string `toml:"counter"`
 	Gauge   []string `toml:"gauge"`
@@ -20,6 +37,7 @@ type MetricTypes struct {
 	filterGauge   filter.Filter
 }
 
+// Init initializes the MetricTypes by compiling the filters for counter and gauge metrics.
 func (mt *MetricTypes) Init() error {
 	// Setup the explicit type mappings
 	var err error
@@ -34,6 +52,7 @@ func (mt *MetricTypes) Init() error {
 	return nil
 }
 
+// DetermineType determines the type of the metric based on its name and the configured filters.
 func (mt *MetricTypes) DetermineType(name string, m telegraf.Metric) telegraf.ValueType {
 	metricType := m.Type()
 	if mt.filterCounter != nil && mt.filterCounter.Match(name) {
@@ -43,21 +62,6 @@ func (mt *MetricTypes) DetermineType(name string, m telegraf.Metric) telegraf.Va
 		metricType = telegraf.Gauge
 	}
 	return metricType
-}
-
-type FormatConfig struct {
-	ExportTimestamp bool `toml:"prometheus_export_timestamp"`
-	SortMetrics     bool `toml:"prometheus_sort_metrics"`
-	StringAsLabel   bool `toml:"prometheus_string_as_label"`
-	// CompactEncoding defines whether to include
-	// HELP metadata in Prometheus payload. Setting to true
-	// helps to reduce payload size.
-	CompactEncoding bool        `toml:"prometheus_compact_encoding"`
-	TypeMappings    MetricTypes `toml:"prometheus_metric_types"`
-}
-
-type Serializer struct {
-	FormatConfig
 }
 
 func (s *Serializer) Init() error {

--- a/plugins/serializers/splunkmetric/splunkmetric.go
+++ b/plugins/serializers/splunkmetric/splunkmetric.go
@@ -14,7 +14,7 @@ type Serializer struct {
 	OmitEventTag bool `toml:"splunkmetric_omit_event_tag"`
 }
 
-type CommonTags struct {
+type commonTags struct {
 	Time   float64
 	Host   string
 	Index  string
@@ -22,7 +22,7 @@ type CommonTags struct {
 	Fields map[string]interface{}
 }
 
-type HECTimeSeries struct {
+type hecTimeSeries struct {
 	Time   float64                `json:"time"`
 	Event  string                 `json:"event,omitempty"`
 	Host   string                 `json:"host,omitempty"`
@@ -51,7 +51,7 @@ func (s *Serializer) SerializeBatch(metrics []telegraf.Metric) ([]byte, error) {
 	return serialized, nil
 }
 
-func (s *Serializer) createMulti(metric telegraf.Metric, dataGroup HECTimeSeries, commonTags CommonTags) (metricGroup []byte, err error) {
+func (s *Serializer) createMulti(metric telegraf.Metric, dataGroup hecTimeSeries, commonTags commonTags) (metricGroup []byte, err error) {
 	/* When splunkmetric_multimetric is true, then we can write out multiple name=value pairs as part of the same
 	** event payload. This only works when the time, host, and dimensions are the same for every name=value pair
 	** in the timeseries data.
@@ -101,7 +101,7 @@ func (s *Serializer) createMulti(metric telegraf.Metric, dataGroup HECTimeSeries
 	return metricGroup, nil
 }
 
-func (s *Serializer) createSingle(metric telegraf.Metric, dataGroup HECTimeSeries, commonTags CommonTags) (metricGroup []byte, err error) {
+func (s *Serializer) createSingle(metric telegraf.Metric, dataGroup hecTimeSeries, commonTags commonTags) (metricGroup []byte, err error) {
 	/* The default mode is to generate one JSON entity per metric (required for pre-8.0 Splunks)
 	**
 	** The format for single metric is 'nameOfMetric = valueOfMetric'
@@ -160,10 +160,10 @@ func (s *Serializer) createObject(metric telegraf.Metric) ([]byte, error) {
 		 ** All other index fields become dimensions.
 	*/
 
-	dataGroup := HECTimeSeries{}
+	dataGroup := hecTimeSeries{}
 
 	// The tags are common to all events in this timeseries
-	commonTags := CommonTags{}
+	commonTags := commonTags{}
 
 	commonTags.Fields = make(map[string]interface{}, len(metric.Tags()))
 

--- a/plugins/serializers/test_benchmark.go
+++ b/plugins/serializers/test_benchmark.go
@@ -8,6 +8,7 @@ import (
 	"github.com/influxdata/telegraf/metric"
 )
 
+// BenchmarkMetrics returns a set of metrics for benchmarking.
 func BenchmarkMetrics(b *testing.B) [4]telegraf.Metric {
 	b.Helper()
 	now := time.Now()

--- a/plugins/serializers/wavefront/replacers.go
+++ b/plugins/serializers/wavefront/replacers.go
@@ -23,6 +23,7 @@ var tagValueReplacer = strings.NewReplacer("\"", "\\\"", "*", "-")
 
 var pathReplacer = strings.NewReplacer("_", ".")
 
+// Sanitize replaces invalid characters in metric and tag names with '-'
 func Sanitize(strict bool, val string) string {
 	if strict {
 		return strictSanitizedChars.Replace(val)


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

Address findings for [revive:exported ](https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#exported ) in `plugins/serializers`.

As part of this effort for files from `plugins/serializers`, the following actions were taken:
- Type names (`const`, `var`, `struct`, `func`, etc) were changed to unexported, wherever they didn't need to be exported.
- All remaining exported types were given comments in the appropriate form – this does not apply to exported methods that implement "known" plugin interfaces (`Init |SampleConfig |Gather |Start |Stop |GetState |SetState |SetParser |SetParserFunc |SetTranslator |Probe |Serialize |SerializeBatch `).
- The order of methods was organized (exported methods first, then unexported, with `init` at the very end).

It is only part of the bigger work (for issue: https://github.com/influxdata/telegraf/issues/15813).

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR