### PR TITLE
feat(migrations): Add option migration for inputs.ntpq

### DIFF
--- a/migrations/all/inputs_ntpq.go
+++ b/migrations/all/inputs_ntpq.go
@@ -1,0 +1,5 @@
+//go:build !custom || (migrations && (inputs || inputs.ntpq))
+
+package all
+
+import _ "github.com/influxdata/telegraf/migrations/inputs_ntpq" // register migration

--- a/migrations/inputs_ntpq/migration.go
+++ b/migrations/inputs_ntpq/migration.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/influxdata/toml"
 	"github.com/influxdata/toml/ast"
+	"github.com/kballard/go-shellquote"
 
 	"github.com/influxdata/telegraf/migrations"
 )
@@ -35,11 +36,15 @@ func migrate(tbl *ast.Table) ([]byte, string, error) {
 			// Merge the option with the replacement
 			var options []string
 			if rawOptions, found := plugin["options"]; found {
-				o, ok := rawOptions.(string)
+				opts, ok := rawOptions.(string)
 				if !ok {
 					return nil, "", fmt.Errorf("unexpected type %T for 'options'", rawOptions)
 				}
-				options = strings.Split(o, " ")
+				o, err := shellquote.Split(opts)
+				if err != nil {
+					return nil, "", fmt.Errorf("splitting 'options' failed: %w", err)
+				}
+				options = o
 			} else {
 				options = append(options, "-p")
 			}

--- a/migrations/inputs_ntpq/migration.go
+++ b/migrations/inputs_ntpq/migration.go
@@ -1,0 +1,73 @@
+package inputs_ntpq
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/influxdata/toml"
+	"github.com/influxdata/toml/ast"
+
+	"github.com/influxdata/telegraf/migrations"
+)
+
+// Migration function
+func migrate(tbl *ast.Table) ([]byte, string, error) {
+	// Decode the old data structure
+	var plugin map[string]interface{}
+	if err := toml.UnmarshalTable(tbl, &plugin); err != nil {
+		return nil, "", err
+	}
+
+	// Check for deprecated option(s) and migrate them
+	var applied bool
+	if rawOldDNSLookup, found := plugin["dns_lookup"]; found {
+		applied = true
+
+		// Convert the options to the actual type
+		oldDNSLookup, ok := rawOldDNSLookup.(bool)
+		if !ok {
+			return nil, "", fmt.Errorf("unexpected type %T for 'dns_lookup'", rawOldDNSLookup)
+		}
+
+		// Only insert options if dns_lookup was actually set to false
+		if !oldDNSLookup {
+			// Merge the option with the replacement
+			var options []string
+			if rawOptions, found := plugin["options"]; found {
+				o, ok := rawOptions.(string)
+				if !ok {
+					return nil, "", fmt.Errorf("unexpected type %T for 'options'", rawOptions)
+				}
+				options = strings.Split(o, " ")
+			} else {
+				options = append(options, "-p")
+			}
+
+			if !slices.Contains(options, "-n") {
+				options = append(options, "-n")
+			}
+			plugin["options"] = strings.Join(options, " ")
+		}
+
+		// Remove the deprecated option
+		delete(plugin, "dns_lookup")
+	}
+
+	// No options migrated so we can exit early
+	if !applied {
+		return nil, "", migrations.ErrNotApplicable
+	}
+
+	// Create the corresponding plugin configurations
+	cfg := migrations.CreateTOMLStruct("inputs", "ntpq")
+	cfg.Add("inputs", "ntpq", plugin)
+
+	output, err := toml.Marshal(cfg)
+	return output, "", err
+}
+
+// Register the migration function for the plugin type
+func init() {
+	migrations.AddPluginOptionMigration("inputs.ntpq", migrate)
+}

--- a/migrations/inputs_ntpq/migration_test.go
+++ b/migrations/inputs_ntpq/migration_test.go
@@ -1,0 +1,73 @@
+package inputs_ntpq_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/influxdata/telegraf/config"
+	_ "github.com/influxdata/telegraf/migrations/inputs_ntpq" // register migration
+	"github.com/influxdata/telegraf/plugins/inputs/ntpq"      // register plugin
+)
+
+func TestNoMigration(t *testing.T) {
+	plugin := &ntpq.NTPQ{}
+	defaultCfg := plugin.SampleConfig()
+
+	// Migrate and check that nothing changed
+	output, n, err := config.ApplyMigrations([]byte(defaultCfg))
+	require.NoError(t, err)
+	require.NotEmpty(t, output)
+	require.Zero(t, n)
+	require.Equal(t, defaultCfg, string(output))
+}
+
+func TestCases(t *testing.T) {
+	// Get all directories in testdata
+	folders, err := os.ReadDir("testcases")
+	require.NoError(t, err)
+
+	for _, f := range folders {
+		// Only handle folders
+		if !f.IsDir() {
+			continue
+		}
+
+		t.Run(f.Name(), func(t *testing.T) {
+			testcasePath := filepath.Join("testcases", f.Name())
+			inputFile := filepath.Join(testcasePath, "telegraf.conf")
+			expectedFile := filepath.Join(testcasePath, "expected.conf")
+
+			// Read the expected output
+			expected := config.NewConfig()
+			require.NoError(t, expected.LoadConfig(expectedFile))
+			require.NotEmpty(t, expected.Inputs)
+
+			// Read the input data
+			input, remote, err := config.LoadConfigFile(inputFile)
+			require.NoError(t, err)
+			require.False(t, remote)
+			require.NotEmpty(t, input)
+
+			// Migrate
+			output, n, err := config.ApplyMigrations(input)
+			require.NoError(t, err)
+			require.NotEmpty(t, output)
+			require.GreaterOrEqual(t, n, uint64(1))
+			actual := config.NewConfig()
+			require.NoError(t, actual.LoadConfigData(output, config.EmptySourcePath))
+
+			// Test the output
+			require.Len(t, actual.Inputs, len(expected.Inputs))
+			actualIDs := make([]string, 0, len(expected.Inputs))
+			expectedIDs := make([]string, 0, len(expected.Inputs))
+			for i := range actual.Inputs {
+				actualIDs = append(actualIDs, actual.Inputs[i].ID())
+				expectedIDs = append(expectedIDs, expected.Inputs[i].ID())
+			}
+			require.ElementsMatch(t, expectedIDs, actualIDs, string(output))
+		})
+	}
+}

--- a/migrations/inputs_ntpq/testcases/deprecated_dns_lookup/expected.conf
+++ b/migrations/inputs_ntpq/testcases/deprecated_dns_lookup/expected.conf
@@ -1,0 +1,2 @@
+[[inputs.ntpq]]
+options = "-p -n"

--- a/migrations/inputs_ntpq/testcases/deprecated_dns_lookup/telegraf.conf
+++ b/migrations/inputs_ntpq/testcases/deprecated_dns_lookup/telegraf.conf
@@ -1,0 +1,21 @@
+# Get standard NTP query metrics, requires ntpq executable.
+[[inputs.ntpq]]
+  ## Servers to query with ntpq.
+  ## If no server is given, the local machine is queried.
+  # servers = []
+
+  ## If false, set the -n ntpq flag. Can reduce metric gather time.
+  ## DEPRECATED since 1.24.0: add '-n' to 'options' instead to skip DNS lookup
+  dns_lookup = false
+
+  ## Options to pass to the ntpq command.
+  # options = "-p"
+
+  ## Output format for the 'reach' field.
+  ## Available values are
+  ##   octal   --  output as is in octal representation e.g. 377 (default)
+  ##   decimal --  convert value to decimal representation e.g. 371 -> 249
+  ##   count   --  count the number of bits in the value. This represents
+  ##               the number of successful reaches, e.g. 37 -> 5
+  ##   ratio   --  output the ratio of successful attempts e.g. 37 -> 5/8 = 0.625
+  # reach_format = "octal"

--- a/migrations/inputs_ntpq/testcases/deprecated_dns_lookup_duplicate/expected.conf
+++ b/migrations/inputs_ntpq/testcases/deprecated_dns_lookup_duplicate/expected.conf
@@ -1,0 +1,2 @@
+[[inputs.ntpq]]
+options = "-4 -n -p"

--- a/migrations/inputs_ntpq/testcases/deprecated_dns_lookup_duplicate/telegraf.conf
+++ b/migrations/inputs_ntpq/testcases/deprecated_dns_lookup_duplicate/telegraf.conf
@@ -1,0 +1,21 @@
+# Get standard NTP query metrics, requires ntpq executable.
+[[inputs.ntpq]]
+  ## Servers to query with ntpq.
+  ## If no server is given, the local machine is queried.
+  # servers = []
+
+  ## If false, set the -n ntpq flag. Can reduce metric gather time.
+  ## DEPRECATED since 1.24.0: add '-n' to 'options' instead to skip DNS lookup
+  dns_lookup = false
+
+  ## Options to pass to the ntpq command.
+  options = "-4 -n -p"
+
+  ## Output format for the 'reach' field.
+  ## Available values are
+  ##   octal   --  output as is in octal representation e.g. 377 (default)
+  ##   decimal --  convert value to decimal representation e.g. 371 -> 249
+  ##   count   --  count the number of bits in the value. This represents
+  ##               the number of successful reaches, e.g. 37 -> 5
+  ##   ratio   --  output the ratio of successful attempts e.g. 37 -> 5/8 = 0.625
+  # reach_format = "octal"

