### PR TITLE
Disk buffer issue 16981

### DIFF
--- a/models/buffer.go
+++ b/models/buffer.go
@@ -104,7 +104,7 @@ func NewBuffer(name, id, alias string, capacity int, strategy, path string) (Buf
 	case "", "memory":
 		return NewMemoryBuffer(capacity, bs)
 	case "disk_write_through":
-		return NewDiskBuffer(name, id, path, bs)
+		return NewDiskBuffer(id, path, bs)
 	}
 	return nil, fmt.Errorf("invalid buffer strategy %q", strategy)
 }

--- a/models/buffer_disk.go
+++ b/models/buffer_disk.go
@@ -41,17 +41,11 @@ type DiskBuffer struct {
 	mask []int
 }
 
-func NewDiskBuffer(name, id, path string, stats BufferStats) (*DiskBuffer, error) {
+func NewDiskBuffer(id, path string, stats BufferStats) (*DiskBuffer, error) {
 	filePath := filepath.Join(path, id)
 	walFile, err := wal.Open(filePath, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open wal file: %w", err)
-	}
-	//nolint:errcheck // cannot error here
-	if index, _ := walFile.FirstIndex(); index == 0 {
-		// simple way to test if the walfile is freshly initialized, meaning no existing file was found
-		log.Printf("I! WAL file not found for plugin outputs.%s (%s), "+
-			"this can safely be ignored if you added this plugin instance for the first time", name, id)
 	}
 
 	buf := &DiskBuffer{

--- a/models/buffer_disk_test.go
+++ b/models/buffer_disk_test.go
@@ -201,3 +201,63 @@ func TestDiskBufferEmptyReuse(t *testing.T) {
 	tx.AcceptAll()
 	buf.EndTransaction(tx)
 }
+
+// TestDiskBufferEmptyClose is a regression test for making sure that we do not
+// encounter any metrics in a reopened buffer if it was closed in an empty state.
+// This should be the normal case if all metrics are successfully written when
+// stopping Telegraf. On next startup the buffer should be empty. Related to
+// https://github.com/influxdata/telegraf/issues/16981
+func TestDiskBufferEmptyClose(t *testing.T) {
+	tmpdir := t.TempDir()
+
+	// Create a disk buffer
+	buf, err := NewBuffer("test", "id123", "", 0, "disk_write_through", tmpdir)
+	require.NoError(t, err)
+	defer buf.Close()
+	diskBuf, ok := buf.(*DiskBuffer)
+	require.True(t, ok, "buffer is not a disk buffer")
+
+	// Add some metrics to the buffer
+	expected := make([]telegraf.Metric, 0, 5)
+	for i := range 5 {
+		m := metric.New("test", map[string]string{}, map[string]interface{}{"value": i}, time.Now())
+		buf.Add(m)
+		expected = append(expected, m)
+	}
+
+	// Read the complete set of metrics such that the buffer is empty again
+	tx := buf.BeginTransaction(5)
+	testutil.RequireMetricsEqual(t, expected, tx.Batch)
+	tx.AcceptAll()
+	buf.EndTransaction(tx)
+
+	// Make sure the buffer was fully emptied
+	require.True(t, diskBuf.isEmpty)
+	require.Equal(t, 0, diskBuf.length())
+
+	// Close the buffer to simulate stopping Telegraf in a normal shutdown
+	require.NoError(t, diskBuf.Close())
+
+	// Reopen the buffer with the parameters above to see the same buffer
+	reopened, err := NewBuffer("test", "id123", "", 0, "disk_write_through", tmpdir)
+	require.NoError(t, err)
+	defer reopened.Close()
+	_, ok = reopened.(*DiskBuffer)
+	require.True(t, ok, "reopened buffer is not a disk buffer")
+
+	// Try to read the buffer again. This should return an empty transaction...
+	tx = reopened.BeginTransaction(5)
+	require.Empty(t, tx.Batch)
+	reopened.EndTransaction(tx)
+
+	// However, adding a new metric to the buffer should work
+	// Now add another set of metrics and make sure we can read it
+	m := metric.New("test", map[string]string{}, map[string]interface{}{"value": 42}, time.Now())
+	reopened.Add(m)
+
+	// Read the complete set of metrics such that the buffer is empty again
+	tx = reopened.BeginTransaction(5)
+	testutil.RequireMetricsEqual(t, []telegraf.Metric{m}, tx.Batch)
+	tx.AcceptAll()
+	reopened.EndTransaction(tx)
+}


### PR DESCRIPTION
## Summary

When fully emptying a disk-buffer and then restarting (i.e. shutdown and start) Telegraf then empty disk-buffer still contains a (masked) metric due to restrictions in the upstream library. At runtime this is not an issue because we keep track of the empty state of the buffer and do not send the metric again. However, when shutting down Telegraf the WAL file still contains the (masked) metric but the mask and the "empty buffer" flag gets lost as it is not persisted to disk. As a consequence, we will resend the last metric even though it already has been sent.

This PR deletes the WAL file(s) when closing the empty buffer to make sure we do not send the metric again. This code can likely go away again if either https://github.com/tidwall/wal/pull/31 or https://github.com/tidwall/wal/pull/29 are merged.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

related to #16981
