### PR TITLE
chore(inputs.internal): Replace multiple string operations with single replacer

### DIFF
--- a/plugins/inputs/internal/internal.go
+++ b/plugins/inputs/internal/internal.go
@@ -17,6 +17,9 @@ import (
 //go:embed sample.conf
 var sampleConfig string
 
+// Converts /cpu/classes/gc/mark/assist:cpu-seconds to cpu_classes_gc_mark_assist_cpu_seconds
+var replacer = strings.NewReplacer("/", "_", ":", "_", "-", "_")
+
 type Internal struct {
 	CollectMemstats bool `toml:"collect_memstats"`
 	CollectGostats  bool `toml:"collect_gostats"`
@@ -106,13 +109,8 @@ func collectGoStat(acc telegraf.Accumulator) {
 	acc.AddFields("internal_gostats", fields, tags)
 }
 
-// Converts /cpu/classes/gc/mark/assist:cpu-seconds to cpu_classes_gc_mark_assist_cpu_seconds
 func sanitizeName(name string) string {
-	name = strings.TrimPrefix(name, "/")
-	name = strings.ReplaceAll(name, "/", "_")
-	name = strings.ReplaceAll(name, ":", "_")
-	name = strings.ReplaceAll(name, "-", "_")
-	return name
+	return replacer.Replace(strings.TrimPrefix(name, "/"))
 }
 
 func medianBucket(h *metrics.Float64Histogram) float64 {


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
While reviewing another PR, I noticed this and took the opportunity to improve it.

Replaced three separate `strings.ReplaceAll()` calls with a single `strings.NewReplacer()`, reducing the number of string operations from four to two per call. This simplifies the code and improves efficiency slightly.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->
