### PR TITLE
fix(inputs.gnmi): Avoid interpreting path elements with multiple colons as namespace

### DIFF
--- a/plugins/inputs/gnmi/path.go
+++ b/plugins/inputs/gnmi/path.go
@@ -195,7 +195,7 @@ func (pi *pathInfo) normalize() {
 
 	// Extract namespaces from segments
 	for i, s := range pi.segments {
-		if ns, id, found := strings.Cut(s.id, ":"); found {
+		if ns, id, found := strings.Cut(s.id, ":"); found && strings.Count(s.id, ":") == 1 {
 			pi.segments[i].namespace = ns
 			pi.segments[i].id = id
 		}

--- a/plugins/inputs/gnmi/testcases/issue_17279/expected.out
+++ b/plugins/inputs/gnmi/testcases/issue_17279/expected.out
@@ -1,0 +1,1 @@
+igmpsnooping900,path=eos_native:/Sysdb/bridging/igmpsnooping/forwarding/status/vlanStatus/900/ethGroup/01:00:5e:1e:1e:1e/intf,source=127.0.0.1 900/ethGroup/01:00:5e:1e:1e:1e/intf/Ethernet1=true 1751459159001750895

--- a/plugins/inputs/gnmi/testcases/issue_17279/responses.json
+++ b/plugins/inputs/gnmi/testcases/issue_17279/responses.json
@@ -1,0 +1,56 @@
+[
+    {
+        "update": {
+            "timestamp": "1751459159001750895",
+            "prefix": {
+                "origin": "eos_native",
+                "elem": [
+                    {
+                        "name": "Sysdb"
+                    },
+                    {
+                        "name": "bridging"
+                    },
+                    {
+                        "name": "igmpsnooping"
+                    },
+                    {
+                        "name": "forwarding"
+                    },
+                    {
+                        "name": "status"
+                    },
+                    {
+                        "name": "vlanStatus"
+                    },
+                    {
+                        "name": "900"
+                    },
+                    {
+                        "name": "ethGroup"
+                    },
+                    {
+                        "name": "01:00:5e:1e:1e:1e"
+                    },
+                    {
+                        "name": "intf"
+                    }
+                ]
+            },
+            "update": [
+                {
+                    "path": {
+                        "elem": [
+                            {
+                                "name": "Ethernet1"
+                            }
+                        ]
+                    },
+                    "val": {
+                        "boolVal": true
+                    }
+                }
+            ]
+        }
+    }
+]

--- a/plugins/inputs/gnmi/testcases/issue_17279/telegraf.conf
+++ b/plugins/inputs/gnmi/testcases/issue_17279/telegraf.conf
@@ -1,0 +1,9 @@
+[[inputs.gnmi]]
+  addresses = ["dummy"]
+
+  [[inputs.gnmi.subscription]]
+    name = "igmpsnooping900"
+    origin = "eos_native"
+    subscription_mode = "sample"
+    path = "/Sysdb/bridging/igmpsnooping/forwarding/status/vlanStatus"
+    sample_interval = "10s"


### PR DESCRIPTION
## Summary

The current code splits every path element at the first colon interpreting the part before as namespace. However, MAC addresses or IPv6 addresses might contain colons and as a consequence the first group will be stripped in paths.

This PR fixes the issue by leaving alone path element with multiple colons.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #17279 
