### PR TITLE
feat(outputs.elasticsearch): Support array headers and preserve commas in values

### DIFF
--- a/plugins/outputs/elasticsearch/README.md
+++ b/plugins/outputs/elasticsearch/README.md
@@ -334,10 +334,15 @@ to use them.
   # use_pipeline = "{{es_pipeline}}"
   # default_pipeline = "my_pipeline"
   #
-  # Custom HTTP headers
-  # To pass custom HTTP headers please define it in a given below section
+  ## Custom HTTP headers
+  ## To pass custom HTTP headers please define it in a given below section
   # [outputs.elasticsearch.headers]
-  #    "X-Custom-Header" = "custom-value"
+  ##  Single values - commas are preserved as part of the value
+  #   "X-Custom-Header1" = "custom-value1"
+  #   "X-Custom-Header2" = "custom-value2,with,commas,preserved"
+  #
+  ##   Multiple values - creates multiple headers with same name
+  #   "X-Custom-Header3" = ["custom-value3a", "custom-value3b"]
 
   ## Template Index Settings
   ## Overrides the template settings.index section with any provided options.

--- a/plugins/outputs/elasticsearch/sample.conf
+++ b/plugins/outputs/elasticsearch/sample.conf
@@ -82,10 +82,15 @@
   # use_pipeline = "{{es_pipeline}}"
   # default_pipeline = "my_pipeline"
   #
-  # Custom HTTP headers
-  # To pass custom HTTP headers please define it in a given below section
+  ## Custom HTTP headers
+  ## To pass custom HTTP headers please define it in a given below section
   # [outputs.elasticsearch.headers]
-  #    "X-Custom-Header" = "custom-value"
+  ##  Single values - commas are preserved as part of the value
+  #   "X-Custom-Header1" = "custom-value1"
+  #   "X-Custom-Header2" = "custom-value2,with,commas,preserved"
+  #
+  ##   Multiple values - creates multiple headers with same name
+  #   "X-Custom-Header3" = ["custom-value3a", "custom-value3b"]
 
   ## Template Index Settings
   ## Overrides the template settings.index section with any provided options.


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Fixes issue where comma-separated values in Elasticsearch output headers were incorrectly split into multiple headers. Adds support for array configuration to enable multiple header values when needed.

The current implementation splits header values on commas (introduced in PR #15477), breaking legitimate use cases where header values contain commas as content:

```toml
# BROKEN: Gets split into 3 separate headers
"VL-Stream-Fields" = "tag.Source,tag.Channel,tag.EventID"
```

### Solution

Changed `Headers` field from `map[string]string` to `map[string]interface{}` to support both:

**Single values (commas preserved):**
```toml
"VL-Stream-Fields" = "tag.Source,tag.Channel,tag.EventID"  # One header value
```

**Multiple values (arrays):**
```toml
"Accept" = ["application/json", "text/plain"]  # Multiple header entries
```

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #17452
