### PR TITLE
docs(inputs.ntpq): Remove deprecated option

### DIFF
--- a/plugins/inputs/ntpq/README.md
+++ b/plugins/inputs/ntpq/README.md
@@ -29,10 +29,6 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## If no server is given, the local machine is queried.
   # servers = []
 
-  ## If false, set the -n ntpq flag. Can reduce metric gather time.
-  ## DEPRECATED since 1.24.0: add '-n' to 'options' instead to skip DNS lookup
-  # dns_lookup = true
-
   ## Options to pass to the ntpq command.
   # options = "-p"
 

--- a/plugins/inputs/ntpq/sample.conf
+++ b/plugins/inputs/ntpq/sample.conf
@@ -4,10 +4,6 @@
   ## If no server is given, the local machine is queried.
   # servers = []
 
-  ## If false, set the -n ntpq flag. Can reduce metric gather time.
-  ## DEPRECATED since 1.24.0: add '-n' to 'options' instead to skip DNS lookup
-  # dns_lookup = true
-
   ## Options to pass to the ntpq command.
   # options = "-p"
 


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
removed deprecated option `dns_lookup` from docs

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
