### PR TITLE
feat(inputs): load targets dynamically without restarting agent

### DIFF
--- a/cmd/telegraf/main.go
+++ b/cmd/telegraf/main.go
@@ -246,6 +246,7 @@ func runApp(args []string, outputBuffer io.Writer, pprof Server, c TelegrafConfi
 			once:                    cCtx.Bool("once"),
 			quiet:                   cCtx.Bool("quiet"),
 			unprotected:             cCtx.Bool("unprotected"),
+			watchInputsOnly:         cCtx.Bool("watch-inputs-only"),
 		}
 
 		w := WindowFlags{
@@ -344,6 +345,12 @@ func runApp(args []string, outputBuffer io.Writer, pprof Server, c TelegrafConfi
 					Name: "test",
 					Usage: "enable test mode: gather metrics, print them out, and exit. " +
 						"Note: Test mode only runs inputs, processors, and aggregators, but not outputs",
+				},
+				&cli.BoolFlag{
+					Name: "watch-inputs-only",
+					Usage: "When set, only inputs diff will be (re)loaded when a config changes keeping the other plugins running" +
+						" (unchanged inputs, processors, aggregators, outputs) as is. use this along with --watch-config or --config-url-watch-interval otherwise this has no effect",
+					DefaultText: "disabled",
 				},
 				&cli.StringSliceFlag{
 					Name: "select",

--- a/config/diff/diff.go
+++ b/config/diff/diff.go
@@ -1,0 +1,213 @@
+package diff
+
+import (
+	"log"
+	"reflect"
+
+	"github.com/fatih/color"
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/config"
+	isnmp "github.com/influxdata/telegraf/internal/snmp"
+	"github.com/influxdata/telegraf/models"
+	"github.com/influxdata/telegraf/plugins/inputs/gnmi"
+	"github.com/influxdata/telegraf/plugins/inputs/snmp"
+)
+
+// placeholder for the input plugin diff
+
+type InputPluginDiff struct {
+	Add []*models.RunningInput
+	Del []*models.RunningInput
+}
+
+func NewInputPluginDiff() *InputPluginDiff {
+	d := &InputPluginDiff{
+		Add: make([]*models.RunningInput, 0),
+		Del: make([]*models.RunningInput, 0),
+	}
+	return d
+}
+
+func (d *InputPluginDiff) IsEmpty() bool {
+	return len(d.Add) == 0 && len(d.Del) == 0
+}
+
+func GetPluginUniqueName(input *models.RunningInput) string {
+	id := input.ID()
+	if id == "" { // this can only hit if plguin in of type pluginWithID and its set to empty
+		id = input.Config.ID
+	}
+	return input.Config.Name + "-" + id
+}
+
+func GetPluginNames(op []*models.RunningInput) []string {
+	names := make([]string, len(op))
+	for i, input := range op {
+		names[i] = GetPluginUniqueName(input)
+	}
+	return names
+}
+
+type compareFunc[T any] func(x, y T) bool
+
+var _diffFuncs = map[reflect.Type]func(x, y *telegraf.Input) bool{
+	reflect.TypeOf((*snmp.Snmp)(nil)).Elem(): deepEqualSNMP,
+	reflect.TypeOf((*gnmi.GNMI)(nil)).Elem(): deepEqualGNMI,
+}
+
+// Helper function to compare two slices.
+func compareSlices[T any](a, b []T, comp compareFunc[T]) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if !comp(a[i], b[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func compareSnmpTable(x, y isnmp.Table) bool {
+	// specific logic to compare SNMP tables
+
+	if x.Name != y.Name ||
+		x.IndexAsTag != y.IndexAsTag ||
+		x.Oid != y.Oid ||
+		!reflect.DeepEqual(x.InheritTags, y.InheritTags) {
+		return false
+	}
+	return compareSlices(x.Fields, y.Fields, compareSnmpField)
+}
+
+func compareSnmpField(x, y isnmp.Field) bool {
+	// specific logic to compare SNMP fields
+	return x.Name == y.Name &&
+		x.Oid == y.Oid &&
+		x.OidIndexSuffix == y.OidIndexSuffix &&
+		x.OidIndexLength == y.OidIndexLength &&
+		x.IsTag == y.IsTag &&
+		x.Translate == y.Translate &&
+		x.Conversion == y.Conversion &&
+		x.SecondaryIndexTable == y.SecondaryIndexTable &&
+		x.SecondaryIndexUse == y.SecondaryIndexUse &&
+		x.SecondaryOuterJoin == y.SecondaryOuterJoin
+}
+
+func compareSecrets(a, b config.Secret) bool {
+	// both are empty
+	if a.Empty() && b.Empty() {
+		return true
+	}
+
+	// one is empty
+	if a.Empty() || b.Empty() {
+		return false
+	}
+
+	aVal, aErr := a.Get()
+
+	if aErr != nil {
+		return false
+	}
+	res, err := b.EqualTo(aVal.Bytes())
+	if err != nil {
+		return false
+	}
+
+	return res
+}
+
+// CompareClientConfig compares two ClientConfig objects except the Translator field.
+func CompareClientConfig(a, b *isnmp.ClientConfig) bool {
+	if a.Timeout != b.Timeout ||
+		a.Retries != b.Retries ||
+		a.Version != b.Version ||
+		a.UnconnectedUDPSocket != b.UnconnectedUDPSocket ||
+		a.Community != b.Community ||
+		a.MaxRepetitions != b.MaxRepetitions ||
+		a.ContextName != b.ContextName ||
+		a.SecLevel != b.SecLevel ||
+		a.SecName != b.SecName ||
+		a.AuthProtocol != b.AuthProtocol ||
+		a.PrivProtocol != b.PrivProtocol ||
+		!compareSlices(a.Path, b.Path, func(x, y string) bool { return x == y }) ||
+		!compareSecrets(a.AuthPassword, b.AuthPassword) ||
+		!compareSecrets(a.PrivPassword, b.PrivPassword) {
+		return false
+	}
+	return true
+}
+
+func deepEqualSNMP(x, y *telegraf.Input) bool {
+	// specific logic to compare SNMP inputs
+	// with this i can make sure if someone adds same inputs (all fields, tables, etc) more than once i will not consider them as different
+
+	snmpX, okX := (*x).(*snmp.Snmp)
+	snmpY, okY := (*y).(*snmp.Snmp)
+
+	if !okX || !okY {
+		msg := color.RedString("Type mismatch: x is %T, y is %T\n", *x, *y)
+		log.Print("E! [config_dif] ", msg)
+		return false
+	}
+
+	// Compare addresses, fields, tables, and other properties
+	return reflect.DeepEqual(snmpX.Agents, snmpY.Agents) &&
+		compareSlices(snmpX.Fields, snmpY.Fields, compareSnmpField) &&
+		compareSlices(snmpX.Tables, snmpY.Tables, compareSnmpTable) &&
+		CompareClientConfig(&snmpX.ClientConfig, &snmpY.ClientConfig) &&
+		snmpX.AgentHostTag == snmpY.AgentHostTag &&
+		snmpX.Name == snmpY.Name
+}
+
+func deepEqualGNMI(x, y *telegraf.Input) bool {
+	// Add specific logic to compare GNMI inputs
+	return reflect.DeepEqual(x, y)
+}
+
+func Diff(oc, nc []*models.RunningInput) *InputPluginDiff {
+	diff := NewInputPluginDiff()
+
+	oldCopy := make([]*models.RunningInput, len(oc))
+	copy(oldCopy, oc)
+
+	if len(oc) == 0 {
+		diff.Add = nc
+		return diff
+	}
+	if len(nc) == 0 {
+		diff.Del = oc
+		return diff
+	}
+
+	for _, ni := range nc {
+		index := -1
+		for ind, oi := range oldCopy {
+			if reflect.TypeOf(ni.Input).Elem() == reflect.TypeOf(oi.Input).Elem() { // same input type i can compare
+				if op, exists := _diffFuncs[reflect.TypeOf(ni.Input).Elem()]; exists {
+					if op(&ni.Input, &oi.Input) {
+						index = ind
+						break
+					}
+				} else {
+					if reflect.DeepEqual(ni.Input, oi.Input) { // same input plugin
+						index = ind
+						break
+					}
+				}
+			}
+		}
+
+		if index == -1 { // i didin't find the input
+			diff.Add = append(diff.Add, ni)
+		} else { // remove the identified input to speed up next search
+			oldCopy = append(oldCopy[:index], oldCopy[index+1:]...)
+		}
+	}
+
+	// what's left over is either changed or deleted items
+	diff.Del = append(diff.Del, oldCopy...)
+
+	return diff
+}

--- a/config/diff/diff_test.go
+++ b/config/diff/diff_test.go
@@ -1,0 +1,698 @@
+package diff
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/config"
+	isnmp "github.com/influxdata/telegraf/internal/snmp"
+	"github.com/influxdata/telegraf/models"
+	"github.com/influxdata/telegraf/plugins/inputs/gnmi"
+	"github.com/influxdata/telegraf/plugins/inputs/snmp"
+)
+
+func TestGetPluginName(t *testing.T) {
+	input := &models.RunningInput{
+		Config: &models.InputConfig{
+			Name: "example",
+			ID:   "1234",
+		},
+	}
+
+	expected := "example-1234"
+	actual := GetPluginUniqueName(input)
+
+	if actual != expected {
+		t.Errorf("GetPluginUniqueName() = %v, want %v", actual, expected)
+	}
+}
+
+func TestGetPluginNames(t *testing.T) {
+	inputs := []*models.RunningInput{
+		{
+			Config: &models.InputConfig{
+				Name: "example1",
+				ID:   "1234",
+			},
+		},
+		{
+			Config: &models.InputConfig{
+				Name: "example2",
+				ID:   "5678",
+			},
+		},
+	}
+
+	expected := []string{"example1-1234", "example2-5678"}
+	actual := GetPluginNames(inputs)
+
+	if !reflect.DeepEqual(actual, expected) {
+		t.Errorf("GetPluginNames() = %v, want %v", actual, expected)
+	}
+}
+
+func TestCompareSlices(t *testing.T) {
+	intComp := func(x, y int) bool { return x == y }
+	stringComp := func(x, y string) bool { return x == y }
+
+	intSlice1 := []int{1, 2, 3}
+	intSlice2 := []int{1, 2, 3}
+	intSlice3 := []int{1, 2, 4}
+
+	stringSlice1 := []string{"a", "b", "c"}
+	stringSlice2 := []string{"a", "b", "c"}
+	stringSlice3 := []string{"a", "b", "d"}
+
+	if !compareSlices(intSlice1, intSlice2, intComp) {
+		t.Errorf("compareSlices(intSlice1, intSlice2) = false, want true")
+	}
+
+	if compareSlices(intSlice1, intSlice3, intComp) {
+		t.Errorf("compareSlices(intSlice1, intSlice3) = true, want false")
+	}
+
+	if !compareSlices(stringSlice1, stringSlice2, stringComp) {
+		t.Errorf("compareSlices(stringSlice1, stringSlice2) = false, want true")
+	}
+
+	if compareSlices(stringSlice1, stringSlice3, stringComp) {
+		t.Errorf("compareSlices(stringSlice1, stringSlice3) = true, want false")
+	}
+}
+
+func TestDiffFuncs(t *testing.T) {
+	snmp1 := &models.RunningInput{
+		Input: &snmp.Snmp{},
+	}
+	snmp2 := &models.RunningInput{
+		Input: &snmp.Snmp{},
+	}
+	gnmi1 := &models.RunningInput{
+		Input: &gnmi.GNMI{},
+	}
+	gnmi2 := &models.RunningInput{
+		Input: &gnmi.GNMI{},
+	}
+
+	if !_diffFuncs[reflect.TypeOf(snmp1.Input).Elem()](&snmp1.Input, &snmp2.Input) {
+		t.Errorf("deepEqualSNMP() = false, want true")
+	}
+
+	if _diffFuncs[reflect.TypeOf(snmp1.Input).Elem()](&snmp1.Input, &gnmi1.Input) {
+		t.Errorf("deepEqualSNMP() = true, want false")
+	}
+
+	if _diffFuncs[reflect.TypeOf(gnmi1.Input).Elem()](&snmp1.Input, &gnmi1.Input) {
+		t.Errorf("deepEqualGNMI() = true, want false")
+	}
+	if !_diffFuncs[reflect.TypeOf(gnmi2.Input).Elem()](&gnmi2.Input, &gnmi1.Input) {
+		t.Errorf("deepEqualGNMI() = false, want true")
+	}
+}
+
+func TestDiff(t *testing.T) {
+	tests := map[string]struct {
+		input1       []*models.RunningInput
+		input2       []*models.RunningInput
+		expectedDiff InputPluginDiff
+	}{
+		"same SNMP inputs": {
+			input1: []*models.RunningInput{
+				{Input: &snmp.Snmp{}},
+			},
+			input2: []*models.RunningInput{
+				{Input: &snmp.Snmp{}},
+			},
+			expectedDiff: InputPluginDiff{
+				Add: make([]*models.RunningInput, 0),
+				Del: make([]*models.RunningInput, 0),
+			},
+		},
+		"SNMP to GNMI": {
+			input1: []*models.RunningInput{
+				{Input: &snmp.Snmp{}},
+			},
+			input2: []*models.RunningInput{
+				{Input: &gnmi.GNMI{}},
+			},
+			expectedDiff: InputPluginDiff{
+				Add: []*models.RunningInput{
+					{Input: &gnmi.GNMI{}},
+				},
+				Del: []*models.RunningInput{
+					{Input: &snmp.Snmp{}},
+				},
+			},
+		},
+		"same GNMI inputs": {
+			input1: []*models.RunningInput{
+				{Input: &gnmi.GNMI{}},
+			},
+			input2: []*models.RunningInput{
+				{Input: &gnmi.GNMI{}},
+			},
+			expectedDiff: InputPluginDiff{
+				Add: make([]*models.RunningInput, 0),
+				Del: make([]*models.RunningInput, 0),
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			d := Diff(tc.input1, tc.input2)
+			if !reflect.DeepEqual(d, &tc.expectedDiff) {
+				t.Errorf("Diff(%v, %v) = %v, want %v", tc.input1, tc.input2, d, tc.expectedDiff)
+			}
+		})
+	}
+}
+
+func TestCompareSnmpField(t *testing.T) {
+	tests := map[string]struct {
+		field1      isnmp.Field
+		field2      isnmp.Field
+		expectedRes bool
+	}{
+		"equal fields": {
+			field1: isnmp.Field{
+				Name:                "field1",
+				Oid:                 "1.3.6.1.2.1.1.1",
+				OidIndexSuffix:      "0",
+				OidIndexLength:      1,
+				IsTag:               true,
+				Translate:           true,
+				SecondaryIndexTable: true,
+				SecondaryIndexUse:   true,
+				SecondaryOuterJoin:  true,
+			},
+			field2: isnmp.Field{
+				Name:                "field1",
+				Oid:                 "1.3.6.1.2.1.1.1",
+				OidIndexSuffix:      "0",
+				OidIndexLength:      1,
+				IsTag:               true,
+				Translate:           true,
+				SecondaryIndexTable: true,
+				SecondaryIndexUse:   true,
+				SecondaryOuterJoin:  true,
+			},
+			expectedRes: true,
+		},
+		"equal fields case 2": {
+			field1: isnmp.Field{
+				Name: "field_random",
+				Oid:  ".1.3.6.1.2.4.6.7",
+			},
+			field2: isnmp.Field{
+				Name: "field_random",
+				Oid:  ".1.3.6.1.2.4.6.7",
+			},
+			expectedRes: true,
+		},
+		"equal fields case 3": {
+			field1: isnmp.Field{
+				Name:  "field_random_tag",
+				Oid:   ".1.3.6.1.2.4.6.7",
+				IsTag: true,
+			},
+			field2: isnmp.Field{
+				Name:  "field_random_tag",
+				Oid:   ".1.3.6.1.2.4.6.7",
+				IsTag: true,
+			},
+			expectedRes: true,
+		},
+		"field with same oid not a tag": {
+			field1: isnmp.Field{
+				Name:  "field_random_tag",
+				Oid:   ".1.3.6.1.2.4.6.7",
+				IsTag: true,
+			},
+			field2: isnmp.Field{
+				Name:  "field_random_tag",
+				Oid:   ".1.3.6.1.2.4.6.7",
+				IsTag: false,
+			},
+			expectedRes: false,
+		},
+		"field with different name": {
+			field1: isnmp.Field{
+				Name:                "field1",
+				Oid:                 "1.3.6.1.2.1.1.1",
+				OidIndexSuffix:      "0",
+				OidIndexLength:      1,
+				IsTag:               true,
+				Translate:           true,
+				SecondaryIndexTable: true,
+				SecondaryIndexUse:   true,
+				SecondaryOuterJoin:  true,
+			},
+			field2: isnmp.Field{
+				Name:                "field2",
+				Oid:                 "1.3.6.1.2.1.1.1",
+				OidIndexSuffix:      "0",
+				OidIndexLength:      1,
+				IsTag:               true,
+				Translate:           true,
+				SecondaryIndexTable: true,
+				SecondaryIndexUse:   true,
+				SecondaryOuterJoin:  true,
+			},
+			expectedRes: false,
+		},
+		"different oid": {
+			field1: isnmp.Field{
+				Name:           "field1",
+				Oid:            "1.3.6.1.2.1.1.1",
+				OidIndexSuffix: "0",
+				OidIndexLength: 1,
+				IsTag:          true,
+			},
+			field2: isnmp.Field{
+				Name:           "field1",
+				Oid:            "1.3.6.1.2.1.1.2",
+				OidIndexSuffix: "0",
+				OidIndexLength: 1,
+				IsTag:          true,
+			},
+			expectedRes: false,
+		},
+		"different tag": {
+			field1: isnmp.Field{
+				Name:                "field1",
+				Oid:                 "1.3.6.1.2.1.1.1",
+				OidIndexSuffix:      "0",
+				OidIndexLength:      1,
+				IsTag:               true,
+				Translate:           true,
+				SecondaryIndexTable: true,
+				SecondaryIndexUse:   true,
+				SecondaryOuterJoin:  true,
+			},
+			field2: isnmp.Field{
+				Name:                "field1",
+				Oid:                 "1.3.6.1.2.1.1.1",
+				OidIndexSuffix:      "0",
+				OidIndexLength:      1,
+				IsTag:               false,
+				Translate:           true,
+				SecondaryIndexTable: true,
+				SecondaryIndexUse:   true,
+				SecondaryOuterJoin:  true,
+			},
+			expectedRes: false,
+		},
+		"different conversion": {
+			field1: isnmp.Field{
+				Name:       "field1",
+				Oid:        "1.3.6.1.2.1.1.1",
+				Conversion: "conversion1",
+			},
+			field2: isnmp.Field{
+				Name:       "field1",
+				Oid:        "1.3.6.1.2.1.1.1",
+				Conversion: "conversion2",
+			},
+			expectedRes: false,
+		},
+		"same conversion": {
+			field1: isnmp.Field{
+				Name:       "field1",
+				Oid:        "1.3.6.1.2.1.1.1",
+				Conversion: "conversion1",
+			},
+			field2: isnmp.Field{
+				Name:       "field1",
+				Oid:        "1.3.6.1.2.1.1.1",
+				Conversion: "conversion1",
+			},
+			expectedRes: true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			if equal := compareSnmpField(tc.field1, tc.field2); equal != tc.expectedRes {
+				t.Errorf("compareSnmpField(%v, %v) = %v, want %v", tc.field1, tc.field2, equal, tc.expectedRes)
+			}
+		})
+	}
+}
+
+func TestCompareSnmpTable(t *testing.T) {
+	tests := map[string]struct {
+		table1      isnmp.Table
+		table2      isnmp.Table
+		expectedRes bool
+	}{
+		"equal tables": {
+			table1: isnmp.Table{
+				Name:        "table1",
+				IndexAsTag:  true,
+				Oid:         "1.3.6.1.2.1.2.2",
+				InheritTags: []string{"tag1", "tag2"},
+				Fields: []isnmp.Field{
+					{Name: "field1", Oid: "1.3.6.1.2.1.2.2.1.1"},
+					{Name: "field2", Oid: "1.3.6.1.2.1.2.2.1.2"},
+				},
+			},
+			table2: isnmp.Table{
+				Name:        "table1",
+				IndexAsTag:  true,
+				Oid:         "1.3.6.1.2.1.2.2",
+				InheritTags: []string{"tag1", "tag2"},
+				Fields: []isnmp.Field{
+					{Name: "field1", Oid: "1.3.6.1.2.1.2.2.1.1"},
+					{Name: "field2", Oid: "1.3.6.1.2.1.2.2.1.2"},
+				},
+			},
+			expectedRes: true,
+		},
+		"same table with different names": {
+			table1: isnmp.Table{
+				Name:        "table1",
+				IndexAsTag:  true,
+				Oid:         "1.3.6.1.2.1.2.2",
+				InheritTags: []string{"tag1", "tag2"},
+				Fields: []isnmp.Field{
+					{Name: "field1", Oid: "1.3.6.1.2.1.2.2.1.1"},
+					{Name: "field2", Oid: "1.3.6.1.2.1.2.2.1.2"},
+				},
+			},
+			table2: isnmp.Table{
+				Name:        "table2",
+				IndexAsTag:  true,
+				Oid:         "1.3.6.1.2.1.2.2",
+				InheritTags: []string{"tag1", "tag2"},
+				Fields: []isnmp.Field{
+					{Name: "field1", Oid: "1.3.6.1.2.1.2.2.1.1"},
+					{Name: "field2", Oid: "1.3.6.1.2.1.2.2.1.2"},
+				},
+			},
+			expectedRes: false,
+		},
+		"different fields": {
+			table1: isnmp.Table{
+				Name:        "table1",
+				IndexAsTag:  true,
+				Oid:         "1.3.6.1.2.1.2.2",
+				InheritTags: []string{"tag1", "tag2"},
+				Fields: []isnmp.Field{
+					{Name: "field1", Oid: "1.3.6.1.2.1.2.2.1.1"},
+					{Name: "field2", Oid: "1.3.6.1.2.1.2.2.1.2"},
+				},
+			},
+			table2: isnmp.Table{
+				Name:        "table1",
+				IndexAsTag:  true,
+				Oid:         "1.3.6.1.2.1.2.2",
+				InheritTags: []string{"tag1", "tag2"},
+				Fields: []isnmp.Field{
+					{Name: "field3", Oid: "1.3.6.1.2.1.2.2.1.3"},
+				},
+			},
+			expectedRes: false,
+		},
+		"different OIDs": {
+			table1: isnmp.Table{
+				Name:        "table1",
+				IndexAsTag:  true,
+				Oid:         "1.3.6.1.2.1.2.2",
+				InheritTags: []string{"tag1", "tag2"},
+				Fields: []isnmp.Field{
+					{Name: "field1", Oid: "1.3.6.1.2.1.2.2.1.1"},
+					{Name: "field2", Oid: "1.3.6.1.2.1.2.2.1.2"},
+				},
+			},
+			table2: isnmp.Table{
+				Name:        "table1",
+				IndexAsTag:  true,
+				Oid:         "1.3.6.1.2.1.2.3",
+				InheritTags: []string{"tag1", "tag2"},
+				Fields: []isnmp.Field{
+					{Name: "field1", Oid: "1.3.6.1.2.1.2.2.1.1"},
+					{Name: "field2", Oid: "1.3.6.1.2.1.2.2.1.2"},
+				},
+			},
+			expectedRes: false,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			if equal := compareSnmpTable(tc.table1, tc.table2); equal != tc.expectedRes {
+				t.Errorf("compareSnmpTable(%v, %v) = %v, want %v", tc.table1, tc.table2, equal, tc.expectedRes)
+			}
+		})
+	}
+}
+
+func TestCompareSecrets(t *testing.T) {
+	tests := map[string]struct {
+		secret1     config.Secret
+		secret2     config.Secret
+		expectedRes bool
+	}{
+		"both secrets empty": {
+			secret1:     config.Secret{},
+			secret2:     config.Secret{},
+			expectedRes: true,
+		},
+		"one secret empty": {
+			secret1:     config.Secret{},
+			secret2:     config.NewSecret([]byte("secret")),
+			expectedRes: false,
+		},
+		"equal secrets": {
+			secret1:     config.NewSecret([]byte("secret")),
+			secret2:     config.NewSecret([]byte("secret")),
+			expectedRes: true,
+		},
+		"different secrets": {
+			secret1:     config.NewSecret([]byte("secret1")),
+			secret2:     config.NewSecret([]byte("secret2")),
+			expectedRes: false,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			if equal := compareSecrets(tc.secret1, tc.secret2); equal != tc.expectedRes {
+				t.Errorf("compareSecrets(%v, %v) = %v, want %v", tc.secret1, tc.secret2, equal, tc.expectedRes)
+			}
+		})
+	}
+}
+
+func TestCompareClientConfig(t *testing.T) {
+	tests := map[string]struct {
+		config1     isnmp.ClientConfig
+		config2     isnmp.ClientConfig
+		expectedRes bool
+	}{
+		"equal configs": {
+			config1: isnmp.ClientConfig{
+				Timeout:              5,
+				Retries:              3,
+				Version:              2,
+				UnconnectedUDPSocket: true,
+				Community:            "public",
+				MaxRepetitions:       10,
+				ContextName:          "context",
+				SecLevel:             "authPriv",
+				SecName:              "user",
+				AuthProtocol:         "MD5",
+				PrivProtocol:         "DES",
+				Path:                 []string{"path1", "path2"},
+				AuthPassword:         config.NewSecret([]byte("authpass")),
+				PrivPassword:         config.NewSecret([]byte("privpass")),
+			},
+			config2: isnmp.ClientConfig{
+				Timeout:              5,
+				Retries:              3,
+				Version:              2,
+				UnconnectedUDPSocket: true,
+				Community:            "public",
+				MaxRepetitions:       10,
+				ContextName:          "context",
+				SecLevel:             "authPriv",
+				SecName:              "user",
+				AuthProtocol:         "MD5",
+				PrivProtocol:         "DES",
+				Path:                 []string{"path1", "path2"},
+				AuthPassword:         config.NewSecret([]byte("authpass")),
+				PrivPassword:         config.NewSecret([]byte("privpass")),
+			},
+			expectedRes: true,
+		},
+		"different timeouts": {
+			config1:     isnmp.ClientConfig{Timeout: 5},
+			config2:     isnmp.ClientConfig{Timeout: 10},
+			expectedRes: false,
+		},
+		"different paths": {
+			config1:     isnmp.ClientConfig{Path: []string{"path1"}},
+			config2:     isnmp.ClientConfig{Path: []string{"path2"}},
+			expectedRes: false,
+		},
+		"different secrets": {
+			config1:     isnmp.ClientConfig{AuthPassword: config.NewSecret([]byte("authpass1"))},
+			config2:     isnmp.ClientConfig{AuthPassword: config.NewSecret([]byte("authpass2"))},
+			expectedRes: false,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			if equal := CompareClientConfig(&tc.config1, &tc.config2); equal != tc.expectedRes {
+				t.Errorf("CompareClientConfig(%v, %v) = %v, want %v", tc.config1, tc.config2, equal, tc.expectedRes)
+			}
+		})
+	}
+}
+
+func TestDeepEqualSNMP(t *testing.T) {
+	tests := map[string]struct {
+		snmp1       *snmp.Snmp
+		snmp2       *snmp.Snmp
+		expectedRes bool
+	}{
+		"equal SNMP configs": {
+			snmp1: &snmp.Snmp{
+				Agents:       []string{"agent1", "agent2"},
+				Fields:       []isnmp.Field{{Name: "field1", Oid: "1.3.6.1.2.1.1.1"}},
+				Tables:       []isnmp.Table{{Name: "table1", Oid: "1.3.6.1.2.1.2.2"}},
+				ClientConfig: isnmp.ClientConfig{Timeout: 5},
+				AgentHostTag: "host1",
+				Name:         "snmp1",
+			},
+			snmp2: &snmp.Snmp{
+				Agents:       []string{"agent1", "agent2"},
+				Fields:       []isnmp.Field{{Name: "field1", Oid: "1.3.6.1.2.1.1.1"}},
+				Tables:       []isnmp.Table{{Name: "table1", Oid: "1.3.6.1.2.1.2.2"}},
+				ClientConfig: isnmp.ClientConfig{Timeout: 5},
+				AgentHostTag: "host1",
+				Name:         "snmp1",
+			},
+			expectedRes: true,
+		},
+		"equal SNMP configs with different id": {
+			snmp1: &snmp.Snmp{
+				Agents:       []string{"agent1", "agent2"},
+				Fields:       []isnmp.Field{{Name: "field1", Oid: "1.3.6.1.2.1.1.1"}},
+				Tables:       []isnmp.Table{{Name: "table1", Oid: "1.3.6.1.2.1.2.2"}},
+				ClientConfig: isnmp.ClientConfig{Timeout: 5},
+				AgentHostTag: "host1",
+				Name:         "snmp1",
+				PluginID:     "1234",
+			},
+			snmp2: &snmp.Snmp{
+				Agents:       []string{"agent1", "agent2"},
+				Fields:       []isnmp.Field{{Name: "field1", Oid: "1.3.6.1.2.1.1.1"}},
+				Tables:       []isnmp.Table{{Name: "table1", Oid: "1.3.6.1.2.1.2.2"}},
+				ClientConfig: isnmp.ClientConfig{Timeout: 5},
+				AgentHostTag: "host1",
+				Name:         "snmp1",
+				PluginID:     "5678",
+			},
+			expectedRes: true,
+		},
+		"different agents": {
+			snmp1: &snmp.Snmp{
+				Agents:       []string{"agent1", "agent2"},
+				Fields:       []isnmp.Field{{Name: "field1", Oid: "1.3.6.1.2.1.1.1"}},
+				Tables:       []isnmp.Table{{Name: "table1", Oid: "1.3.6.1.2.1.2.2"}},
+				ClientConfig: isnmp.ClientConfig{Timeout: 5},
+				AgentHostTag: "host1",
+				Name:         "snmp1",
+			},
+			snmp2: &snmp.Snmp{
+				Agents:       []string{"agent3"},
+				Fields:       []isnmp.Field{{Name: "field1", Oid: "1.3.6.1.2.1.1.1"}},
+				Tables:       []isnmp.Table{{Name: "table1", Oid: "1.3.6.1.2.1.2.2"}},
+				ClientConfig: isnmp.ClientConfig{Timeout: 5},
+				AgentHostTag: "host1",
+				Name:         "snmp1",
+			},
+			expectedRes: false,
+		},
+		"different fields": {
+			snmp1: &snmp.Snmp{
+				Agents:       []string{"agent1", "agent2"},
+				Fields:       []isnmp.Field{{Name: "field1", Oid: "1.3.6.1.2.1.1.1"}},
+				Tables:       []isnmp.Table{{Name: "table1", Oid: "1.3.6.1.2.1.2.2"}},
+				ClientConfig: isnmp.ClientConfig{Timeout: 5},
+				AgentHostTag: "host1",
+				Name:         "snmp1",
+			},
+			snmp2: &snmp.Snmp{
+				Agents:       []string{"agent1", "agent2"},
+				Fields:       []isnmp.Field{{Name: "field2", Oid: "1.3.6.1.2.1.1.2"}},
+				Tables:       []isnmp.Table{{Name: "table1", Oid: "1.3.6.1.2.1.2.2"}},
+				ClientConfig: isnmp.ClientConfig{Timeout: 5},
+				AgentHostTag: "host1",
+				Name:         "snmp1",
+			},
+			expectedRes: false,
+		},
+		"different tables": {
+			snmp1: &snmp.Snmp{
+				Agents:       []string{"agent1", "agent2"},
+				Fields:       []isnmp.Field{{Name: "field1", Oid: "1.3.6.1.2.1.1.1"}},
+				Tables:       []isnmp.Table{{Name: "table1", Oid: "1.3.6.1.2.1.2.2"}},
+				ClientConfig: isnmp.ClientConfig{Timeout: 5},
+				AgentHostTag: "host1",
+				Name:         "snmp1",
+			},
+			snmp2: &snmp.Snmp{
+				Agents:       []string{"agent1", "agent2"},
+				Fields:       []isnmp.Field{{Name: "field1", Oid: "1.3.6.1.2.1.1.1"}},
+				Tables:       []isnmp.Table{{Name: "table2", Oid: "1.3.6.1.2.1.2.3"}},
+				ClientConfig: isnmp.ClientConfig{Timeout: 5},
+				AgentHostTag: "host1",
+				Name:         "snmp1",
+			},
+			expectedRes: false,
+		},
+		"different client config": {
+			snmp1: &snmp.Snmp{
+				Agents:       []string{"agent1", "agent2"},
+				Fields:       []isnmp.Field{{Name: "field1", Oid: "1.3.6.1.2.1.1.1"}},
+				Tables:       []isnmp.Table{{Name: "table1", Oid: "1.3.6.1.2.1.2.2"}},
+				ClientConfig: isnmp.ClientConfig{Timeout: 5},
+				AgentHostTag: "host1",
+				Name:         "snmp1",
+			},
+			snmp2: &snmp.Snmp{
+				Agents:       []string{"agent1", "agent2"},
+				Fields:       []isnmp.Field{{Name: "field1", Oid: "1.3.6.1.2.1.1.1"}},
+				Tables:       []isnmp.Table{{Name: "table1", Oid: "1.3.6.1.2.1.2.2"}},
+				ClientConfig: isnmp.ClientConfig{Timeout: 10},
+				AgentHostTag: "host1",
+				Name:         "snmp1",
+			},
+			expectedRes: false,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			snmpInput1 := telegraf.Input(tc.snmp1)
+			snmpInput2 := telegraf.Input(tc.snmp2)
+			if equal := deepEqualSNMP(&snmpInput1, &snmpInput2); equal != tc.expectedRes {
+				t.Errorf("deepEqualSNMP(%v, %v) = %v, want %v", tc.snmp1, tc.snmp2, equal, tc.expectedRes)
+			}
+		})
+	}
+
+	snmpInput := telegraf.Input(&snmp.Snmp{})
+	gnmiInput := telegraf.Input(&gnmi.GNMI{})
+	res := deepEqualSNMP(&snmpInput, &gnmiInput)
+	t.Run("TestDeepEqualSNMPWithDifferentTypes", func(t *testing.T) {
+		if res {
+			t.Errorf("Expected res to be false, got true")
+		}
+	})
+}

--- a/plugins/inputs/snmp/snmp.go
+++ b/plugins/inputs/snmp/snmp.go
@@ -18,6 +18,7 @@ import (
 var sampleConfig string
 
 type Snmp struct {
+	PluginID string `toml:"id"`
 	// The SNMP agent to query. Format is [SCHEME://]ADDR[:PORT] (e.g.
 	// udp://1.2.3.4:161).  If the scheme is not specified then "udp" is used.
 	Agents []string `toml:"agents"`
@@ -48,6 +49,11 @@ func (*Snmp) SampleConfig() string {
 
 func (s *Snmp) SetTranslator(name string) {
 	s.Translator = name
+}
+
+// let's support pluginWithID interface
+func (s *Snmp) ID() string {
+	return s.PluginID
 }
 
 func (s *Snmp) Init() error {


### PR DESCRIPTION
## Summary

Added new arg `--watch-inputs-only` to watch only input's config changes and update them on the flow without restarting telegraf. Can be used with any telegraf watching options 

I have been using this for almost a year now

e.g
`./telegraf --config test-sim.conf --watch-config ionotify --watch-inputs-only`

````
sk % ./telegraf --config test-sim.conf --watch-config ionotify --watch-inputs-only
2025-01-27T12:47:40Z I! Loading config: test-sim.conf
2025-01-27T12:47:40Z I! Starting Telegraf 1.34.0-ac6a8cf1 brought to you by InfluxData the makers of InfluxDB
2025-01-27T12:47:40Z I! Available plugins: 236 inputs, 9 aggregators, 33 processors, 26 parsers, 63 outputs, 5 secret-stores
2025-01-27T12:47:40Z I! Loaded inputs: snmp
2025-01-27T12:47:40Z I! Loaded aggregators:
2025-01-27T12:47:40Z I! Loaded processors:
2025-01-27T12:47:40Z I! Loaded secretstores:
2025-01-27T12:47:40Z I! Loaded outputs: file
2025-01-27T12:47:40Z I! Tags enabled:
2025-01-27T12:47:40Z I! [agent] Config: Interval:30s, Quiet:false, Hostname:"", Flush Interval:10s
2025-01-27T12:47:40Z W! [agent] The default value of 'skip_processors_after_aggregators' will change to 'true' with Telegraf v1.40.0! If you need the current default behavior, please explicitly set the option to 'false'!
2025-01-27T12:47:40Z D! [agent] Initializing plugins
2025-01-27T12:47:40Z D! [agent] Connecting outputs
2025-01-27T12:47:40Z D! [agent] Attempting connection to [outputs.file]
2025-01-27T12:47:40Z I! Config watcher started for test-sim.conf
2025-01-27T12:47:40Z D! [agent] Successfully connected to outputs.file
2025-01-27T12:47:40Z D! [agent] Starting service inputs
switch_interface,hostname=device2,ifDescr=interface\ description\ 1,source=127.0.0.1 ifInOctets=0i,ifInErrors=0i,ifHCInUcastPkts=0i,ifOutDiscards=0i,ifHCInOctets=264981396490i,ifHCOutOctets=749538511733i,ifOperStatus=1i,ifSpeed=1000000000i,ifHCInMulticastPkts=4864817i,ifHCOutMulticastPkts=2755379i,ifHCOutUcastPkts=0i,ifHCInBroadcastPkts=5117i,ifHCOutBroadcastPkts=12i,ifAdminStatus=1i,ifHighSpeed=10000i 1737982080000000000
switch_interface,hostname=device2,ifDescr=interface\ description\ 2,source=127.0.0.1 ifHighSpeed=10000i,ifSpeed=1000000000i,ifHCInBroadcastPkts=5117i,ifHCOutBroadcastPkts=12i,ifOperStatus=1i,ifHCInUcastPkts=0i,ifOutDiscards=0i,ifHCInMulticastPkts=4864817i,ifHCOutMulticastPkts=2755379i,ifAdminStatus=1i,ifHCInOctets=264981396490i,ifInErrors=0i,ifHCOutUcastPkts=0i,ifHCOutOctets=749538511733i,ifInOctets=0i 1737982080000000000
switch_interface,hostname=device1,ifDescr=interface\ description\ 1,source=127.0.0.1 ifHCOutOctets=749538511733i,ifInOctets=0i,ifHCInMulticastPkts=4864817i,ifOutDiscards=0i,ifHCOutUcastPkts=0i,ifOperStatus=1i,ifInErrors=0i,ifHCOutBroadcastPkts=12i,ifAdminStatus=1i,ifHighSpeed=10000i,ifSpeed=1000000000i,ifHCInOctets=264981396490i,ifHCInUcastPkts=0i,ifHCInBroadcastPkts=5117i,ifHCOutMulticastPkts=2755379i 1737982080000000000
switch_interface,hostname=device1,ifDescr=interface\ description\ 2,source=127.0.0.1 ifHCInMulticastPkts=4864817i,ifHCOutMulticastPkts=2755379i,ifHCInOctets=264981396490i,ifHighSpeed=10000i,ifSpeed=1000000000i,ifHCOutOctets=749538511733i,ifInOctets=0i,ifInErrors=0i,ifHCInUcastPkts=0i,ifHCInBroadcastPkts=5117i,ifHCOutBroadcastPkts=12i,ifAdminStatus=1i,ifOutDiscards=0i,ifHCOutUcastPkts=0i,ifOperStatus=1i 1737982080000000000
2025-01-27T12:48:00Z D! [outputs.file] Wrote batch of 4 metrics in 647.575µs
2025-01-27T12:48:00Z D! [outputs.file] Buffer fullness: 0 / 500000 metrics
2025-01-27T12:48:11Z I! Config file/directory "test-sim.conf" overwritten
2025-01-27T12:48:11Z I! Reloading Telegraf config
2025-01-27T12:48:11Z I! Loading config: test-sim.conf
2025-01-27T12:48:11Z I! [agent] Updating inputs based on reloaded configuration diff
2025-01-27T12:48:11Z I! [agent] Adding new inputs: internal-1f5e9dab1052b5311f25061dd0528848b3ca6d93f91c4b67d01a15fe08f7c49f
2025-01-27T12:48:11Z D! [agent] Starting service inputs
2025-01-27T12:48:13Z I! Config watcher started for test-sim.conf
2025-01-27T12:48:20Z D! [outputs.file] Buffer fullness: 0 / 500000 metrics
internal_agent,go_version=1.23.0,version=1.34.0-ac6a8cf1 metrics_rejected=0i,metrics_dropped=0i,metrics_gathered=4i,gather_errors=0i,gather_timeouts=0i,metrics_written=4i 1737982110000000000
internal_serializer,type=influx,version=1.34.0-ac6a8cf1 errors=0i,metrics_serialized=4i,bytes_serialized=1704i,serialization_time_ns=85968i 1737982110000000000
internal_write,output=file,version=1.34.0-ac6a8cf1 metrics_filtered=0i,startup_errors=0i,errors=0i,buffer_limit=500000i,write_time_ns=647575i,metrics_written=4i,metrics_dropped=0i,metrics_added=4i,metrics_rejected=0i,buffer_size=0i 1737982110000000000
internal_gather,input=snmp,version=1.34.0-ac6a8cf1 gather_time_ns=464754052i,gather_timeouts=0i,errors=0i,metrics_gathered=4i 1737982110000000000
internal_write,input=snmp,version=1.34.0-ac6a8cf1 startup_errors=0i 1737982110000000000
internal_gather,input=internal,version=1.34.0-ac6a8cf1 metrics_gathered=0i,gather_time_ns=0i,gather_timeouts=0i,errors=0i 1737982110000000000
internal_write,input=internal,version=1.34.0-ac6a8cf1 startup_errors=0i 1737982110000000000
internal_memstats alloc_bytes=50110280i,total_alloc_bytes=71680832i,sys_bytes=78955740i,pointer_lookups=0i,mallocs=485249i,frees=389449i,heap_alloc_bytes=50110280i,heap_idle_bytes=14901248i,heap_released_bytes=3375104i,heap_objects=95800i,num_gc=3i,heap_sys_bytes=70320128i,heap_in_use_bytes=55418880i 1737982110000000000
switch_interface,hostname=device2,ifDescr=interface\ description\ 2,source=127.0.0.1 ifOutDiscards=0i,ifHCOutMulticastPkts=2755379i,ifAdminStatus=1i,ifHCInUcastPkts=0i,ifHCOutUcastPkts=0i,ifOperStatus=1i,ifHCInOctets=264981396490i,ifInOctets=0i,ifInErrors=0i,ifHCInBroadcastPkts=5117i,ifSpeed=1000000000i,ifHCOutOctets=749538511733i,ifHCInMulticastPkts=4864817i,ifHCOutBroadcastPkts=12i,ifHighSpeed=10000i 1737982110000000000
switch_interface,hostname=device2,ifDescr=interface\ description\ 1,source=127.0.0.1 ifHCOutOctets=749538511733i,ifHCOutUcastPkts=0i,ifInErrors=0i,ifOperStatus=1i,ifInOctets=0i,ifHCInMulticastPkts=4864817i,ifHCOutBroadcastPkts=12i,ifAdminStatus=1i,ifHighSpeed=10000i,ifHCInOctets=264981396490i,ifHCInUcastPkts=0i,ifHCInBroadcastPkts=5117i,ifOutDiscards=0i,ifHCOutMulticastPkts=2755379i,ifSpeed=1000000000i 1737982110000000000
switch_interface,hostname=device1,ifDescr=interface\ description\ 2,source=127.0.0.1 ifHCInMulticastPkts=4864817i,ifHCOutUcastPkts=0i,ifHCOutMulticastPkts=2755379i,ifHighSpeed=10000i,ifHCInOctets=264981396490i,ifHCOutOctets=749538511733i,ifHCInUcastPkts=0i,ifHCOutBroadcastPkts=12i,ifOperStatus=1i,ifInErrors=0i,ifHCInBroadcastPkts=5117i,ifOutDiscards=0i,ifInOctets=0i,ifAdminStatus=1i,ifSpeed=1000000000i 1737982110000000000
switch_interface,hostname=device1,ifDescr=interface\ description\ 1,source=127.0.0.1 ifHCOutOctets=749538511733i,ifInErrors=0i,ifHCInBroadcastPkts=5117i,ifHCOutMulticastPkts=2755379i,ifOperStatus=1i,ifHCInOctets=264981396490i,ifInOctets=0i,ifHighSpeed=10000i,ifHCInUcastPkts=0i,ifSpeed=1000000000i,ifHCInMulticastPkts=4864817i,ifOutDiscards=0i,ifHCOutBroadcastPkts=12i,ifHCOutUcastPkts=0i,ifAdminStatus=1i 1737982110000000000
2025-01-27T12:48:40Z D! [outputs.file] Wrote batch of 12 metrics in 311.646µs
2025-01-27T12:48:40Z D! [outputs.file] Buffer fullness: 0 / 500000 metrics
internal_gather,input=snmp,version=1.34.0-ac6a8cf1 gather_timeouts=0i,errors=0i,metrics_gathered=8i,gather_time_ns=454673347i 1737982140000000000
internal_write,input=snmp,version=1.34.0-ac6a8cf1 startup_errors=0i 1737982140000000000
internal_gather,input=internal,version=1.34.0-ac6a8cf1 gather_time_ns=527931i,gather_timeouts=0i,errors=0i,metrics_gathered=8i 1737982140000000000
internal_write,input=internal,version=1.34.0-ac6a8cf1 startup_errors=0i 1737982140000000000
internal_agent,go_version=1.23.0,version=1.34.0-ac6a8cf1 metrics_dropped=0i,metrics_gathered=16i,gather_errors=0i,gather_timeouts=0i,metrics_written=16i,metrics_rejected=0i 1737982140000000000
internal_serializer,type=influx,version=1.34.0-ac6a8cf1 serialization_time_ns=167852i,errors=0i,metrics_serialized=16i,bytes_serialized=4801i 1737982140000000000
internal_write,output=file,version=1.34.0-ac6a8cf1 startup_errors=0i,metrics_dropped=0i,metrics_added=16i,buffer_limit=500000i,buffer_size=0i,metrics_filtered=0i,metrics_rejected=0i,errors=0i,metrics_written=16i,write_time_ns=311646i 1737982140000000000
internal_memstats mallocs=500604i,frees=391161i,heap_alloc_bytes=50676432i,heap_sys_bytes=70320128i,heap_idle_bytes=14843904i,heap_objects=109443i,num_gc=3i,alloc_bytes=50676432i,total_alloc_bytes=72246984i,sys_bytes=78955740i,pointer_lookups=0i,heap_in_use_bytes=55476224i,heap_released_bytes=3325952i 1737982140000000000
switch_interface,hostname=device2,ifDescr=interface\ description\ 2,source=127.0.0.1 ifOutDiscards=0i,ifHCOutBroadcastPkts=12i,ifHighSpeed=10000i,ifHCInOctets=264981396490i,ifInOctets=0i,ifHCOutMulticastPkts=2755379i,ifAdminStatus=1i,ifHCOutOctets=749538511733i,ifHCOutUcastPkts=0i,ifSpeed=1000000000i,ifHCInMulticastPkts=4864817i,ifHCInUcastPkts=0i,ifHCInBroadcastPkts=5117i,ifOperStatus=1i,ifInErrors=0i 1737982140000000000
switch_interface,hostname=device2,ifDescr=interface\ description\ 1,source=127.0.0.1 ifHCOutMulticastPkts=2755379i,ifHighSpeed=10000i,ifInErrors=0i,ifHCInBroadcastPkts=5117i,ifHCOutUcastPkts=0i,ifAdminStatus=1i,ifOperStatus=1i,ifSpeed=1000000000i,ifHCOutOctets=749538511733i,ifInOctets=0i,ifHCInUcastPkts=0i,ifHCOutBroadcastPkts=12i,ifOutDiscards=0i,ifHCInOctets=264981396490i,ifHCInMulticastPkts=4864817i 1737982140000000000
switch_interface,hostname=device1,ifDescr=interface\ description\ 1,source=127.0.0.1 ifHCInMulticastPkts=4864817i,ifOutDiscards=0i,ifHCOutBroadcastPkts=12i,ifHCInUcastPkts=0i,ifHCOutOctets=749538511733i,ifInErrors=0i,ifHCOutMulticastPkts=2755379i,ifAdminStatus=1i,ifSpeed=1000000000i,ifHCInOctets=264981396490i,ifOperStatus=1i,ifHCOutUcastPkts=0i,ifHCInBroadcastPkts=5117i,ifHighSpeed=10000i,ifInOctets=0i 1737982140000000000
switch_interface,hostname=device1,ifDescr=interface\ description\ 2,source=127.0.0.1 ifInOctets=0i,ifHCInUcastPkts=0i,ifHCInBroadcastPkts=5117i,ifHCOutBroadcastPkts=12i,ifHCInOctets=264981396490i,ifHCOutOctets=749538511733i,ifHCInMulticastPkts=4864817i,ifOperStatus=1i,ifOutDiscards=0i,ifSpeed=1000000000i,ifInErrors=0i,ifHCOutMulticastPkts=2755379i,ifHCOutUcastPkts=0i,ifAdminStatus=1i,ifHighSpeed=10000i 1737982140000000000
2025-01-27T12:49:00Z D! [outputs.file] Wrote batch of 12 metrics in 289.528µs
2025-01-27T12:49:00Z D! [outputs.file] Buffer fullness: 0 / 500000 metrics
2025-01-27T12:49:20Z D! [outputs.file] Buffer fullness: 0 / 500000 metrics
2025-01-27T12:49:34Z I! Config file/directory "test-sim.conf" overwritten
2025-01-27T12:49:34Z I! Reloading Telegraf config
2025-01-27T12:49:34Z I! Loading config: test-sim.conf
2025-01-27T12:49:34Z I! [agent] Updating inputs based on reloaded configuration diff
2025-01-27T12:49:34Z I! [agent] Adding new inputs: snmp-50bcb7dace88002aac5339368d64cb6ada0bcd9e801d4229fa50d4206e7b3212
2025-01-27T12:49:34Z D! [agent] Starting service inputs
2025-01-27T12:49:36Z I! Config watcher started for test-sim.conf
internal_agent,go_version=1.23.0,version=1.34.0-ac6a8cf1 gather_timeouts=0i,metrics_written=28i,metrics_rejected=0i,metrics_dropped=0i,metrics_gathered=28i,gather_errors=0i 1737982170000000000
internal_serializer,type=influx,version=1.34.0-ac6a8cf1 bytes_serialized=7910i,serialization_time_ns=241125i,errors=0i,metrics_serialized=28i 1737982170000000000
internal_write,output=file,version=1.34.0-ac6a8cf1 buffer_size=0i,startup_errors=0i,buffer_limit=500000i,metrics_dropped=0i,metrics_added=28i,metrics_written=28i,metrics_filtered=0i,errors=0i,write_time_ns=289528i,metrics_rejected=0i 1737982170000000000
internal_gather,input=snmp,version=1.34.0-ac6a8cf1 errors=0i,metrics_gathered=12i,gather_time_ns=481344612i,gather_timeouts=0i 1737982170000000000
internal_write,input=snmp,version=1.34.0-ac6a8cf1 startup_errors=0i 1737982170000000000
internal_gather,input=internal,version=1.34.0-ac6a8cf1 errors=0i,metrics_gathered=16i,gather_time_ns=233740i,gather_timeouts=0i 1737982170000000000
internal_write,input=internal,version=1.34.0-ac6a8cf1 startup_errors=0i 1737982170000000000
internal_memstats total_alloc_bytes=72805856i,frees=392825i,heap_alloc_bytes=51235304i,heap_in_use_bytes=55828480i,heap_released_bytes=3055616i,heap_idle_bytes=14524416i,heap_objects=122972i,num_gc=3i,alloc_bytes=51235304i,sys_bytes=78955740i,pointer_lookups=0i,mallocs=515797i,heap_sys_bytes=70352896i 1737982170000000000
switch_interface,hostname=device2,ifDescr=interface\ description\ 1,source=127.0.0.1 ifHCOutOctets=749538511733i,ifSpeed=1000000000i,ifInOctets=0i,ifOutDiscards=0i,ifHCOutUcastPkts=0i,ifHighSpeed=10000i,ifOperStatus=1i,ifHCInOctets=264981396490i,ifHCInUcastPkts=0i,ifHCOutMulticastPkts=2755379i,ifInErrors=0i,ifHCInBroadcastPkts=5117i,ifHCInMulticastPkts=4864817i,ifHCOutBroadcastPkts=12i,ifAdminStatus=1i 1737982170000000000
switch_interface,hostname=device2,ifDescr=interface\ description\ 2,source=127.0.0.1 ifOutDiscards=0i,ifHighSpeed=10000i,ifSpeed=1000000000i,ifInOctets=0i,ifHCInBroadcastPkts=5117i,ifHCInOctets=264981396490i,ifHCInMulticastPkts=4864817i,ifHCOutMulticastPkts=2755379i,ifHCOutBroadcastPkts=12i,ifHCOutUcastPkts=0i,ifHCOutOctets=749538511733i,ifInErrors=0i,ifHCInUcastPkts=0i,ifAdminStatus=1i,ifOperStatus=1i 1737982170000000000
switch_interface,hostname=device1,ifDescr=interface\ description\ 1,source=127.0.0.1 ifHCInOctets=264981396490i,ifHCInUcastPkts=0i,ifOutDiscards=0i,ifAdminStatus=1i,ifHCOutOctets=749538511733i,ifInOctets=0i,ifInErrors=0i,ifHCOutMulticastPkts=2755379i,ifOperStatus=1i,ifHCOutBroadcastPkts=12i,ifHCOutUcastPkts=0i,ifHCInBroadcastPkts=5117i,ifHCInMulticastPkts=4864817i,ifHighSpeed=10000i,ifSpeed=1000000000i 1737982170000000000
switch_interface,hostname=device1,ifDescr=interface\ description\ 2,source=127.0.0.1 ifHCInOctets=264981396490i,ifInErrors=0i,ifHCOutBroadcastPkts=12i,ifHCOutMulticastPkts=2755379i,ifAdminStatus=1i,ifOperStatus=1i,ifOutDiscards=0i,ifHCOutUcastPkts=0i,ifInOctets=0i,ifHCInBroadcastPkts=5117i,ifHCInMulticastPkts=4864817i,ifSpeed=1000000000i,ifHCOutOctets=749538511733i,ifHCInUcastPkts=0i,ifHighSpeed=10000i 1737982170000000000
2025-01-27T12:49:40Z D! [outputs.file] Wrote batch of 12 metrics in 555.194µs
2025-01-27T12:49:40Z D! [outputs.file] Buffer fullness: 0 / 500000 metrics
internal_write,input=internal,version=1.34.0-ac6a8cf1 startup_errors=0i 1737982200000000000
internal_agent,go_version=1.23.0,version=1.34.0-ac6a8cf1 metrics_rejected=0i,metrics_dropped=0i,metrics_gathered=40i,gather_errors=0i,gather_timeouts=0i,metrics_written=40i 1737982200000000000
internal_serializer,type=influx,version=1.34.0-ac6a8cf1 bytes_serialized=11021i,serialization_time_ns=350079i,errors=0i,metrics_serialized=40i 1737982200000000000
internal_write,output=file,version=1.34.0-ac6a8cf1 errors=0i,write_time_ns=555194i,metrics_written=40i,buffer_size=0i,metrics_added=40i,metrics_dropped=0i,metrics_filtered=0i,metrics_rejected=0i,buffer_limit=500000i,startup_errors=0i 1737982200000000000
internal_gather,input=snmp,version=1.34.0-ac6a8cf1 metrics_gathered=16i,gather_time_ns=420517062i,gather_timeouts=0i,errors=0i 1737982200000000000
internal_write,input=snmp,version=1.34.0-ac6a8cf1 startup_errors=0i 1737982200000000000
internal_gather,input=internal,version=1.34.0-ac6a8cf1 gather_time_ns=482205i,gather_timeouts=0i,errors=0i,metrics_gathered=24i 1737982200000000000
internal_memstats alloc_bytes=60465160i,total_alloc_bytes=82035712i,pointer_lookups=0i,heap_alloc_bytes=60465160i,heap_sys_bytes=78741504i,heap_in_use_bytes=64815104i,sys_bytes=87344348i,mallocs=535269i,frees=395386i,heap_idle_bytes=13926400i,heap_released_bytes=3317760i,heap_objects=139883i,num_gc=3i 1737982200000000000
switch_interface,hostname=device3,source=127.0.0.1 ifHCInOctets=264981396490i,ifHCOutOctets=749538511733i 1737982200000000000
switch_interface,hostname=device3,source=127.0.0.1 ifHCInOctets=264981396490i,ifHCOutOctets=749538511733i 1737982200000000000
switch_interface,hostname=device1,ifDescr=interface\ description\ 1,source=127.0.0.1 ifHCOutUcastPkts=0i,ifInErrors=0i,ifHCInUcastPkts=0i,ifHCOutBroadcastPkts=12i,ifHCInBroadcastPkts=5117i,ifHighSpeed=10000i,ifOperStatus=1i,ifSpeed=1000000000i,ifHCInOctets=264981396490i,ifHCOutOctets=749538511733i,ifInOctets=0i,ifAdminStatus=1i,ifHCInMulticastPkts=4864817i,ifOutDiscards=0i,ifHCOutMulticastPkts=2755379i 1737982200000000000
switch_interface,hostname=device1,ifDescr=interface\ description\ 2,source=127.0.0.1 ifHCOutBroadcastPkts=12i,ifHCInOctets=264981396490i,ifHCOutOctets=749538511733i,ifInErrors=0i,ifOutDiscards=0i,ifHCInUcastPkts=0i,ifHCInMulticastPkts=4864817i,ifAdminStatus=1i,ifInOctets=0i,ifHCOutUcastPkts=0i,ifHighSpeed=10000i,ifOperStatus=1i,ifHCInBroadcastPkts=5117i,ifHCOutMulticastPkts=2755379i,ifSpeed=1000000000i 1737982200000000000
switch_interface,hostname=device2,ifDescr=interface\ description\ 1,source=127.0.0.1 ifHCOutUcastPkts=0i,ifHCInBroadcastPkts=5117i,ifHCInMulticastPkts=4864817i,ifOutDiscards=0i,ifAdminStatus=1i,ifHCInUcastPkts=0i,ifInErrors=0i,ifHCOutMulticastPkts=2755379i,ifHCOutBroadcastPkts=12i,ifHighSpeed=10000i,ifOperStatus=1i,ifSpeed=1000000000i,ifHCOutOctets=749538511733i,ifInOctets=0i,ifHCInOctets=264981396490i 1737982200000000000
switch_interface,hostname=device2,ifDescr=interface\ description\ 2,source=127.0.0.1 ifHCInOctets=264981396490i,ifHCOutOctets=749538511733i,ifInOctets=0i,ifHCInBroadcastPkts=5117i,ifAdminStatus=1i,ifHCInUcastPkts=0i,ifHCOutMulticastPkts=2755379i,ifHCOutUcastPkts=0i,ifOutDiscards=0i,ifHCOutBroadcastPkts=12i,ifHighSpeed=10000i,ifOperStatus=1i,ifSpeed=1000000000i,ifInErrors=0i,ifHCInMulticastPkts=4864817i 1737982200000000000
2025-01-27T12:50:00Z D! [outputs.file] Wrote batch of 14 metrics in 364.554µs
2025-01-27T12:50:00Z D! [outputs.file] Buffer fullness: 0 / 500000 metrics
2025-01-27T12:50:20Z D! [outputs.file] Buffer fullness: 0 / 500000 metrics
2025-01-27T12:50:35Z I! Config file/directory "test-sim.conf" overwritten
2025-01-27T12:50:35Z I! Reloading Telegraf config
2025-01-27T12:50:35Z I! Loading config: test-sim.conf
2025-01-27T12:50:35Z I! [agent] Updating inputs based on reloaded configuration diff
2025-01-27T12:50:35Z I! [agent] Deleting Input : snmp-50bcb7dace88002aac5339368d64cb6ada0bcd9e801d4229fa50d4206e7b3212
2025-01-27T12:50:35Z I! [agent] Adding new inputs: snmp-test-device-3
2025-01-27T12:50:35Z D! [agent] Starting service inputs
2025-01-27T12:50:37Z I! Config watcher started for test-sim.conf
internal_agent,go_version=1.23.0,version=1.34.0-ac6a8cf1 metrics_rejected=0i,metrics_dropped=0i,metrics_gathered=54i,gather_errors=0i,gather_timeouts=0i,metrics_written=54i 1737982230000000000
internal_serializer,type=influx,version=1.34.0-ac6a8cf1 serialization_time_ns=422705i,errors=0i,metrics_serialized=54i,bytes_serialized=14385i 1737982230000000000
internal_write,output=file,version=1.34.0-ac6a8cf1 metrics_rejected=0i,buffer_limit=500000i,metrics_written=54i,metrics_dropped=0i,metrics_filtered=0i,metrics_added=54i,buffer_size=0i,errors=0i,write_time_ns=364554i,startup_errors=0i 1737982230000000000
internal_gather,input=snmp,version=1.34.0-ac6a8cf1 errors=0i,metrics_gathered=22i,gather_time_ns=282609492i,gather_timeouts=0i 1737982230000000000
internal_write,input=snmp,version=1.34.0-ac6a8cf1 startup_errors=0i 1737982230000000000
internal_gather,input=internal,version=1.34.0-ac6a8cf1 gather_timeouts=0i,errors=0i,metrics_gathered=32i,gather_time_ns=280100i 1737982230000000000
internal_write,input=internal,version=1.34.0-ac6a8cf1 startup_errors=0i 1737982230000000000
internal_memstats pointer_lookups=0i,mallocs=552500i,frees=459666i,heap_alloc_bytes=41520224i,heap_in_use_bytes=47071232i,alloc_bytes=41520224i,total_alloc_bytes=82743224i,sys_bytes=87409884i,heap_released_bytes=6627328i,heap_objects=92834i,num_gc=4i,heap_sys_bytes=78741504i,heap_idle_bytes=31670272i 1737982230000000000
switch_interface,hostname=device3,source=127.0.0.1 ifHCInOctets=264981396490i,ifHCOutOctets=749538511733i 1737982230000000000
switch_interface,hostname=device3,source=127.0.0.1 ifHCOutOctets=749538511733i,ifHCInOctets=264981396490i 1737982230000000000
switch_interface,hostname=device2,ifDescr=interface\ description\ 1,source=127.0.0.1 ifHCInOctets=264981396490i,ifHCInBroadcastPkts=5117i,ifOutDiscards=0i,ifSpeed=1000000000i,ifHCInMulticastPkts=4864817i,ifHCOutMulticastPkts=2755379i,ifHCOutBroadcastPkts=12i,ifHCOutUcastPkts=0i,ifHighSpeed=10000i,ifOperStatus=1i,ifHCOutOctets=749538511733i,ifInOctets=0i,ifInErrors=0i,ifHCInUcastPkts=0i,ifAdminStatus=1i 1737982230000000000
switch_interface,hostname=device2,ifDescr=interface\ description\ 2,source=127.0.0.1 ifHCInBroadcastPkts=5117i,ifOutDiscards=0i,ifHCOutUcastPkts=0i,ifSpeed=1000000000i,ifInErrors=0i,ifInOctets=0i,ifHCOutOctets=749538511733i,ifHCOutMulticastPkts=2755379i,ifHCOutBroadcastPkts=12i,ifHCInMulticastPkts=4864817i,ifHCInUcastPkts=0i,ifAdminStatus=1i,ifHighSpeed=10000i,ifOperStatus=1i,ifHCInOctets=264981396490i 1737982230000000000
switch_interface,hostname=device1,ifDescr=interface\ description\ 1,source=127.0.0.1 ifHCInOctets=264981396490i,ifHCOutOctets=749538511733i,ifInOctets=0i,ifInErrors=0i,ifHCOutUcastPkts=0i,ifHighSpeed=10000i,ifOutDiscards=0i,ifAdminStatus=1i,ifHCOutBroadcastPkts=12i,ifHCInUcastPkts=0i,ifHCInBroadcastPkts=5117i,ifHCInMulticastPkts=4864817i,ifHCOutMulticastPkts=2755379i,ifOperStatus=1i,ifSpeed=1000000000i 1737982230000000000
switch_interface,hostname=device1,ifDescr=interface\ description\ 2,source=127.0.0.1 ifOperStatus=1i,ifSpeed=1000000000i,ifHCOutOctets=749538511733i,ifHCInMulticastPkts=4864817i,ifHCOutUcastPkts=0i,ifAdminStatus=1i,ifHCInOctets=264981396490i,ifInOctets=0i,ifInErrors=0i,ifHighSpeed=10000i,ifOutDiscards=0i,ifHCOutMulticastPkts=2755379i,ifHCOutBroadcastPkts=12i,ifHCInUcastPkts=0i,ifHCInBroadcastPkts=5117i 1737982230000000000
2025-01-27T12:50:40Z D! [outputs.file] Wrote batch of 14 metrics in 959.06µs
2025-01-27T12:50:40Z D! [outputs.file] Buffer fullness: 0 / 500000 metrics
internal_gather,input=snmp,version=1.34.0-ac6a8cf1 errors=0i,metrics_gathered=28i,gather_time_ns=245256916i,gather_timeouts=0i 1737982260000000000
internal_write,input=snmp,version=1.34.0-ac6a8cf1 startup_errors=0i 1737982260000000000
internal_gather,input=internal,version=1.34.0-ac6a8cf1 gather_time_ns=198770i,gather_timeouts=0i,errors=0i,metrics_gathered=40i 1737982260000000000
internal_write,input=internal,version=1.34.0-ac6a8cf1 startup_errors=0i 1737982260000000000
internal_agent,go_version=1.23.0,version=1.34.0-ac6a8cf1 metrics_rejected=0i,metrics_dropped=0i,metrics_gathered=68i,gather_errors=0i,gather_timeouts=0i,metrics_written=68i 1737982260000000000
internal_serializer,type=influx,version=1.34.0-ac6a8cf1 errors=0i,metrics_serialized=68i,bytes_serialized=17748i,serialization_time_ns=544431i 1737982260000000000
internal_write,output=file,version=1.34.0-ac6a8cf1 errors=0i,metrics_added=68i,metrics_rejected=0i,metrics_dropped=0i,buffer_limit=500000i,buffer_size=0i,startup_errors=0i,metrics_filtered=0i,metrics_written=68i,write_time_ns=959060i 1737982260000000000
internal_memstats heap_sys_bytes=78675968i,heap_objects=110689i,alloc_bytes=50751872i,sys_bytes=87409884i,pointer_lookups=0i,mallocs=573028i,frees=462339i,heap_alloc_bytes=50751872i,num_gc=4i,total_alloc_bytes=91974872i,heap_idle_bytes=23093248i,heap_in_use_bytes=55582720i,heap_released_bytes=4579328i 1737982260000000000
switch_interfacei_1,hostname=device3,source=127.0.0.1 ifHCInOctets=264981396490i,ifHCOutOctets=749538511733i 1737982260000000000
switch_interfacei_1,hostname=device3,source=127.0.0.1 ifHCOutOctets=749538511733i,ifHCInOctets=264981396490i 1737982260000000000
switch_interface,hostname=device1,ifDescr=interface\ description\ 2,source=127.0.0.1 ifHCOutMulticastPkts=2755379i,ifInOctets=0i,ifHCInUcastPkts=0i,ifHCInMulticastPkts=4864817i,ifOutDiscards=0i,ifHCOutBroadcastPkts=12i,ifHCOutUcastPkts=0i,ifAdminStatus=1i,ifSpeed=1000000000i,ifInErrors=0i,ifHCInBroadcastPkts=5117i,ifHighSpeed=10000i,ifOperStatus=1i,ifHCInOctets=264981396490i,ifHCOutOctets=749538511733i 1737982260000000000
switch_interface,hostname=device1,ifDescr=interface\ description\ 1,source=127.0.0.1 ifHCInBroadcastPkts=5117i,ifHCOutMulticastPkts=2755379i,ifHCOutOctets=749538511733i,ifInOctets=0i,ifInErrors=0i,ifHCInMulticastPkts=4864817i,ifOutDiscards=0i,ifHCOutUcastPkts=0i,ifOperStatus=1i,ifSpeed=1000000000i,ifHCInOctets=264981396490i,ifHCOutBroadcastPkts=12i,ifHCInUcastPkts=0i,ifHighSpeed=10000i,ifAdminStatus=1i 1737982260000000000
switch_interface,hostname=device2,ifDescr=interface\ description\ 1,source=127.0.0.1 ifHCOutUcastPkts=0i,ifHighSpeed=10000i,ifHCInOctets=264981396490i,ifHCOutOctets=749538511733i,ifHCOutBroadcastPkts=12i,ifSpeed=1000000000i,ifInOctets=0i,ifHCInUcastPkts=0i,ifHCInMulticastPkts=4864817i,ifOutDiscards=0i,ifHCOutMulticastPkts=2755379i,ifOperStatus=1i,ifInErrors=0i,ifHCInBroadcastPkts=5117i,ifAdminStatus=1i 1737982260000000000
switch_interface,hostname=device2,ifDescr=interface\ description\ 2,source=127.0.0.1 ifHCOutOctets=749538511733i,ifHCInBroadcastPkts=5117i,ifHCOutMulticastPkts=2755379i,ifOutDiscards=0i,ifHCOutUcastPkts=0i,ifAdminStatus=1i,ifHighSpeed=10000i,ifOperStatus=1i,ifHCInOctets=264981396490i,ifInOctets=0i,ifHCInUcastPkts=0i,ifHCInMulticastPkts=4864817i,ifHCOutBroadcastPkts=12i,ifInErrors=0i,ifSpeed=1000000000i 1737982260000000000
2025-01-27T12:51:00Z D! [outputs.file] Wrote batch of 14 metrics in 1.083154ms
2025-01-27T12:51:00Z D! [outputs.file] Buffer fullness: 0 / 500000 metrics
^C2025-01-27T12:51:09Z E! Recived Signal: 'interrupt' - Stopping Telegraf
2025-01-27T12:51:09Z D! [agent] Stopping service inputs
2025-01-27T12:51:09Z D! [agent] Input channel closed
2025-01-27T12:51:09Z I! [agent] Hang on, flushing any cached metrics before shutdown
2025-01-27T12:51:09Z D! [outputs.file] Buffer fullness: 0 / 500000 metrics
2025-01-27T12:51:09Z I! [agent] Stopping running outputs
2025-01-27T12:51:09Z D! [agent] Stopped Successfully
2025-01-27T12:51:09Z I! Loading config: test-sim.conf
2025-01-27T12:51:09Z I! Config watcher started for test-sim.conf
2025-01-27T12:51:09Z I! [agent] No input plugin changes to update
sk %
````

## Checklist
- [ ] No AI generated code was used in this PR

## Related issues
related to #272
