### PR TITLE
chore(common): Move outputs.groundwork slog adapter to common

### DIFF
--- a/plugins/common/slog/adapter.go
+++ b/plugins/common/slog/adapter.go
@@ -1,4 +1,4 @@
-package groundwork
+package slog
 
 import (
 	"context"
@@ -9,8 +9,8 @@ import (
 	"github.com/influxdata/telegraf"
 )
 
-// newLogger creates telegraf.Logger adapter for slog.Logger
-func newLogger(l telegraf.Logger) *slog.Logger {
+// NewLogger creates telegraf.Logger adapter for slog.Logger
+func NewLogger(l telegraf.Logger) *slog.Logger {
 	return slog.New(&tlgHandler{Log: l})
 }
 

--- a/plugins/outputs/groundwork/groundwork.go
+++ b/plugins/outputs/groundwork/groundwork.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
+	"github.com/influxdata/telegraf/plugins/common/slog"
 	"github.com/influxdata/telegraf/plugins/outputs"
 )
 
@@ -95,7 +96,7 @@ func (g *Groundwork) Init() error {
 	password.Destroy()
 
 	/* adapt SDK logger */
-	log.Logger = newLogger(g.Log).WithGroup("tcg.sdk")
+	log.Logger = slog.NewLogger(g.Log).WithGroup("tcg.sdk")
 
 	return nil
 }


### PR DESCRIPTION
## Summary
Moves the `log/slog` adapter for the telegraf logger to common code, will be used in #17270

## Checklist
- [x] No AI generated code was used in this PR

## Related issues
resolves #
