### PR TITLE
feat(migrations): Add option migration for inputs.http_response

### DIFF
--- a/migrations/all/inputs_http_response.go
+++ b/migrations/all/inputs_http_response.go
@@ -1,0 +1,5 @@
+//go:build !custom || (migrations && (inputs || inputs.http_response))
+
+package all
+
+import _ "github.com/influxdata/telegraf/migrations/inputs_http_response" // register migration

--- a/migrations/inputs_http_response/migration.go
+++ b/migrations/inputs_http_response/migration.go
@@ -1,0 +1,67 @@
+package inputs_http_response
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/influxdata/toml"
+	"github.com/influxdata/toml/ast"
+
+	"github.com/influxdata/telegraf/migrations"
+)
+
+// Migration function
+func migrate(tbl *ast.Table) ([]byte, string, error) {
+	// Decode the old data structure
+	var plugin map[string]interface{}
+	if err := toml.UnmarshalTable(tbl, &plugin); err != nil {
+		return nil, "", err
+	}
+
+	// Check for deprecated option(s) and migrate them
+	var applied bool
+	if rawOldAddress, found := plugin["address"]; found {
+		applied = true
+
+		// Convert the options to the actual type
+		oldAddress, ok := rawOldAddress.(string)
+		if !ok {
+			return nil, "", fmt.Errorf("unexpected type %T for 'address'", rawOldAddress)
+		}
+
+		// Merge the option with the replacement
+		var urls []string
+		if rawNewURLs, found := plugin["urls"]; found {
+			var err error
+			urls, err = migrations.AsStringSlice(rawNewURLs)
+			if err != nil {
+				return nil, "", fmt.Errorf("'directories' option: %w", err)
+			}
+		}
+
+		if !slices.Contains(urls, oldAddress) {
+			urls = append(urls, oldAddress)
+		}
+
+		// Remove the deprecated option and replace the modified one
+		plugin["urls"] = urls
+		delete(plugin, "address")
+	}
+
+	// No options migrated so we can exit early
+	if !applied {
+		return nil, "", migrations.ErrNotApplicable
+	}
+
+	// Create the corresponding plugin configurations
+	cfg := migrations.CreateTOMLStruct("inputs", "http_response")
+	cfg.Add("inputs", "http_response", plugin)
+
+	output, err := toml.Marshal(cfg)
+	return output, "", err
+}
+
+// Register the migration function for the plugin type
+func init() {
+	migrations.AddPluginOptionMigration("inputs.http_response", migrate)
+}

--- a/migrations/inputs_http_response/migration_test.go
+++ b/migrations/inputs_http_response/migration_test.go
@@ -1,0 +1,73 @@
+package inputs_http_response_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/influxdata/telegraf/config"
+	_ "github.com/influxdata/telegraf/migrations/inputs_http_response" // register migration
+	"github.com/influxdata/telegraf/plugins/inputs/http_response"      // register plugin
+)
+
+func TestNoMigration(t *testing.T) {
+	plugin := &http_response.HTTPResponse{}
+	defaultCfg := plugin.SampleConfig()
+
+	// Migrate and check that nothing changed
+	output, n, err := config.ApplyMigrations([]byte(defaultCfg))
+	require.NoError(t, err)
+	require.NotEmpty(t, output)
+	require.Zero(t, n)
+	require.Equal(t, defaultCfg, string(output))
+}
+
+func TestCases(t *testing.T) {
+	// Get all directories in testdata
+	folders, err := os.ReadDir("testcases")
+	require.NoError(t, err)
+
+	for _, f := range folders {
+		// Only handle folders
+		if !f.IsDir() {
+			continue
+		}
+
+		t.Run(f.Name(), func(t *testing.T) {
+			testcasePath := filepath.Join("testcases", f.Name())
+			inputFile := filepath.Join(testcasePath, "telegraf.conf")
+			expectedFile := filepath.Join(testcasePath, "expected.conf")
+
+			// Read the expected output
+			expected := config.NewConfig()
+			require.NoError(t, expected.LoadConfig(expectedFile))
+			require.NotEmpty(t, expected.Inputs)
+
+			// Read the input data
+			input, remote, err := config.LoadConfigFile(inputFile)
+			require.NoError(t, err)
+			require.False(t, remote)
+			require.NotEmpty(t, input)
+
+			// Migrate
+			output, n, err := config.ApplyMigrations(input)
+			require.NoError(t, err)
+			require.NotEmpty(t, output)
+			require.GreaterOrEqual(t, n, uint64(1))
+			actual := config.NewConfig()
+			require.NoError(t, actual.LoadConfigData(output, config.EmptySourcePath))
+
+			// Test the output
+			require.Len(t, actual.Inputs, len(expected.Inputs))
+			actualIDs := make([]string, 0, len(expected.Inputs))
+			expectedIDs := make([]string, 0, len(expected.Inputs))
+			for i := range actual.Inputs {
+				actualIDs = append(actualIDs, actual.Inputs[i].ID())
+				expectedIDs = append(expectedIDs, expected.Inputs[i].ID())
+			}
+			require.ElementsMatch(t, expectedIDs, actualIDs, string(output))
+		})
+	}
+}

