### PR TITLE
chore(deps): Bump github.com/facebook/time to latest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -86,7 +86,7 @@ require (
 	github.com/dynatrace-oss/dynatrace-metric-utils-go v0.5.0
 	github.com/eclipse/paho.golang v0.22.0
 	github.com/eclipse/paho.mqtt.golang v1.5.0
-	github.com/facebook/time v0.0.0-20240626113945-18207c5d8ddc
+	github.com/facebook/time v0.0.0-20250903103710-a5911c32cdb9
 	github.com/fatih/color v1.18.0
 	github.com/go-ldap/ldap/v3 v3.4.11
 	github.com/go-logfmt/logfmt v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -1201,8 +1201,8 @@ github.com/envoyproxy/protoc-gen-validate v0.9.1/go.mod h1:OKNgG7TCp5pF4d6XftA0+
 github.com/envoyproxy/protoc-gen-validate v0.10.1/go.mod h1:DRjgyB0I43LtJapqN6NiRwroiAU2PaFuvk/vjgh61ss=
 github.com/envoyproxy/protoc-gen-validate v1.2.1 h1:DEo3O99U8j4hBFwbJfrz9VtgcDfUKS7KJ7spH3d86P8=
 github.com/envoyproxy/protoc-gen-validate v1.2.1/go.mod h1:d/C80l/jxXLdfEIhX1W2TmLfsJ31lvEjwamM4DxlWXU=
-github.com/facebook/time v0.0.0-20240626113945-18207c5d8ddc h1:0VQsg5ZXW9MPUxzemUHW7UBK8gfIO8K+YJGbdv4kBIM=
-github.com/facebook/time v0.0.0-20240626113945-18207c5d8ddc/go.mod h1:2UFAomOuD2vAK1x68czUtCVjAqmyWCEnAXOlmGqf+G0=
+github.com/facebook/time v0.0.0-20250903103710-a5911c32cdb9 h1:IghB0/AakzNKu4+KBY+RT7J4TiMXwmZ1DCzOTR+0wmQ=
+github.com/facebook/time v0.0.0-20250903103710-a5911c32cdb9/go.mod h1:bp0KsBqhjbum8LF5Canem6aGBHWk5EGZRRN7z3rMp0E=
 github.com/facebookgo/stack v0.0.0-20160209184415-751773369052 h1:JWuenKqqX8nojtoVVWjGfOF9635RETekkoH6Cc9SX0A=
 github.com/facebookgo/stack v0.0.0-20160209184415-751773369052/go.mod h1:UbMTZqLaRiH3MsBH8va0n7s1pQYcu3uTb8G4tygF4Zg=
 github.com/facebookgo/stackerr v0.0.0-20150612192056-c2fcf88613f4 h1:fP04zlkPjAGpsduG7xN3rRkxjAqkJaIQnnkNYYw/pAk=

--- a/plugins/inputs/chrony/chrony.go
+++ b/plugins/inputs/chrony/chrony.go
@@ -381,10 +381,10 @@ func (c *Chrony) getSourceName(ip net.IP) (string, error) {
 	}
 
 	// Cut the string at null termination
-	if termidx := bytes.Index(sourceName.Name[:], []byte{0}); termidx >= 0 {
-		return string(sourceName.Name[:termidx]), nil
+	if termidx := bytes.Index([]byte(sourceName.Name), []byte{0}); termidx >= 0 {
+		return sourceName.Name[:termidx], nil
 	}
-	return string(sourceName.Name[:]), nil
+	return sourceName.Name, nil
 }
 
 func (c *Chrony) gatherSources(acc telegraf.Accumulator) error {


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Updated `go.mod` to latest [facebook/time](https://github.com/facebook/time/commit/87bed4b54021f847a0f3b60bcedd1fc013aea9f6) (includes my upstream fix).
This introduced a type change (`ReplyNTPSourceName.Name` → string), causing compilation errors.

PR updates:

1. Bump dependency to latest version
2. Fix code to handle string type (`[]byte(sourceName.Name)`, remove redundant `string()` casts)

Chrony plugin now builds and all tests pass.




## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #17453
