### PR TITLE
fix(filter): Handle multiple conditions correctly

### DIFF
--- a/filter/filter_test.go
+++ b/filter/filter_test.go
@@ -49,6 +49,54 @@ func TestCompile(t *testing.T) {
 	require.False(t, f.Match("cpu.field,measurement.count"))
 }
 
+func TestMultiple(t *testing.T) {
+	tests := []struct {
+		name     string
+		pattern  []string
+		value    string
+		expected bool
+	}{
+		{
+			name:     "issue 9265",
+			pattern:  []string{"*process32:*.exe:*.*", "otherWantedMetric*"},
+			value:    "cpu.process32:testcase.exe:caserunner.2222",
+			expected: true,
+		},
+		{
+			name:     "issue 9265",
+			pattern:  []string{"*process32:*.exe:*.*", "otherWantedMetric*"},
+			value:    "process32:testcase.exe:caserunner.2222",
+			expected: true,
+		},
+		{
+			name:     "issue 9265",
+			pattern:  []string{"*process32:*.exe:*.*", "otherWantedMetric*"},
+			value:    "otherWantedMetric",
+			expected: true,
+		},
+		{
+			name:     "issue 9265",
+			pattern:  []string{"*process32:*.exe:*.*", "otherWantedMetric*"},
+			value:    "otherWantedMetric.ABC",
+			expected: true,
+		},
+		{
+			name:     "issue 9265",
+			pattern:  []string{"*process32:*.exe:*.*", "otherWantedMetric*"},
+			value:    "unwantedMetric",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name+"-"+tt.value, func(t *testing.T) {
+			f, err := Compile(tt.pattern)
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, f.Match(tt.value))
+		})
+	}
+}
+
 func TestIncludeExclude(t *testing.T) {
 	labels := []string{"best", "com_influxdata", "timeseries", "com_influxdata_telegraf", "ever"}
 	tags := make([]string, 0, len(labels))

--- a/filter/implementations.go
+++ b/filter/implementations.go
@@ -1,0 +1,56 @@
+package filter
+
+import "github.com/gobwas/glob"
+
+type filterSingle struct {
+	s string
+}
+
+func (f *filterSingle) Match(s string) bool {
+	return f.s == s
+}
+
+type filterNoGlob struct {
+	m map[string]struct{}
+}
+
+func newFilterNoGlob(filters []string) Filter {
+	out := filterNoGlob{m: make(map[string]struct{})}
+	for _, filter := range filters {
+		out.m[filter] = struct{}{}
+	}
+	return &out
+}
+
+func (f *filterNoGlob) Match(s string) bool {
+	_, ok := f.m[s]
+	return ok
+}
+
+type filterGlobMultiple struct {
+	set []glob.Glob
+}
+
+func newFilterGlobMultiple(filters []string, separators ...rune) (Filter, error) {
+	f := &filterGlobMultiple{set: make([]glob.Glob, 0, len(filters))}
+
+	for _, pattern := range filters {
+		g, err := glob.Compile(pattern, separators...)
+		if err != nil {
+			return nil, err
+		}
+		f.set = append(f.set, g)
+	}
+
+	return f, nil
+}
+
+func (f *filterGlobMultiple) Match(s string) bool {
+	for _, g := range f.set {
+		if g.Match(s) {
+			return true
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
## Summary

This PR fixes an issue where some filter conditions are silently ignored when multiple filter expressions are provided. This is an issue in the upstream library, so this PR works around the issue as the upstream library is unmaintained...

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #9265 
