### PR TITLE
fix(inputs.kibana): Support Kibana 8.x status API format change

### DIFF
--- a/plugins/inputs/kibana/kibana_test.go
+++ b/plugins/inputs/kibana/kibana_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/influxdata/telegraf/testutil"
 )
 
-func defaultTags6_3() map[string]string {
+func defaulttags63() map[string]string {
 	return map[string]string{
 		"name":    "my-kibana",
 		"source":  "example.com:5601",
@@ -18,12 +18,39 @@ func defaultTags6_3() map[string]string {
 	}
 }
 
-func defaultTags6_5() map[string]string {
+func defaulttags65() map[string]string {
 	return map[string]string{
 		"name":    "my-kibana",
 		"source":  "example.com:5601",
 		"version": "6.5.4",
 		"status":  "green",
+	}
+}
+
+func defaulttags815() map[string]string {
+	return map[string]string{
+		"name":    "my-kibana",
+		"source":  "example.com:5601",
+		"version": "8.15.2",
+		"status":  "green", // available maps to green
+	}
+}
+
+func defaulttags815Degraded() map[string]string {
+	return map[string]string{
+		"name":    "my-kibana",
+		"source":  "example.com:5601",
+		"version": "8.15.2",
+		"status":  "yellow", // degraded maps to yellow
+	}
+}
+
+func defaulttags815Unavailable() map[string]string {
+	return map[string]string{
+		"name":    "my-kibana",
+		"source":  "example.com:5601",
+		"version": "8.15.2",
+		"status":  "red", // unavailable maps to red
 	}
 }
 
@@ -50,34 +77,227 @@ func (t *transportMock) RoundTrip(r *http.Request) (*http.Response, error) {
 	return res, nil
 }
 
-func checkKibanaStatusResult(version string, t *testing.T, acc *testutil.Accumulator) {
-	if version == "6.3.2" {
-		tags := defaultTags6_3()
-		acc.AssertContainsTaggedFields(t, "kibana", kibanaStatusExpected6_3, tags)
-	} else {
-		tags := defaultTags6_5()
-		acc.AssertContainsTaggedFields(t, "kibana", kibanaStatusExpected6_5, tags)
+func checkKibanaStatusResult(version, statusLevel string, t *testing.T, acc *testutil.Accumulator) {
+	switch version {
+	case "6.3.2":
+		tags := defaulttags63()
+		acc.AssertContainsTaggedFields(t, "kibana", kibanastatusexpected63, tags)
+	case "6.5.4":
+		tags := defaulttags65()
+		acc.AssertContainsTaggedFields(t, "kibana", kibanastatusexpected65, tags)
+	case "8.15.2":
+		switch statusLevel {
+		case "available":
+			tags := defaulttags815()
+			acc.AssertContainsTaggedFields(t, "kibana", kibanastatusexpected815, tags)
+		case "degraded":
+			tags := defaulttags815Degraded()
+			acc.AssertContainsTaggedFields(t, "kibana", kibanastatusexpected815Degraded, tags)
+		case "unavailable":
+			tags := defaulttags815Unavailable()
+			acc.AssertContainsTaggedFields(t, "kibana", kibanastatusexpected815Unavailable, tags)
+		}
 	}
 }
 
 func TestGather(t *testing.T) {
 	ks := newKibanahWithClient()
 	ks.Servers = []string{"http://example.com:5601"}
+
 	// Unit test for Kibana version < 6.4
-	ks.client.Transport = newTransportMock(http.StatusOK, kibanaStatusResponse6_3)
+	ks.client.Transport = newTransportMock(http.StatusOK, kibanastatusresponse63)
 	var acc1 testutil.Accumulator
 	if err := acc1.GatherError(ks.Gather); err != nil {
 		t.Fatal(err)
 	}
-	checkKibanaStatusResult(defaultTags6_3()["version"], t, &acc1)
+	checkKibanaStatusResult(defaulttags63()["version"], "", t, &acc1)
 
 	// Unit test for Kibana version >= 6.4
-	ks.client.Transport = newTransportMock(http.StatusOK, kibanaStatusResponse6_5)
+	ks.client.Transport = newTransportMock(http.StatusOK, kibanastatusresponse65)
 	var acc2 testutil.Accumulator
 	if err := acc2.GatherError(ks.Gather); err != nil {
 		t.Fatal(err)
 	}
-	checkKibanaStatusResult(defaultTags6_5()["version"], t, &acc2)
+	checkKibanaStatusResult(defaulttags65()["version"], "", t, &acc2)
+
+	// Unit test for Kibana 8.x with "available" status
+	ks.client.Transport = newTransportMock(http.StatusOK, kibanastatusresponse815)
+	var acc3 testutil.Accumulator
+	if err := acc3.GatherError(ks.Gather); err != nil {
+		t.Fatal(err)
+	}
+	checkKibanaStatusResult(defaulttags815()["version"], "available", t, &acc3)
+
+	// Unit test for Kibana 8.x with "degraded" status
+	ks.client.Transport = newTransportMock(http.StatusOK, kibanastatusresponse815Degraded)
+	var acc4 testutil.Accumulator
+	if err := acc4.GatherError(ks.Gather); err != nil {
+		t.Fatal(err)
+	}
+	checkKibanaStatusResult(defaulttags815()["version"], "degraded", t, &acc4)
+
+	// Unit test for Kibana 8.x with "unavailable" status
+	ks.client.Transport = newTransportMock(http.StatusOK, kibanastatusresponse815Unavailable)
+	var acc5 testutil.Accumulator
+	if err := acc5.GatherError(ks.Gather); err != nil {
+		t.Fatal(err)
+	}
+	checkKibanaStatusResult(defaulttags815()["version"], "unavailable", t, &acc5)
+}
+
+// Test error handling with different HTTP status codes
+func TestGatherErrors(t *testing.T) {
+	ks := newKibanahWithClient()
+	ks.Servers = []string{"http://example.com:5601"}
+
+	// Test 500 Internal Server Error
+	ks.client.Transport = newTransportMock(http.StatusInternalServerError, `{"error": "internal server error"}`)
+	var acc1 testutil.Accumulator
+	err := acc1.GatherError(ks.Gather)
+	if err == nil {
+		t.Fatal("Expected error for 500 status code")
+	}
+
+	// Test 404 Not Found
+	ks.client.Transport = newTransportMock(http.StatusNotFound, `{"error": "not found"}`)
+	var acc2 testutil.Accumulator
+	err = acc2.GatherError(ks.Gather)
+	if err == nil {
+		t.Fatal("Expected error for 404 status code")
+	}
+
+	// Test 401 Unauthorized
+	ks.client.Transport = newTransportMock(http.StatusUnauthorized, `{"error": "unauthorized"}`)
+	var acc3 testutil.Accumulator
+	err = acc3.GatherError(ks.Gather)
+	if err == nil {
+		t.Fatal("Expected error for 401 status code")
+	}
+
+	// Test 503 Service Unavailable
+	ks.client.Transport = newTransportMock(http.StatusServiceUnavailable, `{"error": "service unavailable"}`)
+	var acc4 testutil.Accumulator
+	err = acc4.GatherError(ks.Gather)
+	if err == nil {
+		t.Fatal("Expected error for 503 status code")
+	}
+}
+
+// Test invalid JSON response
+func TestGatherInvalidJSON(t *testing.T) {
+	ks := newKibanahWithClient()
+	ks.Servers = []string{"http://example.com:5601"}
+
+	// Test invalid JSON
+	ks.client.Transport = newTransportMock(http.StatusOK, `{invalid json}`)
+	var acc testutil.Accumulator
+	err := acc.GatherError(ks.Gather)
+	if err == nil {
+		t.Fatal("Expected error for invalid JSON")
+	}
+}
+
+// Test status mapping functions specifically
+func TestStatusMapping(t *testing.T) {
+	// Test legacy status mapping (Kibana 7.x and earlier)
+	testCases := []struct {
+		input    string
+		expected int
+	}{
+		{"green", 1},
+		{"yellow", 2},
+		{"red", 3},
+		{"unknown", 0},
+		{"", 0},
+	}
+
+	for _, tc := range testCases {
+		result := mapHealthStatusToCode(tc.input)
+		if result != tc.expected {
+			t.Errorf("mapHealthStatusToCode(%q) = %d, expected %d", tc.input, result, tc.expected)
+		}
+	}
+}
+
+// Test Kibana 8.x status level mapping
+func TestKibana8xStatusMapping(t *testing.T) {
+	testCases := []struct {
+		level    string
+		expected string
+	}{
+		{"available", "green"},
+		{"degraded", "yellow"},
+		{"unavailable", "red"},
+		{"critical", "red"},
+		{"unknown", "unknown"},
+		{"", "unknown"},
+	}
+
+	for _, tc := range testCases {
+		result := mapKibana8xStatus(tc.level)
+		if result != tc.expected {
+			t.Errorf("mapKibana8xStatus(%q) = %q, expected %q", tc.level, result, tc.expected)
+		}
+	}
+}
+
+// Test getStatusValue function with both legacy and new formats
+func TestGetStatusValue(t *testing.T) {
+	testCases := []struct {
+		name     string
+		overall  overallStatus
+		expected string
+	}{
+		{
+			name:     "Legacy green state",
+			overall:  overallStatus{State: "green"},
+			expected: "green",
+		},
+		{
+			name:     "Legacy yellow state",
+			overall:  overallStatus{State: "yellow"},
+			expected: "yellow",
+		},
+		{
+			name:     "Kibana 8.x available level",
+			overall:  overallStatus{Level: "available"},
+			expected: "green",
+		},
+		{
+			name:     "Kibana 8.x degraded level",
+			overall:  overallStatus{Level: "degraded"},
+			expected: "yellow",
+		},
+		{
+			name:     "Kibana 8.x unavailable level",
+			overall:  overallStatus{Level: "unavailable"},
+			expected: "red",
+		},
+		{
+			name:     "Kibana 8.x critical level",
+			overall:  overallStatus{Level: "critical"},
+			expected: "red",
+		},
+		{
+			name:     "Both fields present, level takes precedence",
+			overall:  overallStatus{State: "green", Level: "degraded"},
+			expected: "yellow",
+		},
+		{
+			name:     "No fields present",
+			overall:  overallStatus{},
+			expected: "unknown",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := getStatusValue(tc.overall)
+			if result != tc.expected {
+				t.Errorf("getStatusValue(%+v) = %q, expected %q", tc.overall, result, tc.expected)
+			}
+		})
+	}
 }
 
 func newKibanahWithClient() *Kibana {

--- a/plugins/inputs/kibana/testdata_test6_3.go
+++ b/plugins/inputs/kibana/testdata_test6_3.go
@@ -1,6 +1,6 @@
 package kibana
 
-const kibanaStatusResponse6_3 = `
+const kibanastatusresponse63 = `
 {
 	"name": "my-kibana",
 	"uuid": "00000000-0000-0000-0000-000000000000",
@@ -187,7 +187,7 @@ const kibanaStatusResponse6_3 = `
 }
 `
 
-var kibanaStatusExpected6_3 = map[string]interface{}{
+var kibanastatusexpected63 = map[string]interface{}{
 	"status_code":            1,
 	"heap_total_bytes":       int64(149954560),
 	"heap_max_bytes":         int64(149954560),

--- a/plugins/inputs/kibana/testdata_test6_5.go
+++ b/plugins/inputs/kibana/testdata_test6_5.go
@@ -1,6 +1,6 @@
 package kibana
 
-const kibanaStatusResponse6_5 = `
+const kibanastatusresponse65 = `
 {
 	"name": "my-kibana",
 	"uuid": "00000000-0000-0000-0000-000000000000",
@@ -214,7 +214,7 @@ const kibanaStatusResponse6_5 = `
 }
 `
 
-var kibanaStatusExpected6_5 = map[string]interface{}{
+var kibanastatusexpected65 = map[string]interface{}{
 	"status_code":            1,
 	"heap_total_bytes":       int64(149954560),
 	"heap_max_bytes":         int64(149954560),

--- a/plugins/inputs/kibana/testdata_test8_15.go
+++ b/plugins/inputs/kibana/testdata_test8_15.go
@@ -1,0 +1,206 @@
+package kibana
+
+// Kibana 8.x test data with new "level" field
+const kibanastatusresponse815 = `
+{
+	"name": "my-kibana",
+	"uuid": "00000000-0000-0000-0000-000000000000",
+	"version": {
+		"number": "8.15.2",
+		"build_hash": "bd7e2f0e02aa2ff6de58cfc9c70ac1aa6f84b2e7",
+		"build_number": 76543,
+		"build_snapshot": false
+	},
+	"status": {
+		"overall": {
+			"level": "available",
+			"summary": "Kibana is operating normally"
+		},
+		"core": {
+			"elasticsearch": {
+				"level": "available",
+				"summary": "Elasticsearch is available"
+			},
+			"savedObjects": {
+				"level": "available", 
+				"summary": "SavedObjects service has completed migrations and is available"
+			}
+		},
+		"plugins": {
+			"monitoring": {
+				"level": "available",
+				"summary": "Ready"
+			},
+			"security": {
+				"level": "available",
+				"summary": "Ready"
+			}
+		}
+	},
+	"metrics": {
+		"last_updated": "2025-01-15T09:40:17.733Z",
+		"collection_interval_in_millis": 5000,
+		"process": {
+			"memory": {
+				"heap": {
+					"total_in_bytes": 505769984,
+					"used_in_bytes": 411445984,
+					"size_limit": 2197815296
+				},
+				"resident_set_size_in_bytes": 625000000
+			},
+			"event_loop_delay": 1.2,
+			"pid": 1,
+			"uptime_in_millis": 1039853908
+		},
+		"os": {
+			"load": {
+				"1m": 1.5,
+				"5m": 1.8,
+				"15m": 2.1
+			},
+			"memory": {
+				"total_in_bytes": 8589934592,
+				"free_in_bytes": 4294967296,
+				"used_in_bytes": 4294967296
+			},
+			"uptime_in_millis": 86400000
+		},
+		"response_times": {
+			"avg_in_millis": 6,
+			"max_in_millis": 11
+		},
+		"requests": {
+			"total": 2,
+			"disconnects": 0,
+			"status_codes": {
+				"200": 2
+			}
+		},
+		"concurrent_connections": 1
+	}
+}
+`
+
+// Test data for Kibana 8.x with degraded status
+const kibanastatusresponse815Degraded = `
+{
+	"name": "my-kibana",
+	"uuid": "00000000-0000-0000-0000-000000000000",
+	"version": {
+		"number": "8.15.2",
+		"build_hash": "bd7e2f0e02aa2ff6de58cfc9c70ac1aa6f84b2e7",
+		"build_number": 76543,
+		"build_snapshot": false
+	},
+	"status": {
+		"overall": {
+			"level": "degraded",
+			"summary": "Kibana is degraded"
+		}
+	},
+	"metrics": {
+		"last_updated": "2025-01-15T09:40:17.733Z",
+		"collection_interval_in_millis": 5000,
+		"process": {
+			"memory": {
+				"heap": {
+					"total_in_bytes": 505769984,
+					"used_in_bytes": 411445984,
+					"size_limit": 2197815296
+				}
+			},
+			"uptime_in_millis": 1039853908
+		},
+		"response_times": {
+			"avg_in_millis": 6,
+			"max_in_millis": 11
+		},
+		"requests": {
+			"total": 2
+		},
+		"concurrent_connections": 1
+	}
+}
+`
+
+// Test data for Kibana 8.x with unavailable status
+const kibanastatusresponse815Unavailable = `
+{
+	"name": "my-kibana",
+	"uuid": "00000000-0000-0000-0000-000000000000",
+	"version": {
+		"number": "8.15.2",
+		"build_hash": "bd7e2f0e02aa2ff6de58cfc9c70ac1aa6f84b2e7",
+		"build_number": 76543,
+		"build_snapshot": false
+	},
+	"status": {
+		"overall": {
+			"level": "unavailable",
+			"summary": "Kibana is unavailable"
+		}
+	},
+	"metrics": {
+		"last_updated": "2025-01-15T09:40:17.733Z",
+		"collection_interval_in_millis": 5000,
+		"process": {
+			"memory": {
+				"heap": {
+					"total_in_bytes": 505769984,
+					"used_in_bytes": 411445984,
+					"size_limit": 2197815296
+				}
+			},
+			"uptime_in_millis": 1039853908
+		},
+		"response_times": {
+			"avg_in_millis": 6,
+			"max_in_millis": 11
+		},
+		"requests": {
+			"total": 2
+		},
+		"concurrent_connections": 1
+	}
+}
+`
+
+var kibanastatusexpected815 = map[string]interface{}{
+	"status_code":            1, // available -> green -> 1
+	"heap_total_bytes":       int64(505769984),
+	"heap_max_bytes":         int64(505769984),
+	"heap_used_bytes":        int64(411445984),
+	"heap_size_limit":        int64(2197815296),
+	"uptime_ms":              int64(1039853908),
+	"response_time_avg_ms":   float64(6),
+	"response_time_max_ms":   int64(11),
+	"concurrent_connections": int64(1),
+	"requests_per_sec":       float64(0.4),
+}
+
+var kibanastatusexpected815Degraded = map[string]interface{}{
+	"status_code":            2, // degraded -> yellow -> 2
+	"heap_total_bytes":       int64(505769984),
+	"heap_max_bytes":         int64(505769984),
+	"heap_used_bytes":        int64(411445984),
+	"heap_size_limit":        int64(2197815296),
+	"uptime_ms":              int64(1039853908),
+	"response_time_avg_ms":   float64(6),
+	"response_time_max_ms":   int64(11),
+	"concurrent_connections": int64(1),
+	"requests_per_sec":       float64(0.4),
+}
+
+var kibanastatusexpected815Unavailable = map[string]interface{}{
+	"status_code":            3, // unavailable -> red -> 3
+	"heap_total_bytes":       int64(505769984),
+	"heap_max_bytes":         int64(505769984),
+	"heap_used_bytes":        int64(411445984),
+	"heap_size_limit":        int64(2197815296),
+	"uptime_ms":              int64(1039853908),
+	"response_time_avg_ms":   float64(6),
+	"response_time_max_ms":   int64(11),
+	"concurrent_connections": int64(1),
+	"requests_per_sec":       float64(0.4),
+}


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
This PR fixes a compatibility issue where the Kibana input plugin's `status_code` field always returned `0` when monitoring Kibana 8.x instances.

**Root Cause:** Kibana 8.x changed the `/api/status` endpoint structure:
- **Legacy (7.x and earlier):** `status.overall.state` with values `"green"`, `"yellow"`, `"red"`
- **New (8.x+):** `status.overall.level` with values `"available"`, `"degraded"`, `"unavailable"`, `"critical"`

Since the plugin only looked for the `state` field, it couldn't find status information in Kibana 8.x responses, causing `status_code` to default to `0` (unknown).

## **Changes**

- **Added dual-field support** - Plugin now checks both `level` (8.x+) and `state` (legacy) fields
- **Status mapping** - Maps new 8.x values to legacy equivalents:
  - `available` → `green` → `status_code: 1`
  - `degraded` → `yellow` → `status_code: 2` 
  - `unavailable`/`critical` → `red` → `status_code: 3`
- **Backward compatibility** - Continues to work with Kibana 7.x and earlier versions
- **Enhanced test coverage** - Added comprehensive tests for all Kibana versions and status levels

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #17250
