### PR TITLE
feat(migrations): Add migration for inputs.sqlserver

### DIFF
--- a/migrations/all/inputs_sqlserver.go
+++ b/migrations/all/inputs_sqlserver.go
@@ -1,0 +1,5 @@
+//go:build !custom || (migrations && (inputs || inputs.sqlserver))
+
+package all
+
+import _ "github.com/influxdata/telegraf/migrations/inputs_sqlserver" // register migration

--- a/migrations/inputs_sqlserver/migration.go
+++ b/migrations/inputs_sqlserver/migration.go
@@ -1,0 +1,88 @@
+package inputs_sqlserver
+
+import (
+	"github.com/influxdata/telegraf/migrations"
+	"github.com/influxdata/toml"
+	"github.com/influxdata/toml/ast"
+)
+
+// Migration function to migrate deprecated SQL Server options
+func migrate(tbl *ast.Table) ([]byte, string, error) {
+	// Decode the old data structure
+	var plugin map[string]interface{}
+	if err := toml.UnmarshalTable(tbl, &plugin); err != nil {
+		return nil, "", err
+	}
+
+	// Check for deprecated options and migrate them
+	var applied bool
+	var message string
+
+	// Check if database_type is already set - if so, don't override
+	_, databaseTypeExists := plugin["database_type"]
+	var foundAzureDB bool
+
+	// Migrate azuredb -> database_type
+	if azuredbValue, found := plugin["azuredb"]; found {
+		applied = true
+		foundAzureDB = true
+
+		// Only set database_type if it's not already set (don't overwrite existing)
+		if !databaseTypeExists {
+			if azuredb, ok := azuredbValue.(bool); ok && azuredb {
+				// azuredb = true means Azure SQL Database
+				plugin["database_type"] = "AzureSQLDB"
+			} else {
+				// azuredb = false means on-premises SQL Server
+				plugin["database_type"] = "SQLServer"
+			}
+		}
+
+		// Remove the deprecated setting
+		delete(plugin, "azuredb")
+		message = "migrated deprecated 'azuredb' option to 'database_type'"
+	}
+
+	// Migrate query_version -> database_type (only if azuredb wasn't found)
+	if _, found := plugin["query_version"]; found && !foundAzureDB {
+		applied = true
+
+		// Only set database_type if it's not already set (don't overwrite existing)
+		if !databaseTypeExists {
+			// For query_version, default to SQLServer regardless of the version
+			plugin["database_type"] = "SQLServer"
+		}
+
+		// Remove the deprecated setting
+		delete(plugin, "query_version")
+		if message != "" {
+			message += "; migrated deprecated 'query_version' option to 'database_type'"
+		} else {
+			message = "migrated deprecated 'query_version' option to 'database_type'"
+		}
+	} else if _, found := plugin["query_version"]; found {
+		// Remove query_version even if azuredb was processed
+		delete(plugin, "query_version")
+		if message != "" {
+			message += "; removed deprecated 'query_version' option"
+		} else {
+			message = "removed deprecated 'query_version' option"
+		}
+	}
+
+	// No options migrated so we can exit early
+	if !applied {
+		return nil, "", migrations.ErrNotApplicable
+	}
+
+	// Create the corresponding plugin configuration
+	cfg := migrations.CreateTOMLStruct("inputs", "sqlserver")
+	cfg.Add("inputs", "sqlserver", plugin)
+	output, err := toml.Marshal(cfg)
+	return output, message, err
+}
+
+// Register the migration function for the plugin type
+func init() {
+	migrations.AddPluginOptionMigration("inputs.sqlserver", migrate)
+}

--- a/migrations/inputs_sqlserver/migration_test.go
+++ b/migrations/inputs_sqlserver/migration_test.go
@@ -1,0 +1,74 @@
+package inputs_sqlserver_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/influxdata/telegraf/config"
+	_ "github.com/influxdata/telegraf/migrations/inputs_sqlserver" // register migration
+	"github.com/influxdata/telegraf/plugins/inputs/sqlserver"
+)
+
+func TestNoMigration(t *testing.T) {
+	plugin := &sqlserver.SQLServer{}
+	defaultCfg := []byte(plugin.SampleConfig())
+
+	// Migrate and check that nothing changed
+	output, n, err := config.ApplyMigrations(defaultCfg)
+	require.NoError(t, err)
+	require.NotEmpty(t, output)
+	require.Zero(t, n)
+	require.Equal(t, string(defaultCfg), string(output))
+}
+
+func TestCases(t *testing.T) {
+	// Get all directories in testcases
+	folders, err := os.ReadDir("testcases")
+	require.NoError(t, err)
+
+	for _, f := range folders {
+		// Only handle folders
+		if !f.IsDir() {
+			continue
+		}
+
+		t.Run(f.Name(), func(t *testing.T) {
+			testcasePath := filepath.Join("testcases", f.Name())
+			inputFile := filepath.Join(testcasePath, "telegraf.conf")
+			expectedFile := filepath.Join(testcasePath, "expected.conf")
+
+			// Read the expected output
+			expected := config.NewConfig()
+			require.NoError(t, expected.LoadConfig(expectedFile))
+			require.NotEmpty(t, expected.Inputs)
+
+			// Read the input data
+			input, remote, err := config.LoadConfigFile(inputFile)
+			require.NoError(t, err)
+			require.False(t, remote)
+			require.NotEmpty(t, input)
+
+			// Migrate
+			output, n, err := config.ApplyMigrations(input)
+			require.NoError(t, err)
+			require.NotEmpty(t, output)
+			require.GreaterOrEqual(t, n, uint64(1))
+
+			actual := config.NewConfig()
+			require.NoError(t, actual.LoadConfigData(output, config.EmptySourcePath))
+
+			// Test the output
+			require.Len(t, actual.Inputs, len(expected.Inputs))
+			actualIDs := make([]string, 0, len(expected.Inputs))
+			expectedIDs := make([]string, 0, len(expected.Inputs))
+			for i := range actual.Inputs {
+				actualIDs = append(actualIDs, actual.Inputs[i].ID())
+				expectedIDs = append(expectedIDs, expected.Inputs[i].ID())
+			}
+			require.ElementsMatch(t, expectedIDs, actualIDs, string(output))
+		})
+	}
+}

--- a/migrations/inputs_sqlserver/testcases/azuredb_false/expected.conf
+++ b/migrations/inputs_sqlserver/testcases/azuredb_false/expected.conf
@@ -1,0 +1,8 @@
+# SQL Server plugin with migrated database_type
+[[inputs.sqlserver]]
+  auth_method = "connection_string"
+  database_type = "SQLServer"
+  exclude_query = []
+  include_query = []
+  query_timeout = "5s"
+  servers = ["Server=192.168.1.10;Port=1433;User Id=myuser;Password=mypass;app name=telegraf;log=1;"]

--- a/migrations/inputs_sqlserver/testcases/azuredb_false/telegraf.conf
+++ b/migrations/inputs_sqlserver/testcases/azuredb_false/telegraf.conf
@@ -1,0 +1,10 @@
+# SQL Server plugin with deprecated azuredb option set to false
+[[inputs.sqlserver]]
+  servers = [
+    "Server=192.168.1.10;Port=1433;User Id=myuser;Password=mypass;app name=telegraf;log=1;"
+  ]
+  auth_method = "connection_string"
+  azuredb = false
+  query_timeout = "5s"
+  include_query = []
+  exclude_query = []

--- a/migrations/inputs_sqlserver/testcases/azuredb_true/expected.conf
+++ b/migrations/inputs_sqlserver/testcases/azuredb_true/expected.conf
@@ -1,0 +1,8 @@
+# SQL Server plugin with migrated database_type
+[[inputs.sqlserver]]
+  auth_method = "connection_string"
+  database_type = "AzureSQLDB"
+  exclude_query = []
+  include_query = []
+  query_timeout = "5s"
+  servers = ["Server=myazureserver.database.windows.net;Port=1433;User Id=myuser;Password=mypass;database=mydatabase;app name=telegraf;log=1;"]

--- a/migrations/inputs_sqlserver/testcases/azuredb_true/telegraf.conf
+++ b/migrations/inputs_sqlserver/testcases/azuredb_true/telegraf.conf
@@ -1,0 +1,10 @@
+# SQL Server plugin with deprecated azuredb option set to true
+[[inputs.sqlserver]]
+  servers = [
+    "Server=myazureserver.database.windows.net;Port=1433;User Id=myuser;Password=mypass;database=mydatabase;app name=telegraf;log=1;"
+  ]
+  auth_method = "connection_string"
+  azuredb = true
+  query_timeout = "5s"
+  include_query = []
+  exclude_query = []

--- a/migrations/inputs_sqlserver/testcases/both_deprecated/expected.conf
+++ b/migrations/inputs_sqlserver/testcases/both_deprecated/expected.conf
@@ -1,0 +1,8 @@
+# SQL Server plugin with migrated database_type
+[[inputs.sqlserver]]
+  auth_method = "connection_string"
+  database_type = "AzureSQLDB"
+  exclude_query = []
+  include_query = []
+  query_timeout = "5s"
+  servers = ["Server=myazureserver.database.windows.net;Port=1433;User Id=myuser;Password=mypass;database=mydatabase;app name=telegraf;log=1;"]

--- a/migrations/inputs_sqlserver/testcases/both_deprecated/telegraf.conf
+++ b/migrations/inputs_sqlserver/testcases/both_deprecated/telegraf.conf
@@ -1,0 +1,10 @@
+[[inputs.sqlserver]]
+  servers = [
+    "Server=myazureserver.database.windows.net;Port=1433;User Id=myuser;Password=mypass;database=mydatabase;app name=telegraf;log=1;"
+  ]
+  auth_method = "connection_string"
+  azuredb = true
+  query_version = 2
+  query_timeout = "5s"
+  include_query = []
+  exclude_query = []

--- a/migrations/inputs_sqlserver/testcases/existing_database_type/expected.conf
+++ b/migrations/inputs_sqlserver/testcases/existing_database_type/expected.conf
@@ -1,0 +1,8 @@
+# SQL Server plugin with preserved database_type and deprecated options removed
+[[inputs.sqlserver]]
+  auth_method = "connection_string"
+  database_type = "AzureSQLManagedInstance"
+  exclude_query = []
+  include_query = []
+  query_timeout = "5s"
+  servers = ["Server=192.168.1.10;Port=1433;User Id=myuser;Password=mypass;app name=telegraf;log=1;"]

--- a/migrations/inputs_sqlserver/testcases/existing_database_type/telegraf.conf
+++ b/migrations/inputs_sqlserver/testcases/existing_database_type/telegraf.conf
@@ -1,0 +1,12 @@
+# SQL Server plugin with existing database_type and deprecated options
+[[inputs.sqlserver]]
+  servers = [
+    "Server=192.168.1.10;Port=1433;User Id=myuser;Password=mypass;app name=telegraf;log=1;"
+  ]
+  auth_method = "connection_string"
+  database_type = "AzureSQLManagedInstance"
+  azuredb = true
+  query_version = 2
+  query_timeout = "5s"
+  include_query = []
+  exclude_query = []

--- a/migrations/inputs_sqlserver/testcases/query_version_1/expected.conf
+++ b/migrations/inputs_sqlserver/testcases/query_version_1/expected.conf
@@ -1,0 +1,8 @@
+# SQL Server plugin with migrated database_type
+[[inputs.sqlserver]]
+  auth_method = "connection_string"
+  database_type = "SQLServer"
+  exclude_query = []
+  include_query = []
+  query_timeout = "10s"
+  servers = ["Server=onprem-sql.company.com;Port=1433;User Id=telegraf;Password=secret;app name=telegraf;log=1;"]

--- a/migrations/inputs_sqlserver/testcases/query_version_1/telegraf.conf
+++ b/migrations/inputs_sqlserver/testcases/query_version_1/telegraf.conf
@@ -1,0 +1,10 @@
+# SQL Server plugin with deprecated query_version option set to 1
+[[inputs.sqlserver]]
+  servers = [
+    "Server=onprem-sql.company.com;Port=1433;User Id=telegraf;Password=secret;app name=telegraf;log=1;"
+  ]
+  auth_method = "connection_string"
+  query_version = 1
+  query_timeout = "10s"
+  include_query = []
+  exclude_query = []

--- a/migrations/inputs_sqlserver/testcases/query_version_2/expected.conf
+++ b/migrations/inputs_sqlserver/testcases/query_version_2/expected.conf
@@ -1,0 +1,8 @@
+# SQL Server plugin with migrated database_type
+[[inputs.sqlserver]]
+  auth_method = "connection_string"
+  database_type = "SQLServer"
+  exclude_query = []
+  include_query = []
+  query_timeout = "5s"
+  servers = ["Server=192.168.1.10;Port=1433;User Id=myuser;Password=mypass;app name=telegraf;log=1;"]

--- a/migrations/inputs_sqlserver/testcases/query_version_2/telegraf.conf
+++ b/migrations/inputs_sqlserver/testcases/query_version_2/telegraf.conf
@@ -1,0 +1,10 @@
+# SQL Server plugin with deprecated query_version option
+[[inputs.sqlserver]]
+  servers = [
+    "Server=192.168.1.10;Port=1433;User Id=myuser;Password=mypass;app name=telegraf;log=1;"
+  ]
+  auth_method = "connection_string"
+  query_version = 2
+  query_timeout = "5s"
+  include_query = []
+  exclude_query = []

