### PR TITLE
feat(migrations): Add option migration for outputs.wavefront

### DIFF
--- a/migrations/all/outputs_wavefront.go
+++ b/migrations/all/outputs_wavefront.go
@@ -1,0 +1,5 @@
+//go:build !custom || (migrations && (outputs || outputs.wavefront))
+
+package all
+
+import _ "github.com/influxdata/telegraf/migrations/outputs_wavefront" // register migration

--- a/migrations/outputs_wavefront/migration.go
+++ b/migrations/outputs_wavefront/migration.go
@@ -1,0 +1,76 @@
+package outputs_wavefront
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/influxdata/toml"
+	"github.com/influxdata/toml/ast"
+
+	"github.com/influxdata/telegraf/migrations"
+)
+
+// Migration function
+func migrate(tbl *ast.Table) ([]byte, string, error) {
+	// Decode the old data structure
+	var plugin map[string]interface{}
+	if err := toml.UnmarshalTable(tbl, &plugin); err != nil {
+		return nil, "", err
+	}
+
+	// Check for deprecated option(s) and migrate them
+	var applied bool
+	msg := ""
+
+	rawHost, foundHost := plugin["host"]
+	rawPort, foundPort := plugin["port"]
+
+	if foundHost && foundPort {
+		host, ok := rawHost.(string)
+		if !ok {
+			return nil, "", fmt.Errorf("unexpected type %T for 'host'", rawHost)
+		}
+
+		port, ok := rawPort.(int64)
+		if !ok {
+			return nil, "", fmt.Errorf("unexpected type %T for 'port'", rawPort)
+		}
+
+		newURL := fmt.Sprintf("http://%s:%d", host, port)
+
+		if rawURL, found := plugin["url"]; found {
+			if url, ok := rawURL.(string); !ok {
+				return nil, "", fmt.Errorf("unexpected type %T for 'url'", rawURL)
+			} else if url != newURL {
+				return nil, "", errors.New("contradicting setting for 'host' and 'port' with 'url'")
+			}
+		}
+
+		applied = true
+		delete(plugin, "host")
+		delete(plugin, "port")
+		plugin["url"] = newURL
+	}
+
+	// Cannot automatically migrate 'string_to_number' option, give a message if it is set
+	if _, found := plugin["string_to_number"]; found {
+		msg = "The 'string_to_number' cannot be migrated automatically and requires manual intervention!"
+	}
+
+	// No options migrated so we can exit early
+	if !applied {
+		return nil, msg, migrations.ErrNotApplicable
+	}
+
+	// Create the corresponding plugin configurations
+	cfg := migrations.CreateTOMLStruct("outputs", "wavefront")
+	cfg.Add("outputs", "wavefront", plugin)
+
+	output, err := toml.Marshal(cfg)
+	return output, msg, err
+}
+
+// Register the migration function for the plugin type
+func init() {
+	migrations.AddPluginOptionMigration("outputs.wavefront", migrate)
+}

--- a/migrations/outputs_wavefront/migration_test.go
+++ b/migrations/outputs_wavefront/migration_test.go
@@ -1,0 +1,73 @@
+package outputs_wavefront_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/influxdata/telegraf/config"
+	_ "github.com/influxdata/telegraf/migrations/outputs_wavefront" // register migration
+	_ "github.com/influxdata/telegraf/plugins/outputs/wavefront"    // register plugin
+)
+
+func TestCannotMigrateStringToNumber(t *testing.T) {
+	cfg := []byte(`
+[[outputs.wavefront]]
+  string_to_number = "test_key"
+`)
+	// Migrate and check that nothing changed
+	output, n, err := config.ApplyMigrations(cfg)
+	require.NoError(t, err)
+	require.Equal(t, cfg, output)
+	require.Equal(t, uint64(0), n)
+}
+
+func TestCases(t *testing.T) {
+	// Get all directories in testdata
+	folders, err := os.ReadDir("testcases")
+	require.NoError(t, err)
+
+	for _, f := range folders {
+		// Only handle folders
+		if !f.IsDir() {
+			continue
+		}
+
+		t.Run(f.Name(), func(t *testing.T) {
+			testcasePath := filepath.Join("testcases", f.Name())
+			inputFile := filepath.Join(testcasePath, "telegraf.conf")
+			expectedFile := filepath.Join(testcasePath, "expected.conf")
+
+			// Read the expected output
+			expected := config.NewConfig()
+			require.NoError(t, expected.LoadConfig(expectedFile))
+			require.NotEmpty(t, expected.Outputs)
+
+			// Read the input data
+			input, remote, err := config.LoadConfigFile(inputFile)
+			require.NoError(t, err)
+			require.False(t, remote)
+			require.NotEmpty(t, input)
+
+			// Migrate
+			output, n, err := config.ApplyMigrations(input)
+			require.NoError(t, err)
+			require.NotEmpty(t, output)
+			require.GreaterOrEqual(t, n, uint64(1))
+			actual := config.NewConfig()
+			require.NoError(t, actual.LoadConfigData(output, config.EmptySourcePath))
+
+			// Test the output
+			require.Len(t, actual.Outputs, len(expected.Outputs))
+			actualIDs := make([]string, 0, len(expected.Outputs))
+			expectedIDs := make([]string, 0, len(expected.Outputs))
+			for i := range actual.Outputs {
+				actualIDs = append(actualIDs, actual.Outputs[i].ID())
+				expectedIDs = append(expectedIDs, expected.Outputs[i].ID())
+			}
+			require.ElementsMatch(t, expectedIDs, actualIDs, string(output))
+		})
+	}
+}

--- a/migrations/outputs_wavefront/testcases/host_port/expected.conf
+++ b/migrations/outputs_wavefront/testcases/host_port/expected.conf
@@ -1,0 +1,2 @@
+[[outputs.wavefront]]
+  url = "http://localhost:8080"

--- a/migrations/outputs_wavefront/testcases/host_port/telegraf.conf
+++ b/migrations/outputs_wavefront/testcases/host_port/telegraf.conf
@@ -1,0 +1,3 @@
+[[outputs.wavefront]]
+  host = "localhost"
+  port = 8080

--- a/plugins/outputs/wavefront/wavefront.go
+++ b/plugins/outputs/wavefront/wavefront.go
@@ -32,26 +32,23 @@ type authCSPClientCredentials struct {
 }
 
 type Wavefront struct {
-	URL                      string                          `toml:"url"`
-	Token                    config.Secret                   `toml:"token"`
-	CSPBaseURL               string                          `toml:"auth_csp_base_url"`
-	AuthCSPAPIToken          config.Secret                   `toml:"auth_csp_api_token"`
-	AuthCSPClientCredentials *authCSPClientCredentials       `toml:"auth_csp_client_credentials"`
-	Host                     string                          `toml:"host" deprecated:"1.28.0;1.35.0;use url instead"`
-	Port                     int                             `toml:"port" deprecated:"1.28.0;1.35.0;use url instead"`
-	Prefix                   string                          `toml:"prefix"`
-	SimpleFields             bool                            `toml:"simple_fields"`
-	MetricSeparator          string                          `toml:"metric_separator"`
-	ConvertPaths             bool                            `toml:"convert_paths"`
-	ConvertBool              bool                            `toml:"convert_bool"`
-	HTTPMaximumBatchSize     int                             `toml:"http_maximum_batch_size"`
-	UseRegex                 bool                            `toml:"use_regex"`
-	UseStrict                bool                            `toml:"use_strict"`
-	TruncateTags             bool                            `toml:"truncate_tags"`
-	ImmediateFlush           bool                            `toml:"immediate_flush"`
-	SendInternalMetrics      bool                            `toml:"send_internal_metrics"`
-	SourceOverride           []string                        `toml:"source_override"`
-	StringToNumber           map[string][]map[string]float64 `toml:"string_to_number" deprecated:"1.9.0;1.35.0;use the enum processor instead"`
+	URL                      string                    `toml:"url"`
+	Token                    config.Secret             `toml:"token"`
+	CSPBaseURL               string                    `toml:"auth_csp_base_url"`
+	AuthCSPAPIToken          config.Secret             `toml:"auth_csp_api_token"`
+	AuthCSPClientCredentials *authCSPClientCredentials `toml:"auth_csp_client_credentials"`
+	Prefix                   string                    `toml:"prefix"`
+	SimpleFields             bool                      `toml:"simple_fields"`
+	MetricSeparator          string                    `toml:"metric_separator"`
+	ConvertPaths             bool                      `toml:"convert_paths"`
+	ConvertBool              bool                      `toml:"convert_bool"`
+	HTTPMaximumBatchSize     int                       `toml:"http_maximum_batch_size"`
+	UseRegex                 bool                      `toml:"use_regex"`
+	UseStrict                bool                      `toml:"use_strict"`
+	TruncateTags             bool                      `toml:"truncate_tags"`
+	ImmediateFlush           bool                      `toml:"immediate_flush"`
+	SendInternalMetrics      bool                      `toml:"send_internal_metrics"`
+	SourceOverride           []string                  `toml:"source_override"`
 
 	common_http.HTTPClientConfig
 
@@ -72,12 +69,7 @@ func (*Wavefront) SampleConfig() string {
 
 func (w *Wavefront) parseConnectionURL() (string, error) {
 	if w.URL == "" {
-		if w.Host == "" || w.Port <= 0 {
-			return "", errors.New("no URL specified")
-		}
-		generatedURL := fmt.Sprintf("http://%s:%d", w.Host, w.Port)
-		w.Log.Warnf("translating host/port into url: %s\n", generatedURL)
-		return generatedURL, nil
+		return "", errors.New("no URL specified")
 	}
 
 	u, err := url.ParseRequestURI(w.URL)
@@ -293,18 +285,6 @@ func buildValue(v interface{}, name string, w *Wavefront) (float64, error) {
 		return float64(v.(uint64)), nil
 	case float64:
 		return v.(float64), nil
-	case string:
-		for prefix, mappings := range w.StringToNumber {
-			if strings.HasPrefix(name, prefix) {
-				for _, mapping := range mappings {
-					val, hasVal := mapping[p]
-					if hasVal {
-						return val, nil
-					}
-				}
-			}
-		}
-		return 0, fmt.Errorf("unexpected type: %T, with value: %v, for: %s", v, v, name)
 	default:
 		return 0, fmt.Errorf("unexpected type: %T, with value: %v, for: %s", v, v, name)
 	}

--- a/plugins/outputs/wavefront/wavefront_test.go
+++ b/plugins/outputs/wavefront/wavefront_test.go
@@ -19,8 +19,7 @@ import (
 // default config used by Tests
 func defaultWavefront() *Wavefront {
 	return &Wavefront{
-		Host:            "localhost",
-		Port:            2878,
+		URL:             "http://localhost:2878",
 		Prefix:          "testWF.",
 		SimpleFields:    false,
 		MetricSeparator: ".",
@@ -299,36 +298,6 @@ func TestBuildValue(t *testing.T) {
 	}
 }
 
-func TestBuildValueString(t *testing.T) {
-	w := defaultWavefront()
-	w.StringToNumber = map[string][]map[string]float64{
-		"test1": {{"green": 1, "red": 10}},
-		"test2": {{"active": 1, "hidden": 2}},
-	}
-
-	var valuetests = []struct {
-		value interface{}
-		name  string
-		out   float64
-		isErr bool
-	}{
-		{value: int64(123), name: "", out: 123},
-		{value: "green", name: "test1", out: 1},
-		{value: "red", name: "test1", out: 10},
-		{value: "hidden", name: "test2", out: 2},
-		{value: "bad", name: "test1", out: 0, isErr: true},
-	}
-
-	for _, vt := range valuetests {
-		value, err := buildValue(vt.value, vt.name, w)
-		if vt.isErr && err == nil {
-			t.Errorf("\nexpected error with\t%+v\nreceived\t%+v\n", vt.out, value)
-		} else if value != vt.out {
-			t.Errorf("\nexpected\t%+v\nreceived\t%+v\n", vt.out, value)
-		}
-	}
-}
-
 func TestTagLimits(t *testing.T) {
 	w := defaultWavefront()
 	w.TruncateTags = true
@@ -386,9 +355,8 @@ func TestParseConnectionUrlReturnsAllowsTokensInUrl(t *testing.T) {
 
 func TestParseConnectionUrlUsesHostAndPortWhenUrlIsOmitted(t *testing.T) {
 	w := &Wavefront{
-		Host: "surf.wavefront.com",
-		Port: 8080,
-		Log:  testutil.Logger{},
+		URL: "http://surf.wavefront.com:8080",
+		Log: testutil.Logger{},
 	}
 
 	url, err := w.parseConnectionURL()


### PR DESCRIPTION
## Summary
Adds migrations for the `host` and `port` options to the newer `url` option. Also displays a message about not being able to automatically migrate the `string_to_number` option

## Checklist
- [x] No AI generated code was used in this PR

## Related issues
resolves #16942
