### PR TITLE
feat(inputs.internal): Allow to collect statistics per plugin instance

### DIFF
--- a/metric.go
+++ b/metric.go
@@ -112,6 +112,11 @@ type Metric interface {
 	// HashID returns an unique identifier for the series.
 	HashID() uint64
 
+	// HashIDWithFieldsFiltered returns a unique identifier for the metric
+	// including the field keys while ignoring tags and fields with the
+	// specified keys.
+	HashIDWithFieldsFiltered(excludedTags, excludedFields []string) uint64
+
 	// Copy returns a deep copy of the Metric.
 	Copy() Metric
 

--- a/models/buffer.go
+++ b/models/buffer.go
@@ -98,7 +98,14 @@ type BufferStats struct {
 func NewBuffer(name, id, alias string, capacity int, strategy, path string) (Buffer, error) {
 	registerGob()
 
-	bs := NewBufferStats(name, alias, capacity)
+	tags := map[string]string{
+		"_id":    id,
+		"output": name,
+	}
+	if alias != "" {
+		tags["alias"] = alias
+	}
+	bs := NewBufferStats(tags, capacity)
 
 	switch strategy {
 	case "", "memory":
@@ -109,12 +116,7 @@ func NewBuffer(name, id, alias string, capacity int, strategy, path string) (Buf
 	return nil, fmt.Errorf("invalid buffer strategy %q", strategy)
 }
 
-func NewBufferStats(name, alias string, capacity int) BufferStats {
-	tags := map[string]string{"output": name}
-	if alias != "" {
-		tags["alias"] = alias
-	}
-
+func NewBufferStats(tags map[string]string, capacity int) BufferStats {
 	bs := BufferStats{
 		MetricsAdded: selfstat.Register(
 			"write",

--- a/models/running_aggregator.go
+++ b/models/running_aggregator.go
@@ -25,7 +25,10 @@ type RunningAggregator struct {
 }
 
 func NewRunningAggregator(aggregator telegraf.Aggregator, config *AggregatorConfig) *RunningAggregator {
-	tags := map[string]string{"aggregator": config.Name}
+	tags := map[string]string{
+		"_id":        config.ID,
+		"aggregator": config.Name,
+	}
 	if config.Alias != "" {
 		tags["alias"] = config.Alias
 	}

--- a/models/running_input.go
+++ b/models/running_input.go
@@ -37,7 +37,10 @@ type RunningInput struct {
 }
 
 func NewRunningInput(input telegraf.Input, config *InputConfig) *RunningInput {
-	tags := map[string]string{"input": config.Name}
+	tags := map[string]string{
+		"_id":   config.ID,
+		"input": config.Name,
+	}
 	if config.Alias != "" {
 		tags["alias"] = config.Alias
 	}

--- a/models/running_output.go
+++ b/models/running_output.go
@@ -72,7 +72,10 @@ type RunningOutput struct {
 }
 
 func NewRunningOutput(output telegraf.Output, config *OutputConfig, batchSize, bufferLimit int) *RunningOutput {
-	tags := map[string]string{"output": config.Name}
+	tags := map[string]string{
+		"output": config.Name,
+		"_id":    config.ID,
+	}
 	if config.Alias != "" {
 		tags["alias"] = config.Alias
 	}

--- a/models/running_output_test.go
+++ b/models/running_output_test.go
@@ -590,6 +590,7 @@ func TestRunningOutputInternalMetrics(t *testing.T) {
 		testutil.MustMetric(
 			"internal_write",
 			map[string]string{
+				"_id":    "",
 				"output": "test_name",
 				"alias":  "test_alias",
 			},
@@ -616,7 +617,6 @@ func TestRunningOutputInternalMetrics(t *testing.T) {
 			actual = append(actual, m)
 		}
 	}
-
 	testutil.RequireMetricsEqual(t, expected, actual, testutil.IgnoreTime())
 }
 

--- a/models/running_processor.go
+++ b/models/running_processor.go
@@ -33,7 +33,10 @@ type ProcessorConfig struct {
 }
 
 func NewRunningProcessor(processor telegraf.StreamingProcessor, config *ProcessorConfig) *RunningProcessor {
-	tags := map[string]string{"processor": config.Name}
+	tags := map[string]string{
+		"_id":       config.ID,
+		"processor": config.Name,
+	}
 	if config.Alias != "" {
 		tags["alias"] = config.Alias
 	}

--- a/plugins/inputs/internal/README.md
+++ b/plugins/inputs/internal/README.md
@@ -29,6 +29,9 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## If true, collect metrics from Go's runtime.metrics. For a full list see:
   ##   https://pkg.go.dev/runtime/metrics
   # collect_gostats = false
+
+  ## Collect statistics per plugin instance and not per plugin type
+  # per_instance = false
 ```
 
 ## Metrics

--- a/plugins/inputs/internal/internal.go
+++ b/plugins/inputs/internal/internal.go
@@ -20,6 +20,7 @@ var sampleConfig string
 type Internal struct {
 	CollectMemstats bool `toml:"collect_memstats"`
 	CollectGostats  bool `toml:"collect_gostats"`
+	PerInstance     bool `toml:"per_instance"`
 }
 
 func (*Internal) SampleConfig() string {
@@ -27,12 +28,10 @@ func (*Internal) SampleConfig() string {
 }
 
 func (s *Internal) Gather(acc telegraf.Accumulator) error {
-	for _, m := range selfstat.Metrics() {
-		if m.Name() == "internal_agent" {
-			m.AddTag("go_version", strings.TrimPrefix(runtime.Version(), "go"))
-		}
-		m.AddTag("version", inter.Version)
-		acc.AddFields(m.Name(), m.Fields(), m.Tags(), m.Time())
+	if s.PerInstance {
+		collectIndividualPluginStat(acc)
+	} else {
+		collectAccumulatedPluginStat(acc)
 	}
 
 	if s.CollectMemstats {
@@ -44,6 +43,44 @@ func (s *Internal) Gather(acc telegraf.Accumulator) error {
 	}
 
 	return nil
+}
+
+func collectIndividualPluginStat(acc telegraf.Accumulator) {
+	for _, m := range selfstat.Metrics() {
+		if m.Name() == "internal_agent" {
+			m.AddTag("go_version", strings.TrimPrefix(runtime.Version(), "go"))
+		}
+		m.AddTag("version", inter.Version)
+		acc.AddFields(m.Name(), m.Fields(), m.Tags(), m.Time())
+	}
+}
+
+func collectAccumulatedPluginStat(acc telegraf.Accumulator) {
+	accumulated := make(map[uint64]telegraf.Metric)
+	for _, m := range selfstat.Metrics() {
+		if m.Name() == "internal_agent" {
+			m.AddTag("go_version", strings.TrimPrefix(runtime.Version(), "go"))
+		}
+		m.AddTag("version", inter.Version)
+		key := m.HashIDWithFieldsFiltered([]string{"_id"}, nil)
+		am, found := accumulated[key]
+		if !found {
+			accumulated[key] = m.Copy()
+			accumulated[key].RemoveTag("_id")
+			continue
+		}
+		for _, f := range m.FieldList() {
+			var av int64
+			if af, found := am.GetField(f.Key); found {
+				av = af.(int64)
+			}
+			am.AddField(f.Key, av+f.Value.(int64))
+		}
+	}
+
+	for _, m := range accumulated {
+		acc.AddMetric(m)
+	}
 }
 
 func collectMemStat(acc telegraf.Accumulator) {

--- a/plugins/inputs/internal/internal_test.go
+++ b/plugins/inputs/internal/internal_test.go
@@ -1,10 +1,14 @@
 package internal
 
 import (
+	"strconv"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/metric"
 	"github.com/influxdata/telegraf/selfstat"
 	"github.com/influxdata/telegraf/testutil"
 )
@@ -20,6 +24,7 @@ func TestSelfPlugin(t *testing.T) {
 
 	// test that a registered stat is incremented
 	stat := selfstat.Register("mytest", "test", map[string]string{"test": "foo"})
+	defer selfstat.Unregister("mytest", "test", map[string]string{"test": "foo"})
 	stat.Incr(1)
 	stat.Incr(2)
 	require.NoError(t, s.Gather(acc))
@@ -52,6 +57,7 @@ func TestSelfPlugin(t *testing.T) {
 	// test that regular and timing stats can share the same measurement, and
 	// that timings are set properly.
 	timing := selfstat.RegisterTiming("mytest", "test_ns", map[string]string{"test": "foo"})
+	defer selfstat.Unregister("mytest", "test_ns", map[string]string{"test": "foo"})
 	timing.Incr(100)
 	timing.Incr(200)
 	require.NoError(t, s.Gather(acc))
@@ -90,24 +96,164 @@ func TestGostats(t *testing.T) {
 	require.False(t, acc.HasMeasurement("internal_memstats"))
 	require.True(t, acc.HasMeasurement("internal_gostats"))
 
-	var metric *testutil.Metric
+	var actual *testutil.Metric
 	for _, m := range acc.Metrics {
 		if m.Measurement == "internal_gostats" {
-			metric = m
+			actual = m
 			break
 		}
 	}
 
-	require.NotNil(t, metric)
-	require.Equal(t, "internal_gostats", metric.Measurement)
-	require.Len(t, metric.Tags, 1)
-	require.Contains(t, metric.Tags, "go_version")
+	require.NotNil(t, actual)
+	require.Equal(t, "internal_gostats", actual.Measurement)
+	require.Len(t, actual.Tags, 1)
+	require.Contains(t, actual.Tags, "go_version")
 
-	for name, value := range metric.Fields {
+	for name, value := range actual.Fields {
 		switch value.(type) {
 		case int64, uint64, float64:
 		default:
 			require.Failf(t, "Wrong type of field", "Field %s is of non-numeric type %T", name, value)
 		}
 	}
+}
+
+func TestPerInstance(t *testing.T) {
+	// Setup plugin statistics to gather with different plugin IDs
+	for i := range 3 {
+		selfstat.Register(
+			"mytest",
+			"calls",
+			map[string]string{"test": "foo", "_id": "id-" + strconv.Itoa(i)},
+		).Incr(int64(100 + i))
+		selfstat.Register(
+			"mytest",
+			"writes",
+			map[string]string{"test": "foo", "_id": "id-" + strconv.Itoa(i)},
+		).Incr(3 * int64(100+i))
+	}
+	defer func() {
+		for i := range 3 {
+			selfstat.Unregister(
+				"mytest",
+				"calls",
+				map[string]string{"test": "foo", "_id": "id-" + strconv.Itoa(i)},
+			)
+			selfstat.Unregister(
+				"mytest",
+				"writes",
+				map[string]string{"test": "foo", "_id": "id-" + strconv.Itoa(i)},
+			)
+		}
+	}()
+
+	// Setup the internal plugin to collect statistics per plugin _instance_
+	plugin := Internal{
+		PerInstance: true,
+	}
+
+	// Collect
+	var acc testutil.Accumulator
+	require.NoError(t, plugin.Gather(&acc))
+
+	// Check the resulting metrics
+	expected := []telegraf.Metric{
+		metric.New(
+			"internal_mytest",
+			map[string]string{"_id": "id-0", "test": "foo", "version": "unknown"},
+			map[string]interface{}{"calls": 100, "writes": 300},
+			time.Unix(0, 0),
+		),
+		metric.New(
+			"internal_mytest",
+			map[string]string{"_id": "id-1", "test": "foo", "version": "unknown"},
+			map[string]interface{}{"calls": 101, "writes": 303},
+			time.Unix(0, 0),
+		),
+		metric.New(
+			"internal_mytest",
+			map[string]string{"_id": "id-2", "test": "foo", "version": "unknown"},
+			map[string]interface{}{"calls": 102, "writes": 306},
+			time.Unix(0, 0),
+		),
+	}
+	testutil.RequireMetricsEqual(t, expected, acc.GetTelegrafMetrics(), testutil.IgnoreTime(), testutil.SortMetrics())
+}
+
+func TestAccumulatedPerType(t *testing.T) {
+	// Setup plugin statistics to gather with different plugin IDs
+	for i := range 2 {
+		selfstat.Register(
+			"mytest",
+			"calls",
+			map[string]string{"test": "foo", "_id": "id-" + strconv.Itoa(i)},
+		).Incr(int64(10 + i))
+		selfstat.Register(
+			"mytest",
+			"writes",
+			map[string]string{"test": "foo", "_id": "id-" + strconv.Itoa(i)},
+		).Incr(3 * int64(10+i))
+	}
+	for i := range 2 {
+		selfstat.Register(
+			"mytest",
+			"calls",
+			map[string]string{"test": "bar", "_id": "id-" + strconv.Itoa(10+i)},
+		).Incr(int64(100 + i))
+		selfstat.Register(
+			"mytest",
+			"writes",
+			map[string]string{"test": "bar", "_id": "id-" + strconv.Itoa(10+i)},
+		).Incr(2 * int64(100+i))
+	}
+	defer func() {
+		for i := range 2 {
+			selfstat.Unregister(
+				"mytest",
+				"calls",
+				map[string]string{"test": "foo", "_id": "id-" + strconv.Itoa(i)},
+			)
+			selfstat.Unregister(
+				"mytest",
+				"writes",
+				map[string]string{"test": "foo", "_id": "id-" + strconv.Itoa(i)},
+			)
+		}
+		for i := range 2 {
+			selfstat.Unregister(
+				"mytest",
+				"calls",
+				map[string]string{"test": "bar", "_id": "id-" + strconv.Itoa(10+i)},
+			)
+			selfstat.Unregister(
+				"mytest",
+				"writes",
+				map[string]string{"test": "bar", "_id": "id-" + strconv.Itoa(10+i)},
+			)
+		}
+	}()
+
+	// Setup the internal plugin to collect statistics per plugin _type_ not instance
+	plugin := Internal{}
+
+	// Collect
+	var acc testutil.Accumulator
+	require.NoError(t, plugin.Gather(&acc))
+
+	// Check the resulting metrics
+	expected := []telegraf.Metric{
+		metric.New(
+			"internal_mytest",
+			map[string]string{"test": "foo", "version": "unknown"},
+			map[string]interface{}{"calls": 21, "writes": 63},
+			time.Unix(0, 0),
+		),
+		metric.New(
+			"internal_mytest",
+			map[string]string{"test": "bar", "version": "unknown"},
+			map[string]interface{}{"calls": 201, "writes": 402},
+			time.Unix(0, 0),
+		),
+	}
+	testutil.RequireMetricsEqual(t, expected, acc.GetTelegrafMetrics(), testutil.IgnoreTime(), testutil.SortMetrics())
 }

--- a/plugins/inputs/internal/sample.conf
+++ b/plugins/inputs/internal/sample.conf
@@ -6,3 +6,6 @@
   ## If true, collect metrics from Go's runtime.metrics. For a full list see:
   ##   https://pkg.go.dev/runtime/metrics
   # collect_gostats = false
+
+  ## Collect statistics per plugin instance and not per plugin type
+  # per_instance = false


### PR DESCRIPTION
## Summary

The `inputs.internal` plugin allows to collect statistics about plugins and Telegraf in general. For plugins, these statistics are collected per **plugin type** currently, i.e. if you do have multiple instances of input plugin `A` the statistics are accumulated over all plugins of type `A`. To get individual metrics you currently need to define an `alias` per instance.

This PR changes the plugin models to emit the statistics per plugin instance using the unique `id` of plugins. In the internal input plugin this PR adds a flag to output metrics on a per **plugin instance** basis. By default the metrics are emitted accumulated over the same plugin **type** to be backward compatible.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #15769 
