### PR TITLE
fix: corrected app name for fabric output plugin

### DIFF
--- a/plugins/outputs/microsoft_fabric/event_house.go
+++ b/plugins/outputs/microsoft_fabric/event_house.go
@@ -87,7 +87,7 @@ func (e *eventhouse) init() error {
 }
 
 func (e *eventhouse) Connect() error {
-	client, err := e.NewClient("Kusto.Telegraf", e.log)
+	client, err := e.NewClient("MSFabric.Telegraf", e.log)
 	if err != nil {
 		return fmt.Errorf("creating new client failed: %w", err)
 	}


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Changed the app name for the MS Fabric output plugin to ensure that the correct app name is displayed.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