--- a/plugins/inputs/sqlserver/sqlserver.go
+++ b/plugins/inputs/sqlserver/sqlserver.go
@@ -50,8 +50,6 @@ type SQLServer struct {
 	QueryTimeout config.Duration  `toml:"query_timeout"`
 	AuthMethod   string           `toml:"auth_method"`
 	ClientID     string           `toml:"client_id"`
-	QueryVersion int              `toml:"query_version" deprecated:"1.16.0;1.35.0;use 'database_type' instead"`
-	AzureDB      bool             `toml:"azuredb" deprecated:"1.16.0;1.35.0;use 'database_type' instead"`
 	DatabaseType string           `toml:"database_type"`
 	IncludeQuery []string         `toml:"include_query"`
 	ExcludeQuery []string         `toml:"exclude_query"`
@@ -226,7 +224,13 @@ func (s *SQLServer) Stop() {
 func (s *SQLServer) initQueries() error {
 	s.queries = make(mapQuery)
 	queries := s.queries
-	s.Log.Infof("Config: database_type: %s , query_version:%d , azuredb: %t", s.DatabaseType, s.QueryVersion, s.AzureDB)
+	s.Log.Infof("Config: database_type: %s", s.DatabaseType)
+
+	// If database_type is not set, default to SQLServer for backward compatibility
+	if s.DatabaseType == "" {
+		s.DatabaseType = typeSQLServer
+		s.Log.Warnf("database_type not specified, defaulting to %s", typeSQLServer)
+	}
 
 	// To prevent query definition conflicts
 	// Constant definitions for type "AzureSQLDB" start with sqlAzureDB
@@ -292,34 +296,8 @@ func (s *SQLServer) initQueries() error {
 		queries["SQLServerPersistentVersionStore"] =
 			query{ScriptName: "SQLServerPersistentVersionStore", Script: sqlServerPersistentVersionStore, ResultByRow: false}
 	} else {
-		// If this is an AzureDB instance, grab some extra metrics
-		if s.AzureDB {
-			queries["AzureDBResourceStats"] = query{ScriptName: "AzureDBPerformanceCounters", Script: sqlAzureDBResourceStats, ResultByRow: false}
-			queries["AzureDBResourceGovernance"] = query{ScriptName: "AzureDBPerformanceCounters", Script: sqlAzureDBResourceGovernance, ResultByRow: false}
-		}
-		// Decide if we want to run version 1 or version 2 queries
-		if s.QueryVersion == 2 {
-			queries["PerformanceCounters"] = query{ScriptName: "PerformanceCounters", Script: sqlPerformanceCountersV2, ResultByRow: true}
-			queries["WaitStatsCategorized"] = query{ScriptName: "WaitStatsCategorized", Script: sqlWaitStatsCategorizedV2, ResultByRow: false}
-			queries["DatabaseIO"] = query{ScriptName: "DatabaseIO", Script: sqlDatabaseIOV2, ResultByRow: false}
-			queries["ServerProperties"] = query{ScriptName: "ServerProperties", Script: sqlServerPropertiesV2, ResultByRow: false}
-			queries["MemoryClerk"] = query{ScriptName: "MemoryClerk", Script: sqlMemoryClerkV2, ResultByRow: false}
-			queries["Schedulers"] = query{ScriptName: "Schedulers", Script: sqlServerSchedulersV2, ResultByRow: false}
-			queries["SqlRequests"] = query{ScriptName: "SqlRequests", Script: sqlServerRequestsV2, ResultByRow: false}
-			queries["VolumeSpace"] = query{ScriptName: "VolumeSpace", Script: sqlServerVolumeSpaceV2, ResultByRow: false}
-			queries["Cpu"] = query{ScriptName: "Cpu", Script: sqlServerCPUV2, ResultByRow: false}
-		} else {
-			queries["PerformanceCounters"] = query{ScriptName: "PerformanceCounters", Script: sqlPerformanceCounters, ResultByRow: true}
-			queries["WaitStatsCategorized"] = query{ScriptName: "WaitStatsCategorized", Script: sqlWaitStatsCategorized, ResultByRow: false}
-			queries["CPUHistory"] = query{ScriptName: "CPUHistory", Script: sqlCPUHistory, ResultByRow: false}
-			queries["DatabaseIO"] = query{ScriptName: "DatabaseIO", Script: sqlDatabaseIO, ResultByRow: false}
-			queries["DatabaseSize"] = query{ScriptName: "DatabaseSize", Script: sqlDatabaseSize, ResultByRow: false}
-			queries["DatabaseStats"] = query{ScriptName: "DatabaseStats", Script: sqlDatabaseStats, ResultByRow: false}
-			queries["DatabaseProperties"] = query{ScriptName: "DatabaseProperties", Script: sqlDatabaseProperties, ResultByRow: false}
-			queries["MemoryClerk"] = query{ScriptName: "MemoryClerk", Script: sqlMemoryClerk, ResultByRow: false}
-			queries["VolumeSpace"] = query{ScriptName: "VolumeSpace", Script: sqlVolumeSpace, ResultByRow: false}
-			queries["PerformanceMetrics"] = query{ScriptName: "PerformanceMetrics", Script: sqlPerformanceMetrics, ResultByRow: false}
-		}
+		return fmt.Errorf("unsupported database_type: %s. Supported types are: %s, %s, %s, %s, %s",
+			s.DatabaseType, typeAzureSQLDB, typeAzureSQLManagedInstance, typeAzureSQLPool, typeAzureArcSQLManagedInstance, typeSQLServer)
 	}
 
 	filterQueries, err := filter.NewIncludeExcludeFilter(s.IncludeQuery, s.ExcludeQuery)
@@ -458,24 +436,11 @@ func (s *SQLServer) accHealth(healthMetrics map[string]*healthMetric, acc telegr
 		fields := map[string]interface{}{
 			healthMetricAttemptedQueries:  connectionStats.attemptedQueries,
 			healthMetricSuccessfulQueries: connectionStats.successfulQueries,
-			healthMetricDatabaseType:      s.getDatabaseTypeToLog(),
+			healthMetricDatabaseType:      s.DatabaseType,
 		}
 
 		acc.AddFields(healthMetricName, fields, tags, time.Now())
 	}
-}
-
-// getDatabaseTypeToLog returns the type of database monitored by this plugin instance
-func (s *SQLServer) getDatabaseTypeToLog() string {
-	if s.DatabaseType == typeAzureSQLDB || s.DatabaseType == typeAzureSQLManagedInstance || s.DatabaseType == typeSQLServer {
-		return s.DatabaseType
-	}
-
-	logname := fmt.Sprintf("QueryVersion-%d", s.QueryVersion)
-	if s.AzureDB {
-		logname += "-AzureDB"
-	}
-	return logname
 }
 
 // ------------------------------------------------------------------------------

--- a/plugins/inputs/sqlserver/sqlserver_test.go
+++ b/plugins/inputs/sqlserver/sqlserver_test.go
@@ -16,22 +16,22 @@ import (
 func TestSqlServer_QueriesInclusionExclusion(t *testing.T) {
 	cases := []map[string]interface{}{
 		{
-			"IncludeQuery": make([]string, 0),
-			"ExcludeQuery": []string{"WaitStatsCategorized", "DatabaseIO", "ServerProperties", "MemoryClerk", "Schedulers", "VolumeSpace", "Cpu"},
-			"queries":      []string{"PerformanceCounters", "SqlRequests"},
+			"IncludeQuery": []string{},
+			"ExcludeQuery": []string{"SQLServerWaitStatsCategorized", "SQLServerDatabaseIO", "SQLServerProperties", "SQLServerMemoryClerks", "SQLServerSchedulers", "SQLServerVolumeSpace", "SQLServerCpu", "SQLServerAvailabilityReplicaStates", "SQLServerDatabaseReplicaStates", "SQLServerRecentBackups", "SQLServerPersistentVersionStore"},
+			"queries":      []string{"SQLServerPerformanceCounters", "SQLServerRequests"},
 			"queriesTotal": 2,
 		},
 		{
-			"IncludeQuery": []string{"PerformanceCounters", "SqlRequests"},
-			"ExcludeQuery": []string{"SqlRequests", "WaitStatsCategorized", "DatabaseIO", "VolumeSpace", "Cpu"},
-			"queries":      []string{"PerformanceCounters"},
+			"IncludeQuery": []string{"SQLServerPerformanceCounters", "SQLServerRequests"},
+			"ExcludeQuery": []string{"SQLServerRequests", "SQLServerWaitStatsCategorized", "SQLServerDatabaseIO", "SQLServerVolumeSpace", "SQLServerCpu"},
+			"queries":      []string{"SQLServerPerformanceCounters"},
 			"queriesTotal": 1,
 		},
 	}
 
 	for _, test := range cases {
 		s := SQLServer{
-			QueryVersion: 2,
+			DatabaseType: "SQLServer",
 			IncludeQuery: test["IncludeQuery"].([]string),
 			ExcludeQuery: test["ExcludeQuery"].([]string),
 			Log:          testutil.Logger{},
@@ -158,14 +158,16 @@ func TestSqlServerIntegration_MultipleInstanceWithHealthMetric(t *testing.T) {
 	sl := config.NewSecret([]byte(testServer))
 	s := &SQLServer{
 		Servers:      []*config.Secret{&sl},
-		ExcludeQuery: []string{"MemoryClerk"},
+		DatabaseType: "SQLServer",
+		ExcludeQuery: []string{"SQLServerMemoryClerks"},
 		Log:          testutil.Logger{},
 	}
 
 	sl2 := config.NewSecret([]byte(testServer))
 	s2 := &SQLServer{
 		Servers:      []*config.Secret{&sl2},
-		ExcludeQuery: []string{"DatabaseSize"},
+		DatabaseType: "SQLServer",
+		ExcludeQuery: []string{"SQLServerDatabaseIO"},
 		HealthMetric: true,
 		Log:          testutil.Logger{},
 	}
@@ -175,7 +177,7 @@ func TestSqlServerIntegration_MultipleInstanceWithHealthMetric(t *testing.T) {
 	err := s.Gather(&acc)
 	require.NoError(t, err)
 
-	require.NoError(t, s2.Start(&acc))
+	require.NoError(t, s2.Start(&acc2))
 	err = s2.Gather(&acc2)
 	require.NoError(t, err)
 
@@ -204,7 +206,8 @@ func TestSqlServer_HealthMetric(t *testing.T) {
 
 	s1 := &SQLServer{
 		Servers:      []*config.Secret{&fs1, &fs2},
-		IncludeQuery: []string{"DatabaseSize", "MemoryClerk"},
+		DatabaseType: "SQLServer",
+		IncludeQuery: []string{"SQLServerDatabaseIO", "SQLServerMemoryClerks"},
 		HealthMetric: true,
 		AuthMethod:   "connection_string",
 		Log:          testutil.Logger{},
@@ -213,7 +216,8 @@ func TestSqlServer_HealthMetric(t *testing.T) {
 	sl2 := config.NewSecret([]byte(fakeServer1))
 	s2 := &SQLServer{
 		Servers:      []*config.Secret{&sl2},
-		IncludeQuery: []string{"DatabaseSize"},
+		DatabaseType: "SQLServer",
+		IncludeQuery: []string{"SQLServerDatabaseIO"},
 		AuthMethod:   "connection_string",
 		Log:          testutil.Logger{},
 	}
@@ -238,23 +242,28 @@ func TestSqlServer_HealthMetric(t *testing.T) {
 
 	// acc2 should not have the health metric because it is not specified in the config
 	var acc2 testutil.Accumulator
+	require.NoError(t, s2.Start(&acc2))
 	require.NoError(t, s2.Gather(&acc2))
 	require.False(t, acc2.HasMeasurement(healthMetricName))
 }
 
 func TestSqlServer_MultipleInit(t *testing.T) {
-	s := &SQLServer{Log: testutil.Logger{}}
+	s := &SQLServer{
+		DatabaseType: "SQLServer",
+		Log:          testutil.Logger{},
+	}
 	s2 := &SQLServer{
-		ExcludeQuery: []string{"DatabaseSize"},
+		DatabaseType: "SQLServer",
+		ExcludeQuery: []string{"SQLServerDatabaseIO"},
 		Log:          testutil.Logger{},
 	}
 
 	require.NoError(t, s.initQueries())
-	_, ok := s.queries["DatabaseSize"]
+	_, ok := s.queries["SQLServerDatabaseIO"]
 	require.True(t, ok)
 
-	require.NoError(t, s.initQueries())
-	_, ok = s2.queries["DatabaseSize"]
+	require.NoError(t, s2.initQueries())
+	_, ok = s2.queries["SQLServerDatabaseIO"]
 	require.False(t, ok)
 	s.Stop()
 	s2.Stop()
@@ -374,8 +383,8 @@ func TestSqlServerIntegration_AGQueriesApplicableForDatabaseTypeSQLServer(t *tes
 	err := s.Gather(&acc)
 	require.NoError(t, err)
 
+	require.NoError(t, s2.Start(&acc2))
 	err = s2.Gather(&acc2)
-	require.NoError(t, s2.Start(&acc))
 	require.NoError(t, err)
 
 	// acc includes size metrics, and excludes memory metrics
@@ -428,8 +437,8 @@ func TestSqlServerIntegration_AGQueryFieldsOutputBasedOnSQLServerVersion(t *test
 	err := s2019.Gather(&acc2019)
 	require.NoError(t, err)
 
-	err = s2012.Gather(&acc2012)
 	require.NoError(t, s2012.Start(&acc2012))
+	err = s2012.Gather(&acc2012)
 	require.NoError(t, err)
 
 	// acc2019 includes new HADR query fields


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Replace the following options in the plugin and provide a migration
```
  inputs.sqlserver/azuredb                 ERROR since 1.16.0 removal in 1.35.0 use 'database_type' instead
  inputs.sqlserver/query_version           ERROR since 1.16.0 removal in 1.35.0 use 'database_type' instead
```

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #16933 
