### PR TITLE
chore(deps): Migrate from cloud.google.com/go/pubsub to v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ godebug x509negativeserial=1
 require (
 	cloud.google.com/go/bigquery v1.69.0
 	cloud.google.com/go/monitoring v1.24.2
-	cloud.google.com/go/pubsub v1.49.0
+	cloud.google.com/go/pubsub/v2 v2.0.0
 	cloud.google.com/go/storage v1.56.0
 	collectd.org v0.6.0
 	github.com/99designs/keyring v1.2.2

--- a/go.sum
+++ b/go.sum
@@ -347,8 +347,6 @@ cloud.google.com/go/kms v1.8.0/go.mod h1:4xFEhYFqvW+4VMELtZyxomGSYtSQKzM178ylFW4
 cloud.google.com/go/kms v1.9.0/go.mod h1:qb1tPTgfF9RQP8e1wq4cLFErVuTJv7UsSC915J8dh3w=
 cloud.google.com/go/kms v1.10.0/go.mod h1:ng3KTUtQQU9bPX3+QGLsflZIHlkbn8amFAMY63m8d24=
 cloud.google.com/go/kms v1.10.1/go.mod h1:rIWk/TryCkR59GMC3YtHtXeLzd634lBbKenvyySAyYI=
-cloud.google.com/go/kms v1.22.0 h1:dBRIj7+GDeeEvatJeTB19oYZNV0aj6wEqSIT/7gLqtk=
-cloud.google.com/go/kms v1.22.0/go.mod h1:U7mf8Sva5jpOb4bxYZdtw/9zsbIjrklYwPcvMk34AL8=
 cloud.google.com/go/language v1.4.0/go.mod h1:F9dRpNFQmJbkaop6g0JhSBXCNlO90e1KWx5iDdxbWic=
 cloud.google.com/go/language v1.6.0/go.mod h1:6dJ8t3B+lUYfStgls25GusK04NLh3eDLQnWM3mdEbhI=
 cloud.google.com/go/language v1.7.0/go.mod h1:DJ6dYN/W+SQOjF8e1hLQXMF21AkH2w9wiPzPCJa2MIE=
@@ -448,8 +446,8 @@ cloud.google.com/go/pubsub v1.26.0/go.mod h1:QgBH3U/jdJy/ftjPhTkyXNj543Tin1pRYcd
 cloud.google.com/go/pubsub v1.27.1/go.mod h1:hQN39ymbV9geqBnfQq6Xf63yNhUAhv9CZhzp5O6qsW0=
 cloud.google.com/go/pubsub v1.28.0/go.mod h1:vuXFpwaVoIPQMGXqRyUQigu/AX1S3IWugR9xznmcXX8=
 cloud.google.com/go/pubsub v1.30.0/go.mod h1:qWi1OPS0B+b5L+Sg6Gmc9zD1Y+HaM0MdUr7LsupY1P4=
-cloud.google.com/go/pubsub v1.49.0 h1:5054IkbslnrMCgA2MAEPcsN3Ky+AyMpEZcii/DoySPo=
-cloud.google.com/go/pubsub v1.49.0/go.mod h1:K1FswTWP+C1tI/nfi3HQecoVeFvL4HUOB1tdaNXKhUY=
+cloud.google.com/go/pubsub/v2 v2.0.0 h1:0qS6mRJ41gD1lNmM/vdm6bR7DQu6coQcVwD+VPf0Bz0=
+cloud.google.com/go/pubsub/v2 v2.0.0/go.mod h1:0aztFxNzVQIRSZ8vUr79uH2bS3jwLebwK6q1sgEub+E=
 cloud.google.com/go/pubsublite v1.5.0/go.mod h1:xapqNQ1CuLfGi23Yda/9l4bBCKz/wC3KIJ5gKcxveZg=
 cloud.google.com/go/pubsublite v1.6.0/go.mod h1:1eFCS0U11xlOuMFV/0iBqw3zP12kddMeCbj/F3FSj9k=
 cloud.google.com/go/pubsublite v1.7.0/go.mod h1:8hVMwRXfDfvGm3fahVbtDbiLePT3gpoiJYJY+vxWxVM=

--- a/plugins/inputs/cloud_pubsub/README.md
+++ b/plugins/inputs/cloud_pubsub/README.md
@@ -78,7 +78,7 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
   ## The following are optional Subscription ReceiveSettings in PubSub.
   ## Read more about these values:
-  ## https://godoc.org/cloud.google.com/go/pubsub#ReceiveSettings
+  ## https://godoc.org/cloud.google.com/go/pubsub/v2#ReceiveSettings
 
   ## Optional. Maximum number of seconds for which a PubSub subscription
   ## should auto-extend the PubSub ACK deadline for each message. If less than

--- a/plugins/inputs/cloud_pubsub/cloud_pubsub.go
+++ b/plugins/inputs/cloud_pubsub/cloud_pubsub.go
@@ -10,7 +10,7 @@ import (
 	"sync"
 	"time"
 
-	"cloud.google.com/go/pubsub"
+	"cloud.google.com/go/pubsub/v2"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/option"
 
@@ -337,7 +337,7 @@ func (ps *PubSub) getGCPSubscription(subID string) (subscription, error) {
 	if err != nil {
 		return nil, err
 	}
-	s := client.Subscription(subID)
+	s := client.Subscriber(subID)
 	s.ReceiveSettings = pubsub.ReceiveSettings{
 		NumGoroutines:          ps.MaxReceiverGoRoutines,
 		MaxExtension:           time.Duration(ps.MaxExtension),

--- a/plugins/inputs/cloud_pubsub/sample.conf
+++ b/plugins/inputs/cloud_pubsub/sample.conf
@@ -43,7 +43,7 @@
 
   ## The following are optional Subscription ReceiveSettings in PubSub.
   ## Read more about these values:
-  ## https://godoc.org/cloud.google.com/go/pubsub#ReceiveSettings
+  ## https://godoc.org/cloud.google.com/go/pubsub/v2#ReceiveSettings
 
   ## Optional. Maximum number of seconds for which a PubSub subscription
   ## should auto-extend the PubSub ACK deadline for each message. If less than

--- a/plugins/inputs/cloud_pubsub/subscription_gcp.go
+++ b/plugins/inputs/cloud_pubsub/subscription_gcp.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 
-	"cloud.google.com/go/pubsub"
+	"cloud.google.com/go/pubsub/v2"
 )
 
 type (
@@ -31,7 +31,7 @@ type (
 	}
 
 	gcpSubscription struct {
-		sub *pubsub.Subscription
+		sub *pubsub.Subscriber
 	}
 
 	gcpMessage struct {

--- a/plugins/outputs/cloud_pubsub/README.md
+++ b/plugins/outputs/cloud_pubsub/README.md
@@ -48,7 +48,7 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
   ## The following publish_* parameters specifically configures batching
   ## requests made to the GCP Cloud PubSub API via the PubSub Golang library. Read
-  ## more here: https://godoc.org/cloud.google.com/go/pubsub#PublishSettings
+  ## more here: https://godoc.org/cloud.google.com/go/pubsub/v2#PublishSettings
 
   ## Optional. Send a request to PubSub (i.e. actually publish a batch)
   ## when it has this many PubSub messages. If send_batched is true,

--- a/plugins/outputs/cloud_pubsub/cloud_pubsub.go
+++ b/plugins/outputs/cloud_pubsub/cloud_pubsub.go
@@ -10,7 +10,7 @@ import (
 	"sync"
 	"time"
 
-	"cloud.google.com/go/pubsub"
+	"cloud.google.com/go/pubsub/v2"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/option"
 
@@ -127,7 +127,7 @@ func (ps *PubSub) refreshTopic() {
 	if ps.stubTopic != nil {
 		ps.t = ps.stubTopic(ps.Topic)
 	} else {
-		t := ps.c.Topic(ps.Topic)
+		t := ps.c.Publisher(ps.Topic)
 		ps.t = &topicWrapper{t}
 	}
 	ps.t.SetPublishSettings(ps.publishSettings())

--- a/plugins/outputs/cloud_pubsub/cloud_pubsub_test.go
+++ b/plugins/outputs/cloud_pubsub/cloud_pubsub_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/base64"
 	"testing"
 
-	"cloud.google.com/go/pubsub"
+	"cloud.google.com/go/pubsub/v2"
 	"github.com/stretchr/testify/require"
 
 	"github.com/influxdata/telegraf"

--- a/plugins/outputs/cloud_pubsub/sample.conf
+++ b/plugins/outputs/cloud_pubsub/sample.conf
@@ -27,7 +27,7 @@
 
   ## The following publish_* parameters specifically configures batching
   ## requests made to the GCP Cloud PubSub API via the PubSub Golang library. Read
-  ## more here: https://godoc.org/cloud.google.com/go/pubsub#PublishSettings
+  ## more here: https://godoc.org/cloud.google.com/go/pubsub/v2#PublishSettings
 
   ## Optional. Send a request to PubSub (i.e. actually publish a batch)
   ## when it has this many PubSub messages. If send_batched is true,

--- a/plugins/outputs/cloud_pubsub/topic_gcp.go
+++ b/plugins/outputs/cloud_pubsub/topic_gcp.go
@@ -3,7 +3,7 @@ package cloud_pubsub
 import (
 	"context"
 
-	"cloud.google.com/go/pubsub"
+	"cloud.google.com/go/pubsub/v2"
 )
 
 type (
@@ -20,7 +20,7 @@ type (
 	}
 
 	topicWrapper struct {
-		topic *pubsub.Topic
+		topic *pubsub.Publisher
 	}
 )
 

--- a/plugins/outputs/cloud_pubsub/topic_stubbed.go
+++ b/plugins/outputs/cloud_pubsub/topic_stubbed.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"cloud.google.com/go/pubsub"
+	"cloud.google.com/go/pubsub/v2"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/api/support/bundler"
 


### PR DESCRIPTION
## Summary
Migrates from the v1 to v2 of this library, following the [migration guide](https://github.com/googleapis/google-cloud-go/blob/main/pubsub/MIGRATING.md)

Related: #17403, which deprecated the v1 of the library

## Checklist
- [x] No AI generated code was used in this PR

## Related issues

resolves #
