### PR TITLE
docs(processors): Add plugin metadata and update description for a* to o*

### DIFF
--- a/plugins/processors/aws_ec2/README.md
+++ b/plugins/processors/aws_ec2/README.md
@@ -1,9 +1,13 @@
 # AWS EC2 Metadata Processor Plugin
 
-AWS EC2 Metadata processor plugin appends metadata gathered from [AWS IMDS][]
+This plugin appends metadata gathered from [AWS IMDS][aws_imds]
 to metrics associated with EC2 instances.
 
-[AWS IMDS]: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html
+⭐ Telegraf v1.18.0
+🏷️ annotation, cloud
+💻 all
+
+[aws_imds]: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html
 
 ## Global configuration options <!-- @/docs/includes/plugin_config.md -->
 

--- a/plugins/processors/batch/README.md
+++ b/plugins/processors/batch/README.md
@@ -1,10 +1,14 @@
 # Batch Processor Plugin
 
-This processor groups metrics into batches by adding a batch tag. This is
-useful for parallel processing of metrics where downstream processors,
-aggregators or outputs can then select a batch using `tagpass` or `metricpass`.
+This plugin groups metrics into batches by adding a batch tag. This is useful
+for parallel processing of metrics where downstream processors,aggregators or
+outputs can then select a batch using `tagpass` or `metricpass`.
 
 Metrics are distributed across batches using the round-robin scheme.
+
+⭐ Telegraf v1.33.0
+🏷️ grouping
+💻 all
 
 ## Global configuration options <!-- @/docs/includes/plugin_config.md -->
 
@@ -27,7 +31,7 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   batches = 16
 
   ## Do not assign metrics with an existing batch assignment to a
-  ## different batch. 
+  ## different batch.
   # skip_existing = false
 ```
 
@@ -39,7 +43,7 @@ The example below uses these settings:
 [[processors.batch]]
   ## The tag key to use for batching
   batch_tag = "batch"
-  
+
   ## The number of batches to create
   batches = 3
 ```

--- a/plugins/processors/clone/README.md
+++ b/plugins/processors/clone/README.md
@@ -1,27 +1,19 @@
 # Clone Processor Plugin
 
-The clone processor plugin create a copy of each metric passing through it,
-preserving untouched the original metric and allowing modifications in the
-copied one.
+This plugin create a copy of each metric passing through it, preserving the
+original metric and allowing modifications such as [metric modifiers][modifiers]
+in the copied metric.
 
-The modifications allowed are the ones supported by input plugins and
-aggregators:
+> [!NOTE]
+> [Metric filtering][filtering] options apply to both the clone and the
+> original metric.
 
-* name_override
-* name_prefix
-* name_suffix
-* tags
+⭐ Telegraf v1.13.0
+🏷️ transformation
+💻 all
 
