### PR TITLE
feat(migrations): Add migration for inputs.http_listener

### DIFF
--- a/migrations/all/inputs_http_listener.go
+++ b/migrations/all/inputs_http_listener.go
@@ -1,0 +1,5 @@
+//go:build !custom || (migrations && (inputs || inputs.http_listener))
+
+package all
+
+import _ "github.com/influxdata/telegraf/migrations/inputs_http_listener" // register migration

--- a/migrations/inputs_http_listener/migration.go
+++ b/migrations/inputs_http_listener/migration.go
@@ -1,0 +1,31 @@
+package inputs_http_listener
+
+import (
+	"github.com/influxdata/toml"
+	"github.com/influxdata/toml/ast"
+
+	"github.com/influxdata/telegraf/migrations"
+)
+
+// Migration function to migrate http_listener to influxdb_listener
+func migrate(tbl *ast.Table) ([]byte, string, error) {
+	// Decode the old plugin configuration
+	var plugin map[string]interface{}
+	if err := toml.UnmarshalTable(tbl, &plugin); err != nil {
+		return nil, "", err
+	}
+
+	// Create the new plugin configuration with the same settings
+	// but under the "influxdb_listener" plugin name instead of "http_listener"
+	cfg := migrations.CreateTOMLStruct("inputs", "influxdb_listener")
+	cfg.Add("inputs", "influxdb_listener", plugin)
+
+	output, err := toml.Marshal(cfg)
+	message := "migrated from deprecated 'http_listener' to 'influxdb_listener'"
+	return output, message, err
+}
+
+// Register the migration function for the deprecated plugin
+func init() {
+	migrations.AddPluginMigration("inputs.http_listener", migrate)
+}

--- a/migrations/inputs_http_listener/migration_test.go
+++ b/migrations/inputs_http_listener/migration_test.go
@@ -1,0 +1,75 @@
+package inputs_http_listener_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/influxdata/telegraf/config"
+	_ "github.com/influxdata/telegraf/migrations/inputs_http_listener" // register migration
+	"github.com/influxdata/telegraf/plugins/inputs/influxdb_listener"
+)
+
+func TestNoMigration(t *testing.T) {
+	// Test that configs without the deprecated plugin remain unchanged
+	plugin := &influxdb_listener.InfluxDBListener{}
+	defaultCfg := []byte(plugin.SampleConfig())
+
+	// Replace influxdb_listener with http_listener to test the reverse case
+	// (configs that already use influxdb_listener should not be affected)
+	output, n, err := config.ApplyMigrations(defaultCfg)
+	require.NoError(t, err)
+	require.NotEmpty(t, output)
+	require.Zero(t, n) // No migrations applied
+	require.Equal(t, string(defaultCfg), string(output))
+}
+
+func TestCases(t *testing.T) {
+	// Get all directories in testdata
+	folders, err := os.ReadDir("testcases")
+	require.NoError(t, err)
+
+	for _, f := range folders {
+		// Only handle folders
+		if !f.IsDir() {
+			continue
+		}
+
+		t.Run(f.Name(), func(t *testing.T) {
+			testcasePath := filepath.Join("testcases", f.Name())
+			inputFile := filepath.Join(testcasePath, "telegraf.conf")
+			expectedFile := filepath.Join(testcasePath, "expected.conf")
+
+			// Read the expected output
+			expected := config.NewConfig()
+			require.NoError(t, expected.LoadConfig(expectedFile))
+			require.NotEmpty(t, expected.Inputs)
+
+			// Read the input data
+			input, remote, err := config.LoadConfigFile(inputFile)
+			require.NoError(t, err)
+			require.False(t, remote)
+			require.NotEmpty(t, input)
+
+			// Migrate
+			output, n, err := config.ApplyMigrations(input)
+			require.NoError(t, err)
+			require.NotEmpty(t, output)
+			require.GreaterOrEqual(t, n, uint64(1))
+			actual := config.NewConfig()
+			require.NoError(t, actual.LoadConfigData(output, config.EmptySourcePath))
+
+			// Test the output
+			require.Len(t, actual.Inputs, len(expected.Inputs))
+			actualIDs := make([]string, 0, len(expected.Inputs))
+			expectedIDs := make([]string, 0, len(expected.Inputs))
+			for i := range actual.Inputs {
+				actualIDs = append(actualIDs, actual.Inputs[i].ID())
+				expectedIDs = append(expectedIDs, expected.Inputs[i].ID())
+			}
+			require.ElementsMatch(t, expectedIDs, actualIDs, string(output))
+		})
+	}
+}

--- a/migrations/inputs_http_listener/testcases/deprecated_alias/expected.conf
+++ b/migrations/inputs_http_listener/testcases/deprecated_alias/expected.conf
@@ -1,0 +1,55 @@
+# Accept metrics over InfluxDB 1.x HTTP API
+[[inputs.influxdb_listener]]
+  ## Address and port to host HTTP listener on
+  service_address = ":8186"
+
+  ## maximum duration before timing out read of the request
+  read_timeout = "10s"
+  ## maximum duration before timing out write of the response
+  write_timeout = "10s"
+
+  ## Maximum allowed HTTP request body size in bytes.
+  ## 0 means to use the default of 32MiB.
+  max_body_size = 0
+
+  ## Set one or more allowed client CA certificate file names to
+  ## enable mutually authenticated TLS connections
+  # tls_allowed_cacerts = ["/etc/telegraf/clientca.pem"]
+
+  ## Add service certificate and key
+  # tls_cert = "/etc/telegraf/cert.pem"
+  # tls_key = "/etc/telegraf/key.pem"
+
+  ## Optional tag name used to store the database name.
+  ## If the write has a database in the query string then it will be kept in this tag name.
+  ## This tag can be used in downstream outputs.
+  ## The default value of nothing means it will be off and the database will not be recorded.
+  ## If you have a tag that is the same as the one specified below, and supply a database,
+  ## the tag will be overwritten with the database supplied.
+  # database_tag = ""
+
+  ## If set the retention policy specified in the write query will be added as
+  ## the value of this tag name.
+  # retention_policy_tag = ""
+
+  ## Optional username and password to accept for HTTP basic authentication
+  ## or authentication token.
+  ## You probably want to make sure you have TLS configured above for this.
+  ## Use these options for the authentication token in the form
+  ##   Authentication: Token <basic_username>:<basic_password>
+  # basic_username = "foobar"
+  # basic_password = "barfoo"
+
+  ## Optional JWT token authentication for HTTP requests
+  ## Please see the documentation at
+  ##   https://docs.influxdata.com/influxdb/v1.8/administration/authentication_and_authorization/#authenticate-using-jwt-tokens
+  ## for further details.
+  ## Please note: Token authentication and basic authentication cannot be used
+  ##              at the same time.
+  # token_shared_secret = ""
+  # token_username = ""
+
+  ## Influx line protocol parser
+  ## 'internal' is the default. 'upstream' is a newer parser that is faster
+  ## and more memory efficient.
+  # parser_type = "internal"

--- a/migrations/inputs_http_listener/testcases/deprecated_alias/telegraf.conf
+++ b/migrations/inputs_http_listener/testcases/deprecated_alias/telegraf.conf
@@ -1,0 +1,55 @@
+# Accept metrics over InfluxDB 1.x HTTP API
+[[inputs.http_listener]]
+  ## Address and port to host HTTP listener on
+  service_address = ":8186"
+
+  ## maximum duration before timing out read of the request
+  read_timeout = "10s"
+  ## maximum duration before timing out write of the response
+  write_timeout = "10s"
+
+  ## Maximum allowed HTTP request body size in bytes.
+  ## 0 means to use the default of 32MiB.
+  max_body_size = 0
+
+  ## Set one or more allowed client CA certificate file names to
+  ## enable mutually authenticated TLS connections
+  # tls_allowed_cacerts = ["/etc/telegraf/clientca.pem"]
+
+  ## Add service certificate and key
+  # tls_cert = "/etc/telegraf/cert.pem"
+  # tls_key = "/etc/telegraf/key.pem"
+
+  ## Optional tag name used to store the database name.
+  ## If the write has a database in the query string then it will be kept in this tag name.
+  ## This tag can be used in downstream outputs.
+  ## The default value of nothing means it will be off and the database will not be recorded.
+  ## If you have a tag that is the same as the one specified below, and supply a database,
+  ## the tag will be overwritten with the database supplied.
+  # database_tag = ""
+
+  ## If set the retention policy specified in the write query will be added as
+  ## the value of this tag name.
+  # retention_policy_tag = ""
+
+  ## Optional username and password to accept for HTTP basic authentication
+  ## or authentication token.
+  ## You probably want to make sure you have TLS configured above for this.
+  ## Use these options for the authentication token in the form
+  ##   Authentication: Token <basic_username>:<basic_password>
+  # basic_username = "foobar"
+  # basic_password = "barfoo"
+
+  ## Optional JWT token authentication for HTTP requests
+  ## Please see the documentation at
+  ##   https://docs.influxdata.com/influxdb/v1.8/administration/authentication_and_authorization/#authenticate-using-jwt-tokens
+  ## for further details.
+  ## Please note: Token authentication and basic authentication cannot be used
+  ##              at the same time.
+  # token_shared_secret = ""
+  # token_username = ""
+
+  ## Influx line protocol parser
+  ## 'internal' is the default. 'upstream' is a newer parser that is faster
+  ## and more memory efficient.
+  # parser_type = "internal"

--- a/plugins/inputs/influxdb_listener/influxdb_listener.go
+++ b/plugins/inputs/influxdb_listener/influxdb_listener.go
@@ -527,13 +527,6 @@ func getPrecisionMultiplier(precision string) time.Duration {
 }
 
 func init() {
-	// http_listener deprecated in 1.9
-	inputs.Add("http_listener", func() telegraf.Input {
-		return &InfluxDBListener{
-			ServiceAddress: ":8186",
-			timeFunc:       time.Now,
-		}
-	})
 	inputs.Add("influxdb_listener", func() telegraf.Input {
 		return &InfluxDBListener{
 			ServiceAddress: ":8186",


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Replace the following plugin alias and provide a migration
```
  inputs.http_listener                     ERROR since 1.9.0 removal in 1.35.0 has been renamed to 'influxdb_listener', use 'inputs.influxdb_listener' or 'inputs.http_listener_v2' instead
```

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #16945
