### PR TITLE
feat(migrations): Add option migration for inputs.filecount

### DIFF
--- a/migrations/all/inputs_filecount.go
+++ b/migrations/all/inputs_filecount.go
@@ -1,0 +1,5 @@
+//go:build !custom || (migrations && (inputs || inputs.filecount))
+
+package all
+
+import _ "github.com/influxdata/telegraf/migrations/inputs_filecount" // register migration

--- a/migrations/inputs_filecount/migration.go
+++ b/migrations/inputs_filecount/migration.go
@@ -1,0 +1,67 @@
+package inputs_filecount
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/influxdata/toml"
+	"github.com/influxdata/toml/ast"
+
+	"github.com/influxdata/telegraf/migrations"
+)
+
+// Migration function
+func migrate(tbl *ast.Table) ([]byte, string, error) {
+	// Decode the old data structure
+	var plugin map[string]interface{}
+	if err := toml.UnmarshalTable(tbl, &plugin); err != nil {
+		return nil, "", err
+	}
+
+	// Check for deprecated option(s) and migrate them
+	var applied bool
+	if rawOldDirectory, found := plugin["directory"]; found {
+		applied = true
+
+		// Convert the options to the actual type
+		oldDirectory, ok := rawOldDirectory.(string)
+		if !ok {
+			return nil, "", fmt.Errorf("unexpected type %T for 'directory'", rawOldDirectory)
+		}
+
+		// Merge the option with the replacement
+		var directories []string
+		if rawNewDirectories, found := plugin["directories"]; found {
+			var err error
+			directories, err = migrations.AsStringSlice(rawNewDirectories)
+			if err != nil {
+				return nil, "", fmt.Errorf("'directories' option: %w", err)
+			}
+		}
+
+		if !slices.Contains(directories, oldDirectory) {
+			directories = append(directories, oldDirectory)
+		}
+
+		// Remove the deprecated option and replace the modified one
+		delete(plugin, "directory")
+		plugin["directories"] = directories
+	}
+
+	// No options migrated so we can exit early
+	if !applied {
+		return nil, "", migrations.ErrNotApplicable
+	}
+
+	// Create the corresponding plugin configurations
+	cfg := migrations.CreateTOMLStruct("inputs", "filecount")
+	cfg.Add("inputs", "filecount", plugin)
+
+	output, err := toml.Marshal(cfg)
+	return output, "", err
+}
+
+// Register the migration function for the plugin type
+func init() {
+	migrations.AddPluginOptionMigration("inputs.filecount", migrate)
+}

--- a/migrations/inputs_filecount/migration_test.go
+++ b/migrations/inputs_filecount/migration_test.go
@@ -1,0 +1,73 @@
+package inputs_filecount_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/influxdata/telegraf/config"
+	_ "github.com/influxdata/telegraf/migrations/inputs_filecount" // register migration
+	"github.com/influxdata/telegraf/plugins/inputs/filecount"      // register plugin
+)
+
+func TestNoMigration(t *testing.T) {
+	plugin := &filecount.FileCount{}
+	defaultCfg := plugin.SampleConfig()
+
+	// Migrate and check that nothing changed
+	output, n, err := config.ApplyMigrations([]byte(defaultCfg))
+	require.NoError(t, err)
+	require.NotEmpty(t, output)
+	require.Zero(t, n)
+	require.Equal(t, defaultCfg, string(output))
+}
+
+func TestCases(t *testing.T) {
+	// Get all directories in testdata
+	folders, err := os.ReadDir("testcases")
+	require.NoError(t, err)
+
+	for _, f := range folders {
+		// Only handle folders
+		if !f.IsDir() {
+			continue
+		}
+
+		t.Run(f.Name(), func(t *testing.T) {
+			testcasePath := filepath.Join("testcases", f.Name())
+			inputFile := filepath.Join(testcasePath, "telegraf.conf")
+			expectedFile := filepath.Join(testcasePath, "expected.conf")
+
+			// Read the expected output
+			expected := config.NewConfig()
+			require.NoError(t, expected.LoadConfig(expectedFile))
+			require.NotEmpty(t, expected.Inputs)
+
+			// Read the input data
+			input, remote, err := config.LoadConfigFile(inputFile)
+			require.NoError(t, err)
+			require.False(t, remote)
+			require.NotEmpty(t, input)
+
+			// Migrate
+			output, n, err := config.ApplyMigrations(input)
+			require.NoError(t, err)
+			require.NotEmpty(t, output)
+			require.GreaterOrEqual(t, n, uint64(1))
+			actual := config.NewConfig()
+			require.NoError(t, actual.LoadConfigData(output, config.EmptySourcePath))
+
+			// Test the output
+			require.Len(t, actual.Inputs, len(expected.Inputs))
+			actualIDs := make([]string, 0, len(expected.Inputs))
+			expectedIDs := make([]string, 0, len(expected.Inputs))
+			for i := range actual.Inputs {
+				actualIDs = append(actualIDs, actual.Inputs[i].ID())
+				expectedIDs = append(expectedIDs, expected.Inputs[i].ID())
+			}
+			require.ElementsMatch(t, expectedIDs, actualIDs, string(output))
+		})
+	}
+}

--- a/migrations/inputs_filecount/testcases/deprecated_directory/expected.conf
+++ b/migrations/inputs_filecount/testcases/deprecated_directory/expected.conf
@@ -1,0 +1,8 @@
+[[inputs.filecount]]
+directories = ["/tmp"]
+name = "*"
+recursive = true
+regular_only = true
+follow_symlinks = false
+size = "0B"
+mtime = "0s"

--- a/migrations/inputs_filecount/testcases/deprecated_directory/telegraf.conf
+++ b/migrations/inputs_filecount/testcases/deprecated_directory/telegraf.conf
@@ -1,0 +1,26 @@
+# Count files in a directory
+[[inputs.filecount]]
+  directory = "/tmp"
+
+  ## Only count files that match the name pattern. Defaults to "*".
+  name = "*"
+
+  ## Count files in subdirectories. Defaults to true.
+  recursive = true
+
+  ## Only count regular files. Defaults to true.
+  regular_only = true
+
+  ## Follow all symlinks while walking the directory tree. Defaults to false.
+  follow_symlinks = false
+
+  ## Only count files that are at least this size. If size is
+  ## a negative number, only count files that are smaller than the
+  ## absolute value of size. Acceptable units are B, KiB, MiB, KB, ...
+  ## Without quotes and units, interpreted as size in bytes.
+  size = "0B"
+
+  ## Only count files that have not been touched for at least this
+  ## duration. If mtime is negative, only count files that have been
+  ## touched in this duration. Defaults to "0s".
+  mtime = "0s"

--- a/migrations/inputs_filecount/testcases/deprecated_directory_duplicate/expected.conf
+++ b/migrations/inputs_filecount/testcases/deprecated_directory_duplicate/expected.conf
@@ -1,0 +1,8 @@
+[[inputs.filecount]]
+directories = ["/var/cache/apt", "/tmp"]
+name = "*"
+recursive = true
+regular_only = true
+follow_symlinks = false
+size = "0B"
+mtime = "0s"

--- a/migrations/inputs_filecount/testcases/deprecated_directory_duplicate/telegraf.conf
+++ b/migrations/inputs_filecount/testcases/deprecated_directory_duplicate/telegraf.conf
@@ -1,0 +1,33 @@
+# Count files in a directory
+[[inputs.filecount]]
+  ## Directories to gather stats about.
+  ## This accept standard unit glob matching rules, but with the addition of
+  ## ** as a "super asterisk". ie:
+  ##   /var/log/**    -> recursively find all directories in /var/log and count files in each directories
+  ##   /var/log/*/*   -> find all directories with a parent dir in /var/log and count files in each directories
+  ##   /var/log       -> count all files in /var/log and all of its subdirectories
+  directories = ["/var/cache/apt", "/tmp"]
+  directory = "/tmp"
+
+  ## Only count files that match the name pattern. Defaults to "*".
+  name = "*"
+
+  ## Count files in subdirectories. Defaults to true.
+  recursive = true
+
+  ## Only count regular files. Defaults to true.
+  regular_only = true
+
+  ## Follow all symlinks while walking the directory tree. Defaults to false.
+  follow_symlinks = false
+
+  ## Only count files that are at least this size. If size is
+  ## a negative number, only count files that are smaller than the
+  ## absolute value of size. Acceptable units are B, KiB, MiB, KB, ...
+  ## Without quotes and units, interpreted as size in bytes.
+  size = "0B"
+
+  ## Only count files that have not been touched for at least this
+  ## duration. If mtime is negative, only count files that have been
+  ## touched in this duration. Defaults to "0s".
+  mtime = "0s"

--- a/migrations/inputs_filecount/testcases/deprecated_directory_existing/expected.conf
+++ b/migrations/inputs_filecount/testcases/deprecated_directory_existing/expected.conf
@@ -1,0 +1,8 @@
+[[inputs.filecount]]
+directories = ["/var/cache/apt", "/tmp", "/opt/foo"]
+name = "*"
+recursive = true
+regular_only = true
+follow_symlinks = false
+size = "0B"
+mtime = "0s"

--- a/migrations/inputs_filecount/testcases/deprecated_directory_existing/telegraf.conf
+++ b/migrations/inputs_filecount/testcases/deprecated_directory_existing/telegraf.conf
@@ -1,0 +1,33 @@
+# Count files in a directory
+[[inputs.filecount]]
+  ## Directories to gather stats about.
+  ## This accept standard unit glob matching rules, but with the addition of
+  ## ** as a "super asterisk". ie:
+  ##   /var/log/**    -> recursively find all directories in /var/log and count files in each directories
+  ##   /var/log/*/*   -> find all directories with a parent dir in /var/log and count files in each directories
+  ##   /var/log       -> count all files in /var/log and all of its subdirectories
+  directories = ["/var/cache/apt", "/tmp"]
+  directory = "/opt/foo"
+
+  ## Only count files that match the name pattern. Defaults to "*".
+  name = "*"
+
+  ## Count files in subdirectories. Defaults to true.
+  recursive = true
+
+  ## Only count regular files. Defaults to true.
+  regular_only = true
+
+  ## Follow all symlinks while walking the directory tree. Defaults to false.
+  follow_symlinks = false
+
+  ## Only count files that are at least this size. If size is
+  ## a negative number, only count files that are smaller than the
+  ## absolute value of size. Acceptable units are B, KiB, MiB, KB, ...
+  ## Without quotes and units, interpreted as size in bytes.
+  size = "0B"
+
+  ## Only count files that have not been touched for at least this
+  ## duration. If mtime is negative, only count files that have been
+  ## touched in this duration. Defaults to "0s".
+  mtime = "0s"

--- a/plugins/inputs/filecount/filecount.go
+++ b/plugins/inputs/filecount/filecount.go
@@ -21,7 +21,6 @@ import (
 var sampleConfig string
 
 type FileCount struct {
-	Directory      string          `toml:"directory" deprecated:"1.9.0;1.35.0;use 'directories' instead"`
 	Directories    []string        `toml:"directories"`
 	Name           string          `toml:"name"`
 	Recursive      bool            `toml:"recursive"`
@@ -277,10 +276,6 @@ func (fc *FileCount) getDirs() []string {
 		dirs = append(dirs, filepath.Clean(dir))
 	}
 
-	if fc.Directory != "" {
-		dirs = append(dirs, filepath.Clean(fc.Directory))
-	}
-
 	return dirs
 }
 
@@ -299,7 +294,6 @@ func (fc *FileCount) initGlobPaths(acc telegraf.Accumulator) {
 
 func newFileCount() *FileCount {
 	return &FileCount{
-		Directory:      "",
 		Name:           "*",
 		Recursive:      true,
 		RegularOnly:    true,


### PR DESCRIPTION
## Summary

This PR migrates the `directory` option of the plugin and removes the deprecated option.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #16918 
