### PR TITLE
feat(migrations): Add option migration for inputs.icinga2

### DIFF
--- a/migrations/all/inputs_icinga2.go
+++ b/migrations/all/inputs_icinga2.go
@@ -1,0 +1,5 @@
+//go:build !custom || (migrations && (inputs || inputs.icinga2))
+
+package all
+
+import _ "github.com/influxdata/telegraf/migrations/inputs_icinga2" // register migration

--- a/migrations/inputs_icinga2/migration.go
+++ b/migrations/inputs_icinga2/migration.go
@@ -1,0 +1,67 @@
+package inputs_icinga2
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/influxdata/toml"
+	"github.com/influxdata/toml/ast"
+
+	"github.com/influxdata/telegraf/migrations"
+)
+
+// Migration function
+func migrate(tbl *ast.Table) ([]byte, string, error) {
+	// Decode the old data structure
+	var plugin map[string]interface{}
+	if err := toml.UnmarshalTable(tbl, &plugin); err != nil {
+		return nil, "", err
+	}
+
+	// Check for deprecated option(s) and migrate them
+	var applied bool
+	if rawOldObjectType, found := plugin["object_type"]; found {
+		applied = true
+
+		// Convert the options to the actual type
+		oldObjectTypes, ok := rawOldObjectType.(string)
+		if !ok {
+			return nil, "", fmt.Errorf("unexpected type %T for 'object_type'", rawOldObjectType)
+		}
+
+		// Merge the option with the replacement
+		var objects []string
+		if rawNewObjects, found := plugin["objects"]; found {
+			var err error
+			objects, err = migrations.AsStringSlice(rawNewObjects)
+			if err != nil {
+				return nil, "", fmt.Errorf("'objects' option: %w", err)
+			}
+		}
+
+		if !slices.Contains(objects, oldObjectTypes) {
+			objects = append(objects, oldObjectTypes)
+		}
+
+		// Remove the deprecated option and replace the modified one
+		plugin["objects"] = objects
+		delete(plugin, "object_type")
+	}
+
+	// No options migrated so we can exit early
+	if !applied {
+		return nil, "", migrations.ErrNotApplicable
+	}
+
+	// Create the corresponding plugin configurations
+	cfg := migrations.CreateTOMLStruct("inputs", "icinga2")
+	cfg.Add("inputs", "icinga2", plugin)
+
+	output, err := toml.Marshal(cfg)
+	return output, "", err
+}
+
+// Register the migration function for the plugin type
+func init() {
+	migrations.AddPluginOptionMigration("inputs.icinga2", migrate)
+}

--- a/migrations/inputs_icinga2/migration_test.go
+++ b/migrations/inputs_icinga2/migration_test.go
@@ -1,0 +1,73 @@
+package inputs_icinga2_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/influxdata/telegraf/config"
+	_ "github.com/influxdata/telegraf/migrations/inputs_icinga2" // register migration
+	"github.com/influxdata/telegraf/plugins/inputs/icinga2"      // register plugin
+)
+
+func TestNoMigration(t *testing.T) {
+	plugin := &icinga2.Icinga2{}
+	defaultCfg := plugin.SampleConfig()
+
+	// Migrate and check that nothing changed
+	output, n, err := config.ApplyMigrations([]byte(defaultCfg))
+	require.NoError(t, err)
+	require.NotEmpty(t, output)
+	require.Zero(t, n)
+	require.Equal(t, defaultCfg, string(output))
+}
+
+func TestCases(t *testing.T) {
+	// Get all directories in testdata
+	folders, err := os.ReadDir("testcases")
+	require.NoError(t, err)
+
+	for _, f := range folders {
+		// Only handle folders
+		if !f.IsDir() {
+			continue
+		}
+
+		t.Run(f.Name(), func(t *testing.T) {
+			testcasePath := filepath.Join("testcases", f.Name())
+			inputFile := filepath.Join(testcasePath, "telegraf.conf")
+			expectedFile := filepath.Join(testcasePath, "expected.conf")
+
+			// Read the expected output
+			expected := config.NewConfig()
+			require.NoError(t, expected.LoadConfig(expectedFile))
+			require.NotEmpty(t, expected.Inputs)
+
+			// Read the input data
+			input, remote, err := config.LoadConfigFile(inputFile)
+			require.NoError(t, err)
+			require.False(t, remote)
+			require.NotEmpty(t, input)
+
+			// Migrate
+			output, n, err := config.ApplyMigrations(input)
+			require.NoError(t, err)
+			require.NotEmpty(t, output)
+			require.GreaterOrEqual(t, n, uint64(1))
+			actual := config.NewConfig()
+			require.NoError(t, actual.LoadConfigData(output, config.EmptySourcePath))
+
+			// Test the output
+			require.Len(t, actual.Inputs, len(expected.Inputs))
+			actualIDs := make([]string, 0, len(expected.Inputs))
+			expectedIDs := make([]string, 0, len(expected.Inputs))
+			for i := range actual.Inputs {
+				actualIDs = append(actualIDs, actual.Inputs[i].ID())
+				expectedIDs = append(expectedIDs, expected.Inputs[i].ID())
+			}
+			require.ElementsMatch(t, expectedIDs, actualIDs, string(output))
+		})
+	}
+}

