### PR TITLE
fix(json): json serialize and gnmi output

### DIFF
--- a/metric/metric.go
+++ b/metric/metric.go
@@ -408,6 +408,42 @@ func convertField(v interface{}) interface{} {
 		if v != nil {
 			return float64(*v)
 		}
+	// Handle scalar lists (slices/arrays), we should not skip here it's serializer job to skip unsupported types or error out
+	case []interface{}:
+		// Process each element recursively using convertField
+		result := make([]interface{}, len(v))
+		for i, elem := range v {
+			result[i] = convertField(elem)
+		}
+		return result
+	case []int:
+		result := make([]int64, len(v))
+		for i, elem := range v {
+			result[i] = int64(elem)
+		}
+		return result
+	case []float64:
+		return v
+	case []string:
+		return v
+	case []bool:
+		return v
+	case []int64:
+		return v
+	case []uint:
+		result := make([]uint64, len(v))
+		for i, elem := range v {
+			result[i] = uint64(elem)
+		}
+		return result
+	case []uint64:
+		return v
+	case []float32:
+		result := make([]float64, len(v))
+		for i, elem := range v {
+			result[i] = float64(elem)
+		}
+		return result
 	default:
 		return nil
 	}

--- a/metric/metric_test.go
+++ b/metric/metric_test.go
@@ -400,8 +400,8 @@ func TestMetric_AddFieldAndNew_ScalarSlices(t *testing.T) {
 
 func TestMetric_AddField_ScalarSlices(t *testing.T) {
 	m := baseMetric()
-	m.AddField("mixed", []interface{}{int(5), float64(6.6), "c"})
+	m.AddField("mixed", []any{int(5), float64(6.6), "c"})
 	outFields := m.Fields()
-	require.IsType(t, []interface{}{}, outFields["mixed"])
-	require.Equal(t, []interface{}{int64(5), float64(6.6), "c"}, outFields["mixed"])
+	require.IsType(t, make([]any, 0), outFields["mixed"])
+	require.Equal(t, []any{int64(5), float64(6.6), "c"}, outFields["mixed"])
 }

--- a/plugins/inputs/gnmi/gnmi_test.go
+++ b/plugins/inputs/gnmi/gnmi_test.go
@@ -1227,3 +1227,20 @@ func TestCases(t *testing.T) {
 		})
 	}
 }
+
+func TestFlatten_ScalarArray(t *testing.T) {
+	result := flatten([]interface{}{1, 2, 3})
+	require.Len(t, result, 1)
+	require.Nil(t, result[0].key)
+	require.Equal(t, []interface{}{1, 2, 3}, result[0].value)
+
+	resultStr := flatten([]interface{}{"a", "b"})
+	require.Len(t, resultStr, 1)
+	require.Nil(t, resultStr[0].key)
+	require.Equal(t, []interface{}{"a", "b"}, resultStr[0].value)
+
+	resultBool := flatten([]interface{}{true, false})
+	require.Len(t, resultBool, 1)
+	require.Nil(t, resultBool[0].key)
+	require.Equal(t, []interface{}{true, false}, resultBool[0].value)
+}

--- a/plugins/inputs/gnmi/update_fields.go
+++ b/plugins/inputs/gnmi/update_fields.go
@@ -160,13 +160,28 @@ func flatten(nested interface{}) []keyValuePair {
 			}
 		}
 	case []interface{}:
-		for i, child := range n {
-			k := strconv.Itoa(i)
-			for _, c := range flatten(child) {
-				values = append(values, keyValuePair{
-					key:   append([]string{k}, c.key...),
-					value: c.value,
-				})
+		allNonNested := true
+		for _, child := range n {
+			switch child.(type) {
+			case map[string]interface{}, []interface{}:
+				allNonNested = false
+			}
+			if !allNonNested {
+				break
+			}
+		}
+		if allNonNested {
+			// send as it is, let serializer handle it
+			values = append(values, keyValuePair{value: n})
+		} else {
+			for i, child := range n {
+				k := strconv.Itoa(i)
+				for _, c := range flatten(child) {
+					values = append(values, keyValuePair{
+						key:   append([]string{k}, c.key...),
+						value: c.value,
+					})
+				}
 			}
 		}
 	default:

--- a/plugins/serializers/json/json_test.go
+++ b/plugins/serializers/json/json_test.go
@@ -133,15 +133,15 @@ func TestSerializeNestedFieldKeys(t *testing.T) {
 	require.True(t, ok, "missing system field")
 	cpu, ok := system["cpu"].(map[string]interface{})
 	require.True(t, ok)
-	require.Equal(t, 55.5, cpu["usage"])
+	require.InDelta(t, 55.5, cpu["usage"], 1e-9)
 
 	// Check nested mem usage
 	mem, ok := system["mem"].(map[string]interface{})
 	require.True(t, ok)
-	require.Equal(t, 70.1, mem["usage"])
+	require.InDelta(t, 70.1, mem["usage"], 1e-9)
 
 	// Check flat field
-	require.Equal(t, float64(123), fieldsOut["flat_field"])
+	require.InDelta(t, 123.0, fieldsOut["flat_field"], 1e-9)
 }
 
 func TestSerializeMetricInt(t *testing.T) {


### PR DESCRIPTION
## Summary
for an array values 
`counterName: [100 114 111 112 86 111 113 73 110 80 111 114 116 78 111 116 86 108 97 110 77 101 109 98 101 114 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0]
`

we are getting like

```
0_fap_49_65535/counterName_0:82,0_fap_49_65535/counterName_1:111,0_fap_49_65535/counterName_2:117,0_fap_49_65535/counterName_3:116, .... 0_fap_49_65535/counterName_17:101
```

also the json serializer is treating paths as a string `system/cpu/usage` instead of treating as a nested dict

Added fix for all these

## Checklist
- [ ] No AI generated code was used in this PR

## Related issues


resolves #17629
