### PR TITLE
feat(migrations): Add migration for inputs.cloudwatch

### DIFF
--- a/migrations/all/inputs_cloudwatch.go
+++ b/migrations/all/inputs_cloudwatch.go
@@ -1,0 +1,5 @@
+//go:build !custom || (migrations && (inputs || inputs.cloudwatch))
+
+package all
+
+import _ "github.com/influxdata/telegraf/migrations/inputs_cloudwatch" // register migration

--- a/migrations/inputs_cloudwatch/migration.go
+++ b/migrations/inputs_cloudwatch/migration.go
@@ -1,0 +1,100 @@
+package inputs_cloudwatch
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/influxdata/toml"
+	"github.com/influxdata/toml/ast"
+
+	"github.com/influxdata/telegraf/migrations"
+)
+
+// Migration function to migrate deprecated namespace option to namespaces
+func migrate(tbl *ast.Table) ([]byte, string, error) {
+	// Decode the old data structure
+	var plugin map[string]interface{}
+	if err := toml.UnmarshalTable(tbl, &plugin); err != nil {
+		return nil, "", err
+	}
+
+	var applied bool
+	var messages []string
+
+	// Check if deprecated 'namespace' option exists
+	if namespaceValue, found := plugin["namespace"]; found {
+		applied = true
+
+		// Get the namespace value as string
+		namespaceStr, ok := namespaceValue.(string)
+		if !ok {
+			return nil, "", fmt.Errorf("namespace value is not a string: %T", namespaceValue)
+		}
+
+		// Check if 'namespaces' already exists
+		if namespacesValue, exists := plugin["namespaces"]; exists {
+			// namespaces already exists, we need to merge them
+			namespacesSlice, ok := namespacesValue.([]interface{})
+			if !ok {
+				return nil, "", fmt.Errorf("namespaces value is not a slice: %T", namespacesValue)
+			}
+
+			// Convert to string slice for easier handling
+			var existingNamespaces []string
+			for _, ns := range namespacesSlice {
+				if nsStr, ok := ns.(string); ok {
+					existingNamespaces = append(existingNamespaces, nsStr)
+				}
+			}
+
+			// Check if the namespace is already in namespaces
+			found := false
+			for _, existing := range existingNamespaces {
+				if existing == namespaceStr {
+					found = true
+					break
+				}
+			}
+
+			if !found {
+				// Add the namespace to the existing namespaces
+				existingNamespaces = append(existingNamespaces, namespaceStr)
+				// Convert back to []interface{} for TOML
+				var newNamespaces []interface{}
+				for _, ns := range existingNamespaces {
+					newNamespaces = append(newNamespaces, ns)
+				}
+				plugin["namespaces"] = newNamespaces
+				messages = append(messages, fmt.Sprintf("merged 'namespace' value '%s' into existing 'namespaces' array", namespaceStr))
+			} else {
+				messages = append(messages, fmt.Sprintf("removed deprecated 'namespace' option (value '%s' already exists in 'namespaces')", namespaceStr))
+			}
+		} else {
+			// namespaces doesn't exist, create it with the namespace value
+			plugin["namespaces"] = []interface{}{namespaceStr}
+			messages = append(messages, fmt.Sprintf("migrated 'namespace' option to 'namespaces' array with value '%s'", namespaceStr))
+		}
+
+		// Remove the deprecated setting
+		delete(plugin, "namespace")
+	}
+
+	// No options migrated so we can exit early
+	if !applied {
+		return nil, "", migrations.ErrNotApplicable
+	}
+
+	// Create the corresponding plugin configuration
+	cfg := migrations.CreateTOMLStruct("inputs", "cloudwatch")
+	cfg.Add("inputs", "cloudwatch", plugin)
+
+	output, err := toml.Marshal(cfg)
+	message := strings.Join(messages, "; ")
+
+	return output, message, err
+}
+
+// Register the migration function for the plugin type
+func init() {
+	migrations.AddPluginOptionMigration("inputs.cloudwatch", migrate)
+}

