### PR TITLE
fix(outputs.sql): Fix integration test for empty timestamp column

### DIFF
--- a/plugins/outputs/sql/sql_test.go
+++ b/plugins/outputs/sql/sql_test.go
@@ -782,6 +782,7 @@ func TestMysqlEmptyTimestampColumnIntegration(t *testing.T) {
 		DataSourceName:    address,
 		Convert:           defaultConvert,
 		InitSQL:           "SET sql_mode='ANSI_QUOTES';",
+		TimestampColumn:   "",
 		ConnectionMaxIdle: 2,
 		Log:               testutil.Logger{},
 	}


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
The plugin defaults to `TimestampColumn: "timestamp"`, but the test doesn't explicitly override it.

As a result:

* The plugin initialises with `TimestampColumn` set to `"timestamp"`.
* Since the test doesn't change this, it remains `"timestamp"`.
* When `generateCreateTable` runs, the following condition evaluates to true:

  ```go
  if p.TimestampColumn != "" {
      columns = append(columns, fmt.Sprintf("%s %s", quoteIdent(p.TimestampColumn), p.Convert.Timestamp))
  }
  ```

  So a timestamp column is added to the table.

However, the expected output in the test doesn’t include this timestamp column, causing a mismatch.



## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
