### PR TITLE
feat(migrations): Add option migration for inputs.internet_speed

### DIFF
--- a/migrations/all/inputs_internet_speed.go
+++ b/migrations/all/inputs_internet_speed.go
@@ -1,0 +1,5 @@
+//go:build !custom || (migrations && (inputs || inputs.internet_speed))
+
+package all
+
+import _ "github.com/influxdata/telegraf/migrations/inputs_internet_speed" // register migration

--- a/migrations/inputs_internet_speed/migration.go
+++ b/migrations/inputs_internet_speed/migration.go
@@ -1,0 +1,63 @@
+package inputs_internet_speed
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/influxdata/toml"
+	"github.com/influxdata/toml/ast"
+
+	"github.com/influxdata/telegraf/migrations"
+)
+
+// Migration function
+func migrate(tbl *ast.Table) ([]byte, string, error) {
+	// Decode the old data structure
+	var plugin map[string]interface{}
+	if err := toml.UnmarshalTable(tbl, &plugin); err != nil {
+		return nil, "", err
+	}
+
+	// Check for deprecated option(s) and migrate them
+	var applied bool
+	if rawOldEnableFileDownload, found := plugin["enable_file_download"]; found {
+		applied = true
+
+		// Convert the options to the actual type
+		oldEnableFileDownload, ok := rawOldEnableFileDownload.(bool)
+		if !ok {
+			return nil, "", fmt.Errorf("unexpected type %T for 'enable_file_download'", rawOldEnableFileDownload)
+		}
+
+		// Merge the option with the replacement
+		if rawNewMemorySavingMode, found := plugin["memory_saving_mode"]; found {
+			if newMemorySavingMode, ok := rawNewMemorySavingMode.(bool); !ok {
+				return nil, "", fmt.Errorf("unexpected type %T for 'memory_saving_mode'", rawNewMemorySavingMode)
+			} else if newMemorySavingMode != oldEnableFileDownload {
+				return nil, "", errors.New("contradicting setting for 'enable_file_download' and 'memory_saving_mode'")
+			}
+		} else if oldEnableFileDownload {
+			plugin["memory_saving_mode"] = true
+		}
+
+		// Remove the deprecated option and replace the modified one
+		delete(plugin, "enable_file_download")
+	}
+
+	// No options migrated so we can exit early
+	if !applied {
+		return nil, "", migrations.ErrNotApplicable
+	}
+
+	// Create the corresponding plugin configurations
+	cfg := migrations.CreateTOMLStruct("inputs", "internet_speed")
+	cfg.Add("inputs", "internet_speed", plugin)
+
+	output, err := toml.Marshal(cfg)
+	return output, "", err
+}
+
+// Register the migration function for the plugin type
+func init() {
+	migrations.AddPluginOptionMigration("inputs.internet_speed", migrate)
+}

--- a/migrations/inputs_internet_speed/migration_test.go
+++ b/migrations/inputs_internet_speed/migration_test.go
@@ -1,0 +1,86 @@
+package inputs_internet_speed_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/influxdata/telegraf/config"
+	_ "github.com/influxdata/telegraf/migrations/inputs_internet_speed" // register migration
+	"github.com/influxdata/telegraf/plugins/inputs/internet_speed"      // register plugin
+)
+
+func TestNoMigration(t *testing.T) {
+	plugin := &internet_speed.InternetSpeed{}
+	defaultCfg := plugin.SampleConfig()
+
+	// Migrate and check that nothing changed
+	output, n, err := config.ApplyMigrations([]byte(defaultCfg))
+	require.NoError(t, err)
+	require.NotEmpty(t, output)
+	require.Zero(t, n)
+	require.Equal(t, defaultCfg, string(output))
+}
+
+func TestEnableFileDownloadConflict(t *testing.T) {
+	cfg := []byte(`
+		[[inputs.internet_speed]]
+		memory_saving_mode = true
+		enable_file_download = false
+	`)
+
+	// Migrate and check that nothing changed
+	output, n, err := config.ApplyMigrations(cfg)
+	require.ErrorContains(t, err, "contradicting setting for 'enable_file_download' and 'memory_saving_mode'")
+	require.Empty(t, output)
+	require.Zero(t, n)
+}
+func TestCases(t *testing.T) {
+	// Get all directories in testdata
+	folders, err := os.ReadDir("testcases")
+	require.NoError(t, err)
+
+	for _, f := range folders {
+		// Only handle folders
+		if !f.IsDir() {
+			continue
+		}
+
+		t.Run(f.Name(), func(t *testing.T) {
+			testcasePath := filepath.Join("testcases", f.Name())
+			inputFile := filepath.Join(testcasePath, "telegraf.conf")
+			expectedFile := filepath.Join(testcasePath, "expected.conf")
+
+			// Read the expected output
+			expected := config.NewConfig()
+			require.NoError(t, expected.LoadConfig(expectedFile))
+			require.NotEmpty(t, expected.Inputs)
+
+			// Read the input data
+			input, remote, err := config.LoadConfigFile(inputFile)
+			require.NoError(t, err)
+			require.False(t, remote)
+			require.NotEmpty(t, input)
+
+			// Migrate
+			output, n, err := config.ApplyMigrations(input)
+			require.NoError(t, err)
+			require.NotEmpty(t, output)
+			require.GreaterOrEqual(t, n, uint64(1))
+			actual := config.NewConfig()
+			require.NoError(t, actual.LoadConfigData(output, config.EmptySourcePath))
+
+			// Test the output
+			require.Len(t, actual.Inputs, len(expected.Inputs))
+			actualIDs := make([]string, 0, len(expected.Inputs))
+			expectedIDs := make([]string, 0, len(expected.Inputs))
+			for i := range actual.Inputs {
+				actualIDs = append(actualIDs, actual.Inputs[i].ID())
+				expectedIDs = append(expectedIDs, expected.Inputs[i].ID())
+			}
+			require.ElementsMatch(t, expectedIDs, actualIDs, string(output))
+		})
+	}
+}

--- a/migrations/inputs_internet_speed/testcases/deprecated_enable_file_download/expected.conf
+++ b/migrations/inputs_internet_speed/testcases/deprecated_enable_file_download/expected.conf
@@ -1,0 +1,2 @@
+[[inputs.internet_speed]]
+memory_saving_mode = true

--- a/migrations/inputs_internet_speed/testcases/deprecated_enable_file_download/telegraf.conf
+++ b/migrations/inputs_internet_speed/testcases/deprecated_enable_file_download/telegraf.conf
@@ -1,0 +1,37 @@
+# Monitors internet speed using speedtest.net service
+[[inputs.internet_speed]]
+  ## This plugin downloads many MB of data each time it is run. As such
+  ## consider setting a higher interval for this plugin to reduce the
+  ## demand on your internet connection.
+  # interval = "60m"
+
+  ## Enable to reduce memory usage
+  # memory_saving_mode = false
+  enable_file_download = true
+
+  ## Caches the closest server location
+  # cache = false
+
+  ## Number of concurrent connections
+  ## By default or set to zero, the number of CPU cores is used. Use this to
+  ## reduce the impact on system performance or to increase the connections on
+  ## faster connections to ensure the fastest speed.
+  # connections = 0
+
+  ## Test mode
+  ## By default, a single sever is used for testing. This may work for most,
+  ## however, setting to "multi" will reach out to multiple servers in an
+  ## attempt to get closer to ideal internet speeds.
+  ## And "multi" will use all available servers to calculate average packet loss.
+  # test_mode = "single"
+
+  ## Server ID exclude filter
+  ## Allows the user to exclude or include specific server IDs received by
+  ## speedtest-go. Values in the exclude option will be skipped over. Values in
+  ## the include option are the only options that will be picked from.
+  ##
+  ## See the list of servers speedtest-go will return at:
+  ##     https://www.speedtest.net/api/js/servers?engine=js&limit=10
+  ##
+  # server_id_exclude = []
+  # server_id_include = []

--- a/migrations/inputs_internet_speed/testcases/deprecated_enable_file_download_existing/expected.conf
+++ b/migrations/inputs_internet_speed/testcases/deprecated_enable_file_download_existing/expected.conf
@@ -1,0 +1,2 @@
+[[inputs.internet_speed]]
+memory_saving_mode = true

--- a/migrations/inputs_internet_speed/testcases/deprecated_enable_file_download_existing/telegraf.conf
+++ b/migrations/inputs_internet_speed/testcases/deprecated_enable_file_download_existing/telegraf.conf
@@ -1,0 +1,37 @@
+# Monitors internet speed using speedtest.net service
+[[inputs.internet_speed]]
+  ## This plugin downloads many MB of data each time it is run. As such
+  ## consider setting a higher interval for this plugin to reduce the
+  ## demand on your internet connection.
+  # interval = "60m"
+
+  ## Enable to reduce memory usage
+  memory_saving_mode = true
+  enable_file_download = true
+
+  ## Caches the closest server location
+  # cache = false
+
+  ## Number of concurrent connections
+  ## By default or set to zero, the number of CPU cores is used. Use this to
+  ## reduce the impact on system performance or to increase the connections on
+  ## faster connections to ensure the fastest speed.
+  # connections = 0
+
+  ## Test mode
+  ## By default, a single sever is used for testing. This may work for most,
+  ## however, setting to "multi" will reach out to multiple servers in an
+  ## attempt to get closer to ideal internet speeds.
+  ## And "multi" will use all available servers to calculate average packet loss.
+  # test_mode = "single"
+
+  ## Server ID exclude filter
+  ## Allows the user to exclude or include specific server IDs received by
+  ## speedtest-go. Values in the exclude option will be skipped over. Values in
+  ## the include option are the only options that will be picked from.
+  ##
+  ## See the list of servers speedtest-go will return at:
+  ##     https://www.speedtest.net/api/js/servers?engine=js&limit=10
+  ##
+  # server_id_exclude = []
+  # server_id_include = []

--- a/migrations/inputs_internet_speed/testcases/deprecated_enable_file_download_false/expected.conf
+++ b/migrations/inputs_internet_speed/testcases/deprecated_enable_file_download_false/expected.conf
@@ -1,0 +1,1 @@
+[[inputs.internet_speed]]

--- a/migrations/inputs_internet_speed/testcases/deprecated_enable_file_download_false/telegraf.conf
+++ b/migrations/inputs_internet_speed/testcases/deprecated_enable_file_download_false/telegraf.conf
@@ -1,0 +1,37 @@
+# Monitors internet speed using speedtest.net service
+[[inputs.internet_speed]]
+  ## This plugin downloads many MB of data each time it is run. As such
+  ## consider setting a higher interval for this plugin to reduce the
+  ## demand on your internet connection.
+  # interval = "60m"
+
+  ## Enable to reduce memory usage
+  # memory_saving_mode = false
+  enable_file_download = false
+
+  ## Caches the closest server location
+  # cache = false
+
+  ## Number of concurrent connections
+  ## By default or set to zero, the number of CPU cores is used. Use this to
+  ## reduce the impact on system performance or to increase the connections on
+  ## faster connections to ensure the fastest speed.
+  # connections = 0
+
+  ## Test mode
+  ## By default, a single sever is used for testing. This may work for most,
+  ## however, setting to "multi" will reach out to multiple servers in an
+  ## attempt to get closer to ideal internet speeds.
+  ## And "multi" will use all available servers to calculate average packet loss.
+  # test_mode = "single"
+
+  ## Server ID exclude filter
+  ## Allows the user to exclude or include specific server IDs received by
+  ## speedtest-go. Values in the exclude option will be skipped over. Values in
+  ## the include option are the only options that will be picked from.
+  ##
+  ## See the list of servers speedtest-go will return at:
+  ##     https://www.speedtest.net/api/js/servers?engine=js&limit=10
+  ##
+  # server_id_exclude = []
+  # server_id_include = []

--- a/plugins/inputs/internet_speed/internet_speed.go
+++ b/plugins/inputs/internet_speed/internet_speed.go
@@ -29,13 +29,12 @@ const (
 )
 
 type InternetSpeed struct {
-	ServerIDInclude    []string `toml:"server_id_include"`
-	ServerIDExclude    []string `toml:"server_id_exclude"`
-	EnableFileDownload bool     `toml:"enable_file_download" deprecated:"1.25.0;1.35.0;use 'memory_saving_mode' instead"`
-	MemorySavingMode   bool     `toml:"memory_saving_mode"`
-	Cache              bool     `toml:"cache"`
-	Connections        int      `toml:"connections"`
-	TestMode           string   `toml:"test_mode"`
+	ServerIDInclude  []string `toml:"server_id_include"`
+	ServerIDExclude  []string `toml:"server_id_exclude"`
+	MemorySavingMode bool     `toml:"memory_saving_mode"`
+	Cache            bool     `toml:"cache"`
+	Connections      int      `toml:"connections"`
+	TestMode         string   `toml:"test_mode"`
 
 	Log telegraf.Logger `toml:"-"`
 
@@ -56,8 +55,6 @@ func (is *InternetSpeed) Init() error {
 	default:
 		return fmt.Errorf("unrecognized test mode: %q", is.TestMode)
 	}
-
-	is.MemorySavingMode = is.MemorySavingMode || is.EnableFileDownload
 
 	var err error
 	is.serverFilter, err = filter.NewIncludeExcludeFilterDefaults(is.ServerIDInclude, is.ServerIDExclude, false, false)


### PR DESCRIPTION
## Summary

This PR migrates the `enable_file_download` option of the plugin and removes the deprecated option.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #16925 
