### PR TITLE
fix(outputs): Retrigger batch-available-events only if at least one metric was written successfully

### DIFF
--- a/models/running_output.go
+++ b/models/running_output.go
@@ -406,8 +406,10 @@ func (r *RunningOutput) updateTransaction(tx *Transaction, err error) {
 		return
 	}
 
-	// Transfer the accepted and rejected indices based on the write error values
-	r.lastWriteFailed.Store(false)
+	// Transfer the accepted and rejected indices based on the write error
+	// values. Only allow to retrigger before the flush interval if at least
+	// one metric was accepted in order to avoid
+	r.lastWriteFailed.Store(len(writeErr.MetricsAccept) == 0)
 	tx.Accept = writeErr.MetricsAccept
 	tx.Reject = writeErr.MetricsReject
 }

--- a/models/running_output_test.go
+++ b/models/running_output_test.go
@@ -637,7 +637,7 @@ func TestRunningOutputNoRetriggerOnError(t *testing.T) {
 	require.Equal(t, totalMetrics, ro.buffer.Len())
 }
 
-func TestRunningOutputNoRetriggerOnPartialWriteError(t *testing.T) {
+func TestRunningOutputNoRetriggerOnSuccessfulPartialWriteError(t *testing.T) {
 	// Setup output with a post-write hook to be able to block write until
 	// we added more metrics
 	conf := &OutputConfig{
@@ -680,6 +680,7 @@ func TestRunningOutputNoRetriggerOnPartialWriteError(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
+	var triggerCount atomic.Uint32
 	var errCount atomic.Uint32
 	var wg sync.WaitGroup
 	wg.Add(1)
@@ -690,6 +691,7 @@ func TestRunningOutputNoRetriggerOnPartialWriteError(t *testing.T) {
 			case <-cctx.Done():
 				return
 			case <-ro.BatchReady:
+				triggerCount.Add(1)
 				if err := ro.Write(); err != nil {
 					errCount.Add(1)
 				}
@@ -706,7 +708,73 @@ func TestRunningOutputNoRetriggerOnPartialWriteError(t *testing.T) {
 	// Check for writing errors and make sure all metrics were written,
 	// including the ones added while writing took place
 	require.Equal(t, errCount.Load(), plugin.writes.Load())
+	require.Equal(t, triggerCount.Load(), plugin.writes.Load())
 	require.Equal(t, batchCount, int(plugin.writes.Load()))
+}
+
+func TestRunningOutputNoRetriggerOnUnsuccessfulPartialWriteError(t *testing.T) {
+	// Setup output with a post-write hook to be able to block write until
+	// we added more metrics
+	conf := &OutputConfig{
+		Filter: Filter{},
+	}
+
+	plugin := &mockOutput{
+		batchAcceptSize: 0,
+		preWriteHook: func(m []telegraf.Metric) error {
+			return &internal.PartialWriteError{
+				Err: errors.New("unable to connect"),
+			}
+		},
+	}
+	const batchSize = 5
+	ro := NewRunningOutput(plugin, conf, batchSize, 100)
+
+	// Create a multiple of batch size many metrics beyond the batch size
+	const batchCount = 10
+	const totalMetrics = batchCount * batchSize
+	inputs := make([]telegraf.Metric, 0, totalMetrics)
+	for i := range totalMetrics {
+		inputs = append(inputs, testutil.TestMetric(i, "test"))
+	}
+
+	// Add the metrics
+	for _, m := range inputs {
+		ro.AddMetric(m)
+	}
+
+	// Setup a event based writing loop similar to what the agent code does.
+	// Remember the first write will block to allow us adding more metrics.
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+
+	var triggerCount atomic.Uint32
+	var errCount atomic.Uint32
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func(cctx context.Context) {
+		defer wg.Done()
+		for {
+			select {
+			case <-cctx.Done():
+				return
+			case <-ro.BatchReady:
+				triggerCount.Add(1)
+				if err := ro.Write(); err != nil {
+					errCount.Add(1)
+				}
+			}
+		}
+	}(ctx)
+
+	// Wait for the trigger loop to exit. This should happen latest after the
+	// defined timeout.
+	wg.Wait()
+	cancel()
+
+	// Check for writing errors and make sure all metrics were written,
+	// including the ones added while writing took place
+	require.Equal(t, 1, int(triggerCount.Load()))
 }
 
 func TestRunningOutputInternalMetrics(t *testing.T) {

--- a/models/running_output_test.go
+++ b/models/running_output_test.go
@@ -721,7 +721,7 @@ func TestRunningOutputNoRetriggerOnUnsuccessfulPartialWriteError(t *testing.T) {
 
 	plugin := &mockOutput{
 		batchAcceptSize: 0,
-		preWriteHook: func(m []telegraf.Metric) error {
+		preWriteHook: func([]telegraf.Metric) error {
 			return &internal.PartialWriteError{
 				Err: errors.New("unable to connect"),
 			}


### PR DESCRIPTION
## Summary

When output plugins (such as `outputs.influxdb_v2`) return partial-write errors additional writes might be triggered if the buffer contains more than batch-size metrics. However, those plugins _might_ return partial-write errors for cases where no metric was written successfully, e.g. if a server is not reachable, to cover cases with serialization errors etc.

This PR updates the retrigger logic to require at least **one** metric to be written successfully to enable retriggering. If no metric was accepted by the output retriggering is disabled until the next flush-interval.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #17415
resolves #17378 
