### PR TITLE
feat(outputs.influxdb): Add internal statistics for written bytes

### DIFF
--- a/plugins/outputs/influxdb/http.go
+++ b/plugins/outputs/influxdb/http.go
@@ -13,12 +13,14 @@ import (
 	"net/url"
 	"path"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/internal"
 	"github.com/influxdata/telegraf/plugins/serializers/influx"
+	"github.com/influxdata/telegraf/selfstat"
 )
 
 const (
@@ -108,6 +110,8 @@ type HTTPConfig struct {
 	InfluxUintSupport bool `toml:"influx_uint_support"`
 	Serializer        *influx.Serializer
 	Log               telegraf.Logger
+
+	BytesWritten selfstat.Stat
 }
 
 type httpClient struct {
@@ -346,6 +350,7 @@ func (c *httpClient) writeBatch(ctx context.Context, db, rp string, metrics []te
 
 	reader := c.requestBodyReader(metrics)
 	defer reader.Close()
+	defer func() { c.config.BytesWritten.Incr(reader.bytesWritten.Load()) }()
 
 	req, err := c.makeWriteRequest(loc, reader)
 	if err != nil {
@@ -489,14 +494,14 @@ func (c *httpClient) makeWriteRequest(address string, body io.Reader) (*http.Req
 
 // requestBodyReader warp io.Reader from influx.NewReader to io.ReadCloser, which is useful to fast close the write
 // side of the connection in case of error
-func (c *httpClient) requestBodyReader(metrics []telegraf.Metric) io.ReadCloser {
+func (c *httpClient) requestBodyReader(metrics []telegraf.Metric) *wrappedReader {
 	reader := influx.NewReader(metrics, c.config.Serializer)
-
 	if c.config.ContentEncoding == "gzip" {
-		return internal.CompressWithGzip(reader)
+		reader = internal.CompressWithGzip(reader)
 	}
 
-	return io.NopCloser(reader)
+	// Create a wrapper to be able to able to extract the number of bytes written
+	return &wrappedReader{r: io.NopCloser(reader)}
 }
 
 func (c *httpClient) addHeaders(req *http.Request) error {
@@ -591,4 +596,19 @@ func makeQueryURL(loc *url.URL) (string, error) {
 
 func (c *httpClient) Close() {
 	c.client.CloseIdleConnections()
+}
+
+type wrappedReader struct {
+	r            io.ReadCloser
+	bytesWritten atomic.Int64
+}
+
+func (r *wrappedReader) Read(p []byte) (int, error) {
+	n, err := r.r.Read(p)
+	r.bytesWritten.Add(int64(n))
+	return n, err
+}
+
+func (r *wrappedReader) Close() error {
+	return r.r.Close()
 }

--- a/plugins/outputs/influxdb/http.go
+++ b/plugins/outputs/influxdb/http.go
@@ -605,7 +605,11 @@ type wrappedReader struct {
 
 func (r *wrappedReader) Read(p []byte) (int, error) {
 	n, err := r.r.Read(p)
+
+	// Atomically update bytesWritten to ensure thread-safe tracking during
+	// concurrent reads
 	r.bytesWritten.Add(int64(n))
+
 	return n, err
 }
 

--- a/plugins/outputs/influxdb/influxdb.go
+++ b/plugins/outputs/influxdb/influxdb.go
@@ -100,6 +100,7 @@ func (i *InfluxDB) Init() error {
 
 func (i *InfluxDB) Connect() error {
 	ctx := context.Background()
+	i.clients = make([]Client, 0, len(i.URLs))
 
 	for _, u := range i.URLs {
 		parts, err := url.Parse(u)
@@ -180,10 +181,7 @@ func (i *InfluxDB) Close() error {
 	for _, client := range i.clients {
 		client.Close()
 	}
-
-	// Unregister internal statistics
-	i.Collector.Unregister("write", "bytes_written", nil)
-	i.bytesWritten = nil
+	i.clients = make([]Client, 0)
 
 	return nil
 }

--- a/plugins/outputs/influxdb/influxdb_test.go
+++ b/plugins/outputs/influxdb/influxdb_test.go
@@ -254,7 +254,7 @@ func TestInfluxDBLocalAddress(t *testing.T) {
 
 	require.NoError(t, output.Init())
 	require.NoError(t, output.Connect())
-	defer output.Close()
+	output.Close()
 }
 
 func TestBytesWrittenHTTP(t *testing.T) {

--- a/plugins/outputs/influxdb/udp_test.go
+++ b/plugins/outputs/influxdb/udp_test.go
@@ -103,7 +103,7 @@ func TestUDP_Simple(t *testing.T) {
 		},
 		BytesWritten: selfstat.Register("write", "bytes_written", nil),
 	}
-	defer selfstat.Unregister("write", "bytes_written", nil)
+	defer config.BytesWritten.Unregister()
 
 	client, err := influxdb.NewUDPClient(config)
 	require.NoError(t, err)
@@ -130,7 +130,7 @@ func TestUDP_DialError(t *testing.T) {
 		},
 		BytesWritten: selfstat.Register("write", "bytes_written", nil),
 	}
-	defer selfstat.Unregister("write", "bytes_written", nil)
+	defer config.BytesWritten.Unregister()
 
 	client, err := influxdb.NewUDPClient(config)
 	require.NoError(t, err)
@@ -159,7 +159,7 @@ func TestUDP_WriteError(t *testing.T) {
 		},
 		BytesWritten: selfstat.Register("write", "bytes_written", nil),
 	}
-	defer selfstat.Unregister("write", "bytes_written", nil)
+	defer config.BytesWritten.Unregister()
 
 	client, err := influxdb.NewUDPClient(config)
 	require.NoError(t, err)
@@ -225,7 +225,7 @@ func TestUDP_ErrorLogging(t *testing.T) {
 			log.SetOutput(&b)
 
 			tt.config.BytesWritten = selfstat.Register("write", "bytes_written", nil)
-			defer selfstat.Unregister("write", "bytes_written", nil)
+			defer tt.config.BytesWritten.Unregister()
 
 			client, err := influxdb.NewUDPClient(tt.config)
 			require.NoError(t, err)
@@ -269,7 +269,7 @@ func TestUDP_WriteWithRealConn(t *testing.T) {
 		URL:          u,
 		BytesWritten: selfstat.Register("write", "bytes_written", nil),
 	}
-	defer selfstat.Unregister("write", "bytes_written", nil)
+	defer config.BytesWritten.Unregister()
 
 	client, err := influxdb.NewUDPClient(config)
 	require.NoError(t, err)

--- a/plugins/outputs/influxdb/udp_test.go
+++ b/plugins/outputs/influxdb/udp_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/metric"
 	"github.com/influxdata/telegraf/plugins/outputs/influxdb"
+	"github.com/influxdata/telegraf/selfstat"
 	"github.com/influxdata/telegraf/testutil"
 )
 
@@ -100,7 +101,10 @@ func TestUDP_Simple(t *testing.T) {
 				return conn, nil
 			},
 		},
+		BytesWritten: selfstat.Register("write", "bytes_written", nil),
 	}
+	defer selfstat.Unregister("write", "bytes_written", nil)
+
 	client, err := influxdb.NewUDPClient(config)
 	require.NoError(t, err)
 
@@ -124,12 +128,14 @@ func TestUDP_DialError(t *testing.T) {
 				return nil, errors.New(`unsupported scheme [invalid://localhost:9999]: "invalid"`)
 			},
 		},
+		BytesWritten: selfstat.Register("write", "bytes_written", nil),
 	}
+	defer selfstat.Unregister("write", "bytes_written", nil)
+
 	client, err := influxdb.NewUDPClient(config)
 	require.NoError(t, err)
 
-	err = client.Write(t.Context(), []telegraf.Metric{getMetric()})
-	require.Error(t, err)
+	require.Error(t, client.Write(t.Context(), []telegraf.Metric{getMetric()}))
 }
 
 func TestUDP_WriteError(t *testing.T) {
@@ -151,12 +157,14 @@ func TestUDP_WriteError(t *testing.T) {
 				return conn, nil
 			},
 		},
+		BytesWritten: selfstat.Register("write", "bytes_written", nil),
 	}
+	defer selfstat.Unregister("write", "bytes_written", nil)
+
 	client, err := influxdb.NewUDPClient(config)
 	require.NoError(t, err)
 
-	err = client.Write(t.Context(), []telegraf.Metric{getMetric()})
-	require.Error(t, err)
+	require.Error(t, client.Write(t.Context(), []telegraf.Metric{getMetric()}))
 	require.True(t, closed)
 }
 
@@ -216,11 +224,13 @@ func TestUDP_ErrorLogging(t *testing.T) {
 			var b bytes.Buffer
 			log.SetOutput(&b)
 
+			tt.config.BytesWritten = selfstat.Register("write", "bytes_written", nil)
+			defer selfstat.Unregister("write", "bytes_written", nil)
+
 			client, err := influxdb.NewUDPClient(tt.config)
 			require.NoError(t, err)
 
-			err = client.Write(t.Context(), tt.metrics)
-			require.NoError(t, err)
+			require.NoError(t, client.Write(t.Context(), tt.metrics))
 			require.Contains(t, b.String(), tt.logContains)
 		})
 	}
@@ -256,13 +266,14 @@ func TestUDP_WriteWithRealConn(t *testing.T) {
 	require.NoError(t, err)
 
 	config := influxdb.UDPConfig{
-		URL: u,
+		URL:          u,
+		BytesWritten: selfstat.Register("write", "bytes_written", nil),
 	}
+	defer selfstat.Unregister("write", "bytes_written", nil)
+
 	client, err := influxdb.NewUDPClient(config)
 	require.NoError(t, err)
-
-	err = client.Write(t.Context(), metrics)
-	require.NoError(t, err)
+	require.NoError(t, client.Write(t.Context(), metrics))
 
 	wg.Wait()
 


### PR DESCRIPTION
## Summary

This PR adds an internal statistic about the number of metric `bytes_written` . This statistic can be collected using the `internal` input plugin.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

based on #17554 
resolves #4889
