### PR TITLE
fix(agent): Update help message for CLI flag --test

### DIFF
--- a/cmd/telegraf/main.go
+++ b/cmd/telegraf/main.go
@@ -339,7 +339,7 @@ func runApp(args []string, outputBuffer io.Writer, pprof Server, c TelegrafConfi
 				&cli.BoolFlag{
 					Name: "test",
 					Usage: "enable test mode: gather metrics, print them out, and exit. " +
-						"Note: Test mode only runs inputs, not processors, aggregators, or outputs",
+						"Note: Test mode only runs inputs, processors, and aggregators, but not outputs",
 				},
 				//
 				// Duration flags


### PR DESCRIPTION
## Summary

Because:
- PR https://github.com/influxdata/telegraf/pull/7474 enabled processors and aggregators in test mode
- The current help message for the `--test` CLI flag does not reflect that

This PR updates the help output  of the `--test` CLI flag to state processors and aggregators are run as well

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #17450 