--- a/migrations/inputs_ntpq/testcases/deprecated_dns_lookup_existing/expected.conf
+++ b/migrations/inputs_ntpq/testcases/deprecated_dns_lookup_existing/expected.conf
@@ -1,0 +1,2 @@
+[[inputs.ntpq]]
+options = "-4 -p -n"

--- a/migrations/inputs_ntpq/testcases/deprecated_dns_lookup_existing/telegraf.conf
+++ b/migrations/inputs_ntpq/testcases/deprecated_dns_lookup_existing/telegraf.conf
@@ -1,0 +1,21 @@
+# Get standard NTP query metrics, requires ntpq executable.
+[[inputs.ntpq]]
+  ## Servers to query with ntpq.
+  ## If no server is given, the local machine is queried.
+  # servers = []
+
+  ## If false, set the -n ntpq flag. Can reduce metric gather time.
+  ## DEPRECATED since 1.24.0: add '-n' to 'options' instead to skip DNS lookup
+  dns_lookup = false
+
+  ## Options to pass to the ntpq command.
+  options = "-4 -p"
+
+  ## Output format for the 'reach' field.
+  ## Available values are
+  ##   octal   --  output as is in octal representation e.g. 377 (default)
+  ##   decimal --  convert value to decimal representation e.g. 371 -> 249
+  ##   count   --  count the number of bits in the value. This represents
+  ##               the number of successful reaches, e.g. 37 -> 5
+  ##   ratio   --  output the ratio of successful attempts e.g. 37 -> 5/8 = 0.625
+  # reach_format = "octal"

--- a/migrations/inputs_ntpq/testcases/deprecated_dns_lookup_true/expected.conf
+++ b/migrations/inputs_ntpq/testcases/deprecated_dns_lookup_true/expected.conf
@@ -1,0 +1,1 @@
+[[inputs.ntpq]]

--- a/migrations/inputs_ntpq/testcases/deprecated_dns_lookup_true/telegraf.conf
+++ b/migrations/inputs_ntpq/testcases/deprecated_dns_lookup_true/telegraf.conf
@@ -1,0 +1,21 @@
+# Get standard NTP query metrics, requires ntpq executable.
+[[inputs.ntpq]]
+  ## Servers to query with ntpq.
+  ## If no server is given, the local machine is queried.
+  # servers = []
+
+  ## If false, set the -n ntpq flag. Can reduce metric gather time.
+  ## DEPRECATED since 1.24.0: add '-n' to 'options' instead to skip DNS lookup
+  dns_lookup = true
+
+  ## Options to pass to the ntpq command.
+  # options = "-p"
+
+  ## Output format for the 'reach' field.
+  ## Available values are
+  ##   octal   --  output as is in octal representation e.g. 377 (default)
+  ##   decimal --  convert value to decimal representation e.g. 371 -> 249
+  ##   count   --  count the number of bits in the value. This represents
+  ##               the number of successful reaches, e.g. 37 -> 5
+  ##   ratio   --  output the ratio of successful attempts e.g. 37 -> 5/8 = 0.625
+  # reach_format = "octal"

--- a/plugins/inputs/ntpq/ntpq.go
+++ b/plugins/inputs/ntpq/ntpq.go
@@ -41,7 +41,6 @@ const (
 )
 
 type NTPQ struct {
-	DNSLookup   bool     `toml:"dns_lookup" deprecated:"1.24.0;1.35.0;add '-n' to 'options' instead to skip DNS lookup"`
 	Options     string   `toml:"options"`
 	Servers     []string `toml:"servers"`
 	ReachFormat string   `toml:"reach_format"`
@@ -85,11 +84,6 @@ func (n *NTPQ) Init() error {
 		options, err := shellquote.Split(n.Options)
 		if err != nil {
 			return fmt.Errorf("splitting options failed: %w", err)
-		}
-		if !n.DNSLookup {
-			if !slices.Contains(options, "-n") {
-				options = append(options, "-n")
-			}
 		}
 		if !slices.Contains(options, "-p") {
 			options = append(options, "-p")
@@ -307,8 +301,6 @@ func processLine(line string) (string, []string) {
 
 func init() {
 	inputs.Add("ntpq", func() telegraf.Input {
-		return &NTPQ{
-			DNSLookup: true,
-		}
+		return &NTPQ{}
 	})
 }


### PR DESCRIPTION
## Summary

This PR migrates the `dns_lookup` option of the plugin and removes the deprecated option.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #16929 
