### PR TITLE
feat(inputs.amqp_consumer): Allow string values in queue arguments

### DIFF
--- a/plugins/inputs/amqp_consumer/amqp_consumer.go
+++ b/plugins/inputs/amqp_consumer/amqp_consumer.go
@@ -31,28 +31,28 @@ type externalAuth struct{}
 type semaphore chan empty
 
 type AMQPConsumer struct {
-	URL                    string            `toml:"url" deprecated:"1.7.0;1.35.0;use 'brokers' instead"`
-	Brokers                []string          `toml:"brokers"`
-	Username               config.Secret     `toml:"username"`
-	Password               config.Secret     `toml:"password"`
-	Exchange               string            `toml:"exchange"`
-	ExchangeType           string            `toml:"exchange_type"`
-	ExchangeDurability     string            `toml:"exchange_durability"`
-	ExchangePassive        bool              `toml:"exchange_passive"`
-	ExchangeArguments      map[string]string `toml:"exchange_arguments"`
-	MaxUndeliveredMessages int               `toml:"max_undelivered_messages"`
-	Queue                  string            `toml:"queue"`
-	QueueDurability        string            `toml:"queue_durability"`
-	QueuePassive           bool              `toml:"queue_passive"`
-	QueueArguments         map[string]int    `toml:"queue_arguments"`
-	QueueConsumeArguments  map[string]string `toml:"queue_consume_arguments"`
-	BindingKey             string            `toml:"binding_key"`
-	PrefetchCount          int               `toml:"prefetch_count"`
-	AuthMethod             string            `toml:"auth_method"`
-	ContentEncoding        string            `toml:"content_encoding"`
-	MaxDecompressionSize   config.Size       `toml:"max_decompression_size"`
-	Timeout                config.Duration   `toml:"timeout"`
-	Log                    telegraf.Logger   `toml:"-"`
+	URL                    string                 `toml:"url" deprecated:"1.7.0;1.35.0;use 'brokers' instead"`
+	Brokers                []string               `toml:"brokers"`
+	Username               config.Secret          `toml:"username"`
+	Password               config.Secret          `toml:"password"`
+	Exchange               string                 `toml:"exchange"`
+	ExchangeType           string                 `toml:"exchange_type"`
+	ExchangeDurability     string                 `toml:"exchange_durability"`
+	ExchangePassive        bool                   `toml:"exchange_passive"`
+	ExchangeArguments      map[string]string      `toml:"exchange_arguments"`
+	MaxUndeliveredMessages int                    `toml:"max_undelivered_messages"`
+	Queue                  string                 `toml:"queue"`
+	QueueDurability        string                 `toml:"queue_durability"`
+	QueuePassive           bool                   `toml:"queue_passive"`
+	QueueArguments         map[string]interface{} `toml:"queue_arguments"`
+	QueueConsumeArguments  map[string]string      `toml:"queue_consume_arguments"`
+	BindingKey             string                 `toml:"binding_key"`
+	PrefetchCount          int                    `toml:"prefetch_count"`
+	AuthMethod             string                 `toml:"auth_method"`
+	ContentEncoding        string                 `toml:"content_encoding"`
+	MaxDecompressionSize   config.Size            `toml:"max_decompression_size"`
+	Timeout                config.Duration        `toml:"timeout"`
+	Log                    telegraf.Logger        `toml:"-"`
 	tls.ClientConfig
 
 	deliveries map[telegraf.TrackingID]amqp.Delivery


### PR DESCRIPTION
## Summary
Mirrored classic queues are deprecated in RabbitMQ 4.0.x and are removed in 4.1.x, leaving quorum queues as the only option for clustering.  In order for the amqp_consumer plugin to create or read from a quorum queue it needs to have the following (string) queue argument:

```
queue_arguments = {"x-queue-type" = "quorum"}
```

This is not currently possible as the queue arguments functionality was coded to only accept int values.

This PR will enable both int and string values to be passed in queue_arguments. 

## Checklist
- [x] No AI generated code was used in this PR

## Related issues
resolves [17120](https://github.com/influxdata/telegraf/issues/17120)
resolves [6591](https://github.com/influxdata/telegraf/issues/6591)
