### PR TITLE
feat(migrations): Add option migration for inputs.http_listener_v2

### DIFF
--- a/migrations/all/inputs_http_listener_v2.go
+++ b/migrations/all/inputs_http_listener_v2.go
@@ -1,0 +1,5 @@
+//go:build !custom || (migrations && (inputs || inputs.http_listener_v2))
+
+package all
+
+import _ "github.com/influxdata/telegraf/migrations/inputs_http_listener_v2" // register migration

--- a/migrations/inputs_http_listener_v2/migration.go
+++ b/migrations/inputs_http_listener_v2/migration.go
@@ -1,0 +1,119 @@
+package inputs_http_listener_v2
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"slices"
+	"strconv"
+
+	"github.com/influxdata/toml"
+	"github.com/influxdata/toml/ast"
+
+	"github.com/influxdata/telegraf/migrations"
+)
+
+// Migration function
+func migrate(tbl *ast.Table) ([]byte, string, error) {
+	// Decode the old data structure
+	var plugin map[string]interface{}
+	if err := toml.UnmarshalTable(tbl, &plugin); err != nil {
+		return nil, "", err
+	}
+
+	// Check for deprecated option(s) and migrate them
+	var applied bool
+
+	if rawOldPath, found := plugin["path"]; found {
+		applied = true
+
+		// Convert the options to the actual type
+		oldPath, ok := rawOldPath.(string)
+		if !ok {
+			return nil, "", fmt.Errorf("unexpected type %T for 'path'", rawOldPath)
+		}
+
+		// Merge the option with the replacement
+		var paths []string
+		if rawNewPaths, found := plugin["paths"]; found {
+			var err error
+			paths, err = migrations.AsStringSlice(rawNewPaths)
+			if err != nil {
+				return nil, "", fmt.Errorf("'paths' option: %w", err)
+			}
+		}
+
+		if !slices.Contains(paths, oldPath) {
+			paths = append(paths, oldPath)
+		}
+
+		// Remove the deprecated option and replace the modified one
+		delete(plugin, "path")
+		plugin["paths"] = paths
+	}
+
+	if rawOldPort, found := plugin["port"]; found {
+		applied = true
+
+		// Convert the options to the actual type
+		oldPort, ok := rawOldPort.(int64)
+		if !ok {
+			return nil, "", fmt.Errorf("unexpected type %T for 'port'", rawOldPort)
+		}
+
+		// Check if the new setting is present and if so, check if the values are
+		// conflicting.
+		var address string
+		if rawNewServiceAddress, found := plugin["service_address"]; found {
+			newServiceAddress, ok := rawNewServiceAddress.(string)
+			if !ok {
+				return nil, "", fmt.Errorf("unexpected type %T for 'service_address'", rawNewServiceAddress)
+			}
+			address = newServiceAddress
+		}
+
+		// Check if the port of the service-address matches
+		u, err := url.Parse(address)
+		if err != nil {
+			return nil, "", fmt.Errorf("parsing 'service_address' failed: %w", err)
+		}
+
+		if u.Scheme == "" {
+			u.Scheme = "tcp"
+		}
+
+		if u.Port() != "" {
+			newPort, err := strconv.ParseInt(u.Port(), 10, 64)
+			if err != nil {
+				return nil, "", fmt.Errorf("converting port of 'service_address' failed: %w", err)
+			}
+			if newPort != oldPort {
+				return nil, "", errors.New("contradicting setting for 'port' and port of 'service_address'")
+			}
+		} else {
+			u.Host = fmt.Sprintf("%s:%d", u.Host, oldPort)
+			address = u.String()
+		}
+
+		// Remove the deprecated option and replace the modified one
+		delete(plugin, "port")
+		plugin["service_address"] = address
+	}
+
+	// No options migrated so we can exit early
+	if !applied {
+		return nil, "", migrations.ErrNotApplicable
+	}
+
+	// Create the corresponding plugin configurations
+	cfg := migrations.CreateTOMLStruct("inputs", "http_listener_v2")
+	cfg.Add("inputs", "http_listener_v2", plugin)
+
+	output, err := toml.Marshal(cfg)
+	return output, "", err
+}
+
+// Register the migration function for the plugin type
+func init() {
+	migrations.AddPluginOptionMigration("inputs.http_listener_v2", migrate)
+}

