### PR TITLE
chore: comment openweathermap default units configuration

### DIFF
--- a/plugins/inputs/openweathermap/README.md
+++ b/plugins/inputs/openweathermap/README.md
@@ -50,6 +50,7 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
   ## Preferred unit system for temperature and wind speed. Can be one of
   ## "metric", "imperial", or "standard".
+  ## The default is "metric" if not specified.
   # units = "metric"
 
   ## Style to query the current weather; available options

--- a/plugins/inputs/openweathermap/sample.conf
+++ b/plugins/inputs/openweathermap/sample.conf
@@ -23,6 +23,7 @@
 
   ## Preferred unit system for temperature and wind speed. Can be one of
   ## "metric", "imperial", or "standard".
+  ## The default is "metric" if not specified.
   # units = "metric"
 
   ## Style to query the current weather; available options


### PR DESCRIPTION
## Summary

Clarify the default units setting in the openweathermap plugin configuration by explicitly noting that `metric` is used when no units are specified.

Documentation:
- Add a comment in [README.md](https://github.com/influxdata/telegraf/blob/master/plugins/inputs/openweathermap/README.md) stating that the default unit system is `metric` if not specified.
- Add the same default-units comment in the [sample.conf](https://github.com/influxdata/telegraf/blob/master/plugins/inputs/openweathermap/sample.conf) for the openweathermap plugin.

## Why add a comment?

The default units is `standard` at official [OpenWeatherMap API](https://openweathermap.org/current) if not specified.

<img width="910" height="394" alt="image" src="https://github.com/user-attachments/assets/8fd371fd-8ce9-4325-8b21-9f69f6218dc1" />

However, [OpenWeatherMap Input Plugin](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/openweathermap) is `metric` by default.

https://github.com/influxdata/telegraf/blob/5d62207dcf9114dceae6d31753b15b7f8039915b/plugins/inputs/openweathermap/openweathermap.go#L64-L72

This difference is likely to confuse the users.
This PR fix that misunderstanding.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

N/A