### PR TITLE
feat(selfstat): Implement collection of plugin-internal statistics

### DIFF
--- a/models/common.go
+++ b/models/common.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 
 	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/selfstat"
 )
 
 // logName returns the log-friendly name/type.
@@ -26,13 +27,35 @@ func SetLoggerOnPlugin(i interface{}, logger telegraf.Logger) {
 		return
 	}
 
-	switch field.Type().String() {
-	case "telegraf.Logger":
-		if field.CanSet() {
-			field.Set(reflect.ValueOf(logger))
-		}
-	default:
-		logger.Debugf("Plugin %q defines a 'Log' field on its struct of an unexpected type %q. Expected telegraf.Logger",
-			valI.Type().Name(), field.Type().String())
+	if field.Type().String() != "telegraf.Logger" || !field.CanSet() {
+		logger.Debugf(
+			"Plugin %q defines a 'Log' field on its struct of an unexpected type %q. Expected telegraf.Logger",
+			valI.Type().Name(), field.Type().String(),
+		)
+		return
 	}
+
+	field.Set(reflect.ValueOf(logger))
+}
+
+func SetStatisticsOnPlugin(plugin interface{}, logger telegraf.Logger, tags map[string]string) {
+	// Find the statistics collector
+	instance := reflect.Indirect(reflect.ValueOf(plugin))
+	field := instance.FieldByName("Statistics")
+	if !field.IsValid() {
+		return
+	}
+
+	// Validate the type and make sure we can actually set the struct field
+	if field.Type().String() != "*selfstat.Collector" || !field.CanSet() {
+		logger.Debugf(
+			"Plugin %q defines a 'Statistics' field on its struct of an unexpected type %q. Expected *selfstat.Collector",
+			instance.Type().Name(), field.Type().String(),
+		)
+		return
+	}
+
+	// Create a new collector and set it
+	collector := selfstat.NewCollector(tags)
+	field.Set(reflect.ValueOf(collector))
 }

--- a/models/running_output.go
+++ b/models/running_output.go
@@ -89,6 +89,7 @@ func NewRunningOutput(output telegraf.Output, config *OutputConfig, batchSize, b
 		logger.Error(err)
 	}
 	SetLoggerOnPlugin(output, logger)