--- a/migrations/inputs_cloudwatch/migration_test.go
+++ b/migrations/inputs_cloudwatch/migration_test.go
@@ -1,0 +1,75 @@
+package inputs_cloudwatch_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/influxdata/telegraf/config"
+	_ "github.com/influxdata/telegraf/migrations/inputs_cloudwatch" // register migration
+	"github.com/influxdata/telegraf/plugins/inputs/cloudwatch"
+)
+
+func TestNoMigration(t *testing.T) {
+	plugin := &cloudwatch.CloudWatch{}
+	defaultCfg := []byte(plugin.SampleConfig())
+
+	// Migrate and check that nothing changed
+	output, n, err := config.ApplyMigrations(defaultCfg)
+	require.NoError(t, err)
+	require.NotEmpty(t, output)
+	require.Zero(t, n)
+	require.Equal(t, string(defaultCfg), string(output))
+}
+
+func TestCases(t *testing.T) {
+	// Get all directories in testcases
+	folders, err := os.ReadDir("testcases")
+	require.NoError(t, err)
+
+	for _, f := range folders {
+		// Only handle folders
+		if !f.IsDir() {
+			continue
+		}
+
+		t.Run(f.Name(), func(t *testing.T) {
+			testcasePath := filepath.Join("testcases", f.Name())
+			inputFile := filepath.Join(testcasePath, "telegraf.conf")
+			expectedFile := filepath.Join(testcasePath, "expected.conf")
+
+			// Read the expected output
+			expected := config.NewConfig()
+			require.NoError(t, expected.LoadConfig(expectedFile))
+			require.NotEmpty(t, expected.Inputs)
+
+			// Read the input data
+			input, remote, err := config.LoadConfigFile(inputFile)
+			require.NoError(t, err)
+			require.False(t, remote)
+			require.NotEmpty(t, input)
+
+			// Migrate
+			output, n, err := config.ApplyMigrations(input)
+			require.NoError(t, err)
+			require.NotEmpty(t, output)
+			require.GreaterOrEqual(t, n, uint64(1))
+
+			actual := config.NewConfig()
+			require.NoError(t, actual.LoadConfigData(output, config.EmptySourcePath))
+
+			// Test the output
+			require.Len(t, actual.Inputs, len(expected.Inputs))
+
+			actualIDs := make([]string, 0, len(expected.Inputs))
+			expectedIDs := make([]string, 0, len(expected.Inputs))
+			for i := range actual.Inputs {
+				actualIDs = append(actualIDs, actual.Inputs[i].ID())
+				expectedIDs = append(expectedIDs, expected.Inputs[i].ID())
+			}
+			require.ElementsMatch(t, expectedIDs, actualIDs, string(output))
+		})
+	}
+}

--- a/migrations/inputs_cloudwatch/testcases/multiple_cloudwatch_instances/expected.conf
+++ b/migrations/inputs_cloudwatch/testcases/multiple_cloudwatch_instances/expected.conf
@@ -1,0 +1,18 @@
+# Multiple CloudWatch instances with migrated namespaces
+[[inputs.cloudwatch]]
+  region = "us-east-1"
+  namespaces = ["AWS/ELB"]
+  period = "5m"
+  delay = "5m"
+
+[[inputs.cloudwatch]]
+  region = "us-west-2"
+  namespaces = ["AWS/EC2"]
+  period = "5m"
+  delay = "5m"
+
+[[inputs.cloudwatch]]
+  region = "eu-west-1"
+  namespaces = ["AWS/Lambda", "AWS/RDS"]
+  period = "5m"
+  delay = "5m"

--- a/migrations/inputs_cloudwatch/testcases/multiple_cloudwatch_instances/telegraf.conf
+++ b/migrations/inputs_cloudwatch/testcases/multiple_cloudwatch_instances/telegraf.conf
@@ -1,0 +1,19 @@
+# Multiple CloudWatch instances with different scenarios
+[[inputs.cloudwatch]]
+  region = "us-east-1"
+  namespace = "AWS/ELB"
+  period = "5m"
+  delay = "5m"
+
+[[inputs.cloudwatch]]
+  region = "us-west-2"
+  namespaces = ["AWS/EC2"]
+  period = "5m"
+  delay = "5m"
+
+[[inputs.cloudwatch]]
+  region = "eu-west-1"
+  namespace = "AWS/RDS"
+  namespaces = ["AWS/Lambda"]
+  period = "5m"
+  delay = "5m"

--- a/migrations/inputs_cloudwatch/testcases/namespace_duplicate_in_namespaces/expected.conf
+++ b/migrations/inputs_cloudwatch/testcases/namespace_duplicate_in_namespaces/expected.conf
@@ -1,0 +1,6 @@
+# CloudWatch with duplicate namespace removed
+[[inputs.cloudwatch]]
+  region = "us-east-1"
+  namespaces = ["AWS/ELB", "AWS/EC2"]
+  period = "5m"
+  delay = "5m"

--- a/migrations/inputs_cloudwatch/testcases/namespace_duplicate_in_namespaces/telegraf.conf
+++ b/migrations/inputs_cloudwatch/testcases/namespace_duplicate_in_namespaces/telegraf.conf
@@ -1,0 +1,7 @@
+# CloudWatch with namespace already in namespaces (duplicate case)
+[[inputs.cloudwatch]]
+  region = "us-east-1"
+  namespace = "AWS/ELB"
+  namespaces = ["AWS/ELB", "AWS/EC2"]
+  period = "5m"
+  delay = "5m"

--- a/migrations/inputs_cloudwatch/testcases/namespace_merge_with_namespaces/expected.conf
+++ b/migrations/inputs_cloudwatch/testcases/namespace_merge_with_namespaces/expected.conf
@@ -1,0 +1,6 @@
+# CloudWatch with merged namespaces
+[[inputs.cloudwatch]]
+  region = "us-east-1"
+  namespaces = ["AWS/EC2", "AWS/RDS", "AWS/ELB"]
+  period = "5m"
+  delay = "5m"

--- a/migrations/inputs_cloudwatch/testcases/namespace_merge_with_namespaces/telegraf.conf
+++ b/migrations/inputs_cloudwatch/testcases/namespace_merge_with_namespaces/telegraf.conf
@@ -1,0 +1,7 @@
+# CloudWatch with both namespace and namespaces (merge case)
+[[inputs.cloudwatch]]
+  region = "us-east-1"
+  namespace = "AWS/ELB"
+  namespaces = ["AWS/EC2", "AWS/RDS"]
+  period = "5m"
+  delay = "5m"

--- a/migrations/inputs_cloudwatch/testcases/namespace_to_namespaces/expected.conf
+++ b/migrations/inputs_cloudwatch/testcases/namespace_to_namespaces/expected.conf
@@ -1,0 +1,13 @@
+# CloudWatch with migrated namespaces option
+[[inputs.cloudwatch]]
+  region = "us-east-1"
+  namespaces = ["AWS/ELB"]
+  period = "5m"
+  delay = "5m"
+  
+  [[inputs.cloudwatch.metrics]]
+    names = ["Latency", "RequestCount"]
+    
+    [[inputs.cloudwatch.metrics.dimensions]]
+      name = "LoadBalancerName"
+      value = "p-example"

--- a/migrations/inputs_cloudwatch/testcases/namespace_to_namespaces/telegraf.conf
+++ b/migrations/inputs_cloudwatch/testcases/namespace_to_namespaces/telegraf.conf
@@ -1,0 +1,13 @@
+# CloudWatch with deprecated namespace option
+[[inputs.cloudwatch]]
+  region = "us-east-1"
+  namespace = "AWS/ELB"
+  period = "5m"
+  delay = "5m"
+
+  [[inputs.cloudwatch.metrics]]
+    names = ["Latency", "RequestCount"]
+
+    [[inputs.cloudwatch.metrics.dimensions]]
+      name = "LoadBalancerName"
+      value = "p-example"

--- a/plugins/inputs/cloudwatch/cloudwatch.go
+++ b/plugins/inputs/cloudwatch/cloudwatch.go
@@ -40,7 +40,6 @@ type CloudWatch struct {
 
 	Period                config.Duration     `toml:"period"`
 	Delay                 config.Duration     `toml:"delay"`
-	Namespace             string              `toml:"namespace" deprecated:"1.25.0;1.35.0;use 'namespaces' instead"`
 	Namespaces            []string            `toml:"namespaces"`
 	Metrics               []*cloudwatchMetric `toml:"metrics"`
 	CacheTTL              config.Duration     `toml:"cache_ttl"`
@@ -97,11 +96,6 @@ func (*CloudWatch) SampleConfig() string {
 }
 
 func (c *CloudWatch) Init() error {
-	// For backward compatibility
-	if len(c.Namespace) != 0 {
-		c.Namespaces = append(c.Namespaces, c.Namespace)
-	}
-
 	// Check user settings
 	switch c.MetricFormat {
 	case "":

--- a/plugins/inputs/cloudwatch/cloudwatch_test.go
+++ b/plugins/inputs/cloudwatch/cloudwatch_test.go
@@ -32,12 +32,12 @@ func TestGather(t *testing.T) {
 		CredentialConfig: common_aws.CredentialConfig{
 			Region: "us-east-1",
 		},
-		Namespace: "AWS/ELB",
-		Delay:     config.Duration(1 * time.Minute),
-		Period:    config.Duration(1 * time.Minute),
-		RateLimit: 200,
-		BatchSize: 500,
-		Log:       testutil.Logger{},
+		Namespaces: []string{"AWS/ELB"},
+		Delay:      config.Duration(1 * time.Minute),
+		Period:     config.Duration(1 * time.Minute),
+		RateLimit:  200,
+		BatchSize:  500,
+		Log:        testutil.Logger{},
 	}
 	require.NoError(t, plugin.Init())
 	plugin.client = defaultMockClient("AWS/ELB")
@@ -86,7 +86,7 @@ func TestGatherDenseMetric(t *testing.T) {
 		CredentialConfig: common_aws.CredentialConfig{
 			Region: "us-east-1",
 		},
-		Namespace:    "AWS/ELB",
+		Namespaces:   []string{"AWS/ELB"},
 		Delay:        config.Duration(1 * time.Minute),
 		Period:       config.Duration(1 * time.Minute),
 		RateLimit:    200,
@@ -143,7 +143,7 @@ func TestMultiAccountGather(t *testing.T) {
 		CredentialConfig: common_aws.CredentialConfig{
 			Region: "us-east-1",
 		},
-		Namespace:             "AWS/ELB",
+		Namespaces:            []string{"AWS/ELB"},
 		Delay:                 config.Duration(1 * time.Minute),
 		Period:                config.Duration(1 * time.Minute),
 		RateLimit:             200,
@@ -289,11 +289,11 @@ func TestSelectMetrics(t *testing.T) {
 		CredentialConfig: common_aws.CredentialConfig{
 			Region: "us-east-1",
 		},
-		Namespace: "AWS/ELB",
-		Delay:     config.Duration(1 * time.Minute),
-		Period:    config.Duration(1 * time.Minute),
-		RateLimit: 200,
-		BatchSize: 500,
+		Namespaces: []string{"AWS/ELB"},
+		Delay:      config.Duration(1 * time.Minute),
+		Period:     config.Duration(1 * time.Minute),
+		RateLimit:  200,
+		BatchSize:  500,
 		Metrics: []*cloudwatchMetric{
 			{
 				MetricNames: []string{"Latency", "RequestCount"},
@@ -326,11 +326,11 @@ func TestSelectMetricsSummaryOnly(t *testing.T) {
 		CredentialConfig: common_aws.CredentialConfig{
 			Region: "us-east-1",
 		},
-		Namespace: "AWS/ELB",
-		Delay:     config.Duration(1 * time.Minute),
-		Period:    config.Duration(1 * time.Minute),
-		RateLimit: 200,
-		BatchSize: 500,
+		Namespaces: []string{"AWS/ELB"},
+		Delay:      config.Duration(1 * time.Minute),
+		Period:     config.Duration(1 * time.Minute),
+		RateLimit:  200,
+		BatchSize:  500,
 		Metrics: []*cloudwatchMetric{
 			{
 				MetricNames: []string{"Latency", "RequestCount"},
@@ -452,11 +452,11 @@ func TestMetricsCacheTimeout(t *testing.T) {
 
 func TestUpdateWindow(t *testing.T) {
 	plugin := &CloudWatch{
-		Namespace: "AWS/ELB",
-		Delay:     config.Duration(1 * time.Minute),
-		Period:    config.Duration(1 * time.Minute),
-		BatchSize: 500,
-		Log:       testutil.Logger{},
+		Namespaces: []string{"AWS/ELB"},
+		Delay:      config.Duration(1 * time.Minute),
+		Period:     config.Duration(1 * time.Minute),
+		BatchSize:  500,
+		Log:        testutil.Logger{},
 	}
 
 	now := time.Now()
@@ -496,14 +496,13 @@ func TestProxyFunction(t *testing.T) {
 
 func TestCombineNamespaces(t *testing.T) {
 	plugin := &CloudWatch{
-		Namespace:  "AWS/ELB",
 		Namespaces: []string{"AWS/EC2", "AWS/Billing"},
 		BatchSize:  500,
 		Log:        testutil.Logger{},
 	}
 
 	require.NoError(t, plugin.Init())
-	require.Equal(t, []string{"AWS/EC2", "AWS/Billing", "AWS/ELB"}, plugin.Namespaces)
+	require.Equal(t, []string{"AWS/EC2", "AWS/Billing"}, plugin.Namespaces)
 }
 
 // INTERNAL mock client implementation


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Replace the following options in the plugin and provide a migration
```
  inputs.cloudwatch/namespace              ERROR since 1.25.0 removal in 1.35.0 use 'namespaces' instead
```

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #16914
