### PR TITLE
feat(outputs.datadog): Allow Datadog output to accept API Key via environment variable

### DIFF
--- a/plugins/outputs/datadog/README.md
+++ b/plugins/outputs/datadog/README.md
@@ -23,8 +23,11 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 ```toml @sample.conf
 # Configuration for DataDog API to send metrics to.
 [[outputs.datadog]]
-  ## Datadog API key
+  ## Datadog API key (ignored if envvar is also set and it has a value)
   apikey = "my-secret-key"
+
+  ## Optional. Name of environment variable containing API key
+  # envvar = "DD_API_KEY"
 
   ## Connection timeout.
   # timeout = "5s"

--- a/plugins/outputs/datadog/sample.conf
+++ b/plugins/outputs/datadog/sample.conf
@@ -1,7 +1,10 @@
 # Configuration for DataDog API to send metrics to.
 [[outputs.datadog]]
-  ## Datadog API key
+  ## Datadog API key (ignored if envvar is also set and it has a value)
   apikey = "my-secret-key"
+
+  ## Optional. Name of environment variable containing API key
+  # envvar = "DD_API_KEY"
 
   ## Connection timeout.
   # timeout = "5s"


### PR DESCRIPTION
## Summary

This is to enable the use of an environment variable to pass the DataDog API key. This can be useful for many different setups, but in my case, I want to pass a secret key in Kubernetes.

### Example Helmfile

```yaml
releases:
  - name: telegraf
    namespace: telegraf
    createNamespace: true
    chart: influxdata/telegraf
    version: 1.8.57
    needs:
      - datadog-api-key
    values:
      - config:
          agent:
            env:
              - name: DD_API_KEY
                valueFrom:
                  secretKeyRef:
                    name: datadog-api-key
                    key: token
          processors: []
          outputs:
            - datadog:
                apikey: ""
                envvar: "DD_API_KEY"
```

```yaml
apiVersion: v1
kind: Secret
metadata:
  name: datadog-api-key
data: [[ redacted ]]
```

A `Secret` has been created with the API key contained within.

This is not only useful for those running Telegraf inside Kubernetes, but for anybody that would prefer to pass this via env vars than having it hard-coded into config.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #17075
