### PR TITLE
feat(migrations): Add option migration for inputs.http

### DIFF
--- a/migrations/all/inputs_http.go
+++ b/migrations/all/inputs_http.go
@@ -1,0 +1,5 @@
+//go:build !custom || (migrations && (inputs || inputs.http))
+
+package all
+
+import _ "github.com/influxdata/telegraf/migrations/inputs_http" // register migration

--- a/migrations/inputs_http/migration.go
+++ b/migrations/inputs_http/migration.go
@@ -1,0 +1,62 @@
+package inputs_http
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/influxdata/toml"
+	"github.com/influxdata/toml/ast"
+
+	"github.com/influxdata/telegraf/migrations"
+)
+
+// Migration function
+func migrate(tbl *ast.Table) ([]byte, string, error) {
+	// Decode the old data structure
+	var plugin map[string]interface{}
+	if err := toml.UnmarshalTable(tbl, &plugin); err != nil {
+		return nil, "", err
+	}
+
+	// Check for deprecated option(s) and migrate them
+	var applied bool
+	if rawOldBearerToken, found := plugin["bearer_token"]; found {
+		// Convert the options to the actual type
+		oldBearerToken, ok := rawOldBearerToken.(string)
+		if !ok {
+			return nil, "", fmt.Errorf("unexpected type %T for 'bearer_token'", rawOldBearerToken)
+		}
+
+		// Check if the new setting is present and if so, check if the values are
+		// conflicting.
+		if rawNewTokenFile, found := plugin["token_file"]; found {
+			if newTokenFile, ok := rawNewTokenFile.(string); !ok {
+				return nil, "", fmt.Errorf("unexpected type %T for 'token_file'", rawNewTokenFile)
+			} else if oldBearerToken != newTokenFile {
+				return nil, "", errors.New("contradicting setting for 'bearer_token' and 'token_file'")
+			}
+		}
+		applied = true
+
+		// Remove the deprecated option and replace the modified one
+		plugin["token_file"] = oldBearerToken
+		delete(plugin, "bearer_token")
+	}
+
+	// No options migrated so we can exit early
+	if !applied {
+		return nil, "", migrations.ErrNotApplicable
+	}
+
+	// Create the corresponding plugin configurations
+	cfg := migrations.CreateTOMLStruct("inputs", "http")
+	cfg.Add("inputs", "http", plugin)
+
+	output, err := toml.Marshal(cfg)
+	return output, "", err
+}
+
+// Register the migration function for the plugin type
+func init() {
+	migrations.AddPluginOptionMigration("inputs.http", migrate)
+}

--- a/migrations/inputs_http/migration_test.go
+++ b/migrations/inputs_http/migration_test.go
@@ -1,0 +1,91 @@
+package inputs_http_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/influxdata/telegraf/config"
+	_ "github.com/influxdata/telegraf/migrations/inputs_http" // register migration
+	"github.com/influxdata/telegraf/plugins/inputs/http"      // register plugin
+	_ "github.com/influxdata/telegraf/plugins/parsers/influx" // register parser
+)
+
+func TestNoMigration(t *testing.T) {
+	plugin := &http.HTTP{}
+	defaultCfg := plugin.SampleConfig()
+
+	// Migrate and check that nothing changed
+	output, n, err := config.ApplyMigrations([]byte(defaultCfg))
+	require.NoError(t, err)
+	require.NotEmpty(t, output)
+	require.Zero(t, n)
+	require.Equal(t, defaultCfg, string(output))
+}
+
+func TestBearerToken(t *testing.T) {
+	cfg := []byte(`
+		[[inputs.http]]
+		urls = [
+			"http://localhost/metrics",
+			"http+unix:///run/user/420/podman/podman.sock:/d/v4.0.0/libpod/pods/json"
+		]
+		token_file = "/path/to/file"
+		bearer_token = "/path/to/another/file"
+  	`)
+	// Migrate and check that nothing changed
+	output, n, err := config.ApplyMigrations(cfg)
+	require.ErrorContains(t, err, "contradicting setting for 'bearer_token' and 'token_file'")
+	require.Empty(t, output)
+	require.Zero(t, n)
+}
+
+func TestCases(t *testing.T) {
+	// Get all directories in testdata
+	folders, err := os.ReadDir("testcases")
+	require.NoError(t, err)
+
+	for _, f := range folders {
+		// Only handle folders
+		if !f.IsDir() {
+			continue
+		}
+
+		t.Run(f.Name(), func(t *testing.T) {
+			testcasePath := filepath.Join("testcases", f.Name())
+			inputFile := filepath.Join(testcasePath, "telegraf.conf")
+			expectedFile := filepath.Join(testcasePath, "expected.conf")
+
+			// Read the expected output
+			expected := config.NewConfig()
+			require.NoError(t, expected.LoadConfig(expectedFile))
+			require.NotEmpty(t, expected.Inputs)
+
+			// Read the input data
+			input, remote, err := config.LoadConfigFile(inputFile)
+			require.NoError(t, err)
+			require.False(t, remote)
+			require.NotEmpty(t, input)
+
+			// Migrate
+			output, n, err := config.ApplyMigrations(input)
+			require.NoError(t, err)
+			require.NotEmpty(t, output)
+			require.GreaterOrEqual(t, n, uint64(1))
+			actual := config.NewConfig()
+			require.NoError(t, actual.LoadConfigData(output, config.EmptySourcePath))
+
+			// Test the output
+			require.Len(t, actual.Inputs, len(expected.Inputs))
+			actualIDs := make([]string, 0, len(expected.Inputs))
+			expectedIDs := make([]string, 0, len(expected.Inputs))
+			for i := range actual.Inputs {
+				actualIDs = append(actualIDs, actual.Inputs[i].ID())
+				expectedIDs = append(expectedIDs, expected.Inputs[i].ID())
+			}
+			require.ElementsMatch(t, expectedIDs, actualIDs, string(output))
+		})
+	}
+}

--- a/migrations/inputs_http/testcases/deprecated_bearer_token/expected.conf
+++ b/migrations/inputs_http/testcases/deprecated_bearer_token/expected.conf
@@ -1,0 +1,3 @@
+[[inputs.http]]
+  urls = ["http://localhost/metrics"]
+  token_file = "/path/to/file"

--- a/migrations/inputs_http/testcases/deprecated_bearer_token/telegraf.conf
+++ b/migrations/inputs_http/testcases/deprecated_bearer_token/telegraf.conf
@@ -1,0 +1,85 @@
+# Read formatted metrics from one or more HTTP endpoints
+[[inputs.http]]
+  ## One or more URLs from which to read formatted metrics.
+  urls = ["http://localhost/metrics"]
+
+  ## HTTP method
+  # method = "GET"
+
+  ## Optional HTTP headers
+  # headers = {"X-Special-Header" = "Special-Value"}
+
+  ## HTTP entity-body to send with POST/PUT requests.
+  # body = ""
+
+  ## HTTP Content-Encoding for write request body, can be set to "gzip" to
+  ## compress body or "identity" to apply no encoding.
+  # content_encoding = "identity"
+
+  ## Optional Bearer token settings to use for the API calls.
+  ## Use either the token itself or the token file if you need a token.
+  # token = "eyJhbGc...Qssw5c"
+  # token_file = "/path/to/file"
+  bearer_token = "/path/to/file"
+
+  ## Optional HTTP Basic Auth Credentials
+  # username = "username"
+  # password = "pa$$word"
+
+  ## OAuth2 Client Credentials. The options 'client_id', 'client_secret', and 'token_url' are required to use OAuth2.
+  # client_id = "clientid"
+  # client_secret = "secret"
+  # token_url = "https://indentityprovider/oauth2/v1/token"
+  # scopes = ["urn:opc:idm:__myscopes__"]
+
+  ## HTTP Proxy support
+  # use_system_proxy = false
+  # http_proxy_url = ""
+
+  ## Optional TLS Config
+  ## Set to true/false to enforce TLS being enabled/disabled. If not set,
+  ## enable TLS only if any of the other options are specified.
+  # tls_enable =
+  ## Trusted root certificates for server
+  # tls_ca = "/path/to/cafile"
+  ## Used for TLS client certificate authentication
+  # tls_cert = "/path/to/certfile"
+  ## Used for TLS client certificate authentication
+  # tls_key = "/path/to/keyfile"
+  ## Password for the key file if it is encrypted
+  # tls_key_pwd = ""
+  ## Send the specified TLS server name via SNI
+  # tls_server_name = "kubernetes.example.com"
+  ## Minimal TLS version to accept by the client
+  # tls_min_version = "TLS12"
+  ## List of ciphers to accept, by default all secure ciphers will be accepted
+  ## See https://pkg.go.dev/crypto/tls#pkg-constants for supported values.
+  ## Use "all", "secure" and "insecure" to add all support ciphers, secure
+  ## suites or insecure suites respectively.
+  # tls_cipher_suites = ["secure"]
+  ## Renegotiation method, "never", "once" or "freely"
+  # tls_renegotiation_method = "never"
+  ## Use TLS but skip chain & host verification
+  # insecure_skip_verify = false
+
+  ## Optional Cookie authentication
+  # cookie_auth_url = "https://localhost/authMe"
+  # cookie_auth_method = "POST"
+  # cookie_auth_username = "username"
+  # cookie_auth_password = "pa$$word"
+  # cookie_auth_headers = { Content-Type = "application/json", X-MY-HEADER = "hello" }
+  # cookie_auth_body = '{"username": "user", "password": "pa$$word", "authenticate": "me"}'
+  ## cookie_auth_renewal not set or set to "0" will auth once and never renew the cookie
+  # cookie_auth_renewal = "5m"
+
+  ## Amount of time allowed to complete the HTTP request
+  # timeout = "5s"
+
+  ## List of success status codes
+  # success_status_codes = [200]
+
+  ## Data format to consume.
+  ## Each data format has its own unique set of configuration options, read
+  ## more about them here:
+  ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_INPUT.md
+  # data_format = "influx"

--- a/migrations/inputs_http/testcases/deprecated_bearer_token_existing/expected.conf
+++ b/migrations/inputs_http/testcases/deprecated_bearer_token_existing/expected.conf
@@ -1,0 +1,3 @@
+[[inputs.http]]
+  urls = ["http://localhost/metrics"]
+  token_file = "/path/to/another/file"

--- a/migrations/inputs_http/testcases/deprecated_bearer_token_existing/telegraf.conf
+++ b/migrations/inputs_http/testcases/deprecated_bearer_token_existing/telegraf.conf
@@ -1,0 +1,85 @@
+# Read formatted metrics from one or more HTTP endpoints
+[[inputs.http]]
+  ## One or more URLs from which to read formatted metrics.
+  urls = ["http://localhost/metrics"]
+
+  ## HTTP method
+  # method = "GET"
+
+  ## Optional HTTP headers
+  # headers = {"X-Special-Header" = "Special-Value"}
+
+  ## HTTP entity-body to send with POST/PUT requests.
+  # body = ""
+
+  ## HTTP Content-Encoding for write request body, can be set to "gzip" to
+  ## compress body or "identity" to apply no encoding.
+  # content_encoding = "identity"
+
+  ## Optional Bearer token settings to use for the API calls.
+  ## Use either the token itself or the token file if you need a token.
+  # token = "eyJhbGc...Qssw5c"
+  token_file = "/path/to/another/file"
+  bearer_token = "/path/to/another/file"
+
+  ## Optional HTTP Basic Auth Credentials
+  # username = "username"
+  # password = "pa$$word"
+
+  ## OAuth2 Client Credentials. The options 'client_id', 'client_secret', and 'token_url' are required to use OAuth2.
+  # client_id = "clientid"
+  # client_secret = "secret"
+  # token_url = "https://indentityprovider/oauth2/v1/token"
+  # scopes = ["urn:opc:idm:__myscopes__"]
+
+  ## HTTP Proxy support
+  # use_system_proxy = false
+  # http_proxy_url = ""
+
+  ## Optional TLS Config
+  ## Set to true/false to enforce TLS being enabled/disabled. If not set,
+  ## enable TLS only if any of the other options are specified.
+  # tls_enable =
+  ## Trusted root certificates for server
+  # tls_ca = "/path/to/cafile"
+  ## Used for TLS client certificate authentication
+  # tls_cert = "/path/to/certfile"
+  ## Used for TLS client certificate authentication
+  # tls_key = "/path/to/keyfile"
+  ## Password for the key file if it is encrypted
+  # tls_key_pwd = ""
+  ## Send the specified TLS server name via SNI
+  # tls_server_name = "kubernetes.example.com"
+  ## Minimal TLS version to accept by the client
+  # tls_min_version = "TLS12"
+  ## List of ciphers to accept, by default all secure ciphers will be accepted
+  ## See https://pkg.go.dev/crypto/tls#pkg-constants for supported values.
+  ## Use "all", "secure" and "insecure" to add all support ciphers, secure
+  ## suites or insecure suites respectively.
+  # tls_cipher_suites = ["secure"]
+  ## Renegotiation method, "never", "once" or "freely"
+  # tls_renegotiation_method = "never"
+  ## Use TLS but skip chain & host verification
+  # insecure_skip_verify = false
+
+  ## Optional Cookie authentication
+  # cookie_auth_url = "https://localhost/authMe"
+  # cookie_auth_method = "POST"
+  # cookie_auth_username = "username"
+  # cookie_auth_password = "pa$$word"
+  # cookie_auth_headers = { Content-Type = "application/json", X-MY-HEADER = "hello" }
+  # cookie_auth_body = '{"username": "user", "password": "pa$$word", "authenticate": "me"}'
+  ## cookie_auth_renewal not set or set to "0" will auth once and never renew the cookie
+  # cookie_auth_renewal = "5m"
+
+  ## Amount of time allowed to complete the HTTP request
+  # timeout = "5s"
+
+  ## List of success status codes
+  # success_status_codes = [200]
+
+  ## Data format to consume.
+  ## Each data format has its own unique set of configuration options, read
+  ## more about them here:
+  ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_INPUT.md
+  # data_format = "influx"

--- a/plugins/inputs/http/http.go
+++ b/plugins/inputs/http/http.go
@@ -36,9 +36,8 @@ type HTTP struct {
 	Password config.Secret `toml:"password"`
 
 	// Bearer authentication
-	BearerToken string        `toml:"bearer_token" deprecated:"1.28.0;1.35.0;use 'token_file' instead"`
-	Token       config.Secret `toml:"token"`
-	TokenFile   string        `toml:"token_file"`
+	Token     config.Secret `toml:"token"`
+	TokenFile string        `toml:"token_file"`
 
 	Headers            map[string]*config.Secret `toml:"headers"`
 	SuccessStatusCodes []int                     `toml:"success_status_codes"`
@@ -55,13 +54,6 @@ func (*HTTP) SampleConfig() string {
 }
 
 func (h *HTTP) Init() error {
-	// For backward compatibility
-	if h.TokenFile != "" && h.BearerToken != "" && h.TokenFile != h.BearerToken {
-		return errors.New("conflicting settings for 'bearer_token' and 'token_file'")
-	} else if h.TokenFile == "" && h.BearerToken != "" {
-		h.TokenFile = h.BearerToken
-	}
-
 	// We cannot use multiple sources for tokens
 	if h.TokenFile != "" && !h.Token.Empty() {
 		return errors.New("either use 'token_file' or 'token' not both")


### PR DESCRIPTION
## Summary

This PR migrates the `bearer_token` option of the plugin and removes the deprecated option.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #16920 
