### PR TITLE
feat(inputs.ldap): Allow ldapi:// URI scheme, EXTERNAL SASL Bind (#17477)

### DIFF
--- a/plugins/inputs/ldap/389ds.go
+++ b/plugins/inputs/ldap/389ds.go
@@ -79,10 +79,6 @@ func (l *LDAP) new389dsConfig() []request {
 }
 
 func (l *LDAP) convert389ds(result *ldap.SearchResult, ts time.Time) []telegraf.Metric {
-	tags := map[string]string{
-		"server": l.host,
-		"port":   l.port,
-	}
 	fields := make(map[string]interface{})
 	for _, entry := range result.Entries {
 		for _, attr := range entry.Attributes {
@@ -110,6 +106,6 @@ func (l *LDAP) convert389ds(result *ldap.SearchResult, ts time.Time) []telegraf.
 		}
 	}
 
-	m := metric.New("389ds", tags, fields, ts)
+	m := metric.New("389ds", l.tags, fields, ts)
 	return []telegraf.Metric{m}
 }

--- a/plugins/inputs/ldap/README.md
+++ b/plugins/inputs/ldap/README.md
@@ -30,12 +30,19 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ##    ldap://...      -- unencrypted (non-TLS) connection
   ##    ldaps://...     -- TLS connection
   ##    starttls://...  --  StartTLS connection
+  ##    ldapi://...     -- UNIX socket connection
   ## If no port is given, the default ports, 389 for ldap and starttls and
-  ## 636 for ldaps, are used.
+  ## 636 for ldaps, are used, there is no port on UNIX sockets.
   server = "ldap://localhost"
 
   ## Server dialect, can be "openldap" or "389ds"
   # dialect = "openldap"
+
+  # What sort of Bind to use
+  ## Empty or "simple" means to use a simple LDAP bind, otherwise use a
+  ## specified SASL mechanism (only EXTERNAL currently supported - for TLS
+  ## client certs or UNIX credentials)
+  bind_mechanism = "simple"
 
   # DN and password to bind with
   ## If bind_dn is empty an anonymous bind is performed.
@@ -87,6 +94,10 @@ are usually named according to the selected dialect.
 
 - server -- Server name or IP
 - port   -- Port used for connecting
+
+Or with the ldapi scheme:
+
+- path -- Path used to connect
 
 ## Example Output
 

--- a/plugins/inputs/ldap/ldap.go
+++ b/plugins/inputs/ldap/ldap.go
@@ -7,6 +7,7 @@ import (
 	_ "embed"
 	"fmt"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/go-ldap/ldap/v3"
@@ -23,6 +24,7 @@ var sampleConfig string
 type LDAP struct {
 	Server            string        `toml:"server"`
 	Dialect           string        `toml:"dialect"`
+	BindMech          string        `toml:"bind_mechanism"`
 	BindDn            string        `toml:"bind_dn"`
 	BindPassword      config.Secret `toml:"bind_password"`
 	ReverseFieldNames bool          `toml:"reverse_field_names"`
@@ -31,8 +33,7 @@ type LDAP struct {
 	tlsCfg   *tls.Config
 	requests []request
 	mode     string
-	host     string
-	port     string
+	tags     map[string]string
 }
 
 type request struct {
@@ -49,6 +50,20 @@ func (l *LDAP) Init() error {
 		l.Server = "ldap://localhost:389"
 	}
 
+	var hostname string
+	// Work around net/url not accepting %2f in the "host" part
+	ldapiChunk, isLdapi := strings.CutPrefix(l.Server, "ldapi://")
+	if isLdapi {
+		var err error
+		host, rest, _ := strings.Cut(ldapiChunk, "/")
+		l.Server = "ldapi:///" + rest
+
+		hostname, err = url.PathUnescape(host)
+		if err != nil {
+			return fmt.Errorf("parsing server failed: %w", err)
+		}
+	}
+
 	u, err := url.Parse(l.Server)
 	if err != nil {
 		return fmt.Errorf("parsing server failed: %w", err)
@@ -58,26 +73,31 @@ func (l *LDAP) Init() error {
 	var tlsEnable bool
 	switch u.Scheme {
 	case "ldap":
-		if u.Port() == "" {
-			u.Host = u.Host + ":389"
-		}
 		tlsEnable = false
+	case "ldapi":
+		tlsEnable = false
+		u.Host = hostname
 	case "starttls":
-		if u.Port() == "" {
-			u.Host = u.Host + ":389"
-		}
+		u.Scheme = "ldap"
 		tlsEnable = true
 	case "ldaps":
-		if u.Port() == "" {
-			u.Host = u.Host + ":636"
-		}
 		tlsEnable = true
 	default:
 		return fmt.Errorf("invalid scheme: %q", u.Scheme)
 	}
 	l.mode = u.Scheme
-	l.Server = u.Host
-	l.host, l.port = u.Hostname(), u.Port()
+	l.Server = u.String()
+
+	if u.Scheme == "ldapi" {
+		l.tags = map[string]string{
+			"path": u.Hostname(),
+		}
+	} else {
+		l.tags = map[string]string{
+			"server": u.Hostname(),
+			"port":   u.Port(),
+		}
+	}
 
 	// Force TLS depending on the selected mode
 	l.ClientConfig.Enable = &tlsEnable
@@ -131,29 +151,37 @@ func (l *LDAP) Gather(acc telegraf.Accumulator) error {
 func (l *LDAP) connect() (*ldap.Conn, error) {
 	var conn *ldap.Conn
 	switch l.mode {
-	case "ldap":
+	case "ldap", "ldapi":
 		var err error
-		conn, err = ldap.DialURL("ldap://" + l.Server)
+		conn, err = ldap.DialURL(l.Server)
 		if err != nil {
 			return nil, err
+		}
+		if *l.ClientConfig.Enable {
+			if err := conn.StartTLS(l.tlsCfg); err != nil {
+				return nil, err
+			}
 		}
 	case "ldaps":
 		var err error
-		conn, err = ldap.DialURL("ldaps://"+l.Server, ldap.DialWithTLSConfig(l.tlsCfg))
+		conn, err = ldap.DialURL(l.Server, ldap.DialWithTLSConfig(l.tlsCfg))
 		if err != nil {
-			return nil, err
-		}
-	case "starttls":
-		var err error
-		conn, err = ldap.DialURL("ldap://" + l.Server)
-		if err != nil {
-			return nil, err
-		}
-		if err := conn.StartTLS(l.tlsCfg); err != nil {
 			return nil, err
 		}
 	default:
 		return nil, fmt.Errorf("invalid tls_mode: %s", l.mode)
+	}
+
+	switch l.BindMech {
+	case "", "simple":
+		// simple bind, handled below
+	case "external":
+		if err := conn.ExternalBind(); err != nil {
+			return nil, fmt.Errorf("external bind failed: %w", err)
+		}
+		return conn, nil
+	default:
+		return nil, fmt.Errorf("unsupported bind type: %s", l.mode)
 	}
 
 	if l.BindDn == "" && l.BindPassword.Empty() {

--- a/plugins/inputs/ldap/ldap_test.go
+++ b/plugins/inputs/ldap/ldap_test.go
@@ -65,6 +65,48 @@ func TestMockResult(t *testing.T) {
 	testutil.RequireMetricsEqual(t, expected, actual)
 }
 
+func TestMockLDAPI(t *testing.T) {
+	// mock a query result
+	mockSearchResult := &ldap.SearchResult{
+		Entries: []*ldap.Entry{
+			{
+				DN:         "cn=Total,cn=Connections,cn=Monitor",
+				Attributes: []*ldap.EntryAttribute{{Name: "monitorCounter", Values: []string{"1"}}},
+			},
+		},
+	}
+
+	// Setup the plugin
+	plugin := &LDAP{
+		Server: "ldapi://%2ftmp%2fsocket",
+	}
+	require.NoError(t, plugin.Init())
+
+	// Setup the expectations
+	expected := []telegraf.Metric{
+		metric.New(
+			"openldap",
+			map[string]string{
+				"path": "/tmp/socket",
+			},
+			map[string]interface{}{
+				"total_connections": int64(1),
+			},
+			time.Unix(0, 0),
+		),
+	}
+
+	// Retrieve the converter
+	requests := plugin.newOpenLDAPConfig()
+	require.Len(t, requests, 1)
+	converter := requests[0].convert
+	require.NotNil(t, converter)
+
+	// Test metric conversion
+	actual := converter(mockSearchResult, time.Unix(0, 0))
+	testutil.RequireMetricsEqual(t, expected, actual)
+}
+
 func TestInvalidTLSMode(t *testing.T) {
 	plugin := &LDAP{
 		Server: "foo://localhost",

--- a/plugins/inputs/ldap/openldap.go
+++ b/plugins/inputs/ldap/openldap.go
@@ -40,11 +40,6 @@ func (l *LDAP) newOpenLDAPConfig() []request {
 }
 
 func (l *LDAP) convertOpenLDAP(result *ldap.SearchResult, ts time.Time) []telegraf.Metric {
-	tags := map[string]string{
-		"server": l.host,
-		"port":   l.port,
-	}
-
 	fields := make(map[string]interface{})
 	for _, entry := range result.Entries {
 		prefix := openLDAPAttrConvertDN(entry.DN, l.ReverseFieldNames)
@@ -58,7 +53,7 @@ func (l *LDAP) convertOpenLDAP(result *ldap.SearchResult, ts time.Time) []telegr
 		}
 	}
 
-	m := metric.New("openldap", tags, fields, ts)
+	m := metric.New("openldap", l.tags, fields, ts)
 	return []telegraf.Metric{m}
 }
 

--- a/plugins/inputs/ldap/sample.conf
+++ b/plugins/inputs/ldap/sample.conf
@@ -5,12 +5,19 @@
   ##    ldap://...      -- unencrypted (non-TLS) connection
   ##    ldaps://...     -- TLS connection
   ##    starttls://...  --  StartTLS connection
+  ##    ldapi://...     -- UNIX socket connection
   ## If no port is given, the default ports, 389 for ldap and starttls and
-  ## 636 for ldaps, are used.
+  ## 636 for ldaps, are used, there is no port on UNIX sockets.
   server = "ldap://localhost"
 
   ## Server dialect, can be "openldap" or "389ds"
   # dialect = "openldap"
+
+  # What sort of Bind to use
+  ## Empty or "simple" means to use a simple LDAP bind, otherwise use a
+  ## specified SASL mechanism (only EXTERNAL currently supported - for TLS
+  ## client certs or UNIX credentials)
+  bind_mechanism = "simple"
 
   # DN and password to bind with
   ## If bind_dn is empty an anonymous bind is performed.

--- a/plugins/inputs/ldap/sample.conf.in
+++ b/plugins/inputs/ldap/sample.conf.in
@@ -5,12 +5,19 @@
   ##    ldap://...      -- unencrypted (non-TLS) connection
   ##    ldaps://...     -- TLS connection
   ##    starttls://...  --  StartTLS connection
+  ##    ldapi://...     -- UNIX socket connection
   ## If no port is given, the default ports, 389 for ldap and starttls and
-  ## 636 for ldaps, are used.
+  ## 636 for ldaps, are used, there is no port on UNIX sockets.
   server = "ldap://localhost"
 
   ## Server dialect, can be "openldap" or "389ds"
   # dialect = "openldap"
+
+  # What sort of Bind to use
+  ## Empty or "simple" means to use a simple LDAP bind, otherwise use a
+  ## specified SASL mechanism (only EXTERNAL currently supported - for TLS
+  ## client certs or UNIX credentials)
+  bind_mechanism = "simple"
 
   # DN and password to bind with
   ## If bind_dn is empty an anonymous bind is performed.


### PR DESCRIPTION
## Summary
Implements #17477 (enabling Unix socket support and EXTERNAL SASL binds)

## Checklist
- [x] No AI generated code was used in this PR

## Related issues
resolves #17477