### PR TITLE
fix(disk-buffer): Correctly reset the mask after adding to an empty buffer

### DIFF
--- a/models/buffer_disk.go
+++ b/models/buffer_disk.go
@@ -124,12 +124,11 @@ func (b *DiskBuffer) addSingleMetric(m telegraf.Metric) bool {
 	if err != nil {
 		panic(err)
 	}
-	err = b.file.Write(b.writeIndex(), data)
-	if err == nil {
-		b.metricAdded()
-		return true
+	if err := b.file.Write(b.writeIndex(), data); err != nil {
+		return false
 	}
-	return false
+	b.metricAdded()
+	return true
 }
 
 func (b *DiskBuffer) BeginTransaction(batchSize int) *Transaction {

--- a/models/buffer_disk.go
+++ b/models/buffer_disk.go
@@ -292,5 +292,6 @@ func (b *DiskBuffer) handleEmptyFile() {
 		log.Printf("E! readIndex: %d, buffer len: %d", b.readIndex(), b.length())
 		panic(err)
 	}
+	b.mask = b.mask[1:]
 	b.isEmpty = false
 }


### PR DESCRIPTION
## Summary

This PR fixes an issue occurring when fully emptying a disk-buffers and then adding new metrics. In case of an empty disk-buffer we need to keep one metric around due to restrictions in the upstream library. We do so but mask the remaining entry so it is not sent again. However, when adding more metrics (after the buffer was filled and is fully empty again) we truncate the first entry in the file **but do not reset the mask**, effectively masking the first new added metric.
This leads to loosing the first new metric every time the buffer was completely drained.

This PR correctly resets the mask if a metric was added to an empty buffer, improves readability and adds a unit-test for this case.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

related to #16981 
