### PR TITLE
fix(inputs.procstat): Fix user filter conditional logic

### DIFF
--- a/plugins/inputs/procstat/filter.go
+++ b/plugins/inputs/procstat/filter.go
@@ -139,7 +139,7 @@ func (f *filter) applyFilter() ([]processGroup, error) {
 		for _, p := range g.processes {
 			// Users
 			if f.filterUser != nil {
-				if username := username(p); username != "" || !f.filterUser.Match(username) {
+				if username := username(p); username == "" || !f.filterUser.Match(username) {
 					// This can happen if we don't have permissions or the process no longer exists
 					continue
 				}


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Filter by users conditional logic is incorrect. Currently, it will continue (skip the process) when:

1. `username != ""` (username is not empty) **OR**
2. `!f.filterUser.Match(username)` (username doesn't match the filter)

This means it will skip processes even when they have valid usernames that DO match the filter, which is likely not what we want.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
