### PR TITLE
docs(outputs.kinesis): Remove deprecated option

### DIFF
--- a/plugins/outputs/kinesis/README.md
+++ b/plugins/outputs/kinesis/README.md
@@ -140,20 +140,6 @@ Kinesis stream. It is important to note that the stream *MUST* be pre-configured
 for this plugin to function correctly. If the stream does not exist the plugin
 will result in telegraf exiting with an exit code of 1.
 
-### partitionkey [DEPRECATED]
-
-This is used to group data within a stream. Currently this plugin only supports
-a single partitionkey.  Manually configuring different hosts, or groups of hosts
-with manually selected partitionkeys might be a workable solution to scale out.
-
-### use_random_partitionkey [DEPRECATED]
-
-When true a random UUID will be generated and used as the partitionkey when
-sending data to Kinesis. This allows data to evenly spread across multiple
-shards in the stream. Due to using a random partitionKey there can be no
-guarantee of ordering when consuming the data off the shards.  If true then the
-partitionkey option will be ignored.
-
 ### partition
 
 This is used to group data within a stream. Currently four methods are


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
removed deprecated option `partitionkey` `use_random_partitionkey` from docs
## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
