### PR TITLE
feat(outputs.nats): Enable batch serialization with use_batch_format

### DIFF
--- a/plugins/outputs/nats/testcases/no-js-batch.conf
+++ b/plugins/outputs/nats/testcases/no-js-batch.conf
@@ -1,0 +1,7 @@
+## NATS output with jetstream, but no config provided(use defaults)
+[[outputs.nats]]
+  ## URLs of NATS servers
+  servers = ["nats://localhost:4222"]
+  subject = "telegraf-subject"
+  data_format = "influx"
+  use_batch_format = true

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -63,6 +63,12 @@ func MockMetrics() []telegraf.Metric {
 	return []telegraf.Metric{TestMetric(1.0)}
 }
 
+// MockMultipleMetrics returns a mock []telegraf.Metric object with multiple
+// metrics for using in unit tests of telegraf output sinks.
+func MockMultipleMetrics() []telegraf.Metric {
+	return []telegraf.Metric{TestMetric(1.0), TestMetric(2.0)}
+}
+
 func MockMetricsWithValue(value float64) []telegraf.Metric {
 	return []telegraf.Metric{TestMetric(value)}
 }


### PR DESCRIPTION
## Summary
Before this change, the NATS output plugin sent one metric per NATS message. With this PR, if `use_batch_format = true`, the NATS output plugin will send multiple metrics per NATS message (using `serializer.SerializeBatch(metrics)`).

## Checklist
- [x] No AI generated code was used in this PR