--- a/migrations/inputs_icinga2/testcases/deprecated_object_type/expected.conf
+++ b/migrations/inputs_icinga2/testcases/deprecated_object_type/expected.conf
@@ -1,0 +1,2 @@
+[[inputs.icinga2]]
+objects = ["hosts"]

--- a/migrations/inputs_icinga2/testcases/deprecated_object_type/telegraf.conf
+++ b/migrations/inputs_icinga2/testcases/deprecated_object_type/telegraf.conf
@@ -1,0 +1,28 @@
+# Gather Icinga2 status
+[[inputs.icinga2]]
+  ## Required Icinga2 server address
+  # server = "https://localhost:5665"
+
+  ## Collected Icinga2 objects ("services", "hosts")
+  ## Specify at least one object to collect from /v1/objects endpoint.
+  # objects = ["services"]
+  object_type = "hosts"
+
+  ## Collect metrics from /v1/status endpoint
+  ## Choose from:
+  ##     "ApiListener", "CIB", "IdoMysqlConnection", "IdoPgsqlConnection"
+  # status = []
+
+  ## Credentials for basic HTTP authentication
+  # username = "admin"
+  # password = "admin"
+
+  ## Maximum time to receive response.
+  # response_timeout = "5s"
+
+  ## Optional TLS Config
+  # tls_ca = "/etc/telegraf/ca.pem"
+  # tls_cert = "/etc/telegraf/cert.pem"
+  # tls_key = "/etc/telegraf/key.pem"
+  ## Use TLS but skip chain & host verification
+  # insecure_skip_verify = true

--- a/migrations/inputs_icinga2/testcases/deprecated_object_type_duplicate/expected.conf
+++ b/migrations/inputs_icinga2/testcases/deprecated_object_type_duplicate/expected.conf
@@ -1,0 +1,2 @@
+[[inputs.icinga2]]
+objects = ["services", "hosts"]

--- a/migrations/inputs_icinga2/testcases/deprecated_object_type_duplicate/telegraf.conf
+++ b/migrations/inputs_icinga2/testcases/deprecated_object_type_duplicate/telegraf.conf
@@ -1,0 +1,28 @@
+# Gather Icinga2 status
+[[inputs.icinga2]]
+  ## Required Icinga2 server address
+  # server = "https://localhost:5665"
+
+  ## Collected Icinga2 objects ("services", "hosts")
+  ## Specify at least one object to collect from /v1/objects endpoint.
+  objects = ["services", "hosts"]
+  object_type = "hosts"
+
+  ## Collect metrics from /v1/status endpoint
+  ## Choose from:
+  ##     "ApiListener", "CIB", "IdoMysqlConnection", "IdoPgsqlConnection"
+  # status = []
+
+  ## Credentials for basic HTTP authentication
+  # username = "admin"
+  # password = "admin"
+
+  ## Maximum time to receive response.
+  # response_timeout = "5s"
+
+  ## Optional TLS Config
+  # tls_ca = "/etc/telegraf/ca.pem"
+  # tls_cert = "/etc/telegraf/cert.pem"
+  # tls_key = "/etc/telegraf/key.pem"
+  ## Use TLS but skip chain & host verification
+  # insecure_skip_verify = true

