### PR TITLE
chore: Fix linter findings for `revive:exported` in `plugins/aggregators`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -337,7 +337,6 @@ linters:
             - "**/metric.go"
             - "**/parser.go"
             - "**/plugin.go"
-            - "**/plugins/aggregators/**"
             - "**/plugins/common/**"
             - "**/plugins/outputs/**"
             - "**/plugins/parsers/**"
@@ -524,7 +523,7 @@ linters:
 
       # revive:exported
       - path: (.+)\.go$
-        text: exported method .*\.(Init |SampleConfig |Gather |Start |Stop |GetState |SetState |SetParser |SetParserFunc |SetTranslator |Probe )should have comment or be unexported
+        text: exported method .*\.(Init |SampleConfig |Gather |Start |Stop |GetState |SetState |SetParser |SetParserFunc |SetTranslator |Probe |Add |Push |Reset )should have comment or be unexported
 
       # EXC0001 errcheck: Almost all programs ignore errors on these functions, and in most cases it's ok
       - path: (.+)\.go$

--- a/plugins/aggregators/basicstats/basicstats_test.go
+++ b/plugins/aggregators/basicstats/basicstats_test.go
@@ -39,7 +39,7 @@ var m2 = metric.New("m1",
 )
 
 func BenchmarkApply(b *testing.B) {
-	minmax := NewBasicStats()
+	minmax := newBasicStats()
 	minmax.Log = testutil.Logger{}
 	minmax.initConfiguredStats()
 
@@ -52,7 +52,7 @@ func BenchmarkApply(b *testing.B) {
 // Test two metrics getting added.
 func TestBasicStatsWithPeriod(t *testing.T) {
 	acc := testutil.Accumulator{}
-	minmax := NewBasicStats()
+	minmax := newBasicStats()
 	minmax.Log = testutil.Logger{}
 	minmax.initConfiguredStats()
 
@@ -110,7 +110,7 @@ func TestBasicStatsWithPeriod(t *testing.T) {
 // getting added in different periods.)
 func TestBasicStatsDifferentPeriods(t *testing.T) {
 	acc := testutil.Accumulator{}
-	minmax := NewBasicStats()
+	minmax := newBasicStats()
 	minmax.Stats = []string{"count", "max", "min", "mean", "last", "first"}
 	minmax.Log = testutil.Logger{}
 	minmax.initConfiguredStats()
@@ -210,7 +210,7 @@ func TestBasicStatsDifferentPeriods(t *testing.T) {
 
 // Test only aggregating count
 func TestBasicStatsWithOnlyCount(t *testing.T) {
-	aggregator := NewBasicStats()
+	aggregator := newBasicStats()
 	aggregator.Stats = []string{"count"}
 	aggregator.Log = testutil.Logger{}
 	aggregator.initConfiguredStats()
@@ -238,7 +238,7 @@ func TestBasicStatsWithOnlyCount(t *testing.T) {
 
 // Test only aggregating minimum
 func TestBasicStatsWithOnlyMin(t *testing.T) {
-	aggregator := NewBasicStats()
+	aggregator := newBasicStats()
 	aggregator.Stats = []string{"min"}
 	aggregator.Log = testutil.Logger{}
 	aggregator.initConfiguredStats()
@@ -266,7 +266,7 @@ func TestBasicStatsWithOnlyMin(t *testing.T) {
 
 // Test only aggregating maximum
 func TestBasicStatsWithOnlyMax(t *testing.T) {
-	aggregator := NewBasicStats()
+	aggregator := newBasicStats()
 	aggregator.Stats = []string{"max"}
 	aggregator.Log = testutil.Logger{}
 	aggregator.initConfiguredStats()
@@ -294,7 +294,7 @@ func TestBasicStatsWithOnlyMax(t *testing.T) {
 
 // Test only aggregating mean
 func TestBasicStatsWithOnlyMean(t *testing.T) {
-	aggregator := NewBasicStats()
+	aggregator := newBasicStats()
 	aggregator.Stats = []string{"mean"}
 	aggregator.Log = testutil.Logger{}
 	aggregator.initConfiguredStats()
@@ -322,7 +322,7 @@ func TestBasicStatsWithOnlyMean(t *testing.T) {
 
 // Test only aggregating sum
 func TestBasicStatsWithOnlySum(t *testing.T) {
-	aggregator := NewBasicStats()
+	aggregator := newBasicStats()
 	aggregator.Stats = []string{"sum"}
 	aggregator.Log = testutil.Logger{}
 	aggregator.initConfiguredStats()
@@ -381,7 +381,7 @@ func TestBasicStatsWithOnlySumFloatingPointErrata(t *testing.T) {
 		time.Now(),
 	)
 
-	aggregator := NewBasicStats()
+	aggregator := newBasicStats()
 	aggregator.Stats = []string{"sum"}
 	aggregator.Log = testutil.Logger{}
 	aggregator.initConfiguredStats()
@@ -403,7 +403,7 @@ func TestBasicStatsWithOnlySumFloatingPointErrata(t *testing.T) {
 
 // Test only aggregating variance
 func TestBasicStatsWithOnlyVariance(t *testing.T) {
-	aggregator := NewBasicStats()
+	aggregator := newBasicStats()
 	aggregator.Stats = []string{"s2"}
 	aggregator.Log = testutil.Logger{}
 	aggregator.initConfiguredStats()
@@ -429,7 +429,7 @@ func TestBasicStatsWithOnlyVariance(t *testing.T) {
 
 // Test only aggregating standard deviation
 func TestBasicStatsWithOnlyStandardDeviation(t *testing.T) {
-	aggregator := NewBasicStats()
+	aggregator := newBasicStats()
 	aggregator.Stats = []string{"stdev"}
 	aggregator.Log = testutil.Logger{}
 	aggregator.initConfiguredStats()
@@ -455,7 +455,7 @@ func TestBasicStatsWithOnlyStandardDeviation(t *testing.T) {
 
 // Test only aggregating minimum and maximum
 func TestBasicStatsWithMinAndMax(t *testing.T) {
-	aggregator := NewBasicStats()
+	aggregator := newBasicStats()
 	aggregator.Stats = []string{"min", "max"}
 	aggregator.Log = testutil.Logger{}
 	aggregator.initConfiguredStats()
@@ -490,7 +490,7 @@ func TestBasicStatsWithMinAndMax(t *testing.T) {
 
 // Test only aggregating diff
 func TestBasicStatsWithDiff(t *testing.T) {
-	aggregator := NewBasicStats()
+	aggregator := newBasicStats()
 	aggregator.Stats = []string{"diff"}
 	aggregator.Log = testutil.Logger{}
 	aggregator.initConfiguredStats()
@@ -515,7 +515,7 @@ func TestBasicStatsWithDiff(t *testing.T) {
 }
 
 func TestBasicStatsWithRate(t *testing.T) {
-	aggregator := NewBasicStats()
+	aggregator := newBasicStats()
 	aggregator.Stats = []string{"rate"}
 	aggregator.Log = testutil.Logger{}
 	aggregator.initConfiguredStats()
@@ -539,7 +539,7 @@ func TestBasicStatsWithRate(t *testing.T) {
 }
 
 func TestBasicStatsWithNonNegativeRate(t *testing.T) {
-	aggregator := NewBasicStats()
+	aggregator := newBasicStats()
 	aggregator.Stats = []string{"non_negative_rate"}
 	aggregator.Log = testutil.Logger{}
 	aggregator.initConfiguredStats()
@@ -563,7 +563,7 @@ func TestBasicStatsWithNonNegativeRate(t *testing.T) {
 }
 
 func TestBasicStatsWithPctChange(t *testing.T) {
-	aggregator := NewBasicStats()
+	aggregator := newBasicStats()
 	aggregator.Stats = []string{"percent_change"}
 	aggregator.Log = testutil.Logger{}
 	aggregator.initConfiguredStats()
@@ -587,7 +587,7 @@ func TestBasicStatsWithPctChange(t *testing.T) {
 }
 
 func TestBasicStatsWithInterval(t *testing.T) {
-	aggregator := NewBasicStats()
+	aggregator := newBasicStats()
 	aggregator.Stats = []string{"interval"}
 	aggregator.Log = testutil.Logger{}
 	aggregator.initConfiguredStats()
@@ -613,7 +613,7 @@ func TestBasicStatsWithInterval(t *testing.T) {
 
 // Test only aggregating non_negative_diff
 func TestBasicStatsWithNonNegativeDiff(t *testing.T) {
-	aggregator := NewBasicStats()
+	aggregator := newBasicStats()
 	aggregator.Stats = []string{"non_negative_diff"}
 	aggregator.Log = testutil.Logger{}
 	aggregator.initConfiguredStats()
@@ -639,7 +639,7 @@ func TestBasicStatsWithNonNegativeDiff(t *testing.T) {
 // Test aggregating with all stats
 func TestBasicStatsWithAllStats(t *testing.T) {
 	acc := testutil.Accumulator{}
-	minmax := NewBasicStats()
+	minmax := newBasicStats()
 	minmax.Log = testutil.Logger{}
 	minmax.Stats = []string{"count", "min", "max", "mean", "stdev", "s2", "sum", "last", "first"}
 	minmax.initConfiguredStats()
@@ -717,7 +717,7 @@ func TestBasicStatsWithAllStats(t *testing.T) {
 
 // Test that if an empty array is passed, no points are pushed
 func TestBasicStatsWithNoStats(t *testing.T) {
-	aggregator := NewBasicStats()
+	aggregator := newBasicStats()
 	aggregator.Stats = make([]string, 0)
 	aggregator.Log = testutil.Logger{}
 	aggregator.initConfiguredStats()
@@ -733,7 +733,7 @@ func TestBasicStatsWithNoStats(t *testing.T) {
 
 // Test that if an unknown stat is configured, it doesn't explode
 func TestBasicStatsWithUnknownStat(t *testing.T) {
-	aggregator := NewBasicStats()
+	aggregator := newBasicStats()
 	aggregator.Stats = []string{"crazy"}
 	aggregator.Log = testutil.Logger{}
 	aggregator.initConfiguredStats()
@@ -752,7 +752,7 @@ func TestBasicStatsWithUnknownStat(t *testing.T) {
 // otherwise user's working systems will suddenly (and surprisingly) start
 // capturing sum without their input.
 func TestBasicStatsWithDefaultStats(t *testing.T) {
-	aggregator := NewBasicStats()
+	aggregator := newBasicStats()
 	aggregator.Log = testutil.Logger{}
 	aggregator.initConfiguredStats()
 
@@ -772,7 +772,7 @@ func TestBasicStatsWithDefaultStats(t *testing.T) {
 }
 
 func TestBasicStatsWithOnlyLast(t *testing.T) {
-	aggregator := NewBasicStats()
+	aggregator := newBasicStats()
 	aggregator.Stats = []string{"last"}
 	aggregator.Log = testutil.Logger{}
 	aggregator.initConfiguredStats()
@@ -799,7 +799,7 @@ func TestBasicStatsWithOnlyLast(t *testing.T) {
 }
 
 func TestBasicStatsWithOnlyFirst(t *testing.T) {
-	aggregator := NewBasicStats()
+	aggregator := newBasicStats()
 	aggregator.Stats = []string{"first"}
 	aggregator.Log = testutil.Logger{}
 	aggregator.initConfiguredStats()

--- a/plugins/aggregators/derivative/derivative_test.go
+++ b/plugins/aggregators/derivative/derivative_test.go
@@ -90,7 +90,7 @@ func TestTwoFullEventsWithParameterReverseSequence(t *testing.T) {
 
 func TestTwoFullEventsWithoutParameter(t *testing.T) {
 	acc := testutil.Accumulator{}
-	derivative := NewDerivative()
+	derivative := newDerivative()
 	derivative.Log = testutil.Logger{}
 	err := derivative.Init()
 	require.NoError(t, err)
@@ -268,7 +268,7 @@ func TestIgnoresMissingVariable(t *testing.T) {
 
 func TestMergesDifferentMetricsWithSameHash(t *testing.T) {
 	acc := testutil.Accumulator{}
-	derivative := NewDerivative()
+	derivative := newDerivative()
 	derivative.Log = testutil.Logger{}
 	err := derivative.Init()
 	require.NoError(t, err)
@@ -369,7 +369,7 @@ func TestCalculatesCorrectDerivativeOnTwoConsecutivePeriods(t *testing.T) {
 	acc := testutil.Accumulator{}
 	period, err := time.ParseDuration("10s")
 	require.NoError(t, err)
-	derivative := NewDerivative()
+	derivative := newDerivative()
 	derivative.Log = testutil.Logger{}
 	require.NoError(t, derivative.Init())
 

--- a/plugins/aggregators/final/final.go
+++ b/plugins/aggregators/final/final.go
@@ -23,12 +23,6 @@ type Final struct {
 	metricCache map[uint64]telegraf.Metric
 }
 
-func NewFinal() *Final {
-	return &Final{
-		SeriesTimeout: config.Duration(5 * time.Minute),
-	}
-}
-
 func (*Final) SampleConfig() string {
 	return sampleConfig
 }
@@ -83,8 +77,14 @@ func (m *Final) Push(acc telegraf.Accumulator) {
 func (*Final) Reset() {
 }
 
+func newFinal() *Final {
+	return &Final{
+		SeriesTimeout: config.Duration(5 * time.Minute),
+	}
+}
+
 func init() {
 	aggregators.Add("final", func() telegraf.Aggregator {
-		return NewFinal()
+		return newFinal()
 	})
 }

--- a/plugins/aggregators/final/final_test.go
+++ b/plugins/aggregators/final/final_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestSimple(t *testing.T) {
 	acc := testutil.Accumulator{}
-	final := NewFinal()
+	final := newFinal()
 	require.NoError(t, final.Init())
 
 	tags := map[string]string{"foo": "bar"}
@@ -50,7 +50,7 @@ func TestSimple(t *testing.T) {
 
 func TestTwoTags(t *testing.T) {
 	acc := testutil.Accumulator{}
-	final := NewFinal()
+	final := newFinal()
 	require.NoError(t, final.Init())
 
 	tags1 := map[string]string{"foo": "bar"}
@@ -96,7 +96,7 @@ func TestTwoTags(t *testing.T) {
 
 func TestLongDifference(t *testing.T) {
 	acc := testutil.Accumulator{}
-	final := NewFinal()
+	final := newFinal()
 	final.SeriesTimeout = config.Duration(30 * time.Second)
 	require.NoError(t, final.Init())
 	tags := map[string]string{"foo": "bar"}

--- a/plugins/aggregators/histogram/histogram_test.go
+++ b/plugins/aggregators/histogram/histogram_test.go
@@ -16,15 +16,15 @@ import (
 type fields map[string]interface{}
 type tags map[string]string
 
-// NewTestHistogram creates new test histogram aggregation with specified config
-func NewTestHistogram(cfg []bucketConfig, reset, cumulative, pushOnlyOnUpdate bool) telegraf.Aggregator {
-	return NewTestHistogramWithExpirationInterval(cfg, reset, cumulative, pushOnlyOnUpdate, 0)
+// newTestHistogram creates new test histogram aggregation with specified config
+func newTestHistogram(cfg []bucketConfig, reset, cumulative, pushOnlyOnUpdate bool) telegraf.Aggregator {
+	return newTestHistogramWithExpirationInterval(cfg, reset, cumulative, pushOnlyOnUpdate, 0)
 }
 
-func NewTestHistogramWithExpirationInterval(
+func newTestHistogramWithExpirationInterval(
 	cfg []bucketConfig, reset, cumulative, pushOnlyOnUpdate bool, expirationInterval config.Duration,
 ) telegraf.Aggregator {
-	htm := NewHistogramAggregator()
+	htm := newHistogramAggregator()
 	htm.Configs = cfg
 	htm.ResetBuckets = reset
 	htm.Cumulative = cumulative
@@ -70,7 +70,7 @@ var secondMetric = metric.New(
 
 // BenchmarkApply runs benchmarks
 func BenchmarkApply(b *testing.B) {
-	histogram := NewHistogramAggregator()
+	histogram := newHistogramAggregator()
 
 	for n := 0; n < b.N; n++ {
 		histogram.Add(firstMetric1)
@@ -83,7 +83,7 @@ func BenchmarkApply(b *testing.B) {
 func TestHistogram(t *testing.T) {
 	var cfg []bucketConfig
 	cfg = append(cfg, bucketConfig{Metric: "first_metric_name", Fields: []string{"a"}, Buckets: []float64{0.0, 10.0, 20.0, 30.0, 40.0}})
-	histogram := NewTestHistogram(cfg, false, true, false)
+	histogram := newTestHistogram(cfg, false, true, false)
 
 	acc := &testutil.Accumulator{}
 
@@ -105,7 +105,7 @@ func TestHistogram(t *testing.T) {
 func TestHistogramPushOnUpdate(t *testing.T) {
 	var cfg []bucketConfig
 	cfg = append(cfg, bucketConfig{Metric: "first_metric_name", Fields: []string{"a"}, Buckets: []float64{0.0, 10.0, 20.0, 30.0, 40.0}})
-	histogram := NewTestHistogram(cfg, false, true, true)
+	histogram := newTestHistogram(cfg, false, true, true)
 
 	acc := &testutil.Accumulator{}
 
@@ -141,7 +141,7 @@ func TestHistogramPushOnUpdate(t *testing.T) {
 func TestHistogramNonCumulative(t *testing.T) {
 	var cfg []bucketConfig
 	cfg = append(cfg, bucketConfig{Metric: "first_metric_name", Fields: []string{"a"}, Buckets: []float64{0.0, 10.0, 20.0, 30.0, 40.0}})
-	histogram := NewTestHistogram(cfg, false, false, false)
+	histogram := newTestHistogram(cfg, false, false, false)
 
 	acc := &testutil.Accumulator{}
 
@@ -163,7 +163,7 @@ func TestHistogramNonCumulative(t *testing.T) {
 func TestHistogramWithReset(t *testing.T) {
 	var cfg []bucketConfig
 	cfg = append(cfg, bucketConfig{Metric: "first_metric_name", Fields: []string{"a"}, Buckets: []float64{0.0, 10.0, 20.0, 30.0, 40.0}})
-	histogram := NewTestHistogram(cfg, true, true, false)
+	histogram := newTestHistogram(cfg, true, true, false)
 
 	acc := &testutil.Accumulator{}
 
@@ -187,7 +187,7 @@ func TestHistogramWithAllFields(t *testing.T) {
 		{Metric: "first_metric_name", Buckets: []float64{0.0, 15.5, 20.0, 30.0, 40.0}},
 		{Metric: "second_metric_name", Buckets: []float64{0.0, 4.0, 10.0, 23.0, 30.0}},
 	}
-	histogram := NewTestHistogram(cfg, false, true, false)
+	histogram := newTestHistogram(cfg, false, true, false)
 
 	acc := &testutil.Accumulator{}
 
@@ -266,7 +266,7 @@ func TestHistogramWithAllFieldsNonCumulative(t *testing.T) {
 		{Metric: "first_metric_name", Buckets: []float64{0.0, 15.5, 20.0, 30.0, 40.0}},
 		{Metric: "second_metric_name", Buckets: []float64{0.0, 4.0, 10.0, 23.0, 30.0}},
 	}
-	histogram := NewTestHistogram(cfg, false, false, false)
+	histogram := newTestHistogram(cfg, false, false, false)
 
 	acc := &testutil.Accumulator{}
 
@@ -368,7 +368,7 @@ func TestHistogramWithAllFieldsNonCumulative(t *testing.T) {
 func TestHistogramWithTwoPeriodsAndAllFields(t *testing.T) {
 	var cfg []bucketConfig
 	cfg = append(cfg, bucketConfig{Metric: "first_metric_name", Buckets: []float64{0.0, 10.0, 20.0, 30.0, 40.0}})
-	histogram := NewTestHistogram(cfg, false, true, false)
+	histogram := newTestHistogram(cfg, false, true, false)
 
 	acc := &testutil.Accumulator{}
 	histogram.Add(firstMetric1)
@@ -413,7 +413,7 @@ func TestWrongBucketsOrder(t *testing.T) {
 
 	var cfg []bucketConfig
 	cfg = append(cfg, bucketConfig{Metric: "first_metric_name", Buckets: []float64{0.0, 90.0, 20.0, 30.0, 40.0}})
-	histogram := NewTestHistogram(cfg, false, true, false)
+	histogram := newTestHistogram(cfg, false, true, false)
 	histogram.Add(firstMetric2)
 }
 
@@ -431,7 +431,7 @@ func TestHistogramMetricExpiration(t *testing.T) {
 		{Metric: "first_metric_name", Fields: []string{"a"}, Buckets: []float64{0.0, 10.0, 20.0, 30.0, 40.0}},
 		{Metric: "second_metric_name", Buckets: []float64{0.0, 4.0, 10.0, 23.0, 30.0}},
 	}
-	histogram := NewTestHistogramWithExpirationInterval(cfg, false, true, false, config.Duration(30))
+	histogram := newTestHistogramWithExpirationInterval(cfg, false, true, false, config.Duration(30))
 
 	acc := &testutil.Accumulator{}
 

--- a/plugins/aggregators/minmax/minmax.go
+++ b/plugins/aggregators/minmax/minmax.go
@@ -15,12 +15,6 @@ type MinMax struct {
 	cache map[uint64]aggregate
 }
 
-func NewMinMax() telegraf.Aggregator {
-	mm := &MinMax{}
-	mm.Reset()
-	return mm
-}
-
 type aggregate struct {
 	fields map[string]minmax
 	name   string
@@ -107,8 +101,14 @@ func convert(in interface{}) (float64, bool) {
 	}
 }
 
+func newMinMax() telegraf.Aggregator {
+	mm := &MinMax{}
+	mm.Reset()
+	return mm
+}
+
 func init() {
 	aggregators.Add("minmax", func() telegraf.Aggregator {
-		return NewMinMax()
+		return newMinMax()
 	})
 }

--- a/plugins/aggregators/minmax/minmax_test.go
+++ b/plugins/aggregators/minmax/minmax_test.go
@@ -46,7 +46,7 @@ var m2 = metric.New("m1",
 )
 
 func BenchmarkApply(b *testing.B) {
-	minmax := NewMinMax()
+	minmax := newMinMax()
 
 	for n := 0; n < b.N; n++ {
 		minmax.Add(m1)
@@ -57,7 +57,7 @@ func BenchmarkApply(b *testing.B) {
 // Test two metrics getting added.
 func TestMinMaxWithPeriod(t *testing.T) {
 	acc := testutil.Accumulator{}
-	minmax := NewMinMax()
+	minmax := newMinMax()
 
 	minmax.Add(m1)
 	minmax.Add(m2)
@@ -99,7 +99,7 @@ func TestMinMaxWithPeriod(t *testing.T) {
 // getting added in different periods.)
 func TestMinMaxDifferentPeriods(t *testing.T) {
 	acc := testutil.Accumulator{}
-	minmax := NewMinMax()
+	minmax := newMinMax()
 
 	minmax.Add(m1)
 	minmax.Push(&acc)

--- a/plugins/aggregators/quantile/algorithms.go
+++ b/plugins/aggregators/quantile/algorithms.go
@@ -25,6 +25,7 @@ func newExactR7(_ float64) (algorithm, error) {
 	return &exactAlgorithmR7{xs: make([]float64, 0, 100), sorted: false}, nil
 }
 
+// Add adds a value to the algorithm.
 func (e *exactAlgorithmR7) Add(value float64) error {
 	e.xs = append(e.xs, value)
 	e.sorted = false
@@ -32,6 +33,7 @@ func (e *exactAlgorithmR7) Add(value float64) error {
 	return nil
 }
 
+// Quantile returns the quantile value for the given q.
 func (e *exactAlgorithmR7) Quantile(q float64) float64 {
 	size := len(e.xs)
 
@@ -71,6 +73,7 @@ func newExactR8(_ float64) (algorithm, error) {
 	return &exactAlgorithmR8{xs: make([]float64, 0, 100), sorted: false}, nil
 }
 
+// Add adds a value to the algorithm.
 func (e *exactAlgorithmR8) Add(value float64) error {
 	e.xs = append(e.xs, value)
 	e.sorted = false
@@ -78,6 +81,7 @@ func (e *exactAlgorithmR8) Add(value float64) error {
 	return nil
 }
 
+// Quantile returns the quantile value for the given q.
 func (e *exactAlgorithmR8) Quantile(q float64) float64 {
 	size := len(e.xs)
 

--- a/plugins/aggregators/registry.go
+++ b/plugins/aggregators/registry.go
@@ -2,10 +2,13 @@ package aggregators
 
 import "github.com/influxdata/telegraf"
 
+// Creator is the function to create a new aggregator
 type Creator func() telegraf.Aggregator
 
+// Aggregators contains the registry of all known aggregators
 var Aggregators = make(map[string]Creator)
 
+// Add adds an aggregator to the registry. Usually this function is called in the plugin's init function
 func Add(name string, creator Creator) {
 	Aggregators[name] = creator
 }

--- a/plugins/aggregators/starlark/starlark.go
+++ b/plugins/aggregators/starlark/starlark.go
@@ -102,7 +102,6 @@ func (s *Starlark) Reset() {
 	}
 }
 
-// init initializes starlark aggregator plugin
 func init() {
 	aggregators.Add("starlark", func() telegraf.Aggregator {
 		return &Starlark{

--- a/plugins/aggregators/valuecounter/valuecounter_test.go
+++ b/plugins/aggregators/valuecounter/valuecounter_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/influxdata/telegraf/testutil"
 )
 
-// Create a valuecounter with config
-func NewTestValueCounter(fields []string) telegraf.Aggregator {
+// Create a ValueCounter with config
+func newTestValueCounter(fields []string) telegraf.Aggregator {
 	vc := &ValueCounter{
 		Fields: fields,
 	}
@@ -40,7 +40,7 @@ var m2 = metric.New("m1",
 )
 
 func BenchmarkApply(b *testing.B) {
-	vc := NewTestValueCounter([]string{"status"})
+	vc := newTestValueCounter([]string{"status"})
 
 	for n := 0; n < b.N; n++ {
 		vc.Add(m1)
@@ -50,7 +50,7 @@ func BenchmarkApply(b *testing.B) {
 
 // Test basic functionality
 func TestBasic(t *testing.T) {
-	vc := NewTestValueCounter([]string{"status"})
+	vc := newTestValueCounter([]string{"status"})
 	acc := testutil.Accumulator{}
 
 	vc.Add(m1)
@@ -70,7 +70,7 @@ func TestBasic(t *testing.T) {
 
 // Test with multiple fields to count
 func TestMultipleFields(t *testing.T) {
-	vc := NewTestValueCounter([]string{"status", "somefield", "boolfield"})
+	vc := newTestValueCounter([]string{"status", "somefield", "boolfield"})
 	acc := testutil.Accumulator{}
 
 	vc.Add(m1)
@@ -92,7 +92,7 @@ func TestMultipleFields(t *testing.T) {
 
 // Test with a reset between two runs
 func TestWithReset(t *testing.T) {
-	vc := NewTestValueCounter([]string{"status"})
+	vc := newTestValueCounter([]string{"status"})
 	acc := testutil.Accumulator{}
 
 	vc.Add(m1)


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

Address findings for [revive:exported ](https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#exported ) in `plugins/aggregators`.

As part of this effort for files from `plugins/aggregators`, the following actions were taken:
- Type names (`const`, `var`, `struct`, `func`, etc) were changed to unexported, wherever they didn't need to be exported.
- All remaining exported types were given comments in the appropriate form – this does not apply to exported methods that implement "known" plugin interfaces (`Init |SampleConfig |Gather |Start |Stop |GetState |SetState |SetParser |SetParserFunc |SetTranslator |Probe |Add |Push |Reset `).
- The order of methods was organized (exported methods first, then unexported, with `init` at the very end).

It is only part of the bigger work (for issue: https://github.com/influxdata/telegraf/issues/15813).

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR