### PR TITLE
feat(migrations): Add migration for inputs.influxdb_listener

### DIFF
--- a/migrations/all/inputs_influxdb_listener.go
+++ b/migrations/all/inputs_influxdb_listener.go
@@ -1,0 +1,5 @@
+//go:build !custom || (migrations && (inputs || inputs.influxdb_listener))
+
+package all
+
+import _ "github.com/influxdata/telegraf/migrations/inputs_influxdb_listener" // register migration

--- a/migrations/inputs_influxdb_listener/migration.go
+++ b/migrations/inputs_influxdb_listener/migration.go
@@ -1,0 +1,44 @@
+package inputs_influxdb_listener
+
+import (
+	"github.com/influxdata/toml"
+	"github.com/influxdata/toml/ast"
+
+	"github.com/influxdata/telegraf/migrations"
+)
+
+// Migration function to migrate deprecated InfluxDB Listener options
+func migrate(tbl *ast.Table) ([]byte, string, error) {
+	// Decode the old data structure
+	var plugin map[string]interface{}
+	if err := toml.UnmarshalTable(tbl, &plugin); err != nil {
+		return nil, "", err
+	}
+
+	// Check for deprecated options and migrate them
+	var applied bool
+
+	// Remove the deprecated max_line_size option (parser now handles unlimited length)
+	if _, found := plugin["max_line_size"]; found {
+		applied = true
+		// Remove the deprecated setting
+		delete(plugin, "max_line_size")
+	}
+
+	// No options migrated so we can exit early
+	if !applied {
+		return nil, "", migrations.ErrNotApplicable
+	}
+
+	// Create the corresponding plugin configuration
+	cfg := migrations.CreateTOMLStruct("inputs", "influxdb_listener")
+	cfg.Add("inputs", "influxdb_listener", plugin)
+
+	output, err := toml.Marshal(cfg)
+	return output, "", err
+}
+
+// Register the migration function for the plugin type
+func init() {
+	migrations.AddPluginOptionMigration("inputs.influxdb_listener", migrate)
+}

--- a/migrations/inputs_influxdb_listener/migration_test.go
+++ b/migrations/inputs_influxdb_listener/migration_test.go
@@ -1,0 +1,74 @@
+package inputs_influxdb_listener_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/influxdata/telegraf/config"
+	_ "github.com/influxdata/telegraf/migrations/inputs_influxdb_listener" // register migration
+	"github.com/influxdata/telegraf/plugins/inputs/influxdb_listener"      // register plugin
+)
+
+func TestNoMigration(t *testing.T) {
+	plugin := &influxdb_listener.InfluxDBListener{}
+	defaultCfg := []byte(plugin.SampleConfig())
+
+	// Migrate and check that nothing changed
+	output, n, err := config.ApplyMigrations(defaultCfg)
+	require.NoError(t, err)
+	require.NotEmpty(t, output)
+	require.Zero(t, n)
+	require.Equal(t, string(defaultCfg), string(output))
+}
+
+func TestCases(t *testing.T) {
+	// Get all directories in testcases
+	folders, err := os.ReadDir("testcases")
+	require.NoError(t, err)
+
+	for _, f := range folders {
+		// Only handle folders
+		if !f.IsDir() {
+			continue
+		}
+
+		t.Run(f.Name(), func(t *testing.T) {
+			testcasePath := filepath.Join("testcases", f.Name())
+			inputFile := filepath.Join(testcasePath, "telegraf.conf")
+			expectedFile := filepath.Join(testcasePath, "expected.conf")
+
+			// Read the expected output
+			expected := config.NewConfig()
+			require.NoError(t, expected.LoadConfig(expectedFile))
+			require.NotEmpty(t, expected.Inputs)
+
+			// Read the input data
+			input, remote, err := config.LoadConfigFile(inputFile)
+			require.NoError(t, err)
+			require.False(t, remote)
+			require.NotEmpty(t, input)
+
+			// Migrate
+			output, n, err := config.ApplyMigrations(input)
+			require.NoError(t, err)
+			require.NotEmpty(t, output)
+			require.GreaterOrEqual(t, n, uint64(1))
+
+			actual := config.NewConfig()
+			require.NoError(t, actual.LoadConfigData(output, config.EmptySourcePath))
+
+			// Test the output
+			require.Len(t, actual.Inputs, len(expected.Inputs))
+			actualIDs := make([]string, 0, len(expected.Inputs))
+			expectedIDs := make([]string, 0, len(expected.Inputs))
+			for i := range actual.Inputs {
+				actualIDs = append(actualIDs, actual.Inputs[i].ID())
+				expectedIDs = append(expectedIDs, expected.Inputs[i].ID())
+			}
+			require.ElementsMatch(t, expectedIDs, actualIDs, string(output))
+		})
+	}
+}

--- a/migrations/inputs_influxdb_listener/testcases/deprecated_max_line_size/expected.conf
+++ b/migrations/inputs_influxdb_listener/testcases/deprecated_max_line_size/expected.conf
@@ -1,0 +1,9 @@
+[[inputs.influxdb_listener]]
+  service_address = ":8186"
+  read_timeout = "10s"
+  write_timeout = "10s"
+  max_body_size = "32MiB"
+  basic_username = "telegraf"
+  basic_password = "secret"
+  database_tag = "database"
+  parser_type = "internal"

--- a/migrations/inputs_influxdb_listener/testcases/deprecated_max_line_size/telegraf.conf
+++ b/migrations/inputs_influxdb_listener/testcases/deprecated_max_line_size/telegraf.conf
@@ -1,0 +1,10 @@
+[[inputs.influxdb_listener]]
+  service_address = ":8186"
+  read_timeout = "10s"
+  write_timeout = "10s"
+  max_body_size = "32MiB"
+  max_line_size = "64KiB"
+  basic_username = "telegraf"
+  basic_password = "secret"
+  database_tag = "database"
+  parser_type = "internal"

--- a/plugins/inputs/influxdb_listener/influxdb_listener.go
+++ b/plugins/inputs/influxdb_listener/influxdb_listener.go
@@ -41,7 +41,6 @@ type InfluxDBListener struct {
 	ReadTimeout        config.Duration `toml:"read_timeout"`
 	WriteTimeout       config.Duration `toml:"write_timeout"`
 	MaxBodySize        config.Size     `toml:"max_body_size"`
-	MaxLineSize        config.Size     `toml:"max_line_size" deprecated:"1.14.0;1.35.0;parser now handles lines of unlimited length and option is ignored"`
 	BasicUsername      string          `toml:"basic_username"`
 	BasicPassword      string          `toml:"basic_password"`
 	TokenSharedSecret  string          `toml:"token_shared_secret"`


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Replace the following options in the plugin and provide a migration
```
  inputs.influxdb_listener/max_line_size   ERROR since 1.14.0 removal in 1.35.0 parser now handles lines of unlimited length and option is ignored
```

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #16924
