### PR TITLE
feat(inputs.redis): Add metric for cluster info

### DIFF
--- a/plugins/inputs/redis/README.md
+++ b/plugins/inputs/redis/README.md
@@ -65,7 +65,7 @@ The plugin gathers the results of the [INFO](https://redis.io/commands/info)
 redis command.  There are two separate measurements: _redis_ and
 _redis\_keyspace_, the latter is used for gathering database related statistics.
 
-If the Redis instance is running in cluster mode, the plugin will also gather the results of the [CLUSTER INFO](https://redis.io/docs/latest/commands/cluster-info) command and report a `cluster_info` measurement.
+If the Redis instance is running in cluster mode, the plugin will also gather the results of the [CLUSTER INFO](https://redis.io/docs/latest/commands/cluster-info) command and report a `redis_cluster_info` measurement.
 
 Additionally the plugin also calculates the hit/miss ratio (keyspace\_hitrate)
 and the elapsed time since the last rdb save (rdb\_last\_save\_time\_elapsed).

--- a/plugins/inputs/redis/README.md
+++ b/plugins/inputs/redis/README.md
@@ -65,7 +65,10 @@ The plugin gathers the results of the [INFO](https://redis.io/commands/info)
 redis command.  There are two separate measurements: _redis_ and
 _redis\_keyspace_, the latter is used for gathering database related statistics.
 
-If the Redis instance is running in cluster mode, the plugin will also gather the results of the [CLUSTER INFO](https://redis.io/docs/latest/commands/cluster-info) command and report a `redis_cluster_info` measurement.
+If the Redis instance is running in cluster mode, the plugin will also gather
+the results of the
+[CLUSTER INFO](https://redis.io/docs/latest/commands/cluster-info) command and
+report a `redis_cluster_info` measurement.
 
 Additionally the plugin also calculates the hit/miss ratio (keyspace\_hitrate)
 and the elapsed time since the last rdb save (rdb\_last\_save\_time\_elapsed).

--- a/plugins/inputs/redis/README.md
+++ b/plugins/inputs/redis/README.md
@@ -65,6 +65,8 @@ The plugin gathers the results of the [INFO](https://redis.io/commands/info)
 redis command.  There are two separate measurements: _redis_ and
 _redis\_keyspace_, the latter is used for gathering database related statistics.
 
+If the Redis instance is running in cluster mode, the plugin will also gather the results of the [CLUSTER INFO](https://redis.io/docs/latest/commands/cluster-info) command and report a `cluster_info` measurement.
+
 Additionally the plugin also calculates the hit/miss ratio (keyspace\_hitrate)
 and the elapsed time since the last rdb save (rdb\_last\_save\_time\_elapsed).
 
@@ -185,6 +187,20 @@ and the elapsed time since the last rdb save (rdb\_last\_save\_time\_elapsed).
     - err
   - fields:
     - total (int, number)
+
+- redis_cluster_info
+  - cluster_state (string)
+  - cluster_slots_assigned (int, number)
+  - cluster_slots_ok (int, number)
+  - cluster_slots_pfail (int, number)
+  - cluster_slots_fail (int, number)
+  - cluster_known_nodes (int, number)
+  - cluster_size (int, number)
+  - cluster_current_epoch (int, number)
+  - cluster_my_epoch (int, number)
+  - cluster_stats_messages_sent (int, number)
+  - cluster_stats_messages_received (int, number)
+  - total_cluster_links_buffer_limit_exceeded (int, number)
 
 All measurements have the following tags:
 

--- a/plugins/inputs/redis/redis.go
+++ b/plugins/inputs/redis/redis.go
@@ -171,18 +171,18 @@ type redisFieldTypes struct {
 }
 
 type redisClusterFieldTypes struct {
-	ClusterState                         string  `json:"cluster_state"`
-	ClusterSlotsAssigned                 int64   `json:"cluster_slots_assigned"`
-	ClusterSlotsOk                       int64   `json:"cluster_slots_ok"`
-	ClusterSlotsPfail                    int64   `json:"cluster_slots_pfail"`
-	ClusterSlotsFail                     int64   `json:"cluster_slots_fail"`
-	ClusterKnownNodes                    int64   `json:"cluster_known_nodes"`
-	ClusterSize                          int64   `json:"cluster_size"`
-	ClusterCurrentEpoch                  int64   `json:"cluster_current_epoch"`
-	ClusterMyEpoch                       int64   `json:"cluster_my_epoch"`
-	ClusterStatsMessagesSent             int64   `json:"cluster_stats_messages_sent"`
-	ClusterStatsMessagesReceived         int64   `json:"cluster_stats_messages_received"`
-	TotalClusterLinksBufferLimitExceeded int64   `json:"total_cluster_links_buffer_limit_exceeded"`
+	ClusterState                         string `json:"cluster_state"`
+	ClusterSlotsAssigned                 int64  `json:"cluster_slots_assigned"`
+	ClusterSlotsOk                       int64  `json:"cluster_slots_ok"`
+	ClusterSlotsPfail                    int64  `json:"cluster_slots_pfail"`
+	ClusterSlotsFail                     int64  `json:"cluster_slots_fail"`
+	ClusterKnownNodes                    int64  `json:"cluster_known_nodes"`
+	ClusterSize                          int64  `json:"cluster_size"`
+	ClusterCurrentEpoch                  int64  `json:"cluster_current_epoch"`
+	ClusterMyEpoch                       int64  `json:"cluster_my_epoch"`
+	ClusterStatsMessagesSent             int64  `json:"cluster_stats_messages_sent"`
+	ClusterStatsMessagesReceived         int64  `json:"cluster_stats_messages_received"`
+	TotalClusterLinksBufferLimitExceeded int64  `json:"total_cluster_links_buffer_limit_exceeded"`
 }
 
 type client interface {

--- a/plugins/inputs/redis/redis_test.go
+++ b/plugins/inputs/redis/redis_test.go
@@ -428,17 +428,17 @@ func TestRedis_ParseClusterInfo(t *testing.T) {
 	require.NoError(t, err)
 
 	fields := map[string]interface{}{
-		"cluster_state":                   "ok",
-		"cluster_slots_assigned":          int64(16384),
-		"cluster_slots_ok":                int64(16384),
-		"cluster_slots_pfail":             int64(0),
-		"cluster_slots_fail":              int64(0),
-		"cluster_known_nodes":             int64(3),
-		"cluster_size":                    int64(3),
-		"cluster_current_epoch":           int64(6),
-		"cluster_my_epoch":                int64(2),
-		"cluster_stats_messages_sent":     int64(857),
-		"cluster_stats_messages_received": int64(857),
+		"cluster_state":                             "ok",
+		"cluster_slots_assigned":                    int64(16384),
+		"cluster_slots_ok":                          int64(16384),
+		"cluster_slots_pfail":                       int64(0),
+		"cluster_slots_fail":                        int64(0),
+		"cluster_known_nodes":                       int64(3),
+		"cluster_size":                              int64(3),
+		"cluster_current_epoch":                     int64(6),
+		"cluster_my_epoch":                          int64(2),
+		"cluster_stats_messages_sent":               int64(857),
+		"cluster_stats_messages_received":           int64(857),
 		"total_cluster_links_buffer_limit_exceeded": int64(1),
 	}
 	acc.AssertContainsTaggedFields(t, "redis_cluster_info", fields, tags)


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

This change is to capture a new redis_cluster_info measurement to gather results from the redis [CLUSTER INFO](https://redis.io/docs/latest/commands/cluster-info/) command only when the redis instance has cluster_enabled set to 1. The reason for this is to provide useful information about the current state of the cluster which is lacking from the results of the redis INFO command.

```
> redis_cluster_info,host=mbp-016682,port=7000,server=127.0.0.1 cluster_current_epoch=6i,cluster_known_nodes=6i,cluster_my_epoch=1i,cluster_size=3i,cluster_slots_assigned=16384i,cluster_slots_fail=0i,cluster_slots_ok=16384i,cluster_slots_pfail=0i,cluster_state="ok",cluster_stats_messages_meet_received="5",cluster_stats_messages_ping_received="300",cluster_stats_messages_ping_sent="285",cluster_stats_messages_pong_received="285",cluster_stats_messages_pong_sent="305",cluster_stats_messages_received=590i,cluster_stats_messages_sent=590i,total_cluster_links_buffer_limit_exceeded=0i 1752272069000000000
```

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #17314
