### PR TITLE
feat(migrations): Add option migration for inputs.vsphere

### DIFF
--- a/migrations/all/inputs_vsphere.go
+++ b/migrations/all/inputs_vsphere.go
@@ -1,0 +1,5 @@
+//go:build !custom || (migrations && (inputs || inputs.vsphere))
+
+package all
+
+import _ "github.com/influxdata/telegraf/migrations/inputs_vsphere" // register migration

--- a/migrations/inputs_vsphere/migration.go
+++ b/migrations/inputs_vsphere/migration.go
@@ -1,0 +1,43 @@
+package inputs_vsphere
+
+import (
+	"github.com/influxdata/toml"
+	"github.com/influxdata/toml/ast"
+
+	"github.com/influxdata/telegraf/migrations"
+)
+
+// Migration function
+func migrate(tbl *ast.Table) ([]byte, string, error) {
+	// Decode the old data structure
+	var plugin map[string]interface{}
+	if err := toml.UnmarshalTable(tbl, &plugin); err != nil {
+		return nil, "", err
+	}
+
+	// Check for deprecated option(s) and migrate them
+	var applied bool
+	if _, found := plugin["force_discover_on_init"]; found {
+		applied = true
+
+		// Remove the deprecated option as it is ignored in the code
+		delete(plugin, "force_discover_on_init")
+	}
+
+	// No options migrated so we can exit early
+	if !applied {
+		return nil, "", migrations.ErrNotApplicable
+	}
+
+	// Create the corresponding plugin configurations
+	cfg := migrations.CreateTOMLStruct("inputs", "vsphere")
+	cfg.Add("inputs", "vsphere", plugin)
+
+	output, err := toml.Marshal(cfg)
+	return output, "", err
+}
+
+// Register the migration function for the plugin type
+func init() {
+	migrations.AddPluginOptionMigration("inputs.vsphere", migrate)
+}

--- a/migrations/inputs_vsphere/migration_test.go
+++ b/migrations/inputs_vsphere/migration_test.go
@@ -1,0 +1,73 @@
+package inputs_vsphere_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/influxdata/telegraf/config"
+	_ "github.com/influxdata/telegraf/migrations/inputs_vsphere" // register migration
+	"github.com/influxdata/telegraf/plugins/inputs/vsphere"      // register plugin
+)
+
+func TestNoMigration(t *testing.T) {
+	plugin := &vsphere.VSphere{}
+	defaultCfg := plugin.SampleConfig()
+
+	// Migrate and check that nothing changed
+	output, n, err := config.ApplyMigrations([]byte(defaultCfg))
+	require.NoError(t, err)
+	require.NotEmpty(t, output)
+	require.Zero(t, n)
+	require.Equal(t, defaultCfg, string(output))
+}
+
+func TestCases(t *testing.T) {
+	// Get all directories in testdata
+	folders, err := os.ReadDir("testcases")
+	require.NoError(t, err)
+
+	for _, f := range folders {
+		// Only handle folders
+		if !f.IsDir() {
+			continue
+		}
+
+		t.Run(f.Name(), func(t *testing.T) {
+			testcasePath := filepath.Join("testcases", f.Name())
+			inputFile := filepath.Join(testcasePath, "telegraf.conf")
+			expectedFile := filepath.Join(testcasePath, "expected.conf")
+
+			// Read the expected output
+			expected := config.NewConfig()
+			require.NoError(t, expected.LoadConfig(expectedFile))
+			require.NotEmpty(t, expected.Inputs)
+
+			// Read the input data
+			input, remote, err := config.LoadConfigFile(inputFile)
+			require.NoError(t, err)
+			require.False(t, remote)
+			require.NotEmpty(t, input)
+
+			// Migrate
+			output, n, err := config.ApplyMigrations(input)
+			require.NoError(t, err)
+			require.NotEmpty(t, output)
+			require.GreaterOrEqual(t, n, uint64(1))
+			actual := config.NewConfig()
+			require.NoError(t, actual.LoadConfigData(output, config.EmptySourcePath))
+
+			// Test the output
+			require.Len(t, actual.Inputs, len(expected.Inputs))
+			actualIDs := make([]string, 0, len(expected.Inputs))
+			expectedIDs := make([]string, 0, len(expected.Inputs))
+			for i := range actual.Inputs {
+				actualIDs = append(actualIDs, actual.Inputs[i].ID())
+				expectedIDs = append(expectedIDs, expected.Inputs[i].ID())
+			}
+			require.ElementsMatch(t, expectedIDs, actualIDs, string(output))
+		})
+	}
+}

