### PR TITLE
feat(migrations): Add migration for inputs.elasticsearch

### DIFF
--- a/migrations/all/inputs_elasticsearch.go
+++ b/migrations/all/inputs_elasticsearch.go
@@ -1,0 +1,5 @@
+//go:build !custom || (migrations && (inputs || inputs.elasticsearch))
+
+package all
+
+import _ "github.com/influxdata/telegraf/migrations/inputs_elasticsearch" // register migration

--- a/migrations/inputs_elasticsearch/migration.go
+++ b/migrations/inputs_elasticsearch/migration.go
@@ -1,0 +1,60 @@
+package inputs_elasticsearch
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/influxdata/toml"
+	"github.com/influxdata/toml/ast"
+
+	"github.com/influxdata/telegraf/migrations"
+)
+
+// Migration function to migrate a deprecated http_timeout option to timeout
+func migrate(tbl *ast.Table) ([]byte, string, error) {
+	// Decode the old data structure
+	var plugin map[string]interface{}
+	if err := toml.UnmarshalTable(tbl, &plugin); err != nil {
+		return nil, "", err
+	}
+
+	var applied bool
+	var messages []string
+
+	// Check if deprecated 'http_timeout' option exists
+	if httpTimeoutValue, found := plugin["http_timeout"]; found {
+		applied = true
+
+		// Check if 'timeout' already exists
+		if timeoutValue, exists := plugin["timeout"]; exists {
+			// Both exist - remove deprecated one but keep existing timeout
+			messages = append(messages, fmt.Sprintf("removed deprecated 'http_timeout' option (kept existing 'timeout' value: %v)", timeoutValue))
+		} else {
+			// Only http_timeout exists - migrate it to timeout
+			plugin["timeout"] = httpTimeoutValue
+			messages = append(messages, fmt.Sprintf("migrated 'http_timeout' option to 'timeout' with value: %v", httpTimeoutValue))
+		}
+
+		// Remove the deprecated setting
+		delete(plugin, "http_timeout")
+	}
+
+	// No options migrated so we can exit early
+	if !applied {
+		return nil, "", migrations.ErrNotApplicable
+	}
+
+	// Create the corresponding plugin configuration
+	cfg := migrations.CreateTOMLStruct("inputs", "elasticsearch")
+	cfg.Add("inputs", "elasticsearch", plugin)
+
+	output, err := toml.Marshal(cfg)
+	message := strings.Join(messages, "; ")
+
+	return output, message, err
+}
+
+// Register the migration function for the plugin type
+func init() {
+	migrations.AddPluginOptionMigration("inputs.elasticsearch", migrate)
+}

--- a/migrations/inputs_elasticsearch/migration_test.go
+++ b/migrations/inputs_elasticsearch/migration_test.go
@@ -24,6 +24,21 @@ func TestNoMigration(t *testing.T) {
 	require.Equal(t, string(defaultCfg), string(output))
 }
 
+func TestTimeoutConflict(t *testing.T) {
+	cfg := []byte(`
+[[inputs.elasticsearch]]
+  servers = ["http://localhost:9200"]
+  http_timeout = "10s"
+  timeout = "15s"
+	`)
+
+	// Migrate and check that it fails with conflict error
+	output, n, err := config.ApplyMigrations(cfg)
+	require.ErrorContains(t, err, "contradicting setting for 'http_timeout' (10s) and 'timeout' (15s)")
+	require.Empty(t, output)
+	require.Zero(t, n)
+}
+
 func TestCases(t *testing.T) {
 	// Get all directories in testcases
 	folders, err := os.ReadDir("testcases")

--- a/migrations/inputs_elasticsearch/migration_test.go
+++ b/migrations/inputs_elasticsearch/migration_test.go
@@ -1,0 +1,75 @@
+package inputs_elasticsearch_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/influxdata/telegraf/config"
+	_ "github.com/influxdata/telegraf/migrations/inputs_elasticsearch" // register migration
+	"github.com/influxdata/telegraf/plugins/inputs/elasticsearch"
+)
+
+func TestNoMigration(t *testing.T) {
+	plugin := &elasticsearch.Elasticsearch{}
+	defaultCfg := []byte(plugin.SampleConfig())
+
+	// Migrate and check that nothing changed
+	output, n, err := config.ApplyMigrations(defaultCfg)
+	require.NoError(t, err)
+	require.NotEmpty(t, output)
+	require.Zero(t, n)
+	require.Equal(t, string(defaultCfg), string(output))
+}
+
+func TestCases(t *testing.T) {
+	// Get all directories in testcases
+	folders, err := os.ReadDir("testcases")
+	require.NoError(t, err)
+
+	for _, f := range folders {
+		// Only handle folders
+		if !f.IsDir() {
+			continue
+		}
+
+		t.Run(f.Name(), func(t *testing.T) {
+			testcasePath := filepath.Join("testcases", f.Name())
+			inputFile := filepath.Join(testcasePath, "telegraf.conf")
+			expectedFile := filepath.Join(testcasePath, "expected.conf")
+
+			// Read the expected output
+			expected := config.NewConfig()
+			require.NoError(t, expected.LoadConfig(expectedFile))
+			require.NotEmpty(t, expected.Inputs)
+
+			// Read the input data
+			input, remote, err := config.LoadConfigFile(inputFile)
+			require.NoError(t, err)
+			require.False(t, remote)
+			require.NotEmpty(t, input)
+
+			// Migrate
+			output, n, err := config.ApplyMigrations(input)
+			require.NoError(t, err)
+			require.NotEmpty(t, output)
+			require.GreaterOrEqual(t, n, uint64(1))
+
+			actual := config.NewConfig()
+			require.NoError(t, actual.LoadConfigData(output, config.EmptySourcePath))
+
+			// Test the output
+			require.Len(t, actual.Inputs, len(expected.Inputs))
+
+			actualIDs := make([]string, 0, len(expected.Inputs))
+			expectedIDs := make([]string, 0, len(expected.Inputs))
+			for i := range actual.Inputs {
+				actualIDs = append(actualIDs, actual.Inputs[i].ID())
+				expectedIDs = append(expectedIDs, expected.Inputs[i].ID())
+			}
+			require.ElementsMatch(t, expectedIDs, actualIDs, string(output))
+		})
+	}
+}

--- a/migrations/inputs_elasticsearch/testcases/http_timeout_to_timeout/expected.conf
+++ b/migrations/inputs_elasticsearch/testcases/http_timeout_to_timeout/expected.conf
@@ -1,0 +1,9 @@
+# Elasticsearch with migrated timeout option
+[[inputs.elasticsearch]]
+  servers = ["http://localhost:9200"]
+  local = true
+  cluster_health = false
+  cluster_stats = false
+  timeout = "10s"
+  indices_include = ["_all"]
+  indices_level = "shards"

--- a/migrations/inputs_elasticsearch/testcases/http_timeout_to_timeout/telegraf.conf
+++ b/migrations/inputs_elasticsearch/testcases/http_timeout_to_timeout/telegraf.conf
@@ -1,0 +1,9 @@
+# Elasticsearch with deprecated http_timeout option
+[[inputs.elasticsearch]]
+  servers = ["http://localhost:9200"]
+  local = true
+  cluster_health = false
+  cluster_stats = false
+  http_timeout = "10s"
+  indices_include = ["_all"]
+  indices_level = "shards"

--- a/migrations/inputs_elasticsearch/testcases/http_timeout_with_auth/expected.conf
+++ b/migrations/inputs_elasticsearch/testcases/http_timeout_with_auth/expected.conf
@@ -1,0 +1,16 @@
+# Elasticsearch with migrated timeout and authentication
+[[inputs.elasticsearch]]
+  servers = ["http://user:password@localhost:9200"]
+  local = true
+  cluster_health = true
+  cluster_stats = true
+  cluster_stats_only_from_master = true
+  enrich_stats = false
+  timeout = "30s"
+  indices_include = ["application-*", "system-*"]
+  indices_level = "shards"
+  username = "elastic"
+  password = "changeme"
+
+  [inputs.elasticsearch.headers]
+    "X-Custom-Header" = "telegraf"

--- a/migrations/inputs_elasticsearch/testcases/http_timeout_with_auth/telegraf.conf
+++ b/migrations/inputs_elasticsearch/testcases/http_timeout_with_auth/telegraf.conf
@@ -1,0 +1,16 @@
+# Elasticsearch with http_timeout and authentication
+[[inputs.elasticsearch]]
+  servers = ["http://user:password@localhost:9200"]
+  local = true
+  cluster_health = true
+  cluster_stats = true
+  cluster_stats_only_from_master = true
+  enrich_stats = false
+  http_timeout = "30s"
+  indices_include = ["application-*", "system-*"]
+  indices_level = "shards"
+  username = "elastic"
+  password = "changeme"
+
+  [inputs.elasticsearch.headers]
+    "X-Custom-Header" = "telegraf"

--- a/migrations/inputs_elasticsearch/testcases/http_timeout_with_existing_timeout/expected.conf
+++ b/migrations/inputs_elasticsearch/testcases/http_timeout_with_existing_timeout/expected.conf
@@ -1,0 +1,9 @@
+# Elasticsearch with conflict resolved (timeout preserved, http_timeout removed)
+[[inputs.elasticsearch]]
+  servers = ["http://localhost:9200"]
+  local = true
+  cluster_health = false
+  cluster_stats = false
+  timeout = "15s"
+  indices_include = ["_all"]
+  indices_level = "shards"

--- a/migrations/inputs_elasticsearch/testcases/http_timeout_with_existing_timeout/telegraf.conf
+++ b/migrations/inputs_elasticsearch/testcases/http_timeout_with_existing_timeout/telegraf.conf
@@ -1,10 +1,10 @@
-# Elasticsearch with both http_timeout and timeout (conflict case)
+# Elasticsearch with both http_timeout and timeout (same values - no conflict)
 [[inputs.elasticsearch]]
   servers = ["http://localhost:9200"]
   local = true
   cluster_health = false
   cluster_stats = false
-  http_timeout = "10s"
+  http_timeout = "15s"
   timeout = "15s"
   indices_include = ["_all"]
   indices_level = "shards"

--- a/migrations/inputs_elasticsearch/testcases/http_timeout_with_existing_timeout/telegraf.conf
+++ b/migrations/inputs_elasticsearch/testcases/http_timeout_with_existing_timeout/telegraf.conf
@@ -1,0 +1,10 @@
+# Elasticsearch with both http_timeout and timeout (conflict case)
+[[inputs.elasticsearch]]
+  servers = ["http://localhost:9200"]
+  local = true
+  cluster_health = false
+  cluster_stats = false
+  http_timeout = "10s"
+  timeout = "15s"
+  indices_include = ["_all"]
+  indices_level = "shards"

--- a/migrations/inputs_elasticsearch/testcases/http_timeout_with_tls/expected.conf
+++ b/migrations/inputs_elasticsearch/testcases/http_timeout_with_tls/expected.conf
@@ -1,0 +1,22 @@
+# Elasticsearch with migrated timeout and TLS configuration
+[[inputs.elasticsearch]]
+  servers = ["https://elasticsearch.example.com:9200"]
+  local = false
+  cluster_health = true
+  cluster_stats = true
+  cluster_health_level = "cluster"
+  timeout = "45s"
+  indices_include = ["_all"]
+  indices_level = "cluster"
+  node_stats = ["jvm", "http", "process"]
+  num_most_recent_indices = 5
+
+  # TLS Configuration
+  #tls_ca = "/etc/telegraf/ca.pem"
+  #tls_cert = "/etc/telegraf/cert.pem"
+  #tls_key = "/etc/telegraf/key.pem"
+  insecure_skip_verify = false
+
+  # Proxy Configuration
+  use_system_proxy = false
+  http_proxy_url = "http://proxy.example.com:8080"

--- a/migrations/inputs_elasticsearch/testcases/http_timeout_with_tls/telegraf.conf
+++ b/migrations/inputs_elasticsearch/testcases/http_timeout_with_tls/telegraf.conf
@@ -1,0 +1,22 @@
+# Elasticsearch with http_timeout and TLS configuration
+[[inputs.elasticsearch]]
+  servers = ["https://elasticsearch.example.com:9200"]
+  local = false
+  cluster_health = true
+  cluster_stats = true
+  cluster_health_level = "cluster"
+  http_timeout = "45s"
+  indices_include = ["_all"]
+  indices_level = "cluster"
+  node_stats = ["jvm", "http", "process"]
+  num_most_recent_indices = 5
+
+  # TLS Configuration
+  #tls_ca = "/etc/telegraf/ca.pem"
+  #tls_cert = "/etc/telegraf/cert.pem"
+  #tls_key = "/etc/telegraf/key.pem"
+  insecure_skip_verify = false
+
+  # Proxy Configuration
+  use_system_proxy = false
+  http_proxy_url = "http://proxy.example.com:8080"

--- a/migrations/inputs_elasticsearch/testcases/multiple_elasticsearch_instances/expected.conf
+++ b/migrations/inputs_elasticsearch/testcases/multiple_elasticsearch_instances/expected.conf
@@ -1,0 +1,24 @@
+# Multiple Elasticsearch instances with migrated timeouts
+[[inputs.elasticsearch]]
+  servers = ["http://localhost:9200"]
+  local = true
+  cluster_health = true
+  cluster_stats = false
+  timeout = "5s"
+  indices_include = ["_all"]
+
+[[inputs.elasticsearch]]
+  servers = ["http://elasticsearch2:9200"]
+  local = false
+  cluster_health = false
+  cluster_stats = true
+  timeout = "20s"
+  indices_include = ["logs-*"]
+
+[[inputs.elasticsearch]]
+  servers = ["http://elasticsearch3:9200"]
+  local = true
+  cluster_health = true
+  cluster_stats = true
+  timeout = "12s"
+  indices_include = ["metrics-*"]

--- a/migrations/inputs_elasticsearch/testcases/multiple_elasticsearch_instances/telegraf.conf
+++ b/migrations/inputs_elasticsearch/testcases/multiple_elasticsearch_instances/telegraf.conf
@@ -20,6 +20,6 @@
   local = true
   cluster_health = true
   cluster_stats = true
-  http_timeout = "8s"
+  http_timeout = "12s"
   timeout = "12s"
   indices_include = ["metrics-*"]

--- a/migrations/inputs_elasticsearch/testcases/multiple_elasticsearch_instances/telegraf.conf
+++ b/migrations/inputs_elasticsearch/testcases/multiple_elasticsearch_instances/telegraf.conf
@@ -1,0 +1,25 @@
+# Multiple Elasticsearch instances with different scenarios
+[[inputs.elasticsearch]]
+  servers = ["http://localhost:9200"]
+  local = true
+  cluster_health = true
+  cluster_stats = false
+  http_timeout = "5s"
+  indices_include = ["_all"]
+
+[[inputs.elasticsearch]]
+  servers = ["http://elasticsearch2:9200"]
+  local = false
+  cluster_health = false
+  cluster_stats = true
+  timeout = "20s"
+  indices_include = ["logs-*"]
+
+[[inputs.elasticsearch]]
+  servers = ["http://elasticsearch3:9200"]
+  local = true
+  cluster_health = true
+  cluster_stats = true
+  http_timeout = "8s"
+  timeout = "12s"
+  indices_include = ["metrics-*"]

--- a/plugins/inputs/elasticsearch/elasticsearch.go
+++ b/plugins/inputs/elasticsearch/elasticsearch.go
@@ -39,7 +39,6 @@ type Elasticsearch struct {
 	Local                      bool              `toml:"local"`
 	Servers                    []string          `toml:"servers"`
 	HTTPHeaders                map[string]string `toml:"headers"`
-	HTTPTimeout                config.Duration   `toml:"http_timeout" deprecated:"1.29.0;1.35.0;use 'timeout' instead"`
 	ClusterHealth              bool              `toml:"cluster_health"`
 	ClusterHealthLevel         string            `toml:"cluster_health_level"`
 	ClusterStats               bool              `toml:"cluster_stats"`
@@ -273,10 +272,6 @@ func (e *Elasticsearch) Stop() {
 
 func (e *Elasticsearch) createHTTPClient() (*http.Client, error) {
 	ctx := context.Background()
-	if e.HTTPTimeout != 0 {
-		e.HTTPClientConfig.Timeout = e.HTTPTimeout
-		e.HTTPClientConfig.ResponseHeaderTimeout = e.HTTPTimeout
-	}
 	return e.HTTPClientConfig.CreateClient(ctx, e.Log)
 }
 


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Replace the following options in the plugin and provide a migration

```
  inputs.elasticsearch/http_timeout        ERROR since 1.29.0 removal in 1.35.0 use 'timeout' instead
```

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #16917