+	SetStatisticsOnPlugin(output, logger, tags)
 
 	if config.MetricBufferLimit > 0 {
 		bufferLimit = config.MetricBufferLimit

--- a/selfstat/collector.go
+++ b/selfstat/collector.go
@@ -1,0 +1,106 @@
+package selfstat
+
+import (
+	"bytes"
+	"maps"
+	"slices"
+)
+
+type Collector struct {
+	tags       map[string]string
+	statistics map[string]Stat
+}
+
+func NewCollector(tags map[string]string) *Collector {
+	var cap int
+	if tags != nil {
+		cap += len(tags)
+	}
+
+	s := &Collector{
+		tags:       make(map[string]string, cap),
+		statistics: make(map[string]Stat),
+	}
+
+	// Collect all tags and add the plugin ID
+	if tags != nil {
+		maps.Copy(s.tags, tags)
+	}
+
+	return s
+}
+
+func (s *Collector) Register(measurement, field string, tags map[string]string) {
+	cap := len(s.tags)
+	if tags != nil {
+		cap += len(tags)
+	}
+
+	t := make(map[string]string, cap)
+	maps.Copy(t, s.tags)
+	if tags != nil {
+		maps.Copy(t, tags)
+	}
+
+	key := collectorKey(measurement, field, tags)
+	s.statistics[key] = Register(measurement, field, t)
+}
+
+func (s *Collector) RegisterTiming(measurement, field string, tags map[string]string) {
+	cap := len(s.tags)
+	if tags != nil {
+		cap += len(tags)
+	}
+
+	t := make(map[string]string, cap)
+	maps.Copy(t, s.tags)
+	if tags != nil {
+		maps.Copy(t, tags)
+	}
+
+	key := collectorKey(measurement, field, tags)
+	s.statistics[key] = RegisterTiming(measurement, field, t)
+}
+
+func (s *Collector) Unregister(measurement, field string, tags map[string]string) {
+	cap := len(s.tags)
+	if tags != nil {
+		cap += len(tags)
+	}
+
+	t := make(map[string]string, cap)
+	maps.Copy(t, s.tags)
+	if tags != nil {
+		maps.Copy(t, tags)
+	}
+
+	Unregister(measurement, field, t)
+}
+
+func (s *Collector) Get(measurement, field string, tags map[string]string) Stat {
+	key := collectorKey(measurement, field, tags)
+	return s.statistics[key]
+}
+
+func (s *Collector) Reset(measurement, field string, tags map[string]string) {
+	key := collectorKey(measurement, field, tags)
+	if stats := s.statistics[key]; stats != nil {
+		stats.Set(0)
+	}
+}
+
+func collectorKey(measurement, field string, tags map[string]string) string {
+	var buf bytes.Buffer
+	buf.WriteString(measurement + "\n")
+	buf.WriteString(field + "\n")
+
+	if tags == nil {
+		return buf.String()
+	}
+
+	for _, k := range slices.Sorted(maps.Keys(tags)) {
+		v := tags[k]
+		buf.WriteString(k + "=" + v + "\n")
+	}
+	return buf.String()
+}

--- a/selfstat/collector_test.go
+++ b/selfstat/collector_test.go
@@ -1,0 +1,145 @@
+package selfstat
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/metric"
+	"github.com/influxdata/telegraf/testutil"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/maps"
+)
+
+func TestCollectorRegisterIncrSet(t *testing.T) {
+	defer maps.Clear(registry.stats)
+
+	// Create a new collector with global tags
+	collector := NewCollector(map[string]string{"global": "zoo"})
+
+	// Register two statistics
+	fields := []string{"field1", "field2"}
+	tags := map[string]string{"test": "foo"}
+	for _, f := range fields {
+		collector.Register("test", f, tags)
+	}
+	require.Len(t, collector.statistics, len(fields))
+
+	// Check for initial state of the registry
+	require.Len(t, registry.stats, 1)
+	stats := maps.Values(registry.stats)[0]
+	require.Len(t, stats, len(fields))
+	require.ElementsMatch(t, fields, maps.Keys(stats))
+
+	// Check initial stats values
+	for _, f := range fields {
+		require.Equalf(t, int64(0), collector.Get("test", f, tags).Get(), "field %q has wrong value", f)
+	}
+
+	// Increase the statistics
+	collector.Get("test", "field1", tags).Incr(10)
+	collector.Get("test", "field2", tags).Incr(5)
+
+	// Check the values
+	expected := []telegraf.Metric{
+		metric.New(
+			"internal_test",
+			map[string]string{"global": "zoo", "test": "foo"},
+			map[string]interface{}{"field1": int64(10), "field2": int64(5)},
+			time.Unix(0, 0),
+		),
+	}
+	options := []cmp.Option{testutil.IgnoreTime(), testutil.SortMetrics()}
+	testutil.RequireMetricsEqual(t, expected, Metrics(), options...)
+
+	// Make sure that re-registering a field does not override the values
+	collector.Register("test", "field1", tags)
+	testutil.RequireMetricsEqual(t, expected, Metrics(), options...)
+
+	// Make sure that registering with different tags creates a new metric
+	collector.Register("test", "field1", map[string]string{"test": "bar"})
+	collector.Get("test", "field1", map[string]string{"test": "bar"}).Set(42)
+
+	expected = []telegraf.Metric{
+		metric.New(
+			"internal_test",
+			map[string]string{"global": "zoo", "test": "foo"},
+			map[string]interface{}{"field1": int64(10), "field2": int64(5)},
+			time.Unix(0, 0),
+		),
+		metric.New(
+			"internal_test",
+			map[string]string{"global": "zoo", "test": "bar"},
+			map[string]interface{}{"field1": int64(42)},
+			time.Unix(0, 0),
+		),
+	}
+	testutil.RequireMetricsEqual(t, expected, Metrics(), options...)
+}
+
+func TestCollectorRegisterTimingIncrSet(t *testing.T) {
+	defer maps.Clear(registry.stats)
+
+	// Create a new collector with global tags
+	collector := NewCollector(map[string]string{"global": "zoo"})
+
+	// Register two statistics
+	fields := []string{"field1_ns", "field2_ns"}
+	tags := map[string]string{"test": "foo"}
+	for _, f := range fields {
+		collector.RegisterTiming("test", f, tags)
+	}
+	require.Len(t, collector.statistics, len(fields))
+
+	// Check for initial state of the registry
+	require.Len(t, registry.stats, 1)
+	stats := maps.Values(registry.stats)[0]
+	require.Len(t, stats, len(fields))
+	require.ElementsMatch(t, fields, maps.Keys(stats))
+
+	// Check initial stats values
+	for _, f := range fields {
+		require.Equalf(t, int64(0), collector.Get("test", f, tags).Get(), "field %q has wrong value", f)
+	}
+
+	// Increase the statistics
+	collector.Get("test", "field1_ns", tags).Incr(10)
+	collector.Get("test", "field2_ns", tags).Incr(5)
+
+	// Check the values
+	expected := []telegraf.Metric{
+		metric.New(
+			"internal_test",
+			map[string]string{"global": "zoo", "test": "foo"},
+			map[string]interface{}{"field1_ns": int64(10), "field2_ns": int64(5)},
+			time.Unix(0, 0),
+		),
+	}
+	options := []cmp.Option{testutil.IgnoreTime(), testutil.SortMetrics()}
+	testutil.RequireMetricsEqual(t, expected, Metrics(), options...)
+
+	// Make sure that re-registering a field does not override the values
+	collector.Register("test", "field1_ns", tags)
+	testutil.RequireMetricsEqual(t, expected, Metrics(), options...)
+
+	// Make sure that registering with different tags creates a new metric
+	collector.Register("test", "field1_ns", map[string]string{"test": "bar"})
+	collector.Get("test", "field1_ns", map[string]string{"test": "bar"}).Set(42)
+
+	expected = []telegraf.Metric{
+		metric.New(
+			"internal_test",
+			map[string]string{"global": "zoo", "test": "foo"},
+			map[string]interface{}{"field1_ns": int64(10), "field2_ns": int64(5)},
+			time.Unix(0, 0),
+		),
+		metric.New(
+			"internal_test",
+			map[string]string{"global": "zoo", "test": "bar"},
+			map[string]interface{}{"field1_ns": int64(42)},
+			time.Unix(0, 0),
+		),
+	}
+	testutil.RequireMetricsEqual(t, expected, Metrics(), options...)
+}