--- a/migrations/inputs_vsphere/testcases/deprecated_force_discover_on_init/expected.conf
+++ b/migrations/inputs_vsphere/testcases/deprecated_force_discover_on_init/expected.conf
@@ -1,0 +1,6 @@
+[[inputs.vsphere]]
+host_metric_include = ["*"]
+password = "secret"
+username = "user@corp.local"
+vcenters = ["https://vcenter.local/sdk"]
+vm_metric_include = ["*"]

--- a/migrations/inputs_vsphere/testcases/deprecated_force_discover_on_init/telegraf.conf
+++ b/migrations/inputs_vsphere/testcases/deprecated_force_discover_on_init/telegraf.conf
@@ -1,0 +1,135 @@
+# Read metrics from one or many vCenters
+[[inputs.vsphere]]
+  ## List of vCenter URLs to be monitored. These three lines must be uncommented
+  ## and edited for the plugin to work.
+  vcenters = [ "https://vcenter.local/sdk" ]
+  username = "user@corp.local"
+  password = "secret"
+
+  ## VMs
+  ## Typical VM metrics (if omitted or empty, all metrics are collected)
+  # vm_include = [ "/*/vm/**"] # Inventory path to VMs to collect (by default all are collected)
+  # vm_exclude = [] # Inventory paths to exclude
+  vm_metric_include = ["*"]
+  # vm_metric_exclude = [] ## Nothing is excluded by default
+  # vm_instances = true ## true by default
+
+  ## Hosts
+  ## Typical host metrics (if omitted or empty, all metrics are collected)
+  # host_include = [ "/*/host/**"] # Inventory path to hosts to collect (by default all are collected)
+  # host_exclude [] # Inventory paths to exclude
+  host_metric_include = ["*"]
+    ## Collect IP addresses? Valid values are "ipv4" and "ipv6"
+  # ip_addresses = ["ipv6", "ipv4" ]
+
+  # host_metric_exclude = [] ## Nothing excluded by default
+  # host_instances = true ## true by default
+
+
+  ## Clusters
+  # cluster_include = [ "/*/host/**"] # Inventory path to clusters to collect (by default all are collected)
+  # cluster_exclude = [] # Inventory paths to exclude
+  # cluster_metric_include = [] ## if omitted or empty, all metrics are collected
+  # cluster_metric_exclude = [] ## Nothing excluded by default
+  # cluster_instances = false ## false by default
+
+  ## Resource Pools
+  # resource_pool_include = [ "/*/host/**"] # Inventory path to resource pools to collect (by default all are collected)
+  # resource_pool_exclude = [] # Inventory paths to exclude
+  # resource_pool_metric_include = [] ## if omitted or empty, all metrics are collected
+  # resource_pool_metric_exclude = [] ## Nothing excluded by default
+  # resource_pool_instances = false ## false by default
+
+  ## Datastores
+  # datastore_include = [ "/*/datastore/**"] # Inventory path to datastores to collect (by default all are collected)
+  # datastore_exclude = [] # Inventory paths to exclude
+  # datastore_metric_include = [] ## if omitted or empty, all metrics are collected
+  # datastore_metric_exclude = [] ## Nothing excluded by default
+  # datastore_instances = false ## false by default
+
+  ## Datacenters
+  # datacenter_include = [ "/*/host/**"] # Inventory path to clusters to collect (by default all are collected)
+  # datacenter_exclude = [] # Inventory paths to exclude
+  # datacenter_metric_include = [] ## if omitted or empty, all metrics are collected
+  # datacenter_metric_exclude = [ "*" ] ## Datacenters are not collected by default.
+  # datacenter_instances = false ## false by default
+
+  ## VSAN
+  # vsan_metric_include = [] ## if omitted or empty, all metrics are collected
+  # vsan_metric_exclude = [ "*" ] ## vSAN are not collected by default.
+  ## Whether to skip verifying vSAN metrics against the ones from GetSupportedEntityTypes API.
+  # vsan_metric_skip_verify = false ## false by default.
+
+  ## Interval for sampling vSAN performance metrics, can be reduced down to
+  ## 30 seconds for vSAN 8 U1.
+  # vsan_interval = "5m"
+
+  ## Plugin Settings
+  ## separator character to use for measurement and field names (default: "_")
+  # separator = "_"
+
+  ## number of objects to retrieve per query for realtime resources (vms and hosts)
+  ## set to 64 for vCenter 5.5 and 6.0 (default: 256)
+  # max_query_objects = 256
+
+  ## number of metrics to retrieve per query for non-realtime resources (clusters and datastores)
+  ## set to 64 for vCenter 5.5 and 6.0 (default: 256)
+  # max_query_metrics = 256
+
+  ## number of go routines to use for collection and discovery of objects and metrics
+  # collect_concurrency = 1
+  # discover_concurrency = 1
+
+  ## the interval before (re)discovering objects subject to metrics collection (default: 300s)
+  # object_discovery_interval = "300s"
+
+  ## timeout applies to any of the api request made to vcenter
+  # timeout = "60s"
+
+  ## When set to true, all samples are sent as integers. This makes the output
+  ## data types backwards compatible with Telegraf 1.9 or lower. Normally all
+  ## samples from vCenter, with the exception of percentages, are integer
+  ## values, but under some conditions, some averaging takes place internally in
+  ## the plugin. Setting this flag to "false" will send values as floats to
+  ## preserve the full precision when averaging takes place.
+  # use_int_samples = true
+
+  ## Custom attributes from vCenter can be very useful for queries in order to slice the
+  ## metrics along different dimension and for forming ad-hoc relationships. They are disabled
+  ## by default, since they can add a considerable amount of tags to the resulting metrics. To
+  ## enable, simply set custom_attribute_exclude to [] (empty set) and use custom_attribute_include
+  ## to select the attributes you want to include.
+  ## By default, since they can add a considerable amount of tags to the resulting metrics. To
+  ## enable, simply set custom_attribute_exclude to [] (empty set) and use custom_attribute_include
+  ## to select the attributes you want to include.
+  # custom_attribute_include = []
+  # custom_attribute_exclude = ["*"]
+
+  ## The number of vSphere 5 minute metric collection cycles to look back for non-realtime metrics. In
+  ## some versions (6.7, 7.0 and possible more), certain metrics, such as cluster metrics, may be reported
+  ## with a significant delay (>30min). If this happens, try increasing this number. Please note that increasing
+  ## it too much may cause performance issues.
+  # metric_lookback = 3
+
+  ## Optional SSL Config
+  # ssl_ca = "/path/to/cafile"
+  # ssl_cert = "/path/to/certfile"
+  # ssl_key = "/path/to/keyfile"
+  ## Use SSL but skip chain & host verification
+  # insecure_skip_verify = false
+
+  ## The Historical Interval value must match EXACTLY the interval in the daily
+  # "Interval Duration" found on the VCenter server under Configure > General > Statistics > Statistic intervals
+  # historical_interval = "5m"
+
+  ## Specifies plugin behavior regarding disconnected servers
+  ## Available choices :
+  ##   - error: telegraf will return an error on startup if one the servers is unreachable
+  ##   - ignore: telegraf will ignore unreachable servers on both startup and gather
+  # disconnected_servers_behavior = "error"
+
+  ## HTTP Proxy support
+  # use_system_proxy = true
+  # http_proxy_url = ""
+
+  force_discover_on_init = true

--- a/plugins/inputs/vsphere/vsphere.go
+++ b/plugins/inputs/vsphere/vsphere.go
@@ -70,7 +70,6 @@ type VSphere struct {
 	MaxQueryMetrics             int             `toml:"max_query_metrics"`
 	CollectConcurrency          int             `toml:"collect_concurrency"`
 	DiscoverConcurrency         int             `toml:"discover_concurrency"`
-	ForceDiscoverOnInit         bool            `toml:"force_discover_on_init" deprecated:"1.14.0;1.35.0;option is ignored"`
 	ObjectDiscoveryInterval     config.Duration `toml:"object_discovery_interval"`
 	Timeout                     config.Duration `toml:"timeout"`
 	HistoricalInterval          config.Duration `toml:"historical_interval"`
@@ -169,7 +168,6 @@ func init() {
 			CollectConcurrency:          1,
 			DiscoverConcurrency:         1,
 			MetricLookback:              3,
-			ForceDiscoverOnInit:         true,
 			ObjectDiscoveryInterval:     config.Duration(time.Second * 300),
 			Timeout:                     config.Duration(time.Second * 60),
 			HistoricalInterval:          config.Duration(time.Second * 300),

--- a/plugins/inputs/vsphere/vsphere_test.go
+++ b/plugins/inputs/vsphere/vsphere_test.go
@@ -135,7 +135,6 @@ func defaultVSphere() *VSphere {
 		MaxQueryMetrics:         256,
 		ObjectDiscoveryInterval: config.Duration(time.Second * 300),
 		Timeout:                 config.Duration(time.Second * 20),
-		ForceDiscoverOnInit:     true,
 		DiscoverConcurrency:     1,
 		CollectConcurrency:      1,
 		Separator:               ".",


### PR DESCRIPTION
## Summary

This PR migrates the `force_discover_on_init` option of the plugin and removes the deprecated option.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #16935
