### PR TITLE
feat(common.http): Implement startup error behavior for cookie auth

### DIFF
--- a/migrations/inputs_httpjson/migration_test.go
+++ b/migrations/inputs_httpjson/migration_test.go
@@ -127,6 +127,8 @@ func TestParsing(t *testing.T) {
 			addr := server.URL + "/stats"
 			plugin.URLs = []string{addr}
 			require.NoError(t, plugin.Init())
+			require.NoError(t, plugin.Start(nil))
+			defer plugin.Stop()
 			var acc testutil.Accumulator
 			require.NoError(t, plugin.Gather(&acc))
 

--- a/plugins/common/http/config.go
+++ b/plugins/common/http/config.go
@@ -58,6 +58,12 @@ func (h *HTTPClientConfig) CreateClient(ctx context.Context, log telegraf.Logger
 		Transport: transport,
 	}
 
+	timeout := h.Timeout
+	if timeout == 0 {
+		timeout = config.Duration(time.Second * 5)
+	}
+	client.Timeout = time.Duration(timeout)
+
 	// While CreateOauth2Client returns a http.Client keeping the Transport configuration,
 	// it does not keep other http.Client parameters (e.g. Timeout).
 	client = h.OAuth2Config.CreateOauth2Client(ctx, client)
@@ -67,12 +73,6 @@ func (h *HTTPClientConfig) CreateClient(ctx context.Context, log telegraf.Logger
 			return nil, err
 		}
 	}
-
-	timeout := h.Timeout
-	if timeout == 0 {
-		timeout = config.Duration(time.Second * 5)
-	}
-	client.Timeout = time.Duration(timeout)
 
 	return client, nil
 }

--- a/plugins/inputs/http/README.md
+++ b/plugins/inputs/http/README.md
@@ -18,6 +18,23 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 [CONFIGURATION.md]: ../../../docs/CONFIGURATION.md#plugins
 
+## Startup error behavior options <!-- @/docs/includes/startup_error_behavior.md -->
+
+In addition to the plugin-specific and global configuration settings the plugin
+supports options for specifying the behavior when experiencing startup errors
+using the `startup_error_behavior` setting. Available values are:
+
+- `error`:  Telegraf with stop and exit in case of startup errors. This is the
+            default behavior.
+- `ignore`: Telegraf will ignore startup errors for this plugin and disables it
+            but continues processing for all other plugins.
+- `retry`:  Telegraf will try to startup the plugin in every gather or write
+            cycle in case of startup errors. The plugin is disabled until
+            the startup succeeds.
+- `probe`:  Telegraf will probe the plugin's function (if possible) and disables the plugin
+            in case probing fails. If the plugin does not support probing, Telegraf will
+            behave as if `ignore` was set instead.
+
 ## Secret-store support
 
 This plugin supports secrets from secret-stores for the `username`, `password`,


### PR DESCRIPTION
## Summary

This PR implements startup-error-behavior options for the cookie auth part of the common HTTP client. As a consequence you can now configure e.g. the `http` input to retry starting up the plugin if the cookie authentication is not reachable during startup of Telegraf.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #12959
