### PR TITLE
chore(deps): Switch to maintained yaml library

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -229,7 +229,7 @@ require (
 	go.opentelemetry.io/proto/otlp/profiles/v1development v0.1.0
 	go.starlark.net v0.0.0-20250906160240-bf296ed553ea
 	go.step.sm/crypto v0.70.0
-	go.yaml.in/yaml/v2 v2.4.3
+	go.yaml.in/yaml/v3 v3.0.4
 	golang.org/x/crypto v0.42.0
 	golang.org/x/exp v0.0.0-20250911091902-df9299821621
 	golang.org/x/mod v0.28.0
@@ -559,7 +559,7 @@ require (
 	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
-	go.yaml.in/yaml/v3 v3.0.4 // indirect
+	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	golang.org/x/telemetry v0.0.0-20250908211612-aef8a434d053 // indirect
 	golang.org/x/time v0.13.0 // indirect
 	golang.org/x/tools v0.37.0 // indirect

--- a/plugins/inputs/beanstalkd/beanstalkd.go
+++ b/plugins/inputs/beanstalkd/beanstalkd.go
@@ -8,7 +8,7 @@ import (
 	"net/textproto"
 	"sync"
 
-	"go.yaml.in/yaml/v2"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/plugins/inputs"

--- a/plugins/inputs/puppetagent/puppetagent.go
+++ b/plugins/inputs/puppetagent/puppetagent.go
@@ -8,7 +8,7 @@ import (
 	"reflect"
 	"strings"
 
-	"go.yaml.in/yaml/v2"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/plugins/inputs"


### PR DESCRIPTION
## Summary
Moves from `gopkg.in/yaml.v2` to `go.yaml.in/yaml/v2`

The libraries are the same, but the old name had its repo deprecated and its version pinned at 2.4.0: https://github.com/go-yaml/yaml/tree/v2.4.0

The new library is located here on github: https://github.com/yaml/go-yaml/tree/v2/

## Checklist
- [x] No AI generated code was used in this PR

## Related issues
resolves #

