### PR TITLE
fix(disk-buffer): Expire metric tracking information in the right place

### DIFF
--- a/metric/tracking.go
+++ b/metric/tracking.go
@@ -94,13 +94,6 @@ func newTrackingMetric(metric telegraf.Metric, fn NotifyFunc) (telegraf.Metric, 
 	return m, m.d.Id
 }
 
-func rebuildTrackingMetric(metric telegraf.Metric, td telegraf.TrackingData) telegraf.Metric {
-	return &trackingMetric{
-		Metric: metric,
-		d:      td.(*trackingData),
-	}
-}
-
 func newTrackingMetricGroup(group []telegraf.Metric, fn NotifyFunc) ([]telegraf.Metric, telegraf.TrackingID) {
 	d := &trackingData{
 		Id:          newTrackingID(),
@@ -159,6 +152,9 @@ func (m *trackingMetric) decr() {
 
 	if v == 0 {
 		m.d.notify()
+		mu.Lock()
+		delete(trackingStore, m.d.Id)
+		defer mu.Unlock()
 	}
 }
 


### PR DESCRIPTION
## Summary

The current code tries to cleanup the tracking information cache during deserialization. That is, if the refcount of the metric is _one_ on deserialization the tracking information is removed from the cache. However, if that metric cannot be sent it is pushed back into (or rather left in) the buffer but now the required tracking information is gone. In turn the metric is skipped due to missing tracking information and the input is potentially never notified.

This PR moves the cache cleanup into the refcount decrementation function and only removes the entry if notifications are sent, i.e. if the refcount reaches zero.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #16981
