### PR TITLE
docs(inputs): Add plugin metadata and update description for p*

### DIFF
--- a/plugins/inputs/p4runtime/README.md
+++ b/plugins/inputs/p4runtime/README.md
@@ -1,19 +1,23 @@
 # P4 Runtime Input Plugin
 
-P4 is a language for programming the data plane of network devices,
-such as Programmable Switches or Programmable Network Interface Cards.
-The P4Runtime API is a control plane specification to manage
-the data plane elements of those devices dynamically by a P4 program.
+This plugin collects metrics from the data plane of network devices, such as
+Programmable Switches or Programmable Network Interface Cards by reading the
+`Counter` values of the [P4 program][p4lang] running on the device.
+Metrics are collected through a gRPC connection with the [P4 runtime][p4runtime]
+server.
 
-The `p4runtime` plugin gathers metrics about `Counter` values
-present in P4 Program loaded onto networking device.
-Metrics are collected through gRPC connection with
-[P4Runtime](https://github.com/p4lang/p4runtime) server.
+> [!TIP]
+> If you want to gather information about the program name, please follow the
+> instruction in [6.2.1. Annotating P4 code with PkgInfo][p4annotation] to
+> modify your P4 program.
 
-P4Runtime Plugin uses `PkgInfo.Name` field.
-If user wants to gather information about program name, please follow
-[6.2.1. Annotating P4 code with PkgInfo] instruction and apply changes
-to your P4 program.
+⭐ Telegraf v1.26.0
+🏷️ network, applications
+💻 all
+
+[p4lang]: https://p4.org
+[p4runtime]: https://github.com/p4lang/p4runtime
+[p4annotation]: https://p4.org/p4-spec/p4runtime/main/P4Runtime-Spec.html#sec-annotating-p4-code-with-pkginfo
 
 ## Global configuration options <!-- @/docs/includes/plugin_config.md -->
 
@@ -54,24 +58,20 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 ## Metrics
 
-P4Runtime gRPC server communicates using [p4runtime.proto] Protocol Buffer.
-Static information about P4 program loaded into programmable switch
-are collected by `GetForwardingPipelineConfigRequest` message.
-Plugin gathers dynamic metrics with `Read` method.
-`Readrequest` is defined with single `Entity` of type `CounterEntry`.
-Since P4 Counter is array, plugin collects values of every cell of array
-by [wildcard query].
+The P4 runtime server communicates using the
+[P4 Protocol Buffer definition][p4proto].  Static information about the program
+loaded into programmable switch are collected by
+`GetForwardingPipelineConfigRequest` message. The plugin gathers dynamic metrics
+using the `Read` method. `Readrequest` is defined with single `Entity` of type
+`CounterEntry`. Since a P4 Counter is an array type, the plugin collects values
+of every cell of array by [wildcard queries][wildcards].
 
-Counters defined in P4 Program have unique ID and name.
-Counters are arrays, thus `counter_index` informs
-which cell value of array is described in metric.
+Counters defined in a P4 Program have a unique ID and name. The `counter_index`
+defines which cell value of the counter array is used in the metric.
 
 Tags are constructed in given manner:
 
 - `p4program_name`: P4 program name provided by user.
-If user wants to gather information about program name, please follow
-[6.2.1. Annotating P4 code with PkgInfo] instruction and apply changes
-to your P4 program.
 - `counter_name`: Name of given counter in P4 program.
 - `counter_type`: Type of counter (BYTES, PACKETS, BOTH).
 
@@ -83,13 +83,9 @@ Fields are constructed in given manner:
 
 ## Example Output
 
-Expected output for p4runtime plugin instance
-running on host named `p4runtime-host`:
-
 ```text
 p4_runtime,counter_name=MyIngress.egressTunnelCounter,counter_type=BOTH,host=p4 bytes=408i,packets=4i,counter_index=200i 1675175030000000000
 ```
 
-[6.2.1. Annotating P4 code with PkgInfo]: https://p4.org/p4-spec/p4runtime/main/P4Runtime-Spec.html#sec-annotating-p4-code-with-pkginfo
-[p4runtime.proto]: https://github.com/p4lang/p4runtime/blob/main/proto/p4/v1/p4runtime.proto
-[wildcard query]: https://github.com/p4lang/p4runtime/blob/main/proto/p4/v1/p4runtime.proto#L379
+[p4proto]: https://github.com/p4lang/p4runtime/blob/main/proto/p4/v1/p4runtime.proto
+[wildcards]: https://github.com/p4lang/p4runtime/blob/main/proto/p4/v1/p4runtime.proto#L379

--- a/plugins/inputs/passenger/README.md
+++ b/plugins/inputs/passenger/README.md
@@ -1,25 +1,24 @@
 # Passenger Input Plugin
 
-Gather [Phusion Passenger](https://www.phusionpassenger.com/) metrics using the
-`passenger-status` command line utility.
+This plugin gathers metrics from the [Phusion Passenger][phusion] service.
 
-## Series Cardinality Warning
+> [!WARNING]
+> Depending on your environment, this plugin can create a high number of series
+> which can cause high load on your database. Please use
+> [measurement filtering][metric_filtering] to manage your series cardinality!
 
-Depending on your environment, this `passenger_process` measurement of this
-plugin can quickly create a high number of series which, when unchecked, can
-cause high load on your database.  You can use the following techniques to
-manage your series cardinality:
+The plugin uses the `passenger-status` command line tool.
 
-- Use the
-  [measurement filtering](https://docs.influxdata.com/telegraf/latest/administration/configuration/#measurement-filtering)
-  options to exclude unneeded tags.  In some environments, you may wish to use
-  `tagexclude` to remove the `pid` and `process_group_id` tags.
-- Write to a database with an appropriate
-  [retention policy](https://docs.influxdata.com/influxdb/latest/guides/downsampling_and_retention/).
-- Consider using the
-  [Time Series Index](https://docs.influxdata.com/influxdb/latest/concepts/time-series-index/).
-- Monitor your databases
-  [series cardinality](https://docs.influxdata.com/influxdb/latest/query_language/spec/#show-cardinality).
+> [!NOTE]
+> This plugin requires the `passenger-status` binary to be installed on the
+> system and to be executable by Telegraf.
+
+⭐ Telegraf v0.10.1
+🏷️ web
+💻 all
+
+[phusion]: https://www.phusionpassenger.com/
+[metric_filtering]: /docs/CONFIGURATION.md#metric-filtering
 
 ## Global configuration options <!-- @/docs/includes/plugin_config.md -->
 
@@ -50,6 +49,24 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 Telegraf must have permission to execute the `passenger-status` command.  On
 most systems, Telegraf runs as the `telegraf` user.
+
+### Series Cardinality
+
+Depending on your environment, this `passenger_process` measurement of this
+plugin can quickly create a high number of series which, when unchecked, can
+cause high load on your database.  You can use the following techniques to
+manage your series cardinality:
+
+- Use the
+  [measurement filtering](https://docs.influxdata.com/telegraf/latest/administration/configuration/#measurement-filtering)
+  options to exclude unneeded tags.  In some environments, you may wish to use
+  `tagexclude` to remove the `pid` and `process_group_id` tags.
+- Write to a database with an appropriate
+  [retention policy](https://docs.influxdata.com/influxdb/latest/guides/downsampling_and_retention/).
+- Consider using the
+  [Time Series Index](https://docs.influxdata.com/influxdb/latest/concepts/time-series-index/).
+- Monitor your databases
+  [series cardinality](https://docs.influxdata.com/influxdb/latest/query_language/spec/#show-cardinality).
 
 ## Metrics
 

--- a/plugins/inputs/pf/README.md
+++ b/plugins/inputs/pf/README.md
@@ -1,26 +1,16 @@
 # PF Input Plugin
 
-The pf plugin gathers information from the FreeBSD/OpenBSD pf
-firewall. Currently it can retrieve information about the state table: the
-number of current entries in the table, and counters for the number of searches,
-inserts, and removals to the table.
+This plugin gathers information from the FreeBSD or OpenBSD pf firewall like
+the number of current entries in the table, counters for the number of searches,
+inserts, and removals to tables using the `pfctl` command.
 
-The pf plugin retrieves this information by invoking the `pfstat` command. The
-`pfstat` command requires read access to the device file `/dev/pf`. You have
-several options to permit telegraf to run `pfctl`:
+> [!NOTE]
+> This plugin requires the `pfctl` binary to be executable by Telegraf. It
+> requires read access to the device file `/dev/pf`.
 
-* Run telegraf as root. This is strongly discouraged.
-* Change the ownership and permissions for /dev/pf such that the user telegraf runs at can read the /dev/pf device file. This is probably not that good of an idea either.
-* Configure sudo to grant telegraf to run `pfctl` as root. This is the most restrictive option, but require sudo setup.
-* Add "telegraf" to the "proxy" group as /dev/pf is owned by root:proxy.
-
-## Using sudo
-
-You may edit your sudo configuration with the following:
-
-```sudo
-telegraf ALL=(root) NOPASSWD: /sbin/pfctl -s info
-```
+⭐ Telegraf v1.5.0
+🏷️ system, network
+💻 freebsd
 
 ## Global configuration options <!-- @/docs/includes/plugin_config.md -->
 
@@ -43,28 +33,45 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   use_sudo = false
 ```
 
+### Permissions
+
+You have several options to grant Telegraf the permissions to run `pfctl`:
+
+- Run telegraf as root. This is strongly discouraged.
+- Change the ownership and permissions for `/dev/pf` to allow being read by the
+  Telegraf user. This is discouraged.
+- Configure sudo to allow running `pfctl` as root by the Telegraf user.
+  This is the most restrictive option, but require sudo setup.
+- Add the Telegraf user to the `proxy` group as `/dev/pf`.
+
+For the `sudo` option you may add the following to the sudo configuration:
+
+```sudo
+telegraf ALL=(root) NOPASSWD: /sbin/pfctl -s info
+```
+
 ## Metrics
 
-* pf
-  * entries (integer, count)
-  * searches (integer, count)
-  * inserts (integer, count)
-  * removals (integer, count)
-  * match (integer, count)
-  * bad-offset (integer, count)
-  * fragment (integer, count)
-  * short (integer, count)
-  * normalize (integer, count)
-  * memory (integer, count)
-  * bad-timestamp (integer, count)
-  * congestion (integer, count)
-  * ip-option (integer, count)
-  * proto-cksum (integer, count)
-  * state-mismatch (integer, count)
-  * state-insert (integer, count)
-  * state-limit (integer, count)
-  * src-limit (integer, count)
-  * synproxy (integer, count)
+- pf
+  - entries (integer, count)
+  - searches (integer, count)
+  - inserts (integer, count)
+  - removals (integer, count)
+  - match (integer, count)
+  - bad-offset (integer, count)
+  - fragment (integer, count)
+  - short (integer, count)
+  - normalize (integer, count)
+  - memory (integer, count)
+  - bad-timestamp (integer, count)
+  - congestion (integer, count)
+  - ip-option (integer, count)
+  - proto-cksum (integer, count)
+  - state-mismatch (integer, count)
+  - state-insert (integer, count)
+  - state-limit (integer, count)
+  - src-limit (integer, count)
+  - synproxy (integer, count)
 
 ## Example Output
 

--- a/plugins/inputs/pgbouncer/README.md
+++ b/plugins/inputs/pgbouncer/README.md
@@ -1,11 +1,18 @@
 # PgBouncer Input Plugin
 
-The `pgbouncer` plugin provides metrics for your PgBouncer load balancer.
+This plugin collects metrics from a [PgBouncer load balancer][pgbouncer]
+instance. Check the [documentation][metric_docs] for available metrics and their
+meaning.
 
-More information about the meaning of these metrics can be found in the
-[PgBouncer Documentation](https://pgbouncer.github.io/usage.html).
+> [!NOTE]
+> This plugin requires PgBouncer v1.5+.
 
-- PgBouncer minimum tested version: 1.5
+⭐ Telegraf v1.8.0
+🏷️ server, web
+💻 all
+
+[pgbouncer]: https://pgbouncer.github.io
+[metric_docs]: https://pgbouncer.github.io/usage.html
 
 ## Global configuration options <!-- @/docs/includes/plugin_config.md -->
 
@@ -36,15 +43,13 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   # show_commands = ["stats", "pools"]
 ```
 
-### `address`
-
-Specify address via a postgresql connection string:
+To specify the `address` use either a PostgreSQL connection string:
 
 ```text
 host=/run/postgresql port=6432 user=telegraf database=pgbouncer
 ```
 
-Or via an url matching:
+or via an URL of the following form:
 
 ```text
 postgres://[pqgotest[:password]]@host:port[/dbname]?sslmode=[disable|verify-ca|verify-full]
@@ -52,9 +57,9 @@ postgres://[pqgotest[:password]]@host:port[/dbname]?sslmode=[disable|verify-ca|v
 
 All connection parameters are optional.
 
-Without the dbname parameter, the driver will default to a database with the
-same name as the user.  This dbname is just for instantiating a connection with
-the server and doesn't restrict the databases we are trying to grab metrics for.
+Without the `dbname` parameter, the driver will default to a database with the
+same name as the user. The `dbname` is for instantiating a connection with the
+server only and doesn't restrict access to the databases queried.
 
 ## Metrics
 

--- a/plugins/inputs/phpfpm/README.md
+++ b/plugins/inputs/phpfpm/README.md
@@ -1,6 +1,13 @@
 # PHP-FPM Input Plugin
 
-Get phpfpm stats using either HTTP status page or fpm socket.
+This plugin gathers statistics of the [PHP FastCGI Process Manager][phpfpm]
+using either the HTTP status page or the fpm socket.
+
+⭐ Telegraf v0.1.10
+🏷️ server, web
+💻 all
+
+[phpfpm]: https://www.php.net/manual/en/install.fpm.php
 
 ## Global configuration options <!-- @/docs/includes/plugin_config.md -->
 

--- a/plugins/inputs/ping/README.md
+++ b/plugins/inputs/ping/README.md
@@ -1,27 +1,15 @@
 # Ping Input Plugin
 
-Sends a ping message by executing the system ping command and reports the
-results.
+This plugin collects metrics on ICMP ping packets including the round-trip time,
+response times and other packet statistics.
 
-This plugin has two main methods of operation: `exec` and `native`.  The
-recommended method is `native`, which has greater system compatibility and
-performance.  However, for backwards compatibility the `exec` method is the
-default.
+> [!NOTE]
+> When using the `exec` method the `ping` command must be available on the
+> systems and executable by Telegraf.
 
-When using `method = "exec"`, the systems ping utility is executed to send the
-ping packets.
-
-Most ping command implementations are supported, one notable exception being
-that there is currently no support for GNU Inetutils ping.  You may instead use
-the iputils-ping implementation:
-
-```sh
-apt-get install iputils-ping
-```
-
-When using `method = "native"` a ping is sent and the results are reported in
-native Go by the Telegraf process, eliminating the need to execute the system
-`ping` command.
+⭐ Telegraf v0.1.8
+🏷️ network
+💻 all
 
 ## Global configuration options <!-- @/docs/includes/plugin_config.md -->
 
@@ -93,6 +81,26 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   # size = 56
 ```
 
+### Ping methods
+
+This plugin has two main methods of operation, the `exec` and `native` mode.
+The latter is the recommended method as it provides better system compatibility
+and performance. However, for backwards compatibility the `exec` method is the
+default.
+
+When using the `exec` method, most ping command implementations are supported,
+one notable exception being the GNU `inetutils` ping. You may instead use the
+iputils-ping implementation:
+
+```sh
+apt-get install iputils-ping
+```
+
+For the `native` method a corresponding ICMP packet is sent and the results are
+reported in native Go by the Telegraf process, eliminating the need to execute
+the system `ping` command. Therefore, this method doesn't have external
+dependencies.
+
 ### File Limit
 
 Since this plugin runs the ping command, it may need to open multiple files per
@@ -125,8 +133,8 @@ systemctl restart telegraf
 
 ### Linux Permissions
 
-When using `method = "native"`, Telegraf will attempt to use privileged raw ICMP
-sockets.  On most systems, doing so requires `CAP_NET_RAW` capabilities or for
+When using the `native` method, Telegraf will attempt to use privileged raw ICMP
+sockets. On most systems, doing so requires `CAP_NET_RAW` capabilities or for
 Telegraf to be run as root.
 
 With systemd:

--- a/plugins/inputs/postfix/README.md
+++ b/plugins/inputs/postfix/README.md
@@ -1,11 +1,15 @@
 # Postfix Input Plugin
 
-The postfix plugin reports metrics on the postfix queues.
+This plugin collects metrics on a local [Postfix][postfix] instance reporting
+the length, size and age of the active, hold, incoming, maildrop, and deferred
+[queues][queues].
 
-For each of the active, hold, incoming, maildrop, and deferred queues
-(<http://www.postfix.org/QSHAPE_README.html#queues>), it will report the queue
-length (number of items), size (bytes used by items), and age (age of oldest
-item in seconds).
+⭐ Telegraf v1.5.0
+🏷️ server
+💻 freebsd, linux, macos, solaris
+
+[postfix]: https://www.postfix.org/
+[queues]: https://www.postfix.org/QSHAPE_README.html#queues
 
 ## Global configuration options <!-- @/docs/includes/plugin_config.md -->
 

--- a/plugins/inputs/postgresql/README.md
+++ b/plugins/inputs/postgresql/README.md
@@ -1,8 +1,14 @@
 # PostgreSQL Input Plugin
 
-The `postgresql` plugin provides metrics for your PostgreSQL Server instance.
+This plugin provides metrics for a [PostgreSQL][postgres] Server instance.
 Recorded metrics are lightweight and use Dynamic Management Views supplied
 by PostgreSQL.
+
+⭐ Telegraf v0.10.3
+🏷️ datastore
+💻 all
+
+[postgres]: https://www.postgresql.org/
 
 ## Global configuration options <!-- @/docs/includes/plugin_config.md -->
 

--- a/plugins/inputs/postgresql_extensible/README.md
+++ b/plugins/inputs/postgresql_extensible/README.md
@@ -1,15 +1,18 @@
 # PostgreSQL Extensible Input Plugin
 
-This postgresql plugin provides metrics for your postgres database. It has been
-designed to parse SQL queries in the plugin section of your `telegraf.conf`.
+This plugin queries a [PostgreSQL][postgres] server and provides metrics for
+the returned result. This is useful when using PostgreSQL extensions to collect
+additional metrics.
 
-The example below has two queries are specified, with the following parameters:
+> [!TIP]
+> Please also check the more generic [sql input plugin][inputs_sql].
 
-* The SQL query itself
-* The minimum PostgreSQL version supported (the numeric display visible in pg_settings)
-* A boolean to define if the query has to be run against some specific database (defined in the `databases` variable of the plugin section)
-* The name of the measurement
-* A list of the columns to be defined as tags
+⭐ Telegraf v0.12.0
+🏷️ datastore
+💻 all
+
+[postgres]: https://www.postgresql.org/
+[inputs_sql]: /plugins/inputs/sql/README.md
 
 ## Global configuration options <!-- @/docs/includes/plugin_config.md -->
 
@@ -100,16 +103,14 @@ to use them.
 ```
 
 The system can be easily extended using homemade metrics collection tools or
-using postgresql extensions ([pg_stat_statements][1], [pg_proctab][2] or
-[powa][3])
+using the postgresql extensions [pg_stat_statements][pg_stat_statements],
+[pg_proctab][pg_proctab] or [powa][powa].
 
-[1]: http://www.postgresql.org/docs/current/static/pgstatstatements.html
+[pg_stat_statements]: http://www.postgresql.org/docs/current/static/pgstatstatements.html
+[pg_proctab]: https://github.com/markwkm/pg_proctab
+[powa]: http://dalibo.github.io/powa/
 
-[2]: https://github.com/markwkm/pg_proctab
-
-[3]: http://dalibo.github.io/powa/
-
-## Sample Queries
+### Sample Queries
 
 * telegraf.conf postgresql_extensible queries (assuming that you have configured
  correctly your connection)
@@ -165,7 +166,7 @@ using postgresql extensions ([pg_stat_statements][1], [pg_proctab][2] or
   tagvalue="type,enabled"
 ```
 
-## Postgresql Side
+### Postgresql Side
 
 postgresql.conf :
 
@@ -188,7 +189,7 @@ create extension pg_proctab;
 * pg_stat_kcache is available on the postgresql.org yum repo
 * pg_proctab is available at : <https://github.com/markwkm/pg_proctab>
 
-## Views
+### Views
 
 * Blocking sessions
 

--- a/plugins/inputs/powerdns/README.md
+++ b/plugins/inputs/powerdns/README.md
@@ -1,6 +1,16 @@
 # PowerDNS Input Plugin
 
-The powerdns plugin gathers metrics about PowerDNS using unix socket.
+This plugin gathers metrics from [PowerDNS][powerdns] servers using unix
+sockets.
+
+> [!NOTE]
+> This plugin will need access to the powerdns control socket.
+
+⭐ Telegraf v0.10.2
+🏷️ server
+💻 all
+
+[powerdns]: https://www.powerdns.com/
 
 ## Global configuration options <!-- @/docs/includes/plugin_config.md -->
 

--- a/plugins/inputs/powerdns_recursor/README.md
+++ b/plugins/inputs/powerdns_recursor/README.md
@@ -1,7 +1,17 @@
 # PowerDNS Recursor Input Plugin
 
-The `powerdns_recursor` plugin gathers metrics about PowerDNS Recursor using
-the unix controlsocket.
+This plugin gathers metrics from [PowerDNS Recursor][powerdns_recursor]
+instances using the unix control-sockets.
+
+> [!NOTE]
+> Telegraf will need read and write access to the control socket and the
+> `socket_dir`.
+
+⭐ Telegraf v1.11.0
+🏷️ server
+💻 all
+
+[powerdns_recursor]: https://www.powerdns.com/powerdns-recursor
 
 ## Global configuration options <!-- @/docs/includes/plugin_config.md -->
 

--- a/plugins/inputs/processes/README.md
+++ b/plugins/inputs/processes/README.md
@@ -1,12 +1,15 @@
 # Processes Input Plugin
 
-This plugin gathers info about the total number of processes and groups
-them by status (zombie, sleeping, running, etc.)
+This plugin gathers info about the total number of processes and groups them by
+status (zombie, sleeping, running, etc.)
 
-On linux this plugin requires access to procfs (/proc), on other OSes
-it requires access to execute `ps`.
+> [!NOTE]
+> On Linux this plugin requires access to procfs (/proc), on other operating
+> systems the plugin must be able to execute the `ps` command.
 
-**Supported Platforms**: Linux, FreeBSD, Darwin
+⭐ Telegraf v0.11.0
+🏷️ system
+💻 freebsd, linux, macos
 
 ## Global configuration options <!-- @/docs/includes/plugin_config.md -->
 
@@ -73,13 +76,11 @@ Defaults!PS !logfile, !syslog, !pam_session
     - parked (linux only)
     - total_threads (linux only)
 
-## Process State Mappings
-
 Different OSes use slightly different State codes for their processes, these
 state codes are documented in `man ps`, and I will give a mapping of what major
 OS state codes correspond to in telegraf metrics:
 
-```sh
+```text
 Linux  FreeBSD  Darwin  meaning
   R       R       R     running
   S       S       S     sleeping

--- a/plugins/inputs/procstat/README.md
+++ b/plugins/inputs/procstat/README.md
@@ -1,19 +1,14 @@
 # Procstat Input Plugin
 
-The procstat plugin can be used to monitor the system resource usage of one or
-more processes.  The procstat_lookup metric displays the query information,
-specifically the number of PIDs returned on a search
+This plugin allows to monitor the system resource usage of one or more
+processes. The plugin provides metrics about the individual processes as well as
+accumulated metrics on the number of PIDs returned on a search. Processes can
+be filtered e.g. by regular expressions on the command, the user owning the
+process or the service that started the process.
 
-Processes can be selected for monitoring using one of several methods:
-
-- pidfile
-- exe
-- pattern
-- user
-- systemd_unit
-- cgroup
-- supervisor_unit
-- win_service
+⭐ Telegraf v0.2.0
+🏷️ system
+💻 all
 
 ## Global configuration options <!-- @/docs/includes/plugin_config.md -->
 
@@ -137,8 +132,9 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 ### Windows support
 
-Preliminary support for Windows has been added, however you may prefer using
-the `win_perf_counters` input plugin as a more mature alternative.
+The plugin reports process information on Windows, however if you need more
+in-depth information about the process you may prefer using the
+`win_perf_counters` or `win_wmi` input plugins.
 
 ### Darwin specifics
 

--- a/plugins/inputs/prometheus/README.md
+++ b/plugins/inputs/prometheus/README.md
@@ -1,11 +1,14 @@
 # Prometheus Input Plugin
 
-The prometheus input plugin gathers metrics from HTTP servers exposing metrics
-in Prometheus format.
+This plugin gathers metrics from [Prometheus][prometheus] metric endpoints such
+as applications implementing such an endpoint or node-exporter instances. This
+plugin also supports various service-discovery methods.
 
 ⭐ Telegraf v0.1.5
 🏷️ applications, server
 💻 all
+
+[prometheus]: https://prometheus.io/
 
 ## Global configuration options <!-- @/docs/includes/plugin_config.md -->
 

--- a/plugins/inputs/proxmox/README.md
+++ b/plugins/inputs/proxmox/README.md
@@ -1,9 +1,13 @@
 # Proxmox Input Plugin
 
-The proxmox plugin gathers metrics about containers and VMs using the Proxmox
-API.
+This plugin gathers metrics about containers and VMs running on a
+[Proxmox][proxmox] instance using the Proxmox API.
 
-Telegraf minimum version: Telegraf 1.16.0
+⭐ Telegraf v1.16.0
+🏷️ server
+💻 all
+
+[proxmox]: https://www.proxmox.com
 
 ## Global configuration options <!-- @/docs/includes/plugin_config.md -->
 
@@ -62,36 +66,35 @@ pveum user token add influx@pve monitoring -privsep 1
 pveum acl modify / -role PVEAuditor -token 'influx@pve!monitoring'
 ```
 
-See this [Proxmox docs example][1] for further details.
+See this [Proxmox docs example][docs] for further details.
 
-[1]: https://pve.proxmox.com/wiki/User_Management#_limited_api_token_for_monitoring
+[docs]: https://pve.proxmox.com/wiki/User_Management#_limited_api_token_for_monitoring
 
 ## Metrics
 
 - proxmox
-  - status
-  - uptime
-  - cpuload
-  - mem_used
-  - mem_total
-  - mem_free
-  - mem_used_percentage
-  - swap_used
-  - swap_total
-  - swap_free
-  - swap_used_percentage
-  - disk_used
-  - disk_total
-  - disk_free
-  - disk_used_percentage
-
-### Tags
-
-- node_fqdn - FQDN of the node telegraf is running on
-- vm_name - Name of the VM/container
-- vm_fqdn - FQDN of the VM/container
-- vm_type - Type of the VM/container (lxc, qemu)
-- vm_id - ID of the VM/container
+  - tags:
+    - node_fqdn - FQDN of the node telegraf is running on
+    - vm_name - Name of the VM/container
+    - vm_fqdn - FQDN of the VM/container
+    - vm_type - Type of the VM/container (lxc, qemu)
+    - vm_id - ID of the VM/container
+  - fields:
+    - status
+    - uptime
+    - cpuload
+    - mem_used
+    - mem_total
+    - mem_free
+    - mem_used_percentage
+    - swap_used
+    - swap_total
+    - swap_free
+    - swap_used_percentage
+    - disk_used
+    - disk_total
+    - disk_free
+    - disk_used_percentage
 
 ## Example Output
 

--- a/plugins/inputs/puppetagent/README.md
+++ b/plugins/inputs/puppetagent/README.md
@@ -1,81 +1,13 @@
-# PuppetAgent Input Plugin
+# Puppet Agent Input Plugin
 
-The puppetagent plugin collects variables outputted from the
-'last_run_summary.yaml' file usually located in `/var/lib/puppet/state/`
-[PuppetAgent Runs][1].
+This plugin gathers metrics of a [Puppet agent][puppet] by parsing variables
+from the local last-run-summary file.
 
-```sh
-cat /var/lib/puppet/state/last_run_summary.yaml
+⭐ Telegraf v0.2.0
+🏷️ system
+💻 all
 
----
-  events:
-    failure: 0
-    total: 0
-    success: 0
-  resources:
-    failed: 0
-    scheduled: 0
-    changed: 0
-    skipped: 0
-    total: 109
-    failed_to_restart: 0
-    restarted: 0
-    out_of_sync: 0
-  changes:
-    total: 0
-  time:
-    user: 0.004331
-    schedule: 0.001123
-    filebucket: 0.000353
-    file: 0.441472
-    exec: 0.508123
-    anchor: 0.000555
-    yumrepo: 0.006989
-    ssh_authorized_key: 0.000764
-    service: 1.807795
-    package: 1.325788
-    total: 8.85354707064819
-    config_retrieval: 4.75567007064819
-    last_run: 1444936531
-    cron: 0.000584
-  version:
-    config: 1444936521
-    puppet: "3.7.5"
-```
-
-```sh
-jcross@pit-devops-02 ~ >sudo ./telegraf_linux_amd64 --input-filter puppetagent --config tele.conf --test
-* Plugin: puppetagent, Collection 1
-> [] puppetagent_events_failure value=0
-> [] puppetagent_events_total value=0
-> [] puppetagent_events_success value=0
-> [] puppetagent_resources_failed value=0
-> [] puppetagent_resources_scheduled value=0
-> [] puppetagent_resources_changed value=0
-> [] puppetagent_resources_skipped value=0
-> [] puppetagent_resources_total value=109
-> [] puppetagent_resources_failedtorestart value=0
-> [] puppetagent_resources_restarted value=0
-> [] puppetagent_resources_outofsync value=0
-> [] puppetagent_changes_total value=0
-> [] puppetagent_time_user value=0.00393
-> [] puppetagent_time_schedule value=0.001234
-> [] puppetagent_time_filebucket value=0.000244
-> [] puppetagent_time_file value=0.587734
-> [] puppetagent_time_exec value=0.389584
-> [] puppetagent_time_anchor value=0.000399
-> [] puppetagent_time_sshauthorizedkey value=0.000655
-> [] puppetagent_time_service value=0
-> [] puppetagent_time_package value=1.297537
-> [] puppetagent_time_total value=9.45297606225586
-> [] puppetagent_time_configretrieval value=5.89822006225586
-> [] puppetagent_time_lastrun value=1444940131
-> [] puppetagent_time_cron value=0.000646
-> [] puppetagent_version_config value=1444940121
-> [] puppetagent_version_puppet value=3.7.5
-```
-
-[1]: https://puppet.com/blog/puppet-monitoring-how-to-monitor-success-or-failure-of-puppet-runs/
+[puppet]: https://www.puppet.com/
 
 ## Global configuration options <!-- @/docs/includes/plugin_config.md -->
 
@@ -166,3 +98,7 @@ Measurement names:
 - puppetagent_version_puppet
 
 ## Example Output
+
+```text
+puppetagent,location=last_run_summary.yaml changes_total=0i,events_failure=0i,events_noop=0i,events_success=0i,events_total=0i,resources_changed=0i,resources_correctivechange=0i,resources_failed=0i,resources_failedtorestart=0i,resources_outofsync=0i,resources_restarted=0i,resources_scheduled=0i,resources_skipped=0i,resources_total=109i,time_anchor=0.000555,time_catalogapplication=0.010555,time_configretrieval=4.75567007064819,time_convertcatalog=1.3,time_cron=0.000584,time_exec=0.508123,time_factgeneration=0.34,time_file=0.441472,time_filebucket=0.000353,time_group=0,time_lastrun=1444936531i,time_noderetrieval=1.235,time_notify=0.00035,time_package=1.325788,time_pluginsync=0.325788,time_schedule=0.001123,time_service=1.807795,time_sshauthorizedkey=0.000764,time_total=8.85354707064819,time_transactionevaluation=4.69765,time_user=0.004331,version_configstring="environment:d6018ce",version_puppet="3.7.5" 1747757240432097335
+```


### PR DESCRIPTION
## Summary

This PR adds some metadata to the input plugins starting with o like the version this plugin was introduced, labels and the supported operating systems. Furthermore, the PR unifies the plugin descriptions a bit and uses [Github Markdown alerts](https://docs.github.com/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts) for notes and other important information.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues
