### PR TITLE
feat(migrations): Add option migration for inputs.gnmi

### DIFF
--- a/migrations/inputs_gnmi/migration_test.go
+++ b/migrations/inputs_gnmi/migration_test.go
@@ -24,6 +24,29 @@ func TestNoMigration(t *testing.T) {
 	require.Equal(t, string(defaultCfg), string(output))
 }
 
+func TestEnableTLSConflict(t *testing.T) {
+	cfg := []byte(`
+		[[inputs.gnmi]]
+		addresses = ["10.49.234.114:57777"]
+		username = "cisco"
+		password = "cisco"
+		enable_tls = true
+		tls_enable = false
+		[[inputs.gnmi.subscription]]
+			name = "ifcounters"
+			origin = "openconfig-interfaces"
+			path = "/interfaces/interface/state/counters"
+			subscription_mode = "sample"
+			sample_interval = "10s"
+	`)
+
+	// Migrate and check that nothing changed
+	output, n, err := config.ApplyMigrations(cfg)
+	require.ErrorContains(t, err, "contradicting setting for 'enable_tls' and 'tls_enable'")
+	require.Empty(t, output)
+	require.Zero(t, n)
+}
+
 func TestCases(t *testing.T) {
 	// Get all directories in testdata
 	folders, err := os.ReadDir("testcases")

--- a/migrations/inputs_gnmi/testcases/deprecated_enable_tls/expected.conf
+++ b/migrations/inputs_gnmi/testcases/deprecated_enable_tls/expected.conf
@@ -1,0 +1,12 @@
+[[inputs.gnmi]]
+addresses = ["10.49.234.114:57777"]
+password = "cisco"
+path_guessing_strategy = "common path"
+username = "cisco"
+tls_enable = true
+[[inputs.gnmi.subscription]]
+name = "ifcounters"
+origin = "openconfig-interfaces"
+path = "/interfaces/interface/state/counters"
+subscription_mode = "sample"
+sample_interval = "10s"

--- a/migrations/inputs_gnmi/testcases/deprecated_enable_tls/telegraf.conf
+++ b/migrations/inputs_gnmi/testcases/deprecated_enable_tls/telegraf.conf
@@ -1,0 +1,110 @@
+# gNMI telemetry input plugin
+[[inputs.gnmi]]
+  ## Address and port of the gNMI GRPC server
+  addresses = ["10.49.234.114:57777"]
+
+  ## define credentials
+  username = "cisco"
+  password = "cisco"
+
+  ## gNMI encoding requested (one of: "proto", "json", "json_ietf", "bytes")
+  # encoding = "proto"
+
+  ## redial in case of failures after
+  # redial = "10s"
+
+  ## gRPC Maximum Message Size
+  # max_msg_size = "4MB"
+
+  ## Enable to get the canonical path as field-name
+  # canonical_field_names = false
+
+  ## Remove leading slashes and dots in field-name
+  # trim_field_names = false
+
+  ## Guess the path-tag if an update does not contain a prefix-path
+  ## If enabled, the common-path of all elements in the update is used.
+  path_guessing_strategy = "common path"
+
+  ## enable client-side TLS and define CA to authenticate the device
+  enable_tls = true
+
+  # tls_ca = "/etc/telegraf/ca.pem"
+  ## Minimal TLS version to accept by the client
+  # tls_min_version = "TLS12"
+  ## Use TLS but skip chain & host verification
+  # insecure_skip_verify = true
+
+  ## define client-side TLS certificate & key to authenticate to the device
+  # tls_cert = "/etc/telegraf/cert.pem"
+  # tls_key = "/etc/telegraf/key.pem"
+
+  ## gNMI subscription prefix (optional, can usually be left empty)
+  ## See: https://github.com/openconfig/reference/blob/master/rpc/gnmi/gnmi-specification.md#222-paths
+  # origin = ""
+  # prefix = ""
+  # target = ""
+
+  ## Vendor specific options
+  ## This defines what vendor specific options to load.
+  ## * Juniper Header Extension (juniper_header): some sensors are directly managed by
+  ##   Linecard, which adds the Juniper GNMI Header Extension. Enabling this
+  ##   allows the decoding of the Extension header if present. Currently this knob
+  ##   adds component, component_id & sub_component_id as additional tags
+  # vendor_specific = []
+
+  ## Define additional aliases to map encoding paths to measurement names
+  # [inputs.gnmi.aliases]
+  #   ifcounters = "openconfig:/interfaces/interface/state/counters"
+
+  [[inputs.gnmi.subscription]]
+    ## Name of the measurement that will be emitted
+    name = "ifcounters"
+
+    ## Origin and path of the subscription
+    ## See: https://github.com/openconfig/reference/blob/master/rpc/gnmi/gnmi-specification.md#222-paths
+    ##
+    ## origin usually refers to a (YANG) data model implemented by the device
+    ## and path to a specific substructure inside it that should be subscribed
+    ## to (similar to an XPath). YANG models can be found e.g. here:
+    ## https://github.com/YangModels/yang/tree/master/vendor/cisco/xr
+    origin = "openconfig-interfaces"
+    path = "/interfaces/interface/state/counters"
+
+    ## Subscription mode ("target_defined", "sample", "on_change") and interval
+    subscription_mode = "sample"
+    sample_interval = "10s"
+
+    ## Suppress redundant transmissions when measured values are unchanged
+    # suppress_redundant = false
+
+    ## If suppression is enabled, send updates at least every X seconds anyway
+    # heartbeat_interval = "60s"
+
+  ## Tag subscriptions are applied as tags to other subscriptions.
+  # [[inputs.gnmi.tag_subscription]]
+  #  ## When applying this value as a tag to other metrics, use this tag name
+  #  name = "descr"
+  #
+  #  ## All other subscription fields are as normal
+  #  origin = "openconfig-interfaces"
+  #  path = "/interfaces/interface/state"
+  #  subscription_mode = "on_change"
+  #
+  #  ## Match strategy to use for the tag.
+  #  ## Tags are only applied for metrics of the same address. The following
+  #  ## settings are valid:
+  #  ##   unconditional -- always match
+  #  ##   name          -- match by the "name" key
+  #  ##                    This resembles the previous 'tag-only' behavior.
+  #  ##   elements      -- match by the keys in the path filtered by the path
+  #  ##                    parts specified `elements` below
+  #  ## By default, 'elements' is used if the 'elements' option is provided,
+  #  ## otherwise match by 'name'.
+  #  # match = ""
+  #
+  #  ## For the 'elements' match strategy, at least one path-element name must
+  #  ## be supplied containing at least one key to match on. Multiple path
+  #  ## elements can be specified in any order. All given keys must be equal
+  #  ## for a match.
+  #  # elements = ["description", "interface"]

--- a/plugins/inputs/gnmi/gnmi.go
+++ b/plugins/inputs/gnmi/gnmi.go
@@ -60,9 +60,7 @@ type GNMI struct {
 	CanonicalFieldNames           bool              `toml:"canonical_field_names"`
 	TrimFieldNames                bool              `toml:"trim_field_names"`
 	PrefixTagKeyWithPath          bool              `toml:"prefix_tag_key_with_path"`
-	GuessPathTag                  bool              `toml:"guess_path_tag" deprecated:"1.30.0;1.35.0;use 'path_guessing_strategy' instead"`
 	GuessPathStrategy             string            `toml:"path_guessing_strategy"`
-	EnableTLS                     bool              `toml:"enable_tls" deprecated:"1.27.0;1.35.0;use 'tls_enable' instead"`
 	KeepaliveTime                 config.Duration   `toml:"keepalive_time"`
 	KeepaliveTimeout              config.Duration   `toml:"keepalive_timeout"`
 	YangModelPaths                []string          `toml:"yang_model_paths"`
@@ -121,14 +119,6 @@ func (c *GNMI) Init() error {
 	}
 
 	// Check path guessing and handle deprecated option
-	if c.GuessPathTag {
-		if c.GuessPathStrategy == "" {
-			c.GuessPathStrategy = "common path"
-		}
-		if c.GuessPathStrategy != "common path" {
-			return errors.New("conflicting settings between 'guess_path_tag' and 'path_guessing_strategy'")
-		}
-	}
 	switch c.GuessPathStrategy {
 	case "", "none", "common path", "subscription":
 	default:
@@ -137,7 +127,7 @@ func (c *GNMI) Init() error {
 
 	// Use the new TLS option for enabling
 	// Honor deprecated option
-	enable := (c.ClientConfig.Enable != nil && *c.ClientConfig.Enable) || c.EnableTLS
+	enable := c.ClientConfig.Enable != nil && *c.ClientConfig.Enable
 	c.ClientConfig.Enable = &enable
 
 	// Split the subscriptions into "normal" and "tag" subscription


### PR DESCRIPTION
## Summary

This PR migrates the `enable_tls` option of the plugin and removes the deprecated options `enable_tls` and `guess_path_tag`.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #16919 
