### PR TITLE
fix(inputs.gnmi): handle empty updates in gnmi notification response

### DIFF
--- a/plugins/inputs/gnmi/handler.go
+++ b/plugins/inputs/gnmi/handler.go
@@ -176,6 +176,14 @@ func (h *handler) handleSubscribeResponseUpdate(acc telegraf.Accumulator, respon
 	// add all available tags to the metrics later.
 	var valueFields []updateField
 	for _, update := range response.Update.Update {
+		if update.Path == nil {
+			continue
+		}
+
+		if len(update.Path.Elem) == 0 && prefix.empty() {
+			continue
+		}
+
 		fullPath := prefix.append(update.Path)
 		if h.enforceFirstNamespaceAsOrigin {
 			prefix.enforceFirstNamespaceAsOrigin()

--- a/plugins/inputs/gnmi/testcases/issue_17412/expected.out
+++ b/plugins/inputs/gnmi/testcases/issue_17412/expected.out
@@ -1,0 +1,1 @@
+interface_state_change,name=Eth-Trunk5.1234,source=127.0.0.1 oper_status="down" 1753972839609000000

--- a/plugins/inputs/gnmi/testcases/issue_17412/responses.json
+++ b/plugins/inputs/gnmi/testcases/issue_17412/responses.json
@@ -1,0 +1,71 @@
+[
+  {
+    "update": {
+      "timestamp": "1753972805570000000",
+      "update": [
+        {}
+      ],
+      "delete": [
+        {
+          "elem": [
+            {
+              "name": "huawei-ifm:ifm"
+            },
+            {
+              "name": "interfaces"
+            },
+            {
+              "name": "interface",
+              "key": {
+                "name": "Eth-Trunk5.1234"
+              }
+            },
+            {
+              "name": "dynamic"
+            },
+            {
+              "name": "oper-status"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "update": {
+      "timestamp": "1753972839609000000",
+      "update": [
+        {
+          "path": {
+            "elem": [
+              {
+                "name": "huawei-ifm:ifm"
+              },
+              {
+                "name": "interfaces"
+              },
+              {
+                "name": "interface",
+                "key": {
+                  "name": "Eth-Trunk5.1234"
+                }
+              },
+              {
+                "name": "dynamic"
+              },
+              {
+                "name": "oper-status"
+              }
+            ]
+          },
+          "val": {
+            "jsonVal": "ImRvd24i"
+          }
+        }
+      ],
+      "delete": [
+        {}
+      ]
+    }
+  }
+]

--- a/plugins/inputs/gnmi/testcases/issue_17412/telegraf.conf
+++ b/plugins/inputs/gnmi/testcases/issue_17412/telegraf.conf
@@ -1,0 +1,8 @@
+[[inputs.gnmi]]
+  addresses     = ["dummy"]
+  redial        = "10s"
+
+  [[inputs.gnmi.subscription]]
+    name = "interface_state_change"
+    path = "huawei-ifm:ifm/interfaces/interface/dynamic/oper-status"
+    subscription_mode = "on_change"


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Telegraf crashes when empty update is received with delete event

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #17412
