### PR TITLE
Implement xxhash processor for deduplication purposes

### DIFF
--- a/plugins/processors/all/xxhash.go
+++ b/plugins/processors/all/xxhash.go
@@ -1,0 +1,5 @@
+//go:build !custom || processors || processors.xxhash
+
+package all
+
+import _ "github.com/influxdata/telegraf/plugins/processors/xxhash" // register plugin

--- a/plugins/processors/xxhash/sample.conf
+++ b/plugins/processors/xxhash/sample.conf
@@ -1,0 +1,11 @@
+# Compute the xxhash64 of the given fields and/or tags
+[[processors.xxhash]]
+  ## Keys to include in hash computation (from tags and fields)
+  keys = ["host", "^region$", "^cpu_.*"]
+
+  ## Interpretation mode: "exact", "regex", or "auto"
+  keys_mode = "auto"
+
+  ## Where to store the hash value
+  tag_hash = "xxhash"
+  field_hash = "xxhash_int"

--- a/plugins/processors/xxhash/xxhash.go
+++ b/plugins/processors/xxhash/xxhash.go
@@ -1,0 +1,159 @@
+// Package xxhash provides a Telegraf plugin that computes
+// a deterministic xxHash64 from selected tag and field values.
+package xxhash
+
+import (
+	_ "embed"
+	"fmt"
+
+	"strconv"
+	"strings"
+	"time"
+
+	"encoding"
+	"regexp"
+
+	"github.com/cespare/xxhash/v2"
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/plugins/processors"
+)
+
+//go:embed sample.conf
+var sampleConfig string
+
+type XXHash struct {
+	Keys      []string `toml:"keys"`
+	KeysMode  string   `toml:"keys_mode"`
+	TagHash   string   `toml:"tag_hash"`
+	FieldHash string   `toml:"field_hash"`
+
+	exactKeys map[string]struct{}
+	regexes   []*regexp.Regexp
+}
+
+func (*XXHash) SampleConfig() string {
+	return sampleConfig
+}
+
+func (*XXHash) Description() string {
+	return "Compute xxHash64 of selected metric tags/fields and store as tag/field"
+}
+
+func (p *XXHash) Init() error {
+	p.exactKeys = make(map[string]struct{})
+
+	for _, k := range p.Keys {
+		switch p.KeysMode {
+		case "exact":
+			p.exactKeys[k] = struct{}{}
+		case "regex":
+			re, err := regexp.Compile(k)
+			if err != nil {
+				return fmt.Errorf("invalid regex in keys: %q: %w", k, err)
+			}
+			p.regexes = append(p.regexes, re)
+		case "auto":
+			if looksLikeRegex(k) {
+				re, err := regexp.Compile(k)
+				if err != nil {
+					return fmt.Errorf("invalid regex in keys: %q: %w", k, err)
+				}
+				p.regexes = append(p.regexes, re)
+			} else {
+				p.exactKeys[k] = struct{}{}
+			}
+		default:
+			return fmt.Errorf("invalid keys_mode: %q", p.KeysMode)
+		}
+	}
+	return nil
+}
+
+func (p *XXHash) Apply(metrics ...telegraf.Metric) []telegraf.Metric {
+	for _, metric := range metrics {
+		var combined uint64 = 0
+
+		// XOR hashes of matching tag key=values, using Sum64String
+		for k, v := range metric.Tags() {
+			if p.matchKey(k) {
+				combined ^= xxhash.Sum64String(k + "=" + v)
+			}
+		}
+
+		// XOR hashes of matching field key=values
+		for k, v := range metric.Fields() {
+			if p.matchKey(k) {
+				buf := append([]byte(k+"="), toBytes(v)...)
+				combined ^= xxhash.Sum64(buf)
+			}
+		}
+
+		if combined == 0 {
+			// optionally skip metrics that have no matching keys
+			continue
+		}
+
+		if p.FieldHash != "" {
+			metric.AddField(p.FieldHash, int64(combined))
+		}
+		if p.TagHash != "" {
+			metric.AddTag(p.TagHash, strconv.FormatUint(combined, 10))
+		}
+	}
+	return metrics
+}
+
+func (p *XXHash) matchKey(k string) bool {
+	if _, ok := p.exactKeys[k]; ok {
+		return true
+	}
+	for _, re := range p.regexes {
+		if re.MatchString(k) {
+			return true
+		}
+	}
+	return false
+}
+
+func toBytes(val interface{}) []byte {
+	switch v := val.(type) {
+	case string:
+		return []byte(v)
+	case []byte:
+		return v
+	case bool:
+		if v {
+			return []byte("1")
+		}
+		return []byte("0")
+	case int:
+		return []byte(strconv.FormatInt(int64(v), 10))
+	case int64:
+		return []byte(strconv.FormatInt(v, 10))
+	case uint64:
+		return []byte(strconv.FormatUint(v, 10))
+	case float64:
+		return []byte(strconv.FormatFloat(v, 'g', -1, 64))
+	case float32:
+		return []byte(strconv.FormatFloat(float64(v), 'g', -1, 32))
+	case time.Time:
+		return []byte(v.UTC().Format(time.RFC3339Nano))
+	case encoding.TextMarshaler:
+		if b, err := v.MarshalText(); err == nil {
+			return b
+		}
+	}
+	return []byte(fmt.Sprintf("%v", val))
+}
+
+func looksLikeRegex(s string) bool {
+	return strings.ContainsAny(s, `^$.+*?[]{}()|\\`)
+}
+
+func init() {
+	processors.Add("xxhash", func() telegraf.Processor {
+		return &XXHash{
+			KeysMode: "auto",
+		}
+	})
+}

