### PR TITLE
feat(migrations): Add option migration for inputs.statsd

### DIFF
--- a/migrations/all/inputs_statsd.go
+++ b/migrations/all/inputs_statsd.go
@@ -1,0 +1,5 @@
+//go:build !custom || (migrations && (inputs || inputs.cassandra))
+
+package all
+
+import _ "github.com/influxdata/telegraf/migrations/inputs_cassandra" // register migration

--- a/migrations/all/inputs_statsd.go
+++ b/migrations/all/inputs_statsd.go
@@ -2,4 +2,4 @@
 
 package all
 
-import _ "github.com/influxdata/telegraf/migrations/inputs_cassandra" // register migration
+import _ "github.com/influxdata/telegraf/migrations/inputs_statsd" // register migration

--- a/migrations/all/inputs_statsd.go
+++ b/migrations/all/inputs_statsd.go
@@ -1,4 +1,4 @@
-//go:build !custom || (migrations && (inputs || inputs.cassandra))
+//go:build !custom || (migrations && (inputs || inputs.statsd))
 
 package all
 

--- a/migrations/inputs_statsd/migration.go
+++ b/migrations/inputs_statsd/migration.go
@@ -1,0 +1,72 @@
+package inputs_statsd
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/influxdata/toml"
+	"github.com/influxdata/toml/ast"
+
+	"github.com/influxdata/telegraf/migrations"
+)
+
+// Migration function
+func migrate(tbl *ast.Table) ([]byte, string, error) {
+	// Decode the old data structure
+	var plugin map[string]interface{}
+	if err := toml.UnmarshalTable(tbl, &plugin); err != nil {
+		return nil, "", err
+	}
+
+	// Check for deprecated option(s) and migrate them
+	var applied bool
+
+	// Remove option as it's being ignored
+	if _, found := plugin["udp_packet_size"]; found {
+		applied = true
+		delete(plugin, "udp_packet_size")
+	}
+
+	if rawOldParseDataDogTags, found := plugin["parse_data_dog_tags"]; found {
+		applied = true
+
+		// Convert the options to the actual type
+		oldParseDataDogTags, ok := rawOldParseDataDogTags.(bool)
+		if !ok {
+			return nil, "", fmt.Errorf("unexpected type %T for 'parse_data_dog_tags'", rawOldParseDataDogTags)
+		}
+
+		// Check if the new setting is present and if so, check if the values are
+		// conflicting.
+		if rawNewDataDogExtensions, found := plugin["datadog_extensions"]; found {
+			if newDataDogExtensions, ok := rawNewDataDogExtensions.(bool); !ok {
+				return nil, "", fmt.Errorf("unexpected type %T for 'datadog_extensions'", rawNewDataDogExtensions)
+			} else if oldParseDataDogTags != newDataDogExtensions {
+				return nil, "", errors.New("contradicting setting for 'parse_data_dog_tags' and 'datadog_extensions'")
+			}
+		} else if oldParseDataDogTags {
+			// Only set the option if it is not the default for the new option
+			plugin["datadog_extensions"] = true
+		}
+
+		// Remove the deprecated option and replace the modified one
+		delete(plugin, "parse_data_dog_tags")
+	}
+
+	// No options migrated so we can exit early
+	if !applied {
+		return nil, "", migrations.ErrNotApplicable
+	}
+
+	// Create the corresponding plugin configurations
+	cfg := migrations.CreateTOMLStruct("inputs", "statsd")
+	cfg.Add("inputs", "statsd", plugin)
+
+	output, err := toml.Marshal(cfg)
+	return output, "", err
+}
+
+// Register the migration function for the plugin type
+func init() {
+	migrations.AddPluginOptionMigration("inputs.statsd", migrate)
+}

--- a/migrations/inputs_statsd/migration_test.go
+++ b/migrations/inputs_statsd/migration_test.go
@@ -1,0 +1,73 @@
+package inputs_statsd_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/influxdata/telegraf/config"
+	_ "github.com/influxdata/telegraf/migrations/inputs_statsd" // register migration
+	"github.com/influxdata/telegraf/plugins/inputs/statsd"      // register plugin
+)
+
+func TestNoMigration(t *testing.T) {
+	plugin := &statsd.Statsd{}
+	defaultCfg := plugin.SampleConfig()
+
+	// Migrate and check that nothing changed
+	output, n, err := config.ApplyMigrations([]byte(defaultCfg))
+	require.NoError(t, err)
+	require.NotEmpty(t, output)
+	require.Zero(t, n)
+	require.Equal(t, defaultCfg, string(output))
+}
+
+func TestCases(t *testing.T) {
+	// Get all directories in testdata
+	folders, err := os.ReadDir("testcases")
+	require.NoError(t, err)
+
+	for _, f := range folders {
+		// Only handle folders
+		if !f.IsDir() {
+			continue
+		}
+
+		t.Run(f.Name(), func(t *testing.T) {
+			testcasePath := filepath.Join("testcases", f.Name())
+			inputFile := filepath.Join(testcasePath, "telegraf.conf")
+			expectedFile := filepath.Join(testcasePath, "expected.conf")
+
+			// Read the expected output
+			expected := config.NewConfig()
+			require.NoError(t, expected.LoadConfig(expectedFile))
+			require.NotEmpty(t, expected.Inputs)
+
+			// Read the input data
+			input, remote, err := config.LoadConfigFile(inputFile)
+			require.NoError(t, err)
+			require.False(t, remote)
+			require.NotEmpty(t, input)
+
+			// Migrate
+			output, n, err := config.ApplyMigrations(input)
+			require.NoError(t, err)
+			require.NotEmpty(t, output)
+			require.GreaterOrEqual(t, n, uint64(1))
+			actual := config.NewConfig()
+			require.NoError(t, actual.LoadConfigData(output, config.EmptySourcePath))
+
+			// Test the output
+			require.Len(t, actual.Inputs, len(expected.Inputs))
+			actualIDs := make([]string, 0, len(expected.Inputs))
+			expectedIDs := make([]string, 0, len(expected.Inputs))
+			for i := range actual.Inputs {
+				actualIDs = append(actualIDs, actual.Inputs[i].ID())
+				expectedIDs = append(expectedIDs, expected.Inputs[i].ID())
+			}
+			require.ElementsMatch(t, expectedIDs, actualIDs, string(output))
+		})
+	}
+}

--- a/migrations/inputs_statsd/testcases/deprecated_parse_data_dog_tags/expected.conf
+++ b/migrations/inputs_statsd/testcases/deprecated_parse_data_dog_tags/expected.conf
@@ -1,0 +1,15 @@
+[[inputs.statsd]]
+allowed_pending_messages = 10000
+datadog_distributions = false
+datadog_extensions = true
+datadog_keep_container_tag = false
+delete_counters = true
+delete_gauges = true
+delete_sets = true
+delete_timings = true
+max_tcp_connections = 250
+metric_separator = "_"
+percentile_limit = 1000
+protocol = "udp"
+service_address = ":8125"
+tcp_keep_alive = false

--- a/migrations/inputs_statsd/testcases/deprecated_parse_data_dog_tags/telegraf.conf
+++ b/migrations/inputs_statsd/testcases/deprecated_parse_data_dog_tags/telegraf.conf
@@ -1,0 +1,106 @@
+# Statsd Server
+[[inputs.statsd]]
+  ## Protocol, must be "tcp", "udp4", "udp6" or "udp" (default=udp)
+  protocol = "udp"
+
+  ## MaxTCPConnection - applicable when protocol is set to tcp (default=250)
+  max_tcp_connections = 250
+
+  ## Enable TCP keep alive probes (default=false)
+  tcp_keep_alive = false
+
+  ## Specifies the keep-alive period for an active network connection.
+  ## Only applies to TCP sockets and will be ignored if tcp_keep_alive is false.
+  ## Defaults to the OS configuration.
+  # tcp_keep_alive_period = "2h"
+
+  ## Address and port to host UDP listener on
+  service_address = ":8125"
+
+  ## The following configuration options control when telegraf clears it's cache
+  ## of previous values. If set to false, then telegraf will only clear it's
+  ## cache when the daemon is restarted.
+  ## Reset gauges every interval (default=true)
+  delete_gauges = true
+  ## Reset counters every interval (default=true)
+  delete_counters = true
+  ## Reset sets every interval (default=true)
+  delete_sets = true
+  ## Reset timings & histograms every interval (default=true)
+  delete_timings = true
+
+  ## Enable aggregation temporality adds temporality=delta or temporality=commulative tag, and
+  ## start_time field, which adds the start time of the metric accumulation.
+  ## You should use this when using OpenTelemetry output.
+  # enable_aggregation_temporality = false
+
+  ## Percentiles to calculate for timing & histogram stats.
+  # percentiles = [50.0, 90.0, 99.0, 99.9, 99.95, 100.0]
+
+  ## separator to use between elements of a statsd metric
+  metric_separator = "_"
+
+  ## Parses extensions to statsd in the datadog statsd format
+  ## currently supports metrics and datadog tags.
+  ## http://docs.datadoghq.com/guides/dogstatsd/
+  datadog_extensions = true
+
+  ## Parses distributions metric as specified in the datadog statsd format
+  ## https://docs.datadoghq.com/developers/metrics/types/?tab=distribution#definition
+  datadog_distributions = false
+
+  ## Keep or drop the container id as tag. Included as optional field
+  ## in DogStatsD protocol v1.2 if source is running in Kubernetes
+  ## https://docs.datadoghq.com/developers/dogstatsd/datagram_shell/?tab=metrics#dogstatsd-protocol-v12
+  datadog_keep_container_tag = false
+
+  ## Statsd data translation templates, more info can be read here:
+  ## https://github.com/influxdata/telegraf/blob/master/docs/TEMPLATE_PATTERN.md
+  # templates = [
+  #     "cpu.* measurement*"
+  # ]
+
+  ## Number of UDP messages allowed to queue up, once filled,
+  ## the statsd server will start dropping packets
+  allowed_pending_messages = 10000
+
+  ## Number of worker threads used to parse the incoming messages.
+  # number_workers_threads = 5
+
+  ## Number of timing/histogram values to track per-measurement in the
+  ## calculation of percentiles. Raising this limit increases the accuracy
+  ## of percentiles but also increases the memory usage and cpu time.
+  percentile_limit = 1000
+
+  ## Maximum socket buffer size in bytes, once the buffer fills up, metrics
+  ## will start dropping.  Defaults to the OS default.
+  # read_buffer_size = 65535
+
+  ## Max duration (TTL) for each metric to stay cached/reported without being updated.
+  # max_ttl = "10h"
+
+  ## Sanitize name method
+  ## By default, telegraf will pass names directly as they are received.
+  ## However, upstream statsd now does sanitization of names which can be
+  ## enabled by using the "upstream" method option. This option will a) replace
+  ## white space with '_', replace '/' with '-', and remove characters not
+  ## matching 'a-zA-Z_\-0-9\.;='.
+  #sanitize_name_method = ""
+
+  ## Replace dots (.) with underscore (_) and dashes (-) with
+  ## double underscore (__) in metric names.
+  # convert_names = false
+
+  ## Convert all numeric counters to float
+  ## Enabling this would ensure that both counters and guages are both emitted
+  ## as floats.
+  # float_counters = false
+
+  ## Emit timings `metric_<name>_count` field as float, the same as all other
+  ## histogram fields
+  # float_timings = false
+
+  ## Emit sets as float
+  # float_sets = false
+
+  parse_data_dog_tags = true

--- a/migrations/inputs_statsd/testcases/deprecated_parse_data_dog_tags_false/expected.conf
+++ b/migrations/inputs_statsd/testcases/deprecated_parse_data_dog_tags_false/expected.conf
@@ -1,0 +1,14 @@
+[[inputs.statsd]]
+protocol = "udp"
+max_tcp_connections = 250
+tcp_keep_alive = false
+service_address = ":8125"
+delete_gauges = true
+delete_counters = true
+delete_sets = true
+delete_timings = true
+metric_separator = "_"
+datadog_distributions = false
+datadog_keep_container_tag = false
+allowed_pending_messages = 10000
+percentile_limit = 1000

--- a/migrations/inputs_statsd/testcases/deprecated_parse_data_dog_tags_false/telegraf.conf
+++ b/migrations/inputs_statsd/testcases/deprecated_parse_data_dog_tags_false/telegraf.conf
@@ -1,0 +1,106 @@
+# Statsd Server
+[[inputs.statsd]]
+  ## Protocol, must be "tcp", "udp4", "udp6" or "udp" (default=udp)
+  protocol = "udp"
+
+  ## MaxTCPConnection - applicable when protocol is set to tcp (default=250)
+  max_tcp_connections = 250
+
+  ## Enable TCP keep alive probes (default=false)
+  tcp_keep_alive = false
+
+  ## Specifies the keep-alive period for an active network connection.
+  ## Only applies to TCP sockets and will be ignored if tcp_keep_alive is false.
+  ## Defaults to the OS configuration.
+  # tcp_keep_alive_period = "2h"
+
+  ## Address and port to host UDP listener on
+  service_address = ":8125"
+
+  ## The following configuration options control when telegraf clears it's cache
+  ## of previous values. If set to false, then telegraf will only clear it's
+  ## cache when the daemon is restarted.
+  ## Reset gauges every interval (default=true)
+  delete_gauges = true
+  ## Reset counters every interval (default=true)
+  delete_counters = true
+  ## Reset sets every interval (default=true)
+  delete_sets = true
+  ## Reset timings & histograms every interval (default=true)
+  delete_timings = true
+
+  ## Enable aggregation temporality adds temporality=delta or temporality=commulative tag, and
+  ## start_time field, which adds the start time of the metric accumulation.
+  ## You should use this when using OpenTelemetry output.
+  # enable_aggregation_temporality = false
+
+  ## Percentiles to calculate for timing & histogram stats.
+  #percentiles = [50.0, 90.0, 99.0, 99.9, 99.95, 100.0]
+
+  ## separator to use between elements of a statsd metric
+  metric_separator = "_"
+
+  ## Parses extensions to statsd in the datadog statsd format
+  ## currently supports metrics and datadog tags.
+  ## http://docs.datadoghq.com/guides/dogstatsd/
+  # datadog_extensions = false
+
+  ## Parses distributions metric as specified in the datadog statsd format
+  ## https://docs.datadoghq.com/developers/metrics/types/?tab=distribution#definition
+  datadog_distributions = false
+
+  ## Keep or drop the container id as tag. Included as optional field
+  ## in DogStatsD protocol v1.2 if source is running in Kubernetes
+  ## https://docs.datadoghq.com/developers/dogstatsd/datagram_shell/?tab=metrics#dogstatsd-protocol-v12
+  datadog_keep_container_tag = false
+
+  ## Statsd data translation templates, more info can be read here:
+  ## https://github.com/influxdata/telegraf/blob/master/docs/TEMPLATE_PATTERN.md
+  # templates = [
+  #     "cpu.* measurement*"
+  # ]
+
+  ## Number of UDP messages allowed to queue up, once filled,
+  ## the statsd server will start dropping packets
+  allowed_pending_messages = 10000
+
+  ## Number of worker threads used to parse the incoming messages.
+  # number_workers_threads = 5
+
+  ## Number of timing/histogram values to track per-measurement in the
+  ## calculation of percentiles. Raising this limit increases the accuracy
+  ## of percentiles but also increases the memory usage and cpu time.
+  percentile_limit = 1000
+
+  ## Maximum socket buffer size in bytes, once the buffer fills up, metrics
+  ## will start dropping.  Defaults to the OS default.
+  # read_buffer_size = 65535
+
+  ## Max duration (TTL) for each metric to stay cached/reported without being updated.
+  # max_ttl = "10h"
+
+  ## Sanitize name method
+  ## By default, telegraf will pass names directly as they are received.
+  ## However, upstream statsd now does sanitization of names which can be
+  ## enabled by using the "upstream" method option. This option will a) replace
+  ## white space with '_', replace '/' with '-', and remove characters not
+  ## matching 'a-zA-Z_\-0-9\.;='.
+  #sanitize_name_method = ""
+
+  ## Replace dots (.) with underscore (_) and dashes (-) with
+  ## double underscore (__) in metric names.
+  # convert_names = false
+
+  ## Convert all numeric counters to float
+  ## Enabling this would ensure that both counters and guages are both emitted
+  ## as floats.
+  # float_counters = false
+
+  ## Emit timings `metric_<name>_count` field as float, the same as all other
+  ## histogram fields
+  # float_timings = false
+
+  ## Emit sets as float
+  # float_sets = false
+
+  parse_data_dog_tags = false

--- a/migrations/inputs_statsd/testcases/deprecated_udp_packet_size/expected.conf
+++ b/migrations/inputs_statsd/testcases/deprecated_udp_packet_size/expected.conf
@@ -1,0 +1,15 @@
+[[inputs.statsd]]
+protocol = "udp"
+max_tcp_connections = 250
+tcp_keep_alive = false
+service_address = ":8125"
+delete_gauges = true
+delete_counters = true
+delete_sets = true
+delete_timings = true
+metric_separator = "_"
+datadog_extensions = false
+datadog_distributions = false
+datadog_keep_container_tag = false
+allowed_pending_messages = 10000
+percentile_limit = 1000

--- a/migrations/inputs_statsd/testcases/deprecated_udp_packet_size/telegraf.conf
+++ b/migrations/inputs_statsd/testcases/deprecated_udp_packet_size/telegraf.conf
@@ -1,0 +1,106 @@
+# Statsd Server
+[[inputs.statsd]]
+  ## Protocol, must be "tcp", "udp4", "udp6" or "udp" (default=udp)
+  protocol = "udp"
+
+  ## MaxTCPConnection - applicable when protocol is set to tcp (default=250)
+  max_tcp_connections = 250
+
+  ## Enable TCP keep alive probes (default=false)
+  tcp_keep_alive = false
+
+  ## Specifies the keep-alive period for an active network connection.
+  ## Only applies to TCP sockets and will be ignored if tcp_keep_alive is false.
+  ## Defaults to the OS configuration.
+  # tcp_keep_alive_period = "2h"
+
+  ## Address and port to host UDP listener on
+  service_address = ":8125"
+
+  ## The following configuration options control when telegraf clears it's cache
+  ## of previous values. If set to false, then telegraf will only clear it's
+  ## cache when the daemon is restarted.
+  ## Reset gauges every interval (default=true)
+  delete_gauges = true
+  ## Reset counters every interval (default=true)
+  delete_counters = true
+  ## Reset sets every interval (default=true)
+  delete_sets = true
+  ## Reset timings & histograms every interval (default=true)
+  delete_timings = true
+
+  ## Enable aggregation temporality adds temporality=delta or temporality=commulative tag, and
+  ## start_time field, which adds the start time of the metric accumulation.
+  ## You should use this when using OpenTelemetry output.
+  # enable_aggregation_temporality = false
+
+  ## Percentiles to calculate for timing & histogram stats.
+  # percentiles = [50.0, 90.0, 99.0, 99.9, 99.95, 100.0]
+
+  ## separator to use between elements of a statsd metric
+  metric_separator = "_"
+
+  ## Parses extensions to statsd in the datadog statsd format
+  ## currently supports metrics and datadog tags.
+  ## http://docs.datadoghq.com/guides/dogstatsd/
+  datadog_extensions = false
+
+  ## Parses distributions metric as specified in the datadog statsd format
+  ## https://docs.datadoghq.com/developers/metrics/types/?tab=distribution#definition
+  datadog_distributions = false
+
+  ## Keep or drop the container id as tag. Included as optional field
+  ## in DogStatsD protocol v1.2 if source is running in Kubernetes
+  ## https://docs.datadoghq.com/developers/dogstatsd/datagram_shell/?tab=metrics#dogstatsd-protocol-v12
+  datadog_keep_container_tag = false
+
+  ## Statsd data translation templates, more info can be read here:
+  ## https://github.com/influxdata/telegraf/blob/master/docs/TEMPLATE_PATTERN.md
+  # templates = [
+  #     "cpu.* measurement*"
+  # ]
+
+  ## Number of UDP messages allowed to queue up, once filled,
+  ## the statsd server will start dropping packets
+  allowed_pending_messages = 10000
+
+  ## Number of worker threads used to parse the incoming messages.
+  # number_workers_threads = 5
+
+  ## Number of timing/histogram values to track per-measurement in the
+  ## calculation of percentiles. Raising this limit increases the accuracy
+  ## of percentiles but also increases the memory usage and cpu time.
+  percentile_limit = 1000
+
+  ## Maximum socket buffer size in bytes, once the buffer fills up, metrics
+  ## will start dropping.  Defaults to the OS default.
+  # read_buffer_size = 65535
+
+  ## Max duration (TTL) for each metric to stay cached/reported without being updated.
+  # max_ttl = "10h"
+
+  ## Sanitize name method
+  ## By default, telegraf will pass names directly as they are received.
+  ## However, upstream statsd now does sanitization of names which can be
+  ## enabled by using the "upstream" method option. This option will a) replace
+  ## white space with '_', replace '/' with '-', and remove characters not
+  ## matching 'a-zA-Z_\-0-9\.;='.
+  #sanitize_name_method = ""
+
+  ## Replace dots (.) with underscore (_) and dashes (-) with
+  ## double underscore (__) in metric names.
+  # convert_names = false
+
+  ## Convert all numeric counters to float
+  ## Enabling this would ensure that both counters and guages are both emitted
+  ## as floats.
+  # float_counters = false
+
+  ## Emit timings `metric_<name>_count` field as float, the same as all other
+  ## histogram fields
+  # float_timings = false
+
+  ## Emit sets as float
+  # float_sets = false
+
+  udp_packet_size = 65535

--- a/plugins/inputs/statsd/statsd.go
+++ b/plugins/inputs/statsd/statsd.go
@@ -68,9 +68,6 @@ type Statsd struct {
 
 	// MetricSeparator is the separator between parts of the metric name.
 	MetricSeparator string `toml:"metric_separator"`
-	// This flag enables parsing of tags in the dogstatsd extension to the
-	// statsd protocol (http://docs.datadoghq.com/guides/dogstatsd/)
-	ParseDataDogTags bool `toml:"parse_data_dog_tags" deprecated:"1.10.0;1.35.0;use 'datadog_extensions' instead"`
 
 	// Parses extensions to statsd in the datadog statsd format
 	// currently supports metrics and datadog tags.
@@ -86,12 +83,6 @@ type Statsd struct {
 	// Requires the DataDogExtension flag to be enabled.
 	// https://docs.datadoghq.com/developers/dogstatsd/datagram_shell/?tab=metrics#dogstatsd-protocol-v12
 	DataDogKeepContainerTag bool `toml:"datadog_keep_container_tag"`
-
-	// UDPPacketSize is deprecated, it's only here for legacy support
-	// we now always create 1 max size buffer and then copy only what we need
-	// into the in channel
-	// see https://github.com/influxdata/telegraf/pull/992
-	UDPPacketSize int `toml:"udp_packet_size" deprecated:"0.12.1;1.35.0;option is ignored"`
 
 	ReadBufferSize      int              `toml:"read_buffer_size"`
 	SanitizeNamesMethod string           `toml:"sanitize_name_method"`
@@ -233,10 +224,6 @@ func (*Statsd) SampleConfig() string {
 }
 
 func (s *Statsd) Start(ac telegraf.Accumulator) error {
-	if s.ParseDataDogTags {
-		s.DataDogExtensions = true
-	}
-
 	s.acc = ac
 
 	// Make data structures


### PR DESCRIPTION
## Summary

This PR migrates the `parse_data_dog_tags` option of the plugin and removes the deprecated option including the ignored `udp_packet_size` option.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #16934
