### PR TITLE
feat(migrations): Add migration for inputs.smart

### DIFF
--- a/migrations/all/inputs_smart.go
+++ b/migrations/all/inputs_smart.go
@@ -1,0 +1,5 @@
+//go:build !custom || (migrations && (inputs || inputs.smart))
+
+package all
+
+import _ "github.com/influxdata/telegraf/migrations/inputs_smart" // register migration

--- a/migrations/inputs_smart/migration.go
+++ b/migrations/inputs_smart/migration.go
@@ -1,0 +1,44 @@
+package inputs_smart
+
+import (
+	"github.com/influxdata/toml"
+	"github.com/influxdata/toml/ast"
+
+	"github.com/influxdata/telegraf/migrations"
+)
+
+func migrate(tbl *ast.Table) ([]byte, string, error) {
+	var plugin map[string]interface{}
+	if err := toml.UnmarshalTable(tbl, &plugin); err != nil {
+		return nil, "", err
+	}
+
+	var applied bool
+
+	if path, found := plugin["path"]; found {
+		if _, found := plugin["path_smartctl"]; found {
+			return nil, "Cannot migrate 'inputs.smart' 'path' option, as 'path_smartctl' is already set", nil
+		}
+		plugin["path_smartctl"] = path
+		delete(plugin, "path")
+		applied = true
+	}
+
+	// No options migrated so we can exit early
+	if !applied {
+		return nil, "", migrations.ErrNotApplicable
+	}
+
+	// Create the corresponding plugin configurations
+	cfg := migrations.CreateTOMLStruct("inputs", "smart")
+	cfg.Add("inputs", "smart", plugin)
+
+	output, err := toml.Marshal(cfg)
+
+	return output, "", err
+}
+
+// Register the migration function for the plugin type
+func init() {
+	migrations.AddPluginMigration("inputs.smart", migrate)
+}

--- a/migrations/inputs_smart/migration_test.go
+++ b/migrations/inputs_smart/migration_test.go
@@ -1,0 +1,70 @@
+package inputs_smart_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/influxdata/telegraf/config"
+	_ "github.com/influxdata/telegraf/migrations/inputs_smart" // register migration
+	_ "github.com/influxdata/telegraf/plugins/inputs/smart"    // register plugin
+)
+
+func TestCases(t *testing.T) {
+	testcases := []struct {
+		folder     string
+		shouldFail bool
+	}{
+		{
+			folder:     "standard",
+			shouldFail: false,
+		},
+		{
+			folder:     "failed",
+			shouldFail: true,
+		},
+	}
+
+	for _, testcase := range testcases {
+		t.Run(testcase.folder, func(t *testing.T) {
+			testcasePath := filepath.Join("testcases", testcase.folder)
+			inputFile := filepath.Join(testcasePath, "telegraf.conf")
+			expectedFile := filepath.Join(testcasePath, "expected.conf")
+
+			// Read the expected output
+			expected := config.NewConfig()
+			require.NoError(t, expected.LoadConfig(expectedFile))
+			require.NotEmpty(t, expected.Inputs)
+
+			// Read the input data
+			input, remote, err := config.LoadConfigFile(inputFile)
+			require.NoError(t, err)
+			require.False(t, remote)
+			require.NotEmpty(t, input)
+
+			// Migrate
+			output, n, err := config.ApplyMigrations(input)
+			require.NoError(t, err)
+
+			if testcase.shouldFail {
+				require.Empty(t, output)
+				return
+			}
+			require.NotEmpty(t, output)
+			require.GreaterOrEqual(t, uint64(1), n)
+			actual := config.NewConfig()
+			require.NoError(t, actual.LoadConfigData(output, config.EmptySourcePath))
+
+			// Test the output
+			require.Len(t, actual.Inputs, len(expected.Inputs))
+			actualIDs := make([]string, 0, len(expected.Inputs))
+			expectedIDs := make([]string, 0, len(expected.Inputs))
+			for i := range actual.Inputs {
+				actualIDs = append(actualIDs, actual.Inputs[i].ID())
+				expectedIDs = append(expectedIDs, expected.Inputs[i].ID())
+			}
+			require.ElementsMatchf(t, expectedIDs, actualIDs, "generated config: %s", string(output))
+		})
+	}
+}

--- a/migrations/inputs_smart/testcases/failed/expected.conf
+++ b/migrations/inputs_smart/testcases/failed/expected.conf
@@ -1,0 +1,3 @@
+[[inputs.smart]]
+    path = "/usr/bin/smartctl_path"
+    path_smartctl = "/usr/bin/smartctl_pathsmartctl"

--- a/migrations/inputs_smart/testcases/failed/telegraf.conf
+++ b/migrations/inputs_smart/testcases/failed/telegraf.conf
@@ -1,0 +1,3 @@
+[[inputs.smart]]
+    path = "/usr/bin/smartctl_path"
+    path_smartctl = "/usr/bin/smartctl_pathsmartctl"

--- a/migrations/inputs_smart/testcases/standard/expected.conf
+++ b/migrations/inputs_smart/testcases/standard/expected.conf
@@ -1,0 +1,2 @@
+[[inputs.smart]]
+    path_smartctl = "/usr/bin/smartctl"

--- a/migrations/inputs_smart/testcases/standard/telegraf.conf
+++ b/migrations/inputs_smart/testcases/standard/telegraf.conf
@@ -1,0 +1,2 @@
+[[inputs.smart]]
+    path = "/usr/bin/smartctl"


### PR DESCRIPTION
## Summary
Replace the following options in the plugin and provide a migration
```
  inputs.smart/path                        ERROR since 1.16.0 removal in 1.35.0 use 'path_smartctl' instead
```

## Checklist
- [X] No AI generated code was used in this PR

## Related issues
resolves #16932
