### PR TITLE
test(inputs.mysql): Update MariaDB Galera integration test to use legacy repository

### DIFF
--- a/plugins/inputs/mysql/mysql_test.go
+++ b/plugins/inputs/mysql/mysql_test.go
@@ -157,7 +157,7 @@ func TestGaleraIntegration(t *testing.T) {
 	}
 
 	container := testutil.Container{
-		Image:        "bitnami/mariadb-galera",
+		Image:        "bitnamilegacy/mariadb-galera",
 		Env:          map[string]string{"ALLOW_EMPTY_PASSWORD": "yes"},
 		ExposedPorts: []string{servicePort},
 		WaitingFor: wait.ForAll(


### PR DESCRIPTION
## Summary
Update the Galera integration test to use the legacy registry image reference for MariaDB Galera.

- Changed test container image from bitnami/mariadb-galera to bitnamilegacy/mariadb-galera.
- Rationale: As documented in the referenced issue, the original Bitnami MariaDB Galera image was deprecated/moved and is no longer available under the bitnami/ namespace. This caused CI/integration tests to fail when attempting to pull the image. Switching to the bitnamilegacy/ namespace restores test stability without changing the test semantics.
- This is a test-only change; no production code paths are affected.

### Background information
https://github.com/bitnami/containers/issues/83267

## Checklist
- [x] No AI-generated code was used in this PR

