### PR TITLE
feat(migrations): Add option migration for outputs.librato

### DIFF
--- a/migrations/all/outputs_librato.go
+++ b/migrations/all/outputs_librato.go
@@ -1,0 +1,5 @@
+//go:build !custom || (migrations && (outputs || outputs.librato))
+
+package all
+
+import _ "github.com/influxdata/telegraf/migrations/outputs_librato" // register migration

--- a/migrations/outputs_librato/migration.go
+++ b/migrations/outputs_librato/migration.go
@@ -1,0 +1,59 @@
+package outputs_librato
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/influxdata/toml"
+	"github.com/influxdata/toml/ast"
+
+	"github.com/influxdata/telegraf/migrations"
+)
+
+// Migration function
+func migrate(tbl *ast.Table) ([]byte, string, error) {
+	// Decode the old data structure
+	var plugin map[string]interface{}
+	if err := toml.UnmarshalTable(tbl, &plugin); err != nil {
+		return nil, "", err
+	}
+
+	// Check for deprecated option(s) and migrate them
+	var applied bool
+	if rawSourceTag, found := plugin["source_tag"]; found {
+		// Convert the options to the actual type
+		sourceTag, ok := rawSourceTag.(string)
+		if !ok {
+			return nil, "", fmt.Errorf("unexpected type %T for 'source_tag'", rawSourceTag)
+		}
+
+		if rawTemplate, found := plugin["template"]; found {
+			if template, ok := rawTemplate.(string); !ok {
+				return nil, "", fmt.Errorf("unexpected type %T for 'template'", rawTemplate)
+			} else if sourceTag != template {
+				return nil, "", errors.New("contradicting setting for 'source_tag' and 'template'")
+			}
+		}
+
+		applied = true
+		plugin["template"] = sourceTag
+		delete(plugin, "source_tag")
+	}
+
+	// No options migrated so we can exit early
+	if !applied {
+		return nil, "", migrations.ErrNotApplicable
+	}
+
+	// Create the corresponding plugin configurations
+	cfg := migrations.CreateTOMLStruct("outputs", "librato")
+	cfg.Add("outputs", "librato", plugin)
+
+	output, err := toml.Marshal(cfg)
+	return output, "", err
+}
+
+// Register the migration function for the plugin type
+func init() {
+	migrations.AddPluginOptionMigration("outputs.librato", migrate)
+}

--- a/migrations/outputs_librato/migration_test.go
+++ b/migrations/outputs_librato/migration_test.go
@@ -1,0 +1,61 @@
+package outputs_librato_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/influxdata/telegraf/config"
+	_ "github.com/influxdata/telegraf/migrations/outputs_librato" // register migration
+	_ "github.com/influxdata/telegraf/plugins/outputs/librato"    // register plugin
+)
+
+func TestCases(t *testing.T) {
+	// Get all directories in testdata
+	folders, err := os.ReadDir("testcases")
+	require.NoError(t, err)
+
+	for _, f := range folders {
+		// Only handle folders
+		if !f.IsDir() {
+			continue
+		}
+
+		t.Run(f.Name(), func(t *testing.T) {
+			testcasePath := filepath.Join("testcases", f.Name())
+			inputFile := filepath.Join(testcasePath, "telegraf.conf")
+			expectedFile := filepath.Join(testcasePath, "expected.conf")
+
+			// Read the expected output
+			expected := config.NewConfig()
+			require.NoError(t, expected.LoadConfig(expectedFile))
+			require.NotEmpty(t, expected.Outputs)
+
+			// Read the input data
+			input, remote, err := config.LoadConfigFile(inputFile)
+			require.NoError(t, err)
+			require.False(t, remote)
+			require.NotEmpty(t, input)
+
+			// Migrate
+			output, n, err := config.ApplyMigrations(input)
+			require.NoError(t, err)
+			require.NotEmpty(t, output)
+			require.GreaterOrEqual(t, n, uint64(1))
+			actual := config.NewConfig()
+			require.NoError(t, actual.LoadConfigData(output, config.EmptySourcePath))
+
+			// Test the output
+			require.Len(t, actual.Outputs, len(expected.Outputs))
+			actualIDs := make([]string, 0, len(expected.Outputs))
+			expectedIDs := make([]string, 0, len(expected.Outputs))
+			for i := range actual.Outputs {
+				actualIDs = append(actualIDs, actual.Outputs[i].ID())
+				expectedIDs = append(expectedIDs, expected.Outputs[i].ID())
+			}
+			require.ElementsMatch(t, expectedIDs, actualIDs, string(output))
+		})
+	}
+}

--- a/migrations/outputs_librato/testcases/simple/expected.conf
+++ b/migrations/outputs_librato/testcases/simple/expected.conf
@@ -1,0 +1,2 @@
+[[outputs.librato]]
+  template = "some_template"

--- a/migrations/outputs_librato/testcases/simple/telegraf.conf
+++ b/migrations/outputs_librato/testcases/simple/telegraf.conf
@@ -1,0 +1,2 @@
+[[outputs.librato]]
+  source_tag = "some_template"

--- a/plugins/outputs/librato/librato.go
+++ b/plugins/outputs/librato/librato.go
@@ -23,13 +23,12 @@ var sampleConfig string
 
 // Librato structure for configuration and client
 type Librato struct {
-	APIUser   config.Secret   `toml:"api_user"`
-	APIToken  config.Secret   `toml:"api_token"`
-	Debug     bool            `toml:"debug"`
-	SourceTag string          `toml:"source_tag" deprecated:"1.0.0;1.35.0;use 'template' instead"`
-	Timeout   config.Duration `toml:"timeout"`
-	Template  string          `toml:"template"`
-	Log       telegraf.Logger `toml:"-"`
+	APIUser  config.Secret   `toml:"api_user"`
+	APIToken config.Secret   `toml:"api_token"`
+	Debug    bool            `toml:"debug"`
+	Timeout  config.Duration `toml:"timeout"`
+	Template string          `toml:"template"`
+	Log      telegraf.Logger `toml:"-"`
 
 	APIUrl string
 	client *http.Client
@@ -86,9 +85,6 @@ func (l *Librato) Write(metrics []telegraf.Metric) error {
 	}
 	if l.Template == "" {
 		l.Template = "host"
-	}
-	if l.SourceTag != "" {
-		l.Template = l.SourceTag
 	}
 
 	var tempGauges []*Gauge


### PR DESCRIPTION
## Summary
Adds an option migration from `source_tag` to the newer `template` option.

## Checklist
- [x] No AI generated code was used in this PR

## Related issues
resolves #16939
