### PR TITLE
feat(migrations): Add option migration for inputs.nsq_consumer

### DIFF
--- a/migrations/all/inputs_nsq_consumer.go
+++ b/migrations/all/inputs_nsq_consumer.go
@@ -1,0 +1,5 @@
+//go:build !custom || (migrations && (inputs || inputs.nsq_consumer))
+
+package all
+
+import _ "github.com/influxdata/telegraf/migrations/inputs_nsq_consumer" // register migration

--- a/migrations/inputs_nsq_consumer/migration.go
+++ b/migrations/inputs_nsq_consumer/migration.go
@@ -1,0 +1,67 @@
+package inputs_nsq_consumer
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/influxdata/toml"
+	"github.com/influxdata/toml/ast"
+
+	"github.com/influxdata/telegraf/migrations"
+)
+
+// Migration function
+func migrate(tbl *ast.Table) ([]byte, string, error) {
+	// Decode the old data structure
+	var plugin map[string]interface{}
+	if err := toml.UnmarshalTable(tbl, &plugin); err != nil {
+		return nil, "", err
+	}
+
+	// Check for deprecated option(s) and migrate them
+	var applied bool
+	if rawOldServer, found := plugin["server"]; found {
+		applied = true
+
+		// Convert the options to the actual type
+		oldServer, ok := rawOldServer.(string)
+		if !ok {
+			return nil, "", fmt.Errorf("unexpected type %T for 'server'", rawOldServer)
+		}
+
+		// Merge the option with the replacement
+		var nsqd []string
+		if rawNewNSQD, found := plugin["nsqd"]; found {
+			var err error
+			nsqd, err = migrations.AsStringSlice(rawNewNSQD)
+			if err != nil {
+				return nil, "", fmt.Errorf("'nsqd' option: %w", err)
+			}
+		}
+
+		if !slices.Contains(nsqd, oldServer) {
+			nsqd = append(nsqd, oldServer)
+		}
+
+		// Remove the deprecated option and replace the modified one
+		plugin["nsqd"] = nsqd
+		delete(plugin, "server")
+	}
+
+	// No options migrated so we can exit early
+	if !applied {
+		return nil, "", migrations.ErrNotApplicable
+	}
+
+	// Create the corresponding plugin configurations
+	cfg := migrations.CreateTOMLStruct("inputs", "nsq_consumer")
+	cfg.Add("inputs", "nsq_consumer", plugin)
+
+	output, err := toml.Marshal(cfg)
+	return output, "", err
+}
+
+// Register the migration function for the plugin type
+func init() {
+	migrations.AddPluginOptionMigration("inputs.nsq_consumer", migrate)
+}

--- a/migrations/inputs_nsq_consumer/migration_test.go
+++ b/migrations/inputs_nsq_consumer/migration_test.go
@@ -1,0 +1,74 @@
+package inputs_nsq_consumer_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/influxdata/telegraf/config"
+	_ "github.com/influxdata/telegraf/migrations/inputs_nsq_consumer" // register migration
+	"github.com/influxdata/telegraf/plugins/inputs/nsq_consumer"      // register plugin
+	_ "github.com/influxdata/telegraf/plugins/parsers/influx"         // register parser
+)
+
+func TestNoMigration(t *testing.T) {
+	plugin := &nsq_consumer.NSQConsumer{}
+	defaultCfg := plugin.SampleConfig()
+
+	// Migrate and check that nothing changed
+	output, n, err := config.ApplyMigrations([]byte(defaultCfg))
+	require.NoError(t, err)
+	require.NotEmpty(t, output)
+	require.Zero(t, n)
+	require.Equal(t, defaultCfg, string(output))
+}
+
+func TestCases(t *testing.T) {
+	// Get all directories in testdata
+	folders, err := os.ReadDir("testcases")
+	require.NoError(t, err)
+
+	for _, f := range folders {
+		// Only handle folders
+		if !f.IsDir() {
+			continue
+		}
+
+		t.Run(f.Name(), func(t *testing.T) {
+			testcasePath := filepath.Join("testcases", f.Name())
+			inputFile := filepath.Join(testcasePath, "telegraf.conf")
+			expectedFile := filepath.Join(testcasePath, "expected.conf")
+
+			// Read the expected output
+			expected := config.NewConfig()
+			require.NoError(t, expected.LoadConfig(expectedFile))
+			require.NotEmpty(t, expected.Inputs)
+
+			// Read the input data
+			input, remote, err := config.LoadConfigFile(inputFile)
+			require.NoError(t, err)
+			require.False(t, remote)
+			require.NotEmpty(t, input)
+
+			// Migrate
+			output, n, err := config.ApplyMigrations(input)
+			require.NoError(t, err)
+			require.NotEmpty(t, output)
+			require.GreaterOrEqual(t, n, uint64(1))
+			actual := config.NewConfig()
+			require.NoError(t, actual.LoadConfigData(output, config.EmptySourcePath))
+
+			// Test the output
+			require.Len(t, actual.Inputs, len(expected.Inputs))
+			actualIDs := make([]string, 0, len(expected.Inputs))
+			expectedIDs := make([]string, 0, len(expected.Inputs))
+			for i := range actual.Inputs {
+				actualIDs = append(actualIDs, actual.Inputs[i].ID())
+				expectedIDs = append(expectedIDs, expected.Inputs[i].ID())
+			}
+			require.ElementsMatch(t, expectedIDs, actualIDs, string(output))
+		})
+	}
+}

--- a/migrations/inputs_nsq_consumer/testcases/deprecated_server/expected.conf
+++ b/migrations/inputs_nsq_consumer/testcases/deprecated_server/expected.conf
@@ -1,0 +1,7 @@
+[[inputs.nsq_consumer]]
+nsqd = ["myserver:4150"]
+nsqlookupd = ["localhost:4161"]
+topic = "telegraf"
+channel = "consumer"
+max_in_flight = 100
+data_format = "influx"

--- a/migrations/inputs_nsq_consumer/testcases/deprecated_server/telegraf.conf
+++ b/migrations/inputs_nsq_consumer/testcases/deprecated_server/telegraf.conf
@@ -1,0 +1,29 @@
+# Read metrics from NSQD topic(s)
+[[inputs.nsq_consumer]]
+  ## An array representing the NSQD TCP HTTP Endpoints
+  # nsqd = ["localhost:4150"]
+  server = "myserver:4150"
+
+  ## An array representing the NSQLookupd HTTP Endpoints
+  nsqlookupd = ["localhost:4161"]
+  topic = "telegraf"
+  channel = "consumer"
+  max_in_flight = 100
+
+  ## Max undelivered messages
+  ## This plugin uses tracking metrics, which ensure messages are read to
+  ## outputs before acknowledging them to the original broker to ensure data
+  ## is not lost. This option sets the maximum messages to read from the
+  ## broker that have not been written by an output.
+  ##
+  ## This value needs to be picked with awareness of the agent's
+  ## metric_batch_size value as well. Setting max undelivered messages too high
+  ## can result in a constant stream of data batches to the output. While
+  ## setting it too low may never flush the broker's messages.
+  # max_undelivered_messages = 1000
+
+  ## Data format to consume.
+  ## Each data format has its own unique set of configuration options, read
+  ## more about them here:
+  ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_INPUT.md
+  data_format = "influx"

--- a/migrations/inputs_nsq_consumer/testcases/deprecated_server_duplicate/expected.conf
+++ b/migrations/inputs_nsq_consumer/testcases/deprecated_server_duplicate/expected.conf
@@ -1,0 +1,7 @@
+[[inputs.nsq_consumer]]
+nsqd = ["localhost:4150", "myserver:4150"]
+nsqlookupd = ["localhost:4161"]
+topic = "telegraf"
+channel = "consumer"
+max_in_flight = 100
+data_format = "influx"

--- a/migrations/inputs_nsq_consumer/testcases/deprecated_server_duplicate/telegraf.conf
+++ b/migrations/inputs_nsq_consumer/testcases/deprecated_server_duplicate/telegraf.conf
@@ -1,0 +1,29 @@
+# Read metrics from NSQD topic(s)
+[[inputs.nsq_consumer]]
+  ## An array representing the NSQD TCP HTTP Endpoints
+  nsqd = ["localhost:4150", "myserver:4150"]
+  server = "myserver:4150"
+
+  ## An array representing the NSQLookupd HTTP Endpoints
+  nsqlookupd = ["localhost:4161"]
+  topic = "telegraf"
+  channel = "consumer"
+  max_in_flight = 100
+
+  ## Max undelivered messages
+  ## This plugin uses tracking metrics, which ensure messages are read to
+  ## outputs before acknowledging them to the original broker to ensure data
+  ## is not lost. This option sets the maximum messages to read from the
+  ## broker that have not been written by an output.
+  ##
+  ## This value needs to be picked with awareness of the agent's
+  ## metric_batch_size value as well. Setting max undelivered messages too high
+  ## can result in a constant stream of data batches to the output. While
+  ## setting it too low may never flush the broker's messages.
+  # max_undelivered_messages = 1000
+
+  ## Data format to consume.
+  ## Each data format has its own unique set of configuration options, read
+  ## more about them here:
+  ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_INPUT.md
+  data_format = "influx"

--- a/migrations/inputs_nsq_consumer/testcases/deprecated_server_existing/expected.conf
+++ b/migrations/inputs_nsq_consumer/testcases/deprecated_server_existing/expected.conf
@@ -1,0 +1,7 @@
+[[inputs.nsq_consumer]]
+nsqd = ["localhost:4150", "myserver:4150"]
+nsqlookupd = ["localhost:4161"]
+topic = "telegraf"
+channel = "consumer"
+max_in_flight = 100
+data_format = "influx"

--- a/migrations/inputs_nsq_consumer/testcases/deprecated_server_existing/telegraf.conf
+++ b/migrations/inputs_nsq_consumer/testcases/deprecated_server_existing/telegraf.conf
@@ -1,0 +1,29 @@
+# Read metrics from NSQD topic(s)
+[[inputs.nsq_consumer]]
+  ## An array representing the NSQD TCP HTTP Endpoints
+  nsqd = ["localhost:4150"]
+  server = "myserver:4150"
+
+  ## An array representing the NSQLookupd HTTP Endpoints
+  nsqlookupd = ["localhost:4161"]
+  topic = "telegraf"
+  channel = "consumer"
+  max_in_flight = 100
+
+  ## Max undelivered messages
+  ## This plugin uses tracking metrics, which ensure messages are read to
+  ## outputs before acknowledging them to the original broker to ensure data
+  ## is not lost. This option sets the maximum messages to read from the
+  ## broker that have not been written by an output.
+  ##
+  ## This value needs to be picked with awareness of the agent's
+  ## metric_batch_size value as well. Setting max undelivered messages too high
+  ## can result in a constant stream of data batches to the output. While
+  ## setting it too low may never flush the broker's messages.
+  # max_undelivered_messages = 1000
+
+  ## Data format to consume.
+  ## Each data format has its own unique set of configuration options, read
+  ## more about them here:
+  ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_INPUT.md
+  data_format = "influx"

--- a/plugins/inputs/nsq_consumer/nsq_consumer.go
+++ b/plugins/inputs/nsq_consumer/nsq_consumer.go
@@ -21,7 +21,6 @@ const (
 )
 
 type NSQConsumer struct {
-	Server                 string          `toml:"server" deprecated:"1.5.0;1.35.0;use 'nsqd' instead"`
 	Nsqd                   []string        `toml:"nsqd"`
 	Nsqlookupd             []string        `toml:"nsqlookupd"`
 	Topic                  string          `toml:"topic"`
@@ -59,11 +58,6 @@ func (*NSQConsumer) SampleConfig() string {
 }
 
 func (n *NSQConsumer) Init() error {
-	// For backward compatibility
-	if n.Server != "" {
-		n.Nsqd = append(n.Nsqd, n.Server)
-	}
-
 	// Check if we have anything to connect to
 	if len(n.Nsqlookupd) == 0 && len(n.Nsqd) == 0 {
 		return errors.New("either 'nsqd' or 'nsqlookupd' needs to be specified")


### PR DESCRIPTION
## Summary
This PR migrates the `server` option of the plugin and removes the deprecated option.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #16928 
