### PR TITLE
fix(inputs.ntpq): Fix ntpq field misalignment parsing errors

### DIFF
--- a/plugins/inputs/ntpq/ntpq.go
+++ b/plugins/inputs/ntpq/ntpq.go
@@ -214,91 +214,93 @@ func (n *NTPQ) gatherServer(acc telegraf.Accumulator, server string) {
 		for i, raw := range elements {
 			col := columns[i]
 
+			// Handle tags, empty or invalid entries
 			switch col.etype {
 			case none:
 				continue
 			case tag:
 				tags[col.name] = raw
-			case fieldFloat, fieldDuration, fieldIntDecimal, fieldIntOctal, fieldIntBits, fieldIntRatio8:
+				continue
+			default:
 				// Common validation for all field types to detect misalignment
 				if raw == col.name {
 					// Field misalignment detected - skip this field
 					acc.AddError(fmt.Errorf("%sfield misalignment detected: got column name %q instead of value", msgPrefix, raw))
 					continue
 				}
+			}
 
-				// Handle empty or whitespace-only values
-				if strings.TrimSpace(raw) == "" {
+			// Handle empty or whitespace-only values
+			if strings.TrimSpace(raw) == "" {
+				continue
+			}
+
+			// Type-specific parsing
+			switch col.etype {
+			case fieldFloat:
+				value, err := strconv.ParseFloat(raw, 64)
+				if err != nil {
+					msg := fmt.Sprintf("%sparsing %q (%v) as float failed", msgPrefix, col.name, raw)
+					acc.AddError(fmt.Errorf("%s: %w", msg, err))
 					continue
 				}
-
-				// Now proceed with type-specific parsing
-				switch col.etype {
-				case fieldFloat:
-					value, err := strconv.ParseFloat(raw, 64)
-					if err != nil {
-						msg := fmt.Sprintf("%sparsing %q (%v) as float failed", msgPrefix, col.name, raw)
-						acc.AddError(fmt.Errorf("%s: %w", msg, err))
-						continue
-					}
-					fields[col.name] = value
-				case fieldDuration:
-					// Ignore fields only containing a minus
-					if raw == "-" {
-						continue
-					}
-					factor := int64(1)
-					suffix := raw[len(raw)-1:]
-					switch suffix {
-					case "d":
-						factor = 24 * 3600
-					case "h":
-						factor = 3600
-					case "m":
-						factor = 60
-					default:
-						suffix = ""
-					}
-					value, err := strconv.ParseInt(strings.TrimSuffix(raw, suffix), 10, 64)
-					if err != nil {
-						msg := fmt.Sprintf("%sparsing %q (%v) as duration failed", msgPrefix, col.name, raw)
-						acc.AddError(fmt.Errorf("%s: %w", msg, err))
-						continue
-					}
-					fields[col.name] = value * factor
-				case fieldIntDecimal:
-					value, err := strconv.ParseInt(raw, 10, 64)
-					if err != nil {
-						msg := fmt.Sprintf("%sparsing %q (%v) as int failed", msgPrefix, col.name, raw)
-						acc.AddError(fmt.Errorf("%s: %w", msg, err))
-						continue
-					}
-					fields[col.name] = value
-				case fieldIntOctal:
-					value, err := strconv.ParseInt(raw, 8, 64)
-					if err != nil {
-						msg := fmt.Sprintf("%sparsing %q (%v) as int failed", msgPrefix, col.name, raw)
-						acc.AddError(fmt.Errorf("%s: %w", msg, err))
-						continue
-					}
-					fields[col.name] = value
-				case fieldIntBits:
-					value, err := strconv.ParseUint(raw, 8, 64)
-					if err != nil {
-						msg := fmt.Sprintf("%sparsing %q (%v) as int failed", msgPrefix, col.name, raw)
-						acc.AddError(fmt.Errorf("%s: %w", msg, err))
-						continue
-					}
-					fields[col.name] = bits.OnesCount64(value)
-				case fieldIntRatio8:
-					value, err := strconv.ParseUint(raw, 8, 64)
-					if err != nil {
-						msg := fmt.Sprintf("%sparsing %q (%v) as int failed", msgPrefix, col.name, raw)
-						acc.AddError(fmt.Errorf("%s: %w", msg, err))
-						continue
-					}
-					fields[col.name] = float64(bits.OnesCount64(value)) / float64(8)
+				fields[col.name] = value
+			case fieldDuration:
+				// Ignore fields only containing a minus
+				if raw == "-" {
+					continue
 				}
+				factor := int64(1)
+				suffix := raw[len(raw)-1:]
+				switch suffix {
+				case "d":
+					factor = 24 * 3600
+				case "h":
+					factor = 3600
+				case "m":
+					factor = 60
+				default:
+					suffix = ""
+				}
+				value, err := strconv.ParseInt(strings.TrimSuffix(raw, suffix), 10, 64)
+				if err != nil {
+					msg := fmt.Sprintf("%sparsing %q (%v) as duration failed", msgPrefix, col.name, raw)
+					acc.AddError(fmt.Errorf("%s: %w", msg, err))
+					continue
+				}
+				fields[col.name] = value * factor
+			case fieldIntDecimal:
+				value, err := strconv.ParseInt(raw, 10, 64)
+				if err != nil {
+					msg := fmt.Sprintf("%sparsing %q (%v) as int failed", msgPrefix, col.name, raw)
+					acc.AddError(fmt.Errorf("%s: %w", msg, err))
+					continue
+				}
+				fields[col.name] = value
+			case fieldIntOctal:
+				value, err := strconv.ParseInt(raw, 8, 64)
+				if err != nil {
+					msg := fmt.Sprintf("%sparsing %q (%v) as int failed", msgPrefix, col.name, raw)
+					acc.AddError(fmt.Errorf("%s: %w", msg, err))
+					continue
+				}
+				fields[col.name] = value
+			case fieldIntBits:
+				value, err := strconv.ParseUint(raw, 8, 64)
+				if err != nil {
+					msg := fmt.Sprintf("%sparsing %q (%v) as int failed", msgPrefix, col.name, raw)
+					acc.AddError(fmt.Errorf("%s: %w", msg, err))
+					continue
+				}
+				fields[col.name] = bits.OnesCount64(value)
+			case fieldIntRatio8:
+				value, err := strconv.ParseUint(raw, 8, 64)
+				if err != nil {
+					msg := fmt.Sprintf("%sparsing %q (%v) as int failed", msgPrefix, col.name, raw)
+					acc.AddError(fmt.Errorf("%s: %w", msg, err))
+					continue
+				}
+				fields[col.name] = float64(bits.OnesCount64(value)) / float64(8)
 			}
 		}
 

--- a/plugins/inputs/ntpq/testcases/pool_when_headers_as_data/expected.err
+++ b/plugins/inputs/ntpq/testcases/pool_when_headers_as_data/expected.err
@@ -1,0 +1,6 @@
+field misalignment detected: got column name "when" instead of value
+field misalignment detected: got column name "poll" instead of value
+field misalignment detected: got column name "reach" instead of value
+field misalignment detected: got column name "delay" instead of value
+field misalignment detected: got column name "offset" instead of value
+field misalignment detected: got column name "jitter" instead of value

--- a/plugins/inputs/ntpq/testcases/pool_when_headers_as_data/expected.out
+++ b/plugins/inputs/ntpq/testcases/pool_when_headers_as_data/expected.out
@@ -1,0 +1,1 @@
+ntpq,remote=hostname,refid=.POOL.,stratum=16,type=p poll=64i,reach=0i,delay=0.0,offset=0.0,jitter=0.0 0

--- a/plugins/inputs/ntpq/testcases/pool_when_headers_as_data/input.txt
+++ b/plugins/inputs/ntpq/testcases/pool_when_headers_as_data/input.txt
@@ -1,0 +1,4 @@
+     remote           refid      st t when poll reach   delay   offset  jitter
+==============================================================================
+     remote           refid      st t when poll reach   delay   offset  jitter
+ hostname            .POOL.     16 p    -   64    0    0.000   0.000   0.000

--- a/plugins/inputs/ntpq/testcases/pool_when_headers_as_data/telegraf.conf
+++ b/plugins/inputs/ntpq/testcases/pool_when_headers_as_data/telegraf.conf
@@ -1,0 +1,1 @@
+[[inputs.ntpq]]


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
The ntpq input plugin was failing to parse output when NTP pool configurations were used, resulting in cryptic parsing errors like:

```
E! [inputs.ntpq] Error in plugin: parsing "when" (when) as duration failed: strconv.ParseInt: parsing "when": invalid syntax
```

This occurred when `ntpq -pn` output contained pool entries that caused field misalignment, where column header names appeared as data values instead of actual field values.

### Root Cause

The issue was caused by **field misalignment** in ntpq output where:
1. The parser correctly detected column headers: `["remote", "refid", "st", "t", "when", "poll", "reach", "delay", "offset", "jitter"]`
2. But malformed data lines contained literal column names as values: `["remote", "refid", "st", "t", "when", "poll", "reach", "delay", "offset", "jitter"]`
3. The parser attempted to parse the string "when" as a duration value, causing `strconv.ParseInt` to fail

This commonly happened with:
- NTP pool configurations
- Corrupted ntpq output
- Lines where field alignment was disrupted

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #17147
