### PR TITLE
feat(migrations): Add migration for inputs.kubernetes

### DIFF
--- a/migrations/all/inputs_kubernetes.go
+++ b/migrations/all/inputs_kubernetes.go
@@ -1,0 +1,5 @@
+//go:build !custom || (migrations && (inputs || inputs.kubernetes))
+
+package all
+
+import _ "github.com/influxdata/telegraf/migrations/inputs_kubernetes" // register migration

--- a/migrations/inputs_kubernetes/migration.go
+++ b/migrations/inputs_kubernetes/migration.go
@@ -1,0 +1,52 @@
+package inputs_kubernetes
+
+import (
+	"github.com/influxdata/toml"
+	"github.com/influxdata/toml/ast"
+
+	"github.com/influxdata/telegraf/migrations"
+)
+
+// Migration function to migrate deprecated Kubernetes bearer_token_string option
+func migrate(tbl *ast.Table) ([]byte, string, error) {
+	// Decode the old data structure
+	var plugin map[string]interface{}
+	if err := toml.UnmarshalTable(tbl, &plugin); err != nil {
+		return nil, "", err
+	}
+
+	// Check for deprecated bearer_token_string option
+	var applied bool
+	var message string
+
+	if _, found := plugin["bearer_token_string"]; found {
+		applied = true
+
+		// Only migrate if bearer_token is not already set (don't overwrite existing)
+		if _, bearerTokenExists := plugin["bearer_token"]; !bearerTokenExists {
+			message = "removed deprecated 'bearer_token_string' option; please save the token to a file and use 'bearer_token' option with the file path instead"
+		} else {
+			message = "removed deprecated 'bearer_token_string' option; existing 'bearer_token' configuration preserved"
+		}
+
+		// Always remove the deprecated setting
+		delete(plugin, "bearer_token_string")
+	}
+
+	// No options migrated so we can exit early
+	if !applied {
+		return nil, "", migrations.ErrNotApplicable
+	}
+
+	// Create the corresponding plugin configuration
+	cfg := migrations.CreateTOMLStruct("inputs", "kubernetes")
+	cfg.Add("inputs", "kubernetes", plugin)
+
+	output, err := toml.Marshal(cfg)
+	return output, message, err
+}
+
+// Register the migration function for the plugin type
+func init() {
+	migrations.AddPluginOptionMigration("inputs.kubernetes", migrate)
+}

--- a/migrations/inputs_kubernetes/migration.go
+++ b/migrations/inputs_kubernetes/migration.go
@@ -23,10 +23,8 @@ func migrate(tbl *ast.Table) ([]byte, string, error) {
 		applied = true
 
 		// Only migrate if bearer_token is not already set (don't overwrite existing)
-		if _, bearerTokenExists := plugin["bearer_token"]; !bearerTokenExists {
-			message = "removed deprecated 'bearer_token_string' option; please save the token to a file and use 'bearer_token' option with the file path instead"
-		} else {
-			message = "removed deprecated 'bearer_token_string' option; existing 'bearer_token' configuration preserved"
+		if _, found := plugin["bearer_token"]; !found {
+			message = "removed deprecated 'bearer_token_string' option; please save the token to a file and use the 'bearer_token' option instead"
 		}
 
 		// Always remove the deprecated setting

--- a/migrations/inputs_kubernetes/migration_test.go
+++ b/migrations/inputs_kubernetes/migration_test.go
@@ -1,0 +1,73 @@
+package inputs_kubernetes_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/influxdata/telegraf/config"
+	_ "github.com/influxdata/telegraf/migrations/inputs_kubernetes" // register migration
+	"github.com/influxdata/telegraf/plugins/inputs/kubernetes"
+)
+
+func TestNoMigration(t *testing.T) {
+	plugin := &kubernetes.Kubernetes{}
+	defaultCfg := []byte(plugin.SampleConfig())
+
+	// Migrate and check that nothing changed
+	output, n, err := config.ApplyMigrations(defaultCfg)
+	require.NoError(t, err)
+	require.NotEmpty(t, output)
+	require.Zero(t, n)
+	require.Equal(t, string(defaultCfg), string(output))
+}
+
+func TestCases(t *testing.T) {
+	// Get all directories in testcases
+	folders, err := os.ReadDir("testcases")
+	require.NoError(t, err)
+
+	for _, f := range folders {
+		// Only handle folders
+		if !f.IsDir() {
+			continue
+		}
+
+		t.Run(f.Name(), func(t *testing.T) {
+			testcasePath := filepath.Join("testcases", f.Name())
+			inputFile := filepath.Join(testcasePath, "telegraf.conf")
+			expectedFile := filepath.Join(testcasePath, "expected.conf")
+
+			// Read the expected output
+			expected := config.NewConfig()
+			require.NoError(t, expected.LoadConfig(expectedFile))
+			require.NotEmpty(t, expected.Inputs)
+
+			// Read the input data
+			input, remote, err := config.LoadConfigFile(inputFile)
+			require.NoError(t, err)
+			require.False(t, remote)
+			require.NotEmpty(t, input)
+
+			// Migrate
+			output, n, err := config.ApplyMigrations(input)
+			require.NoError(t, err)
+			require.NotEmpty(t, output)
+			require.GreaterOrEqual(t, n, uint64(1))
+			actual := config.NewConfig()
+			require.NoError(t, actual.LoadConfigData(output, config.EmptySourcePath))
+
+			// Test the output
+			require.Len(t, actual.Inputs, len(expected.Inputs))
+			actualIDs := make([]string, 0, len(expected.Inputs))
+			expectedIDs := make([]string, 0, len(expected.Inputs))
+			for i := range actual.Inputs {
+				actualIDs = append(actualIDs, actual.Inputs[i].ID())
+				expectedIDs = append(expectedIDs, expected.Inputs[i].ID())
+			}
+			require.ElementsMatch(t, expectedIDs, actualIDs, string(output))
+		})
+	}
+}

--- a/migrations/inputs_kubernetes/testcases/bearer_token_string_only/expected.conf
+++ b/migrations/inputs_kubernetes/testcases/bearer_token_string_only/expected.conf
@@ -1,0 +1,24 @@
+# Kubernetes plugin with deprecated bearer_token_string removed
+[[inputs.kubernetes]]
+  ## URL for the kubelet
+  url = "http://127.0.0.1:10255"
+
+  ## Deprecated bearer_token_string removed - save token to file and use bearer_token instead
+  ## Example: bearer_token = "/path/to/token/file"
+
+  ## Kubernetes Node Metric Name
+  node_metric_name = "kubernetes_node"
+
+  ## Pod labels to be added as tags
+  label_include = ["app", "version", "env"]
+  label_exclude = ["*"]
+
+  ## Set response_timeout
+  response_timeout = "5s"
+
+  ## Optional TLS Config
+  # tls_ca = "/path/to/cafile"
+  # tls_cert = "/path/to/certfile"
+  # tls_key = "/path/to/keyfile"
+  ## Use TLS but skip chain & host verification
+  insecure_skip_verify = false

--- a/migrations/inputs_kubernetes/testcases/bearer_token_string_only/telegraf.conf
+++ b/migrations/inputs_kubernetes/testcases/bearer_token_string_only/telegraf.conf
@@ -1,0 +1,24 @@
+# Kubernetes plugin with deprecated bearer_token_string
+[[inputs.kubernetes]]
+  ## URL for the kubelet
+  url = "http://127.0.0.1:10255"
+
+  ## Deprecated bearer_token_string option - should be migrated to bearer_token file
+  bearer_token_string = "abc_123_secret_token"
+
+  ## Kubernetes Node Metric Name
+  node_metric_name = "kubernetes_node"
+
+  ## Pod labels to be added as tags
+  label_include = ["app", "version", "env"]
+  label_exclude = ["*"]
+
+  ## Set response_timeout
+  response_timeout = "5s"
+
+  ## Optional TLS Config
+  # tls_ca = "/path/to/cafile"
+  # tls_cert = "/path/to/certfile"
+  # tls_key = "/path/to/keyfile"
+  ## Use TLS but skip chain & host verification
+  insecure_skip_verify = false

--- a/migrations/inputs_kubernetes/testcases/default_case/expected.conf
+++ b/migrations/inputs_kubernetes/testcases/default_case/expected.conf
@@ -1,0 +1,21 @@
+# Kubernetes plugin with deprecated bearer_token_string removed
+[[inputs.kubernetes]]
+  ## URL for the kubelet (empty to read from all nodes)
+  # url = ""
+
+  ## Deprecated bearer_token_string removed - save token to file and use bearer_token instead
+  ## If no bearer_token is set, default service account token will be used
+
+  ## Kubernetes Node Metric Name
+  # node_metric_name = "kubernetes_node"
+
+  ## Pod labels to be added as tags - exclude all by default
+  # label_include = []
+  label_exclude = ["*"]
+
+  ## Set response_timeout
+  # response_timeout = "5s"
+
+  ## Optional TLS Config
+  ## Use TLS but skip chain & host verification
+  # insecure_skip_verify = false

--- a/migrations/inputs_kubernetes/testcases/default_case/telegraf.conf
+++ b/migrations/inputs_kubernetes/testcases/default_case/telegraf.conf
@@ -1,0 +1,21 @@
+# Kubernetes plugin with deprecated bearer_token_string and no bearer_token
+[[inputs.kubernetes]]
+  ## URL for the kubelet (empty to read from all nodes)
+  # url = ""
+
+  ## Deprecated bearer_token_string option
+  bearer_token_string = "custom_service_account_token_456"
+
+  ## Kubernetes Node Metric Name
+  # node_metric_name = "kubernetes_node"
+
+  ## Pod labels to be added as tags - exclude all by default
+  # label_include = []
+  label_exclude = ["*"]
+
+  ## Set response_timeout
+  # response_timeout = "5s"
+
+  ## Optional TLS Config
+  ## Use TLS but skip chain & host verification
+  # insecure_skip_verify = false

--- a/migrations/inputs_kubernetes/testcases/mixed_tokens/expected.conf
+++ b/migrations/inputs_kubernetes/testcases/mixed_tokens/expected.conf
@@ -1,0 +1,21 @@
+# Kubernetes plugin with preserved bearer_token
+[[inputs.kubernetes]]
+  ## URL for the kubelet
+  url = "https://kubernetes.example.com:10250"
+
+  ## Existing bearer_token preserved (deprecated bearer_token_string was removed)
+  bearer_token = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+  ## Kubernetes Node Metric Name
+  node_metric_name = "k8s_node"
+
+  ## Pod labels to be added as tags
+  label_include = ["app", "version"]
+  label_exclude = ["internal.*"]
+
+  ## Set response_timeout
+  response_timeout = "10s"
+
+  ## Optional TLS Config
+  # tls_ca = "/etc/ssl/certs/ca-certificates.crt"
+  insecure_skip_verify = true

--- a/migrations/inputs_kubernetes/testcases/mixed_tokens/telegraf.conf
+++ b/migrations/inputs_kubernetes/testcases/mixed_tokens/telegraf.conf
@@ -1,0 +1,24 @@
+# Kubernetes plugin with both bearer token options
+[[inputs.kubernetes]]
+  ## URL for the kubelet
+  url = "https://kubernetes.example.com:10250"
+
+  ## User already has bearer_token configured - should be preserved
+  bearer_token = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+  ## Deprecated bearer_token_string - should be removed but not override existing bearer_token
+  bearer_token_string = "old_deprecated_token_123"
+
+  ## Kubernetes Node Metric Name
+  node_metric_name = "k8s_node"
+
+  ## Pod labels to be added as tags
+  label_include = ["app", "version"]
+  label_exclude = ["internal.*"]
+
+  ## Set response_timeout
+  response_timeout = "10s"
+
+  ## Optional TLS Config
+  # tls_ca = "/etc/ssl/certs/ca-certificates.crt"
+  insecure_skip_verify = true


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Replace the following options in the plugin and provide a migration
```
  inputs.kubernetes/bearer_token_string    ERROR since 1.24.0 removal in 1.35.0 use 'BearerToken' with a file instead
```

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #16927
