### PR TITLE
feat(agent): Add debounce for watch events

### DIFF
--- a/cmd/telegraf/main.go
+++ b/cmd/telegraf/main.go
@@ -231,6 +231,7 @@ func runApp(args []string, outputBuffer io.Writer, pprof Server, c TelegrafConfi
 			configURLWatchInterval:  cCtx.Duration("config-url-watch-interval"),
 			watchConfig:             cCtx.String("watch-config"),
 			watchInterval:           cCtx.Duration("watch-interval"),
+			watchDebounceInterval:   cCtx.Duration("watch-debounce-interval"),
 			pidFile:                 cCtx.String("pidfile"),
 			plugindDir:              cCtx.String("plugin-directory"),
 			password:                cCtx.String("password"),
@@ -294,6 +295,12 @@ func runApp(args []string, outputBuffer io.Writer, pprof Server, c TelegrafConfi
 					Name: "watch-config",
 					Usage: "monitoring config changes [notify, poll] of --config and --config-directory options. " +
 						"Notify supports linux, *bsd, and macOS. Poll is required for Windows and checks every 250ms.",
+				},
+				&cli.DurationFlag{
+					Name:        "watch-debounce-interval",
+					Usage:       "Time duration to wait after a config change before reloading",
+					DefaultText: "0s",
+					Value:       0,
 				},
 				&cli.StringFlag{
 					Name:  "pidfile",

--- a/cmd/telegraf/telegraf.go
+++ b/cmd/telegraf/telegraf.go
@@ -234,18 +234,43 @@ func (t *Telegraf) watchLocalConfig(ctx context.Context, signals chan os.Signal,
 	log.Printf("I! Config watcher started for %s\n", fConfig)
 
 	// Setup debounce timer
-	reloadTimer := time.NewTimer(t.watchDebounceInterval)
-	reloadTimer.Stop() // stop immediately to avoid triggering reload
-	reloadPending := false
-
-	// Helper to reset the timer and mark reload as pending
-	resetTimer := func(reason string) {
-		if !reloadPending {
-			reloadPending = true
-		}
-		reloadTimer.Reset(t.watchDebounceInterval)
-		log.Printf("%s", reason)
-	}
+	var reloadTimer *time.Timer
+        var reloadPending bool
+        
+        if t.watchDebounceInterval > 0 {
+            reloadTimer = time.NewTimer(t.watchDebounceInterval)
+            if !reloadTimer.Stop() {
+                <-reloadTimer.C // Drain if already fired
+            }
+        }
+        
+        // Update resetTimer function:
+        resetTimer := func(reason string) {
+            log.Printf("%s", reason)
+            
+            if t.watchDebounceInterval == 0 {
+                // No debouncing - trigger immediately
+                select {
+                case signals <- syscall.SIGHUP:
+                case <-ctx.Done():
+                    return
+                }
+                return
+            }
+            
+            if !reloadPending {
+                reloadPending = true
+            }
+            
+            // Properly drain and reset timer
+            if !reloadTimer.Stop() {
+                select {
+                case <-reloadTimer.C:
+                default:
+                }
+            }
+            reloadTimer.Reset(t.watchDebounceInterval)
+        }
 
 	for {
 		select {
@@ -257,16 +282,24 @@ func (t *Telegraf) watchLocalConfig(ctx context.Context, signals chan os.Signal,
 		case <-changes.Modified:
 			resetTimer(fmt.Sprintf("I! Config file/directory %q modified\n", fConfig))
 
-		case <-changes.Deleted:
-			// deleted can mean moved. wait a bit a check existence
-			<-time.After(time.Second)
-			var reason string
-			if _, err := os.Stat(fConfig); err == nil {
-				reason = fmt.Sprintf("I! Config file/directory %q overwritten\n", fConfig)
-			} else {
-				reason = fmt.Sprintf("W! Config file/directory %q deleted\n", fConfig)
-			}
-			resetTimer(reason)
+		    case <-changes.Deleted:
+                              // Use select with timeout instead of blocking wait
+                              timer := time.NewTimer(time.Second)
+                              select {
+                              case <-timer.C:
+                                  // Proceed with file existence check
+                              case <-ctx.Done():
+                                  timer.Stop()
+                                  return
+                              }
+                              
+                              var reason string
+                              if _, err := os.Stat(fConfig); err == nil {
+                                  reason = fmt.Sprintf("I! Config file/directory %q overwritten\n", fConfig)
+                              } else {
+                                  reason = fmt.Sprintf("W! Config file/directory %q deleted\n", fConfig)
+                              }
+                              resetTimer(reason)
 
 		case <-changes.Truncated:
 			resetTimer(fmt.Sprintf("I! Config file/directory %q truncated\n", fConfig))
@@ -274,12 +307,22 @@ func (t *Telegraf) watchLocalConfig(ctx context.Context, signals chan os.Signal,
 		case <-changes.Created:
 			resetTimer(fmt.Sprintf("I! Config directory %q has new file(s)\n", fConfig))
 
-		case <-reloadTimer.C:
-			if reloadPending {
-				log.Printf("I! Debounce period elapsed, triggering config reload for %q\n", fConfig)
-				signals <- syscall.SIGHUP
-				reloadPending = false
-			}
+                case <-func() <-chan time.Time {
+                    if reloadTimer != nil {
+                        return reloadTimer.C
+                    }
+                    // Return a channel that never fires when debouncing is disabled
+                    return make(<-chan time.Time)
+                }():
+                    if reloadPending {
+                        log.Printf("I! Debounce period elapsed, triggering config reload for %q\n", fConfig)
+                        select {
+                        case signals <- syscall.SIGHUP:
+                        case <-ctx.Done():
+                            return
+                        }
+                        reloadPending = false
+                    }
 
 		case <-mytomb.Dying():
 			reloadTimer.Stop()


### PR DESCRIPTION
## Summary
This PR implements a debounce mechanism for configuration file watching that batches multiple file changes into a single reload operation.
### Changes Made
- **Added `--watch-debounce-interval` CLI flag** to configure the debounce duration (default: 0s for backward compatibility)
- **Implemented timer-based debouncing** in `watchLocalConfig()` function that:
  - Starts a timer when the first file change is detected
  - Resets the timer if additional changes occur during the wait period  
  - Only triggers reload (`SIGHUP`) after the timer expires without interruption
- **Enhanced state tracking** with `reloadPending` flag to prevent unnecessary operations
- **Applied debouncing to all file events**: Modified, Deleted, Truncated, and Created
- **Proper resource cleanup** with timer management in all exit paths

### Behavior Change
- **Before**: 500 config file changes → 500 separate reloads
- **After**: 500 config file changes → 1 batched reload (when debounce interval > 0)
- **Backward Compatible**: Default behavior unchanged (0s debounce = immediate reload)

### Usage Example
```bash
# Enable debouncing with 5-second wait period
telegraf --config-directory /configs --watch-config=notify --watch-debounce-interval=5s
```

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #17047 


```console
➜  telegraf git:(debounce-reload) ✗ go run . --config-directory debounce --watch-config=notify --config agent.conf --watch-debounce-interval=10s
2025-05-21T16:52:12Z I! Loading config: agent.conf
2025-05-21T16:52:12Z I! Loading config: debounce/file0.conf
2025-05-21T16:52:12Z I! Loading config: debounce/file1.conf
2025-05-21T16:52:12Z I! Loading config: debounce/file2.conf
2025-05-21T16:52:12Z I! Starting Telegraf unknown brought to you by InfluxData the makers of InfluxDB
2025-05-21T16:52:12Z I! Available plugins: 241 inputs, 9 aggregators, 34 processors, 26 parsers, 64 outputs, 5 secret-stores
2025-05-21T16:52:12Z I! Loaded inputs: mem (3x)
2025-05-21T16:52:12Z I! Loaded aggregators:
2025-05-21T16:52:12Z I! Loaded processors:
2025-05-21T16:52:12Z I! Loaded secretstores:
2025-05-21T16:52:12Z I! Loaded outputs: file (3x)
2025-05-21T16:52:12Z I! Tags enabled: host=hostname
2025-05-21T16:52:12Z I! [agent] Config: Interval:10s, Quiet:false, Hostname:"hostname", Flush Interval:10s
2025-05-21T16:52:12Z W! [agent] The default value of 'skip_processors_after_aggregators' will change to 'true' with Telegraf v1.40.0! If you need the current default behavior, please explicitly set the option to 'false'!
2025-05-21T16:52:12Z I! Config watcher started for debounce/file0.conf
2025-05-21T16:52:12Z I! Config watcher started for debounce/file2.conf
2025-05-21T16:52:12Z I! Config watcher started for debounce/file1.conf
2025-05-21T16:52:12Z I! Config watcher started for agent.conf
2025-05-21T16:52:12Z I! Config watcher started for debounce
2025-05-21T16:52:28Z I! Config file/directory "debounce" modified
2025-05-21T16:52:28Z I! Config file/directory "debounce" modified
2025-05-21T16:52:28Z I! Config file/directory "debounce" modified
2025-05-21T16:52:38Z I! Debounce period elapsed, triggering config reload for "debounce"
2025-05-21T16:52:38Z I! Reloading Telegraf config
2025-05-21T16:52:38Z I! [agent] Hang on, flushing any cached metrics before shutdown
2025-05-21T16:52:38Z I! [agent] Stopping running outputs
2025-05-21T16:52:38Z I! Config watcher started for agent.conf
2025-05-21T16:52:38Z I! Config watcher started for debounce/file0.conf
2025-05-21T16:52:38Z I! Loading config: agent.conf
2025-05-21T16:52:38Z I! Config watcher started for debounce/file2.conf
2025-05-21T16:52:38Z I! Config watcher started for debounce/file1.conf
2025-05-21T16:52:38Z I! Config watcher started for debounce
2025-05-21T16:52:38Z I! Loading config: debounce/file0.conf
2025-05-21T16:52:38Z I! Loading config: debounce/file1.conf
2025-05-21T16:52:38Z I! Loading config: debounce/file2.conf
2025-05-21T16:52:38Z I! Starting Telegraf unknown brought to you by InfluxData the makers of InfluxDB
2025-05-21T16:52:38Z I! Available plugins: 241 inputs, 9 aggregators, 34 processors, 26 parsers, 64 outputs, 5 secret-stores
2025-05-21T16:52:38Z I! Loaded inputs: mem (3x)
2025-05-21T16:52:38Z I! Loaded aggregators:
2025-05-21T16:52:38Z I! Loaded processors:
2025-05-21T16:52:38Z I! Loaded secretstores:
2025-05-21T16:52:38Z I! Loaded outputs: file (3x)
2025-05-21T16:52:38Z I! Tags enabled: host=hostname
2025-05-21T16:52:38Z I! [agent] Config: Interval:120s, Quiet:false, Hostname:"hostname", Flush Interval:10s
2025-05-21T16:52:38Z W! [agent] The default value of 'skip_processors_after_aggregators' will change to 'true' with Telegraf v1.40.0! If you need the current default behavior, please explicitly set the option to 'false'!
```
Essentially, the config watcher will wait for 10 seconds after the last change to the config directory before reloading the config. This is useful when you have multiple files in a directory and you want to avoid reloading the config multiple times if they are changed in quick succession.
