### PR TITLE
chore(sqlite): Remove freebsd 386 and arm from using the sqlite driver

### DIFF
--- a/plugins/inputs/sql/drivers_sqlite.go
+++ b/plugins/inputs/sql/drivers_sqlite.go
@@ -1,4 +1,4 @@
-//go:build !mips && !mipsle && !mips64 && !ppc64 && !riscv64 && !loong64 && !mips64le && !(windows && (386 || arm))
+//go:build !mips && !mipsle && !mips64 && !ppc64 && !riscv64 && !loong64 && !mips64le && !(windows && (386 || arm)) && !(freebsd && (386 || arm))
 
 package sql
 

--- a/plugins/outputs/sql/sqlite.go
+++ b/plugins/outputs/sql/sqlite.go
@@ -1,4 +1,4 @@
-//go:build !mips && !mipsle && !mips64 && !ppc64 && !riscv64 && !loong64 && !mips64le && !(windows && (386 || arm))
+//go:build !mips && !mipsle && !mips64 && !ppc64 && !riscv64 && !loong64 && !mips64le && !(windows && (386 || arm)) && !(freebsd && (386 || arm))
 
 package sql
 

--- a/plugins/outputs/sql/sqlite_test.go
+++ b/plugins/outputs/sql/sqlite_test.go
@@ -1,4 +1,4 @@
-//go:build !mips && !mipsle && !mips64 && !ppc64 && !riscv64 && !loong64 && !mips64le && !(windows && (386 || arm))
+//go:build !mips && !mipsle && !mips64 && !ppc64 && !riscv64 && !loong64 && !mips64le && !(windows && (386 || arm)) && !(freebsd && (386 || arm))
 
 package sql
 


### PR DESCRIPTION
## Summary
Fixes an incompatibility that appeared with freebsd 386 and arm when updating the modernc.org/sqlite dependency

Needed for #17138 and #17091

Let me know if the title should be named differently, I'm not sure if this driver ever worked on these platforms though which is why I listed this as a chore

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
resolves #
