### PR TITLE
chore(migrations): Remove messages from migration

### DIFF
--- a/migrations/inputs_openldap/testcases/mixed_config/telegraf.conf
+++ b/migrations/inputs_openldap/testcases/mixed_config/telegraf.conf
@@ -3,20 +3,18 @@
   host = "ldap.example.com"
   port = 389
 
-  # User already has tls configured - should NOT be overwritten
+  # User already has configured tls so we should just delete the deprecated
+  # ssl setting
   tls = "starttls"
-
-  # Deprecated ssl option - should be removed but not override existing tls
-  ssl = "ldaps"
+  ssl = "starttls"
 
   # skip peer certificate verification. Default is false.
   insecure_skip_verify = true
 
-  # User already has tls_ca configured - should NOT be overwritten
+  # User already has configured tls_ca so we should just delete the deprecated
+  # ssl_ca setting
   tls_ca = "/etc/ssl/custom-ca.pem"
-
-  # Deprecated ssl_ca option - should be removed but not override existing tls_ca
-  ssl_ca = "/etc/ssl/old-ca.pem"
+  ssl_ca = "/etc/ssl/custom-ca.pem"
 
   # dn/password to bind with. If bind_dn is empty, an anonymous bind is performed.
   bind_dn = ""


### PR DESCRIPTION
## Summary

PR ##17103 introduced some success messages in the migration. This clutters the output and might hide important notifications for the user in success messages. This PR removes the messages and additionally detects value mismatches.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues
