### PR TITLE
chore(processors): Fix linter findings for `revive:exported`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -340,7 +340,6 @@ linters:
             - "**/plugins/common/**"
             - "**/plugins/outputs/**"
             - "**/plugins/parsers/**"
-            - "**/plugins/processors/**"
             - "**/plugins/serializers/**"
             - "**/selfstat/**"
             - "**/serializer.go"
@@ -522,7 +521,7 @@ linters:
 
       # revive:exported
       - path: (.+)\.go$
-        text: exported method .*\.(Init |SampleConfig |Gather |Start |Stop |GetState |SetState |SetParser |SetParserFunc |SetTranslator |Probe |Add |Push |Reset |Get |Set |List |GetResolver )should have comment or be unexported
+        text: exported method .*\.(Init |SampleConfig |Gather |Start |Stop |GetState |SetState |SetParser |SetParserFunc |SetTranslator |Probe |Add |Push |Reset |Get |Set |List |GetResolver |Apply |SetSerializer )should have comment or be unexported
 
       # EXC0001 errcheck: Almost all programs ignore errors on these functions, and in most cases it's ok
       - path: (.+)\.go$

--- a/plugins/processors/aws_ec2/ec2_test.go
+++ b/plugins/processors/aws_ec2/ec2_test.go
@@ -138,10 +138,10 @@ func TestTracking(t *testing.T) {
 
 	// Prepare and start the plugin
 	plugin := &AwsEc2Processor{
-		MaxParallelCalls: DefaultMaxParallelCalls,
-		TagCacheSize:     DefaultCacheSize,
-		Timeout:          config.Duration(DefaultTimeout),
-		CacheTTL:         config.Duration(DefaultCacheTTL),
+		MaxParallelCalls: defaultMaxParallelCalls,
+		TagCacheSize:     defaultCacheSize,
+		Timeout:          config.Duration(defaultTimeout),
+		CacheTTL:         config.Duration(defaultCacheTTL),
 		ImdsTags:         []string{"accountId", "instanceId"},
 		Log:              &testutil.Logger{},
 	}
@@ -150,7 +150,7 @@ func TestTracking(t *testing.T) {
 	// Instead of starting the plugin which tries to connect to the remote
 	// service, we just fill the cache and start the minimum mechanics to
 	// process the metrics.
-	plugin.tagCache = freecache.NewCache(DefaultCacheSize)
+	plugin.tagCache = freecache.NewCache(defaultCacheSize)
 	require.NoError(t, plugin.tagCache.Set([]byte("accountId"), []byte("123456789"), -1))
 	require.NoError(t, plugin.tagCache.Set([]byte("instanceId"), []byte("i-123456789123"), -1))
 

--- a/plugins/processors/clone/clone.go
+++ b/plugins/processors/clone/clone.go
@@ -12,10 +12,10 @@ import (
 var sampleConfig string
 
 type Clone struct {
-	NameOverride string
-	NamePrefix   string
-	NameSuffix   string
-	Tags         map[string]string
+	NameOverride string            `toml:"name_override"`
+	NamePrefix   string            `toml:"name_prefix"`
+	NameSuffix   string            `toml:"name_suffix"`
+	Tags         map[string]string `toml:"tags"`
 }
 
 func (*Clone) SampleConfig() string {

--- a/plugins/processors/converter/converter.go
+++ b/plugins/processors/converter/converter.go
@@ -20,7 +20,16 @@ import (
 //go:embed sample.conf
 var sampleConfig string
 
-type Conversion struct {
+type Converter struct {
+	Tags   *conversion     `toml:"tags"`
+	Fields *conversion     `toml:"fields"`
+	Log    telegraf.Logger `toml:"-"`
+
+	tagConversions   *conversionFilter
+	fieldConversions *conversionFilter
+}
+
+type conversion struct {
 	Measurement       []string `toml:"measurement"`
 	Tag               []string `toml:"tag"`
 	String            []string `toml:"string"`
@@ -33,16 +42,7 @@ type Conversion struct {
 	Base64IEEEFloat32 []string `toml:"base64_ieee_float32"`
 }
 
-type Converter struct {
-	Tags   *Conversion     `toml:"tags"`
-	Fields *Conversion     `toml:"fields"`
-	Log    telegraf.Logger `toml:"-"`
-
-	tagConversions   *ConversionFilter
-	fieldConversions *ConversionFilter
-}
-
-type ConversionFilter struct {
+type conversionFilter struct {
 	Measurement       filter.Filter
 	Tag               filter.Filter
 	String            filter.Filter
@@ -90,13 +90,13 @@ func (p *Converter) compile() error {
 	return nil
 }
 
-func compileFilter(conv *Conversion) (*ConversionFilter, error) {
+func compileFilter(conv *conversion) (*conversionFilter, error) {
 	if conv == nil {
 		return nil, nil
 	}
 
 	var err error
-	cf := &ConversionFilter{}
+	cf := &conversionFilter{}
 	cf.Measurement, err = filter.Compile(conv.Measurement)
 	if err != nil {
 		return nil, err

--- a/plugins/processors/converter/converter_test.go
+++ b/plugins/processors/converter/converter_test.go
@@ -23,7 +23,7 @@ func TestConverter(t *testing.T) {
 		{
 			name: "from tag",
 			converter: &Converter{
-				Tags: &Conversion{
+				Tags: &conversion{
 					String:   []string{"string"},
 					Integer:  []string{"int"},
 					Unsigned: []string{"uint"},
@@ -65,7 +65,7 @@ func TestConverter(t *testing.T) {
 		{
 			name: "from tag unconvertible",
 			converter: &Converter{
-				Tags: &Conversion{
+				Tags: &conversion{
 					Integer:  []string{"int"},
 					Unsigned: []string{"uint"},
 					Boolean:  []string{"bool"},
@@ -95,7 +95,7 @@ func TestConverter(t *testing.T) {
 		{
 			name: "from string field",
 			converter: &Converter{
-				Fields: &Conversion{
+				Fields: &conversion{
 					String:   []string{"a"},
 					Integer:  []string{"b", "b1", "b2", "b3"},
 					Unsigned: []string{"c", "c1", "c2", "c3"},
@@ -150,7 +150,7 @@ func TestConverter(t *testing.T) {
 		{
 			name: "from string field unconvertible",
 			converter: &Converter{
-				Fields: &Conversion{
+				Fields: &conversion{
 					Integer:  []string{"a"},
 					Unsigned: []string{"b"},
 					Boolean:  []string{"c"},
@@ -180,7 +180,7 @@ func TestConverter(t *testing.T) {
 		{
 			name: "from integer field",
 			converter: &Converter{
-				Fields: &Conversion{
+				Fields: &conversion{
 					String:   []string{"a"},
 					Integer:  []string{"b"},
 					Unsigned: []string{"c", "negative_uint"},
@@ -226,7 +226,7 @@ func TestConverter(t *testing.T) {
 		{
 			name: "from unsigned field",
 			converter: &Converter{
-				Fields: &Conversion{
+				Fields: &conversion{
 					String:   []string{"a"},
 					Integer:  []string{"b", "overflow_int"},
 					Unsigned: []string{"c"},
@@ -272,7 +272,7 @@ func TestConverter(t *testing.T) {
 		{
 			name: "out of range for unsigned",
 			converter: &Converter{
-				Fields: &Conversion{
+				Fields: &conversion{
 					Unsigned: []string{"a", "b"},
 				},
 			},
@@ -300,7 +300,7 @@ func TestConverter(t *testing.T) {
 		{
 			name: "boolean field",
 			converter: &Converter{
-				Fields: &Conversion{
+				Fields: &conversion{
 					String:   []string{"a", "af"},
 					Integer:  []string{"b", "bf"},
 					Unsigned: []string{"c", "cf"},
@@ -354,7 +354,7 @@ func TestConverter(t *testing.T) {
 		{
 			name: "from float field",
 			converter: &Converter{
-				Fields: &Conversion{
+				Fields: &conversion{
 					String:   []string{"a"},
 					Integer:  []string{"b", "too_large_int", "too_small_int"},
 					Unsigned: []string{"c", "negative_uint", "too_large_uint", "too_small_uint"},
@@ -408,7 +408,7 @@ func TestConverter(t *testing.T) {
 		{
 			name: "globbing",
 			converter: &Converter{
-				Fields: &Conversion{
+				Fields: &conversion{
 					Integer: []string{"int_*"},
 				},
 			},
@@ -438,7 +438,7 @@ func TestConverter(t *testing.T) {
 		{
 			name: "from string field hexadecimal",
 			converter: &Converter{
-				Fields: &Conversion{
+				Fields: &conversion{
 					Integer:  []string{"a"},
 					Unsigned: []string{"b"},
 					Float:    []string{"c"},
@@ -470,7 +470,7 @@ func TestConverter(t *testing.T) {
 		{
 			name: "from unix timestamp field",
 			converter: &Converter{
-				Fields: &Conversion{
+				Fields: &conversion{
 					Timestamp:       []string{"time"},
 					TimestampFormat: "unix",
 				},
@@ -498,7 +498,7 @@ func TestConverter(t *testing.T) {
 		{
 			name: "from unix timestamp tag",
 			converter: &Converter{
-				Tags: &Conversion{
+				Tags: &conversion{
 					Timestamp:       []string{"time"},
 					TimestampFormat: "unix",
 				},
@@ -527,7 +527,7 @@ func TestConverter(t *testing.T) {
 		{
 			name: "from invalid timestamp tag",
 			converter: &Converter{
-				Tags: &Conversion{
+				Tags: &conversion{
 					Timestamp:       []string{"time"},
 					TimestampFormat: "blah",
 				},
@@ -558,7 +558,7 @@ func TestConverter(t *testing.T) {
 		{
 			name: "from rfc3339 timestamp field",
 			converter: &Converter{
-				Fields: &Conversion{
+				Fields: &conversion{
 					Timestamp:       []string{"time"},
 					TimestampFormat: "rfc3339",
 				},
@@ -586,7 +586,7 @@ func TestConverter(t *testing.T) {
 		{
 			name: "from custom timestamp field",
 			converter: &Converter{
-				Fields: &Conversion{
+				Fields: &conversion{
 					Timestamp:       []string{"time"},
 					TimestampFormat: "2006-01-02 15:04:05 MST",
 				},
@@ -614,7 +614,7 @@ func TestConverter(t *testing.T) {
 		{
 			name: "invalid timestamp format",
 			converter: &Converter{
-				Fields: &Conversion{
+				Fields: &conversion{
 					Timestamp:       []string{"time"},
 					TimestampFormat: "2006-01-0",
 				},
@@ -643,7 +643,7 @@ func TestConverter(t *testing.T) {
 		{
 			name: "no timestamp format",
 			converter: &Converter{
-				Fields: &Conversion{
+				Fields: &conversion{
 					Timestamp: []string{"time"},
 				},
 			},
@@ -683,7 +683,7 @@ func TestConverter(t *testing.T) {
 
 func TestMultipleTimestamps(t *testing.T) {
 	c := &Converter{
-		Fields: &Conversion{
+		Fields: &conversion{
 			Timestamp:       []string{"time", "date"},
 			TimestampFormat: "2006-01-02 15:04:05 MST",
 		},
@@ -718,7 +718,7 @@ func TestMeasurement(t *testing.T) {
 		{
 			name: "measurement from tag",
 			converter: &Converter{
-				Tags: &Conversion{
+				Tags: &conversion{
 					Measurement: []string{"filepath"},
 				},
 			},
@@ -746,7 +746,7 @@ func TestMeasurement(t *testing.T) {
 		{
 			name: "measurement from field",
 			converter: &Converter{
-				Fields: &Conversion{
+				Fields: &conversion{
 					Measurement: []string{"topic"},
 				},
 			},
@@ -773,7 +773,7 @@ func TestMeasurement(t *testing.T) {
 		{
 			name: "float32 from ieee754 float32 encoded as base64",
 			converter: &Converter{
-				Fields: &Conversion{
+				Fields: &conversion{
 					Base64IEEEFloat32: []string{"a", "b"},
 				},
 			},
@@ -845,7 +845,7 @@ func TestTracking(t *testing.T) {
 	}
 
 	plugin := &Converter{
-		Fields: &Conversion{
+		Fields: &conversion{
 			Measurement: []string{"topic"},
 		},
 	}

--- a/plugins/processors/dedup/dedup_test.go
+++ b/plugins/processors/dedup/dedup_test.go
@@ -319,8 +319,8 @@ func TestMetrics(t *testing.T) {
 			// Create plugin instance
 			plugin := &Dedup{
 				DedupInterval: config.Duration(10 * time.Minute),
-				FlushTime:     now.Add(-1 * time.Second),
-				Cache:         make(map[uint64]telegraf.Metric),
+				flushTime:     now.Add(-1 * time.Second),
+				cache:         make(map[uint64]telegraf.Metric),
 			}
 
 			// Feed the input metrics and record the outputs
@@ -330,12 +330,12 @@ func TestMetrics(t *testing.T) {
 
 				// Check the cache content
 				if cm := tt.cacheContent[i]; cm == nil {
-					require.Empty(t, plugin.Cache)
+					require.Empty(t, plugin.cache)
 				} else {
 					id := m.HashID()
-					require.NotEmpty(t, plugin.Cache)
-					require.Contains(t, plugin.Cache, id)
-					testutil.RequireMetricEqual(t, cm, plugin.Cache[id])
+					require.NotEmpty(t, plugin.cache)
+					require.Contains(t, plugin.cache, id)
+					testutil.RequireMetricEqual(t, cm, plugin.cache[id])
 				}
 			}
 
@@ -351,8 +351,8 @@ func TestCacheShrink(t *testing.T) {
 	// Time offset is more than 2 * DedupInterval
 	plugin := &Dedup{
 		DedupInterval: config.Duration(10 * time.Minute),
-		FlushTime:     now.Add(-2 * time.Hour),
-		Cache:         make(map[uint64]telegraf.Metric),
+		flushTime:     now.Add(-2 * time.Hour),
+		cache:         make(map[uint64]telegraf.Metric),
 	}
 
 	// Time offset is more than 1 * DedupInterval
@@ -367,7 +367,7 @@ func TestCacheShrink(t *testing.T) {
 	actual := plugin.Apply(input...)
 	expected := input
 	testutil.RequireMetricsEqual(t, expected, actual)
-	require.Empty(t, plugin.Cache)
+	require.Empty(t, plugin.cache)
 }
 
 func TestTracking(t *testing.T) {
@@ -438,8 +438,8 @@ func TestTracking(t *testing.T) {
 	// Create plugin instance
 	plugin := &Dedup{
 		DedupInterval: config.Duration(10 * time.Minute),
-		FlushTime:     now.Add(-1 * time.Second),
-		Cache:         make(map[uint64]telegraf.Metric),
+		flushTime:     now.Add(-1 * time.Second),
+		cache:         make(map[uint64]telegraf.Metric),
 	}
 
 	// Process expected metrics and compare with resulting metrics
@@ -504,15 +504,15 @@ func TestStatePersistence(t *testing.T) {
 	// Configure the plugin
 	plugin := &Dedup{
 		DedupInterval: config.Duration(10 * time.Hour), // use a long interval to avoid flaky tests
-		FlushTime:     now.Add(-1 * time.Second),
-		Cache:         make(map[uint64]telegraf.Metric),
+		flushTime:     now.Add(-1 * time.Second),
+		cache:         make(map[uint64]telegraf.Metric),
 	}
-	require.Empty(t, plugin.Cache)
+	require.Empty(t, plugin.cache)
 
 	// Setup the "persisted" state
 	var pi telegraf.StatefulPlugin = plugin
 	require.NoError(t, pi.SetState([]byte(state)))
-	require.Len(t, plugin.Cache, 1)
+	require.Len(t, plugin.cache, 1)
 
 	// Process expected metrics and compare with resulting metrics
 	actual := plugin.Apply(input...)

--- a/plugins/processors/execd/execd.go
+++ b/plugins/processors/execd/execd.go
@@ -25,12 +25,23 @@ type Execd struct {
 	Command      []string        `toml:"command"`
 	Environment  []string        `toml:"environment"`
 	RestartDelay config.Duration `toml:"restart_delay"`
-	Log          telegraf.Logger
+	Log          telegraf.Logger `toml:"-"`
 
 	parser     telegraf.Parser
 	serializer telegraf.Serializer
 	acc        telegraf.Accumulator
 	process    *process.Process
+}
+
+func (*Execd) SampleConfig() string {
+	return sampleConfig
+}
+
+func (e *Execd) Init() error {
+	if len(e.Command) == 0 {
+		return errors.New("no command specified")
+	}
+	return nil
 }
 
 func (e *Execd) SetParser(p telegraf.Parser) {
@@ -39,10 +50,6 @@ func (e *Execd) SetParser(p telegraf.Parser) {
 
 func (e *Execd) SetSerializer(s telegraf.Serializer) {
 	e.serializer = s
-}
-
-func (*Execd) SampleConfig() string {
-	return sampleConfig
 }
 
 func (e *Execd) Start(acc telegraf.Accumulator) error {
@@ -166,13 +173,6 @@ func (e *Execd) cmdReadErr(out io.Reader) {
 	if err := scanner.Err(); err != nil {
 		e.Log.Errorf("Error reading stderr: %s", err)
 	}
-}
-
-func (e *Execd) Init() error {
-	if len(e.Command) == 0 {
-		return errors.New("no command specified")
-	}
-	return nil
 }
 
 func init() {

--- a/plugins/processors/filepath/filepath_test.go
+++ b/plugins/processors/filepath/filepath_test.go
@@ -46,8 +46,8 @@ func TestOptions_Apply(t *testing.T) {
 		},
 		{
 			name: "Test Dest Option",
-			o: &Options{
-				BaseName: []BaseOpts{
+			o: &Filepath{
+				BaseName: []baseOpts{
 					{
 						Field: "sourcePath",
 						Tag:   "sourcePath",
@@ -106,8 +106,8 @@ func TestTracking(t *testing.T) {
 		input = append(input, tm)
 	}
 
-	plugin := &Options{
-		BaseName: []BaseOpts{
+	plugin := &Filepath{
+		BaseName: []baseOpts{
 			{
 				Field: "sourcePath",
 				Tag:   "sourcePath",

--- a/plugins/processors/filepath/filepath_test_helpers.go
+++ b/plugins/processors/filepath/filepath_test_helpers.go
@@ -12,47 +12,47 @@ const smokeMetricName = "testmetric"
 
 type testCase struct {
 	name            string
-	o               *Options
+	o               *Filepath
 	inputMetrics    []telegraf.Metric
 	expectedMetrics []telegraf.Metric
 }
 
-func newOptions(basePath string) *Options {
-	return &Options{
-		BaseName: []BaseOpts{
+func newOptions(basePath string) *Filepath {
+	return &Filepath{
+		BaseName: []baseOpts{
 			{
 				Field: "baseField",
 				Tag:   "baseTag",
 			},
 		},
-		DirName: []BaseOpts{
+		DirName: []baseOpts{
 			{
 				Field: "dirField",
 				Tag:   "dirTag",
 			},
 		},
-		Stem: []BaseOpts{
+		Stem: []baseOpts{
 			{
 				Field: "stemField",
 				Tag:   "stemTag",
 			},
 		},
-		Clean: []BaseOpts{
+		Clean: []baseOpts{
 			{
 				Field: "cleanField",
 				Tag:   "cleanTag",
 			},
 		},
-		Rel: []RelOpts{
+		Rel: []relOpts{
 			{
-				BaseOpts: BaseOpts{
+				baseOpts: baseOpts{
 					Field: "relField",
 					Tag:   "relTag",
 				},
 				BasePath: basePath,
 			},
 		},
-		ToSlash: []BaseOpts{
+		ToSlash: []baseOpts{
 			{
 				Field: "slashField",
 				Tag:   "slashTag",

--- a/plugins/processors/ifname/cache.go
+++ b/plugins/processors/ifname/cache.go
@@ -6,56 +6,52 @@ import (
 	"container/list"
 )
 
-type LRUValType = TTLValType
+type lruValType = ttlValType
 
 type hashType map[keyType]*list.Element
 
-type LRUCache struct {
+type lruCache struct {
 	cap uint       // capacity
 	l   *list.List // doubly linked list
 	m   hashType   // hash table for checking if list node exists
 }
 
-// Pair is the value of a list node.
-type Pair struct {
+type pair struct {
 	key   keyType
-	value LRUValType
+	value lruValType
 }
 
-// initializes a new LRUCache.
-func NewLRUCache(capacity uint) LRUCache {
-	return LRUCache{
+func newLRUCache(capacity uint) lruCache {
+	return lruCache{
 		cap: capacity,
 		l:   new(list.List),
 		m:   make(hashType, capacity),
 	}
 }
 
-// Get a list node from the hash map.
-func (c *LRUCache) Get(key keyType) (LRUValType, bool) {
+func (c *lruCache) get(key keyType) (lruValType, bool) {
 	// check if list node exists
 	if node, ok := c.m[key]; ok {
-		val := node.Value.(*list.Element).Value.(Pair).value
+		val := node.Value.(*list.Element).Value.(pair).value
 		// move node to front
 		c.l.MoveToFront(node)
 		return val, true
 	}
-	return LRUValType{}, false
+	return lruValType{}, false
 }
 
-// Put key and value in the LRUCache
-func (c *LRUCache) Put(key keyType, value LRUValType) {
+func (c *lruCache) put(key keyType, value lruValType) {
 	// check if list node exists
 	if node, ok := c.m[key]; ok {
 		// move the node to front
 		c.l.MoveToFront(node)
 		// update the value of a list node
-		node.Value.(*list.Element).Value = Pair{key: key, value: value}
+		node.Value.(*list.Element).Value = pair{key: key, value: value}
 	} else {
 		// delete the last list node if the list is full
 		if uint(c.l.Len()) == c.cap {
 			// get the key that we want to delete
-			idx := c.l.Back().Value.(*list.Element).Value.(Pair).key
+			idx := c.l.Back().Value.(*list.Element).Value.(pair).key
 			// delete the node pointer in the hash map by key
 			delete(c.m, idx)
 			// remove the last list node
@@ -63,7 +59,7 @@ func (c *LRUCache) Put(key keyType, value LRUValType) {
 		}
 		// initialize a list node
 		node := &list.Element{
-			Value: Pair{
+			Value: pair{
 				key:   key,
 				value: value,
 			},
@@ -75,7 +71,7 @@ func (c *LRUCache) Put(key keyType, value LRUValType) {
 	}
 }
 
-func (c *LRUCache) Delete(key keyType) {
+func (c *lruCache) delete(key keyType) {
 	if node, ok := c.m[key]; ok {
 		c.l.Remove(node)
 		delete(c.m, key)

--- a/plugins/processors/ifname/cache_test.go
+++ b/plugins/processors/ifname/cache_test.go
@@ -7,17 +7,17 @@ import (
 )
 
 func TestCache(t *testing.T) {
-	c := NewLRUCache(2)
+	c := newLRUCache(2)
 
-	c.Put("ones", LRUValType{val: nameMap{1: "one"}})
-	twoMap := LRUValType{val: nameMap{2: "two"}}
-	c.Put("twos", twoMap)
-	c.Put("threes", LRUValType{val: nameMap{3: "three"}})
+	c.put("ones", lruValType{val: nameMap{1: "one"}})
+	twoMap := lruValType{val: nameMap{2: "two"}}
+	c.put("twos", twoMap)
+	c.put("threes", lruValType{val: nameMap{3: "three"}})
 
-	_, ok := c.Get("ones")
+	_, ok := c.get("ones")
 	require.False(t, ok)
 
-	v, ok := c.Get("twos")
+	v, ok := c.get("twos")
 	require.True(t, ok)
 	require.Equal(t, twoMap, v)
 }

--- a/plugins/processors/ifname/ifname_test.go
+++ b/plugins/processors/ifname/ifname_test.go
@@ -200,7 +200,7 @@ func TestTracking(t *testing.T) {
 		MaxParallelLookups: 100,
 	}
 	require.NoError(t, plugin.Init())
-	plugin.cache.Put("127.0.0.1", nameMap{1: "lo"})
+	plugin.cache.put("127.0.0.1", nameMap{1: "lo"})
 
 	var acc testutil.Accumulator
 	require.NoError(t, plugin.Start(&acc))

--- a/plugins/processors/ifname/ttl_cache.go
+++ b/plugins/processors/ifname/ttl_cache.go
@@ -5,29 +5,29 @@ import (
 	"time"
 )
 
-type TTLValType struct {
+type ttlValType struct {
 	time time.Time // when entry was added
 	val  valType
 }
 
 type timeFunc func() time.Time
 
-type TTLCache struct {
+type ttlCache struct {
 	validDuration time.Duration
-	lru           LRUCache
+	lru           lruCache
 	now           timeFunc
 }
 
-func NewTTLCache(valid time.Duration, capacity uint) TTLCache {
-	return TTLCache{
-		lru:           NewLRUCache(capacity),
+func newTTLCache(valid time.Duration, capacity uint) ttlCache {
+	return ttlCache{
+		lru:           newLRUCache(capacity),
 		validDuration: valid,
 		now:           time.Now,
 	}
 }
 
-func (c *TTLCache) Get(key keyType) (valType, bool, time.Duration) {
-	v, ok := c.lru.Get(key)
+func (c *ttlCache) get(key keyType) (valType, bool, time.Duration) {
+	v, ok := c.lru.get(key)
 	if !ok {
 		return valType{}, false, 0
 	}
@@ -45,18 +45,18 @@ func (c *TTLCache) Get(key keyType) (valType, bool, time.Duration) {
 		return v.val, ok, age
 	}
 
-	c.lru.Delete(key)
+	c.lru.delete(key)
 	return valType{}, false, 0
 }
 
-func (c *TTLCache) Put(key keyType, value valType) {
-	v := TTLValType{
+func (c *ttlCache) put(key keyType, value valType) {
+	v := ttlValType{
 		val:  value,
 		time: c.now(),
 	}
-	c.lru.Put(key, v)
+	c.lru.put(key, v)
 }
 
-func (c *TTLCache) Delete(key keyType) {
-	c.lru.Delete(key)
+func (c *ttlCache) delete(key keyType) {
+	c.lru.delete(key)
 }

--- a/plugins/processors/ifname/ttl_cache_test.go
+++ b/plugins/processors/ifname/ttl_cache_test.go
@@ -8,36 +8,36 @@ import (
 )
 
 func TestTTLCacheExpire(t *testing.T) {
-	c := NewTTLCache(1*time.Second, 100)
+	c := newTTLCache(1*time.Second, 100)
 
 	c.now = func() time.Time {
 		return time.Unix(0, 0)
 	}
 
-	c.Put("ones", nameMap{1: "one"})
+	c.put("ones", nameMap{1: "one"})
 	require.Len(t, c.lru.m, 1)
 
 	c.now = func() time.Time {
 		return time.Unix(1, 0)
 	}
 
-	_, ok, _ := c.Get("ones")
+	_, ok, _ := c.get("ones")
 	require.False(t, ok)
 	require.Empty(t, c.lru.m)
 	require.Equal(t, 0, c.lru.l.Len())
 }
 
 func TestTTLCache(t *testing.T) {
-	c := NewTTLCache(1*time.Second, 100)
+	c := newTTLCache(1*time.Second, 100)
 
 	c.now = func() time.Time {
 		return time.Unix(0, 0)
 	}
 
 	expected := nameMap{1: "one"}
-	c.Put("ones", expected)
+	c.put("ones", expected)
 
-	actual, ok, _ := c.Get("ones")
+	actual, ok, _ := c.get("ones")
 	require.True(t, ok)
 	require.Equal(t, expected, actual)
 }

--- a/plugins/processors/lookup/lookup.go
+++ b/plugins/processors/lookup/lookup.go
@@ -208,6 +208,7 @@ func (p *Processor) loadCSVKeyValuesFile(fn string) error {
 
 	return nil
 }
+
 func init() {
 	processors.Add("lookup", func() telegraf.Processor {
 		return &Processor{}

--- a/plugins/processors/parser/parser.go
+++ b/plugins/processors/parser/parser.go
@@ -27,6 +27,10 @@ type Parser struct {
 	parser       telegraf.Parser
 }
 
+func (*Parser) SampleConfig() string {
+	return sampleConfig
+}
+
 func (p *Parser) Init() error {
 	switch p.Merge {
 	case "", "override", "override-with-timestamp":
@@ -35,10 +39,6 @@ func (p *Parser) Init() error {
 	}
 
 	return nil
-}
-
-func (*Parser) SampleConfig() string {
-	return sampleConfig
 }
 
 func (p *Parser) SetParser(parser telegraf.Parser) {

--- a/plugins/processors/registry.go
+++ b/plugins/processors/registry.go
@@ -2,17 +2,21 @@ package processors
 
 import "github.com/influxdata/telegraf"
 
+// Creator is a function that returns a new instance of a telegraf.Processor.
 type Creator func() telegraf.Processor
+
+// StreamingCreator is a function that returns a new instance of a telegraf.StreamingProcessor.
 type StreamingCreator func() telegraf.StreamingProcessor
 
-// HasUnwrap indicates the presence of an Unwrap() function to retrieve the
-// underlying telegraf.Processor.
+// HasUnwrap indicates the presence of an Unwrap() function to retrieve the underlying telegraf.Processor.
 type HasUnwrap interface {
+	// Unwrap returns the underlying telegraf.Processor.
 	Unwrap() telegraf.Processor
 }
 
-// all processors are streaming processors.
-// telegraf.Processor processors are upgraded to telegraf.StreamingProcessor
+// Processors is a map of processor names to their respective creator functions.
+// All processors are streaming processors.
+// telegraf.Processor processors are upgraded to telegraf.StreamingProcessor.
 var Processors = make(map[string]StreamingCreator)
 
 // Add adds a telegraf.Processor processor

--- a/plugins/processors/rename/rename.go
+++ b/plugins/processors/rename/rename.go
@@ -11,15 +11,15 @@ import (
 //go:embed sample.conf
 var sampleConfig string
 
-type Replace struct {
+type Rename struct {
+	Replaces []replace `toml:"replace"`
+}
+
+type replace struct {
 	Measurement string `toml:"measurement"`
 	Tag         string `toml:"tag"`
 	Field       string `toml:"field"`
 	Dest        string `toml:"dest"`
-}
-
-type Rename struct {
-	Replaces []Replace `toml:"replace"`
 }
 
 func (*Rename) SampleConfig() string {

--- a/plugins/processors/rename/rename_test.go
+++ b/plugins/processors/rename/rename_test.go
@@ -25,7 +25,7 @@ func newMetric(name string, tags map[string]string, fields map[string]interface{
 
 func TestMeasurementRename(t *testing.T) {
 	r := Rename{
-		Replaces: []Replace{
+		Replaces: []replace{
 			{Measurement: "foo", Dest: "bar"},
 			{Measurement: "baz", Dest: "quux"},
 		},
@@ -41,7 +41,7 @@ func TestMeasurementRename(t *testing.T) {
 
 func TestTagRename(t *testing.T) {
 	r := Rename{
-		Replaces: []Replace{
+		Replaces: []replace{
 			{Tag: "hostname", Dest: "host"},
 		},
 	}
@@ -53,7 +53,7 @@ func TestTagRename(t *testing.T) {
 
 func TestFieldRename(t *testing.T) {
 	r := Rename{
-		Replaces: []Replace{
+		Replaces: []replace{
 			{Field: "time_msec", Dest: "time"},
 		},
 	}
@@ -106,7 +106,7 @@ func TestTracking(t *testing.T) {
 	}
 
 	plugin := &Rename{
-		Replaces: []Replace{
+		Replaces: []replace{
 			{Field: "value", Dest: "new_value"},
 		},
 	}

--- a/plugins/processors/reverse_dns/rdnscache_test.go
+++ b/plugins/processors/reverse_dns/rdnscache_test.go
@@ -11,11 +11,11 @@ import (
 )
 
 func TestSimpleReverseDNSLookup(t *testing.T) {
-	d := NewReverseDNSCache(60*time.Second, 1*time.Second, -1)
-	defer d.Stop()
+	d := newReverseDNSCache(60*time.Second, 1*time.Second, -1)
+	defer d.stop()
 
-	d.Resolver = &localResolver{}
-	answer, err := d.Lookup("127.0.0.1")
+	d.resolver = &localResolver{}
+	answer, err := d.lookup("127.0.0.1")
 	require.NoError(t, err)
 	require.Equal(t, []string{"localhost"}, answer)
 	err = blockAllWorkers(t.Context(), d)
@@ -23,7 +23,7 @@ func TestSimpleReverseDNSLookup(t *testing.T) {
 
 	// do another request with no workers available.
 	// it should read from cache instantly.
-	answer, err = d.Lookup("127.0.0.1")
+	answer, err = d.lookup("127.0.0.1")
 	require.NoError(t, err)
 	require.Equal(t, []string{"localhost"}, answer)
 
@@ -32,30 +32,30 @@ func TestSimpleReverseDNSLookup(t *testing.T) {
 	d.cleanup()
 	require.Len(t, d.expireList, 1) // ttl hasn't hit yet.
 
-	stats := d.Stats()
+	stats := d.getStats()
 
-	require.EqualValues(t, 0, stats.CacheExpire)
-	require.EqualValues(t, 1, stats.CacheMiss)
-	require.EqualValues(t, 1, stats.CacheHit)
-	require.EqualValues(t, 1, stats.RequestsFilled)
-	require.EqualValues(t, 0, stats.RequestsAbandoned)
+	require.EqualValues(t, 0, stats.cacheExpire)
+	require.EqualValues(t, 1, stats.cacheMiss)
+	require.EqualValues(t, 1, stats.cacheHit)
+	require.EqualValues(t, 1, stats.requestsFilled)
+	require.EqualValues(t, 0, stats.requestsAbandoned)
 }
 
 func TestParallelReverseDNSLookup(t *testing.T) {
-	d := NewReverseDNSCache(1*time.Second, 1*time.Second, -1)
-	defer d.Stop()
+	d := newReverseDNSCache(1*time.Second, 1*time.Second, -1)
+	defer d.stop()
 
-	d.Resolver = &localResolver{}
+	d.resolver = &localResolver{}
 	var answer1, answer2 []string
 	var err1, err2 error
 	wg := &sync.WaitGroup{}
 	wg.Add(2)
 	go func() {
-		answer1, err1 = d.Lookup("127.0.0.1")
+		answer1, err1 = d.lookup("127.0.0.1")
 		wg.Done()
 	}()
 	go func() {
-		answer2, err2 = d.Lookup("127.0.0.1")
+		answer2, err2 = d.lookup("127.0.0.1")
 		wg.Done()
 	}()
 
@@ -72,32 +72,32 @@ func TestParallelReverseDNSLookup(t *testing.T) {
 
 	require.Len(t, d.cache, 1)
 
-	stats := d.Stats()
+	stats := d.getStats()
 
-	require.EqualValues(t, 1, stats.CacheMiss)
-	require.EqualValues(t, 1, stats.CacheHit)
+	require.EqualValues(t, 1, stats.cacheMiss)
+	require.EqualValues(t, 1, stats.cacheHit)
 }
 
 func TestUnavailableDNSServerRespectsTimeout(t *testing.T) {
-	d := NewReverseDNSCache(0, 1, -1)
-	defer d.Stop()
+	d := newReverseDNSCache(0, 1, -1)
+	defer d.stop()
 
-	d.Resolver = &timeoutResolver{}
+	d.resolver = &timeoutResolver{}
 
-	result, err := d.Lookup("192.153.33.3")
+	result, err := d.lookup("192.153.33.3")
 	require.Error(t, err)
-	require.Equal(t, ErrTimeout, err)
+	require.Equal(t, errTimeout, err)
 
 	require.Nil(t, result)
 }
 
 func TestCleanupHappens(t *testing.T) {
 	ttl := 100 * time.Millisecond
-	d := NewReverseDNSCache(ttl, 1*time.Second, -1)
-	defer d.Stop()
+	d := newReverseDNSCache(ttl, 1*time.Second, -1)
+	defer d.stop()
 
-	d.Resolver = &localResolver{}
-	_, err := d.Lookup("127.0.0.1")
+	d.resolver = &localResolver{}
+	_, err := d.lookup("127.0.0.1")
 	require.NoError(t, err)
 
 	require.Len(t, d.cache, 1)
@@ -106,21 +106,21 @@ func TestCleanupHappens(t *testing.T) {
 	d.cleanup()
 	require.Empty(t, d.expireList)
 
-	stats := d.Stats()
+	stats := d.getStats()
 
-	require.EqualValues(t, 1, stats.CacheExpire)
-	require.EqualValues(t, 1, stats.CacheMiss)
-	require.EqualValues(t, 0, stats.CacheHit)
+	require.EqualValues(t, 1, stats.cacheExpire)
+	require.EqualValues(t, 1, stats.cacheMiss)
+	require.EqualValues(t, 0, stats.cacheHit)
 }
 
 func TestLookupTimeout(t *testing.T) {
-	d := NewReverseDNSCache(10*time.Second, 10*time.Second, -1)
-	defer d.Stop()
+	d := newReverseDNSCache(10*time.Second, 10*time.Second, -1)
+	defer d.stop()
 
-	d.Resolver = &timeoutResolver{}
-	_, err := d.Lookup("127.0.0.1")
+	d.resolver = &timeoutResolver{}
+	_, err := d.lookup("127.0.0.1")
 	require.Error(t, err)
-	require.EqualValues(t, 1, d.Stats().RequestsAbandoned)
+	require.EqualValues(t, 1, d.getStats().requestsAbandoned)
 }
 
 type timeoutResolver struct{}
@@ -137,6 +137,6 @@ func (*localResolver) LookupAddr(context.Context, string) (names []string, err e
 
 // blockAllWorkers is a test function that eats up all the worker pool space to
 // make sure workers are done running and there's no room to acquire a new worker.
-func blockAllWorkers(testContext context.Context, d *ReverseDNSCache) error {
+func blockAllWorkers(testContext context.Context, d *reverseDNSCache) error {
 	return d.sem.Acquire(testContext, int64(d.maxWorkers))
 }

--- a/plugins/processors/s2geo/s2geo.go
+++ b/plugins/processors/s2geo/s2geo.go
@@ -14,25 +14,25 @@ import (
 //go:embed sample.conf
 var sampleConfig string
 
-type Geo struct {
+type S2Geo struct {
 	LatField  string `toml:"lat_field"`
 	LonField  string `toml:"lon_field"`
 	TagKey    string `toml:"tag_key"`
 	CellLevel int    `toml:"cell_level"`
 }
 
-func (*Geo) SampleConfig() string {
+func (*S2Geo) SampleConfig() string {
 	return sampleConfig
 }
 
-func (g *Geo) Init() error {
+func (g *S2Geo) Init() error {
 	if g.CellLevel < 0 || g.CellLevel > 30 {
 		return fmt.Errorf("invalid cell level %d", g.CellLevel)
 	}
 	return nil
 }
 
-func (g *Geo) Apply(in ...telegraf.Metric) []telegraf.Metric {
+func (g *S2Geo) Apply(in ...telegraf.Metric) []telegraf.Metric {
 	for _, point := range in {
 		var latOk, lonOk bool
 		var lat, lon float64
@@ -57,7 +57,7 @@ func (g *Geo) Apply(in ...telegraf.Metric) []telegraf.Metric {
 
 func init() {
 	processors.Add("s2geo", func() telegraf.Processor {
-		return &Geo{
+		return &S2Geo{
 			LatField:  "lat",
 			LonField:  "lon",
 			TagKey:    "s2_cell_id",

--- a/plugins/processors/s2geo/s2geo_test.go
+++ b/plugins/processors/s2geo/s2geo_test.go
@@ -13,14 +13,14 @@ import (
 )
 
 func TestGeo(t *testing.T) {
-	plugin := &Geo{
+	plugin := &S2Geo{
 		LatField:  "lat",
 		LonField:  "lon",
 		TagKey:    "s2_cell_id",
 		CellLevel: 11,
 	}
 
-	pluginMostlyDefault := &Geo{
+	pluginMostlyDefault := &S2Geo{
 		CellLevel: 11,
 	}
 
@@ -99,7 +99,7 @@ func TestTracking(t *testing.T) {
 		),
 	}
 
-	plugin := &Geo{
+	plugin := &S2Geo{
 		LatField: "lat",
 		LonField: "lon",
 		TagKey:   "s2_cell_id",

--- a/plugins/processors/scale/scale_test.go
+++ b/plugins/processors/scale/scale_test.go
@@ -14,17 +14,17 @@ import (
 )
 
 type scalingValuesMinMax struct {
-	InMin  float64
-	InMax  float64
-	OutMin float64
-	OutMax float64
-	Fields []string
+	inMin  float64
+	inMax  float64
+	outMin float64
+	outMax float64
+	fields []string
 }
 
 type scalingValuesFactor struct {
-	Factor float64
-	Offset float64
-	Fields []string
+	factor float64
+	offset float64
+	fields []string
 }
 
 func TestMinMax(t *testing.T) {
@@ -38,18 +38,18 @@ func TestMinMax(t *testing.T) {
 			name: "Field Scaling",
 			scale: []scalingValuesMinMax{
 				{
-					InMin:  -1,
-					InMax:  1,
-					OutMin: 0,
-					OutMax: 100,
-					Fields: []string{"test1", "test2"},
+					inMin:  -1,
+					inMax:  1,
+					outMin: 0,
+					outMax: 100,
+					fields: []string{"test1", "test2"},
 				},
 				{
-					InMin:  -5,
-					InMax:  0,
-					OutMin: 1,
-					OutMax: 10,
-					Fields: []string{"test3", "test4"},
+					inMin:  -5,
+					inMax:  0,
+					outMin: 1,
+					outMax: 10,
+					fields: []string{"test3", "test4"},
 				},
 			},
 			inputs: []telegraf.Metric{
@@ -98,14 +98,14 @@ func TestMinMax(t *testing.T) {
 			},
 		},
 		{
-			name: "Ignored Fields",
+			name: "Ignored fields",
 			scale: []scalingValuesMinMax{
 				{
-					InMin:  -1,
-					InMax:  1,
-					OutMin: 0,
-					OutMax: 100,
-					Fields: []string{"test1", "test2"},
+					inMin:  -1,
+					inMax:  1,
+					outMin: 0,
+					outMax: 100,
+					fields: []string{"test1", "test2"},
 				},
 			},
 			inputs: []telegraf.Metric{
@@ -129,11 +129,11 @@ func TestMinMax(t *testing.T) {
 			name: "Out of range tests",
 			scale: []scalingValuesMinMax{
 				{
-					InMin:  -1,
-					InMax:  1,
-					OutMin: 0,
-					OutMax: 100,
-					Fields: []string{"test1", "test2"},
+					inMin:  -1,
+					inMax:  1,
+					outMin: 0,
+					outMax: 100,
+					fields: []string{"test1", "test2"},
 				},
 			},
 			inputs: []telegraf.Metric{
@@ -152,14 +152,14 @@ func TestMinMax(t *testing.T) {
 			},
 		},
 		{
-			name: "Missing field Fields",
+			name: "Missing field fields",
 			scale: []scalingValuesMinMax{
 				{
-					InMin:  -1,
-					InMax:  1,
-					OutMin: 0,
-					OutMax: 100,
-					Fields: []string{"test1", "test2"},
+					inMin:  -1,
+					inMax:  1,
+					outMin: 0,
+					outMax: 100,
+					fields: []string{"test1", "test2"},
 				},
 			},
 			inputs: []telegraf.Metric{
@@ -180,16 +180,16 @@ func TestMinMax(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			plugin := &Scale{
-				Scalings: make([]Scaling, 0, len(tt.scale)),
+				Scalings: make([]scaling, 0, len(tt.scale)),
 				Log:      testutil.Logger{},
 			}
 			for i := range tt.scale {
-				plugin.Scalings = append(plugin.Scalings, Scaling{
-					InMin:  &tt.scale[i].InMin,
-					InMax:  &tt.scale[i].InMax,
-					OutMin: &tt.scale[i].OutMin,
-					OutMax: &tt.scale[i].OutMax,
-					Fields: tt.scale[i].Fields,
+				plugin.Scalings = append(plugin.Scalings, scaling{
+					InMin:  &tt.scale[i].inMin,
+					InMax:  &tt.scale[i].inMax,
+					OutMin: &tt.scale[i].outMin,
+					OutMax: &tt.scale[i].outMax,
+					Fields: tt.scale[i].fields,
 				})
 			}
 			require.NoError(t, plugin.Init())
@@ -211,14 +211,14 @@ func TestFactor(t *testing.T) {
 			name: "Field Scaling",
 			scale: []scalingValuesFactor{
 				{
-					Factor: 50.0,
-					Offset: 50.0,
-					Fields: []string{"test1", "test2"},
+					factor: 50.0,
+					offset: 50.0,
+					fields: []string{"test1", "test2"},
 				},
 				{
-					Factor: 1.6,
-					Offset: 9.0,
-					Fields: []string{"test3", "test4"},
+					factor: 1.6,
+					offset: 9.0,
+					fields: []string{"test3", "test4"},
 				},
 			},
 			inputs: []telegraf.Metric{
@@ -267,12 +267,12 @@ func TestFactor(t *testing.T) {
 			},
 		},
 		{
-			name: "Ignored Fields",
+			name: "Ignored fields",
 			scale: []scalingValuesFactor{
 				{
-					Factor: 50.0,
-					Offset: 50.0,
-					Fields: []string{"test1", "test2"},
+					factor: 50.0,
+					offset: 50.0,
+					fields: []string{"test1", "test2"},
 				},
 			},
 			inputs: []telegraf.Metric{
@@ -293,12 +293,12 @@ func TestFactor(t *testing.T) {
 			},
 		},
 		{
-			name: "Missing field Fields",
+			name: "Missing field fields",
 			scale: []scalingValuesFactor{
 				{
-					Factor: 50.0,
-					Offset: 50.0,
-					Fields: []string{"test1", "test2"},
+					factor: 50.0,
+					offset: 50.0,
+					fields: []string{"test1", "test2"},
 				},
 			},
 			inputs: []telegraf.Metric{
@@ -318,8 +318,8 @@ func TestFactor(t *testing.T) {
 			name: "No Offset",
 			scale: []scalingValuesFactor{
 				{
-					Factor: 50.0,
-					Fields: []string{"test1"},
+					factor: 50.0,
+					fields: []string{"test1"},
 				},
 			},
 			inputs: []telegraf.Metric{
@@ -339,8 +339,8 @@ func TestFactor(t *testing.T) {
 			name: "No Factor",
 			scale: []scalingValuesFactor{
 				{
-					Offset: 50.0,
-					Fields: []string{"test1"},
+					offset: 50.0,
+					fields: []string{"test1"},
 				},
 			},
 			inputs: []telegraf.Metric{
@@ -361,18 +361,18 @@ func TestFactor(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			plugin := &Scale{
-				Scalings: make([]Scaling, 0, len(tt.scale)),
+				Scalings: make([]scaling, 0, len(tt.scale)),
 				Log:      testutil.Logger{},
 			}
 			for i := range tt.scale {
-				s := Scaling{
-					Fields: tt.scale[i].Fields,
+				s := scaling{
+					Fields: tt.scale[i].fields,
 				}
-				if tt.scale[i].Factor != 0.0 {
-					s.Factor = &tt.scale[i].Factor
+				if tt.scale[i].factor != 0.0 {
+					s.Factor = &tt.scale[i].factor
 				}
-				if tt.scale[i].Offset != 0.0 {
-					s.Offset = &tt.scale[i].Offset
+				if tt.scale[i].offset != 0.0 {
+					s.Offset = &tt.scale[i].offset
 				}
 				plugin.Scalings = append(plugin.Scalings, s)
 			}
@@ -388,13 +388,13 @@ func TestErrorCasesMinMax(t *testing.T) {
 	a0, a1, a100 := float64(0.0), float64(1.0), float64(100.0)
 	tests := []struct {
 		name             string
-		scaling          []Scaling
+		scaling          []scaling
 		fields           []string
 		expectedErrorMsg string
 	}{
 		{
 			name: "Same input range values",
-			scaling: []Scaling{
+			scaling: []scaling{
 				{
 					InMin:  &a1,
 					InMax:  &a1,
@@ -408,7 +408,7 @@ func TestErrorCasesMinMax(t *testing.T) {
 		},
 		{
 			name: "Same input range values",
-			scaling: []Scaling{
+			scaling: []scaling{
 				{
 					InMin:  &a0,
 					InMax:  &a1,
@@ -422,7 +422,7 @@ func TestErrorCasesMinMax(t *testing.T) {
 		},
 		{
 			name: "Nothing set",
-			scaling: []Scaling{
+			scaling: []scaling{
 				{
 					Fields: []string{"test"},
 				},
@@ -432,7 +432,7 @@ func TestErrorCasesMinMax(t *testing.T) {
 		},
 		{
 			name: "Partial minimum and maximum",
-			scaling: []Scaling{
+			scaling: []scaling{
 				{
 					InMin:  &a0,
 					Fields: []string{"test"},
@@ -443,7 +443,7 @@ func TestErrorCasesMinMax(t *testing.T) {
 		},
 		{
 			name: "Mixed minimum, maximum and factor",
-			scaling: []Scaling{
+			scaling: []scaling{
 				{
 					InMin:  &a0,
 					InMax:  &a1,
@@ -522,7 +522,7 @@ func TestTracking(t *testing.T) {
 	outMax := float64(100)
 
 	plugin := &Scale{
-		Scalings: []Scaling{
+		Scalings: []scaling{
 			{
 				InMin:  &inMin,
 				InMax:  &inMax,

--- a/plugins/processors/snmp_lookup/lookup_test.go
+++ b/plugins/processors/snmp_lookup/lookup_test.go
@@ -54,28 +54,28 @@ func (*testSNMPConnection) Reconnect() error {
 
 func TestRegistry(t *testing.T) {
 	require.Contains(t, processors.Processors, "snmp_lookup")
-	require.IsType(t, &Lookup{}, processors.Processors["snmp_lookup"]())
+	require.IsType(t, &SNMPLookup{}, processors.Processors["snmp_lookup"]())
 }
 
 func TestSampleConfig(t *testing.T) {
 	cfg := config.NewConfig()
 
-	require.NoError(t, cfg.LoadConfigData(testutil.DefaultSampleConfig((&Lookup{}).SampleConfig()), config.EmptySourcePath))
+	require.NoError(t, cfg.LoadConfigData(testutil.DefaultSampleConfig((&SNMPLookup{}).SampleConfig()), config.EmptySourcePath))
 }
 
 func TestInit(t *testing.T) {
 	tests := []struct {
 		name     string
-		plugin   *Lookup
+		plugin   *SNMPLookup
 		expected string
 	}{
 		{
 			name:   "empty",
-			plugin: &Lookup{},
+			plugin: &SNMPLookup{},
 		},
 		{
 			name: "defaults",
-			plugin: &Lookup{
+			plugin: &SNMPLookup{
 				AgentTag:        "source",
 				IndexTag:        "index",
 				ClientConfig:    *snmp.DefaultClientConfig(),
@@ -86,7 +86,7 @@ func TestInit(t *testing.T) {
 		},
 		{
 			name: "wrong SNMP client config",
-			plugin: &Lookup{
+			plugin: &SNMPLookup{
 				ClientConfig: snmp.ClientConfig{
 					Version: 99,
 				},
@@ -95,7 +95,7 @@ func TestInit(t *testing.T) {
 		},
 		{
 			name: "table init",
-			plugin: &Lookup{
+			plugin: &SNMPLookup{
 				Tags: []snmp.Field{
 					{
 						Name: "ifName",
@@ -120,7 +120,7 @@ func TestInit(t *testing.T) {
 }
 
 func TestStart(t *testing.T) {
-	plugin := Lookup{}
+	plugin := SNMPLookup{}
 	require.NoError(t, plugin.Init())
 
 	var acc testutil.NopAccumulator
@@ -161,7 +161,7 @@ func TestGetConnection(t *testing.T) {
 		},
 	}
 
-	p := Lookup{
+	p := SNMPLookup{
 		AgentTag:     "source",
 		ClientConfig: *snmp.DefaultClientConfig(),
 		Log:          testutil.Logger{Name: "processors.snmp_lookup"},
@@ -185,7 +185,7 @@ func TestGetConnection(t *testing.T) {
 }
 
 func TestUpdateAgent(t *testing.T) {
-	p := Lookup{
+	p := SNMPLookup{
 		ClientConfig: *snmp.DefaultClientConfig(),
 		CacheSize:    defaultCacheSize,
 		CacheTTL:     defaultCacheTTL,
@@ -339,7 +339,7 @@ func TestAdd(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			plugin := Lookup{
+			plugin := SNMPLookup{
 				AgentTag:        "source",
 				IndexTag:        "index",
 				ClientConfig:    *snmp.DefaultClientConfig(),
@@ -376,7 +376,7 @@ func TestAdd(t *testing.T) {
 }
 
 func TestExpiry(t *testing.T) {
-	p := Lookup{
+	p := SNMPLookup{
 		AgentTag:        "source",
 		IndexTag:        "index",
 		CacheSize:       defaultCacheSize,
@@ -488,7 +488,7 @@ func TestExpiry(t *testing.T) {
 }
 
 func TestOrdered(t *testing.T) {
-	plugin := Lookup{
+	plugin := SNMPLookup{
 		AgentTag:        "source",
 		IndexTag:        "index",
 		CacheSize:       defaultCacheSize,

--- a/plugins/processors/snmp_lookup/store.go
+++ b/plugins/processors/snmp_lookup/store.go
@@ -1,7 +1,6 @@
 package snmp_lookup
 
 import (
-	"errors"
 	"sync"
 	"time"
 
@@ -10,8 +9,6 @@ import (
 
 	"github.com/influxdata/telegraf/config"
 )
-
-var ErrNotYetAvailable = errors.New("data not yet available")
 
 type store struct {
 	cache                *expirable.LRU[string, *tagMap]

--- a/plugins/processors/streamingprocessor.go
+++ b/plugins/processors/streamingprocessor.go
@@ -5,8 +5,7 @@ import (
 	"github.com/influxdata/telegraf/models"
 )
 
-// NewStreamingProcessorFromProcessor is a converter that turns a standard
-// processor into a streaming processor
+// NewStreamingProcessorFromProcessor is a converter that turns a standard processor into a streaming processor.
 func NewStreamingProcessorFromProcessor(p telegraf.Processor) telegraf.StreamingProcessor {
 	sp := &streamingProcessor{
 		processor: p,
@@ -39,9 +38,7 @@ func (sp *streamingProcessor) Add(m telegraf.Metric, acc telegraf.Accumulator) e
 func (*streamingProcessor) Stop() {
 }
 
-// Make the streamingProcessor of type Initializer to be able
-// to call the Init method of the wrapped processor if
-// needed
+// Init makes the streamingProcessor of type Initializer to be able to call the Init method of the wrapped processor if needed.
 func (sp *streamingProcessor) Init() error {
 	models.SetLoggerOnPlugin(sp.processor, sp.Log)
 	if p, ok := sp.processor.(telegraf.Initializer); ok {
@@ -53,9 +50,8 @@ func (sp *streamingProcessor) Init() error {
 	return nil
 }
 
-// Unwrap lets you retrieve the original telegraf.Processor from the
-// StreamingProcessor. This is necessary because the toml Unmarshaller won't
-// look inside composed types.
+// Unwrap lets you retrieve the original telegraf.Processor from the StreamingProcessor.
+// This is necessary because the toml Unmarshaller won't look inside composed types.
 func (sp *streamingProcessor) Unwrap() telegraf.Processor {
 	return sp.processor
 }

--- a/plugins/processors/strings/strings_test.go
+++ b/plugins/processors/strings/strings_test.go
@@ -55,7 +55,7 @@ func TestFieldConversions(t *testing.T) {
 			plugin: &Strings{
 				Lowercase: []converter{
 					{
-						Field: "request",
+						field: "request",
 					},
 				},
 			},
@@ -70,7 +70,7 @@ func TestFieldConversions(t *testing.T) {
 			plugin: &Strings{
 				Uppercase: []converter{
 					{
-						Field: "request",
+						field: "request",
 					},
 				},
 			},
@@ -85,7 +85,7 @@ func TestFieldConversions(t *testing.T) {
 			plugin: &Strings{
 				Titlecase: []converter{
 					{
-						Field: "request",
+						field: "request",
 					},
 				},
 			},
@@ -100,8 +100,8 @@ func TestFieldConversions(t *testing.T) {
 			plugin: &Strings{
 				Lowercase: []converter{
 					{
-						Field: "request",
-						Dest:  "lowercase_request",
+						field: "request",
+						dest:  "lowercase_request",
 					},
 				},
 			},
@@ -120,8 +120,8 @@ func TestFieldConversions(t *testing.T) {
 			plugin: &Strings{
 				Trim: []converter{
 					{
-						Field:  "request",
-						Cutset: "/w",
+						field:  "request",
+						cutset: "/w",
 					},
 				},
 			},
@@ -136,13 +136,13 @@ func TestFieldConversions(t *testing.T) {
 			plugin: &Strings{
 				Trim: []converter{
 					{
-						Field:  "request",
-						Cutset: "/w",
+						field:  "request",
+						cutset: "/w",
 					},
 				},
 				Lowercase: []converter{
 					{
-						Field: "request",
+						field: "request",
 					},
 				},
 			},
@@ -157,8 +157,8 @@ func TestFieldConversions(t *testing.T) {
 			plugin: &Strings{
 				TrimLeft: []converter{
 					{
-						Field:  "request",
-						Cutset: "/w",
+						field:  "request",
+						cutset: "/w",
 					},
 				},
 			},
@@ -173,8 +173,8 @@ func TestFieldConversions(t *testing.T) {
 			plugin: &Strings{
 				TrimRight: []converter{
 					{
-						Field:  "request",
-						Cutset: "/w",
+						field:  "request",
+						cutset: "/w",
 					},
 				},
 			},
@@ -189,8 +189,8 @@ func TestFieldConversions(t *testing.T) {
 			plugin: &Strings{
 				TrimPrefix: []converter{
 					{
-						Field:  "request",
-						Prefix: "/mixed",
+						field:  "request",
+						prefix: "/mixed",
 					},
 				},
 			},
@@ -205,8 +205,8 @@ func TestFieldConversions(t *testing.T) {
 			plugin: &Strings{
 				TrimSuffix: []converter{
 					{
-						Field:  "request",
-						Suffix: "-1D&to=now",
+						field:  "request",
+						suffix: "-1D&to=now",
 					},
 				},
 			},
@@ -221,7 +221,7 @@ func TestFieldConversions(t *testing.T) {
 			plugin: &Strings{
 				Trim: []converter{
 					{
-						Field: "whitespace",
+						field: "whitespace",
 					},
 				},
 			},
@@ -236,7 +236,7 @@ func TestFieldConversions(t *testing.T) {
 			plugin: &Strings{
 				TrimLeft: []converter{
 					{
-						Field: "whitespace",
+						field: "whitespace",
 					},
 				},
 			},
@@ -251,7 +251,7 @@ func TestFieldConversions(t *testing.T) {
 			plugin: &Strings{
 				TrimRight: []converter{
 					{
-						Field: "whitespace",
+						field: "whitespace",
 					},
 				},
 			},
@@ -266,8 +266,8 @@ func TestFieldConversions(t *testing.T) {
 			plugin: &Strings{
 				Lowercase: []converter{
 					{
-						Field:  "xyzzy",
-						Suffix: "-1D&to=now",
+						field:  "xyzzy",
+						suffix: "-1D&to=now",
 					},
 				},
 			},
@@ -298,7 +298,7 @@ func TestFieldKeyConversions(t *testing.T) {
 			plugin: &Strings{
 				Lowercase: []converter{
 					{
-						FieldKey: "Request",
+						fieldKey: "Request",
 					},
 				},
 			},
@@ -313,7 +313,7 @@ func TestFieldKeyConversions(t *testing.T) {
 			plugin: &Strings{
 				Uppercase: []converter{
 					{
-						FieldKey: "Request",
+						fieldKey: "Request",
 					},
 				},
 			},
@@ -332,8 +332,8 @@ func TestFieldKeyConversions(t *testing.T) {
 			plugin: &Strings{
 				Trim: []converter{
 					{
-						FieldKey: "Request",
-						Cutset:   "eR",
+						fieldKey: "Request",
+						cutset:   "eR",
 					},
 				},
 			},
@@ -353,18 +353,18 @@ func TestFieldKeyConversions(t *testing.T) {
 				//   Trim
 				//   TrimLeft
 				//   TrimRight
-				//   TrimPrefix
+				//   Trimprefix
 				//   TrimSuffix
 				//   Replace
 				Lowercase: []converter{
 					{
-						FieldKey: "Request",
+						fieldKey: "Request",
 					},
 				},
 				Trim: []converter{
 					{
-						FieldKey: "request",
-						Cutset:   "tse",
+						fieldKey: "request",
+						cutset:   "tse",
 					},
 				},
 			},
@@ -379,8 +379,8 @@ func TestFieldKeyConversions(t *testing.T) {
 			plugin: &Strings{
 				TrimLeft: []converter{
 					{
-						FieldKey: "req/sec",
-						Cutset:   "req/",
+						fieldKey: "req/sec",
+						cutset:   "req/",
 					},
 				},
 			},
@@ -395,8 +395,8 @@ func TestFieldKeyConversions(t *testing.T) {
 			plugin: &Strings{
 				TrimRight: []converter{
 					{
-						FieldKey: "req/sec",
-						Cutset:   "req/",
+						fieldKey: "req/sec",
+						cutset:   "req/",
 					},
 				},
 			},
@@ -411,8 +411,8 @@ func TestFieldKeyConversions(t *testing.T) {
 			plugin: &Strings{
 				TrimPrefix: []converter{
 					{
-						FieldKey: "req/sec",
-						Prefix:   "req/",
+						fieldKey: "req/sec",
+						prefix:   "req/",
 					},
 				},
 			},
@@ -427,8 +427,8 @@ func TestFieldKeyConversions(t *testing.T) {
 			plugin: &Strings{
 				TrimSuffix: []converter{
 					{
-						FieldKey: "req/sec",
-						Suffix:   "/sec",
+						fieldKey: "req/sec",
+						suffix:   "/sec",
 					},
 				},
 			},
@@ -443,7 +443,7 @@ func TestFieldKeyConversions(t *testing.T) {
 			plugin: &Strings{
 				Trim: []converter{
 					{
-						FieldKey: " whitespace ",
+						fieldKey: " whitespace ",
 					},
 				},
 			},
@@ -458,7 +458,7 @@ func TestFieldKeyConversions(t *testing.T) {
 			plugin: &Strings{
 				TrimLeft: []converter{
 					{
-						FieldKey: " whitespace ",
+						fieldKey: " whitespace ",
 					},
 				},
 			},
@@ -473,7 +473,7 @@ func TestFieldKeyConversions(t *testing.T) {
 			plugin: &Strings{
 				TrimRight: []converter{
 					{
-						FieldKey: " whitespace ",
+						fieldKey: " whitespace ",
 					},
 				},
 			},
@@ -488,8 +488,8 @@ func TestFieldKeyConversions(t *testing.T) {
 			plugin: &Strings{
 				Lowercase: []converter{
 					{
-						FieldKey: "xyzzy",
-						Suffix:   "-1D&to=now",
+						fieldKey: "xyzzy",
+						suffix:   "-1D&to=now",
 					},
 				},
 			},
@@ -504,8 +504,8 @@ func TestFieldKeyConversions(t *testing.T) {
 			plugin: &Strings{
 				Left: []converter{
 					{
-						Field: "Request",
-						Width: 6,
+						field: "Request",
+						width: 6,
 					},
 				},
 			},
@@ -520,8 +520,8 @@ func TestFieldKeyConversions(t *testing.T) {
 			plugin: &Strings{
 				Left: []converter{
 					{
-						Field: "Request",
-						Width: 600,
+						field: "Request",
+						width: 600,
 					},
 				},
 			},
@@ -552,7 +552,7 @@ func TestTagConversions(t *testing.T) {
 			plugin: &Strings{
 				Lowercase: []converter{
 					{
-						Tag: "s-computername",
+						tag: "s-computername",
 					},
 				},
 			},
@@ -571,8 +571,8 @@ func TestTagConversions(t *testing.T) {
 			plugin: &Strings{
 				Lowercase: []converter{
 					{
-						Tag:  "s-computername",
-						Dest: "s-computername_lowercase",
+						tag:  "s-computername",
+						dest: "s-computername_lowercase",
 					},
 				},
 			},
@@ -595,8 +595,8 @@ func TestTagConversions(t *testing.T) {
 			plugin: &Strings{
 				Uppercase: []converter{
 					{
-						Tag:  "s-computername",
-						Dest: "s-computername_uppercase",
+						tag:  "s-computername",
+						dest: "s-computername_uppercase",
 					},
 				},
 			},
@@ -619,8 +619,8 @@ func TestTagConversions(t *testing.T) {
 			plugin: &Strings{
 				Titlecase: []converter{
 					{
-						Tag:  "s-computername",
-						Dest: "s-computername_titlecase",
+						tag:  "s-computername",
+						dest: "s-computername_titlecase",
 					},
 				},
 			},
@@ -660,8 +660,8 @@ func TestTagKeyConversions(t *testing.T) {
 			plugin: &Strings{
 				Lowercase: []converter{
 					{
-						Tag:    "S-ComputerName",
-						TagKey: "S-ComputerName",
+						tag:    "S-ComputerName",
+						tagKey: "S-ComputerName",
 					},
 				},
 			},
@@ -680,7 +680,7 @@ func TestTagKeyConversions(t *testing.T) {
 			plugin: &Strings{
 				Lowercase: []converter{
 					{
-						TagKey: "S-ComputerName",
+						tagKey: "S-ComputerName",
 					},
 				},
 			},
@@ -702,7 +702,7 @@ func TestTagKeyConversions(t *testing.T) {
 			plugin: &Strings{
 				Uppercase: []converter{
 					{
-						TagKey: "S-ComputerName",
+						tagKey: "S-ComputerName",
 					},
 				},
 			},
@@ -741,7 +741,7 @@ func TestMeasurementConversions(t *testing.T) {
 			plugin: &Strings{
 				Lowercase: []converter{
 					{
-						Measurement: "IIS_log",
+						measurement: "IIS_log",
 					},
 				},
 			},
@@ -764,36 +764,36 @@ func TestMultipleConversions(t *testing.T) {
 	plugin := &Strings{
 		Lowercase: []converter{
 			{
-				Tag: "s-computername",
+				tag: "s-computername",
 			},
 			{
-				Field: "request",
+				field: "request",
 			},
 			{
-				Field: "cs-host",
-				Dest:  "cs-host_lowercase",
+				field: "cs-host",
+				dest:  "cs-host_lowercase",
 			},
 		},
 		Uppercase: []converter{
 			{
-				Tag: "verb",
+				tag: "verb",
 			},
 		},
 		Titlecase: []converter{
 			{
-				Field: "status",
+				field: "status",
 			},
 		},
 		Replace: []converter{
 			{
-				Tag: "foo",
-				Old: "a",
-				New: "x",
+				tag: "foo",
+				old: "a",
+				new: "x",
 			},
 			{
-				Tag: "bar",
-				Old: "b",
-				New: "y",
+				tag: "bar",
+				old: "b",
+				new: "y",
 			},
 		},
 	}
@@ -842,19 +842,19 @@ func TestReadmeExample(t *testing.T) {
 	plugin := &Strings{
 		Lowercase: []converter{
 			{
-				Tag: "uri_stem",
+				tag: "uri_stem",
 			},
 		},
 		TrimPrefix: []converter{
 			{
-				Tag:    "uri_stem",
-				Prefix: "/api/",
+				tag:    "uri_stem",
+				prefix: "/api/",
 			},
 		},
 		Uppercase: []converter{
 			{
-				Field: "cs-host",
-				Dest:  "cs-host_normalised",
+				field: "cs-host",
+				dest:  "cs-host_normalised",
 			},
 		},
 	}
@@ -906,9 +906,9 @@ func TestMeasurementReplace(t *testing.T) {
 	plugin := &Strings{
 		Replace: []converter{
 			{
-				Old:         "_",
-				New:         "-",
-				Measurement: "*",
+				old:         "_",
+				new:         "-",
+				measurement: "*",
 			},
 		},
 	}
@@ -927,9 +927,9 @@ func TestMeasurementCharDeletion(t *testing.T) {
 	plugin := &Strings{
 		Replace: []converter{
 			{
-				Old:         "foo",
-				New:         "",
-				Measurement: "*",
+				old:         "foo",
+				new:         "",
+				measurement: "*",
 			},
 		},
 	}
@@ -956,7 +956,7 @@ func TestBase64Decode(t *testing.T) {
 			plugin: &Strings{
 				Base64Decode: []converter{
 					{
-						Field: "message",
+						field: "message",
 					},
 				},
 			},
@@ -986,7 +986,7 @@ func TestBase64Decode(t *testing.T) {
 			plugin: &Strings{
 				Base64Decode: []converter{
 					{
-						Field: "message",
+						field: "message",
 					},
 				},
 			},
@@ -1016,7 +1016,7 @@ func TestBase64Decode(t *testing.T) {
 			plugin: &Strings{
 				Base64Decode: []converter{
 					{
-						Field: "message",
+						field: "message",
 					},
 				},
 			},
@@ -1063,8 +1063,8 @@ func TestValidUTF8(t *testing.T) {
 			plugin: &Strings{
 				ValidUTF8: []converter{
 					{
-						Field:       "message",
-						Replacement: "r",
+						field:       "message",
+						replacement: "r",
 					},
 				},
 			},
@@ -1094,8 +1094,8 @@ func TestValidUTF8(t *testing.T) {
 			plugin: &Strings{
 				ValidUTF8: []converter{
 					{
-						Field:       "message",
-						Replacement: "r",
+						field:       "message",
+						replacement: "r",
 					},
 				},
 			},
@@ -1125,8 +1125,8 @@ func TestValidUTF8(t *testing.T) {
 			plugin: &Strings{
 				ValidUTF8: []converter{
 					{
-						Field:       "message",
-						Replacement: "",
+						field:       "message",
+						replacement: "",
 					},
 				},
 			},
@@ -1183,7 +1183,7 @@ func TestTrackedMetricNotLost(t *testing.T) {
 	}
 
 	// Process expected metrics and compare with resulting metrics
-	plugin := &Strings{ValidUTF8: []converter{{Field: "message", Replacement: ""}}}
+	plugin := &Strings{ValidUTF8: []converter{{field: "message", replacement: ""}}}
 	actual := plugin.Apply(input...)
 	testutil.RequireMetricsEqual(t, expected, actual)
 

--- a/plugins/processors/tag_limit/tag_limit.go
+++ b/plugins/processors/tag_limit/tag_limit.go
@@ -20,22 +20,6 @@ type TagLimit struct {
 	keepTags map[string]string
 }
 
-func (d *TagLimit) initOnce() error {
-	if d.init {
-		return nil
-	}
-	if len(d.Keep) > d.Limit {
-		return fmt.Errorf("%d keep tags is greater than %d total tag limit", len(d.Keep), d.Limit)
-	}
-	d.keepTags = make(map[string]string)
-	// convert list of tags-to-keep to a map so we can do constant-time lookups
-	for _, tagKey := range d.Keep {
-		d.keepTags[tagKey] = ""
-	}
-	d.init = true
-	return nil
-}
-
 func (*TagLimit) SampleConfig() string {
 	return sampleConfig
 }
@@ -69,6 +53,22 @@ func (d *TagLimit) Apply(in ...telegraf.Metric) []telegraf.Metric {
 	}
 
 	return in
+}
+
+func (d *TagLimit) initOnce() error {
+	if d.init {
+		return nil
+	}
+	if len(d.Keep) > d.Limit {
+		return fmt.Errorf("%d keep tags is greater than %d total tag limit", len(d.Keep), d.Limit)
+	}
+	d.keepTags = make(map[string]string)
+	// convert list of tags-to-keep to a map so we can do constant-time lookups
+	for _, tagKey := range d.Keep {
+		d.keepTags[tagKey] = ""
+	}
+	d.init = true
+	return nil
 }
 
 func init() {

--- a/plugins/processors/tag_limit/tag_limit_test.go
+++ b/plugins/processors/tag_limit/tag_limit_test.go
@@ -12,14 +12,11 @@ import (
 	"github.com/influxdata/telegraf/testutil"
 )
 
-func MustMetric(name string, tags map[string]string, fields map[string]interface{}, metricTime time.Time) telegraf.Metric {
+func mustMetric(name string, tags map[string]string, metricTime time.Time) telegraf.Metric {
 	if tags == nil {
 		tags = map[string]string{}
 	}
-	if fields == nil {
-		fields = map[string]interface{}{}
-	}
-	m := metric.New(name, tags, fields, metricTime)
+	m := metric.New(name, tags, map[string]interface{}{}, metricTime)
 	return m
 }
 
@@ -46,8 +43,8 @@ func TestUnderLimit(t *testing.T) {
 		Keep:  []string{"foo", "bar"},
 	}
 
-	m1 := MustMetric("foo", oneTags, nil, currentTime)
-	m2 := MustMetric("bar", tenTags, nil, currentTime)
+	m1 := mustMetric("foo", oneTags, currentTime)
+	m2 := mustMetric("bar", tenTags, currentTime)
 	limitApply := tagLimitConfig.Apply(m1, m2)
 	require.Equal(t, oneTags, limitApply[0].Tags(), "one tag")
 	require.Equal(t, tenTags, limitApply[1].Tags(), "ten tags")
@@ -78,8 +75,8 @@ func TestTrim(t *testing.T) {
 		Keep:  []string{"a", "b"},
 	}
 
-	m1 := MustMetric("foo", threeTags, nil, currentTime)
-	m2 := MustMetric("bar", tenTags, nil, currentTime)
+	m1 := mustMetric("foo", threeTags, currentTime)
+	m2 := mustMetric("bar", tenTags, currentTime)
 	limitApply := tagLimitConfig.Apply(m1, m2)
 	require.Equal(t, threeTags, limitApply[0].Tags(), "three tags")
 	trimmedTags := limitApply[1].Tags()

--- a/plugins/processors/template/template.go
+++ b/plugins/processors/template/template.go
@@ -16,7 +16,7 @@ import (
 //go:embed sample.conf
 var sampleConfig string
 
-type TemplateProcessor struct {
+type Template struct {
 	Tag      string          `toml:"tag"`
 	Template string          `toml:"template"`
 	Log      telegraf.Logger `toml:"-"`
@@ -25,11 +25,26 @@ type TemplateProcessor struct {
 	tmplValue *template.Template
 }
 
-func (*TemplateProcessor) SampleConfig() string {
+func (*Template) SampleConfig() string {
 	return sampleConfig
 }
 
-func (r *TemplateProcessor) Apply(in ...telegraf.Metric) []telegraf.Metric {
+func (r *Template) Init() error {
+	var err error
+
+	r.tmplTag, err = template.New("tag template").Funcs(sprig.TxtFuncMap()).Parse(r.Tag)
+	if err != nil {
+		return fmt.Errorf("creating tag name template failed: %w", err)
+	}
+
+	r.tmplValue, err = template.New("value template").Funcs(sprig.TxtFuncMap()).Parse(r.Template)
+	if err != nil {
+		return fmt.Errorf("creating value template failed: %w", err)
+	}
+	return nil
+}
+
+func (r *Template) Apply(in ...telegraf.Metric) []telegraf.Metric {
 	// for each metric in "in" array
 	for _, raw := range in {
 		m := raw
@@ -41,7 +56,7 @@ func (r *TemplateProcessor) Apply(in ...telegraf.Metric) []telegraf.Metric {
 			r.Log.Errorf("metric of type %T is not a template metric", raw)
 			continue
 		}
-		newM := TemplateMetric{tm}
+		newM := templateMetric{tm}
 
 		var b strings.Builder
 		if err := r.tmplTag.Execute(&b, &newM); err != nil {
@@ -63,23 +78,8 @@ func (r *TemplateProcessor) Apply(in ...telegraf.Metric) []telegraf.Metric {
 	return in
 }
 
-func (r *TemplateProcessor) Init() error {
-	var err error
-
-	r.tmplTag, err = template.New("tag template").Funcs(sprig.TxtFuncMap()).Parse(r.Tag)
-	if err != nil {
-		return fmt.Errorf("creating tag name template failed: %w", err)
-	}
-
-	r.tmplValue, err = template.New("value template").Funcs(sprig.TxtFuncMap()).Parse(r.Template)
-	if err != nil {
-		return fmt.Errorf("creating value template failed: %w", err)
-	}
-	return nil
-}
-
 func init() {
 	processors.Add("template", func() telegraf.Processor {
-		return &TemplateProcessor{}
+		return &Template{}
 	})
 }

--- a/plugins/processors/template/template_metric.go
+++ b/plugins/processors/template/template_metric.go
@@ -13,39 +13,39 @@ var (
 	onceFieldList sync.Once
 )
 
-type TemplateMetric struct {
+type templateMetric struct {
 	metric telegraf.TemplateMetric
 }
 
-func (m *TemplateMetric) Name() string {
+func (m *templateMetric) Name() string {
 	return m.metric.Name()
 }
 
-func (m *TemplateMetric) Tag(key string) string {
+func (m *templateMetric) Tag(key string) string {
 	return m.metric.Tag(key)
 }
 
-func (m *TemplateMetric) Field(key string) interface{} {
+func (m *templateMetric) Field(key string) interface{} {
 	return m.metric.Field(key)
 }
 
-func (m *TemplateMetric) Time() time.Time {
+func (m *templateMetric) Time() time.Time {
 	return m.metric.Time()
 }
 
-func (m *TemplateMetric) Tags() map[string]string {
+func (m *templateMetric) Tags() map[string]string {
 	return m.metric.Tags()
 }
 
-func (m *TemplateMetric) Fields() map[string]interface{} {
+func (m *templateMetric) Fields() map[string]interface{} {
 	return m.metric.Fields()
 }
 
-func (m *TemplateMetric) String() string {
+func (m *templateMetric) String() string {
 	return m.metric.String()
 }
 
-func (m *TemplateMetric) TagList() map[string]string {
+func (m *templateMetric) TagList() map[string]string {
 	onceTagList.Do(func() {
 		config.PrintOptionValueDeprecationNotice(
 			"processors.template", "template", "{{.TagList}}",
@@ -59,7 +59,7 @@ func (m *TemplateMetric) TagList() map[string]string {
 	return m.metric.Tags()
 }
 
-func (m *TemplateMetric) FieldList() map[string]interface{} {
+func (m *templateMetric) FieldList() map[string]interface{} {
 	onceFieldList.Do(func() {
 		config.PrintOptionValueDeprecationNotice(
 			"processors.template", "template", "{{.FieldList}}",

--- a/plugins/processors/template/template_test.go
+++ b/plugins/processors/template/template_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestName(t *testing.T) {
-	plugin := TemplateProcessor{
+	plugin := Template{
 		Tag:      "measurement",
 		Template: "{{ .Name }}",
 	}
@@ -49,7 +49,7 @@ func TestName(t *testing.T) {
 }
 
 func TestNameTemplate(t *testing.T) {
-	plugin := TemplateProcessor{
+	plugin := Template{
 		Tag:      `{{ .Tag "foo" }}`,
 		Template: `{{ .Name }}`,
 	}
@@ -89,7 +89,7 @@ func TestTagTemplateConcatenate(t *testing.T) {
 	now := time.Now()
 
 	// Create Template processor
-	tmp := TemplateProcessor{Tag: "topic", Template: `{{.Tag "hostname"}}.{{ .Tag "level" }}`}
+	tmp := Template{Tag: "topic", Template: `{{.Tag "hostname"}}.{{ .Tag "level" }}`}
 	// manually init
 	err := tmp.Init()
 
@@ -114,7 +114,7 @@ func TestMetricMissingTagsIsNotLost(t *testing.T) {
 	now := time.Now()
 
 	// Create Template processor
-	tmp := TemplateProcessor{Tag: "topic", Template: `{{.Tag "hostname"}}.{{ .Tag "level" }}`}
+	tmp := Template{Tag: "topic", Template: `{{.Tag "hostname"}}.{{ .Tag "level" }}`}
 	// manually init
 	err := tmp.Init()
 
@@ -138,7 +138,7 @@ func TestTagAndFieldConcatenate(t *testing.T) {
 	now := time.Now()
 
 	// Create Template processor
-	tmp := TemplateProcessor{Tag: "LocalTemp", Template: `{{.Tag "location"}} is {{ .Field "temperature" }}`}
+	tmp := Template{Tag: "LocalTemp", Template: `{{.Tag "location"}} is {{ .Field "temperature" }}`}
 	// manually init
 	err := tmp.Init()
 
@@ -166,7 +166,7 @@ func TestTagAndFieldConcatenate(t *testing.T) {
 
 func TestFieldList(t *testing.T) {
 	// Prepare
-	plugin := TemplateProcessor{Tag: "fields", Template: "{{.FieldList}}"}
+	plugin := Template{Tag: "fields", Template: "{{.FieldList}}"}
 	require.NoError(t, plugin.Init())
 
 	// Run
@@ -181,7 +181,7 @@ func TestFieldList(t *testing.T) {
 
 func TestTagList(t *testing.T) {
 	// Prepare
-	plugin := TemplateProcessor{Tag: "tags", Template: "{{.TagList}}"}
+	plugin := Template{Tag: "tags", Template: "{{.TagList}}"}
 	require.NoError(t, plugin.Init())
 
 	// Run
@@ -196,7 +196,7 @@ func TestTagList(t *testing.T) {
 
 func TestFields(t *testing.T) {
 	// Prepare
-	plugin := TemplateProcessor{
+	plugin := Template{
 		Tag:      "fields",
 		Template: "{{.Fields}}",
 		Log:      testutil.Logger{},
@@ -215,7 +215,7 @@ func TestFields(t *testing.T) {
 
 func TestTags(t *testing.T) {
 	// Prepare
-	plugin := TemplateProcessor{
+	plugin := Template{
 		Tag:      "tags",
 		Template: "{{.Tags}}",
 		Log:      testutil.Logger{},
@@ -234,7 +234,7 @@ func TestTags(t *testing.T) {
 
 func TestString(t *testing.T) {
 	// Prepare
-	plugin := TemplateProcessor{
+	plugin := Template{
 		Tag:      "tags",
 		Template: "{{.}}",
 		Log:      testutil.Logger{},
@@ -253,7 +253,7 @@ func TestString(t *testing.T) {
 
 func TestDot(t *testing.T) {
 	// Prepare
-	plugin := TemplateProcessor{Tag: "metric", Template: "{{.}}"}
+	plugin := Template{Tag: "metric", Template: "{{.}}"}
 	require.NoError(t, plugin.Init())
 
 	// Run
@@ -284,7 +284,7 @@ func TestTracking(t *testing.T) {
 	expected := []telegraf.Metric{e}
 
 	// Configure the plugin
-	plugin := TemplateProcessor{Tag: "metric", Template: "{{.}}"}
+	plugin := Template{Tag: "metric", Template: "{{.}}"}
 	require.NoError(t, plugin.Init())
 
 	// Process expected metrics and compare with resulting metrics
@@ -307,7 +307,7 @@ func TestTracking(t *testing.T) {
 }
 
 func TestSprig(t *testing.T) {
-	plugin := TemplateProcessor{
+	plugin := Template{
 		Tag:      `{{ .Tag "foo" | lower }}`,
 		Template: `{{ .Name | upper }}`,
 	}

--- a/plugins/processors/topk/test_sets.go
+++ b/plugins/processors/topk/test_sets.go
@@ -58,7 +58,7 @@ var metric15 = metric.New(
 	time.Now(),
 )
 
-var MetricsSet1 = []telegraf.Metric{metric11, metric12, metric13, metric14, metric15}
+var metricsSet1 = []telegraf.Metric{metric11, metric12, metric13, metric14, metric15}
 
 // /// Test set 2 /////
 var metric21 = metric.New(
@@ -161,4 +161,4 @@ var metric26 = metric.New(
 	time.Now(),
 )
 
-var MetricsSet2 = []telegraf.Metric{metric21, metric22, metric23, metric24, metric25, metric26}
+var metricsSet2 = []telegraf.Metric{metric21, metric22, metric23, metric24, metric25, metric26}

--- a/plugins/processors/topk/topk_test.go
+++ b/plugins/processors/topk/topk_test.go
@@ -143,7 +143,7 @@ func runAndCompare(topk *TopK, metrics, answer []telegraf.Metric, testID string,
 // Smoke tests
 func TestTopkAggregatorsSmokeTests(t *testing.T) {
 	// Build the processor
-	topk := *New()
+	topk := *newTopK()
 	topk.Period = tenMillisecondsDuration
 	topk.Fields = []string{"a"}
 	topk.GroupBy = []string{"tag_name"}
@@ -151,8 +151,8 @@ func TestTopkAggregatorsSmokeTests(t *testing.T) {
 	aggregators := []string{"mean", "sum", "max", "min"}
 
 	// The answer is equal to the original set for these particular scenarios
-	input := MetricsSet1
-	answer := MetricsSet1
+	input := metricsSet1
+	answer := metricsSet1
 
 	for _, ag := range aggregators {
 		topk.Aggregation = ag
@@ -164,7 +164,7 @@ func TestTopkAggregatorsSmokeTests(t *testing.T) {
 // AddAggregateFields + Mean aggregator
 func TestTopkMeanAddAggregateFields(t *testing.T) {
 	// Build the processor
-	topk := *New()
+	topk := *newTopK()
 	topk.Period = tenMillisecondsDuration
 	topk.Aggregation = "mean"
 	topk.AddAggregateFields = []string{"a"}
@@ -172,7 +172,7 @@ func TestTopkMeanAddAggregateFields(t *testing.T) {
 	topk.GroupBy = []string{"tag_name"}
 
 	// Get the input
-	input := deepCopy(MetricsSet1)
+	input := deepCopy(metricsSet1)
 
 	// Generate the answer
 	chng := fieldList(field{"a_topk_aggregate", float64(28.044)})
@@ -192,7 +192,7 @@ func TestTopkMeanAddAggregateFields(t *testing.T) {
 // AddAggregateFields + Sum aggregator
 func TestTopkSumAddAggregateFields(t *testing.T) {
 	// Build the processor
-	topk := *New()
+	topk := *newTopK()
 	topk.Period = tenMillisecondsDuration
 	topk.Aggregation = "sum"
 	topk.AddAggregateFields = []string{"a"}
@@ -200,7 +200,7 @@ func TestTopkSumAddAggregateFields(t *testing.T) {
 	topk.GroupBy = []string{"tag_name"}
 
 	// Get the input
-	input := deepCopy(MetricsSet1)
+	input := deepCopy(metricsSet1)
 
 	// Generate the answer
 	chng := fieldList(field{"a_topk_aggregate", float64(140.22)})
@@ -220,7 +220,7 @@ func TestTopkSumAddAggregateFields(t *testing.T) {
 // AddAggregateFields + Max aggregator
 func TestTopkMaxAddAggregateFields(t *testing.T) {
 	// Build the processor
-	topk := *New()
+	topk := *newTopK()
 	topk.Period = tenMillisecondsDuration
 	topk.Aggregation = "max"
 	topk.AddAggregateFields = []string{"a"}
@@ -228,7 +228,7 @@ func TestTopkMaxAddAggregateFields(t *testing.T) {
 	topk.GroupBy = []string{"tag_name"}
 
 	// Get the input
-	input := deepCopy(MetricsSet1)
+	input := deepCopy(metricsSet1)
 
 	// Generate the answer
 	chng := fieldList(field{"a_topk_aggregate", float64(50.5)})
@@ -248,7 +248,7 @@ func TestTopkMaxAddAggregateFields(t *testing.T) {
 // AddAggregateFields + Min aggregator
 func TestTopkMinAddAggregateFields(t *testing.T) {
 	// Build the processor
-	topk := *New()
+	topk := *newTopK()
 	topk.Period = tenMillisecondsDuration
 	topk.Aggregation = "min"
 	topk.AddAggregateFields = []string{"a"}
@@ -256,7 +256,7 @@ func TestTopkMinAddAggregateFields(t *testing.T) {
 	topk.GroupBy = []string{"tag_name"}
 
 	// Get the input
-	input := deepCopy(MetricsSet1)
+	input := deepCopy(metricsSet1)
 
 	// Generate the answer
 	chng := fieldList(field{"a_topk_aggregate", float64(0.3)})
@@ -276,7 +276,7 @@ func TestTopkMinAddAggregateFields(t *testing.T) {
 // GroupBy
 func TestTopkGroupby1(t *testing.T) {
 	// Build the processor
-	topk := *New()
+	topk := *newTopK()
 	topk.Period = tenMillisecondsDuration
 	topk.K = 3
 	topk.Aggregation = "sum"
@@ -284,7 +284,7 @@ func TestTopkGroupby1(t *testing.T) {
 	topk.GroupBy = []string{"tag[13]"}
 
 	// Get the input
-	input := deepCopy(MetricsSet2)
+	input := deepCopy(metricsSet2)
 
 	// Generate the answer
 	changeSet := map[int]metricChange{
@@ -300,7 +300,7 @@ func TestTopkGroupby1(t *testing.T) {
 }
 func TestTopkGroupby2(t *testing.T) {
 	// Build the processor
-	topk := *New()
+	topk := *newTopK()
 	topk.Period = tenMillisecondsDuration
 	topk.K = 3
 	topk.Aggregation = "mean"
@@ -308,7 +308,7 @@ func TestTopkGroupby2(t *testing.T) {
 	topk.GroupBy = []string{"tag1"}
 
 	// Get the input
-	input := deepCopy(MetricsSet2)
+	input := deepCopy(metricsSet2)
 
 	// Generate the answer
 	chng1 := fieldList(field{"value_topk_aggregate", float64(66.805)})
@@ -328,7 +328,7 @@ func TestTopkGroupby2(t *testing.T) {
 }
 func TestTopkGroupby3(t *testing.T) {
 	// Build the processor
-	topk := *New()
+	topk := *newTopK()
 	topk.Period = tenMillisecondsDuration
 	topk.K = 1
 	topk.Aggregation = "min"
@@ -336,7 +336,7 @@ func TestTopkGroupby3(t *testing.T) {
 	topk.GroupBy = []string{"tag4"}
 
 	// Get the input
-	input := deepCopy(MetricsSet2)
+	input := deepCopy(metricsSet2)
 
 	// Generate the answer
 	chng := fieldList(field{"value_topk_aggregate", float64(75.3)})
@@ -353,7 +353,7 @@ func TestTopkGroupby3(t *testing.T) {
 // GroupBy + Fields
 func TestTopkGroupbyFields1(t *testing.T) {
 	// Build the processor
-	topk := *New()
+	topk := *newTopK()
 	topk.Period = tenMillisecondsDuration
 	topk.K = 4 // This settings generate less than 3 groups
 	topk.Aggregation = "mean"
@@ -362,7 +362,7 @@ func TestTopkGroupbyFields1(t *testing.T) {
 	topk.Fields = []string{"A"}
 
 	// Get the input
-	input := deepCopy(MetricsSet2)
+	input := deepCopy(metricsSet2)
 
 	// Generate the answer
 	changeSet := map[int]metricChange{
@@ -379,7 +379,7 @@ func TestTopkGroupbyFields1(t *testing.T) {
 
 func TestTopkGroupbyFields2(t *testing.T) {
 	// Build the processor
-	topk := *New()
+	topk := *newTopK()
 	topk.Period = tenMillisecondsDuration
 	topk.K = 2
 	topk.Aggregation = "sum"
@@ -388,7 +388,7 @@ func TestTopkGroupbyFields2(t *testing.T) {
 	topk.Fields = []string{"B", "C"}
 
 	// Get the input
-	input := deepCopy(MetricsSet2)
+	input := deepCopy(metricsSet2)
 
 	// Generate the answer
 	changeSet := map[int]metricChange{
@@ -406,7 +406,7 @@ func TestTopkGroupbyFields2(t *testing.T) {
 // GroupBy metric name
 func TestTopkGroupbyMetricName1(t *testing.T) {
 	// Build the processor
-	topk := *New()
+	topk := *newTopK()
 	topk.Period = tenMillisecondsDuration
 	topk.K = 1
 	topk.Aggregation = "sum"
@@ -414,7 +414,7 @@ func TestTopkGroupbyMetricName1(t *testing.T) {
 	topk.GroupBy = make([]string, 0)
 
 	// Get the input
-	input := deepCopy(MetricsSet2)
+	input := deepCopy(metricsSet2)
 
 	// Generate the answer
 	chng := fieldList(field{"value_topk_aggregate", float64(235.22000000000003)})
@@ -431,7 +431,7 @@ func TestTopkGroupbyMetricName1(t *testing.T) {
 
 func TestTopkGroupbyMetricName2(t *testing.T) {
 	// Build the processor
-	topk := *New()
+	topk := *newTopK()
 	topk.Period = tenMillisecondsDuration
 	topk.K = 2
 	topk.Aggregation = "sum"
@@ -440,7 +440,7 @@ func TestTopkGroupbyMetricName2(t *testing.T) {
 	topk.Fields = []string{"A", "value"}
 
 	// Get the input
-	input := deepCopy(MetricsSet2)
+	input := deepCopy(metricsSet2)
 
 	// Generate the answer
 	changeSet := map[int]metricChange{
@@ -458,7 +458,7 @@ func TestTopkGroupbyMetricName2(t *testing.T) {
 // BottomK
 func TestTopkBottomk(t *testing.T) {
 	// Build the processor
-	topk := *New()
+	topk := *newTopK()
 	topk.Period = tenMillisecondsDuration
 	topk.K = 3
 	topk.Aggregation = "sum"
@@ -466,7 +466,7 @@ func TestTopkBottomk(t *testing.T) {
 	topk.Bottomk = true
 
 	// Get the input
-	input := deepCopy(MetricsSet2)
+	input := deepCopy(metricsSet2)
 
 	// Generate the answer
 	changeSet := map[int]metricChange{
@@ -483,7 +483,7 @@ func TestTopkBottomk(t *testing.T) {
 // GroupByKeyTag
 func TestTopkGroupByKeyTag(t *testing.T) {
 	// Build the processor
-	topk := *New()
+	topk := *newTopK()
 	topk.Period = tenMillisecondsDuration
 	topk.K = 3
 	topk.Aggregation = "sum"
@@ -491,7 +491,7 @@ func TestTopkGroupByKeyTag(t *testing.T) {
 	topk.AddGroupByTag = "gbt"
 
 	// Get the input
-	input := deepCopy(MetricsSet2)
+	input := deepCopy(metricsSet2)
 
 	// Generate the answer
 	changeSet := map[int]metricChange{

--- a/plugins/processors/unpivot/unpivot.go
+++ b/plugins/processors/unpivot/unpivot.go
@@ -19,10 +19,6 @@ type Unpivot struct {
 	ValueKey    string `toml:"value_key"`
 }
 
-func (*Unpivot) SampleConfig() string {
-	return sampleConfig
-}
-
 func (p *Unpivot) Init() error {
 	switch p.FieldNameAs {
 	case "", "tag":
@@ -40,6 +36,10 @@ func (p *Unpivot) Init() error {
 	}
 
 	return nil
+}
+
+func (*Unpivot) SampleConfig() string {
+	return sampleConfig
 }
 
 func (p *Unpivot) Apply(metrics ...telegraf.Metric) []telegraf.Metric {


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

Address findings for [revive:exported ](https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#exported ) in `plugins/processors`.

As part of this effort for files from `plugins/processors`, the following actions were taken:
- Type names (`const`, `var`, `struct`, `func`, etc) were changed to unexported, wherever they didn't need to be exported.
- All remaining exported types were given comments in the appropriate form – this does not apply to exported methods that implement "known" plugin interfaces (`Init |SampleConfig |Gather |Start |Stop |GetState |SetState |SetParser |SetParserFunc |SetTranslator |Probe |Add |Push |Reset |Get |Set |List |GetResolver |Apply |SetSerializer `).
- The order of methods was organized (exported methods first, then unexported, with `init` at the very end).

It is only part of the bigger work (for issue: https://github.com/influxdata/telegraf/issues/15813).

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR