### PR TITLE
fix(outputs.nats): Avoid initializing Jetstream unconditionally

### DIFF
--- a/plugins/outputs/nats/nats.go
+++ b/plugins/outputs/nats/nats.go
@@ -77,7 +77,7 @@ type StreamConfig struct {
 	ConsumerLimits        jetstream.StreamConsumerLimits    `toml:"consumer_limits"`
 	Metadata              map[string]string                 `toml:"metadata"`
 	AsyncPublish          bool                              `toml:"async_publish"`
-	AsyncAckTimeout       config.Duration                   `toml:"async_ack_timeout"`
+	AsyncAckTimeout       *config.Duration                  `toml:"async_ack_timeout"`
 	DisableStreamCreation bool                              `toml:"disable_stream_creation"`
 }
 
@@ -248,6 +248,11 @@ func (n *NATS) Init() error {
 			return errors.New("stream cannot be empty")
 		}
 
+		if n.Jetstream.AsyncAckTimeout == nil {
+			to := config.Duration(5 * time.Second)
+			n.Jetstream.AsyncAckTimeout = &to
+		}
+
 		if len(n.Jetstream.Subjects) == 0 {
 			n.Jetstream.Subjects = []string{n.Subject}
 		}
@@ -312,7 +317,7 @@ func (n *NATS) Write(metrics []telegraf.Metric) error {
 					return fmt.Errorf("publish acknowledgement is an error: %w (retrying)", err)
 				}
 			}
-		case <-time.After(time.Duration(n.Jetstream.AsyncAckTimeout)):
+		case <-time.After(time.Duration(*n.Jetstream.AsyncAckTimeout)):
 			return fmt.Errorf("waiting for acknowledgement timed out, %d messages pending", n.jetstreamClient.PublishAsyncPending())
 		}
 	}
@@ -321,10 +326,6 @@ func (n *NATS) Write(metrics []telegraf.Metric) error {
 
 func init() {
 	outputs.Add("nats", func() telegraf.Output {
-		return &NATS{
-			Jetstream: &StreamConfig{
-				AsyncAckTimeout: config.Duration(time.Second * 5),
-			},
-		}
+		return &NATS{}
 	})
 }


### PR DESCRIPTION
## Summary

With introducing asynchronous publishing in Jetstream (PR #16582) the Jetstream config was initialized unconditionally. However, this breaks checks that assume the structure is only non-nil if the user actually wants NATS to be used with Jetstreams.

This PR avoids initializing the structure unconditionally in `init` and instead handles the default timeout otherwise.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #17290 
