### PR TITLE
feat(migrations): Add migration for inputs.cisco_telemetry_gnmi

### DIFF
--- a/migrations/all/inputs_cisco_telemetry_gnmi.go
+++ b/migrations/all/inputs_cisco_telemetry_gnmi.go
@@ -1,0 +1,5 @@
+//go:build !custom || (migrations && (inputs || inputs.cisco_telemetry_gnmi))
+
+package all
+
+import _ "github.com/influxdata/telegraf/migrations/inputs_cisco_telemetry_gnmi" // register migration

--- a/migrations/inputs_cisco_telemetry_gnmi/migration.go
+++ b/migrations/inputs_cisco_telemetry_gnmi/migration.go
@@ -1,0 +1,31 @@
+package inputs_cisco_telemetry_gnmi
+
+import (
+	"github.com/influxdata/toml"
+	"github.com/influxdata/toml/ast"
+
+	"github.com/influxdata/telegraf/migrations"
+)
+
+// Migration function to migrate cisco_telemetry_gnmi to gnmi
+func migrate(tbl *ast.Table) ([]byte, string, error) {
+	// Decode the old plugin configuration
+	var plugin map[string]interface{}
+	if err := toml.UnmarshalTable(tbl, &plugin); err != nil {
+		return nil, "", err
+	}
+
+	// Create the new plugin configuration with the same settings
+	// but under the "gnmi" plugin name instead of "cisco_telemetry_gnmi"
+	cfg := migrations.CreateTOMLStruct("inputs", "gnmi")
+	cfg.Add("inputs", "gnmi", plugin)
+
+	output, err := toml.Marshal(cfg)
+	message := "migrated from deprecated 'cisco_telemetry_gnmi' to 'gnmi'"
+	return output, message, err
+}
+
+// Register the migration function for the deprecated plugin
+func init() {
+	migrations.AddPluginMigration("inputs.cisco_telemetry_gnmi", migrate)
+}

--- a/migrations/inputs_cisco_telemetry_gnmi/migration_test.go
+++ b/migrations/inputs_cisco_telemetry_gnmi/migration_test.go
@@ -1,0 +1,75 @@
+package inputs_cisco_telemetry_gnmi_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/influxdata/telegraf/config"
+	_ "github.com/influxdata/telegraf/migrations/inputs_cisco_telemetry_gnmi" // register migration
+	"github.com/influxdata/telegraf/plugins/inputs/gnmi"
+)
+
+func TestNoMigration(t *testing.T) {
+	// Test that configs without the deprecated plugin remain unchanged
+	plugin := &gnmi.GNMI{}
+	defaultCfg := []byte(plugin.SampleConfig())
+
+	// Replace gnmi with cisco_telemetry_gnmi to test the reverse case
+	// (configs that already use gnmi should not be affected)
+	output, n, err := config.ApplyMigrations(defaultCfg)
+	require.NoError(t, err)
+	require.NotEmpty(t, output)
+	require.Zero(t, n) // No migrations applied
+	require.Equal(t, string(defaultCfg), string(output))
+}
+
+func TestCases(t *testing.T) {
+	// Get all directories in testdata
+	folders, err := os.ReadDir("testcases")
+	require.NoError(t, err)
+
+	for _, f := range folders {
+		// Only handle folders
+		if !f.IsDir() {
+			continue
+		}
+
+		t.Run(f.Name(), func(t *testing.T) {
+			testcasePath := filepath.Join("testcases", f.Name())
+			inputFile := filepath.Join(testcasePath, "telegraf.conf")
+			expectedFile := filepath.Join(testcasePath, "expected.conf")
+
+			// Read the expected output
+			expected := config.NewConfig()
+			require.NoError(t, expected.LoadConfig(expectedFile))
+			require.NotEmpty(t, expected.Inputs)
+
+			// Read the input data
+			input, remote, err := config.LoadConfigFile(inputFile)
+			require.NoError(t, err)
+			require.False(t, remote)
+			require.NotEmpty(t, input)
+
+			// Migrate
+			output, n, err := config.ApplyMigrations(input)
+			require.NoError(t, err)
+			require.NotEmpty(t, output)
+			require.GreaterOrEqual(t, n, uint64(1))
+			actual := config.NewConfig()
+			require.NoError(t, actual.LoadConfigData(output, config.EmptySourcePath))
+
+			// Test the output
+			require.Len(t, actual.Inputs, len(expected.Inputs))
+			actualIDs := make([]string, 0, len(expected.Inputs))
+			expectedIDs := make([]string, 0, len(expected.Inputs))
+			for i := range actual.Inputs {
+				actualIDs = append(actualIDs, actual.Inputs[i].ID())
+				expectedIDs = append(expectedIDs, expected.Inputs[i].ID())
+			}
+			require.ElementsMatch(t, expectedIDs, actualIDs, string(output))
+		})
+	}
+}

