### PR TITLE
feat(migrations): Add migration for inputs.openldap

### DIFF
--- a/migrations/all/inputs_openldap.go
+++ b/migrations/all/inputs_openldap.go
@@ -1,0 +1,5 @@
+//go:build !custom || (migrations && (inputs || inputs.openldap))
+
+package all
+
+import _ "github.com/influxdata/telegraf/migrations/inputs_openldap" // register migration

--- a/migrations/inputs_openldap/migration.go
+++ b/migrations/inputs_openldap/migration.go
@@ -1,0 +1,66 @@
+package inputs_openldap
+
+import (
+	"github.com/influxdata/toml"
+	"github.com/influxdata/toml/ast"
+
+	"github.com/influxdata/telegraf/migrations"
+)
+
+// Migration function to migrate deprecated SSL options to TLS options
+func migrate(tbl *ast.Table) ([]byte, string, error) {
+	// Decode the old data structure
+	var plugin map[string]interface{}
+	if err := toml.UnmarshalTable(tbl, &plugin); err != nil {
+		return nil, "", err
+	}
+
+	// Check for deprecated options and migrate them
+	var applied bool
+	var message string
+
+	// Migrate ssl -> tls
+	if sslValue, found := plugin["ssl"]; found {
+		applied = true
+		// Only set tls if it's not already set (don't overwrite existing tls setting)
+		if _, tlsExists := plugin["tls"]; !tlsExists {
+			plugin["tls"] = sslValue
+		}
+		// Remove the deprecated setting
+		delete(plugin, "ssl")
+		message = "migrated 'ssl' option to 'tls'"
+	}
+
+	// Migrate ssl_ca -> tls_ca
+	if sslCAValue, found := plugin["ssl_ca"]; found {
+		applied = true
+		// Only set tls_ca if it's not already set (don't overwrite existing tls_ca setting)
+		if _, tlsCAExists := plugin["tls_ca"]; !tlsCAExists {
+			plugin["tls_ca"] = sslCAValue
+		}
+		// Remove the deprecated setting
+		delete(plugin, "ssl_ca")
+		if message != "" {
+			message += "; migrated 'ssl_ca' option to 'tls_ca'"
+		} else {
+			message = "migrated 'ssl_ca' option to 'tls_ca'"
+		}
+	}
+
+	// No options migrated so we can exit early
+	if !applied {
+		return nil, "", migrations.ErrNotApplicable
+	}
+
+	// Create the corresponding plugin configuration
+	cfg := migrations.CreateTOMLStruct("inputs", "openldap")
+	cfg.Add("inputs", "openldap", plugin)
+
+	output, err := toml.Marshal(cfg)
+	return output, message, err
+}
+
+// Register the migration function for the plugin type
+func init() {
+	migrations.AddPluginOptionMigration("inputs.openldap", migrate)
+}

--- a/migrations/inputs_openldap/migration_test.go
+++ b/migrations/inputs_openldap/migration_test.go
@@ -1,0 +1,73 @@
+package inputs_openldap_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/influxdata/telegraf/config"
+	_ "github.com/influxdata/telegraf/migrations/inputs_openldap" // register migration
+	"github.com/influxdata/telegraf/plugins/inputs/openldap"
+)
+
+func TestNoMigration(t *testing.T) {
+	plugin := &openldap.Openldap{}
+	defaultCfg := []byte(plugin.SampleConfig())
+
+	// Migrate and check that nothing changed
+	output, n, err := config.ApplyMigrations(defaultCfg)
+	require.NoError(t, err)
+	require.NotEmpty(t, output)
+	require.Zero(t, n)
+	require.Equal(t, string(defaultCfg), string(output))
+}
+
+func TestCases(t *testing.T) {
+	// Get all directories in testcases
+	folders, err := os.ReadDir("testcases")
+	require.NoError(t, err)
+
+	for _, f := range folders {
+		// Only handle folders
+		if !f.IsDir() {
+			continue
+		}
+
+		t.Run(f.Name(), func(t *testing.T) {
+			testcasePath := filepath.Join("testcases", f.Name())
+			inputFile := filepath.Join(testcasePath, "telegraf.conf")
+			expectedFile := filepath.Join(testcasePath, "expected.conf")
+
+			// Read the expected output
+			expected := config.NewConfig()
+			require.NoError(t, expected.LoadConfig(expectedFile))
+			require.NotEmpty(t, expected.Inputs)
+
+			// Read the input data
+			input, remote, err := config.LoadConfigFile(inputFile)
+			require.NoError(t, err)
+			require.False(t, remote)
+			require.NotEmpty(t, input)
+
+			// Migrate
+			output, n, err := config.ApplyMigrations(input)
+			require.NoError(t, err)
+			require.NotEmpty(t, output)
+			require.GreaterOrEqual(t, n, uint64(1))
+			actual := config.NewConfig()
+			require.NoError(t, actual.LoadConfigData(output, config.EmptySourcePath))
+
+			// Test the output
+			require.Len(t, actual.Inputs, len(expected.Inputs))
+			actualIDs := make([]string, 0, len(expected.Inputs))
+			expectedIDs := make([]string, 0, len(expected.Inputs))
+			for i := range actual.Inputs {
+				actualIDs = append(actualIDs, actual.Inputs[i].ID())
+				expectedIDs = append(expectedIDs, expected.Inputs[i].ID())
+			}
+			require.ElementsMatch(t, expectedIDs, actualIDs, string(output))
+		})
+	}
+}

--- a/migrations/inputs_openldap/testcases/ca_only/expected.conf
+++ b/migrations/inputs_openldap/testcases/ca_only/expected.conf
@@ -1,0 +1,19 @@
+# OpenLDAP cn=Monitor plugin with migrated tls_ca option
+[[inputs.openldap]]
+  host = "localhost"
+  port = 389
+
+  # No ssl or tls option set
+
+  # skip peer certificate verification. Default is false.
+  insecure_skip_verify = false
+
+  # Migrated from ssl_ca option
+  tls_ca = "/path/to/ca-certificates.pem"
+
+  # dn/password to bind with. If bind_dn is empty, an anonymous bind is performed.
+  bind_dn = "cn=readonly,dc=company,dc=org"
+  bind_password = "readonlypass"
+
+  # reverse metric names so they sort more naturally
+  reverse_metric_names = true

--- a/migrations/inputs_openldap/testcases/ca_only/telegraf.conf
+++ b/migrations/inputs_openldap/testcases/ca_only/telegraf.conf
@@ -1,0 +1,19 @@
+# OpenLDAP cn=Monitor plugin with only ssl_ca deprecated option
+[[inputs.openldap]]
+  host = "localhost"
+  port = 389
+
+  # No ssl or tls option set
+
+  # skip peer certificate verification. Default is false.
+  insecure_skip_verify = false
+
+  # Only ssl_ca is deprecated - should be migrated to tls_ca
+  ssl_ca = "/path/to/ca-certificates.pem"
+
+  # dn/password to bind with. If bind_dn is empty, an anonymous bind is performed.
+  bind_dn = "cn=readonly,dc=company,dc=org"
+  bind_password = "readonlypass"
+
+  # reverse metric names so they sort more naturally
+  reverse_metric_names = true

--- a/migrations/inputs_openldap/testcases/mixed_config/expected.conf
+++ b/migrations/inputs_openldap/testcases/mixed_config/expected.conf
@@ -1,0 +1,20 @@
+# OpenLDAP cn=Monitor plugin with preserved TLS options
+[[inputs.openldap]]
+  host = "ldap.example.com"
+  port = 389
+
+  # Existing tls option preserved (ssl option was removed)
+  tls = "starttls"
+
+  # skip peer certificate verification. Default is false.
+  insecure_skip_verify = true
+
+  # Existing tls_ca option preserved (ssl_ca option was removed)
+  tls_ca = "/etc/ssl/custom-ca.pem"
+
+  # dn/password to bind with. If bind_dn is empty, an anonymous bind is performed.
+  bind_dn = ""
+  bind_password = ""
+
+  # reverse metric names so they sort more naturally
+  reverse_metric_names = false

--- a/migrations/inputs_openldap/testcases/mixed_config/telegraf.conf
+++ b/migrations/inputs_openldap/testcases/mixed_config/telegraf.conf
@@ -1,0 +1,26 @@
+# OpenLDAP cn=Monitor plugin with mixed SSL/TLS options
+[[inputs.openldap]]
+  host = "ldap.example.com"
+  port = 389
+
+  # User already has tls configured - should NOT be overwritten
+  tls = "starttls"
+
+  # Deprecated ssl option - should be removed but not override existing tls
+  ssl = "ldaps"
+
+  # skip peer certificate verification. Default is false.
+  insecure_skip_verify = true
+
+  # User already has tls_ca configured - should NOT be overwritten
+  tls_ca = "/etc/ssl/custom-ca.pem"
+
+  # Deprecated ssl_ca option - should be removed but not override existing tls_ca
+  ssl_ca = "/etc/ssl/old-ca.pem"
+
+  # dn/password to bind with. If bind_dn is empty, an anonymous bind is performed.
+  bind_dn = ""
+  bind_password = ""
+
+  # reverse metric names so they sort more naturally
+  reverse_metric_names = false

--- a/migrations/inputs_openldap/testcases/ssl_only/expected.conf
+++ b/migrations/inputs_openldap/testcases/ssl_only/expected.conf
@@ -1,0 +1,20 @@
+# OpenLDAP cn=Monitor plugin with migrated TLS options
+[[inputs.openldap]]
+  host = "localhost"
+  port = 636
+
+  # Migrated from ssl option
+  tls = "ldaps"
+
+  # skip peer certificate verification. Default is false.
+  insecure_skip_verify = false
+
+  # Migrated from ssl_ca option
+  tls_ca = "/etc/ssl/certs.pem"
+
+  # dn/password to bind with. If bind_dn is empty, an anonymous bind is performed.
+  bind_dn = "cn=admin,dc=example,dc=com"
+  bind_password = "secret"
+
+  # reverse metric names so they sort more naturally
+  reverse_metric_names = true

--- a/migrations/inputs_openldap/testcases/ssl_only/telegraf.conf
+++ b/migrations/inputs_openldap/testcases/ssl_only/telegraf.conf
@@ -1,0 +1,20 @@
+# OpenLDAP cn=Monitor plugin with deprecated SSL options
+[[inputs.openldap]]
+  host = "localhost"
+  port = 636
+
+  # Deprecated ssl option - should be migrated to tls
+  ssl = "ldaps"
+
+  # skip peer certificate verification. Default is false.
+  insecure_skip_verify = false
+
+  # Deprecated ssl_ca option - should be migrated to tls_ca
+  ssl_ca = "/etc/ssl/certs.pem"
+
+  # dn/password to bind with. If bind_dn is empty, an anonymous bind is performed.
+  bind_dn = "cn=admin,dc=example,dc=com"
+  bind_password = "secret"
+
+  # reverse metric names so they sort more naturally
+  reverse_metric_names = true

--- a/plugins/inputs/openldap/openldap.go
+++ b/plugins/inputs/openldap/openldap.go
@@ -38,10 +38,8 @@ var (
 type Openldap struct {
 	Host               string `toml:"host"`
 	Port               int    `toml:"port"`
-	SSL                string `toml:"ssl" deprecated:"1.7.0;1.35.0;use 'tls' instead"`
 	TLS                string `toml:"tls"`
 	InsecureSkipVerify bool   `toml:"insecure_skip_verify"`
-	SSLCA              string `toml:"ssl_ca" deprecated:"1.7.0;1.35.0;use 'tls_ca' instead"`
 	TLSCA              string `toml:"tls_ca"`
 	BindDn             string `toml:"bind_dn"`
 	BindPassword       string `toml:"bind_password"`
@@ -53,13 +51,6 @@ func (*Openldap) SampleConfig() string {
 }
 
 func (o *Openldap) Gather(acc telegraf.Accumulator) error {
-	if o.TLS == "" {
-		o.TLS = o.SSL
-	}
-	if o.TLSCA == "" {
-		o.TLSCA = o.SSLCA
-	}
-
 	var err error
 	var l *ldap.Conn
 	if o.TLS != "" {
@@ -93,7 +84,7 @@ func (o *Openldap) Gather(acc telegraf.Accumulator) error {
 				return nil
 			}
 		default:
-			acc.AddError(fmt.Errorf("invalid setting for ssl: %s", o.TLS))
+			acc.AddError(fmt.Errorf("invalid setting for tls: %s", o.TLS))
 			return nil
 		}
 	} else {
@@ -187,10 +178,8 @@ func newOpenldap() *Openldap {
 	return &Openldap{
 		Host:               "localhost",
 		Port:               389,
-		SSL:                "",
 		TLS:                "",
 		InsecureSkipVerify: false,
-		SSLCA:              "",
 		TLSCA:              "",
 		BindDn:             "",
 		BindPassword:       "",

--- a/plugins/inputs/openldap/openldap_test.go
+++ b/plugins/inputs/openldap/openldap_test.go
@@ -141,7 +141,7 @@ func TestOpenldapStartTLSIntegration(t *testing.T) {
 	o := &Openldap{
 		Host:               container.Address,
 		Port:               port,
-		SSL:                "starttls",
+		TLS:                "starttls",
 		InsecureSkipVerify: true,
 		BindDn:             "CN=manager,DC=example,DC=org",
 		BindPassword:       "secret",
@@ -199,7 +199,7 @@ func TestOpenldapLDAPSIntegration(t *testing.T) {
 	o := &Openldap{
 		Host:               container.Address,
 		Port:               port,
-		SSL:                "ldaps",
+		TLS:                "ldaps",
 		InsecureSkipVerify: true,
 		BindDn:             "CN=manager,DC=example,DC=org",
 		BindPassword:       "secret",
@@ -211,7 +211,7 @@ func TestOpenldapLDAPSIntegration(t *testing.T) {
 	commonTests(t, o, &acc)
 }
 
-func TestOpenldapInvalidSSLIntegration(t *testing.T) {
+func TestOpenldapInvalidTLSIntegration(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
@@ -255,7 +255,7 @@ func TestOpenldapInvalidSSLIntegration(t *testing.T) {
 	o := &Openldap{
 		Host:               container.Address,
 		Port:               port,
-		SSL:                "invalid",
+		TLS:                "invalid",
 		InsecureSkipVerify: true,
 	}
 
@@ -293,7 +293,7 @@ func TestOpenldapBindIntegration(t *testing.T) {
 	o := &Openldap{
 		Host:               container.Address,
 		Port:               port,
-		SSL:                "",
+		TLS:                "",
 		InsecureSkipVerify: true,
 		BindDn:             "CN=manager,DC=example,DC=org",
 		BindPassword:       "secret",
@@ -343,7 +343,7 @@ func TestOpenldapReverseMetricsIntegration(t *testing.T) {
 	o := &Openldap{
 		Host:               container.Address,
 		Port:               port,
-		SSL:                "",
+		TLS:                "",
 		InsecureSkipVerify: true,
 		BindDn:             "CN=manager,DC=example,DC=org",
 		BindPassword:       "secret",


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Replace the following options in the plugin and provide a migration
```
  inputs.openldap/ssl                      ERROR since 1.7.0 removal in 1.35.0 use 'tls' instead
```

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #16930
