### PR TITLE
feat(inputs.rapl): Add plugin

### DIFF
--- a/plugins/inputs/all/rapl.go
+++ b/plugins/inputs/all/rapl.go
@@ -1,0 +1,5 @@
+//go:build !custom || inputs || inputs.rapl
+
+package all
+
+import _ "github.com/influxdata/telegraf/plugins/inputs/rapl" // register plugin

--- a/plugins/inputs/rapl/README.md
+++ b/plugins/inputs/rapl/README.md
@@ -1,0 +1,63 @@
+# RAPL Input Plugin
+
+This plugin reports the system energy consumption via the Intel RAPL interface.
+
+⭐ Telegraf v1.35.0
+🏷️ server,system
+💻 linux
+
+## Prerequisites
+
+This plugin requires an Intel or AMD processor supporting the Intel RAPL
+interface, and the associated Linux kernel modules. The system meets the
+requirements if `/sys/devices/virtual/powercap` exists.
+
+This plugin requires either that you run Telegraf as `root` (not recommended)
+or that you grant unprivileged users read permissions to the RAPL energy
+counters (recommended). The following instructions configure `udev` to grant
+the necessary permissions at startup time.
+
+Copy `rapl_init.sh` to `/usr/local/bin/rapl_init.sh`.
+
+Create `/etc/udev/rules.d/99-rapl.rules` with the following contents.
+
+```text
+SUBSYSTEM=="powercap", RUN+="/usr/local/bin/rapl_init.sh"
+```
+
+## Global configuration options <!-- @/docs/includes/plugin_config.md -->
+
+In addition to the plugin-specific configuration settings, plugins support
+additional global and plugin configuration settings. These settings are used to
+modify metrics, tags, and field or create aliases and configure ordering, etc.
+See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
+
+[CONFIGURATION.md]: ../../../docs/CONFIGURATION.md#plugins
+
+## Configuration
+
+```toml
+[[inputs.rapl]]
+```
+
+## Metrics
+
+- rapl
+  - tags:
+    - name - the human-readable name of the power zone (e.g.: `package-0`)
+    - power_zone - the system name of the power zone (e.g.: `intel-rapl:0`)
+  - fields:
+    - energy_joules - the energy counter
+
+Note: The plugin reports the values of the raw RAPL energy counters in Joules.
+To convert energy (Joules) into power (Watt), compute the derivative of the
+energy with respect to time. A practical approach to estimate this derivative
+is to calculate the energy difference between two consecutive metrics and
+divide it by the time interval between them.
+
+## Example Output
+
+```text
+rapl,name=package-0,power_zone=intel-rapl:0 energy_joules=55485.71523
+rapl,name=core,power_zone=intel-rapl:0:0 energy_joules=564.946583
+```

