### PR TITLE
feat(migrations): Add migration for inputs.kube_inventory

### DIFF
--- a/migrations/all/inputs_kube_inventory.go
+++ b/migrations/all/inputs_kube_inventory.go
@@ -1,0 +1,5 @@
+//go:build !custom || (migrations && (inputs || inputs.kube_inventory))
+
+package all
+
+import _ "github.com/influxdata/telegraf/migrations/inputs_kube_inventory" // register migration

--- a/migrations/inputs_kube_inventory/migration.go
+++ b/migrations/inputs_kube_inventory/migration.go
@@ -24,7 +24,8 @@ func migrate(tbl *ast.Table) ([]byte, string, error) {
 
 		// Only migrate if bearer_token is not already set (don't overwrite existing)
 		if _, bearerTokenExists := plugin["bearer_token"]; !bearerTokenExists {
-			message = "removed deprecated 'bearer_token_string' option; please save the token to a file and use 'bearer_token' option with the file path instead"
+			message = "removed deprecated 'bearer_token_string' option; please save the token to a file " +
+				"and use 'bearer_token' option with the file path instead"
 		} else {
 			message = "removed deprecated 'bearer_token_string' option; existing 'bearer_token' configuration preserved"
 		}

--- a/migrations/inputs_kube_inventory/migration.go
+++ b/migrations/inputs_kube_inventory/migration.go
@@ -23,11 +23,8 @@ func migrate(tbl *ast.Table) ([]byte, string, error) {
 		applied = true
 
 		// Only migrate if bearer_token is not already set (don't overwrite existing)
-		if _, bearerTokenExists := plugin["bearer_token"]; !bearerTokenExists {
-			message = "removed deprecated 'bearer_token_string' option; please save the token to a file " +
-				"and use 'bearer_token' option with the file path instead"
-		} else {
-			message = "removed deprecated 'bearer_token_string' option; existing 'bearer_token' configuration preserved"
+		if _, found := plugin["bearer_token"]; !found {
+			message = "removed deprecated 'bearer_token_string' option; please save the token to a file and use the 'bearer_token' option instead"
 		}
 
 		// Always remove the deprecated setting

--- a/migrations/inputs_kube_inventory/migration.go
+++ b/migrations/inputs_kube_inventory/migration.go
@@ -1,0 +1,52 @@
+package inputs_kube_inventory
+
+import (
+	"github.com/influxdata/toml"
+	"github.com/influxdata/toml/ast"
+
+	"github.com/influxdata/telegraf/migrations"
+)
+
+// Migration function to migrate deprecated Kube Inventory bearer_token_string option
+func migrate(tbl *ast.Table) ([]byte, string, error) {
+	// Decode the old data structure
+	var plugin map[string]interface{}
+	if err := toml.UnmarshalTable(tbl, &plugin); err != nil {
+		return nil, "", err
+	}
+
+	// Check for deprecated bearer_token_string option
+	var applied bool
+	var message string
+
+	if _, found := plugin["bearer_token_string"]; found {
+		applied = true
+
+		// Only migrate if bearer_token is not already set (don't overwrite existing)
+		if _, bearerTokenExists := plugin["bearer_token"]; !bearerTokenExists {
+			message = "removed deprecated 'bearer_token_string' option; please save the token to a file and use 'bearer_token' option with the file path instead"
+		} else {
+			message = "removed deprecated 'bearer_token_string' option; existing 'bearer_token' configuration preserved"
+		}
+
+		// Always remove the deprecated setting
+		delete(plugin, "bearer_token_string")
+	}
+
+	// No options migrated so we can exit early
+	if !applied {
+		return nil, "", migrations.ErrNotApplicable
+	}
+
+	// Create the corresponding plugin configuration
+	cfg := migrations.CreateTOMLStruct("inputs", "kube_inventory")
+	cfg.Add("inputs", "kube_inventory", plugin)
+
+	output, err := toml.Marshal(cfg)
+	return output, message, err
+}
+
+// Register the migration function for the plugin type
+func init() {
+	migrations.AddPluginOptionMigration("inputs.kube_inventory", migrate)
+}

--- a/migrations/inputs_kube_inventory/migration_test.go
+++ b/migrations/inputs_kube_inventory/migration_test.go
@@ -1,0 +1,73 @@
+package inputs_kube_inventory_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/influxdata/telegraf/config"
+	_ "github.com/influxdata/telegraf/migrations/inputs_kube_inventory" // register migration
+	"github.com/influxdata/telegraf/plugins/inputs/kube_inventory"
+)
+
+func TestNoMigration(t *testing.T) {
+	plugin := &kube_inventory.KubernetesInventory{}
+	defaultCfg := []byte(plugin.SampleConfig())
+
+	// Migrate and check that nothing changed
+	output, n, err := config.ApplyMigrations(defaultCfg)
+	require.NoError(t, err)
+	require.NotEmpty(t, output)
+	require.Zero(t, n)
+	require.Equal(t, string(defaultCfg), string(output))
+}
+
+func TestCases(t *testing.T) {
+	// Get all directories in testcases
+	folders, err := os.ReadDir("testcases")
+	require.NoError(t, err)
+
+	for _, f := range folders {
+		// Only handle folders
+		if !f.IsDir() {
+			continue
+		}
+
+		t.Run(f.Name(), func(t *testing.T) {
+			testcasePath := filepath.Join("testcases", f.Name())
+			inputFile := filepath.Join(testcasePath, "telegraf.conf")
+			expectedFile := filepath.Join(testcasePath, "expected.conf")
+
+			// Read the expected output
+			expected := config.NewConfig()
+			require.NoError(t, expected.LoadConfig(expectedFile))
+			require.NotEmpty(t, expected.Inputs)
+
+			// Read the input data
+			input, remote, err := config.LoadConfigFile(inputFile)
+			require.NoError(t, err)
+			require.False(t, remote)
+			require.NotEmpty(t, input)
+
+			// Migrate
+			output, n, err := config.ApplyMigrations(input)
+			require.NoError(t, err)
+			require.NotEmpty(t, output)
+			require.GreaterOrEqual(t, n, uint64(1))
+			actual := config.NewConfig()
+			require.NoError(t, actual.LoadConfigData(output, config.EmptySourcePath))
+
+			// Test the output
+			require.Len(t, actual.Inputs, len(expected.Inputs))
+			actualIDs := make([]string, 0, len(expected.Inputs))
+			expectedIDs := make([]string, 0, len(expected.Inputs))
+			for i := range actual.Inputs {
+				actualIDs = append(actualIDs, actual.Inputs[i].ID())
+				expectedIDs = append(expectedIDs, expected.Inputs[i].ID())
+			}
+			require.ElementsMatch(t, expectedIDs, actualIDs, string(output))
+		})
+	}
+}

--- a/migrations/inputs_kube_inventory/testcases/bearer_token_string_only/expected.conf
+++ b/migrations/inputs_kube_inventory/testcases/bearer_token_string_only/expected.conf
@@ -1,0 +1,5 @@
+[[inputs.kube_inventory]]
+namespace = "default"
+resource_exclude = ["deployments", "services"]
+response_timeout = "5s"
+url = "https://kubernetes.default.svc"

--- a/migrations/inputs_kube_inventory/testcases/bearer_token_string_only/telegraf.conf
+++ b/migrations/inputs_kube_inventory/testcases/bearer_token_string_only/telegraf.conf
@@ -1,0 +1,40 @@
+# Kube Inventory plugin with deprecated bearer_token_string
+[[inputs.kube_inventory]]
+  ## URL for the Kubernetes API
+  url = "https://kubernetes.default.svc"
+
+  ## Deprecated bearer_token_string option - should be migrated to bearer_token file
+  bearer_token_string = "eyJhbGciOiJSUzI1NiIsImtpZCI6IjEyMzQ1In0..."
+
+  ## Namespace to use. Set to "" to use all namespaces.
+  namespace = "default"
+
+  ## Use bearer token for authorization. ('bearer_token' takes priority)
+  ## If both of these are empty, we'll use the default serviceaccount:
+  ## at: /var/run/secrets/kubernetes.io/serviceaccount/token
+  # bearer_token = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+  ## Set response_timeout (default 5 seconds)
+  response_timeout = "5s"
+
+  ## Optional Resources to exclude from gathering
+  ## Leave them with blank with try to gather everything available.
+  ## Values can be - "daemonsets", "deployments", "endpoints", "ingress",
+  ## "nodes", "persistentvolumes", "persistentvolumeclaims", "pods", "services",
+  ## "statefulsets"
+  resource_exclude = [ "deployments", "services" ]
+
+  ## Optional Resources to include when gathering
+  ## Overrides resource_exclude when both set.
+  # resource_include = [ "deployments", "nodes", "pods" ]
+
+  ## selectors to include and exclude as tags
+  # selector_include = ["app", "release"]
+  # selector_exclude = ["*"]
+
+  ## Optional TLS Config
+  # tls_ca = "/path/to/cafile"
+  # tls_cert = "/path/to/certfile"
+  # tls_key = "/path/to/keyfile"
+  ## Use TLS but skip chain & host verification
+  # insecure_skip_verify = false

--- a/migrations/inputs_kube_inventory/testcases/mixed_tokens/expected.conf
+++ b/migrations/inputs_kube_inventory/testcases/mixed_tokens/expected.conf
@@ -1,0 +1,10 @@
+[[inputs.kube_inventory]]
+bearer_token = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+insecure_skip_verify = true
+namespace = "monitoring"
+resource_exclude = ["secrets"]
+resource_include = ["deployments", "nodes", "pods", "services"]
+response_timeout = "10s"
+selector_exclude = ["internal.*"]
+selector_include = ["app", "version", "component"]
+url = "https://k8s-api.example.com:6443"

--- a/migrations/inputs_kube_inventory/testcases/mixed_tokens/telegraf.conf
+++ b/migrations/inputs_kube_inventory/testcases/mixed_tokens/telegraf.conf
@@ -1,0 +1,30 @@
+# Kube Inventory plugin with both bearer token options
+[[inputs.kube_inventory]]
+  ## URL for the Kubernetes API
+  url = "https://k8s-api.example.com:6443"
+
+  ## User already has bearer_token configured - should be preserved
+  bearer_token = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+  ## Deprecated bearer_token_string - should be removed but not override existing bearer_token
+  bearer_token_string = "old_deprecated_token_456"
+
+  ## Namespace to use
+  namespace = "monitoring"
+
+  ## Set response_timeout
+  response_timeout = "10s"
+
+  ## Optional Resources to exclude from gathering
+  resource_exclude = [ "secrets" ]
+
+  ## Optional Resources to include when gathering
+  resource_include = [ "deployments", "nodes", "pods", "services" ]
+
+  ## selectors to include and exclude as tags
+  selector_include = ["app", "version", "component"]
+  selector_exclude = ["internal.*"]
+
+  ## Optional TLS Config
+  # tls_ca = "/etc/ssl/certs/ca-certificates.crt"
+  insecure_skip_verify = true

--- a/plugins/inputs/kube_inventory/client.go
+++ b/plugins/inputs/kube_inventory/client.go
@@ -24,7 +24,7 @@ type client struct {
 	*kubernetes.Clientset
 }
 
-func newClient(baseURL, namespace, bearerTokenFile, bearerToken string, timeout time.Duration, tlsConfig tls.ClientConfig) (*client, error) {
+func newClient(baseURL, namespace, bearerTokenFile string, timeout time.Duration, tlsConfig tls.ClientConfig) (*client, error) {
 	var clientConfig *rest.Config
 	var err error
 
@@ -48,8 +48,6 @@ func newClient(baseURL, namespace, bearerTokenFile, bearerToken string, timeout 
 
 		if bearerTokenFile != "" {
 			clientConfig.BearerTokenFile = bearerTokenFile
-		} else if bearerToken != "" {
-			clientConfig.BearerToken = bearerToken
 		}
 	}
 
@@ -80,6 +78,7 @@ func newHTTPClient(tlsConfig tls.ClientConfig, bearerTokenFile string, responseT
 	}
 	return rest.HTTPClientFor(clientConfig)
 }
+
 func (c *client) getDaemonSets(ctx context.Context) (*appsv1.DaemonSetList, error) {
 	ctx, cancel := context.WithTimeout(ctx, c.timeout)
 	defer cancel()

--- a/plugins/inputs/kube_inventory/client_test.go
+++ b/plugins/inputs/kube_inventory/client_test.go
@@ -18,9 +18,9 @@ func toPtr[T any](v T) *T {
 }
 
 func TestNewClient(t *testing.T) {
-	_, err := newClient("https://127.0.0.1:443/", "default", "", "abc123", time.Second, tls.ClientConfig{})
+	_, err := newClient("https://127.0.0.1:443/", "default", "", time.Second, tls.ClientConfig{})
 	require.NoErrorf(t, err, "Failed to create new client: %v", err)
 
-	_, err = newClient("https://127.0.0.1:443/", "default", "nonexistantFile", "", time.Second, tls.ClientConfig{})
+	_, err = newClient("https://127.0.0.1:443/", "default", "nonexistantFile", time.Second, tls.ClientConfig{})
 	require.Errorf(t, err, "Failed to read token file \"file\": open file: no such file or directory: %v", err)
 }

--- a/plugins/inputs/kube_inventory/kube_inventory.go
+++ b/plugins/inputs/kube_inventory/kube_inventory.go
@@ -56,15 +56,14 @@ const (
 )
 
 type KubernetesInventory struct {
-	URL               string          `toml:"url"`
-	KubeletURL        string          `toml:"url_kubelet"`
-	BearerToken       string          `toml:"bearer_token"`
-	BearerTokenString string          `toml:"bearer_token_string" deprecated:"1.24.0;1.35.0;use 'BearerToken' with a file instead"`
-	Namespace         string          `toml:"namespace"`
-	ResponseTimeout   config.Duration `toml:"response_timeout"` // Timeout specified as a string - 3s, 1m, 1h
-	ResourceExclude   []string        `toml:"resource_exclude"`
-	ResourceInclude   []string        `toml:"resource_include"`
-	MaxConfigMapAge   config.Duration `toml:"max_config_map_age"`
+	URL             string          `toml:"url"`
+	KubeletURL      string          `toml:"url_kubelet"`
+	BearerToken     string          `toml:"bearer_token"`
+	Namespace       string          `toml:"namespace"`
+	ResponseTimeout config.Duration `toml:"response_timeout"` // Timeout specified as a string - 3s, 1m, 1h
+	ResourceExclude []string        `toml:"resource_exclude"`
+	ResourceInclude []string        `toml:"resource_include"`
+	MaxConfigMapAge config.Duration `toml:"max_config_map_age"`
 
 	SelectorInclude []string `toml:"selector_include"`
 	SelectorExclude []string `toml:"selector_exclude"`
@@ -84,17 +83,13 @@ func (*KubernetesInventory) SampleConfig() string {
 }
 
 func (ki *KubernetesInventory) Init() error {
-	// If neither are provided, use the default service account.
-	if ki.BearerToken == "" && ki.BearerTokenString == "" {
+	// If bearer_token is not provided, use the default service account.
+	if ki.BearerToken == "" {
 		ki.BearerToken = defaultServiceAccountPath
 	}
 
-	if ki.BearerTokenString != "" {
-		ki.Log.Warn("Telegraf cannot auto-refresh a bearer token string, use BearerToken file instead")
-	}
-
 	var err error
-	ki.client, err = newClient(ki.URL, ki.Namespace, ki.BearerToken, ki.BearerTokenString, time.Duration(ki.ResponseTimeout), ki.ClientConfig)
+	ki.client, err = newClient(ki.URL, ki.Namespace, ki.BearerToken, time.Duration(ki.ResponseTimeout), ki.ClientConfig)
 
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Replace the following options in the plugin and provide a migration
```
  inputs.kube_inventory/bearer_token_string ERROR since 1.24.0 removal in 1.35.0 use 'BearerToken' with a file instead
```

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #16926
