### PR TITLE
fix(plugins.snmp): Update gosnmp to prevent panic in snmp agents

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -113,7 +113,7 @@ require (
 	github.com/gorcon/rcon v1.4.0
 	github.com/gorilla/mux v1.8.1
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
-	github.com/gosnmp/gosnmp v1.41.0
+	github.com/gosnmp/gosnmp v1.42.1
 	github.com/grid-x/modbus v0.0.0-20240503115206-582f2ab60a18
 	github.com/gwos/tcg/sdk v0.0.0-20240830123415-f8a34bba6358
 	github.com/hashicorp/consul/api v1.32.1

--- a/go.sum
+++ b/go.sum
@@ -1520,8 +1520,8 @@ github.com/gorilla/sessions v1.2.1/go.mod h1:dk2InVEVJ0sfLlnXv9EAgkf6ecYs/i80K/z
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 h1:JeSE6pjso5THxAzdVpqr6/geYxZytqFMBCOtn/ujyeo=
 github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674/go.mod h1:r4w70xmWCQKmi1ONH4KIaBptdivuRPyosB9RmPlGEwA=
-github.com/gosnmp/gosnmp v1.41.0 h1:6RI78g2ZsbLvpvJegcV98LapszRQnbvYNKSa5WbCll4=
-github.com/gosnmp/gosnmp v1.41.0/go.mod h1:CxVS6bXqmWZlafUj9pZUnQX5e4fAltqPcijxWpCitDo=
+github.com/gosnmp/gosnmp v1.42.1 h1:MEJxhpC5v1coL3tFRix08PYmky9nyb1TLRRgJAmXm8A=
+github.com/gosnmp/gosnmp v1.42.1/go.mod h1:CxVS6bXqmWZlafUj9pZUnQX5e4fAltqPcijxWpCitDo=
 github.com/grafana/regexp v0.0.0-20240518133315-a468a5bfb3bc h1:GN2Lv3MGO7AS6PrRoT6yV5+wkrOpcszoIsO4+4ds248=
 github.com/grafana/regexp v0.0.0-20240518133315-a468a5bfb3bc/go.mod h1:+JKpmjMGhpgPL+rXZ5nsZieVzvarn86asRlBg4uNGnk=
 github.com/grid-x/modbus v0.0.0-20240503115206-582f2ab60a18 h1:8V5xRtdD70kGC4/IHqFq+kcBSWr4k6nscAUgWwJ6A5k=

--- a/plugins/inputs/snmp_trap/snmp_trap.go
+++ b/plugins/inputs/snmp_trap/snmp_trap.go
@@ -89,7 +89,15 @@ func (s *SnmpTrap) Init() error {
 	}
 
 	// Setup the SNMP parameters
-	params := *gosnmp.Default
+	params := gosnmp.GoSNMP{
+		Port:               gosnmp.Default.Port,
+		Transport:          gosnmp.Default.Transport,
+		Community:          gosnmp.Default.Community,
+		Timeout:            gosnmp.Default.Timeout,
+		Retries:            gosnmp.Default.Retries,
+		ExponentialTimeout: gosnmp.Default.ExponentialTimeout,
+		MaxOids:            gosnmp.Default.MaxOids,
+	}
 	if s.Log.Level().Includes(telegraf.Trace) {
 		params.Logger = gosnmp.NewLogger(&logger{s.Log})
 	}


### PR DESCRIPTION
As described in the respective gosnmp issue [1], gosnmp improperly handled an EOF/closed connection during a SNMP over TCP session.

This led to huge telegraf logs full of stack traces.

The issue has been fixed gosnmp v1.42.1 [2].

[1] https://github.com/gosnmp/gosnmp/issues/521
[2] https://github.com/gosnmp/gosnmp/releases/tag/v1.42.1

## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #17366