### PR TITLE
chore: Update to Go 1.25.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
     working_directory: '/go/src/github.com/influxdata/telegraf'
     resource_class: large
     docker:
-      - image: 'quay.io/influxdb/telegraf-ci:1.24.5'
+      - image: 'quay.io/influxdb/telegraf-ci:1.25.0'
     environment:
       GOFLAGS: -p=4
   mac:

--- a/.github/workflows/readme-linter.yml
+++ b/.github/workflows/readme-linter.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.24.5'
+          go-version: '1.25.0'
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -518,6 +518,10 @@ linters:
       - path: (.+)\.go$
         text: don't use an underscore in package name
 
+      # revive:var-naming
+      - path: (.*)\.go$
+        text: avoid meaningless package names
+
       # revive:var-naming: Exclude mixed-caps packages in migrations, as these migrations are fixing the issues from before.
       - path: migrations/.*\.go$
         text: don't use MixedCaps in package name

--- a/Makefile
+++ b/Makefile
@@ -180,7 +180,7 @@ vet:
 .PHONY: lint-install
 lint-install:
 	@echo "Installing golangci-lint"
-	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.2
+	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.4.0
 
 	@echo "Installing markdownlint"
 	npm install -g markdownlint-cli
@@ -257,8 +257,8 @@ plugins/parsers/influx/machine.go: plugins/parsers/influx/machine.go.rl
 
 .PHONY: ci
 ci:
-	docker build -t quay.io/influxdb/telegraf-ci:1.24.5 - < scripts/ci.docker
-	docker push quay.io/influxdb/telegraf-ci:1.24.5
+	docker build -t quay.io/influxdb/telegraf-ci:1.25.0 - < scripts/ci.docker
+	docker push quay.io/influxdb/telegraf-ci:1.25.0
 
 .PHONY: install
 install: $(buildbin)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/influxdata/telegraf
 
-go 1.24.0
+go 1.25.0
 
 godebug x509negativeserial=1
 

--- a/plugins/outputs/instrumental/instrumental.go
+++ b/plugins/outputs/instrumental/instrumental.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -72,7 +73,7 @@ func (i *Instrumental) Init() error {
 }
 
 func (i *Instrumental) Connect() error {
-	addr := fmt.Sprintf("%s:%d", i.Host, i.Port)
+	addr := net.JoinHostPort(i.Host, strconv.Itoa(i.Port))
 	connection, err := net.DialTimeout("tcp", addr, time.Duration(i.Timeout))
 
 	if err != nil {

--- a/scripts/ci.docker
+++ b/scripts/ci.docker
@@ -1,4 +1,4 @@
-FROM golang:1.24.5
+FROM golang:1.25.0
 
 RUN chmod -R 755 "$GOPATH"
 

--- a/scripts/installgo_linux.sh
+++ b/scripts/installgo_linux.sh
@@ -2,10 +2,10 @@
 
 set -eux
 
-GO_VERSION="1.24.5"
+GO_VERSION="1.25.0"
 GO_ARCH="linux-amd64"
 # from https://go.dev/dl
-GO_VERSION_SHA="10ad9e86233e74c0f6590fe5426895de6bf388964210eac34a6d83f38918ecdc"
+GO_VERSION_SHA="2852af0cb20a13139b3448992e69b868e50ed0f8a1e5940ee1de9e19a123b613"
 
 # Download Go and verify Go tarball
 setup_go () {

--- a/scripts/installgo_mac.sh
+++ b/scripts/installgo_mac.sh
@@ -3,9 +3,9 @@
 set -eux
 
 ARCH=$(uname -m)
-GO_VERSION="1.24.5"
-GO_VERSION_SHA_arm64="92d30a678f306c327c544758f2d2fa5515aa60abe9dba4ca35fbf9b8bfc53212" # from https://go.dev/dl
-GO_VERSION_SHA_amd64="2fe5f3866b8fbcd20625d531f81019e574376b8a840b0a096d8a2180308b1672" # from https://go.dev/dl
+GO_VERSION="1.25.0"
+GO_VERSION_SHA_arm64="544932844156d8172f7a28f77f2ac9c15a23046698b6243f633b0a0b00c0749c" # from https://go.dev/dl
+GO_VERSION_SHA_amd64="5bd60e823037062c2307c71e8111809865116714d6f6b410597cf5075dfd80ef" # from https://go.dev/dl
 
 if [ "$ARCH" = 'arm64' ]; then
     GO_ARCH="darwin-arm64"

--- a/scripts/installgo_windows.sh
+++ b/scripts/installgo_windows.sh
@@ -2,7 +2,7 @@
 
 set -eux
 
-GO_VERSION="1.24.5"
+GO_VERSION="1.25.0"
 
 setup_go () {
     choco upgrade golang --allow-downgrade --version=${GO_VERSION}


### PR DESCRIPTION
## Summary
- Updates Go to 1.25.0
- Updates golangci-lint to 2.4.0 (necessary with Go upgrade)
- Ignores a new package name linter warning
- Fixes a new go vet warning related to ipv6 addresses

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues

resolves #