--- a/migrations/inputs_icinga2/testcases/deprecated_object_type_existing/expected.conf
+++ b/migrations/inputs_icinga2/testcases/deprecated_object_type_existing/expected.conf
@@ -1,0 +1,2 @@
+[[inputs.icinga2]]
+objects = ["services", "hosts"]

--- a/migrations/inputs_icinga2/testcases/deprecated_object_type_existing/telegraf.conf
+++ b/migrations/inputs_icinga2/testcases/deprecated_object_type_existing/telegraf.conf
@@ -1,0 +1,28 @@
+# Gather Icinga2 status
+[[inputs.icinga2]]
+  ## Required Icinga2 server address
+  # server = "https://localhost:5665"
+
+  ## Collected Icinga2 objects ("services", "hosts")
+  ## Specify at least one object to collect from /v1/objects endpoint.
+  objects = ["services"]
+  object_type = "hosts"
+
+  ## Collect metrics from /v1/status endpoint
+  ## Choose from:
+  ##     "ApiListener", "CIB", "IdoMysqlConnection", "IdoPgsqlConnection"
+  # status = []
+
+  ## Credentials for basic HTTP authentication
+  # username = "admin"
+  # password = "admin"
+
+  ## Maximum time to receive response.
+  # response_timeout = "5s"
+
+  ## Optional TLS Config
+  # tls_ca = "/etc/telegraf/ca.pem"
+  # tls_cert = "/etc/telegraf/cert.pem"
+  # tls_key = "/etc/telegraf/key.pem"
+  ## Use TLS but skip chain & host verification
+  # insecure_skip_verify = true

--- a/plugins/inputs/icinga2/icinga2.go
+++ b/plugins/inputs/icinga2/icinga2.go
@@ -27,7 +27,6 @@ type Icinga2 struct {
 	Server          string          `toml:"server"`
 	Objects         []string        `toml:"objects"`
 	Status          []string        `toml:"status"`
-	ObjectType      string          `toml:"object_type" deprecated:"1.26.0;1.35.0;use 'objects' instead"`
 	Username        string          `toml:"username"`
 	Password        string          `toml:"password"`
 	ResponseTimeout config.Duration `toml:"response_timeout"`
@@ -88,11 +87,6 @@ func (i *Icinga2) Init() error {
 		return err
 	}
 	i.client = client
-
-	// For backward config compatibility
-	if i.ObjectType != "" {
-		i.Objects = []string{i.ObjectType}
-	}
 
 	objectEndpoints := []string{"services", "hosts"}
 	if err := choice.CheckSlice(i.Objects, objectEndpoints); err != nil {

--- a/plugins/inputs/icinga2/icinga2_test.go
+++ b/plugins/inputs/icinga2/icinga2_test.go
@@ -27,24 +27,6 @@ func TestIcinga2Default(t *testing.T) {
 	require.Equal(t, []string{"services"}, icinga2.Objects)
 }
 
-func TestIcinga2DeprecatedHostConfig(t *testing.T) {
-	icinga2 := &Icinga2{
-		ObjectType: "hosts", // deprecated
-	}
-	require.NoError(t, icinga2.Init())
-
-	require.Equal(t, []string{"hosts"}, icinga2.Objects)
-}
-
-func TestIcinga2DeprecatedServicesConfig(t *testing.T) {
-	icinga2 := &Icinga2{
-		ObjectType: "services", // deprecated
-	}
-	require.NoError(t, icinga2.Init())
-
-	require.Equal(t, []string{"services"}, icinga2.Objects)
-}
-
 const icinga2ServiceResponse = `{
 	"results": [
 		{


### PR DESCRIPTION
## Summary

This PR migrates the `object_type` option of the plugin and removes the deprecated option.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #16923 
