### PR TITLE
test(testutil): Simplify certificate reading

### DIFF
--- a/testutil/tls.go
+++ b/testutil/tls.go
@@ -2,7 +2,6 @@ package testutil
 
 import (
 	"fmt"
-	"io"
 	"os"
 	"path"
 	"path/filepath"
@@ -147,11 +146,7 @@ func (p *pki) AbsolutePaths() (*PKIPaths, error) {
 }
 
 func readCertificate(filename string) string {
-	file, err := os.Open(filename)
-	if err != nil {
-		panic(fmt.Sprintf("opening %q: %v", filename, err))
-	}
-	octets, err := io.ReadAll(file)
+	octets, err := os.ReadFile(filename)
 	if err != nil {
 		panic(fmt.Sprintf("reading %q: %v", filename, err))
 	}


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Simplified readCertificate function - Replaced the two-step process of os.Open() + io.ReadAll() with a single os.ReadFile() call. This eliminates the need to explicitly open and manage the file handle, reducing overhead.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
