### PR TITLE
feat(inputs.opcua): Allow forcing reconnection on every gather cycle

### DIFF
--- a/plugins/inputs/opcua/opcua_test.go
+++ b/plugins/inputs/opcua/opcua_test.go
@@ -1,7 +1,6 @@
 package opcua
 
 import (
-	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -668,7 +667,7 @@ func TestReconnectErrorThresholdDefaultIntegration(t *testing.T) {
 	// Simulate connection failure by using invalid endpoint
 	originalEndpoint := o.client.OpcUAClient.Config.Endpoint
 	o.client.OpcUAClient.Config.Endpoint = "opc.tcp://invalid-endpoint:4840"
-	require.NoError(t, o.client.Disconnect(context.Background()))
+	require.NoError(t, o.client.Disconnect(t.Context()))
 
 	// First error should trigger forceReconnect (threshold = 1)
 	acc.ClearMetrics()
@@ -806,7 +805,7 @@ func TestReconnectErrorThresholdThreeIntegration(t *testing.T) {
 	// Simulate connection failures by using invalid endpoint
 	originalEndpoint := o.client.OpcUAClient.Config.Endpoint
 	o.client.OpcUAClient.Config.Endpoint = "opc.tcp://invalid-endpoint:4840"
-	require.NoError(t, o.client.Disconnect(context.Background()))
+	require.NoError(t, o.client.Disconnect(t.Context()))
 
 	// First error - should NOT trigger forceReconnect yet
 	acc.ClearMetrics()

--- a/plugins/inputs/opcua/read_client.go
+++ b/plugins/inputs/opcua/read_client.go
@@ -20,7 +20,7 @@ type readClientWorkarounds struct {
 }
 
 type readClientConfig struct {
-	ReconnectErrorThreshold uint64                `toml:"reconnect_error_threshold"`
+	ReconnectErrorThreshold *uint64               `toml:"reconnect_error_threshold"`
 	ReadRetryTimeout        config.Duration       `toml:"read_retry_timeout"`
 	ReadRetries             uint64                `toml:"read_retry_count"`
 	ReadClientWorkarounds   readClientWorkarounds `toml:"request_workarounds"`
@@ -61,9 +61,13 @@ func (rc *readClientConfig) createReadClient(log telegraf.Logger) (*readClient, 
 	}
 
 	// Set default for ReconnectErrorThreshold if not configured
-	reconnectThreshold := rc.ReconnectErrorThreshold
-	if reconnectThreshold == 0 {
-		reconnectThreshold = 1 // Default value
+	var reconnectThreshold uint64
+	if rc.ReconnectErrorThreshold == nil {
+		// Not set by user, use default
+		reconnectThreshold = 1
+	} else {
+		// Explicitly set by user, use their value (including 0)
+		reconnectThreshold = *rc.ReconnectErrorThreshold
 	}
 
 	return &readClient{

--- a/plugins/inputs/opcua/read_client.go
+++ b/plugins/inputs/opcua/read_client.go
@@ -64,7 +64,7 @@ func (rc *readClientConfig) createReadClient(log telegraf.Logger) (*readClient, 
 	// Use the default value of reconnect after every error and
 	// allow the user to override that setting including forcing
 	// a reconnect after every cycle by setting zero.
-	reconnectThreshold := 1
+	reconnectThreshold := uint64(1)
 	if rc.ReconnectErrorThreshold != nil {
 		reconnectThreshold = *rc.ReconnectErrorThreshold
 	}

--- a/plugins/inputs/opcua/read_client.go
+++ b/plugins/inputs/opcua/read_client.go
@@ -61,12 +61,11 @@ func (rc *readClientConfig) createReadClient(log telegraf.Logger) (*readClient, 
 	}
 
 	// Set default for ReconnectErrorThreshold if not configured
-	var reconnectThreshold uint64
-	if rc.ReconnectErrorThreshold == nil {
-		// Not set by user, use default
-		reconnectThreshold = 1
-	} else {
-		// Explicitly set by user, use their value (including 0)
+	// Use the default value of reconnect after every error and
+	// allow the user to override that setting including forcing
+	// a reconnect after every cycle by setting zero.
+	reconnectThreshold := 1
+	if rc.ReconnectErrorThreshold != nil {
 		reconnectThreshold = *rc.ReconnectErrorThreshold
 	}
 


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
This issue was raised in [this comment](https://github.com/influxdata/telegraf/pull/16854#issuecomment-2902052562) following our recent work on [handling session invalidation between gather cycles](https://github.com/influxdata/telegraf/pull/16854).

### Problem
Users with long polling intervals (>1 minute) experience alternating success/failure patterns due to OPC UA session timeouts. The current implementation prevents setting `reconnect_error_threshold = 0` because it forces zero values to default to 1, making it impossible to achieve proactive reconnection behavior.

### Root Cause
With long polling intervals, OPC UA sessions often become stale between reads, leading to this cycle:
1. First read fails (stale session detected)
2. Reconnection is forced for next cycle  
3. Second read succeeds (fresh session)
4. Session becomes stale again during long wait
5. Cycle repeats

The fix is to allow setting `reconnect_error_threshold = 0` so that it can reconnect on every gather cycle.

### Configuration Examples
```toml
# Not configured - uses default of 1 (reconnect after first error)
# reconnect_error_threshold = 

# Set to 0 - forces reconnection every gather (ideal for long polling)
reconnect_error_threshold = 0

# Set to 3 - reconnects after 3 consecutive errors
reconnect_error_threshold = 3
```

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