-Select the metrics to modify using the standard [metric
-filtering](../../../docs/CONFIGURATION.md#metric-filtering) options. Filtering
-options apply to both the clone and the original.
-
-Values of *name_override*, *name_prefix*, *name_suffix* and already present
-*tags* with conflicting keys will be overwritten. Absent *tags* will be
-created.
-
-A typical use-case is gathering metrics once and cloning them to simulate
-having several hosts (modifying ``host`` tag).
+[modifiers]: /docs/CONFIGURATION.md#modifiers
+[filtering]: /docs/CONFIGURATION.md#metric-filtering
 
 ## Global configuration options <!-- @/docs/includes/plugin_config.md -->
 

--- a/plugins/processors/converter/README.md
+++ b/plugins/processors/converter/README.md
@@ -1,22 +1,17 @@
 # Converter Processor Plugin
 
-The converter processor is used to change the type of tag or field values. In
-addition to changing field types it can convert between fields and tags.
+This plugin allows to transform tags into fields or timestamp and to convert
+fields into tags or timestamp. The plugin furthermore allows to change the field
+type.
 
-Values that cannot be converted are dropped.
+> [!IMPORTANT]
+> When converting tags to fields, take care to ensure the series is still
+> uniquely identifiable. Fields with the same series key (measurement + tags)
+> will overwrite one another.
 
-**Note:** When converting tags to fields, take care to ensure the series is
-still uniquely identifiable. Fields with the same series key (measurement +
-tags) will overwrite one another.
-
-**Note on large strings being converted to numeric types:** When converting a
-string value to a numeric type, precision may be lost if the number is too
-large. The largest numeric type this plugin supports is `float64`, and if a
-string 'number' exceeds its size limit, accuracy may be lost.
-
-**Note on multiple measurement or timestamps:** Users can provide multiple
-tags or fields to use as the measurement name or timestamp. However, note that
-the order in the array is not guaranteed!
+⭐ Telegraf v1.7.0
+🏷️ transformation
+💻 all
 
 ## Global configuration options <!-- @/docs/includes/plugin_config.md -->
 
@@ -67,7 +62,7 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
     boolean = []
     float = []
 
-    ## Optional field to use for converting base64 encoding of IEEE 754 Float32 values 
+    ## Optional field to use for converting base64 encoding of IEEE 754 Float32 values
     ## i.e. data_json_content_state_openconfig-platform-psu:output-power":"RKeAAA=="
     ## into a float32 value 1340
     # base64_ieee_float32 = []
@@ -80,6 +75,15 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
     ## format. It is required, when using the timestamp option.
     # timestamp_format = ""
 ```
+
+When converting types, values that cannot be converted are dropped.
+
+When converting a string value to a numeric type, precision may be lost if the
+number is too large. The largest numeric type this plugin supports is `float64`,
+and if a string 'number' exceeds its size limit, accuracy may be lost.
+
+Users can provide multiple tags or fields to use as the measurement name or
+timestamp. However, note that the order in the array is not guaranteed!
 
 ### Example
 

--- a/plugins/processors/cumulative_sum/README.md
+++ b/plugins/processors/cumulative_sum/README.md
@@ -8,6 +8,10 @@ relying on monotonically increasing values
 > Metrics within a series are accumulated in the **order of arrival** and not in
 > order of their timestamps!
 
+⭐ Telegraf v1.35.0
+🏷️ transformation
+💻 all
+
 ## Global configuration options <!-- @/docs/includes/plugin_config.md -->
 
 In addition to the plugin-specific configuration settings, plugins support

--- a/plugins/processors/date/README.md
+++ b/plugins/processors/date/README.md
@@ -1,14 +1,11 @@
 # Date Processor Plugin
 
-Use the `date` processor to add the metric timestamp as a human readable tag.
+This plugin adds the metric timestamp as a human readable tag. A common use is
+to add a tag that can be used to group by month or year.
 
-A common use is to add a tag that can be used to group by month or year.
-
-A few example usecases include:
-
-1) consumption data for utilities on per month basis
-2) bandwidth capacity per month
-3) compare energy production or sales on a yearly or monthly basis
+⭐ Telegraf v1.12.0
+🏷️ transformation
+💻 all
 
 ## Global configuration options <!-- @/docs/includes/plugin_config.md -->
 
@@ -48,7 +45,7 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   # timezone = "UTC"
 ```
 
-### timezone
+### `timezone`
 
 On Windows, only the `Local` and `UTC` zones are available by default.  To use
 other timezones, set the `ZONEINFO` environment variable to the location of

--- a/plugins/processors/dedup/README.md
+++ b/plugins/processors/dedup/README.md
@@ -1,8 +1,12 @@
 # Dedup Processor Plugin
 
-Filter metrics whose field values are exact repetitions of the previous values.
-This plugin will store its state between runs if the `statefile` option in the
-agent config section is set.
+This plugin filters metrics whose field values are exact repetitions of the
+previous values. This plugin will store its state between runs if the
+`statefile` option in the agent config section is set.
+
+⭐ Telegraf v1.14.0
+🏷️ filtering
+💻 all
 
 ## Global configuration options <!-- @/docs/includes/plugin_config.md -->
 

--- a/plugins/processors/defaults/README.md
+++ b/plugins/processors/defaults/README.md
@@ -1,16 +1,11 @@
 # Defaults Processor Plugin
 
-The _Defaults_ processor allows you to ensure certain fields and tags will
-always exist with a specified default value on your metric(s).
+This plugin allows to specify default values for  fields and tags for cases
+where the tag or field does not exist or has an empty value.
 
-There are three cases where this processor will insert a configured default
-field or tag.
-
-1. The field/tag is nil on the incoming metric
-1. The field/tag is not nil, but its value is an empty string.
-1. The field/tag is not nil, but its value is a string of one or more empty spaces.
-
-Telegraf minimum version: Telegraf 1.15.0
+⭐ Telegraf v1.15.0
+🏷️ transformation
+💻 all
 
 ## Global configuration options <!-- @/docs/includes/plugin_config.md -->
 

--- a/plugins/processors/enum/README.md
+++ b/plugins/processors/enum/README.md
@@ -1,13 +1,13 @@
 # Enum Processor Plugin
 
-The Enum Processor allows the configuration of value mappings for metric tags or
-fields.  The main use-case for this is to rewrite status codes such as _red_,
-_amber_ and _green_ by numeric values such as 0, 1, 2. The plugin supports
-string, int, float64 and bool types for the field values. Multiple tags or
-fields can be configured with separate value mappings for each. Default mapping
-values can be configured to be used for all values, which are not contained in
-the value_mappings. The processor supports explicit configuration of a
-destination tag or field. By default the source tag or field is overwritten.
+This plugin allows the mapping of field or tag values according to the
+configured enumeration. The main use-case is to rewrite numerical values into
+human-readable values or vice versa. Default mappings can be configured to be
+used for all remaining values.
+
+⭐ Telegraf v1.8.0
+🏷️ transformation
+💻 all
 
 ## Global configuration options <!-- @/docs/includes/plugin_config.md -->
 

--- a/plugins/processors/execd/README.md
+++ b/plugins/processors/execd/README.md
@@ -1,20 +1,19 @@
 # Execd Processor Plugin
 
-The `execd` processor plugin runs an external program as a separate process and
-pipes metrics in to the process's STDIN and reads processed metrics from its
-STDOUT.  The programs must accept influx line protocol on standard in (STDIN)
-and output metrics in influx line protocol to standard output (STDOUT).
+This plugin runs an external program as a separate process and pipes metrics in
+to the process's `stdin` and reads processed metrics from its `stdout`. Program
+output on `stderr` is logged.
 
-Program output on standard error is mirrored to the telegraf log.
-
-Telegraf minimum version: Telegraf 1.15.0
+⭐ Telegraf v1.15.0
+🏷️ general purpose
+💻 all
 
 ## Caveats
 
-- Metrics with tracking will be considered "delivered" as soon as they are passed
-  to the external process. There is currently no way to match up which metric
-  coming out of the execd process relates to which metric going in (keep in mind
-  that processors can add and drop metrics, and that this is all done
+- Metrics with tracking will be considered "delivered" as soon as they are
+  passed to the external process. There is currently no way to match up which
+  metric coming out of the execd process relates to which metric going in (keep
+  in mind   that processors can add and drop metrics, and that this is all done
   asynchronously).
 - it's not currently possible to use a data_format other than "influx", due to
   the requirement that it is serialize-parse symmetrical and does not lose any

--- a/plugins/processors/filepath/README.md
+++ b/plugins/processors/filepath/README.md
@@ -1,32 +1,12 @@
 # Filepath Processor Plugin
 
-The `filepath` processor plugin maps certain go functions from
-[path/filepath](https://golang.org/pkg/path/filepath/) onto tag and field
-values. Values can be modified in place or stored in another key.
+This plugin allows to transform a path, using e.g. basename to extract the last
+path element, for tag and field values. Values can be modified in place or
+stored in another key.
 
-Implemented functions are:
-
-* [Base](https://golang.org/pkg/path/filepath/#Base) (accessible through `[[processors.filepath.basename]]`)
-* [Rel](https://golang.org/pkg/path/filepath/#Rel) (accessible through `[[processors.filepath.rel]]`)
-* [Dir](https://golang.org/pkg/path/filepath/#Dir) (accessible through `[[processors.filepath.dir]]`)
-* [Clean](https://golang.org/pkg/path/filepath/#Clean) (accessible through `[[processors.filepath.clean]]`)
-* [ToSlash](https://golang.org/pkg/path/filepath/#ToSlash) (accessible through `[[processors.filepath.toslash]]`)
-
-On top of that, the plugin provides an extra function to retrieve the final path
-component without its extension. This function is accessible through the
-`[[processors.filepath.stem]]` configuration item.
-
-Please note that, in this implementation, these functions are processed in the
-order that they appear above( except for `stem` that is applied in the first
-place).
-
-Specify the `tag` and/or `field` that you want processed in each section and
-optionally a `dest` if you want the result stored in a new tag or field.
-
-If you plan to apply multiple transformations to the same `tag`/`field`, bear in
-mind the processing order stated above.
-
-Telegraf minimum version: Telegraf 1.15.0
+⭐ Telegraf v1.15.0
+🏷️ transformation
+💻 all
 
 ## Global configuration options <!-- @/docs/includes/plugin_config.md -->
 
@@ -73,6 +53,14 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 ```
 
 ## Considerations
+
+### Processing order
+
+This plugin processes the specified functions in the order they appear in
+the configuration. One exceptition is the `stem` section which is applied first.
+
+If you plan to apply multiple transformations to the same `tag`/`field`, bear in
+mind the processing order stated above.
 
 ### Clean Automatic Invocation
 

--- a/plugins/processors/filter/README.md
+++ b/plugins/processors/filter/README.md
@@ -1,11 +1,17 @@
 # Filter Processor Plugin
 
-The filter processor plugin allows to specify a set of rules for metrics
-with the ability to _keep_ or _drop_ those metrics. It does _not_ change the
-metric. As such a user might want to apply this processor to remove metrics
-from the processing/output stream.
-__NOTE:__ The filtering is _not_ output specific, but will apply to the metrics
-processed by this processor.
+This plugin allows to specify a set of rules for metrics with the ability to
+_keep_ or _drop_ those metrics. It does _not_ modify the metric. As such a user
+might want to apply this processor to remove metrics from the processing/output
+stream.
+
+> [!NOTE]
+> The filtering is _not_ output specific, but will apply to the metrics
+> processed by this processor.
+
+⭐ Telegraf v1.29.0
+🏷️ filtering
+💻 all
 
 ## Global configuration options <!-- @/docs/includes/plugin_config.md -->
 

--- a/plugins/processors/ifname/README.md
+++ b/plugins/processors/ifname/README.md
@@ -1,8 +1,10 @@
 # Network Interface Name Processor Plugin
 
-The `ifname` plugin looks up network interface names using SNMP.
+This plugin looks up network interface names using SNMP.
 
-Telegraf minimum version: Telegraf 1.15.0
+⭐ Telegraf v1.15.0
+🏷️ annotation
+💻 all
 
 ## Global configuration options <!-- @/docs/includes/plugin_config.md -->
 

--- a/plugins/processors/lookup/README.md
+++ b/plugins/processors/lookup/README.md
@@ -1,10 +1,10 @@
 # Lookup Processor Plugin
 
-The Lookup Processor allows to use one or more files containing a lookup-table
-for annotating incoming metrics. The lookup is _static_ as the files are only
-used on startup. The main use-case for this is to annotate metrics with
-additional tags e.g. dependent on their source. Multiple tags can be added
-depending on the lookup-table _files_.
+This plugin allows to use one or more files containing lookup-tables for
+annotating incoming metrics. The lookup is _static_ as the files are only used
+on startup. The main use-case for this is to annotate metrics with additional
+tags e.g. dependent on their source. Multiple tags can be added depending on the
+lookup-table _files_.
 
 The lookup key can be generated using a Golang template with the ability to
 access the metric name via `{{.Name}}`, the tag values via `{{.Tag "mytag"}}`,
@@ -14,8 +14,13 @@ in an empty string or `nil` respectively. In case the key cannot be found, the
 metric is passed-through unchanged. By default all matching tags are added and
 existing tag-values are overwritten.
 
-Please note: The plugin only supports the addition of tags and thus all mapped
-tag-values need to be strings!
+> [!NOTE]
+> The plugin only supports the addition of tags and thus all mapped
+> tag-values need to be strings!
+
+⭐ Telegraf v1.15.0
+🏷️ annotation
+💻 all
 
 ## Global configuration options <!-- @/docs/includes/plugin_config.md -->
 

--- a/plugins/processors/noise/README.md
+++ b/plugins/processors/noise/README.md
@@ -1,10 +1,13 @@
 # Noise Processor Plugin
 
-The _Noise_ processor is used to add noise to numerical field values. For each
-field a noise is generated using a defined probability density function and
-added to the value. The function type can be configured as _Laplace_, _Gaussian_
-or _Uniform_.  Depending on the function, various parameters need to be
-configured:
+This plugin is used to add noise to numerical field values. For each field a
+noise is generated using a defined probability density function and added to the
+value. The function type can be configured as _Laplace_, _Gaussian_ or
+_Uniform_.
+
+⭐ Telegraf v1.22.0
+🏷️ transformation
+💻 all
 
 ## Global configuration options <!-- @/docs/includes/plugin_config.md -->
 

--- a/plugins/processors/override/README.md
+++ b/plugins/processors/override/README.md
@@ -1,24 +1,20 @@
 # Override Processor Plugin
 
-The override processor plugin allows overriding all modifications that are
-supported by input plugins and aggregators:
-
-* name_override
-* name_prefix
-* name_suffix
-* tags
-
-All metrics passing through this processor will be modified accordingly.  Select
-the metrics to modify using the standard [metric
-filtering](../../../docs/CONFIGURATION.md#metric-filtering) options.
-
-Values of *name_override*, *name_prefix*, *name_suffix* and already present
-*tags* with conflicting keys will be overwritten. Absent *tags* will be
-created.
-
-Use-case of this plugin encompass ensuring certain tags or naming conventions
+This plugin allows to modify metrics using [metric modifiers][modifiers].
+Use-cases of this plugin encompass ensuring certain tags or naming conventions
 are adhered to irrespective of input plugin configurations, e.g. by
 `taginclude`.
+
+> [!NOTE]
+> [Metric filtering][filtering] options apply to both the clone and the
+> original metric.
+
+⭐ Telegraf v1.6.0
+🏷️ transformation
+💻 all
+
+[modifiers]: /docs/CONFIGURATION.md#modifiers
+[filtering]: /docs/CONFIGURATION.md#metric-filtering
 
 ## Global configuration options <!-- @/docs/includes/plugin_config.md -->
 

--- a/tools/readme_linter/rules.go
+++ b/tools/readme_linter/rules.go
@@ -56,9 +56,10 @@ var (
 			"transformation",
 		},
 		pluginProcessor: {
-			"math",
-			"sampling",
-			"statistics",
+			"annotation",
+			"filtering",
+			"general purpose",
+			"grouping",
 			"transformation",
 		},
 	}


### PR DESCRIPTION
## Summary

This PR adds some metadata to the processor plugins like the version this plugin was introduced, labels and the supported operating systems. Furthermore, the PR unifies the plugin descriptions a bit and uses [Github Markdown alerts](https://docs.github.com/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts) for notes and other important information.

Additionally this PR updates the accepted list of tags for processors to reasonable values.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues
