### PR TITLE
fix(inputs.s7comm): Use correct value for string length with 'extra' parameter

### DIFF
--- a/plugins/inputs/s7comm/s7comm.go
+++ b/plugins/inputs/s7comm/s7comm.go
@@ -368,9 +368,9 @@ func handleFieldAddress(address string) (*gos7.S7DataItem, converterFunc, error)
 	case "DT": // 7-byte
 		buflen = 7
 	case "S":
-		amount = extra
 		// Extra bytes as the first byte is the max-length of the string and
 		// the second byte is the actual length of the string.
+		amount = extra + 2
 		buflen = extra + 2
 	default:
 		return nil, nil, errors.New("invalid data type")

--- a/plugins/inputs/s7comm/s7comm_test.go
+++ b/plugins/inputs/s7comm/s7comm_test.go
@@ -375,7 +375,7 @@ func TestFieldMappings(t *testing.T) {
 							WordLen:  0x03,
 							DBNumber: 5,
 							Start:    3,
-							Amount:   10,
+							Amount:   12,
 							Data:     make([]byte, 12),
 						},
 					},
@@ -383,7 +383,9 @@ func TestFieldMappings(t *testing.T) {
 						{
 							measurement: "test",
 							field:       "foo",
-							convert:     func([]byte) interface{} { return "" },
+							convert: func(b []byte) interface{} {
+								return string(b[2 : 2+b[1]])
+							},
 						},
 					},
 				},


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Fix String 'extra' parameter

Config:
```toml
fields = [
        {name="Line_1", address="DB68.S28.19"},
        {name="Line_2", address="DB68.S50.19"},
        {name="Line_3", address="DB68.S72.19"},
        {name="Line_4", address="DB68.S94.19"},
        {name="Line_5", address="DB68.S116.19"},
        {name="Line_6", address="DB68.S138.19"},
        {name="Line_7", address="DB68.S160.19"},
     ]
```
Test run:
```
./telegraf.exe --config ./TEST.conf --test --print-plugin-config-source
2025-08-31T08:12:04Z I! Loading config: ./TEST.conf
2025-08-31T08:12:04Z I! Starting Telegraf unknown (customized) brought to you by InfluxData the makers of InfluxDB
2025-08-31T08:12:04Z I! Available plugins: 1 inputs, 0 aggregators, 0 processors, 1 parsers, 1 outputs, 0 secret-stores
2025-08-31T08:12:04Z I! Loaded inputs: s7comm
+--------+------------+
| NAME   | SOURCE(S)  |
+--------+------------+
| s7comm | ./TEST.conf |
+--------+------------+
2025-08-31T08:12:04Z I! Loaded aggregators:
2025-08-31T08:12:04Z I! Loaded processors:
2025-08-31T08:12:04Z I! Loaded secretstores:
2025-08-31T08:12:04Z W! Outputs are not used in testing mode!
2025-08-31T08:12:04Z I! Tags enabled: host=DESKTOP-*******
2025-08-31T08:12:04Z W! [agent] The default value of 'skip_processors_after_aggregators' will change to 'true' with Telegraf v1.40.0! If you need the current default behavior, please explicitly set the option to 'false'!
> TEST,host=DESKTOP-******* Line_1="Out135_In109_Route1",Line_2="",Line_3="",Line_4="",Line_5="",Line_6="",Line_7="" 1756657201000000000
```

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #17509
