### PR TITLE
fix(inputs.opcua): Fix integration test

### DIFF
--- a/plugins/inputs/opcua/opcua_test.go
+++ b/plugins/inputs/opcua/opcua_test.go
@@ -588,13 +588,15 @@ func TestConsecutiveSessionErrorRecoveryIntegration(t *testing.T) {
 	require.Equal(t, uint64(0), o.consecutiveErrors, "Should reset consecutive errors after successful gather")
 
 	// Simulate multiple consecutive errors with bad endpoint
-	originalEndpoint := o.client.Config.OpcUAClientConfig.Endpoint
-	o.client.Config.OpcUAClientConfig.Endpoint = "opc.tcp://invalid-endpoint:4840"
+	originalEndpoint := o.client.OpcUAClient.Config.Endpoint
+	o.client.OpcUAClient.Config.Endpoint = "opc.tcp://invalid-endpoint:4840"
+	require.NoError(t, o.client.Disconnect(t.Context()))
 
 	// Next gather should fail
 	acc.ClearMetrics()
 	require.Error(t, o.Gather(acc))
 	require.Equal(t, uint64(1), o.consecutiveErrors)
+	require.False(t, o.client.forceReconnect, "Session should not be invalidated yet")
 
 	// Another failure should increment consecutive errors and trigger session invalidation
 	acc.ClearMetrics()
@@ -603,7 +605,7 @@ func TestConsecutiveSessionErrorRecoveryIntegration(t *testing.T) {
 	require.True(t, o.client.forceReconnect, "Should force session invalidation after multiple errors")
 
 	// Restore endpoint to allow recovery
-	o.client.Config.OpcUAClientConfig.Endpoint = originalEndpoint
+	o.client.OpcUAClient.Config.Endpoint = originalEndpoint
 
 	// Next gather should succeed and reset error counter
 	acc.ClearMetrics()


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
--- FAIL: TestConsecutiveSessionErrorRecoveryIntegration (5.84s)
    opcua_test.go:596: 
                Error Trace:    /home/circleci/project/plugins/inputs/opcua/opcua_test.go:596
                Error:          An error is expected but got nil.
                Test:           TestConsecutiveSessionErrorRecoveryIntegration

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