--- a/migrations/inputs_http_response/testcases/deprecated_address/expected.conf
+++ b/migrations/inputs_http_response/testcases/deprecated_address/expected.conf
@@ -1,0 +1,2 @@
+[[inputs.http_response]]
+urls = ["https://myserver:443"]

--- a/migrations/inputs_http_response/testcases/deprecated_address/telegraf.conf
+++ b/migrations/inputs_http_response/testcases/deprecated_address/telegraf.conf
@@ -1,0 +1,93 @@
+# HTTP/HTTPS request given an address a method and a timeout
+[[inputs.http_response]]
+  ## List of urls to query.
+  # urls = ["http://localhost"]
+  address = "https://myserver:443"
+
+  ## Set http_proxy.
+  ## Telegraf uses the system wide proxy settings if it's is not set.
+  # http_proxy = "http://localhost:8888"
+
+  ## Set response_timeout (default 5 seconds)
+  # response_timeout = "5s"
+
+  ## HTTP Request Method
+  # method = "GET"
+
+  ## Whether to follow redirects from the server (defaults to false)
+  # follow_redirects = false
+
+  ## Optional file with Bearer token
+  ## file content is added as an Authorization header
+  # bearer_token = "/path/to/file"
+
+  ## Optional HTTP Basic Auth Credentials
+  # username = "username"
+  # password = "pa$$word"
+
+  ## Optional HTTP Request Body
+  # body = '''
+  # {'fake':'data'}
+  # '''
+
+  ## Optional HTTP Request Body Form
+  ## Key value pairs to encode and set at URL form. Can be used with the POST
+  ## method + application/x-www-form-urlencoded content type to replicate the
+  ## POSTFORM method.
+  # body_form = { "key": "value" }
+
+  ## Optional name of the field that will contain the body of the response.
+  ## By default it is set to an empty String indicating that the body's
+  ## content won't be added
+  # response_body_field = ''
+
+  ## Maximum allowed HTTP response body size in bytes.
+  ## 0 means to use the default of 32MiB.
+  ## If the response body size exceeds this limit a "body_read_error" will
+  ## be raised.
+  # response_body_max_size = "32MiB"
+
+  ## Optional substring or regex match in body of the response (case sensitive)
+  # response_string_match = "\"service_status\": \"up\""
+  # response_string_match = "ok"
+  # response_string_match = "\".*_status\".?:.?\"up\""
+
+  ## Expected response status code.
+  ## The status code of the response is compared to this value. If they match,
+  ## the field "response_status_code_match" will be 1, otherwise it will be 0.
+  ## If the expected status code is 0, the check is disabled and the field
+  ## won't be added.
+  # response_status_code = 0
+
+  ## Optional TLS Config
+  # tls_ca = "/etc/telegraf/ca.pem"
+  # tls_cert = "/etc/telegraf/cert.pem"
+  # tls_key = "/etc/telegraf/key.pem"
+  ## Use TLS but skip chain & host verification
+  # insecure_skip_verify = false
+  ## Use the given name as the SNI server name on each URL
+  # tls_server_name = ""
+  ## TLS renegotiation method, choose from "never", "once", "freely"
+  # tls_renegotiation_method = "never"
+
+  ## HTTP Request Headers (all values must be strings)
+  # [inputs.http_response.headers]
+  #   Host = "github.com"
+
+  ## Optional setting to map response http headers into tags
+  ## If the http header is not present on the request, no corresponding tag will
+  ## be added. If multiple instances of the http header are present, only the
+  ## first value will be used.
+  # http_header_tags = {"HTTP_HEADER" = "TAG_NAME"}
+
+  ## Interface to use when dialing an address
+  # interface = "eth0"
+
+  ## Optional Cookie authentication
+  # cookie_auth_url = "https://localhost/authMe"
+  # cookie_auth_method = "POST"
+  # cookie_auth_username = "username"
+  # cookie_auth_password = "pa$$word"
+  # cookie_auth_body = '{"username": "user", "password": "pa$$word", "authenticate": "me"}'
+  ## cookie_auth_renewal not set or set to "0" will auth once and never renew the cookie
+  # cookie_auth_renewal = "5m"

--- a/migrations/inputs_http_response/testcases/deprecated_address_duplicate/expected.conf
+++ b/migrations/inputs_http_response/testcases/deprecated_address_duplicate/expected.conf
@@ -1,0 +1,2 @@
+[[inputs.http_response]]
+urls = ["http://localhost", "https://myserver:443"]

--- a/migrations/inputs_http_response/testcases/deprecated_address_duplicate/telegraf.conf
+++ b/migrations/inputs_http_response/testcases/deprecated_address_duplicate/telegraf.conf
@@ -1,0 +1,93 @@
+# HTTP/HTTPS request given an address a method and a timeout
+[[inputs.http_response]]
+  ## List of urls to query.
+  urls = ["http://localhost", "https://myserver:443"]
+  address = "https://myserver:443"
+
+  ## Set http_proxy.
+  ## Telegraf uses the system wide proxy settings if it's is not set.
+  # http_proxy = "http://localhost:8888"
+
+  ## Set response_timeout (default 5 seconds)
+  # response_timeout = "5s"
+
+  ## HTTP Request Method
+  # method = "GET"
+
+  ## Whether to follow redirects from the server (defaults to false)
+  # follow_redirects = false
+
+  ## Optional file with Bearer token
+  ## file content is added as an Authorization header
+  # bearer_token = "/path/to/file"
+
+  ## Optional HTTP Basic Auth Credentials
+  # username = "username"
+  # password = "pa$$word"
+
+  ## Optional HTTP Request Body
+  # body = '''
+  # {'fake':'data'}
+  # '''
+
+  ## Optional HTTP Request Body Form
+  ## Key value pairs to encode and set at URL form. Can be used with the POST
+  ## method + application/x-www-form-urlencoded content type to replicate the
+  ## POSTFORM method.
+  # body_form = { "key": "value" }
+
+  ## Optional name of the field that will contain the body of the response.
+  ## By default it is set to an empty String indicating that the body's
+  ## content won't be added
+  # response_body_field = ''
+
+  ## Maximum allowed HTTP response body size in bytes.
+  ## 0 means to use the default of 32MiB.
+  ## If the response body size exceeds this limit a "body_read_error" will
+  ## be raised.
+  # response_body_max_size = "32MiB"
+
+  ## Optional substring or regex match in body of the response (case sensitive)
+  # response_string_match = "\"service_status\": \"up\""
+  # response_string_match = "ok"
+  # response_string_match = "\".*_status\".?:.?\"up\""
+
+  ## Expected response status code.
+  ## The status code of the response is compared to this value. If they match,
+  ## the field "response_status_code_match" will be 1, otherwise it will be 0.
+  ## If the expected status code is 0, the check is disabled and the field
+  ## won't be added.
+  # response_status_code = 0
+
+  ## Optional TLS Config
+  # tls_ca = "/etc/telegraf/ca.pem"
+  # tls_cert = "/etc/telegraf/cert.pem"
+  # tls_key = "/etc/telegraf/key.pem"
+  ## Use TLS but skip chain & host verification
+  # insecure_skip_verify = false
+  ## Use the given name as the SNI server name on each URL
+  # tls_server_name = ""
+  ## TLS renegotiation method, choose from "never", "once", "freely"
+  # tls_renegotiation_method = "never"
+
+  ## HTTP Request Headers (all values must be strings)
+  # [inputs.http_response.headers]
+  #   Host = "github.com"
+
+  ## Optional setting to map response http headers into tags
+  ## If the http header is not present on the request, no corresponding tag will
+  ## be added. If multiple instances of the http header are present, only the
+  ## first value will be used.
+  # http_header_tags = {"HTTP_HEADER" = "TAG_NAME"}
+
+  ## Interface to use when dialing an address
+  # interface = "eth0"
+
+  ## Optional Cookie authentication
+  # cookie_auth_url = "https://localhost/authMe"
+  # cookie_auth_method = "POST"
+  # cookie_auth_username = "username"
+  # cookie_auth_password = "pa$$word"
+  # cookie_auth_body = '{"username": "user", "password": "pa$$word", "authenticate": "me"}'
+  ## cookie_auth_renewal not set or set to "0" will auth once and never renew the cookie
+  # cookie_auth_renewal = "5m"

--- a/migrations/inputs_http_response/testcases/deprecated_address_existing/expected.conf
+++ b/migrations/inputs_http_response/testcases/deprecated_address_existing/expected.conf
@@ -1,0 +1,2 @@
+[[inputs.http_response]]
+urls = ["http://localhost", "https://myserver:443"]

--- a/migrations/inputs_http_response/testcases/deprecated_address_existing/telegraf.conf
+++ b/migrations/inputs_http_response/testcases/deprecated_address_existing/telegraf.conf
@@ -1,0 +1,93 @@
+# HTTP/HTTPS request given an address a method and a timeout
+[[inputs.http_response]]
+  ## List of urls to query.
+  urls = ["http://localhost"]
+  address = "https://myserver:443"
+
+  ## Set http_proxy.
+  ## Telegraf uses the system wide proxy settings if it's is not set.
+  # http_proxy = "http://localhost:8888"
+
+  ## Set response_timeout (default 5 seconds)
+  # response_timeout = "5s"
+
+  ## HTTP Request Method
+  # method = "GET"
+
+  ## Whether to follow redirects from the server (defaults to false)
+  # follow_redirects = false
+
+  ## Optional file with Bearer token
+  ## file content is added as an Authorization header
+  # bearer_token = "/path/to/file"
+
+  ## Optional HTTP Basic Auth Credentials
+  # username = "username"
+  # password = "pa$$word"
+
+  ## Optional HTTP Request Body
+  # body = '''
+  # {'fake':'data'}
+  # '''
+
+  ## Optional HTTP Request Body Form
+  ## Key value pairs to encode and set at URL form. Can be used with the POST
+  ## method + application/x-www-form-urlencoded content type to replicate the
+  ## POSTFORM method.
+  # body_form = { "key": "value" }
+
+  ## Optional name of the field that will contain the body of the response.
+  ## By default it is set to an empty String indicating that the body's
+  ## content won't be added
+  # response_body_field = ''
+
+  ## Maximum allowed HTTP response body size in bytes.
+  ## 0 means to use the default of 32MiB.
+  ## If the response body size exceeds this limit a "body_read_error" will
+  ## be raised.
+  # response_body_max_size = "32MiB"
+
+  ## Optional substring or regex match in body of the response (case sensitive)
+  # response_string_match = "\"service_status\": \"up\""
+  # response_string_match = "ok"
+  # response_string_match = "\".*_status\".?:.?\"up\""
+
+  ## Expected response status code.
+  ## The status code of the response is compared to this value. If they match,
+  ## the field "response_status_code_match" will be 1, otherwise it will be 0.
+  ## If the expected status code is 0, the check is disabled and the field
+  ## won't be added.
+  # response_status_code = 0
+
+  ## Optional TLS Config
+  # tls_ca = "/etc/telegraf/ca.pem"
+  # tls_cert = "/etc/telegraf/cert.pem"
+  # tls_key = "/etc/telegraf/key.pem"
+  ## Use TLS but skip chain & host verification
+  # insecure_skip_verify = false
+  ## Use the given name as the SNI server name on each URL
+  # tls_server_name = ""
+  ## TLS renegotiation method, choose from "never", "once", "freely"
+  # tls_renegotiation_method = "never"
+
+  ## HTTP Request Headers (all values must be strings)
+  # [inputs.http_response.headers]
+  #   Host = "github.com"
+
+  ## Optional setting to map response http headers into tags
+  ## If the http header is not present on the request, no corresponding tag will
+  ## be added. If multiple instances of the http header are present, only the
+  ## first value will be used.
+  # http_header_tags = {"HTTP_HEADER" = "TAG_NAME"}
+
+  ## Interface to use when dialing an address
+  # interface = "eth0"
+
+  ## Optional Cookie authentication
+  # cookie_auth_url = "https://localhost/authMe"
+  # cookie_auth_method = "POST"
+  # cookie_auth_username = "username"
+  # cookie_auth_password = "pa$$word"
+  # cookie_auth_body = '{"username": "user", "password": "pa$$word", "authenticate": "me"}'
+  ## cookie_auth_renewal not set or set to "0" will auth once and never renew the cookie
+  # cookie_auth_renewal = "5m"

--- a/plugins/inputs/http_response/http_response.go
+++ b/plugins/inputs/http_response/http_response.go
@@ -37,7 +37,6 @@ const (
 )
 
 type HTTPResponse struct {
-	Address         string              `toml:"address" deprecated:"1.12.0;1.35.0;use 'urls' instead"`
 	URLs            []string            `toml:"urls"`
 	HTTPProxy       string              `toml:"http_proxy"`
 	Body            string              `toml:"body"`
@@ -99,11 +98,7 @@ func (h *HTTPResponse) Init() error {
 	}
 
 	if len(h.URLs) == 0 {
-		if h.Address == "" {
-			h.URLs = []string{"http://localhost"}
-		} else {
-			h.URLs = []string{h.Address}
-		}
+		h.URLs = []string{"http://localhost"}
 	}
 
 	h.clients = make([]client, 0, len(h.URLs))


### PR DESCRIPTION
## Summary

This PR migrates the `address` option of the plugin and removes the deprecated option.


## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #16922
