### PR TITLE
feat(output.nats): Allow disabling stream creation for externally managed streams

### DIFF
--- a/plugins/outputs/nats/README.md
+++ b/plugins/outputs/nats/README.md
@@ -66,12 +66,6 @@ to use them.
   ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_OUTPUT.md
   data_format = "influx"
 
-  ## Set to true if the stream is managed externally and Telegraf should not attempt
-  ## to create or update it. When true, Telegraf will connect to the existing stream
-  ## and fail if it does not exist.
-  ## Default is false (Telegraf may create or modify the stream).
-  # external_stream_config = false
-
   ## Jetstream specific configuration. If not nil, it will assume Jetstream context.
   ## Since this is a table, it should be present at the end of the plugin section. Else you can use inline table format.
   # [outputs.nats.jetstream]
@@ -105,4 +99,9 @@ to use them.
     # allow_rollup_hdrs = false
     # allow_direct = true
     # mirror_direct = false
+
+    ## Set to true if the stream is managed externally and Telegraf should not attempt
+    ## to create or update it. When true, Telegraf will connect to the existing stream
+    ## and fail if it does not exist.
+    # external_stream_config = false
 ```

--- a/plugins/outputs/nats/README.md
+++ b/plugins/outputs/nats/README.md
@@ -100,8 +100,7 @@ to use them.
     # allow_direct = true
     # mirror_direct = false
 
-    ## Set to true if the stream is managed externally and Telegraf should not attempt
-    ## to create or update it. When true, Telegraf will connect to the existing stream
-    ## and fail if it does not exist.
-    # external_stream_config = false
+    ## Disable creating the stream but assume the stream is managed externally
+    ## and already exists. This will make the plugin fail if the steam does not exist.
+    # disable_stream_creation = false
 ```

--- a/plugins/outputs/nats/README.md
+++ b/plugins/outputs/nats/README.md
@@ -66,6 +66,12 @@ to use them.
   ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_OUTPUT.md
   data_format = "influx"
 
+  ## Set to true if the stream is managed externally and Telegraf should not attempt
+  ## to create or update it. When true, Telegraf will connect to the existing stream
+  ## and fail if it does not exist.
+  ## Default is false (Telegraf may create or modify the stream).
+  # external_stream_config = false
+
   ## Jetstream specific configuration. If not nil, it will assume Jetstream context.
   ## Since this is a table, it should be present at the end of the plugin section. Else you can use inline table format.
   # [outputs.nats.jetstream]

