### PR TITLE
feat(migrations): Add migration for common.tls ssl options

### DIFF
--- a/migrations/all/general_common_tls.go
+++ b/migrations/all/general_common_tls.go
@@ -1,0 +1,5 @@
+//go:build !custom || migrations
+
+package all
+
+import _ "github.com/influxdata/telegraf/migrations/general_common_tls" // register migration

--- a/migrations/general_common_tls/migration.go
+++ b/migrations/general_common_tls/migration.go
@@ -1,0 +1,82 @@
+package general_common_tls
+
+import (
+	"fmt"
+
+	"github.com/influxdata/toml"
+	"github.com/influxdata/toml/ast"
+
+	"github.com/influxdata/telegraf/migrations"
+)
+
+// Migration function
+func migrate(category, name string, tbl *ast.Table) ([]byte, string, error) {
+	// Filter options can only be present in inputs, outputs, processors and
+	// aggregators. Skip everything else...
+	switch category {
+	case "inputs", "outputs", "processors", "aggregators":
+	default:
+		return nil, "", migrations.ErrNotApplicable
+	}
+
+	// Decode the old data structure
+	var plugin map[string]interface{}
+	if err := toml.UnmarshalTable(tbl, &plugin); err != nil {
+		return nil, "", err
+	}
+
+	// Check for deprecated option(s) and migrate them
+	var applied bool
+
+	// Option mapping to replace
+	mapping := map[string]string{
+		"ssl_ca":   "tls_ca",
+		"ssl_cert": "tls_cert",
+		"ssl_key":  "tls_key",
+	}
+
+	// Check if the old settings are present and set the new TLS settings. Warn
+	// on conflicting settings where both the old and the new setting is
+	// present.
+	for oldSetting, newSetting := range mapping {
+		rawOld, found := plugin[oldSetting]
+		if !found {
+			continue
+		}
+		vOld, ok := rawOld.(string)
+		if !ok {
+			return nil, "", fmt.Errorf("unexpected type %T for %q", rawOld, oldSetting)
+		}
+		rawNew, present := plugin[newSetting]
+		if present {
+			if vNew, ok := rawNew.(string); !ok {
+				return nil, "", fmt.Errorf("unexpected type %T for %q", rawOld, newSetting)
+			} else if vOld != vNew {
+				return nil, "", fmt.Errorf("contradicting setting for %q and %q", oldSetting, newSetting)
+			}
+		} else {
+			plugin[newSetting] = vOld
+		}
+		applied = true
+
+		// Remove the deprecated option
+		delete(plugin, oldSetting)
+	}
+
+	// No options migrated so we can exit early
+	if !applied {
+		return nil, "", migrations.ErrNotApplicable
+	}
+
+	// Create the corresponding plugin configurations
+	cfg := migrations.CreateTOMLStruct(category, name)
+	cfg.Add(category, name, plugin)
+
+	output, err := toml.Marshal(cfg)
+	return output, "", err
+}
+
+// Register the migration function for the plugin type
+func init() {
+	migrations.AddGeneralMigration(migrate)
+}

--- a/migrations/general_common_tls/migration_test.go
+++ b/migrations/general_common_tls/migration_test.go
@@ -1,0 +1,228 @@
+package general_common_tls_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/config"
+	_ "github.com/influxdata/telegraf/migrations/general_common_tls" // register migration
+	common_tls "github.com/influxdata/telegraf/plugins/common/tls"
+	"github.com/influxdata/telegraf/plugins/inputs"
+)
+
+func TestNoMigration(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  string
+	}{
+		{
+			name: "input",
+			cfg: `
+# Dummy plugin
+[[inputs.dummy]]
+  ## A dummy server
+  servers = ["tcp://127.0.0.1:1883"]
+
+  ## A commented option
+  # timeout = "10s"
+`,
+		},
+		{
+			name: "output",
+			cfg: `
+# Dummy plugin
+[[output.dummy]]
+  ## A dummy server
+  servers = ["tcp://127.0.0.1:1883"]
+
+  ## A commented option
+  # timeout = "10s"
+`,
+		},
+		{
+			name: "processor",
+			cfg: `
+# Dummy plugin
+[[processor.dummy]]
+  ## A dummy server
+  servers = ["tcp://127.0.0.1:1883"]
+
+  ## A commented option
+  # timeout = "10s"
+`,
+		},
+		{
+			name: "aggregator",
+			cfg: `
+# Dummy plugin
+[[aggregator.dummy]]
+  ## A dummy server
+  servers = ["tcp://127.0.0.1:1883"]
+
+  ## A commented option
+  # timeout = "10s"
+`,
+		},
+		{
+			name: "no old setting",
+			cfg: `
+# Dummy plugin
+[[input.dummy]]
+  ## A dummy server
+  servers = ["tcp://127.0.0.1:1883"]
+
+  # TLS settings
+  tls_ca = "/etc/ca.pem"
+  tls_cert = "/etc/cert.pem"
+  tls_key = "/etc/key"
+
+
+  ## A commented option
+  # timeout = "10s"
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := []byte(tt.cfg)
+
+			// Migrate and check that nothing changed
+			output, n, err := config.ApplyMigrations(cfg)
+			require.NoError(t, err)
+			require.NotEmpty(t, output)
+			require.Zero(t, n)
+			require.Equal(t, tt.cfg, string(output))
+		})
+	}
+}
+
+func TestConflict(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  string
+	}{
+		{
+			name: "ca",
+			cfg: `
+# Dummy plugin
+[[inputs.dummy]]
+  ## A dummy server
+  servers = ["tcp://127.0.0.1:1883"]
+  tls_ca = "foo.pem"
+  ssl_ca = "bar.pem"
+
+  ## A commented option
+  # timeout = "10s"
+`,
+		},
+		{
+			name: "cert",
+			cfg: `
+# Dummy plugin
+[[inputs.dummy]]
+  ## A dummy server
+  servers = ["tcp://127.0.0.1:1883"]
+  tls_cert = "foo.pem"
+  ssl_cert = "bar.pem"
+
+  ## A commented option
+  # timeout = "10s"
+`,
+		},
+		{
+			name: "key",
+			cfg: `
+# Dummy plugin
+[[inputs.dummy]]
+  ## A dummy server
+  servers = ["tcp://127.0.0.1:1883"]
+  tls_key = "foo.pem"
+  ssl_key = "bar.pem"
+
+  ## A commented option
+  # timeout = "10s"
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := []byte(tt.cfg)
+
+			// Migrate and check that nothing changed
+			output, n, err := config.ApplyMigrations(cfg)
+			require.ErrorContains(t, err, "contradicting setting")
+			require.Empty(t, output)
+			require.Zero(t, n)
+		})
+	}
+}
+
+func TestCases(t *testing.T) {
+	// Get all directories in testdata
+	folders, err := os.ReadDir("testcases")
+	require.NoError(t, err)
+
+	inputs.Add("dummy", func() telegraf.Input { return &MockupInputPlugin{} })
+
+	for _, f := range folders {
+		// Only handle folders
+		if !f.IsDir() {
+			continue
+		}
+
+		t.Run(f.Name(), func(t *testing.T) {
+			testcasePath := filepath.Join("testcases", f.Name())
+			inputFile := filepath.Join(testcasePath, "telegraf.conf")
+			expectedFile := filepath.Join(testcasePath, "expected.conf")
+
+			// Read the expected output
+			expected := config.NewConfig()
+			require.NoError(t, expected.LoadConfig(expectedFile))
+			require.NotEmpty(t, expected.Inputs)
+
+			// Read the input data
+			input, remote, err := config.LoadConfigFile(inputFile)
+			require.NoError(t, err)
+			require.False(t, remote)
+			require.NotEmpty(t, input)
+
+			// Migrate
+			output, n, err := config.ApplyMigrations(input)
+			require.NoError(t, err)
+			require.NotEmpty(t, output)
+			require.GreaterOrEqual(t, n, uint64(1))
+			actual := config.NewConfig()
+			require.NoError(t, actual.LoadConfigData(output, config.EmptySourcePath))
+
+			// Test the output
+			require.Len(t, actual.Inputs, len(expected.Inputs))
+			actualIDs := make([]string, 0, len(expected.Inputs))
+			expectedIDs := make([]string, 0, len(expected.Inputs))
+			for i := range actual.Inputs {
+				actualIDs = append(actualIDs, actual.Inputs[i].ID())
+				expectedIDs = append(expectedIDs, expected.Inputs[i].ID())
+			}
+			require.ElementsMatch(t, expectedIDs, actualIDs, string(output))
+		})
+	}
+}
+
+// Implement a mock input plugin for testing
+type MockupInputPlugin struct {
+	Servers []string        `toml:"servers"`
+	Timeout config.Duration `toml:"timeout"`
+	common_tls.ClientConfig
+}
+
+func (*MockupInputPlugin) SampleConfig() string {
+	return "Mockup test input plugin"
+}
+func (*MockupInputPlugin) Gather(telegraf.Accumulator) error {
+	return nil
+}

--- a/migrations/general_common_tls/testcases/deprecated_ssl/expected.conf
+++ b/migrations/general_common_tls/testcases/deprecated_ssl/expected.conf
@@ -1,0 +1,5 @@
+[[inputs.dummy]]
+servers = ["tcp://127.0.0.1:1883"]
+tls_ca = "../../testutil/pki/cacert.pem"
+tls_cert = "../../testutil/pki/client.pem"
+tls_key = "../../testutil/pki/clientkey.pem"

--- a/migrations/general_common_tls/testcases/deprecated_ssl/telegraf.conf
+++ b/migrations/general_common_tls/testcases/deprecated_ssl/telegraf.conf
@@ -1,0 +1,12 @@
+# A dummy plugin
+[[inputs.dummy]]
+  ## A server
+  servers = ["tcp://127.0.0.1:1883"]
+
+  ## Deprecated SSL options
+  ssl_ca = "../../testutil/pki/cacert.pem"
+  ssl_cert = "../../testutil/pki/client.pem"
+  ssl_key = "../../testutil/pki/clientkey.pem"
+
+  ## Default timestamp
+  # timestamp = "10s"

--- a/migrations/inputs_openldap/testcases/mixed_config/expected.conf
+++ b/migrations/inputs_openldap/testcases/mixed_config/expected.conf
@@ -9,8 +9,8 @@
   # skip peer certificate verification. Default is false.
   insecure_skip_verify = true
 
-  # Existing tls_ca option preserved (ssl_ca option was removed)
-  tls_ca = "/etc/ssl/custom-ca.pem"
+  # Deprecated ssl_ca option was removed
+  tls_ca = "/etc/ssl/myca.pem"
 
   # dn/password to bind with. If bind_dn is empty, an anonymous bind is performed.
   bind_dn = ""

--- a/migrations/inputs_openldap/testcases/mixed_config/telegraf.conf
+++ b/migrations/inputs_openldap/testcases/mixed_config/telegraf.conf
@@ -11,10 +11,9 @@
   # skip peer certificate verification. Default is false.
   insecure_skip_verify = true
 
-  # User already has configured tls_ca so we should just delete the deprecated
-  # ssl_ca setting
-  tls_ca = "/etc/ssl/custom-ca.pem"
-  ssl_ca = "/etc/ssl/custom-ca.pem"
+  # User already has tls_ca configured without contradiction
+  tls_ca = "/etc/ssl/myca.pem"
+  ssl_ca = "/etc/ssl/myca.pem"
 
   # dn/password to bind with. If bind_dn is empty, an anonymous bind is performed.
   bind_dn = ""

--- a/plugins/common/tls/config.go
+++ b/plugins/common/tls/config.go
@@ -28,10 +28,6 @@ type ClientConfig struct {
 	ServerName          string   `toml:"tls_server_name"`
 	RenegotiationMethod string   `toml:"tls_renegotiation_method"`
 	Enable              *bool    `toml:"tls_enable"`
-
-	SSLCA   string `toml:"ssl_ca" deprecated:"1.7.0;1.35.0;use 'tls_ca' instead"`
-	SSLCert string `toml:"ssl_cert" deprecated:"1.7.0;1.35.0;use 'tls_cert' instead"`
-	SSLKey  string `toml:"ssl_key" deprecated:"1.7.0;1.35.0;use 'tls_key' instead"`
 }
 
 // ServerConfig represents the standard server TLS config.
@@ -52,17 +48,6 @@ func (c *ClientConfig) TLSConfig() (*tls.Config, error) {
 	// Check if TLS config is forcefully disabled
 	if c.Enable != nil && !*c.Enable {
 		return nil, nil
-	}
-
-	// Support deprecated variable names
-	if c.TLSCA == "" && c.SSLCA != "" {
-		c.TLSCA = c.SSLCA
-	}
-	if c.TLSCert == "" && c.SSLCert != "" {
-		c.TLSCert = c.SSLCert
-	}
-	if c.TLSKey == "" && c.SSLKey != "" {
-		c.TLSKey = c.SSLKey
 	}
 
 	// This check returns a nil (aka "disabled") or an empty config

--- a/plugins/common/tls/config_test.go
+++ b/plugins/common/tls/config_test.go
@@ -140,14 +140,6 @@ func TestClientConfig(t *testing.T) {
 			expErr: false,
 		},
 		{
-			name: "support deprecated ssl field names",
-			client: tls.ClientConfig{
-				SSLCA:   pki.CACertPath(),
-				SSLCert: pki.ClientCertPath(),
-				SSLKey:  pki.ClientKeyPath(),
-			},
-		},
-		{
 			name: "set SNI server name",
 			client: tls.ClientConfig{
 				ServerName: "foo.example.com",


### PR DESCRIPTION
## Summary

This PR migrates the common TLS options for all plugins using them. The PR also removes the deprecated options.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #16947