--- a/plugins/processors/xxhash/xxhash_test.go
+++ b/plugins/processors/xxhash/xxhash_test.go
@@ -1,0 +1,88 @@
+package xxhash
+
+import (
+	"testing"
+	"time"
+
+	"github.com/influxdata/telegraf/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestXXHash_ExactMatch(t *testing.T) {
+	x := &XXHash{
+		Keys:      []string{"host", "cpu_usage"},
+		KeysMode:  "exact",
+		TagHash:   "h",
+		FieldHash: "h64",
+	}
+	require.NoError(t, x.Init())
+
+	m := testutil.MustMetric("cpu",
+		map[string]string{
+			"host": "node01",
+		},
+		map[string]interface{}{
+			"cpu_usage": 42.5,
+			"ignored":   123,
+		},
+		time.Unix(0, 0),
+	)
+
+	x.Apply(m)
+
+	tag := m.Tags()["h"]
+	field, ok := m.Fields()["h64"]
+	require.True(t, ok)
+	require.NotEmpty(t, tag)
+	require.IsType(t, int64(0), field)
+}
+
+func TestXXHash_RegexMatch(t *testing.T) {
+	x := &XXHash{
+		Keys:      []string{"^cpu.*", "^host$"},
+		KeysMode:  "regex",
+		TagHash:   "hash",
+		FieldHash: "hash64",
+	}
+	require.NoError(t, x.Init())
+
+	m := testutil.MustMetric("cpu",
+		map[string]string{
+			"host": "srv",
+			"zone": "z1",
+		},
+		map[string]interface{}{
+			"cpu_user": 1.23,
+			"cpu_sys":  2.34,
+			"disk":     88,
+		},
+		time.Now(),
+	)
+
+	x.Apply(m)
+	require.NotEmpty(t, m.Tags()["hash"])
+	require.IsType(t, int64(0), m.Fields()["hash64"])
+}
+
+func TestXXHash_EmptyMatch(t *testing.T) {
+	x := &XXHash{
+		Keys:      []string{"nonexistent"},
+		KeysMode:  "exact",
+		TagHash:   "h",
+		FieldHash: "h64",
+	}
+	require.NoError(t, x.Init())
+
+	m := testutil.MustMetric("cpu",
+		map[string]string{"env": "prod"},
+		map[string]interface{}{"load": 0.99},
+		time.Now(),
+	)
+
+	x.Apply(m)
+
+	_, tagExists := m.Tags()["h"]
+	_, fieldExists := m.Fields()["h64"]
+	require.False(t, tagExists)
+	require.False(t, fieldExists)
+}


### PR DESCRIPTION
## Summary
Allows to calculate xxhash for selected tags/metrics, to perform db level deduplication (e.g. when using Clickhouse ReplacingMergeTree)

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [ ] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