--- a/migrations/inputs_http_listener_v2/migration_test.go
+++ b/migrations/inputs_http_listener_v2/migration_test.go
@@ -1,0 +1,88 @@
+package inputs_http_listener_v2_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/influxdata/telegraf/config"
+	_ "github.com/influxdata/telegraf/migrations/inputs_http_listener_v2" // register migration
+	"github.com/influxdata/telegraf/plugins/inputs/http_listener_v2"      // register plugin
+	_ "github.com/influxdata/telegraf/plugins/parsers/influx"             // register parser
+)
+
+func TestNoMigration(t *testing.T) {
+	plugin := &http_listener_v2.HTTPListenerV2{}
+	defaultCfg := plugin.SampleConfig()
+
+	// Migrate and check that nothing changed
+	output, n, err := config.ApplyMigrations([]byte(defaultCfg))
+	require.NoError(t, err)
+	require.NotEmpty(t, output)
+	require.Zero(t, n)
+	require.Equal(t, defaultCfg, string(output))
+}
+
+func TestPortConflict(t *testing.T) {
+	cfg := []byte(`
+		[[inputs.http_listener_v2]]
+		service_address = "http://192.168.0.1:8080"
+		port = 443
+	`)
+
+	// Migrate and check that nothing changed
+	output, n, err := config.ApplyMigrations(cfg)
+	require.ErrorContains(t, err, "contradicting setting for 'port' and port of 'service_address'")
+	require.Empty(t, output)
+	require.Zero(t, n)
+}
+
+func TestCases(t *testing.T) {
+	// Get all directories in testdata
+	folders, err := os.ReadDir("testcases")
+	require.NoError(t, err)
+
+	for _, f := range folders {
+		// Only handle folders
+		if !f.IsDir() {
+			continue
+		}
+
+		t.Run(f.Name(), func(t *testing.T) {
+			testcasePath := filepath.Join("testcases", f.Name())
+			inputFile := filepath.Join(testcasePath, "telegraf.conf")
+			expectedFile := filepath.Join(testcasePath, "expected.conf")
+
+			// Read the expected output
+			expected := config.NewConfig()
+			require.NoError(t, expected.LoadConfig(expectedFile))
+			require.NotEmpty(t, expected.Inputs)
+
+			// Read the input data
+			input, remote, err := config.LoadConfigFile(inputFile)
+			require.NoError(t, err)
+			require.False(t, remote)
+			require.NotEmpty(t, input)
+
+			// Migrate
+			output, n, err := config.ApplyMigrations(input)
+			require.NoError(t, err)
+			require.NotEmpty(t, output)
+			require.GreaterOrEqual(t, n, uint64(1))
+			actual := config.NewConfig()
+			require.NoError(t, actual.LoadConfigData(output, config.EmptySourcePath))
+
+			// Test the output
+			require.Len(t, actual.Inputs, len(expected.Inputs))
+			actualIDs := make([]string, 0, len(expected.Inputs))
+			expectedIDs := make([]string, 0, len(expected.Inputs))
+			for i := range actual.Inputs {
+				actualIDs = append(actualIDs, actual.Inputs[i].ID())
+				expectedIDs = append(expectedIDs, expected.Inputs[i].ID())
+			}
+			require.ElementsMatch(t, expectedIDs, actualIDs, string(output))
+		})
+	}
+}

--- a/migrations/inputs_http_listener_v2/testcases/deprecated_path/expected.conf
+++ b/migrations/inputs_http_listener_v2/testcases/deprecated_path/expected.conf
@@ -1,0 +1,4 @@
+[[inputs.http_listener_v2]]
+service_address = "tcp://:8080"
+paths = ["/telegraf"]
+data_format = "influx"

--- a/migrations/inputs_http_listener_v2/testcases/deprecated_path/telegraf.conf
+++ b/migrations/inputs_http_listener_v2/testcases/deprecated_path/telegraf.conf
@@ -1,0 +1,74 @@
+# Generic HTTP write listener
+[[inputs.http_listener_v2]]
+  ## Address to host HTTP listener on
+  ## can be prefixed by protocol tcp, or unix if not provided defaults to tcp
+  ## if unix network type provided it should be followed by absolute path for unix socket
+  service_address = "tcp://:8080"
+  ## service_address = "tcp://:8443"
+  ## service_address = "unix:///tmp/telegraf.sock"
+
+  ## Permission for unix sockets (only available for unix sockets)
+  ## This setting may not be respected by some platforms. To safely restrict
+  ## permissions it is recommended to place the socket into a previously
+  ## created directory with the desired permissions.
+  ##   ex: socket_mode = "777"
+  # socket_mode = ""
+
+  ## Paths to listen to.
+  # paths = ["/telegraf"]
+  path = "/telegraf"
+
+  ## Save path as http_listener_v2_path tag if set to true
+  # path_tag = false
+
+  ## HTTP methods to accept.
+  # methods = ["POST", "PUT"]
+
+  ## Optional HTTP headers
+  ## These headers are applied to the server that is listening for HTTP
+  ## requests and included in responses.
+  # http_headers = {"HTTP_HEADER" = "TAG_NAME"}
+
+  ## HTTP Return Success Code
+  ## This is the HTTP code that will be returned on success
+  # http_success_code = 204
+
+  ## maximum duration before timing out read of the request
+  # read_timeout = "10s"
+  ## maximum duration before timing out write of the response
+  # write_timeout = "10s"
+
+  ## Maximum allowed http request body size in bytes.
+  ## 0 means to use the default of 524,288,000 bytes (500 mebibytes)
+  # max_body_size = "500MB"
+
+  ## Part of the request to consume.  Available options are "body" and
+  ## "query".
+  # data_source = "body"
+
+  ## Set one or more allowed client CA certificate file names to
+  ## enable mutually authenticated TLS connections
+  # tls_allowed_cacerts = ["/etc/telegraf/clientca.pem"]
+
+  ## Add service certificate and key
+  # tls_cert = "/etc/telegraf/cert.pem"
+  # tls_key = "/etc/telegraf/key.pem"
+
+  ## Minimal TLS version accepted by the server
+  # tls_min_version = "TLS12"
+
+  ## Optional username and password to accept for HTTP basic authentication.
+  ## You probably want to make sure you have TLS configured above for this.
+  # basic_username = "foobar"
+  # basic_password = "barfoo"
+
+  ## Optional setting to map http headers into tags
+  ## If the http header is not present on the request, no corresponding tag will be added
+  ## If multiple instances of the http header are present, only the first value will be used
+  # http_header_tags = {"HTTP_HEADER" = "TAG_NAME"}
+
+  ## Data format to consume.
+  ## Each data format has its own unique set of configuration options, read
+  ## more about them here:
+  ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_INPUT.md
+  data_format = "influx"

--- a/migrations/inputs_http_listener_v2/testcases/deprecated_path_duplicate/expected.conf
+++ b/migrations/inputs_http_listener_v2/testcases/deprecated_path_duplicate/expected.conf
@@ -1,0 +1,4 @@
+[[inputs.http_listener_v2]]
+service_address = "tcp://:8080"
+paths = ["/telegraf", "/somewhere"]
+data_format = "influx"

--- a/migrations/inputs_http_listener_v2/testcases/deprecated_path_duplicate/telegraf.conf
+++ b/migrations/inputs_http_listener_v2/testcases/deprecated_path_duplicate/telegraf.conf
@@ -1,0 +1,74 @@
+# Generic HTTP write listener
+[[inputs.http_listener_v2]]
+  ## Address to host HTTP listener on
+  ## can be prefixed by protocol tcp, or unix if not provided defaults to tcp
+  ## if unix network type provided it should be followed by absolute path for unix socket
+  service_address = "tcp://:8080"
+  ## service_address = "tcp://:8443"
+  ## service_address = "unix:///tmp/telegraf.sock"
+
+  ## Permission for unix sockets (only available for unix sockets)
+  ## This setting may not be respected by some platforms. To safely restrict
+  ## permissions it is recommended to place the socket into a previously
+  ## created directory with the desired permissions.
+  ##   ex: socket_mode = "777"
+  # socket_mode = ""
+
+  ## Paths to listen to.
+  paths = ["/telegraf", "/somewhere"]
+  path = "/somewhere"
+
+  ## Save path as http_listener_v2_path tag if set to true
+  # path_tag = false
+
+  ## HTTP methods to accept.
+  # methods = ["POST", "PUT"]
+
+  ## Optional HTTP headers
+  ## These headers are applied to the server that is listening for HTTP
+  ## requests and included in responses.
+  # http_headers = {"HTTP_HEADER" = "TAG_NAME"}
+
+  ## HTTP Return Success Code
+  ## This is the HTTP code that will be returned on success
+  # http_success_code = 204
+
+  ## maximum duration before timing out read of the request
+  # read_timeout = "10s"
+  ## maximum duration before timing out write of the response
+  # write_timeout = "10s"
+
+  ## Maximum allowed http request body size in bytes.
+  ## 0 means to use the default of 524,288,000 bytes (500 mebibytes)
+  # max_body_size = "500MB"
+
+  ## Part of the request to consume.  Available options are "body" and
+  ## "query".
+  # data_source = "body"
+
+  ## Set one or more allowed client CA certificate file names to
+  ## enable mutually authenticated TLS connections
+  # tls_allowed_cacerts = ["/etc/telegraf/clientca.pem"]
+
+  ## Add service certificate and key
+  # tls_cert = "/etc/telegraf/cert.pem"
+  # tls_key = "/etc/telegraf/key.pem"
+
+  ## Minimal TLS version accepted by the server
+  # tls_min_version = "TLS12"
+
+  ## Optional username and password to accept for HTTP basic authentication.
+  ## You probably want to make sure you have TLS configured above for this.
+  # basic_username = "foobar"
+  # basic_password = "barfoo"
+
+  ## Optional setting to map http headers into tags
+  ## If the http header is not present on the request, no corresponding tag will be added
+  ## If multiple instances of the http header are present, only the first value will be used
+  # http_header_tags = {"HTTP_HEADER" = "TAG_NAME"}
+
+  ## Data format to consume.
+  ## Each data format has its own unique set of configuration options, read
+  ## more about them here:
+  ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_INPUT.md
+  data_format = "influx"

--- a/migrations/inputs_http_listener_v2/testcases/deprecated_path_existing/expected.conf
+++ b/migrations/inputs_http_listener_v2/testcases/deprecated_path_existing/expected.conf
@@ -1,0 +1,4 @@
+[[inputs.http_listener_v2]]
+service_address = "tcp://:8080"
+paths = ["/telegraf", "/somewhere"]
+data_format = "influx"

--- a/migrations/inputs_http_listener_v2/testcases/deprecated_path_existing/telegraf.conf
+++ b/migrations/inputs_http_listener_v2/testcases/deprecated_path_existing/telegraf.conf
@@ -1,0 +1,74 @@
+# Generic HTTP write listener
+[[inputs.http_listener_v2]]
+  ## Address to host HTTP listener on
+  ## can be prefixed by protocol tcp, or unix if not provided defaults to tcp
+  ## if unix network type provided it should be followed by absolute path for unix socket
+  service_address = "tcp://:8080"
+  ## service_address = "tcp://:8443"
+  ## service_address = "unix:///tmp/telegraf.sock"
+
+  ## Permission for unix sockets (only available for unix sockets)
+  ## This setting may not be respected by some platforms. To safely restrict
+  ## permissions it is recommended to place the socket into a previously
+  ## created directory with the desired permissions.
+  ##   ex: socket_mode = "777"
+  # socket_mode = ""
+
+  ## Paths to listen to.
+  paths = ["/telegraf"]
+  path = "/somewhere"
+
+  ## Save path as http_listener_v2_path tag if set to true
+  # path_tag = false
+
+  ## HTTP methods to accept.
+  # methods = ["POST", "PUT"]
+
+  ## Optional HTTP headers
+  ## These headers are applied to the server that is listening for HTTP
+  ## requests and included in responses.
+  # http_headers = {"HTTP_HEADER" = "TAG_NAME"}
+
+  ## HTTP Return Success Code
+  ## This is the HTTP code that will be returned on success
+  # http_success_code = 204
+
+  ## maximum duration before timing out read of the request
+  # read_timeout = "10s"
+  ## maximum duration before timing out write of the response
+  # write_timeout = "10s"
+
+  ## Maximum allowed http request body size in bytes.
+  ## 0 means to use the default of 524,288,000 bytes (500 mebibytes)
+  # max_body_size = "500MB"
+
+  ## Part of the request to consume.  Available options are "body" and
+  ## "query".
+  # data_source = "body"
+
+  ## Set one or more allowed client CA certificate file names to
+  ## enable mutually authenticated TLS connections
+  # tls_allowed_cacerts = ["/etc/telegraf/clientca.pem"]
+
+  ## Add service certificate and key
+  # tls_cert = "/etc/telegraf/cert.pem"
+  # tls_key = "/etc/telegraf/key.pem"
+
+  ## Minimal TLS version accepted by the server
+  # tls_min_version = "TLS12"
+
+  ## Optional username and password to accept for HTTP basic authentication.
+  ## You probably want to make sure you have TLS configured above for this.
+  # basic_username = "foobar"
+  # basic_password = "barfoo"
+
+  ## Optional setting to map http headers into tags
+  ## If the http header is not present on the request, no corresponding tag will be added
+  ## If multiple instances of the http header are present, only the first value will be used
+  # http_header_tags = {"HTTP_HEADER" = "TAG_NAME"}
+
+  ## Data format to consume.
+  ## Each data format has its own unique set of configuration options, read
+  ## more about them here:
+  ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_INPUT.md
+  data_format = "influx"

--- a/migrations/inputs_http_listener_v2/testcases/deprecated_port/expected.conf
+++ b/migrations/inputs_http_listener_v2/testcases/deprecated_port/expected.conf
@@ -1,0 +1,3 @@
+[[inputs.http_listener_v2]]
+service_address = "tcp://:443"
+data_format = "influx"

--- a/migrations/inputs_http_listener_v2/testcases/deprecated_port/telegraf.conf
+++ b/migrations/inputs_http_listener_v2/testcases/deprecated_port/telegraf.conf
@@ -1,0 +1,74 @@
+# Generic HTTP write listener
+[[inputs.http_listener_v2]]
+  ## Address to host HTTP listener on
+  ## can be prefixed by protocol tcp, or unix if not provided defaults to tcp
+  ## if unix network type provided it should be followed by absolute path for unix socket
+  # service_address = "tcp://:8080"
+  ## service_address = "tcp://:8443"
+  ## service_address = "unix:///tmp/telegraf.sock"
+  port = 443
+
+  ## Permission for unix sockets (only available for unix sockets)
+  ## This setting may not be respected by some platforms. To safely restrict
+  ## permissions it is recommended to place the socket into a previously
+  ## created directory with the desired permissions.
+  ##   ex: socket_mode = "777"
+  # socket_mode = ""
+
+  ## Paths to listen to.
+  # paths = ["/telegraf"]
+
+  ## Save path as http_listener_v2_path tag if set to true
+  # path_tag = false
+
+  ## HTTP methods to accept.
+  # methods = ["POST", "PUT"]
+
+  ## Optional HTTP headers
+  ## These headers are applied to the server that is listening for HTTP
+  ## requests and included in responses.
+  # http_headers = {"HTTP_HEADER" = "TAG_NAME"}
+
+  ## HTTP Return Success Code
+  ## This is the HTTP code that will be returned on success
+  # http_success_code = 204
+
+  ## maximum duration before timing out read of the request
+  # read_timeout = "10s"
+  ## maximum duration before timing out write of the response
+  # write_timeout = "10s"
+
+  ## Maximum allowed http request body size in bytes.
+  ## 0 means to use the default of 524,288,000 bytes (500 mebibytes)
+  # max_body_size = "500MB"
+
+  ## Part of the request to consume.  Available options are "body" and
+  ## "query".
+  # data_source = "body"
+
+  ## Set one or more allowed client CA certificate file names to
+  ## enable mutually authenticated TLS connections
+  # tls_allowed_cacerts = ["/etc/telegraf/clientca.pem"]
+
+  ## Add service certificate and key
+  # tls_cert = "/etc/telegraf/cert.pem"
+  # tls_key = "/etc/telegraf/key.pem"
+
+  ## Minimal TLS version accepted by the server
+  # tls_min_version = "TLS12"
+
+  ## Optional username and password to accept for HTTP basic authentication.
+  ## You probably want to make sure you have TLS configured above for this.
+  # basic_username = "foobar"
+  # basic_password = "barfoo"
+
+  ## Optional setting to map http headers into tags
+  ## If the http header is not present on the request, no corresponding tag will be added
+  ## If multiple instances of the http header are present, only the first value will be used
+  # http_header_tags = {"HTTP_HEADER" = "TAG_NAME"}
+
+  ## Data format to consume.
+  ## Each data format has its own unique set of configuration options, read
+  ## more about them here:
+  ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_INPUT.md
+  data_format = "influx"

--- a/migrations/inputs_http_listener_v2/testcases/deprecated_port_existing/expected.conf
+++ b/migrations/inputs_http_listener_v2/testcases/deprecated_port_existing/expected.conf
@@ -1,0 +1,3 @@
+[[inputs.http_listener_v2]]
+service_address = "http://192.168.0.1:8080"
+data_format = "influx"

--- a/migrations/inputs_http_listener_v2/testcases/deprecated_port_existing/telegraf.conf
+++ b/migrations/inputs_http_listener_v2/testcases/deprecated_port_existing/telegraf.conf
@@ -1,0 +1,74 @@
+# Generic HTTP write listener
+[[inputs.http_listener_v2]]
+  ## Address to host HTTP listener on
+  ## can be prefixed by protocol tcp, or unix if not provided defaults to tcp
+  ## if unix network type provided it should be followed by absolute path for unix socket
+  service_address = "http://192.168.0.1:8080"
+  ## service_address = "tcp://:8443"
+  ## service_address = "unix:///tmp/telegraf.sock"
+  port = 8080
+
+  ## Permission for unix sockets (only available for unix sockets)
+  ## This setting may not be respected by some platforms. To safely restrict
+  ## permissions it is recommended to place the socket into a previously
+  ## created directory with the desired permissions.
+  ##   ex: socket_mode = "777"
+  # socket_mode = ""
+
+  ## Paths to listen to.
+  # paths = ["/telegraf"]
+
+  ## Save path as http_listener_v2_path tag if set to true
+  # path_tag = false
+
+  ## HTTP methods to accept.
+  # methods = ["POST", "PUT"]
+
+  ## Optional HTTP headers
+  ## These headers are applied to the server that is listening for HTTP
+  ## requests and included in responses.
+  # http_headers = {"HTTP_HEADER" = "TAG_NAME"}
+
+  ## HTTP Return Success Code
+  ## This is the HTTP code that will be returned on success
+  # http_success_code = 204
+
+  ## maximum duration before timing out read of the request
+  # read_timeout = "10s"
+  ## maximum duration before timing out write of the response
+  # write_timeout = "10s"
+
+  ## Maximum allowed http request body size in bytes.
+  ## 0 means to use the default of 524,288,000 bytes (500 mebibytes)
+  # max_body_size = "500MB"
+
+  ## Part of the request to consume.  Available options are "body" and
+  ## "query".
+  # data_source = "body"
+
+  ## Set one or more allowed client CA certificate file names to
+  ## enable mutually authenticated TLS connections
+  # tls_allowed_cacerts = ["/etc/telegraf/clientca.pem"]
+
+  ## Add service certificate and key
+  # tls_cert = "/etc/telegraf/cert.pem"
+  # tls_key = "/etc/telegraf/key.pem"
+
+  ## Minimal TLS version accepted by the server
+  # tls_min_version = "TLS12"
+
+  ## Optional username and password to accept for HTTP basic authentication.
+  ## You probably want to make sure you have TLS configured above for this.
+  # basic_username = "foobar"
+  # basic_password = "barfoo"
+
+  ## Optional setting to map http headers into tags
+  ## If the http header is not present on the request, no corresponding tag will be added
+  ## If multiple instances of the http header are present, only the first value will be used
+  # http_header_tags = {"HTTP_HEADER" = "TAG_NAME"}
+
+  ## Data format to consume.
+  ## Each data format has its own unique set of configuration options, read
+  ## more about them here:
+  ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_INPUT.md
+  data_format = "influx"

--- a/plugins/inputs/http_listener_v2/http_listener_v2.go
+++ b/plugins/inputs/http_listener_v2/http_listener_v2.go
@@ -49,7 +49,6 @@ const (
 type HTTPListenerV2 struct {
 	ServiceAddress string            `toml:"service_address"`
 	SocketMode     string            `toml:"socket_mode"`
-	Path           string            `toml:"path" deprecated:"1.20.0;1.35.0;use 'paths' instead"`
 	Paths          []string          `toml:"paths"`
 	PathTag        bool              `toml:"path_tag"`
 	Methods        []string          `toml:"methods"`
@@ -58,7 +57,6 @@ type HTTPListenerV2 struct {
 	ReadTimeout    config.Duration   `toml:"read_timeout"`
 	WriteTimeout   config.Duration   `toml:"write_timeout"`
 	MaxBodySize    config.Size       `toml:"max_body_size"`
-	Port           int               `toml:"port" deprecated:"1.32.0;1.35.0;use 'service_address' instead"`
 	SuccessCode    int               `toml:"http_success_code"`
 	BasicUsername  string            `toml:"basic_username"`
 	BasicPassword  string            `toml:"basic_password"`
@@ -170,11 +168,6 @@ func (h *HTTPListenerV2) Start(acc telegraf.Accumulator) error {
 	}
 	if h.WriteTimeout < config.Duration(time.Second) {
 		h.WriteTimeout = config.Duration(time.Second * 10)
-	}
-
-	// Append h.Path to h.Paths
-	if h.Path != "" && !choice.Contains(h.Path, h.Paths) {
-		h.Paths = append(h.Paths, h.Path)
 	}
 
 	h.acc = acc

--- a/plugins/inputs/http_listener_v2/http_listener_v2_test.go
+++ b/plugins/inputs/http_listener_v2/http_listener_v2_test.go
@@ -58,7 +58,7 @@ func newTestHTTPListenerV2() (*HTTPListenerV2, error) {
 	listener := &HTTPListenerV2{
 		Log:            testutil.Logger{},
 		ServiceAddress: "localhost:0",
-		Path:           "/write",
+		Paths:          []string{"/write"},
 		Methods:        []string{"POST"},
 		Parser:         parser,
 		timeFunc:       time.Now,
@@ -88,7 +88,7 @@ func newTestHTTPSListenerV2() (*HTTPListenerV2, error) {
 	listener := &HTTPListenerV2{
 		Log:            testutil.Logger{},
 		ServiceAddress: "localhost:0",
-		Path:           "/write",
+		Paths:          []string{"/write"},
 		Methods:        []string{"POST"},
 		Parser:         parser,
 		ServerConfig:   *pki.TLSServerConfig(),
@@ -132,7 +132,7 @@ func TestInvalidListenerConfig(t *testing.T) {
 	listener := &HTTPListenerV2{
 		Log:            testutil.Logger{},
 		ServiceAddress: "address_without_port",
-		Path:           "/write",
+		Paths:          []string{"/write"},
 		Methods:        []string{"POST"},
 		Parser:         parser,
 		timeFunc:       time.Now,
@@ -307,7 +307,7 @@ func TestWriteHTTPWithReturnCode(t *testing.T) {
 func TestWriteHTTPWithMultiplePaths(t *testing.T) {
 	listener, err := newTestHTTPListenerV2()
 	require.NoError(t, err)
-	listener.Paths = []string{"/alternative_write"}
+	listener.Paths = append(listener.Paths, "/alternative_write")
 	listener.PathTag = true
 
 	acc := &testutil.Accumulator{}
@@ -369,7 +369,7 @@ func TestWriteHTTPExactMaxBodySize(t *testing.T) {
 	listener := &HTTPListenerV2{
 		Log:            testutil.Logger{},
 		ServiceAddress: "localhost:0",
-		Path:           "/write",
+		Paths:          []string{"/write"},
 		Methods:        []string{"POST"},
 		Parser:         parser,
 		MaxBodySize:    config.Size(len(hugeMetric)),
@@ -395,7 +395,7 @@ func TestWriteHTTPVerySmallMaxBody(t *testing.T) {
 	listener := &HTTPListenerV2{
 		Log:            testutil.Logger{},
 		ServiceAddress: "localhost:0",
-		Path:           "/write",
+		Paths:          []string{"/write"},
 		Methods:        []string{"POST"},
 		Parser:         parser,
 		MaxBodySize:    config.Size(4096),


### PR DESCRIPTION
## Summary

This PR migrates the `path` and `port` options of the plugin and removes the deprecated options.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #16921 
