### PR TITLE
feat(outputs.sql): Allow sending batches of metrics in transactions

### DIFF
--- a/plugins/outputs/sql/README.md
+++ b/plugins/outputs/sql/README.md
@@ -67,6 +67,9 @@ DEFAULT CURRENT\_TIMESTAMP, {COLUMNS})".
 The mapping of metric types to sql column types can be customized through the
 convert settings.
 
+If your database server supports Prepared Statements / Batch / Bulk Inserts,
+you could improve the ingestion rate, by enabling `batch_transactions`
+
 ## Global configuration options <!-- @/docs/includes/plugin_config.md -->
 
 In addition to the plugin-specific configuration settings, plugins support
@@ -129,6 +132,9 @@ how to use them.
 
   ## Initialization SQL
   # init_sql = ""
+
+  ## Send metrics with the same columns and the same table as batches using prepared statements
+  # batch_transactions = false
 
   ## Maximum amount of time a connection may be idle. "0s" means connections are
   ## never closed due to idle time.

--- a/plugins/outputs/sql/sample.conf
+++ b/plugins/outputs/sql/sample.conf
@@ -41,6 +41,9 @@
   ## Initialization SQL
   # init_sql = ""
 
+  ## Send metrics with the same columns and the same table as batches using prepared statements
+  # batch_transactions = false
+
   ## Maximum amount of time a connection may be idle. "0s" means connections are
   ## never closed due to idle time.
   # connection_max_idle_time = "0s"

--- a/plugins/outputs/sql/sql_test.go
+++ b/plugins/outputs/sql/sql_test.go
@@ -313,6 +313,93 @@ func TestMysqlUpdateSchemeIntegration(t *testing.T) {
 	}
 }
 
+func TestMysqlIntegrationSendBatch(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	initdb, err := filepath.Abs("testdata/mariadb/initdb/script.sql")
+	require.NoError(t, err)
+
+	// initdb/script.sql creates this database
+	const dbname = "foo"
+
+	// The mariadb image lets you set the root password through an env
+	// var. We'll use root to insert and query test data.
+	const username = "root"
+
+	password := testutil.GetRandomString(32)
+	outDir := t.TempDir()
+
+	servicePort := "3306"
+	container := testutil.Container{
+		Image: "mariadb",
+		Env: map[string]string{
+			"MARIADB_ROOT_PASSWORD": password,
+		},
+		Files: map[string]string{
+			"/docker-entrypoint-initdb.d/script.sql": initdb,
+			"/out":                                   outDir,
+		},
+		ExposedPorts: []string{servicePort},
+		WaitingFor: wait.ForAll(
+			wait.ForListeningPort(nat.Port(servicePort)),
+			wait.ForLog("mariadbd: ready for connections.").WithOccurrence(2),
+		),
+	}
+	require.NoError(t, container.Start(), "failed to start container")
+	defer container.Terminate()
+
+	// use the plugin to write to the database
+	address := config.NewSecret([]byte(fmt.Sprintf("%v:%v@tcp(%v:%v)/%v",
+		username, password, container.Address, container.Ports[servicePort], dbname,
+	)))
+	p := &SQL{
+		Driver:            "mysql",
+		DataSourceName:    address,
+		Convert:           defaultConvert,
+		InitSQL:           "SET sql_mode='ANSI_QUOTES';",
+		TimestampColumn:   "timestamp",
+		ConnectionMaxIdle: 2,
+		Log:               testutil.Logger{},
+		BatchTx:           true,
+	}
+	require.NoError(t, p.Init())
+
+	require.NoError(t, p.Connect())
+	require.NoError(t, p.Write(testMetrics))
+
+	files := []string{
+		"./testdata/mariadb/expected_metric_one.sql",
+		"./testdata/mariadb/expected_metric_two.sql",
+		"./testdata/mariadb/expected_metric_three.sql",
+	}
+	for _, fn := range files {
+		expected, err := os.ReadFile(fn)
+		require.NoError(t, err)
+
+		require.Eventually(t, func() bool {
+			rc, out, err := container.Exec([]string{
+				"bash",
+				"-c",
+				"mariadb-dump --user=" + username +
+					" --password=" + password +
+					" --compact" +
+					" --skip-opt " +
+					" --skip-no-autocommit " +
+					dbname,
+			})
+			require.NoError(t, err)
+			require.Equal(t, 0, rc)
+
+			b, err := io.ReadAll(out)
+			require.NoError(t, err)
+
+			return bytes.Contains(b, expected)
+		}, 10*time.Second, 500*time.Millisecond, fn)
+	}
+}
+
 func TestPostgresIntegration(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
@@ -492,6 +579,94 @@ func TestPostgresUpdateSchemeIntegration(t *testing.T) {
 			return bytes.Contains(b, []byte(column))
 		}, 5*time.Second, 500*time.Millisecond, column)
 	}
+}
+
+func TestPostgresIntegrationSendBatch(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	initdb, err := filepath.Abs("testdata/postgres/initdb/init.sql")
+	require.NoError(t, err)
+
+	// initdb/init.sql creates this database
+	const dbname = "foo"
+
+	// default username for postgres is postgres
+	const username = "postgres"
+
+	password := testutil.GetRandomString(32)
+	outDir := t.TempDir()
+
+	servicePort := "5432"
+	container := testutil.Container{
+		Image: "postgres",
+		Env: map[string]string{
+			"POSTGRES_PASSWORD": password,
+		},
+		Files: map[string]string{
+			"/docker-entrypoint-initdb.d/script.sql": initdb,
+			"/out":                                   outDir,
+		},
+		ExposedPorts: []string{servicePort},
+		WaitingFor: wait.ForAll(
+			wait.ForListeningPort(nat.Port(servicePort)),
+			wait.ForLog("database system is ready to accept connections").WithOccurrence(2),
+		),
+	}
+	require.NoError(t, container.Start(), "failed to start container")
+	defer container.Terminate()
+
+	// use the plugin to write to the database
+	// host, port, username, password, dbname
+	address := config.NewSecret([]byte(fmt.Sprintf("postgres://%v:%v@%v:%v/%v",
+		username, password, container.Address, container.Ports[servicePort], dbname,
+	)))
+	p := &SQL{
+		Driver:            "pgx",
+		DataSourceName:    address,
+		Convert:           defaultConvert,
+		TimestampColumn:   "timestamp",
+		ConnectionMaxIdle: 2,
+		Log:               testutil.Logger{},
+		BatchTx:           true,
+	}
+	p.Convert.Real = "double precision"
+	p.Convert.Unsigned = "bigint"
+	p.Convert.ConversionStyle = "literal"
+	require.NoError(t, p.Init())
+
+	require.NoError(t, p.Connect())
+	defer p.Close()
+	require.NoError(t, p.Write(testMetrics))
+	require.NoError(t, p.Close())
+
+	expected, err := os.ReadFile("./testdata/postgres/expected.sql")
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		rc, out, err := container.Exec([]string{
+			"bash",
+			"-c",
+			"pg_dump" +
+				" --username=" + username +
+				" --no-comments" +
+				" " + dbname +
+				// pg_dump's output has comments that include build info
+				// of postgres and pg_dump. The build info changes with
+				// each release. To prevent these changes from causing the
+				// test to fail, we strip out comments. Also strip out
+				// blank lines.
+				"|grep -E -v '(^--|^$|^SET )'",
+		})
+		require.NoError(t, err)
+		require.Equal(t, 0, rc)
+
+		b, err := io.ReadAll(out)
+		require.NoError(t, err)
+
+		return bytes.Contains(b, expected)
+	}, 5*time.Second, 500*time.Millisecond)
 }
 
 func TestClickHouseIntegration(t *testing.T) {
@@ -733,6 +908,102 @@ func TestClickHouseDsnConvert(t *testing.T) {
 		resolvedDsn := resolvedSecret.String()
 		resolvedSecret.Destroy()
 		require.Equal(t, tt.expected, resolvedDsn)
+	}
+}
+
+func TestClickHouseIntegrationSendBatch(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	logConfig, err := filepath.Abs("testdata/clickhouse/enable_stdout_log.xml")
+	require.NoError(t, err)
+
+	initdb, err := filepath.Abs("testdata/clickhouse/initdb/init.sql")
+	require.NoError(t, err)
+
+	// initdb/init.sql creates this database
+	const dbname = "foo"
+
+	// username for connecting to clickhouse
+	const username = "clickhouse"
+
+	password := testutil.GetRandomString(32)
+	outDir := t.TempDir()
+
+	servicePort := "9000"
+	container := testutil.Container{
+		Image:        "clickhouse",
+		ExposedPorts: []string{servicePort, "8123"},
+		Env: map[string]string{
+			"CLICKHOUSE_USER":     "clickhouse",
+			"CLICKHOUSE_PASSWORD": password,
+		},
+		Files: map[string]string{
+			"/docker-entrypoint-initdb.d/script.sql":                initdb,
+			"/etc/clickhouse-server/config.d/enable_stdout_log.xml": logConfig,
+			"/out": outDir,
+		},
+		WaitingFor: wait.ForAll(
+			wait.NewHTTPStrategy("/").WithPort(nat.Port("8123")),
+			wait.ForListeningPort(nat.Port(servicePort)),
+			wait.ForLog("Ready for connections"),
+		),
+	}
+	require.NoError(t, container.Start(), "failed to start container")
+	defer container.Terminate()
+
+	// use the plugin to write to the database
+	// host, port, username, password, dbname
+	address := config.NewSecret([]byte(fmt.Sprintf("tcp://%s:%s/%s?username=%s&password=%s",
+		container.Address, container.Ports[servicePort], dbname, username, password)))
+	p := &SQL{
+		Driver:            "clickhouse",
+		DataSourceName:    address,
+		Convert:           defaultConvert,
+		TimestampColumn:   "timestamp",
+		ConnectionMaxIdle: 2,
+		Log:               testutil.Logger{},
+		BatchTx:           true,
+	}
+	p.Convert.Integer = "Int64"
+	p.Convert.Text = "String"
+	p.Convert.Timestamp = "DateTime"
+	p.Convert.Defaultvalue = "String"
+	p.Convert.Unsigned = "UInt64"
+	p.Convert.Bool = "UInt8"
+	p.Convert.ConversionStyle = "literal"
+	require.NoError(t, p.Init())
+
+	require.NoError(t, p.Connect())
+	require.NoError(t, p.Write(testMetrics))
+
+	cases := []struct {
+		table    string
+		expected string
+	}{
+		{"metric_one", "`float64_one` Float64"},
+		{"metric_two", "`string_one` String"},
+		{"metric three", "`string two` String"},
+	}
+	for _, tc := range cases {
+		require.Eventually(t, func() bool {
+			var out io.Reader
+			_, out, err = container.Exec([]string{
+				"bash",
+				"-c",
+				"clickhouse-client" +
+					" --user=" + username +
+					" --database=" + dbname +
+					" --format=TabSeparatedRaw" +
+					" --multiquery" +
+					` --query="SELECT * FROM \"` + tc.table + `\"; SHOW CREATE TABLE \"` + tc.table + `\""`,
+			})
+			require.NoError(t, err)
+			b, err := io.ReadAll(out)
+			require.NoError(t, err)
+			return bytes.Contains(b, []byte(tc.expected))
+		}, 5*time.Second, 500*time.Millisecond)
 	}
 }
 

--- a/plugins/outputs/sql/sqlite_test.go
+++ b/plugins/outputs/sql/sqlite_test.go
@@ -179,3 +179,124 @@ func TestSqliteUpdateScheme(t *testing.T) {
 		sql,
 	)
 }
+
+func TestSqliteSendBatch(t *testing.T) {
+	dbfile := filepath.Join(t.TempDir(), "db")
+	defer os.Remove(dbfile)
+
+	// Use the plugin to write to the database address :=
+	// fmt.Sprintf("file:%v", dbfile)
+	address := dbfile // accepts a path or a file: URI
+	p := &SQL{
+		Driver:            "sqlite",
+		DataSourceName:    config.NewSecret([]byte(address)),
+		Convert:           defaultConvert,
+		TimestampColumn:   "timestamp",
+		ConnectionMaxIdle: 2,
+		Log:               testutil.Logger{},
+		BatchTx:           true,
+	}
+	require.NoError(t, p.Init())
+
+	require.NoError(t, p.Connect())
+	defer p.Close()
+	require.NoError(t, p.Write(testMetrics))
+
+	// read directly from the database
+	db, err := gosql.Open("sqlite", address)
+	require.NoError(t, err)
+	defer db.Close()
+
+	var countMetricOne int
+	require.NoError(t, db.QueryRow("select count(*) from metric_one").Scan(&countMetricOne))
+	require.Equal(t, 1, countMetricOne)
+
+	var countMetricTwo int
+	require.NoError(t, db.QueryRow("select count(*) from metric_two").Scan(&countMetricTwo))
+	require.Equal(t, 1, countMetricTwo)
+
+	var rows *gosql.Rows
+
+	// Check that tables were created as expected
+	rows, err = db.Query("select sql from sqlite_master")
+	require.NoError(t, err)
+	defer rows.Close()
+	var sql string
+	require.True(t, rows.Next())
+	require.NoError(t, rows.Scan(&sql))
+	require.Equal(t,
+		`CREATE TABLE "metric_one"("timestamp" TIMESTAMP,"tag_one" TEXT,"tag_two" TEXT,"int64_one" INT,`+
+			`"int64_two" INT,"bool_one" BOOL,"bool_two" BOOL,"uint64_one" INT UNSIGNED,"float64_one" DOUBLE)`,
+		sql,
+	)
+	require.True(t, rows.Next())
+	require.NoError(t, rows.Scan(&sql))
+	require.Equal(t,
+		`CREATE TABLE "metric_two"("timestamp" TIMESTAMP,"tag_three" TEXT,"string_one" TEXT)`,
+		sql,
+	)
+	require.True(t, rows.Next())
+	require.NoError(t, rows.Scan(&sql))
+	require.Equal(t,
+		`CREATE TABLE "metric three"("timestamp" TIMESTAMP,"tag four" TEXT,"string two" TEXT)`,
+		sql,
+	)
+	require.False(t, rows.Next())
+
+	// sqlite stores dates as strings. They may be in the local
+	// timezone. The test needs to parse them back into a time.Time to
+	// check them.
+	// timeLayout := "2006-01-02 15:04:05 -0700 MST"
+	timeLayout := "2006-01-02T15:04:05Z"
+	var actualTime time.Time
+
+	// Check contents of tables
+	rows2, err := db.Query("select timestamp, tag_one, tag_two, int64_one, int64_two from metric_one")
+	require.NoError(t, err)
+	defer rows2.Close()
+	require.True(t, rows2.Next())
+	var (
+		a    string
+		b, c string
+		d, e int64
+	)
+	require.NoError(t, rows2.Scan(&a, &b, &c, &d, &e))
+	actualTime, err = time.Parse(timeLayout, a)
+	require.NoError(t, err)
+	require.Equal(t, ts, actualTime.UTC())
+	require.Equal(t, "tag1", b)
+	require.Equal(t, "tag2", c)
+	require.Equal(t, int64(1234), d)
+	require.Equal(t, int64(2345), e)
+	require.False(t, rows2.Next())
+
+	rows3, err := db.Query("select timestamp, tag_three, string_one from metric_two")
+	require.NoError(t, err)
+	defer rows3.Close()
+	require.True(t, rows3.Next())
+	var (
+		f, g, h string
+	)
+	require.NoError(t, rows3.Scan(&f, &g, &h))
+	actualTime, err = time.Parse(timeLayout, f)
+	require.NoError(t, err)
+	require.Equal(t, ts, actualTime.UTC())
+	require.Equal(t, "tag3", g)
+	require.Equal(t, "string1", h)
+	require.False(t, rows3.Next())
+
+	rows4, err := db.Query(`select timestamp, "tag four", "string two" from "metric three"`)
+	require.NoError(t, err)
+	defer rows4.Close()
+	require.True(t, rows4.Next())
+	var (
+		i, j, k string
+	)
+	require.NoError(t, rows4.Scan(&i, &j, &k))
+	actualTime, err = time.Parse(timeLayout, i)
+	require.NoError(t, err)
+	require.Equal(t, ts, actualTime.UTC())
+	require.Equal(t, "tag4", j)
+	require.Equal(t, "string2", k)
+	require.False(t, rows4.Next())
+}


### PR DESCRIPTION
## Summary
The current approach to writing, issues an INSERT query for every metric in the buffer, which while working, leaves room for improvement.

This commit modifies the Write behavior as follows:

- Sort the metrics fields/tags (to ensure greater cache-hit ratio)
- Add Prepared statements option

This option caches multiple metrics, so they are issued as a single query.

The results depends on the metrics buffer, the metric cardinality, the output server configuration, etc.

That being said, in micro-benchmarks and production deployment, we've seen 10-100x improvement in write performance.

Due to a priority shift, the previous PR (#16725) has been closed, this one continues with the suggestion to use a hash in order to cache INSERT query template.

In this PR, we're using XXHash (indirect dependency) as it promises better performance across wide variety of hardware.

INSERT query generation is used by default for both Write paths (Current and Prepared), in order to avoid maintenance burden and simplify the Write logic. It should not affect existing users and provides a minor performance boost for them as well.

### Benchmark:

Batches of 1000, 5000, 10000, 50000 and 100000 metrics.

```
                                   │       Write       │               Prepared               │
                                   │      sec/op       │    sec/op     vs base                │
SqliteThroughput/metrics_1000-4           96.629m ± 1%   6.301m ± 11%  -93.48% (p=0.000 n=10)
SqliteThroughput/metrics_5000-4           479.83m ± 1%   29.68m ±  3%  -93.82% (p=0.000 n=10)
SqliteThroughput/metrics_10000-4          961.55m ± 1%   58.56m ±  1%  -93.91% (p=0.000 n=10)
SqliteThroughput/metrics_50000-4          4831.4m ± 0%   294.8m ±  2%  -93.90% (p=0.000 n=10)
SqliteThroughput/metrics_100000-4         9672.9m ± 0%   586.4m ±  1%  -93.94% (p=0.000 n=10)
geomean                                     1.158        71.69m        -93.81%
```

Note:

There are many flaws with this benchmark: SQLite is not representative of every driver, system-specific conditions, metrics had very low cardinality (fewer INSERT queries).

But while a bad benchmark, it's not completely useless and it shows the stark difference in extreme cases.

## Checklist
- [X] No AI generated code was used in this PR