### PR TITLE
feat(outputs.sql): Fix sql batching

### DIFF
--- a/plugins/outputs/sql/sql.go
+++ b/plugins/outputs/sql/sql.go
@@ -176,11 +176,12 @@ func (p *SQL) deriveDatatype(value interface{}) string {
 	case int64:
 		datatype = p.Convert.Integer
 	case uint64:
-		if p.Convert.ConversionStyle == "unsigned_suffix" {
+		switch p.Convert.ConversionStyle {
+		case "unsigned_suffix":
 			datatype = fmt.Sprintf("%s %s", p.Convert.Integer, p.Convert.Unsigned)
-		} else if p.Convert.ConversionStyle == "literal" {
+		case "literal":
 			datatype = p.Convert.Unsigned
-		} else {
+		default:
 			p.Log.Errorf("unknown conversion style: %s", p.Convert.ConversionStyle)
 		}
 	case float64:

--- a/plugins/outputs/sql/sql.go
+++ b/plugins/outputs/sql/sql.go
@@ -406,14 +406,14 @@ func (p *SQL) Write(metrics []telegraf.Metric) error {
 		}
 		stmt, err := tx.Prepare(insertSQL)
 		if err != nil {
-			tx.Rollback()
+			_ = tx.Rollback()
 			return fmt.Errorf("prepare failed: %w", err)
 		}
-		defer stmt.Close()
+		defer stmt.Close() //nolint:revive,gocritic // done on purpose, closing will be executed properly
 
 		for _, row := range rows {
 			if _, err := stmt.Exec(row...); err != nil {
-				tx.Rollback()
+				_ = tx.Rollback()
 				return fmt.Errorf("exec failed: %w", err)
 			}
 		}

--- a/plugins/outputs/sql/sqlite_test.go
+++ b/plugins/outputs/sql/sqlite_test.go
@@ -178,6 +178,6 @@ func TestSqliteUpdateScheme(t *testing.T) {
 	require.Contains(t, actualStmts,
 		`CREATE TABLE "metric_one"("timestamp" TIMESTAMP,"tag_one" TEXT,"tag_two" TEXT,"int64_one" INT,`+
 			`"int64_two" INT,"bool_one" BOOL,"bool_two" BOOL,"uint64_one" INT UNSIGNED,"float64_one" DOUBLE,`+
-			` "tag_add_after_create" TEXT, "bool_add_after_create" BOOL)`,
+			` "bool_add_after_create" BOOL, "tag_add_after_create" TEXT)`,
 	)
 }


### PR DESCRIPTION
## Summary
Clickhouse insert performance suffers without proper batching
- group batch insertion by table to evade sparse insert
- normalize rows to have same column set per batch (for prepared stmt)
- tx.Rollback in case tx.Prepare or stmt.Exec gone wrong
- alter sqlite_test to not rely on insertion order

## Checklist
- [ x] No AI generated code was used in this PR

## Related issues
resolves #17237