--- a/selfstat/selfstat.go
+++ b/selfstat/selfstat.go
@@ -15,9 +15,7 @@ import (
 	"github.com/influxdata/telegraf/metric"
 )
 
-var (
-	registry *Registry
-)
+var registry *Registry
 
 // Stat is an interface for dealing with telegraf statistics collected
 // on itself.

--- a/selfstat/selfstat_test.go
+++ b/selfstat/selfstat_test.go
@@ -1,7 +1,6 @@
 package selfstat
 
 import (
-	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -9,45 +8,34 @@ import (
 	"github.com/influxdata/telegraf/testutil"
 )
 
-var (
-	// only allow one test at a time
-	// this is because we are dealing with a global registry
-	testLock sync.Mutex
-	a        int64
-)
-
 // testCleanup resets the global registry for test cleanup & unlocks the test lock
 func testCleanup() {
 	registry = &Registry{
 		stats: make(map[uint64]map[string]Stat),
 	}
-	testLock.Unlock()
 }
 
 func BenchmarkStats(b *testing.B) {
-	testLock.Lock()
 	defer testCleanup()
 	b1 := Register("benchmark1", "test_field1", map[string]string{"test": "foo"})
 	for n := 0; n < b.N; n++ {
 		b1.Incr(1)
 		b1.Incr(3)
-		a = b1.Get()
+		b1.Get()
 	}
 }
 
 func BenchmarkTimingStats(b *testing.B) {
-	testLock.Lock()
 	defer testCleanup()
 	b2 := RegisterTiming("benchmark2", "test_field1", map[string]string{"test": "foo"})
 	for n := 0; n < b.N; n++ {
 		b2.Incr(1)
 		b2.Incr(3)
-		a = b2.Get()
+		b2.Get()
 	}
 }
 
 func TestRegisterAndIncrAndSet(t *testing.T) {
-	testLock.Lock()
 	defer testCleanup()
 	s1 := Register("test", "test_field1", map[string]string{"test": "foo"})
 	s2 := Register("test", "test_field2", map[string]string{"test": "foo"})
@@ -77,7 +65,6 @@ func TestRegisterAndIncrAndSet(t *testing.T) {
 }
 
 func TestRegisterTimingAndIncrAndSet(t *testing.T) {
-	testLock.Lock()
 	defer testCleanup()
 	s1 := RegisterTiming("test", "test_field1_ns", map[string]string{"test": "foo"})
 	s2 := RegisterTiming("test", "test_field2_ns", map[string]string{"test": "foo"})
@@ -123,7 +110,6 @@ func TestStatKeyConsistency(t *testing.T) {
 }
 
 func TestRegisterMetricsAndVerify(t *testing.T) {
-	testLock.Lock()
 	defer testCleanup()
 
 	// register two metrics with the same key


### PR DESCRIPTION
## Summary

This PR implements `selfstat.Collector` and injects it into plugins that want to report plugin-internal statistics for gathering
by the `inputs.internal` plugin. This implementation is according to [TSD011](docs/specs/tsd-011-internal-plugin-statistics.md).

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

required for #17277

related to #4889 
related to #6965 
related to #17275 