--- a/migrations/inputs_cisco_telemetry_gnmi/testcases/deprecated_alias/expected.conf
+++ b/migrations/inputs_cisco_telemetry_gnmi/testcases/deprecated_alias/expected.conf
@@ -1,0 +1,158 @@
+# gNMI telemetry input plugin (migrated from cisco_telemetry_gnmi)
+[[inputs.gnmi]]
+  ## Address and port of the gNMI GRPC server
+  addresses = ["10.49.234.114:57777"]
+
+  ## define credentials
+  username = "cisco"
+  password = "cisco"
+
+  ## gNMI encoding requested (one of: "proto", "json", "json_ietf", "bytes")
+  # encoding = "proto"
+
+  ## redial in case of failures after
+  # redial = "10s"
+
+  ## gRPC Keepalive settings
+  ## See https://pkg.go.dev/google.golang.org/grpc/keepalive
+  ## The client will ping the server to see if the transport is still alive if it has
+  ## not see any activity for the given time.
+  ## If not set, none of the keep-alive setting (including those below) will be applied.
+  ## If set and set below 10 seconds, the gRPC library will apply a minimum value of 10s will be used instead.
+  # keepalive_time = ""
+
+  ## Timeout for seeing any activity after the keep-alive probe was
+  ## sent. If no activity is seen the connection is closed.
+  # keepalive_timeout = ""
+
+  ## gRPC Maximum Message Size
+  # max_msg_size = "4MB"
+
+  ## Subtree depth for depth extension (disables if < 1)
+  ## see https://github.com/openconfig/reference/blob/master/rpc/gnmi/gnmi-depth.md
+  # depth = 0
+
+  ## Enable to get the canonical path as field-name
+  # canonical_field_names = false
+
+  ## Remove leading slashes and dots in field-name
+  # trim_field_names = false
+
+  ## Only receive updates for the state, also suppresses receiving the initial state
+  # updates_only = false
+
+  ## Enforces the namespace of the first element as origin for aliases and
+  ## response paths, required for backward compatibility.
+  ## NOTE: Set to 'false' if possible but be aware that this might change the path tag!
+  # enforce_first_namespace_as_origin = true
+
+  ## Guess the path-tag if an update does not contain a prefix-path
+  ## Supported values are
+  ##   none         -- do not add a 'path' tag
+  ##   common path  -- use the common path elements of all fields in an update
+  ##   subscription -- use the subscription path
+  # path_guessing_strategy = "none"
+
+  ## Prefix tags from path keys with the path element
+  # prefix_tag_key_with_path = false
+
+  ## Optional client-side TLS to authenticate the device
+  ## Set to true/false to enforce TLS being enabled/disabled. If not set,
+  ## enable TLS only if any of the other options are specified.
+  # tls_enable =
+  ## Trusted root certificates for server
+  # tls_ca = "/path/to/cafile"
+  ## Used for TLS client certificate authentication
+  # tls_cert = "/path/to/certfile"
+  ## Used for TLS client certificate authentication
+  # tls_key = "/path/to/keyfile"
+  ## Password for the key file if it is encrypted
+  # tls_key_pwd = ""
+  ## Send the specified TLS server name via SNI
+  # tls_server_name = "kubernetes.example.com"
+  ## Minimal TLS version to accept by the client
+  # tls_min_version = "TLS12"
+  ## List of ciphers to accept, by default all secure ciphers will be accepted
+  ## See https://pkg.go.dev/crypto/tls#pkg-constants for supported values.
+  ## Use "all", "secure" and "insecure" to add all support ciphers, secure
+  ## suites or insecure suites respectively.
+  # tls_cipher_suites = ["secure"]
+  ## Renegotiation method, "never", "once" or "freely"
+  # tls_renegotiation_method = "never"
+  ## Use TLS but skip chain & host verification
+  # insecure_skip_verify = false
+
+  ## gNMI subscription prefix (optional, can usually be left empty)
+  ## See: https://github.com/openconfig/reference/blob/master/rpc/gnmi/gnmi-specification.md#222-paths
+  # origin = ""
+  # prefix = ""
+  # target = ""
+
+  ## Vendor specific options
+  ## This defines what vendor specific options to load.
+  ## * Juniper Header Extension (juniper_header): some sensors are directly managed by
+  ##   Linecard, which adds the Juniper GNMI Header Extension. Enabling this
+  ##   allows the decoding of the Extension header if present. Currently this knob
+  ##   adds component, component_id & sub_component_id as additional tags
+  # vendor_specific = []
+
+  ## YANG model paths for decoding IETF JSON payloads
+  ## Model files are loaded recursively from the given directories. Disabled if
+  ## no models are specified.
+  # yang_model_paths = []
+
+  ## Define additional aliases to map encoding paths to measurement names
+  # [inputs.gnmi.aliases]
+  #   ifcounters = "openconfig:/interfaces/interface/state/counters"
+
+  [[inputs.gnmi.subscription]]
+    ## Name of the measurement that will be emitted
+    name = "ifcounters"
+
+    ## Origin and path of the subscription
+    ## See: https://github.com/openconfig/reference/blob/master/rpc/gnmi/gnmi-specification.md#222-paths
+    ##
+    ## origin usually refers to a (YANG) data model implemented by the device
+    ## and path to a specific substructure inside it that should be subscribed
+    ## to (similar to an XPath). YANG models can be found e.g. here:
+    ## https://github.com/YangModels/yang/tree/master/vendor/cisco/xr
+    origin = "openconfig-interfaces"
+    path = "/interfaces/interface/state/counters"
+
+    ## Subscription mode ("target_defined", "sample", "on_change") and interval
+    subscription_mode = "sample"
+    sample_interval = "10s"
+
+    ## Suppress redundant transmissions when measured values are unchanged
+    # suppress_redundant = false
+
+    ## If suppression is enabled, send updates at least every X seconds anyway
+    # heartbeat_interval = "60s"
+
+  ## Tag subscriptions are applied as tags to other subscriptions.
+  # [[inputs.gnmi.tag_subscription]]
+  #  ## When applying this value as a tag to other metrics, use this tag name
+  #  name = "descr"
+  #
+  #  ## All other subscription fields are as normal
+  #  origin = "openconfig-interfaces"
+  #  path = "/interfaces/interface/state"
+  #  subscription_mode = "on_change"
+  #
+  #  ## Match strategy to use for the tag.
+  #  ## Tags are only applied for metrics of the same address. The following
+  #  ## settings are valid:
+  #  ##   unconditional -- always match
+  #  ##   name          -- match by the "name" key
+  #  ##                    This resembles the previous 'tag-only' behavior.
+  #  ##   elements      -- match by the keys in the path filtered by the path
+  #  ##                    parts specified `elements` below
+  #  ## By default, 'elements' is used if the 'elements' option is provided,
+  #  ## otherwise match by 'name'.
+  #  # match = ""
+  #
+  #  ## For the 'elements' match strategy, at least one path-element name must
+  #  ## be supplied containing at least one key to match on. Multiple path
+  #  ## elements can be specified in any order. All given keys must be equal
+  #  ## for a match.
+  #  # elements = ["description", "interface"]

--- a/migrations/inputs_cisco_telemetry_gnmi/testcases/deprecated_alias/telegraf.conf
+++ b/migrations/inputs_cisco_telemetry_gnmi/testcases/deprecated_alias/telegraf.conf
@@ -1,0 +1,158 @@
+# gNMI telemetry input plugin using deprecated alias
+[[inputs.cisco_telemetry_gnmi]]
+  ## Address and port of the gNMI GRPC server
+  addresses = ["10.49.234.114:57777"]
+
+  ## define credentials
+  username = "cisco"
+  password = "cisco"
+
+  ## gNMI encoding requested (one of: "proto", "json", "json_ietf", "bytes")
+  # encoding = "proto"
+
+  ## redial in case of failures after
+  # redial = "10s"
+
+  ## gRPC Keepalive settings
+  ## See https://pkg.go.dev/google.golang.org/grpc/keepalive
+  ## The client will ping the server to see if the transport is still alive if it has
+  ## not see any activity for the given time.
+  ## If not set, none of the keep-alive setting (including those below) will be applied.
+  ## If set and set below 10 seconds, the gRPC library will apply a minimum value of 10s will be used instead.
+  # keepalive_time = ""
+
+  ## Timeout for seeing any activity after the keep-alive probe was
+  ## sent. If no activity is seen the connection is closed.
+  # keepalive_timeout = ""
+
+  ## gRPC Maximum Message Size
+  # max_msg_size = "4MB"
+
+  ## Subtree depth for depth extension (disables if < 1)
+  ## see https://github.com/openconfig/reference/blob/master/rpc/gnmi/gnmi-depth.md
+  # depth = 0
+
+  ## Enable to get the canonical path as field-name
+  # canonical_field_names = false
+
+  ## Remove leading slashes and dots in field-name
+  # trim_field_names = false
+
+  ## Only receive updates for the state, also suppresses receiving the initial state
+  # updates_only = false
+
+  ## Enforces the namespace of the first element as origin for aliases and
+  ## response paths, required for backward compatibility.
+  ## NOTE: Set to 'false' if possible but be aware that this might change the path tag!
+  # enforce_first_namespace_as_origin = true
+
+  ## Guess the path-tag if an update does not contain a prefix-path
+  ## Supported values are
+  ##   none         -- do not add a 'path' tag
+  ##   common path  -- use the common path elements of all fields in an update
+  ##   subscription -- use the subscription path
+  # path_guessing_strategy = "none"
+
+  ## Prefix tags from path keys with the path element
+  # prefix_tag_key_with_path = false
+
+  ## Optional client-side TLS to authenticate the device
+  ## Set to true/false to enforce TLS being enabled/disabled. If not set,
+  ## enable TLS only if any of the other options are specified.
+  # tls_enable =
+  ## Trusted root certificates for server
+  # tls_ca = "/path/to/cafile"
+  ## Used for TLS client certificate authentication
+  # tls_cert = "/path/to/certfile"
+  ## Used for TLS client certificate authentication
+  # tls_key = "/path/to/keyfile"
+  ## Password for the key file if it is encrypted
+  # tls_key_pwd = ""
+  ## Send the specified TLS server name via SNI
+  # tls_server_name = "kubernetes.example.com"
+  ## Minimal TLS version to accept by the client
+  # tls_min_version = "TLS12"
+  ## List of ciphers to accept, by default all secure ciphers will be accepted
+  ## See https://pkg.go.dev/crypto/tls#pkg-constants for supported values.
+  ## Use "all", "secure" and "insecure" to add all support ciphers, secure
+  ## suites or insecure suites respectively.
+  # tls_cipher_suites = ["secure"]
+  ## Renegotiation method, "never", "once" or "freely"
+  # tls_renegotiation_method = "never"
+  ## Use TLS but skip chain & host verification
+  # insecure_skip_verify = false
+
+  ## gNMI subscription prefix (optional, can usually be left empty)
+  ## See: https://github.com/openconfig/reference/blob/master/rpc/gnmi/gnmi-specification.md#222-paths
+  # origin = ""
+  # prefix = ""
+  # target = ""
+
+  ## Vendor specific options
+  ## This defines what vendor specific options to load.
+  ## * Juniper Header Extension (juniper_header): some sensors are directly managed by
+  ##   Linecard, which adds the Juniper GNMI Header Extension. Enabling this
+  ##   allows the decoding of the Extension header if present. Currently this knob
+  ##   adds component, component_id & sub_component_id as additional tags
+  # vendor_specific = []
+
+  ## YANG model paths for decoding IETF JSON payloads
+  ## Model files are loaded recursively from the given directories. Disabled if
+  ## no models are specified.
+  # yang_model_paths = []
+
+  ## Define additional aliases to map encoding paths to measurement names
+  # [inputs.cisco_telemetry_gnmi.aliases]
+  #   ifcounters = "openconfig:/interfaces/interface/state/counters"
+
+  [[inputs.cisco_telemetry_gnmi.subscription]]
+    ## Name of the measurement that will be emitted
+    name = "ifcounters"
+
+    ## Origin and path of the subscription
+    ## See: https://github.com/openconfig/reference/blob/master/rpc/gnmi/gnmi-specification.md#222-paths
+    ##
+    ## origin usually refers to a (YANG) data model implemented by the device
+    ## and path to a specific substructure inside it that should be subscribed
+    ## to (similar to an XPath). YANG models can be found e.g. here:
+    ## https://github.com/YangModels/yang/tree/master/vendor/cisco/xr
+    origin = "openconfig-interfaces"
+    path = "/interfaces/interface/state/counters"
+
+    ## Subscription mode ("target_defined", "sample", "on_change") and interval
+    subscription_mode = "sample"
+    sample_interval = "10s"
+
+    ## Suppress redundant transmissions when measured values are unchanged
+    # suppress_redundant = false
+
+    ## If suppression is enabled, send updates at least every X seconds anyway
+    # heartbeat_interval = "60s"
+
+  ## Tag subscriptions are applied as tags to other subscriptions.
+  # [[inputs.cisco_telemetry_gnmi.tag_subscription]]
+  #  ## When applying this value as a tag to other metrics, use this tag name
+  #  name = "descr"
+  #
+  #  ## All other subscription fields are as normal
+  #  origin = "openconfig-interfaces"
+  #  path = "/interfaces/interface/state"
+  #  subscription_mode = "on_change"
+  #
+  #  ## Match strategy to use for the tag.
+  #  ## Tags are only applied for metrics of the same address. The following
+  #  ## settings are valid:
+  #  ##   unconditional -- always match
+  #  ##   name          -- match by the "name" key
+  #  ##                    This resembles the previous 'tag-only' behavior.
+  #  ##   elements      -- match by the keys in the path filtered by the path
+  #  ##                    parts specified `elements` below
+  #  ## By default, 'elements' is used if the 'elements' option is provided,
+  #  ## otherwise match by 'name'.
+  #  # match = ""
+  #
+  #  ## For the 'elements' match strategy, at least one path-element name must
+  #  ## be supplied containing at least one key to match on. Multiple path
+  #  ## elements can be specified in any order. All given keys must be equal
+  #  ## for a match.
+  #  # elements = ["description", "interface"]

--- a/plugins/inputs/gnmi/gnmi.go
+++ b/plugins/inputs/gnmi/gnmi.go
@@ -480,11 +480,4 @@ func init() {
 			EnforceFirstNamespaceAsOrigin: true,
 		}
 	})
-	// Backwards compatible alias:
-	inputs.Add("cisco_telemetry_gnmi", func() telegraf.Input {
-		return &GNMI{
-			Redial:                        config.Duration(10 * time.Second),
-			EnforceFirstNamespaceAsOrigin: true,
-		}
-	})
 }


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Replace the following plugin alias and provide a migration
```
  inputs.cisco_telemetry_gnmi              ERROR since 1.15.0 removal in 1.35.0 has been renamed to 'gnmi'
```

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #16944