--- a/plugins/inputs/rapl/rapl.go
+++ b/plugins/inputs/rapl/rapl.go
@@ -1,0 +1,178 @@
+//go:build linux && amd64
+
+package rapl
+
+import (
+	_ "embed"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/plugins/inputs"
+)
+
+const intelRAPLDir = "/sys/devices/virtual/powercap/intel-rapl"
+const powerZonePrefix = "intel-rapl"
+
+//go:embed sample.conf
+var sampleConfig string
+
+type RAPL struct {
+	Log telegraf.Logger `toml:"-"`
+
+	rapl           intelRAPL
+	powerZones     []powerZone
+	powerZoneNames []string
+}
+
+func (o *RAPL) Gather(acc telegraf.Accumulator) error {
+	for i, zone := range o.powerZones {
+		energy, err := o.rapl.readEnergy(&zone)
+		if err != nil {
+			return err
+		}
+		fields := map[string]interface{}{
+			"energy_joules": float64(energy) / 1e6,
+		}
+		tags := map[string]string{
+			"name":       o.powerZoneNames[i],
+			"power_zone": zone.name(),
+		}
+		acc.AddFields("rapl", fields, tags)
+	}
+	return nil
+}
+
+func (*RAPL) SampleConfig() string {
+	return sampleConfig
+}
+
+func (o *RAPL) Start(_ telegraf.Accumulator) error {
+	o.rapl = intelRAPL{dir: intelRAPLDir}
+	// Reads and caches the power zones.
+	zones, err := o.rapl.powerZones()
+	if err != nil {
+		return err
+	}
+	o.powerZones = zones
+	// Reads and caches the power zone names.
+	o.powerZoneNames = make([]string, 0)
+	for _, zone := range o.powerZones {
+		name, err := o.rapl.readName(&zone)
+		if err != nil {
+			return err
+		}
+		o.powerZoneNames = append(o.powerZoneNames, name)
+	}
+	return nil
+}
+
+func (*RAPL) Stop() {
+}
+
+func init() {
+	inputs.Add("rapl", func() telegraf.Input {
+		return &RAPL{}
+	})
+}
+
+// Represents a RAPL power zone.
+type powerZone struct {
+	ids []int
+}
+
+// Parses a directory name into a power zone.
+func parsePowerZone(name string) (*powerZone, error) {
+	if !strings.HasPrefix(name, powerZonePrefix) {
+		return nil, fmt.Errorf("invalid power zone %s", name)
+	}
+	ids := make([]int, 0)
+	for _, s := range strings.Split(name, ":")[1:] {
+		id, err := strconv.Atoi(s)
+		if err != nil {
+			return nil, fmt.Errorf("invalid power zone %s: %w", name, err)
+		}
+		ids = append(ids, id)
+	}
+	return &powerZone{ids: ids}, nil
+}
+
+// Returns the directory name of a power zone.
+// Example: `intel-rapl:0:0`.
+func (o *powerZone) name() string {
+	parts := make([]string, len(o.ids)+1)
+	parts[0] = powerZonePrefix
+	for i, id := range o.ids {
+		parts[i+1] = strconv.Itoa(id)
+	}
+	return strings.Join(parts, ":")
+}
+
+// Returns the complete relative path to a power zone.
+// Example: `intel-rapl:0/intel-rapl:0:0`.
+func (o *powerZone) path() string {
+	parts := make([]string, len(o.ids))
+	for i := range len(o.ids) {
+		zone := &powerZone{o.ids[:i+1]}
+		parts[i] = zone.name()
+	}
+	return filepath.Join(parts...)
+}
+
+// Represents an Intel RAPL interface.
+type intelRAPL struct {
+	dir string
+}
+
+// Returns the power zones in an Intel RAPL interface.
+func (o *intelRAPL) powerZones() ([]powerZone, error) {
+	zones := make([]powerZone, 0)
+	todo := []string{o.dir}
+	for len(todo) > 0 {
+		path := todo[0]
+		todo = todo[1:]
+		files, err := os.ReadDir(path)
+		if err != nil {
+			return nil, err
+		}
+		for _, file := range files {
+			name := file.Name()
+			zone, err := parsePowerZone(name)
+			if err != nil {
+				continue
+			}
+			zonePath := filepath.Join(path, name)
+			if zonePath != filepath.Join(o.dir, zone.path()) {
+				return nil, fmt.Errorf("incorrectly nested power zone %s", zonePath)
+			}
+			zones = append(zones, *zone)
+			todo = append(todo, zonePath)
+		}
+	}
+	return zones, nil
+}
+
+// Reads the human-readable name of a power zone.
+func (o *intelRAPL) readName(zone *powerZone) (string, error) {
+	b, err := os.ReadFile(filepath.Join(o.dir, zone.path(), "name"))
+	if err != nil {
+		return "", fmt.Errorf("could not read name: %w", err)
+	}
+	return strings.TrimSuffix(string(b), "\n"), nil
+}
+
+// Reads the energy of a power zone in micro joules (uJ).
+func (o *intelRAPL) readEnergy(zone *powerZone) (uint64, error) {
+	b, err := os.ReadFile(filepath.Join(o.dir, zone.path(), "energy_uj"))
+	if err != nil {
+		return 0, fmt.Errorf("could not read energy: %w", err)
+	}
+	energy, err := strconv.ParseUint(strings.TrimSuffix(string(b), "\n"), 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("could not read energy: %w", err)
+	}
+	return energy, nil
+}

--- a/plugins/inputs/rapl/rapl_init.sh
+++ b/plugins/inputs/rapl/rapl_init.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+find /sys/devices/virtual/powercap/intel-rapl -type f -name energy_uj -exec chmod 444 {} \;

--- a/plugins/inputs/rapl/rapl_notamd64linux.go
+++ b/plugins/inputs/rapl/rapl_notamd64linux.go
@@ -1,0 +1,33 @@
+//go:generate ../../../tools/readme_config_includer/generator
+//go:build !linux || !amd64
+
+package rapl
+
+import (
+	_ "embed"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/plugins/inputs"
+)
+
+//go:embed sample.conf
+var sampleConfig string
+
+type RAPL struct {
+	Log telegraf.Logger `toml:"-"`
+}
+
+func (*RAPL) SampleConfig() string { return sampleConfig }
+
+func (o *RAPL) Init() error {
+	o.Log.Warn("Current platform is not supported")
+	return nil
+}
+
+func (*RAPL) Gather(telegraf.Accumulator) error { return nil }
+
+func init() {
+	inputs.Add("rapl", func() telegraf.Input {
+		return &RAPL{}
+	})
+}

--- a/plugins/inputs/rapl/rapl_test.go
+++ b/plugins/inputs/rapl/rapl_test.go
@@ -1,0 +1,259 @@
+//go:build linux && amd64
+
+package rapl
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParsePowerZone(t *testing.T) {
+	tests := []struct {
+		name string
+		zone *powerZone
+		err  string
+	}{
+		{
+			name: "intel-rapl:0",
+			zone: &powerZone{ids: []int{0}},
+			err:  "",
+		},
+		{
+			name: "intel-rapl:12:34",
+			zone: &powerZone{ids: []int{12, 34}},
+			err:  "",
+		},
+		{
+			name: "foo:0",
+			zone: nil,
+			err:  "invalid power zone",
+		},
+		{
+			name: "intel-rapl:X:Y",
+			zone: nil,
+			err:  "invalid power zone",
+		},
+	}
+	for i, tt := range tests {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			zone, err := parsePowerZone(tt.name)
+			if tt.err == "" {
+				require.NoError(t, err)
+			} else {
+				assert.Contains(t, err.Error(), tt.err)
+			}
+			assert.Equal(t, tt.zone, zone)
+		})
+	}
+}
+
+func TestPowerZoneName(t *testing.T) {
+	tests := []struct {
+		zone *powerZone
+		name string
+	}{
+		{
+			zone: &powerZone{[]int{0}},
+			name: "intel-rapl:0",
+		},
+		{
+			zone: &powerZone{[]int{12, 34}},
+			name: "intel-rapl:12:34",
+		},
+	}
+	for i, tt := range tests {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			assert.Equal(t, tt.name, tt.zone.name())
+		})
+	}
+}
+
+func TestPowerZonePath(t *testing.T) {
+	tests := []struct {
+		zone *powerZone
+		path string
+	}{
+		{
+			zone: &powerZone{[]int{0}},
+			path: "intel-rapl:0",
+		},
+		{
+			zone: &powerZone{[]int{12, 34}},
+			path: "intel-rapl:12/intel-rapl:12:34",
+		},
+	}
+	for i, tt := range tests {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			assert.Equal(t, tt.path, tt.zone.path())
+		})
+	}
+}
+
+func TestReadName(t *testing.T) {
+	tests := []struct {
+		files map[string]string
+		zone  *powerZone
+		name  string
+		err   string
+	}{
+		{
+			files: map[string]string{
+				"intel-rapl:0/name": "package-0",
+			},
+			zone: &powerZone{ids: []int{0}},
+			name: "package-0",
+			err:  "",
+		},
+		{
+			files: map[string]string{
+				"intel-rapl:0/intel-rapl:0:0/name": "core",
+			},
+			zone: &powerZone{ids: []int{0, 0}},
+			name: "core",
+			err:  "",
+		},
+		{
+			files: map[string]string{},
+			zone:  &powerZone{ids: []int{12, 23}},
+			name:  "",
+			err:   "could not read name",
+		},
+	}
+	for i, tt := range tests {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			dir, err := createTempFiles(tt.files)
+			require.NoError(t, err)
+			defer os.RemoveAll(dir)
+			rapl := intelRAPL{dir: dir}
+			name, err := rapl.readName(tt.zone)
+			if tt.err == "" {
+				require.NoError(t, err)
+			} else {
+				assert.Contains(t, err.Error(), tt.err)
+			}
+			assert.Equal(t, tt.name, name)
+		})
+	}
+}
+
+func TestReadEnergy(t *testing.T) {
+	tests := []struct {
+		files  map[string]string
+		zone   *powerZone
+		energy uint64
+		err    string
+	}{
+		{
+			files: map[string]string{
+				"intel-rapl:0/energy_uj": "12345",
+			},
+			zone:   &powerZone{ids: []int{0}},
+			energy: 12345,
+			err:    "",
+		},
+		{
+			files: map[string]string{
+				"intel-rapl:0/intel-rapl:0:0/energy_uj": "54321",
+			},
+			zone:   &powerZone{ids: []int{0, 0}},
+			energy: 54321,
+			err:    "",
+		},
+		{
+			files:  map[string]string{},
+			zone:   &powerZone{ids: []int{12, 23}},
+			energy: 0,
+			err:    "could not read energy",
+		},
+	}
+	for i, tt := range tests {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			dir, err := createTempFiles(tt.files)
+			require.NoError(t, err)
+			defer os.RemoveAll(dir)
+			rapl := intelRAPL{dir: dir}
+			energy, err := rapl.readEnergy(tt.zone)
+			if tt.err == "" {
+				require.NoError(t, err)
+			} else {
+				assert.Contains(t, err.Error(), tt.err)
+			}
+			assert.Equal(t, tt.energy, energy)
+		})
+	}
+}
+
+func TestPowerZones(t *testing.T) {
+	tests := []struct {
+		files map[string]string
+		zones []powerZone
+		err   string
+	}{
+		{
+			files: map[string]string{
+				"intel-rapl:0/name":                "package-0",
+				"intel-rapl:0/intel-rapl:0:0/name": "core",
+			},
+			zones: []powerZone{{ids: []int{0}}, {ids: []int{0, 0}}},
+			err:   "",
+		},
+		{
+			files: map[string]string{
+				"intel-rapl:0/name":                  "package-0",
+				"intel-rapl:0/intel-rapl:12:34/name": "core",
+			},
+			zones: nil,
+			err:   "incorrectly nested power zone",
+		},
+	}
+	for i, tt := range tests {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			dir, err := createTempFiles(tt.files)
+			require.NoError(t, err)
+			defer os.RemoveAll(dir)
+			rapl := intelRAPL{dir: dir}
+			zones, err := rapl.powerZones()
+			if tt.err == "" {
+				require.NoError(t, err)
+			} else {
+				assert.Contains(t, err.Error(), tt.err)
+			}
+			assert.Equal(t, tt.zones, zones)
+		})
+	}
+}
+
+// Creates a temporary directory with the given files.
+// We cannot rely on a testdata dir, because we require file names containing ":".
+func createTempFiles(files map[string]string) (string, error) {
+	dirPath, err := os.MkdirTemp("/tmp", "testdata")
+	if err != nil {
+		return "", err
+	}
+	for path, contents := range files {
+		filePath := filepath.Join(dirPath, path)
+		err := os.MkdirAll(filepath.Dir(filePath), 0750)
+		if err != nil {
+			return "", err
+		}
+		f, err := os.OpenFile(filePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0640)
+		if err != nil {
+			return "", err
+		}
+		_, err = fmt.Fprintf(f, "%s\n", contents)
+		if err != nil {
+			return "", err
+		}
+		err = f.Close()
+		if err != nil {
+			return "", err
+		}
+	}
+	return dirPath, nil
+}

--- a/plugins/inputs/rapl/sample.conf
+++ b/plugins/inputs/rapl/sample.conf
@@ -1,0 +1,1 @@
+[[inputs.rapl]]


### PR DESCRIPTION
## Summary

This PR implements an input plugin to read the RAPL energy counters. One can then derive power usage. I have verified that the readings highly correlate with those of the (unmerged) Turbostat input plugin.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #16876
