### PR TITLE
docs(inputs): Mention secret-store support for radius and tacacs plugin

### DIFF
--- a/plugins/inputs/radius/README.md
+++ b/plugins/inputs/radius/README.md
@@ -11,6 +11,14 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 [CONFIGURATION.md]: ../../../docs/CONFIGURATION.md#plugins
 
+## Secret-store support
+
+This plugin supports secrets from secret-stores for the `username`, `password`
+and `secret` option. See the
+[secret-store documentation][SECRETSTORE] for more details on how to use them.
+
+[SECRETSTORE]: ../../../docs/CONFIGURATION.md#secret-store-secrets
+
 ## Configuration
 
 ```toml @sample.conf

--- a/plugins/inputs/tacacs/README.md
+++ b/plugins/inputs/tacacs/README.md
@@ -15,6 +15,14 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 [CONFIGURATION.md]: ../../../docs/CONFIGURATION.md#plugins
 
+## Secret-store support
+
+This plugin supports secrets from secret-stores for the `username`, `password`
+and `secret` option. See the
+[secret-store documentation][SECRETSTORE] for more details on how to use them.
+
+[SECRETSTORE]: ../../../docs/CONFIGURATION.md#secret-store-secrets
+
 ## Configuration
 
 ```toml @sample.conf


### PR DESCRIPTION
## Summary
The docs for inputs.tacacs and inputs.radius did not mention the standard secret stores support infomessage. Adding that.
Used wording from inputs.prometheus, seems to be the standard one.

## Checklist

- [X] No AI generated code was used in this PR

## Related issues

