### PR TITLE
feat(inputs.x509_cert): Add support for Windows certificate stores

### DIFF
--- a/plugins/inputs/x509_cert/README.md
+++ b/plugins/inputs/x509_cert/README.md
@@ -2,6 +2,9 @@
 
 This plugin provides information about [X.509][x509] certificates accessible
 e.g. via local file, tcp, udp, https or smtp protocols.
+This plugin provides information about X509 certificate accessible via local
+file, tcp, udp, https or smtp protocol. Furthermore, this plugin allows do get
+certificates from the Windows Certificate Store on Windows.
 
 > [!NOTE]
 > When using a UDP address as a certificate source, the server must support
@@ -35,7 +38,8 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
             "/etc/ssl/certs/ssl-cert-snakeoil.pem",
             "/etc/mycerts/*.mydomain.org.pem", "file:///path/to/*.pem",
             "jks:///etc/mycerts/keystore.jks",
-            "pkcs12:///etc/mycerts/keystore.p12"]
+            "pkcs12:///etc/mycerts/keystore.p12",
+            "wincertstore://ROOT", "wincertstore://HKCU:CA"]
 
   ## Timeout for SSL connection
   # timeout = "5s"

--- a/plugins/inputs/x509_cert/sample.conf
+++ b/plugins/inputs/x509_cert/sample.conf
@@ -7,7 +7,8 @@
             "/etc/ssl/certs/ssl-cert-snakeoil.pem",
             "/etc/mycerts/*.mydomain.org.pem", "file:///path/to/*.pem",
             "jks:///etc/mycerts/keystore.jks",
-            "pkcs12:///etc/mycerts/keystore.p12"]
+            "pkcs12:///etc/mycerts/keystore.p12",
+            "wincertstore://ROOT", "wincertstore://HKCU:CA"]
 
   ## Timeout for SSL connection
   # timeout = "5s"

--- a/plugins/inputs/x509_cert/wincertstore.go
+++ b/plugins/inputs/x509_cert/wincertstore.go
@@ -1,0 +1,101 @@
+//go:build windows
+
+package x509_cert
+
+import (
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"strings"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+
+	"github.com/influxdata/telegraf"
+)
+
+type wincertstore struct {
+	store  *uint16
+	flags  uint32
+	source string
+	log    telegraf.Logger
+}
+
+func newWincertStore(path string, log telegraf.Logger) (*wincertstore, error) {
+	var flags uint32 = windows.CERT_STORE_READONLY_FLAG | windows.CERT_STORE_OPEN_EXISTING_FLAG
+
+	// Accept store names containing locations of the forms [<location>:]name
+	var source string
+	before, name, found := strings.Cut(path, ":")
+	if !found {
+		flags |= windows.CERT_SYSTEM_STORE_LOCAL_MACHINE
+		name = path
+		source = "HKEY_LOCAL_MACHINE:" + name
+	} else {
+		switch before {
+		case "HKLM", "HKEY_LOCAL_MACHINE":
+			flags |= windows.CERT_SYSTEM_STORE_LOCAL_MACHINE
+			source = "HKEY_LOCAL_MACHINE:" + name
+		case "HKCU", "HKEY_CURRENT_USER":
+			flags |= windows.CERT_SYSTEM_STORE_CURRENT_USER
+			source = "HKEY_CURRENT_USER:" + name
+		default:
+			return nil, fmt.Errorf("unknown store location %q", before)
+		}
+	}
+	store, err := windows.UTF16PtrFromString(name)
+	if err != nil {
+		return nil, fmt.Errorf("converting store name %q failed: %w", name, err)
+	}
+
+	return &wincertstore{store: store, flags: flags, source: source, log: log}, nil
+}
+
+func (s *wincertstore) read() ([]*x509.Certificate, error) {
+	// Open the actual store for reading
+	handle, err := windows.CertOpenStore(
+		windows.CERT_STORE_PROV_SYSTEM_W,
+		0,
+		0,
+		s.flags,
+		uintptr(unsafe.Pointer(s.store)), //nolint:gosec // G103: Valid use of unsafe call to pass store to API
+	)
+	if err != nil {
+		return nil, fmt.Errorf("opening store failed: %w", err)
+	}
+	defer windows.CertCloseStore(handle, 0)
+
+	// Enumerate all available certificates
+	var certificates []*x509.Certificate
+	var certctx *windows.CertContext
+	for {
+		// Get the next certificate in the store
+		var err error
+		if certctx, err = windows.CertEnumCertificatesInStore(handle, certctx); certctx == nil {
+			break
+		} else if err != nil {
+			if errors.Is(err, windows.Errno(windows.CRYPT_E_NOT_FOUND)) {
+				return certificates, nil
+			}
+			if err := windows.CertFreeCertificateContext(certctx); err != nil {
+				s.log.Errorf("Freeing context failed: %v", err)
+			}
+			return nil, fmt.Errorf("enumerating certificates in store failed: %w", err)
+		}
+
+		// Convert the returned byte pointer into an usable byte-slice and parse
+		// the certificate. We need to copy the byte-slice to avoid
+		// modifications during processing...
+		buf := unsafe.Slice(certctx.EncodedCert, certctx.Length) //nolint:gosec // G103: Valid use of unsafe call to extract cert data
+		cert, err := x509.ParseCertificate(append([]byte{}, buf...))
+		if err != nil {
+			name := make([]uint16, 256)
+			n := windows.CertGetNameString(certctx, windows.CERT_NAME_SIMPLE_DISPLAY_TYPE, 0, nil, &name[0], uint32(len(name)))
+			subject := windows.UTF16ToString(name[:n])
+			s.log.Errorf("parsing certificate for %q failed: %v", subject, err)
+			continue
+		}
+		certificates = append(certificates, cert)
+	}
+	return certificates, nil
+}

--- a/plugins/inputs/x509_cert/wincertstore_notwindows.go
+++ b/plugins/inputs/x509_cert/wincertstore_notwindows.go
@@ -1,0 +1,22 @@
+//go:build !windows
+
+package x509_cert
+
+import (
+	"crypto/x509"
+	"errors"
+
+	"github.com/influxdata/telegraf"
+)
+
+type wincertstore struct {
+	source string
+}
+
+func newWincertStore(string, telegraf.Logger) (*wincertstore, error) {
+	return nil, errors.New("not supported on this platform")
+}
+
+func (*wincertstore) read() ([]*x509.Certificate, error) {
+	return nil, nil
+}


### PR DESCRIPTION
## Summary

This PR adds support for reading certificates from the Windows Certificate Store and check them using the x509 plugin.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #5363
