### PR TITLE
feat(plugins.snmp): Allow debug logging in gosnmp

### DIFF
--- a/internal/snmp/config.go
+++ b/internal/snmp/config.go
@@ -3,6 +3,7 @@ package snmp
 import (
 	"time"
 
+	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
 )
 
@@ -12,6 +13,7 @@ type ClientConfig struct {
 	Retries              int             `toml:"retries"`
 	Version              uint8           `toml:"version"`
 	UnconnectedUDPSocket bool            `toml:"unconnected_udp_socket"`
+	GosnmpDebugLogger    telegraf.Logger `toml:"-"`
 
 	// Parameters for Version 1 & 2
 	Community string `toml:"community"`

--- a/plugins/inputs/snmp/snmp.go
+++ b/plugins/inputs/snmp/snmp.go
@@ -88,6 +88,10 @@ func (s *Snmp) Init() error {
 		})
 	}
 
+	if s.Log != nil && s.Log.Level().Includes(telegraf.Debug) {
+		s.GosnmpDebugLogger = s.Log
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
To debug snmp/gosnmp problems, it's handy to enable verbose logging also in gosnmp.

Remark: You can completely remove the logging code from telegraf using the golang build tag "gosnmp_nodebug".

## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #17364