--- a/plugins/outputs/nats/nats.go
+++ b/plugins/outputs/nats/nats.go
@@ -145,7 +145,7 @@ func (n *NATS) Connect() error {
 			stream, err := n.jetstreamClient.Stream(context.Background(), n.Jetstream.Name)
 			if err != nil {
 				if errors.Is(err, nats.ErrStreamNotFound) {
-					return fmt.Errorf("stream %q does not exist and external_stream_config is true", n.Jetstream.Name)
+					return fmt.Errorf("stream %q does not exist and disable_stream_creation is true", n.Jetstream.Name)
 				}
 				return fmt.Errorf("failed to get stream info, name: %s, err: %w", n.Jetstream.Name, err)
 			}

--- a/plugins/outputs/nats/nats.go
+++ b/plugins/outputs/nats/nats.go
@@ -44,41 +44,41 @@ type NATS struct {
 // StreamConfig is the configuration for creating stream
 // Almost a mirror of https://pkg.go.dev/github.com/nats-io/nats.go/jetstream#StreamConfig but with TOML tags
 type StreamConfig struct {
-	Name                 string                            `toml:"name"`
-	Description          string                            `toml:"description"`
-	Subjects             []string                          `toml:"subjects"`
-	Retention            string                            `toml:"retention"`
-	MaxConsumers         int                               `toml:"max_consumers"`
-	MaxMsgs              int64                             `toml:"max_msgs"`
-	MaxBytes             int64                             `toml:"max_bytes"`
-	Discard              string                            `toml:"discard"`
-	DiscardNewPerSubject bool                              `toml:"discard_new_per_subject"`
-	MaxAge               config.Duration                   `toml:"max_age"`
-	MaxMsgsPerSubject    int64                             `toml:"max_msgs_per_subject"`
-	MaxMsgSize           int32                             `toml:"max_msg_size"`
-	Storage              string                            `toml:"storage"`
-	Replicas             int                               `toml:"num_replicas"`
-	NoAck                bool                              `toml:"no_ack"`
-	Template             string                            `toml:"template_owner"`
-	Duplicates           config.Duration                   `toml:"duplicate_window"`
-	Placement            *jetstream.Placement              `toml:"placement"`
-	Mirror               *jetstream.StreamSource           `toml:"mirror"`
-	Sources              []*jetstream.StreamSource         `toml:"sources"`
-	Sealed               bool                              `toml:"sealed"`
-	DenyDelete           bool                              `toml:"deny_delete"`
-	DenyPurge            bool                              `toml:"deny_purge"`
-	AllowRollup          bool                              `toml:"allow_rollup_hdrs"`
-	Compression          string                            `toml:"compression"`
-	FirstSeq             uint64                            `toml:"first_seq"`
-	SubjectTransform     *jetstream.SubjectTransformConfig `toml:"subject_transform"`
-	RePublish            *jetstream.RePublish              `toml:"republish"`
-	AllowDirect          bool                              `toml:"allow_direct"`
-	MirrorDirect         bool                              `toml:"mirror_direct"`
-	ConsumerLimits       jetstream.StreamConsumerLimits    `toml:"consumer_limits"`
-	Metadata             map[string]string                 `toml:"metadata"`
-	AsyncPublish         bool                              `toml:"async_publish"`
-	AsyncAckTimeout      config.Duration                   `toml:"async_ack_timeout"`
-	ExternalStreamConfig bool                              `toml:"external_stream_config"`
+	Name                  string                            `toml:"name"`
+	Description           string                            `toml:"description"`
+	Subjects              []string                          `toml:"subjects"`
+	Retention             string                            `toml:"retention"`
+	MaxConsumers          int                               `toml:"max_consumers"`
+	MaxMsgs               int64                             `toml:"max_msgs"`
+	MaxBytes              int64                             `toml:"max_bytes"`
+	Discard               string                            `toml:"discard"`
+	DiscardNewPerSubject  bool                              `toml:"discard_new_per_subject"`
+	MaxAge                config.Duration                   `toml:"max_age"`
+	MaxMsgsPerSubject     int64                             `toml:"max_msgs_per_subject"`
+	MaxMsgSize            int32                             `toml:"max_msg_size"`
+	Storage               string                            `toml:"storage"`
+	Replicas              int                               `toml:"num_replicas"`
+	NoAck                 bool                              `toml:"no_ack"`
+	Template              string                            `toml:"template_owner"`
+	Duplicates            config.Duration                   `toml:"duplicate_window"`
+	Placement             *jetstream.Placement              `toml:"placement"`
+	Mirror                *jetstream.StreamSource           `toml:"mirror"`
+	Sources               []*jetstream.StreamSource         `toml:"sources"`
+	Sealed                bool                              `toml:"sealed"`
+	DenyDelete            bool                              `toml:"deny_delete"`
+	DenyPurge             bool                              `toml:"deny_purge"`
+	AllowRollup           bool                              `toml:"allow_rollup_hdrs"`
+	Compression           string                            `toml:"compression"`
+	FirstSeq              uint64                            `toml:"first_seq"`
+	SubjectTransform      *jetstream.SubjectTransformConfig `toml:"subject_transform"`
+	RePublish             *jetstream.RePublish              `toml:"republish"`
+	AllowDirect           bool                              `toml:"allow_direct"`
+	MirrorDirect          bool                              `toml:"mirror_direct"`
+	ConsumerLimits        jetstream.StreamConsumerLimits    `toml:"consumer_limits"`
+	Metadata              map[string]string                 `toml:"metadata"`
+	AsyncPublish          bool                              `toml:"async_publish"`
+	AsyncAckTimeout       config.Duration                   `toml:"async_ack_timeout"`
+	DisableStreamCreation bool                              `toml:"disable_stream_creation"`
 }
 
 func (*NATS) SampleConfig() string {
@@ -141,7 +141,7 @@ func (n *NATS) Connect() error {
 			return fmt.Errorf("failed to connect to jetstream: %w", err)
 		}
 
-		if n.Jetstream.ExternalStreamConfig {
+		if n.Jetstream.DisableStreamCreation {
 			stream, err := n.jetstreamClient.Stream(context.Background(), n.Jetstream.Name)
 			if err != nil {
 				if errors.Is(err, nats.ErrStreamNotFound) {

--- a/plugins/outputs/nats/nats.go
+++ b/plugins/outputs/nats/nats.go
@@ -23,15 +23,14 @@ import (
 var sampleConfig string
 
 type NATS struct {
-	Servers              []string      `toml:"servers"`
-	Secure               bool          `toml:"secure"`
-	Name                 string        `toml:"name"`
-	Username             config.Secret `toml:"username"`
-	Password             config.Secret `toml:"password"`
-	Credentials          string        `toml:"credentials"`
-	Subject              string        `toml:"subject"`
-	Jetstream            *StreamConfig `toml:"jetstream"`
-	ExternalStreamConfig bool          `toml:"external_stream_config"`
+	Servers     []string      `toml:"servers"`
+	Secure      bool          `toml:"secure"`
+	Name        string        `toml:"name"`
+	Username    config.Secret `toml:"username"`
+	Password    config.Secret `toml:"password"`
+	Credentials string        `toml:"credentials"`
+	Subject     string        `toml:"subject"`
+	Jetstream   *StreamConfig `toml:"jetstream"`
 	tls.ClientConfig
 
 	Log telegraf.Logger `toml:"-"`
@@ -79,6 +78,7 @@ type StreamConfig struct {
 	Metadata             map[string]string                 `toml:"metadata"`
 	AsyncPublish         bool                              `toml:"async_publish"`
 	AsyncAckTimeout      config.Duration                   `toml:"async_ack_timeout"`
+	ExternalStreamConfig bool                              `toml:"external_stream_config"`
 }
 
 func (*NATS) SampleConfig() string {
@@ -141,7 +141,7 @@ func (n *NATS) Connect() error {
 			return fmt.Errorf("failed to connect to jetstream: %w", err)
 		}
 
-		if n.ExternalStreamConfig {
+		if n.Jetstream.ExternalStreamConfig {
 			stream, err := n.jetstreamClient.Stream(context.Background(), n.Jetstream.Name)
 			if err != nil {
 				if errors.Is(err, nats.ErrStreamNotFound) {

--- a/plugins/outputs/nats/nats_test.go
+++ b/plugins/outputs/nats/nats_test.go
@@ -249,29 +249,20 @@ func TestConfigParsing(t *testing.T) {
 	}
 }
 
-func createStream(serverURL string, streamConfig nats.StreamConfig) error {
+func createStream(t *testing.T, server string, cfg *nats.StreamConfig) {
+	t.Helper()
+	
 	// Connect to NATS server
-	nc, err := nats.Connect(serverURL)
-	if err != nil {
-		return err
-	}
+	conn, err := nats.Connect(server)
+	require.NoError(t, err)
+	
 	defer func() {
-		if err := nc.Drain(); err != nil {
-			log.Printf("Error during NATS drain: %v", err)
-		}
+		require.NoError(t, conn.Drain(), "draining failed")
 	}()
 
-	// Create JetStream context
-	js, err := nc.JetStream()
-	if err != nil {
-		return err
-	}
-
-	// Add the stream
-	_, err = js.AddStream(&streamConfig)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	// Create the stream in the JetStream context
+	js, err := conn.JetStream()
+	require.NoError(t, err)
+	_, err = js.AddStream(cfg)
+	require.NoError(t, err)
 }

--- a/plugins/outputs/nats/nats_test.go
+++ b/plugins/outputs/nats/nats_test.go
@@ -2,8 +2,6 @@ package nats
 
 import (
 	_ "embed"
-	"fmt"
-	"log"
 	"path/filepath"
 	"testing"
 	"time"
@@ -126,8 +124,8 @@ func TestConnectAndWriteIntegration(t *testing.T) {
 				Name:    "telegraf",
 				Subject: "telegraf",
 				Jetstream: &StreamConfig{
-					Name:                 "my-external-stream",
-					ExternalStreamConfig: true,
+					Name:                  "my-external-stream",
+					DisableStreamCreation: true,
 				},
 				serializer: &influx.Serializer{},
 				Log:        testutil.Logger{},
@@ -152,10 +150,10 @@ func TestConnectAndWriteIntegration(t *testing.T) {
 				Name:    "telegraf",
 				Subject: "telegraf",
 				Jetstream: &StreamConfig{
-					Name:                 "my-external-stream",
-					ExternalStreamConfig: true,
-					MaxMsgs:              10,
-					MaxConsumers:         100,
+					Name:                  "my-external-stream",
+					DisableStreamCreation: true,
+					MaxMsgs:               10,
+					MaxConsumers:          100,
 				},
 				serializer: &influx.Serializer{},
 				Log:        testutil.Logger{},
@@ -177,7 +175,7 @@ func TestConnectAndWriteIntegration(t *testing.T) {
 			defer tc.container.Terminate()
 
 			server := "nats://" + tc.container.Address + ":" + tc.container.Ports[natsServicePort]
-			
+
 			// Create the stream before starting the plugin to simulate
 			// externally managed streams
 			if len(tc.externalStream.Name) > 0 {
@@ -250,11 +248,11 @@ func TestConfigParsing(t *testing.T) {
 
 func createStream(t *testing.T, server string, cfg *nats.StreamConfig) {
 	t.Helper()
-	
+
 	// Connect to NATS server
 	conn, err := nats.Connect(server)
 	require.NoError(t, err)
-	
+
 	defer func() {
 		require.NoError(t, conn.Drain(), "draining failed")
 	}()

--- a/plugins/outputs/nats/nats_test.go
+++ b/plugins/outputs/nats/nats_test.go
@@ -176,16 +176,15 @@ func TestConnectAndWriteIntegration(t *testing.T) {
 			require.NoError(t, err, "failed to start container")
 			defer tc.container.Terminate()
 
-			// If nats cli setup commands are required they need to run
-			// in a nats cli container. The server does not contain the
-			// nats cli tool.
+			server := "nats://" + tc.container.Address + ":" + tc.container.Ports[natsServicePort]
+			
+			// Create the stream before starting the plugin to simulate
+			// externally managed streams
 			if len(tc.externalStream.Name) > 0 {
-				err := createStream(fmt.Sprintf("nats://%s:%s", tc.container.Address, tc.container.Ports[natsServicePort]), tc.externalStream)
-				require.NoError(t, err)
+				createStream(t, server, &tc.externalStream)
 			}
 
-			server := []string{fmt.Sprintf("nats://%s:%s", tc.container.Address, tc.container.Ports[natsServicePort])}
-			tc.nats.Servers = server
+			tc.nats.Servers = []string{server}
 			// Verify that we can connect to the NATS daemon
 			require.NoError(t, tc.nats.Init())
 			err = tc.nats.Connect()

--- a/plugins/outputs/nats/sample.conf
+++ b/plugins/outputs/nats/sample.conf
@@ -33,11 +33,6 @@
   ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_OUTPUT.md
   data_format = "influx"
 
-  ## Set to true if the stream is managed externally and Telegraf should not attempt
-  ## to create or update it. When true, Telegraf will connect to the existing stream
-  ## and fail if it does not exist.
-  # external_stream_config = false
-
   ## Jetstream specific configuration. If not nil, it will assume Jetstream context.
   ## Since this is a table, it should be present at the end of the plugin section. Else you can use inline table format.
   # [outputs.nats.jetstream]
@@ -71,3 +66,8 @@
     # allow_rollup_hdrs = false
     # allow_direct = true
     # mirror_direct = false
+
+    ## Set to true if the stream is managed externally and Telegraf should not attempt
+    ## to create or update it. When true, Telegraf will connect to the existing stream
+    ## and fail if it does not exist.
+    # external_stream_config = false

--- a/plugins/outputs/nats/sample.conf
+++ b/plugins/outputs/nats/sample.conf
@@ -33,6 +33,12 @@
   ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_OUTPUT.md
   data_format = "influx"
 
+  ## Set to true if the stream is managed externally and Telegraf should not attempt
+  ## to create or update it. When true, Telegraf will connect to the existing stream
+  ## and fail if it does not exist.
+  ## Default is false (Telegraf may create or modify the stream).
+  # external_stream_config = false
+
   ## Jetstream specific configuration. If not nil, it will assume Jetstream context.
   ## Since this is a table, it should be present at the end of the plugin section. Else you can use inline table format.
   # [outputs.nats.jetstream]

--- a/plugins/outputs/nats/sample.conf
+++ b/plugins/outputs/nats/sample.conf
@@ -67,7 +67,6 @@
     # allow_direct = true
     # mirror_direct = false
 
-    ## Set to true if the stream is managed externally and Telegraf should not attempt
-    ## to create or update it. When true, Telegraf will connect to the existing stream
-    ## and fail if it does not exist.
-    # external_stream_config = false
+    ## Disable creating the stream but assume the stream is managed externally
+    ## and already exists. This will make the plugin fail if the steam does not exist.
+    # disable_stream_creation = false

--- a/plugins/outputs/nats/sample.conf
+++ b/plugins/outputs/nats/sample.conf
@@ -36,7 +36,6 @@
   ## Set to true if the stream is managed externally and Telegraf should not attempt
   ## to create or update it. When true, Telegraf will connect to the existing stream
   ## and fail if it does not exist.
-  ## Default is false (Telegraf may create or modify the stream).
   # external_stream_config = false
 
   ## Jetstream specific configuration. If not nil, it will assume Jetstream context.


### PR DESCRIPTION
## Summary
Provides a new param that stops Telegraf from trying to alter a stream that is centrally managed on the nats cluster. This should be backwards compatible with existing configurations and functionality.

## Checklist
- [X] No AI generated code was used in this PR

## Related issues
https://github.com/influxdata/telegraf/issues/17072

resolves #17072
