### PR TITLE
test(inputs.whois): Fix flaky test when shutting down server

### DIFF
--- a/plugins/inputs/whois/whois_test.go
+++ b/plugins/inputs/whois/whois_test.go
@@ -151,6 +151,7 @@ func TestCases(t *testing.T) {
 type server struct {
 	responses map[string][]byte
 	listener  net.Listener
+	wg        sync.WaitGroup
 
 	errors []error
 	sync.Mutex
@@ -185,7 +186,9 @@ func (s *server) start() (string, error) {
 	s.listener = listener
 
 	addr := listener.Addr().String()
+	s.wg.Add(1)
 	go func() {
+		defer s.wg.Done()
 		for {
 			conn, err := s.listener.Accept()
 			if err != nil {
@@ -222,6 +225,7 @@ func (s *server) start() (string, error) {
 func (s *server) stop() {
 	if s.listener != nil {
 		s.listener.Close()
+		s.wg.Wait()
 		s.listener = nil
 	}
 }


### PR DESCRIPTION
## Summary
Running whois tests with "go test -count 10000 ." results in panic below.

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0xc85580]

goroutine 66840 [running]:
github.com/influxdata/telegraf/plugins/inputs/whois.(*server).start.func1()
	/home/kaey/.cache/aport-bump/telegraf/plugins/inputs/whois/whois_test.go:190 +0x40
created by github.com/influxdata/telegraf/plugins/inputs/whois.(*server).start in goroutine 66884
	/home/kaey/.cache/aport-bump/telegraf/plugins/inputs/whois/whois_test.go:188 +0xfc
FAIL	github.com/influxdata/telegraf/plugins/inputs/whois	2.669s
FAIL
```

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues

