### PR TITLE
feat(outputs.postgresql): Allow dynamic schema through tag values

### DIFF
--- a/plugins/outputs/postgresql/README.md
+++ b/plugins/outputs/postgresql/README.md
@@ -69,6 +69,8 @@ to use them.
 
   ## Postgres schema to use.
   # schema = "public"
+  ## Interpret the schema as a tag
+  # schema_as_tag = false
 
   ## Store tags as foreign keys in the metrics table. Default is false.
   # tags_as_foreign_keys = false

--- a/plugins/outputs/postgresql/sample.conf
+++ b/plugins/outputs/postgresql/sample.conf
@@ -21,6 +21,8 @@
 
   ## Postgres schema to use.
   # schema = "public"
+  ## Interpret the schema as a tag
+  # schema_as_tag = false
 
   ## Store tags as foreign keys in the metrics table. Default is false.
   # tags_as_foreign_keys = false


### PR DESCRIPTION
## Summary
Would resolve the need for multiple postgresql outputs that use the same database but different schemas.

## Checklist
- [x] No AI generated code was used in this PR

## Related issues
resolves #16747 
