### PR TITLE
fix(inputs.zfs): Allow to output I/O stats as uint64

### DIFF
--- a/plugins/inputs/zfs/README.md
+++ b/plugins/inputs/zfs/README.md
@@ -39,6 +39,11 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## By default, don't gather zpool stats
   # poolMetrics = false
 
+  ## Report pool metrics as UINT64 as defined by ZFS (Linux only)
+  ## This is disabled for backward compatibility but is STRONGLY RECOMMENDED
+  ## to be enabled to avoid overflows. This requires UINT support on the output.
+  ## poolMetricsUint = false
+
   ## By default, don't gather dataset stats
   # datasetMetrics = false
 ```

--- a/plugins/inputs/zfs/sample.conf
+++ b/plugins/inputs/zfs/sample.conf
@@ -16,5 +16,10 @@
   ## By default, don't gather zpool stats
   # poolMetrics = false
 
+  ## Report pool metrics as UINT64 as defined by ZFS (Linux only)
+  ## This is disabled for backward compatibility but is STRONGLY RECOMMENDED
+  ## to be enabled to avoid overflows. This requires UINT support on the output.
+  ## poolMetricsUint = false
+
   ## By default, don't gather dataset stats
   # datasetMetrics = false

--- a/plugins/inputs/zfs/zfs.go
+++ b/plugins/inputs/zfs/zfs.go
@@ -11,11 +11,12 @@ import (
 var sampleConfig string
 
 type Zfs struct {
-	KstatPath      string          `toml:"kstatPath"`
-	KstatMetrics   []string        `toml:"kstatMetrics"`
-	PoolMetrics    bool            `toml:"poolMetrics"`
-	DatasetMetrics bool            `toml:"datasetMetrics"`
-	Log            telegraf.Logger `toml:"-"`
+	KstatPath       string          `toml:"kstatPath"`
+	KstatMetrics    []string        `toml:"kstatMetrics"`
+	PoolMetrics     bool            `toml:"poolMetrics"`
+	PoolMetricsUint bool            `toml:"poolMetricsUint"`
+	DatasetMetrics  bool            `toml:"datasetMetrics"`
+	Log             telegraf.Logger `toml:"-"`
 
 	helper //nolint:unused // for OS-specific usage
 }

--- a/plugins/inputs/zfs/zfs_linux.go
+++ b/plugins/inputs/zfs/zfs_linux.go
@@ -5,6 +5,7 @@ package zfs
 import (
 	"errors"
 	"fmt"
+	"math"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -50,8 +51,7 @@ func (z *Zfs) Gather(acc telegraf.Accumulator) error {
 
 	if z.PoolMetrics && err == nil {
 		for _, pool := range pools {
-			err := gatherPoolStats(pool, acc)
-			if err != nil {
+			if err := z.gatherPoolStats(pool, acc); err != nil {
 				return err
 			}
 		}
@@ -142,7 +142,7 @@ func getTags(pools []poolInfo) map[string]string {
 	return map[string]string{"pools": poolNames}
 }
 
-func gatherPoolStats(pool poolInfo, acc telegraf.Accumulator) error {
+func (z *Zfs) gatherPoolStats(pool poolInfo, acc telegraf.Accumulator) error {
 	lines, err := internal.ReadLines(pool.ioFilename)
 	if err != nil {
 		return err
@@ -155,7 +155,7 @@ func gatherPoolStats(pool poolInfo, acc telegraf.Accumulator) error {
 	case v1:
 		fields, gatherErr = gatherV1(lines)
 	case v2:
-		fields, gatherErr = gatherV2(lines, tags)
+		fields, gatherErr = z.gatherV2(lines, tags)
 	case unknown:
 		return errors.New("unknown metrics version detected")
 	}
@@ -214,7 +214,7 @@ func gather(lines []string, fileLines int) (keys, values []string, err error) {
 // nunlinked                       4    13848
 //
 // For explanation of the first line's values see https://github.com/openzfs/zfs/blob/master/module/os/linux/spl/spl-kstat.c#L61
-func gatherV2(lines []string, tags map[string]string) (map[string]interface{}, error) {
+func (z *Zfs) gatherV2(lines []string, tags map[string]string) (map[string]interface{}, error) {
 	fileLines := 9
 	_, _, err := gather(lines, fileLines)
 	if err != nil {
@@ -227,12 +227,17 @@ func gatherV2(lines []string, tags map[string]string) (map[string]interface{}, e
 		lineFields := strings.Fields(lines[i])
 		fieldName := lineFields[0]
 		fieldData := lineFields[2]
-		value, err := strconv.ParseInt(fieldData, 10, 64)
+		value, err := strconv.ParseUint(fieldData, 10, 64)
 		if err != nil {
 			return nil, err
 		}
-
-		fields[fieldName] = value
+		if z.PoolMetricsUint {
+			fields[fieldName] = value
+		} else if value > math.MaxInt64 {
+			fields[fieldName] = math.MaxInt64
+		} else {
+			fields[fieldName] = int64(value)
+		}
 	}
 
 	return fields, nil


### PR DESCRIPTION
## Summary

This PR adds an option to output pool I/O statistics as `uint64` to match the ZFS definition. Setting this will avoid overflows of the values. If the option is not enabled, values overflowing `int64` will be clipped to the upper bound.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #7502 
