### PR TITLE
test(inputs.snmp_trap): Fix flaky test by waiting for the log message to appear

### DIFF
--- a/plugins/inputs/snmp_trap/snmp_trap_test.go
+++ b/plugins/inputs/snmp_trap/snmp_trap_test.go
@@ -1305,6 +1305,13 @@ func TestOidLookupFail(t *testing.T) {
 
 	// Verify plugin output
 	require.Empty(t, acc.GetTelegrafMetrics())
+
+	// Wait for the logging message to appear and check if it is the one we
+	// expect.
+	require.Eventually(t, func() bool {
+		return len(logger.Errors()) > 0
+	}, 3*time.Second, 100*time.Millisecond)
+
 	var found bool
 	for _, msg := range logger.Errors() {
 		if found = strings.Contains(msg, "unexpected oid"); found {


### PR DESCRIPTION
## Summary

This PR fixes the flaky test when checking for an expected error message by waiting for the log-line to be picked up by the logger.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues
