### PR TITLE
feat(migrations): Add option migration for outputs.remotefile

### DIFF
--- a/migrations/all/outputs_remotefile.go
+++ b/migrations/all/outputs_remotefile.go
@@ -1,0 +1,5 @@
+//go:build !custom || (migrations && (outputs || outputs.remotefile))
+
+package all
+
+import _ "github.com/influxdata/telegraf/migrations/outputs_remotefile" // register migration

--- a/migrations/outputs_remotefile/migration.go
+++ b/migrations/outputs_remotefile/migration.go
@@ -1,0 +1,61 @@
+package outputs_remotefile
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/influxdata/toml"
+	"github.com/influxdata/toml/ast"
+
+	"github.com/influxdata/telegraf/migrations"
+)
+
+// Migration function
+func migrate(tbl *ast.Table) ([]byte, string, error) {
+	// Decode the old data structure
+	var plugin map[string]interface{}
+	if err := toml.UnmarshalTable(tbl, &plugin); err != nil {
+		return nil, "", err
+	}
+
+	// Check for deprecated option(s) and migrate them
+	var applied bool
+	if rawTrace, found := plugin["trace"]; found {
+		// Convert the options to the actual type
+		trace, ok := rawTrace.(bool)
+		if !ok {
+			return nil, "", fmt.Errorf("unexpected type %T for 'trace'", rawTrace)
+		}
+
+		if rawLogLevel, found := plugin["log_level"]; found {
+			if logLevel, ok := rawLogLevel.(string); !ok {
+				return nil, "", fmt.Errorf("unexpected type %T for 'log_level'", rawLogLevel)
+			} else if (trace && logLevel != "trace") || (!trace && logLevel == "trace") {
+				return nil, "", errors.New("contradicting setting for 'trace' and 'log_level'")
+			}
+		}
+
+		applied = true
+		if trace {
+			plugin["log_level"] = "trace"
+		}
+		delete(plugin, "trace")
+	}
+
+	// No options migrated so we can exit early
+	if !applied {
+		return nil, "", migrations.ErrNotApplicable
+	}
+
+	// Create the corresponding plugin configurations
+	cfg := migrations.CreateTOMLStruct("outputs", "remotefile")
+	cfg.Add("outputs", "remotefile", plugin)
+
+	output, err := toml.Marshal(cfg)
+	return output, "", err
+}
+
+// Register the migration function for the plugin type
+func init() {
+	migrations.AddPluginOptionMigration("outputs.remotefile", migrate)
+}

--- a/migrations/outputs_remotefile/migration_test.go
+++ b/migrations/outputs_remotefile/migration_test.go
@@ -1,0 +1,62 @@
+package outputs_remotefile_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/influxdata/telegraf/config"
+	_ "github.com/influxdata/telegraf/migrations/outputs_remotefile" // register migration
+	_ "github.com/influxdata/telegraf/plugins/outputs/remotefile"    // register plugin
+	_ "github.com/influxdata/telegraf/plugins/serializers/influx"    // register serializer
+)
+
+func TestCases(t *testing.T) {
+	// Get all directories in testdata
+	folders, err := os.ReadDir("testcases")
+	require.NoError(t, err)
+
+	for _, f := range folders {
+		// Only handle folders
+		if !f.IsDir() {
+			continue
+		}
+
+		t.Run(f.Name(), func(t *testing.T) {
+			testcasePath := filepath.Join("testcases", f.Name())
+			inputFile := filepath.Join(testcasePath, "telegraf.conf")
+			expectedFile := filepath.Join(testcasePath, "expected.conf")
+
+			// Read the expected output
+			expected := config.NewConfig()
+			require.NoError(t, expected.LoadConfig(expectedFile))
+			require.NotEmpty(t, expected.Outputs)
+
+			// Read the input data
+			input, remote, err := config.LoadConfigFile(inputFile)
+			require.NoError(t, err)
+			require.False(t, remote)
+			require.NotEmpty(t, input)
+
+			// Migrate
+			output, n, err := config.ApplyMigrations(input)
+			require.NoError(t, err)
+			require.NotEmpty(t, output)
+			require.GreaterOrEqual(t, n, uint64(1))
+			actual := config.NewConfig()
+			require.NoError(t, actual.LoadConfigData(output, config.EmptySourcePath))
+
+			// Test the output
+			require.Len(t, actual.Outputs, len(expected.Outputs))
+			actualIDs := make([]string, 0, len(expected.Outputs))
+			expectedIDs := make([]string, 0, len(expected.Outputs))
+			for i := range actual.Outputs {
+				actualIDs = append(actualIDs, actual.Outputs[i].ID())
+				expectedIDs = append(expectedIDs, expected.Outputs[i].ID())
+			}
+			require.ElementsMatch(t, expectedIDs, actualIDs, string(output))
+		})
+	}
+}

--- a/migrations/outputs_remotefile/testcases/simple/expected.conf
+++ b/migrations/outputs_remotefile/testcases/simple/expected.conf
@@ -1,0 +1,3 @@
+[[outputs.remotefile]]
+  data_format = "influx"
+  log_level = "trace"

--- a/migrations/outputs_remotefile/testcases/simple/telegraf.conf
+++ b/migrations/outputs_remotefile/testcases/simple/telegraf.conf
@@ -1,0 +1,3 @@
+[[outputs.remotefile]]
+  data_format = "influx"
+  trace = true

--- a/plugins/outputs/remotefile/remotefile.go
+++ b/plugins/outputs/remotefile/remotefile.go
@@ -33,7 +33,6 @@ type File struct {
 	WriteBackInterval config.Duration `toml:"cache_write_back"`
 	MaxCacheSize      config.Size     `toml:"cache_max_size"`
 	UseBatchFormat    bool            `toml:"use_batch_format"`
-	Trace             bool            `toml:"trace" deprecated:"1.33.0;1.35.0;use 'log_level = \"trace\"' instead"`
 	ForgetFiles       config.Duration `toml:"forget_files_after"`
 	Log               telegraf.Logger `toml:"-"`
 
@@ -79,15 +78,6 @@ func (f *File) Init() error {
 	}
 	if f.MaxCacheSize > 0 {
 		f.vfsopts.CacheMaxSize = fs.SizeSuffix(f.MaxCacheSize)
-	}
-
-	// Redirect logging
-	fs.LogOutput = func(level fs.LogLevel, text string) {
-		if f.Trace {
-			f.Log.Debugf("[%s] %s", level.String(), text)
-		} else {
-			f.Log.Tracef("[%s] %s", level.String(), text)
-		}
 	}
 
 	// Setup custom template functions

--- a/plugins/outputs/remotefile/remotefile.go
+++ b/plugins/outputs/remotefile/remotefile.go
@@ -80,6 +80,10 @@ func (f *File) Init() error {
 		f.vfsopts.CacheMaxSize = fs.SizeSuffix(f.MaxCacheSize)
 	}
 
+	fs.LogOutput = func(level fs.LogLevel, text string) {
+		f.Log.Tracef("[%s] %s", level.String(), text)
+	}
+
 	// Setup custom template functions
 	funcs := template.FuncMap{"now": time.Now}
 


### PR DESCRIPTION
## Summary
Adds an option migration from `trace` to `log_level`

## Checklist
- [x] No AI generated code was used in this PR

## Related issues
resolves #16941
