### PR TITLE
fix(outputs): Retrigger batch-available-events correctly

### DIFF
--- a/models/running_output.go
+++ b/models/running_output.go
@@ -48,8 +48,8 @@ type OutputConfig struct {
 // RunningOutput contains the output configuration
 type RunningOutput struct {
 	// Must be 64-bit aligned
-	newMetricsCount int64
-	droppedMetrics  int64
+	droppedMetrics atomic.Int64
+	writeInFlight  atomic.Bool
 
 	Output            telegraf.Output
 	Config            *OutputConfig
@@ -260,15 +260,26 @@ func (r *RunningOutput) add(metric telegraf.Metric) {
 		metric.AddSuffix(r.Config.NameSuffix)
 	}
 
-	dropped := r.buffer.Add(metric)
-	atomic.AddInt64(&r.droppedMetrics, int64(dropped))
+	r.droppedMetrics.Add(int64(r.buffer.Add(metric)))
 
-	count := atomic.AddInt64(&r.newMetricsCount, 1)
-	if count == int64(r.MetricBatchSize) {
-		atomic.StoreInt64(&r.newMetricsCount, 0)
-		select {
-		case r.BatchReady <- time.Now():
-		default:
+	r.triggerBatchCheck()
+}
+
+func (r *RunningOutput) triggerBatchCheck() {
+	// Make sure we trigger another batch-ready event in case we do have more
+	// metrics than the batch-size in the buffer. We guard this trigger to not
+	// be issued if a write is already ongoing to avoid event storms when adding
+	// new metrics during write.
+	if r.buffer.Len() >= r.MetricBatchSize {
+		// Please note: We cannot merge this if into the one above because then
+		// the compare-and-swap condition would always be evaluated and the
+		// swap happens unconditionally from the buffer fullness.
+		if r.writeInFlight.CompareAndSwap(false, true) {
+			select {
+			case r.BatchReady <- time.Now():
+				fmt.Println("-> triggered")
+			default:
+			}
 		}
 	}
 }
@@ -276,6 +287,14 @@ func (r *RunningOutput) add(metric telegraf.Metric) {
 // Write writes all metrics to the output, stopping when all have been sent on
 // or error.
 func (r *RunningOutput) Write() error {
+	// Make sure we check for triggering another write based on buffer fullness
+	// on exit. This is required to handle cases where a lot of metrics were
+	// added during the time we are writing.
+	defer func() {
+		r.writeInFlight.Store(false)
+		r.triggerBatchCheck()
+	}()
+
 	// Try to connect if we are not yet started up
 	if !r.started {
 		r.retries++
@@ -300,21 +319,13 @@ func (r *RunningOutput) Write() error {
 		r.aggMutex.Unlock()
 	}
 
-	atomic.StoreInt64(&r.newMetricsCount, 0)
-
 	// Only process the metrics in the buffer now. Metrics added while we are
-	// writing will be sent on the next call.
+	// writing will be sent on the next call. We can safely add one more write
+	// because 'doTransaction' will abort early for empty batches.
 	nBuffer := r.buffer.Len()
 	nBatches := nBuffer/r.MetricBatchSize + 1
 	for i := 0; i < nBatches; i++ {
-		tx := r.buffer.BeginTransaction(r.MetricBatchSize)
-		if len(tx.Batch) == 0 {
-			return nil
-		}
-		err := r.writeMetrics(tx.Batch)
-		r.updateTransaction(tx, err)
-		r.buffer.EndTransaction(tx)
-		if err != nil {
+		if err := r.doTransaction(); err != nil {
 			return err
 		}
 	}
@@ -323,6 +334,14 @@ func (r *RunningOutput) Write() error {
 
 // WriteBatch writes a single batch of metrics to the output.
 func (r *RunningOutput) WriteBatch() error {
+	// Make sure we check for triggering another write based on buffer fullness
+	// on exit. This is required to handle cases where a lot of metrics were
+	// added during the time we are writing.
+	defer func() {
+		r.writeInFlight.Store(false)
+		r.triggerBatchCheck()
+	}()
+
 	// Try to connect if we are not yet started up
 	if !r.started {
 		r.retries++
@@ -334,6 +353,10 @@ func (r *RunningOutput) WriteBatch() error {
 		r.log.Debugf("Successfully connected after %d attempts", r.retries)
 	}
 
+	return r.doTransaction()
+}
+
+func (r *RunningOutput) doTransaction() error {
 	tx := r.buffer.BeginTransaction(r.MetricBatchSize)
 	if len(tx.Batch) == 0 {
 		return nil
@@ -346,10 +369,9 @@ func (r *RunningOutput) WriteBatch() error {
 }
 
 func (r *RunningOutput) writeMetrics(metrics []telegraf.Metric) error {
-	dropped := atomic.LoadInt64(&r.droppedMetrics)
-	if dropped > 0 {
+	if dropped := r.droppedMetrics.Load(); dropped > 0 {
 		r.log.Warnf("Metric buffer overflow; %d metrics have been dropped", dropped)
-		atomic.StoreInt64(&r.droppedMetrics, 0)
+		r.droppedMetrics.Store(0)
 	}
 
 	start := time.Now()

--- a/models/running_output_test.go
+++ b/models/running_output_test.go
@@ -1,8 +1,10 @@
 package models
 
 import (
+	"context"
 	"errors"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -412,6 +414,167 @@ func TestRunningOutputWriteFailOrder3(t *testing.T) {
 	require.Equal(t, expected, m.Metrics())
 }
 
+func TestRunningOutputBufferFullyDrained(t *testing.T) {
+	// Setup output with a post-write hook to be able to block write until
+	// we added more metrics
+	conf := &OutputConfig{
+		Filter: Filter{},
+	}
+	var shouldBlock atomic.Bool
+	shouldBlock.Store(true)
+	addMore := make(chan bool)
+	defer func() { close(addMore) }()
+	waitForAddedMetrics := make(chan bool)
+	defer func() { close(waitForAddedMetrics) }()
+	plugin := &mockOutput{
+		batchAcceptSize: 0,
+		postWriteHook: func([]telegraf.Metric) error {
+			// Wait for the first full write and block until the test code
+			// added the new metrics
+			if shouldBlock.CompareAndSwap(true, false) {
+				addMore <- true
+				<-waitForAddedMetrics
+			}
+			return nil
+		},
+	}
+	const batchSize = 5
+	ro := NewRunningOutput(plugin, conf, batchSize, 100)
+
+	// Create a multiple of batch size many metrics beyond the batch size
+	const totalMetrics = 10 * batchSize
+	inputs := make([]telegraf.Metric, 0, totalMetrics)
+	for i := range totalMetrics {
+		inputs = append(inputs, testutil.TestMetric(i, "test"))
+	}
+
+	// Setup a event based writing loop similar to what the agent code does.
+	// Remember the first write will block to allow us adding more metrics.
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	var wg sync.WaitGroup
+	var modelWriteErr error
+	wg.Add(1)
+	go func(cctx context.Context) {
+		defer wg.Done()
+		for {
+			select {
+			case <-cctx.Done():
+				return
+			case <-ro.BatchReady:
+				t.Log("triggered batch ready")
+				if modelWriteErr = ro.Write(); modelWriteErr != nil {
+					return
+				}
+			}
+		}
+	}(ctx)
+
+	// Add a few metrics, i.e. more than batch size
+	for _, m := range inputs[:20] {
+		ro.AddMetric(m)
+	}
+
+	// Wait for entering the actual output write and add the remaining metrics.
+	// Afterwards unblock the writer.
+	<-addMore
+	for _, m := range inputs[20:] {
+		ro.AddMetric(m)
+	}
+	waitForAddedMetrics <- true
+
+	// Wait for writing to finish and stop the write loop
+	require.Eventually(t, func() bool {
+		return len(plugin.Metrics()) >= len(inputs)
+	}, 3*time.Second, 100*time.Millisecond)
+	cancel()
+	wg.Wait()
+
+	// Check for writing errors and make sure all metrics were written,
+	// including the ones added while writing took place
+	require.NoError(t, modelWriteErr)
+	require.Equal(t, 10, int(plugin.writes.Load()))
+	require.Len(t, plugin.Metrics(), totalMetrics)
+}
+
+func TestRunningOutputBufferImmediateRestartOnContinuousWrite(t *testing.T) {
+	// Setup output with a post-write hook to be able to block write until
+	// we added more metrics
+	conf := &OutputConfig{
+		Filter: Filter{},
+	}
+
+	const batchSize = 5
+	var shouldBlock atomic.Bool
+	shouldBlock.Store(true)
+	addMore := make(chan bool)
+	defer func() { close(addMore) }()
+	waitForAddedMetrics := make(chan bool)
+	defer func() { close(waitForAddedMetrics) }()
+	plugin := &mockOutput{
+		batchAcceptSize: 0,
+		preWriteHook: func(ms []telegraf.Metric) error {
+			// Wait for the first non-full write and block until the test code
+			// added the new metrics
+			if len(ms) < batchSize && shouldBlock.CompareAndSwap(true, false) {
+				addMore <- true
+				<-waitForAddedMetrics
+			}
+			return nil
+		},
+	}
+	ro := NewRunningOutput(plugin, conf, batchSize, 100)
+
+	// Create a multiple of batch size many metrics beyond the batch size
+	const totalMetrics = 10 * batchSize
+	inputs := make([]telegraf.Metric, 0, totalMetrics)
+	for i := range totalMetrics {
+		inputs = append(inputs, testutil.TestMetric(i, "test"))
+	}
+
+	// Add a few metrics but not a multiple of the batch size
+	for _, m := range inputs[:19] {
+		ro.AddMetric(m)
+	}
+
+	// Start writing and add new metrics as soon as the last non-full batch is
+	// written. At this time add the remaining metrics to check if we are
+	// immediately getting a new write signal.
+	var modelWriteErr error
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		modelWriteErr = ro.Write()
+	}()
+
+	// Wait for the writer to see the non-full batch, add the remaining metrics
+	// and unblock the writer
+	<-addMore
+	for _, m := range inputs[19:] {
+		ro.AddMetric(m)
+	}
+	waitForAddedMetrics <- true
+
+	// Wait for writing to finish
+	wg.Wait()
+	require.NoError(t, modelWriteErr)
+
+	// Check for the new-batch-available trigger
+	require.Eventually(t, func() bool {
+		select {
+		case <-ro.BatchReady:
+			return true
+		default:
+			return false
+		}
+	}, 3*time.Second, 100*time.Millisecond)
+
+	// Trigger the requested write and make sure all metrics were written,
+	// including the ones added while writing took place
+	require.NoError(t, ro.Write())
+	require.Len(t, plugin.Metrics(), totalMetrics)
+}
 func TestRunningOutputInternalMetrics(t *testing.T) {
 	_ = NewRunningOutput(
 		&mockOutput{},
@@ -553,12 +716,12 @@ func TestRunningOutputRetryableStartupBehaviorRetry(t *testing.T) {
 	ro.AddMetric(testutil.TestMetric(2))
 	require.NoError(t, ro.Write())
 	require.True(t, ro.started)
-	require.Equal(t, 1, mo.writes)
+	require.Equal(t, 1, int(mo.writes.Load()))
 
 	ro.AddMetric(testutil.TestMetric(3))
 	require.NoError(t, ro.Write())
 	require.True(t, ro.started)
-	require.Equal(t, 2, mo.writes)
+	require.Equal(t, 2, int(mo.writes.Load()))
 }
 
 func TestRunningOutputRetryableStartupBehaviorIgnore(t *testing.T) {
@@ -681,17 +844,17 @@ func TestRunningOutputPartiallyStarted(t *testing.T) {
 	ro.AddMetric(testutil.TestMetric(1))
 	require.NoError(t, ro.Write())
 	require.False(t, ro.started)
-	require.Equal(t, 1, mo.writes)
+	require.Equal(t, 1, int(mo.writes.Load()))
 
 	ro.AddMetric(testutil.TestMetric(2))
 	require.NoError(t, ro.Write())
 	require.True(t, ro.started)
-	require.Equal(t, 2, mo.writes)
+	require.Equal(t, 2, int(mo.writes.Load()))
 
 	ro.AddMetric(testutil.TestMetric(3))
 	require.NoError(t, ro.Write())
 	require.True(t, ro.started)
-	require.Equal(t, 3, mo.writes)
+	require.Equal(t, 3, int(mo.writes.Load()))
 }
 
 func TestRunningOutputWritePartialSuccess(t *testing.T) {
@@ -918,7 +1081,12 @@ type mockOutput struct {
 	// Startup error simulation
 	startupError      error
 	startupErrorCount int
-	writes            int
+	writes            atomic.Uint32
+
+	// Utility for getting notified about writes and also to manipulate
+	// the write behavior
+	preWriteHook  func([]telegraf.Metric) error
+	postWriteHook func([]telegraf.Metric) error
 }
 
 func (m *mockOutput) Connect() error {
@@ -940,10 +1108,17 @@ func (*mockOutput) SampleConfig() string {
 }
 
 func (m *mockOutput) Write(metrics []telegraf.Metric) error {
-	m.writes++
+	m.writes.Add(1)
 
 	m.Lock()
 	defer m.Unlock()
+
+	// Execute hook if any
+	if m.preWriteHook != nil {
+		if err := m.preWriteHook(metrics); err != nil {
+			return err
+		}
+	}
 
 	// Simulate a failed write
 	if m.batchAcceptSize < 0 {
@@ -951,22 +1126,31 @@ func (m *mockOutput) Write(metrics []telegraf.Metric) error {
 	}
 
 	// Simulate a successful write
+	var resultErr error
 	if m.batchAcceptSize == 0 || len(metrics) <= m.batchAcceptSize {
 		m.metrics = append(m.metrics, metrics...)
-		return nil
+	} else {
+		// Simulate a partially successful write
+		werr := &internal.PartialWriteError{Err: internal.ErrSizeLimitReached}
+		for i, x := range metrics {
+			if m.metricFatalIndex != nil && i == *m.metricFatalIndex {
+				werr.MetricsReject = append(werr.MetricsReject, i)
+			} else if i < m.batchAcceptSize {
+				m.metrics = append(m.metrics, x)
+				werr.MetricsAccept = append(werr.MetricsAccept, i)
+			}
+		}
+		resultErr = werr
 	}
 
-	// Simulate a partially successful write
-	werr := &internal.PartialWriteError{Err: internal.ErrSizeLimitReached}
-	for i, x := range metrics {
-		if m.metricFatalIndex != nil && i == *m.metricFatalIndex {
-			werr.MetricsReject = append(werr.MetricsReject, i)
-		} else if i < m.batchAcceptSize {
-			m.metrics = append(m.metrics, x)
-			werr.MetricsAccept = append(werr.MetricsAccept, i)
+	// Execute hook if any
+	if m.postWriteHook != nil {
+		if err := m.postWriteHook(metrics); err != nil {
+			return err
 		}
 	}
-	return werr
+
+	return resultErr
 }
 
 func (m *mockOutput) Metrics() []telegraf.Metric {


### PR DESCRIPTION
## Summary

The current code triggers a `Write` for an output as soon as a batch becomes available. This is done via the `BatchReady` channel and as a consequence the agent will call the write which then writes all available batches to quickly empty the buffer.

However, when adding metric during the time we write, the code becomes "racy" because we are resetting `newMetricsCount` after finishing the write which will neglect the fact that metrics were added during the write. As a consequence, you _always_ need to add a complete batch _after_ the write finishes (or wait for the flush interval) to trigger another write. This is an issue if metrics are added in bursts much larger than the batch size.

This PR removes the redundant book-keeping and relies on the buffer fullness to determine if a new batch is available. As such we use the buffer as a single place of truth. To avoid causing trigger storms we avoid retriggering a write if there is one in progress.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #17200
