### PR TITLE
feat(migrations): Add option migration for inputs.consul

### DIFF
--- a/migrations/all/inputs_consul.go
+++ b/migrations/all/inputs_consul.go
@@ -1,0 +1,5 @@
+//go:build !custom || (migrations && (inputs || inputs.consul))
+
+package all
+
+import _ "github.com/influxdata/telegraf/migrations/inputs_consul" // register migration

--- a/migrations/inputs_consul/migration.go
+++ b/migrations/inputs_consul/migration.go
@@ -1,0 +1,62 @@
+package inputs_consul
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/influxdata/toml"
+	"github.com/influxdata/toml/ast"
+
+	"github.com/influxdata/telegraf/migrations"
+)
+
+// Migration function
+func migrate(tbl *ast.Table) ([]byte, string, error) {
+	// Decode the old data structure
+	var plugin map[string]interface{}
+	if err := toml.UnmarshalTable(tbl, &plugin); err != nil {
+		return nil, "", err
+	}
+
+	// Check for deprecated option(s) and migrate them
+	var applied bool
+	if rawOldDatacentre, found := plugin["datacentre"]; found {
+		// Convert the options to the actual type
+		oldDatacentre, ok := rawOldDatacentre.(string)
+		if !ok {
+			return nil, "", fmt.Errorf("unexpected type %T for 'datacentre'", rawOldDatacentre)
+		}
+
+		// Check if the new setting is present and if so, check if the values are
+		// conflicting.
+		if rawNewDatacenter, found := plugin["datacenter"]; found {
+			if newDatacenter, ok := rawNewDatacenter.(string); !ok {
+				return nil, "", fmt.Errorf("unexpected type %T for 'datacenter'", rawNewDatacenter)
+			} else if oldDatacentre != newDatacenter {
+				return nil, "", errors.New("contradicting setting for 'datacentre' and 'datacenter'")
+			}
+		}
+		applied = true
+
+		// Remove the deprecated option and replace the modified one
+		plugin["datacenter"] = oldDatacentre
+		delete(plugin, "datacentre")
+	}
+
+	// No options migrated so we can exit early
+	if !applied {
+		return nil, "", migrations.ErrNotApplicable
+	}
+
+	// Create the corresponding plugin configurations
+	cfg := migrations.CreateTOMLStruct("inputs", "consul")
+	cfg.Add("inputs", "consul", plugin)
+
+	output, err := toml.Marshal(cfg)
+	return output, "", err
+}
+
+// Register the migration function for the plugin type
+func init() {
+	migrations.AddPluginOptionMigration("inputs.consul", migrate)
+}

--- a/migrations/inputs_consul/migration_test.go
+++ b/migrations/inputs_consul/migration_test.go
@@ -1,0 +1,87 @@
+package inputs_consul_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/influxdata/telegraf/config"
+	_ "github.com/influxdata/telegraf/migrations/inputs_consul" // register migration
+	"github.com/influxdata/telegraf/plugins/inputs/consul"      // register plugin
+)
+
+func TestNoMigration(t *testing.T) {
+	plugin := &consul.Consul{}
+	defaultCfg := plugin.SampleConfig()
+
+	// Migrate and check that nothing changed
+	output, n, err := config.ApplyMigrations([]byte(defaultCfg))
+	require.NoError(t, err)
+	require.NotEmpty(t, output)
+	require.Zero(t, n)
+	require.Equal(t, defaultCfg, string(output))
+}
+
+func TestDataCentreConflict(t *testing.T) {
+	cfg := []byte(`
+[[inputs.consul]]
+  address = "localhost:8500"
+  datacenter = "us-est"
+  datacentre = "foobar"
+	`)
+	// Migrate and check that nothing changed
+	output, n, err := config.ApplyMigrations(cfg)
+	require.ErrorContains(t, err, "contradicting setting for 'datacentre' and 'datacenter'")
+	require.Empty(t, output)
+	require.Zero(t, n)
+}
+
+func TestCases(t *testing.T) {
+	// Get all directories in testdata
+	folders, err := os.ReadDir("testcases")
+	require.NoError(t, err)
+
+	for _, f := range folders {
+		// Only handle folders
+		if !f.IsDir() {
+			continue
+		}
+
+		t.Run(f.Name(), func(t *testing.T) {
+			testcasePath := filepath.Join("testcases", f.Name())
+			inputFile := filepath.Join(testcasePath, "telegraf.conf")
+			expectedFile := filepath.Join(testcasePath, "expected.conf")
+
+			// Read the expected output
+			expected := config.NewConfig()
+			require.NoError(t, expected.LoadConfig(expectedFile))
+			require.NotEmpty(t, expected.Inputs)
+
+			// Read the input data
+			input, remote, err := config.LoadConfigFile(inputFile)
+			require.NoError(t, err)
+			require.False(t, remote)
+			require.NotEmpty(t, input)
+
+			// Migrate
+			output, n, err := config.ApplyMigrations(input)
+			require.NoError(t, err)
+			require.NotEmpty(t, output)
+			require.GreaterOrEqual(t, n, uint64(1))
+			actual := config.NewConfig()
+			require.NoError(t, actual.LoadConfigData(output, config.EmptySourcePath))
+
+			// Test the output
+			require.Len(t, actual.Inputs, len(expected.Inputs))
+			actualIDs := make([]string, 0, len(expected.Inputs))
+			expectedIDs := make([]string, 0, len(expected.Inputs))
+			for i := range actual.Inputs {
+				actualIDs = append(actualIDs, actual.Inputs[i].ID())
+				expectedIDs = append(expectedIDs, expected.Inputs[i].ID())
+			}
+			require.ElementsMatch(t, expectedIDs, actualIDs, string(output))
+		})
+	}
+}

--- a/migrations/inputs_consul/testcases/deprecated_centre_existing/expected.conf
+++ b/migrations/inputs_consul/testcases/deprecated_centre_existing/expected.conf
@@ -1,0 +1,2 @@
+[[inputs.consul]]
+datacenter = "foobar"

--- a/migrations/inputs_consul/testcases/deprecated_centre_existing/telegraf.conf
+++ b/migrations/inputs_consul/testcases/deprecated_centre_existing/telegraf.conf
@@ -1,0 +1,38 @@
+# Gather health check statuses from services registered in Consul
+[[inputs.consul]]
+  ## Consul server address
+  # address = "localhost:8500"
+
+  ## URI scheme for the Consul server, one of "http", "https"
+  # scheme = "http"
+
+  ## Metric version controls the mapping from Consul metrics into
+  ## Telegraf metrics. Version 2 moved all fields with string values
+  ## to tags.
+  ##
+  ##   example: metric_version = 1; deprecated in 1.16
+  ##            metric_version = 2; recommended version
+  # metric_version = 1
+
+  ## ACL token used in every request
+  # token = ""
+
+  ## HTTP Basic Authentication username and password.
+  # username = ""
+  # password = ""
+
+  ## Data center to query the health checks from
+  datacenter = "foobar"
+  datacentre = "foobar"
+
+  ## Optional TLS Config
+  # tls_ca = "/etc/telegraf/ca.pem"
+  # tls_cert = "/etc/telegraf/cert.pem"
+  # tls_key = "/etc/telegraf/key.pem"
+  ## Use TLS but skip chain & host verification
+  # insecure_skip_verify = true
+
+  ## Consul checks' tag splitting
+  # When tags are formatted like "key:value" with ":" as a delimiter then
+  # they will be split and reported as proper key:value in Telegraf
+  # tag_delimiter = ":"

--- a/migrations/inputs_consul/testcases/deprecated_datacentre/expected.conf
+++ b/migrations/inputs_consul/testcases/deprecated_datacentre/expected.conf
@@ -1,0 +1,2 @@
+[[inputs.consul]]
+datacenter = "foobar"

--- a/migrations/inputs_consul/testcases/deprecated_datacentre/telegraf.conf
+++ b/migrations/inputs_consul/testcases/deprecated_datacentre/telegraf.conf
@@ -1,0 +1,37 @@
+# Gather health check statuses from services registered in Consul
+[[inputs.consul]]
+  ## Consul server address
+  # address = "localhost:8500"
+
+  ## URI scheme for the Consul server, one of "http", "https"
+  # scheme = "http"
+
+  ## Metric version controls the mapping from Consul metrics into
+  ## Telegraf metrics. Version 2 moved all fields with string values
+  ## to tags.
+  ##
+  ##   example: metric_version = 1; deprecated in 1.16
+  ##            metric_version = 2; recommended version
+  # metric_version = 1
+
+  ## ACL token used in every request
+  # token = ""
+
+  ## HTTP Basic Authentication username and password.
+  # username = ""
+  # password = ""
+
+  ## Data center to query the health checks from
+  datacentre = "foobar"
+
+  ## Optional TLS Config
+  # tls_ca = "/etc/telegraf/ca.pem"
+  # tls_cert = "/etc/telegraf/cert.pem"
+  # tls_key = "/etc/telegraf/key.pem"
+  ## Use TLS but skip chain & host verification
+  # insecure_skip_verify = true
+
+  ## Consul checks' tag splitting
+  # When tags are formatted like "key:value" with ":" as a delimiter then
+  # they will be split and reported as proper key:value in Telegraf
+  # tag_delimiter = ":"

--- a/plugins/inputs/consul/consul.go
+++ b/plugins/inputs/consul/consul.go
@@ -23,7 +23,6 @@ type Consul struct {
 	Token         string `toml:"token"`
 	Username      string `toml:"username"`
 	Password      string `toml:"password"`
-	Datacentre    string `toml:"datacentre" deprecated:"1.10.0;1.35.0;use 'datacenter' instead"`
 	Datacenter    string `toml:"datacenter"`
 	TagDelimiter  string `toml:"tag_delimiter"`
 	MetricVersion int    `toml:"metric_version"`
@@ -57,10 +56,6 @@ func (c *Consul) Init() error {
 
 	if c.Scheme != "" {
 		config.Scheme = c.Scheme
-	}
-
-	if c.Datacentre != "" {
-		config.Datacenter = c.Datacentre
 	}
 
 	if c.Datacenter != "" {


### PR DESCRIPTION
## Summary

This PR migrates the `datacentre` option of the plugin and removes the deprecated option.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #16915 