### PR TITLE
feat(inputs.netflow): Add datatypes to PEN mapping

### DIFF
--- a/plugins/inputs/netflow/README.md
+++ b/plugins/inputs/netflow/README.md
@@ -96,11 +96,17 @@ with the corresponding name and data-type.
 
 Currently the following `data-type`s are supported:
 
-- `uint`   unsigned integer with 8, 16, 32 or 64 bit
-- `hex`    hex-encoding of the raw byte sequence with `0x` prefix
-- `string` string interpretation of the raw byte sequence
-- `ip`     IPv4 or IPv6 address
-- `proto`  mapping of layer-4 protocol numbers to names
+- `bool`    TruthValue according to [RFC5101][RFC5101]
+- `int`     signed integer with 8, 16, 32 or 64 bit
+- `uint`    unsigned integer with 8, 16, 32 or 64 bit
+- `float64` double-precision floating-point number
+- `hex`     hex-encoding of the raw byte sequence with `0x` prefix
+- `string`  string interpretation of the raw byte sequence
+- `mac`     MAC address
+- `ip`      IPv4 or IPv6 address
+- `proto`   mapping of layer-4 protocol numbers to names
+
+[RFC5101]: https://www.rfc-editor.org/rfc/rfc5101#section-6.1.5
 
 ## Troubleshooting
 

--- a/plugins/inputs/netflow/mappings.go
+++ b/plugins/inputs/netflow/mappings.go
@@ -7,11 +7,15 @@ import (
 )
 
 var funcMapping = map[string]decoderFunc{
-	"uint":   decodeUint,
-	"hex":    decodeHex,
-	"string": decodeString,
-	"ip":     decodeIP,
-	"proto":  decodeL4Proto,
+	"bool":    decodeBool,
+	"int":     decodeInt,
+	"uint":    decodeUint,
+	"float64": decodeFloat64,
+	"hex":     decodeHex,
+	"string":  decodeString,
+	"mac":     decodeMAC,
+	"ip":      decodeIP,
+	"proto":   decodeL4Proto,
 }
 
 func loadMapping(filename string) (map[string]fieldMapping, error) {


### PR DESCRIPTION
## Summary

The PEN in question uses boolean, signed integer, double-precision floating-point number and MAC address data types, which cannot be set in the PEN CSV file. The respective decoders are available, they just can't be set in the PEN CSV. This PR makes them available.

We can discuss about the naming. Not sure if one should choose `float` or `float64`. I chose the later, since it is more descriptive.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves: #17623