### PR TITLE
docs: Update documentation to point to the right install key

### DIFF
--- a/docs/INSTALL_GUIDE.md
+++ b/docs/INSTALL_GUIDE.md
@@ -57,7 +57,7 @@ repo GPG key and setup a new sources.list entry:
 #   Primary key fingerprint: 24C9 75CB A61A 024E E1B6  3178 7C3D 5715 9FC2 F927
 #   Subkey fingerprint:      9D53 9D90 D332 8DC7 D6C8  D3B9 D8FF 8E1F 7DF8 B07E
 wget -q https://repos.influxdata.com/influxdata-archive.key
-gpg --no-default-keyring --homedir /nonexistent --show-keys ./influxdata-archive.key | grep -q "24C975CBA61A024EE1B631787C3D57159FC2F927" && cat influxdata-archive.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/influxdata-archive.gpg > /dev/null
+gpg --show-keys --with-fingerprint --with-colons ./influxdata-archive.key 2>&1 | grep -q '^fpr:\+24C975CBA61A024EE1B631787C3D57159FC2F927:$' && cat influxdata-archive.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/influxdata-archive.gpg > /dev/null
 echo 'deb [signed-by=/etc/apt/trusted.gpg.d/influxdata-archive.gpg] https://repos.influxdata.com/debian stable main' | sudo tee /etc/apt/sources.list.d/influxdata.list
 sudo apt-get update && sudo apt-get install telegraf
 ```

--- a/tools/package_incus_test/container.go
+++ b/tools/package_incus_test/container.go
@@ -173,8 +173,8 @@ func (c *Container) configureApt() error {
 		"bash",
 		"-c",
 		"--",
-		"gpg --no-default-keyring --homedir /nonexistent --show-keys ./influxdata-archive.key | "+
-			"grep -q '24C975CBA61A024EE1B631787C3D57159FC2F927' "+
+		"gpg --show-keys --with-fingerprint --with-colons ./influxdata-archive.key 2>&1 | "+
+			"grep -q '^fpr:\\+24C975CBA61A024EE1B631787C3D57159FC2F927:$' "+
 			"&& cat influxdata-archive.key | gpg --dearmor | "+
 			"sudo tee /etc/apt/trusted.gpg.d/influxdata-archive.gpg > /dev/null",
 	)


### PR DESCRIPTION
## Summary

https://www.influxdata.com/blog/linux-package-signing-key-rotation/ discusses the signing key rotation we did in 2023. We are getting to the point of having to rotate the key and this will assist in that work. Most docs and containers are still using the `influxdata-archive_compat.key` which was created for maximum compatibility, but it has limitations because it does not use the modern primary/subkey approach used by `influxdata-archive.key`. The compat key is required for very old systems like RHEL 7 (standard support ended in June 2024), Debian 9 (EOL in June 2022), Ubuntu 18.04 (standard support ended in April 2023).

RHEL 8, Debian 10 (buster; already EOL), Ubuntu 20.04 (standard support ended in April 2025), et al have new enough RPM and APT that supports `influxdata-archive.key`. While the `influxdata-archive_compat.key` isn't going away and we'll recreate it when we perform the key rotation, it is time to default to and document using `influxdata-archive.key` which will allow a better key rotation experience.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues
