### PR TITLE
fix(internal): Extract go version more robustly

### DIFF
--- a/internal/internal.go
+++ b/internal/internal.go
@@ -13,6 +13,7 @@ import (
 	"math/rand"
 	"os"
 	"os/exec"
+	"regexp"
 	"runtime"
 	"strings"
 	"sync"
@@ -31,6 +32,9 @@ var once sync.Once
 var (
 	ErrTimeout        = errors.New("command timed out")
 	ErrNotImplemented = errors.New("not implemented yet")
+
+	// Regexp for extracting the go version from runtime information
+	reGoVer = regexp.MustCompile(`go([^\s]+).*`)
 )
 
 // Set via LDFLAGS -X
@@ -70,8 +74,12 @@ func FormatFullVersion() string {
 
 // ProductToken returns a tag for Telegraf that can be used in user agents.
 func ProductToken() string {
-	return fmt.Sprintf("Telegraf/%s Go/%s",
-		Version, strings.TrimPrefix(runtime.Version(), "go"))
+	gover := strings.TrimPrefix(runtime.Version(), "go")
+	if g := reGoVer.FindStringSubmatch(runtime.Version()); len(g) == 2 {
+		gover = g[1]
+	}
+
+	return fmt.Sprintf("Telegraf/%s Go/%s", Version, gover)
 }
 
 // ReadLines reads contents from a file and splits them by new lines.


### PR DESCRIPTION
## Summary

When setting special options during compilation of Golang, those options are passed on to the version. This leads to situations where the Go runtime versions of distribution packages looks like

```
go1.25.1 X:nodwarf5
```

e.g. in recent ArchLinux builds.

The previous code for building the full Telegraf product version assumes no suffices in the version and in turn will add
`1.25.1 X:nodwarf5` to Telegraf's full product version which in turn makes internal tests fail.

This PR uses a regular expression to more robustly extract the go version.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues
