### PR TITLE
fix(agent): Handle nil timer on telegraf reload when no debounce is specified

### DIFF
--- a/cmd/telegraf/telegraf.go
+++ b/cmd/telegraf/telegraf.go
@@ -327,7 +327,9 @@ func (t *Telegraf) watchLocalConfig(ctx context.Context, signals chan os.Signal,
 			}
 
 		case <-mytomb.Dying():
-			reloadTimer.Stop()
+			if reloadTimer != nil {
+				reloadTimer.Stop()
+			}
 			log.Printf("I! Config watcher %q ended\n", fConfig)
 			return
 		}


### PR DESCRIPTION
## Summary
Telegraf was crashing on watch reload. A condition to check if the timer is not nil is added.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #17372 
