### PR TITLE
fix(inputs.opcua): Fix type mismatch in unit test

### DIFF
--- a/plugins/inputs/opcua/opcua_test.go
+++ b/plugins/inputs/opcua/opcua_test.go
@@ -576,7 +576,7 @@ func TestConsecutiveSessionErrorRecoveryIntegration(t *testing.T) {
 	// First gather should succeed
 	require.NoError(t, o.Gather(acc))
 	require.Len(t, acc.Metrics, 1)
-	require.Equal(t, 0, o.consecutiveErrors)
+	require.Equal(t, uint64(0), o.consecutiveErrors)
 
 	// Simulate a session error
 	o.client.forceReconnect = true
@@ -585,7 +585,7 @@ func TestConsecutiveSessionErrorRecoveryIntegration(t *testing.T) {
 	acc.ClearMetrics()
 	require.NoError(t, o.Gather(acc))
 	require.Len(t, acc.Metrics, 1)
-	require.Equal(t, 0, o.consecutiveErrors, "Should reset consecutive errors after successful gather")
+	require.Equal(t, uint64(0), o.consecutiveErrors, "Should reset consecutive errors after successful gather")
 
 	// Simulate multiple consecutive errors with bad endpoint
 	originalEndpoint := o.client.Config.OpcUAClientConfig.Endpoint
@@ -594,12 +594,12 @@ func TestConsecutiveSessionErrorRecoveryIntegration(t *testing.T) {
 	// Next gather should fail
 	acc.ClearMetrics()
 	require.Error(t, o.Gather(acc))
-	require.Equal(t, 1, o.consecutiveErrors)
+	require.Equal(t, uint64(1), o.consecutiveErrors)
 
 	// Another failure should increment consecutive errors and trigger session invalidation
 	acc.ClearMetrics()
 	require.Error(t, o.Gather(acc))
-	require.Equal(t, 2, o.consecutiveErrors)
+	require.Equal(t, uint64(2), o.consecutiveErrors)
 	require.True(t, o.client.forceReconnect, "Should force session invalidation after multiple errors")
 
 	// Restore endpoint to allow recovery
@@ -609,5 +609,5 @@ func TestConsecutiveSessionErrorRecoveryIntegration(t *testing.T) {
 	acc.ClearMetrics()
 	require.NoError(t, o.Gather(acc))
 	require.Len(t, acc.Metrics, 1)
-	require.Equal(t, 0, o.consecutiveErrors, "Should reset consecutive errors after recovery")
+	require.Equal(t, uint64(0), o.consecutiveErrors, "Should reset consecutive errors after recovery")
 }


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
This is a type mismatch issue, where the consecutiveErrors field in the OpcUA struct is defined as a uint64, but in the test it's being compared to an int value.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #17014
