### PR TITLE
feat(inputs.rabbitmq): Add type tag to queues

### DIFF
--- a/plugins/inputs/rabbitmq/README.md
+++ b/plugins/inputs/rabbitmq/README.md
@@ -81,6 +81,11 @@ to use them.
   ## exchange filters.
   # federation_upstream_include = []
   # federation_upstream_exclude = []
+
+  ## Include queue type as a tag. When enabled, adds a "type" tag to queue metrics
+  ## with the queue type returned by RabbitMQ (e.g., "classic", "quorum", "stream").
+  ## Defaults to "classic" if empty.
+  # include_queue_type_tag = false
 ```
 
 ## Metrics
@@ -173,6 +178,7 @@ to use them.
     - node
     - durable
     - auto_delete
+    - type (queue type as returned by RabbitMQ, if empty it defaults to "classic"; only included when include_queue_type_tag = true)
   - fields:
     - consumer_utilisation (float, percent)
     - consumers (int, int)
@@ -238,7 +244,7 @@ to use them.
 ## Example Output
 
 ```text
-rabbitmq_queue,url=http://amqp.example.org:15672,queue=telegraf,vhost=influxdb,node=rabbit@amqp.example.org,durable=true,auto_delete=false,host=amqp.example.org head_message_timestamp=1493684017,messages_deliver_get=0i,messages_publish=329i,messages_publish_rate=0.2,messages_redeliver_rate=0,message_bytes_ready=0i,message_bytes_unacked=0i,messages_deliver=329i,messages_unack=0i,consumers=1i,idle_since="",messages=0i,messages_deliver_rate=0.2,messages_deliver_get_rate=0.2,messages_redeliver=0i,memory=43032i,message_bytes_ram=0i,messages_ack=329i,messages_ready=0i,messages_ack_rate=0.2,consumer_utilisation=1,message_bytes=0i,message_bytes_persist=0i 1493684035000000000
+rabbitmq_queue,url=http://amqp.example.org:15672,queue=telegraf,vhost=influxdb,node=rabbit@amqp.example.org,durable=true,auto_delete=false,type=classic,host=amqp.example.org head_message_timestamp=1493684017,messages_deliver_get=0i,messages_publish=329i,messages_publish_rate=0.2,messages_redeliver_rate=0,message_bytes_ready=0i,message_bytes_unacked=0i,messages_deliver=329i,messages_unack=0i,consumers=1i,idle_since="",messages=0i,messages_deliver_rate=0.2,messages_deliver_get_rate=0.2,messages_redeliver=0i,memory=43032i,message_bytes_ram=0i,messages_ack=329i,messages_ready=0i,messages_ack_rate=0.2,consumer_utilisation=1,message_bytes=0i,message_bytes_persist=0i 1493684035000000000
 rabbitmq_overview,url=http://amqp.example.org:15672,host=amqp.example.org channels=2i,consumers=1i,exchanges=17i,messages_acked=329i,messages=0i,messages_ready=0i,messages_unacked=0i,connections=2i,queues=1i,messages_delivered=329i,messages_published=329i,clustering_listeners=2i,amqp_listeners=1i 1493684035000000000
 rabbitmq_node,url=http://amqp.example.org:15672,node=rabbit@amqp.example.org,host=amqp.example.org fd_total=1024i,fd_used=32i,mem_limit=8363329126i,sockets_total=829i,disk_free=8175935488i,disk_free_limit=50000000i,mem_used=58771080i,proc_total=1048576i,proc_used=267i,run_queue=0i,sockets_used=2i,running=1i 149368403500000000
 rabbitmq_exchange,url=http://amqp.example.org:15672,exchange=telegraf,type=fanout,vhost=influxdb,internal=false,durable=true,auto_delete=false,host=amqp.example.org messages_publish_in=2i,messages_publish_out=1i 149368403500000000

--- a/plugins/inputs/rabbitmq/rabbitmq_test.go
+++ b/plugins/inputs/rabbitmq/rabbitmq_test.go
@@ -60,18 +60,18 @@ func TestRabbitMQGeneratesMetricsSet1(t *testing.T) {
 				"url": ts.URL,
 			},
 			map[string]interface{}{
-				"messages":               int64(5),
-				"messages_ready":         int64(32),
-				"messages_unacked":       int64(27),
+				"messages":               int64(50),
+				"messages_ready":         int64(72),
+				"messages_unacked":       int64(94),
 				"messages_acked":         int64(5246),
 				"messages_delivered":     int64(5234),
 				"messages_delivered_get": int64(3333),
 				"messages_published":     int64(5258),
 				"channels":               int64(44),
 				"connections":            int64(44),
-				"consumers":              int64(65),
+				"consumers":              int64(70),
 				"exchanges":              int64(43),
-				"queues":                 int64(62),
+				"queues":                 int64(66),
 				"clustering_listeners":   int64(2),
 				"amqp_listeners":         int64(2),
 				"return_unroutable":      int64(10),
@@ -114,6 +114,120 @@ func TestRabbitMQGeneratesMetricsSet1(t *testing.T) {
 				"idle_since":                "2015-11-01 8:22:14",
 				"slave_nodes":               int64(1),
 				"synchronised_slave_nodes":  int64(1),
+			},
+			time.Unix(0, 0),
+		),
+		testutil.MustMetric("rabbitmq_queue",
+			map[string]string{
+				"auto_delete": "false",
+				"durable":     "true",
+				"node":        "rabbit@rmqlocal-0.rmqlocal.ankorabbitstatefulset3.svc.cluster.local",
+				"queue":       "stream_queue_example",
+				"url":         ts.URL,
+				"vhost":       "sorandomsorandom",
+			},
+			map[string]interface{}{
+				"consumers":                 int64(2),
+				"consumer_utilisation":      float64(0.8),
+				"head_message_timestamp":    int64(1446366000),
+				"memory":                    int64(95000),
+				"message_bytes":             int64(1),
+				"message_bytes_ready":       int64(2),
+				"message_bytes_unacked":     int64(3),
+				"message_bytes_ram":         int64(4),
+				"message_bytes_persist":     int64(5),
+				"messages":                  int64(25),
+				"messages_ready":            int64(20),
+				"messages_unack":            int64(25),
+				"messages_ack":              int64(1500),
+				"messages_ack_rate":         float64(5.5),
+				"messages_deliver":          int64(10000),
+				"messages_deliver_rate":     float64(200.0),
+				"messages_deliver_get":      int64(1500),
+				"messages_deliver_get_rate": float64(0.1),
+				"messages_publish":          int64(1500),
+				"messages_publish_rate":     float64(8.5),
+				"messages_redeliver":        int64(15),
+				"messages_redeliver_rate":   float64(1.2),
+				"idle_since":                "2015-11-01 9:15:30",
+				"slave_nodes":               int64(0),
+				"synchronised_slave_nodes":  int64(0),
+			},
+			time.Unix(0, 0),
+		),
+		testutil.MustMetric("rabbitmq_queue",
+			map[string]string{
+				"auto_delete": "false",
+				"durable":     "true",
+				"node":        "rabbit@rmqlocal-0.rmqlocal.ankorabbitstatefulset3.svc.cluster.local",
+				"queue":       "no-type-queue",
+				"url":         ts.URL,
+				"vhost":       "sorandomsorandom",
+			},
+			map[string]interface{}{
+				"consumers":                 int64(1),
+				"consumer_utilisation":      float64(0.9),
+				"head_message_timestamp":    int64(1446372000),
+				"memory":                    int64(50000),
+				"message_bytes":             int64(1),
+				"message_bytes_ready":       int64(1),
+				"message_bytes_unacked":     int64(1),
+				"message_bytes_ram":         int64(1),
+				"message_bytes_persist":     int64(2),
+				"messages":                  int64(10),
+				"messages_ready":            int64(8),
+				"messages_unack":            int64(10),
+				"messages_ack":              int64(500),
+				"messages_ack_rate":         float64(2.0),
+				"messages_deliver":          int64(2000),
+				"messages_deliver_rate":     float64(50.0),
+				"messages_deliver_get":      int64(500),
+				"messages_deliver_get_rate": float64(0.1),
+				"messages_publish":          int64(500),
+				"messages_publish_rate":     float64(3.0),
+				"messages_redeliver":        int64(5),
+				"messages_redeliver_rate":   float64(0.5),
+				"idle_since":                "2015-11-01 10:30:00",
+				"slave_nodes":               int64(0),
+				"synchronised_slave_nodes":  int64(0),
+			},
+			time.Unix(0, 0),
+		),
+		testutil.MustMetric("rabbitmq_queue",
+			map[string]string{
+				"auto_delete": "false",
+				"durable":     "true",
+				"node":        "rabbit@rmqlocal-0.rmqlocal.ankorabbitstatefulset3.svc.cluster.local",
+				"queue":       "invalid-type-queue",
+				"url":         ts.URL,
+				"vhost":       "sorandomsorandom",
+			},
+			map[string]interface{}{
+				"consumers":                 int64(2),
+				"consumer_utilisation":      float64(0.85),
+				"head_message_timestamp":    int64(1446375000),
+				"memory":                    int64(75000),
+				"message_bytes":             int64(1),
+				"message_bytes_ready":       int64(1),
+				"message_bytes_unacked":     int64(2),
+				"message_bytes_ram":         int64(2),
+				"message_bytes_persist":     int64(3),
+				"messages":                  int64(15),
+				"messages_ready":            int64(12),
+				"messages_unack":            int64(15),
+				"messages_ack":              int64(750),
+				"messages_ack_rate":         float64(3.0),
+				"messages_deliver":          int64(3000),
+				"messages_deliver_rate":     float64(75.0),
+				"messages_deliver_get":      int64(750),
+				"messages_deliver_get_rate": float64(0.1),
+				"messages_publish":          int64(750),
+				"messages_publish_rate":     float64(4.5),
+				"messages_redeliver":        int64(8),
+				"messages_redeliver_rate":   float64(0.8),
+				"idle_since":                "2015-11-01 11:45:00",
+				"slave_nodes":               int64(0),
+				"synchronised_slave_nodes":  int64(0),
 			},
 			time.Unix(0, 0),
 		),
@@ -288,9 +402,9 @@ func TestRabbitMQGeneratesMetricsSet2(t *testing.T) {
 				"messages_published":     int64(770025),
 				"channels":               int64(43),
 				"connections":            int64(43),
-				"consumers":              int64(37),
+				"consumers":              int64(40),
 				"exchanges":              int64(8),
-				"queues":                 int64(34),
+				"queues":                 int64(37),
 				"clustering_listeners":   int64(1),
 				"amqp_listeners":         int64(2),
 				"return_unroutable":      int64(0),
@@ -466,6 +580,80 @@ func TestRabbitMQGeneratesMetricsSet2(t *testing.T) {
 				"mem_allocated_unused":      int64(61026048),
 				"mem_reserved_unallocated":  int64(0),
 				"mem_total":                 int64(385548288),
+			},
+			time.Unix(0, 0),
+		),
+		testutil.MustMetric("rabbitmq_queue",
+			map[string]string{
+				"auto_delete": "false",
+				"durable":     "false",
+				"node":        "rabbit@rmqserver",
+				"queue":       "no-type-queue-set2",
+				"url":         ts.URL,
+				"vhost":       "/",
+			},
+			map[string]interface{}{
+				"consumers":                 int64(1),
+				"consumer_utilisation":      float64(1.0),
+				"memory":                    int64(12000),
+				"message_bytes":             int64(0),
+				"message_bytes_ready":       int64(0),
+				"message_bytes_unacked":     int64(0),
+				"message_bytes_ram":         int64(0),
+				"message_bytes_persist":     int64(0),
+				"messages":                  int64(0),
+				"messages_ready":            int64(0),
+				"messages_unack":            int64(0),
+				"messages_ack":              int64(100),
+				"messages_ack_rate":         float64(0.0),
+				"messages_deliver":          int64(100),
+				"messages_deliver_rate":     float64(0.0),
+				"messages_deliver_get":      int64(100),
+				"messages_deliver_get_rate": float64(0.0),
+				"messages_publish":          int64(100),
+				"messages_publish_rate":     float64(0.0),
+				"messages_redeliver":        int64(0),
+				"messages_redeliver_rate":   float64(0.0),
+				"idle_since":                "2021-06-28 15:54:17",
+				"slave_nodes":               int64(0),
+				"synchronised_slave_nodes":  int64(0),
+			},
+			time.Unix(0, 0),
+		),
+		testutil.MustMetric("rabbitmq_queue",
+			map[string]string{
+				"auto_delete": "false",
+				"durable":     "false",
+				"node":        "rabbit@rmqserver",
+				"queue":       "invalid-type-queue-set2",
+				"url":         ts.URL,
+				"vhost":       "/",
+			},
+			map[string]interface{}{
+				"consumers":                 int64(1),
+				"consumer_utilisation":      float64(1.0),
+				"memory":                    int64(15000),
+				"message_bytes":             int64(0),
+				"message_bytes_ready":       int64(0),
+				"message_bytes_unacked":     int64(0),
+				"message_bytes_ram":         int64(0),
+				"message_bytes_persist":     int64(0),
+				"messages":                  int64(0),
+				"messages_ready":            int64(0),
+				"messages_unack":            int64(0),
+				"messages_ack":              int64(200),
+				"messages_ack_rate":         float64(0.0),
+				"messages_deliver":          int64(200),
+				"messages_deliver_rate":     float64(0.0),
+				"messages_deliver_get":      int64(200),
+				"messages_deliver_get_rate": float64(0.0),
+				"messages_publish":          int64(200),
+				"messages_publish_rate":     float64(0.0),
+				"messages_redeliver":        int64(0),
+				"messages_redeliver_rate":   float64(0.0),
+				"idle_since":                "2021-06-28 16:30:45",
+				"slave_nodes":               int64(0),
+				"synchronised_slave_nodes":  int64(0),
 			},
 			time.Unix(0, 0),
 		),
@@ -685,4 +873,98 @@ func TestRabbitMQMetricFilerts(t *testing.T) {
 		require.Len(t, acc.Errors, len(expected))
 		require.ElementsMatch(t, expected, acc.Errors)
 	}
+}
+
+func TestRabbitMQQueueTypeTag(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var jsonFilePath string
+
+		switch r.URL.Path {
+		case "/api/overview":
+			jsonFilePath = "testdata/set1/overview.json"
+		case "/api/nodes":
+			jsonFilePath = "testdata/set1/nodes.json"
+		case "/api/queues":
+			jsonFilePath = "testdata/set1/queues.json"
+		case "/api/exchanges":
+			jsonFilePath = "testdata/set1/exchanges.json"
+		case "/api/federation-links":
+			jsonFilePath = "testdata/set1/federation-links.json"
+		case "/api/nodes/rabbit@vagrant-ubuntu-trusty-64/memory":
+			jsonFilePath = "testdata/set1/memory.json"
+		default:
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Errorf("unknown path %q", r.URL.Path)
+			return
+		}
+
+		data, err := os.ReadFile(jsonFilePath)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Errorf("Could not read from data file %q: %v", jsonFilePath, err)
+			return
+		}
+
+		if _, err = w.Write(data); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Error(err)
+			return
+		}
+	}))
+	defer ts.Close()
+
+	// Test with IncludeQueueTypeTag = false (default)
+	plugin := &RabbitMQ{
+		URL: ts.URL,
+		Log: testutil.Logger{},
+	}
+	require.NoError(t, plugin.Init())
+
+	acc := &testutil.Accumulator{}
+	require.NoError(t, plugin.Gather(acc))
+
+	acc.Wait(4)
+	require.Empty(t, acc.Errors)
+
+	// Check that queue metrics don't have type tag when disabled
+	queueMetrics := acc.GetTelegrafMetrics()
+	for _, metric := range queueMetrics {
+		if metric.Name() == "rabbitmq_queue" {
+			require.False(t, metric.HasTag("type"), "Queue metric should not have type tag when IncludeQueueTypeTag is false")
+		}
+	}
+
+	// Test with IncludeQueueTypeTag = true
+	pluginWithType := &RabbitMQ{
+		URL:                 ts.URL,
+		IncludeQueueTypeTag: true,
+		Log:                 testutil.Logger{},
+	}
+	require.NoError(t, pluginWithType.Init())
+
+	accWithType := &testutil.Accumulator{}
+	require.NoError(t, pluginWithType.Gather(accWithType))
+
+	accWithType.Wait(4)
+	require.Empty(t, accWithType.Errors)
+
+	// Check that queue metrics have type tag when enabled and verify specific queue types
+	queueMetricsWithType := accWithType.GetTelegrafMetrics()
+	queueTypeMap := make(map[string]string) // queue name -> queue type
+
+	for _, metric := range queueMetricsWithType {
+		if metric.Name() == "rabbitmq_queue" {
+			require.True(t, metric.HasTag("type"), "Queue metric should have type tag when IncludeQueueTypeTag is true")
+
+			queueName, _ := metric.GetTag("queue")
+			queueType, _ := metric.GetTag("type")
+			queueTypeMap[queueName] = queueType
+		}
+	}
+
+	require.Len(t, queueTypeMap, 4, "Should have metrics for all 4 queues in test data")
+	require.Equal(t, "quorum", queueTypeMap["reply_a716f0523cd44941ad2ea6ce4a3869c3"], "Quorum queue should have type 'quorum'")
+	require.Equal(t, "stream", queueTypeMap["stream_queue_example"], "Stream queue should have type 'stream'")
+	require.Equal(t, "classic", queueTypeMap["no-type-queue"], "Queue without type field should default to 'classic'")
+	require.Equal(t, "invalid_type", queueTypeMap["invalid-type-queue"], "Queue with invalid type should preserve the invalid type")
 }

--- a/plugins/inputs/rabbitmq/sample.conf
+++ b/plugins/inputs/rabbitmq/sample.conf
@@ -48,3 +48,8 @@
   ## exchange filters.
   # federation_upstream_include = []
   # federation_upstream_exclude = []
+
+  ## Include queue type as a tag. When enabled, adds a "type" tag to queue metrics
+  ## with the queue type returned by RabbitMQ (e.g., "classic", "quorum", "stream").
+  ## Defaults to "classic" if empty.
+  # include_queue_type_tag = false

--- a/plugins/inputs/rabbitmq/testdata/set1/overview.json
+++ b/plugins/inputs/rabbitmq/testdata/set1/overview.json
@@ -24,20 +24,20 @@
   "object_totals": {
     "channels": 44,
     "connections": 44,
-    "consumers": 65,
+    "consumers": 70,
     "exchanges": 43,
-    "queues": 62
+    "queues": 66
   },
   "queue_totals": {
-    "messages": 5,
+    "messages": 50,
     "messages_details": {
       "rate": 0.0
     },
-    "messages_ready": 32,
+    "messages_ready": 72,
     "messages_ready_details": {
       "rate": 0.0
     },
-    "messages_unacknowledged": 27,
+    "messages_unacknowledged": 94,
     "messages_unacknowledged_details": {
       "rate": 0.0
     }

--- a/plugins/inputs/rabbitmq/testdata/set1/queues.json
+++ b/plugins/inputs/rabbitmq/testdata/set1/queues.json
@@ -102,6 +102,7 @@
       "max_heap_size": 0
     },
     "state": "running",
+    "type": "quorum",
     "recoverable_slaves": null,
     "memory": 143776,
     "consumer_utilisation": 1.0,
@@ -110,11 +111,352 @@
     "effective_policy_definition": [],
     "operator_policy": null,
     "policy": null,
-    "slave_nodes":[
+    "slave_nodes": [
       "rabbit@ip-10-1-2-118"
     ],
-    "synchronised_slave_nodes":[
+    "synchronised_slave_nodes": [
       "rabbit@ip-10-1-2-118"
     ]
+  },
+  {
+    "messages_details": {
+      "rate": 0.0
+    },
+    "messages": 25,
+    "messages_unacknowledged_details": {
+      "rate": 0.0
+    },
+    "messages_unacknowledged": 25,
+    "messages_ready_details": {
+      "rate": 0.0
+    },
+    "messages_ready": 20,
+    "reductions_details": {
+      "rate": 150.0
+    },
+    "reductions": 8000000,
+    "message_stats": {
+      "deliver_get_details": {
+        "rate": 0.1
+      },
+      "deliver_get": 1500,
+      "ack_details": {
+        "rate": 5.5
+      },
+      "ack": 1500,
+      "redeliver_details": {
+        "rate": 1.2
+      },
+      "redeliver": 15,
+      "deliver_no_ack_details": {
+        "rate": 0.0
+      },
+      "deliver_no_ack": 0,
+      "deliver_details": {
+        "rate": 200.0
+      },
+      "deliver": 10000,
+      "get_no_ack_details": {
+        "rate": 0.0
+      },
+      "get_no_ack": 0,
+      "get_details": {
+        "rate": 0.0
+      },
+      "get": 0,
+      "publish_details": {
+        "rate": 8.5
+      },
+      "publish": 1500
+    },
+    "node": "rabbit@rmqlocal-0.rmqlocal.ankorabbitstatefulset3.svc.cluster.local",
+    "arguments": {
+      "x-expires": 1800000
+    },
+    "exclusive": false,
+    "auto_delete": false,
+    "durable": true,
+    "vhost": "sorandomsorandom",
+    "name": "stream_queue_example",
+    "message_bytes_paged_out": 0,
+    "messages_paged_out": 0,
+    "idle_since": "2015-11-01 9:15:30",
+    "backing_queue_status": {
+      "avg_ack_egress_rate": 0.1,
+      "avg_ack_ingress_rate": 0.1,
+      "avg_egress_rate": 0.1,
+      "avg_ingress_rate": 0.1,
+      "delta": [
+        "delta",
+        "undefined",
+        0,
+        0,
+        "undefined"
+      ],
+      "len": 0,
+      "mode": "default",
+      "next_seq_id": 1500,
+      "q1": 0,
+      "q2": 0,
+      "q3": 0,
+      "q4": 0,
+      "target_ram_count": 0
+    },
+    "head_message_timestamp": 1446366000,
+    "message_bytes_persistent": 5,
+    "message_bytes_ram": 4,
+    "message_bytes_unacknowledged": 3,
+    "message_bytes_ready": 2,
+    "message_bytes": 1,
+    "messages_persistent": 0,
+    "messages_unacknowledged_ram": 0,
+    "messages_ready_ram": 0,
+    "messages_ram": 0,
+    "garbage_collection": {
+      "minor_gcs": 200,
+      "fullsweep_after": 65535,
+      "min_heap_size": 233,
+      "min_bin_vheap_size": 46422,
+      "max_heap_size": 0
+    },
+    "state": "running",
+    "type": "stream",
+    "recoverable_slaves": null,
+    "memory": 95000,
+    "consumer_utilisation": 0.8,
+    "consumers": 2,
+    "exclusive_consumer_tag": null,
+    "effective_policy_definition": [],
+    "operator_policy": null,
+    "policy": null,
+    "slave_nodes": [],
+    "synchronised_slave_nodes": []
+  },
+  {
+    "messages_details": {
+      "rate": 0.0
+    },
+    "messages": 10,
+    "messages_unacknowledged_details": {
+      "rate": 0.0
+    },
+    "messages_unacknowledged": 10,
+    "messages_ready_details": {
+      "rate": 0.0
+    },
+    "messages_ready": 8,
+    "reductions_details": {
+      "rate": 50.0
+    },
+    "reductions": 2000000,
+    "message_stats": {
+      "deliver_get_details": {
+        "rate": 0.1
+      },
+      "deliver_get": 500,
+      "ack_details": {
+        "rate": 2.0
+      },
+      "ack": 500,
+      "redeliver_details": {
+        "rate": 0.5
+      },
+      "redeliver": 5,
+      "deliver_no_ack_details": {
+        "rate": 0.0
+      },
+      "deliver_no_ack": 0,
+      "deliver_details": {
+        "rate": 50.0
+      },
+      "deliver": 2000,
+      "get_no_ack_details": {
+        "rate": 0.0
+      },
+      "get_no_ack": 0,
+      "get_details": {
+        "rate": 0.0
+      },
+      "get": 0,
+      "publish_details": {
+        "rate": 3.0
+      },
+      "publish": 500
+    },
+    "node": "rabbit@rmqlocal-0.rmqlocal.ankorabbitstatefulset3.svc.cluster.local",
+    "arguments": {
+      "x-expires": 1800000
+    },
+    "exclusive": false,
+    "auto_delete": false,
+    "durable": true,
+    "vhost": "sorandomsorandom",
+    "name": "no-type-queue",
+    "message_bytes_paged_out": 0,
+    "messages_paged_out": 0,
+    "idle_since": "2015-11-01 10:30:00",
+    "backing_queue_status": {
+      "avg_ack_egress_rate": 0.05,
+      "avg_ack_ingress_rate": 0.05,
+      "avg_egress_rate": 0.05,
+      "avg_ingress_rate": 0.05,
+      "delta": [
+        "delta",
+        "undefined",
+        0,
+        0,
+        "undefined"
+      ],
+      "len": 0,
+      "mode": "default",
+      "next_seq_id": 500,
+      "q1": 0,
+      "q2": 0,
+      "q3": 0,
+      "q4": 0,
+      "target_ram_count": 0
+    },
+    "head_message_timestamp": 1446372000,
+    "message_bytes_persistent": 2,
+    "message_bytes_ram": 1,
+    "message_bytes_unacknowledged": 1,
+    "message_bytes_ready": 1,
+    "message_bytes": 1,
+    "messages_persistent": 0,
+    "messages_unacknowledged_ram": 0,
+    "messages_ready_ram": 0,
+    "messages_ram": 0,
+    "garbage_collection": {
+      "minor_gcs": 100,
+      "fullsweep_after": 65535,
+      "min_heap_size": 233,
+      "min_bin_vheap_size": 46422,
+      "max_heap_size": 0
+    },
+    "state": "running",
+    "recoverable_slaves": null,
+    "memory": 50000,
+    "consumer_utilisation": 0.9,
+    "consumers": 1,
+    "exclusive_consumer_tag": null,
+    "effective_policy_definition": [],
+    "operator_policy": null,
+    "policy": null,
+    "slave_nodes": [],
+    "synchronised_slave_nodes": []
+  },
+  {
+    "messages_details": {
+      "rate": 0.0
+    },
+    "messages": 15,
+    "messages_unacknowledged_details": {
+      "rate": 0.0
+    },
+    "messages_unacknowledged": 15,
+    "messages_ready_details": {
+      "rate": 0.0
+    },
+    "messages_ready": 12,
+    "reductions_details": {
+      "rate": 75.0
+    },
+    "reductions": 3000000,
+    "message_stats": {
+      "deliver_get_details": {
+        "rate": 0.1
+      },
+      "deliver_get": 750,
+      "ack_details": {
+        "rate": 3.0
+      },
+      "ack": 750,
+      "redeliver_details": {
+        "rate": 0.8
+      },
+      "redeliver": 8,
+      "deliver_no_ack_details": {
+        "rate": 0.0
+      },
+      "deliver_no_ack": 0,
+      "deliver_details": {
+        "rate": 75.0
+      },
+      "deliver": 3000,
+      "get_no_ack_details": {
+        "rate": 0.0
+      },
+      "get_no_ack": 0,
+      "get_details": {
+        "rate": 0.0
+      },
+      "get": 0,
+      "publish_details": {
+        "rate": 4.5
+      },
+      "publish": 750
+    },
+    "node": "rabbit@rmqlocal-0.rmqlocal.ankorabbitstatefulset3.svc.cluster.local",
+    "arguments": {
+      "x-expires": 1800000
+    },
+    "exclusive": false,
+    "auto_delete": false,
+    "durable": true,
+    "vhost": "sorandomsorandom",
+    "name": "invalid-type-queue",
+    "message_bytes_paged_out": 0,
+    "messages_paged_out": 0,
+    "idle_since": "2015-11-01 11:45:00",
+    "backing_queue_status": {
+      "avg_ack_egress_rate": 0.08,
+      "avg_ack_ingress_rate": 0.08,
+      "avg_egress_rate": 0.08,
+      "avg_ingress_rate": 0.08,
+      "delta": [
+        "delta",
+        "undefined",
+        0,
+        0,
+        "undefined"
+      ],
+      "len": 0,
+      "mode": "default",
+      "next_seq_id": 750,
+      "q1": 0,
+      "q2": 0,
+      "q3": 0,
+      "q4": 0,
+      "target_ram_count": 0
+    },
+    "head_message_timestamp": 1446375000,
+    "message_bytes_persistent": 3,
+    "message_bytes_ram": 2,
+    "message_bytes_unacknowledged": 2,
+    "message_bytes_ready": 1,
+    "message_bytes": 1,
+    "messages_persistent": 0,
+    "messages_unacknowledged_ram": 0,
+    "messages_ready_ram": 0,
+    "messages_ram": 0,
+    "garbage_collection": {
+      "minor_gcs": 150,
+      "fullsweep_after": 65535,
+      "min_heap_size": 233,
+      "min_bin_vheap_size": 46422,
+      "max_heap_size": 0
+    },
+    "state": "running",
+    "type": "invalid_type",
+    "recoverable_slaves": null,
+    "memory": 75000,
+    "consumer_utilisation": 0.85,
+    "consumers": 2,
+    "exclusive_consumer_tag": null,
+    "effective_policy_definition": [],
+    "operator_policy": null,
+    "policy": null,
+    "slave_nodes": [],
+    "synchronised_slave_nodes": []
   }
 ]

--- a/plugins/inputs/rabbitmq/testdata/set2/overview.json
+++ b/plugins/inputs/rabbitmq/testdata/set2/overview.json
@@ -1,1 +1,287 @@
-{"management_version":"3.8.14","rates_mode":"basic","sample_retention_policies":{"global":[600,3600,28800,86400],"basic":[600,3600],"detailed":[600]},"exchange_types":[{"name":"direct","description":"AMQP direct exchange, as per the AMQP specification","enabled":true},{"name":"fanout","description":"AMQP fanout exchange, as per the AMQP specification","enabled":true},{"name":"headers","description":"AMQP headers exchange, as per the AMQP specification","enabled":true},{"name":"topic","description":"AMQP topic exchange, as per the AMQP specification","enabled":true}],"product_version":"3.8.14","product_name":"RabbitMQ","rabbitmq_version":"3.8.14","cluster_name":"rabbit@rmqserver","erlang_version":"23.2.7","erlang_full_version":"Erlang/OTP 23 [erts-11.1.8] [source] [64-bit] [smp:4:4] [ds:4:4:10] [async-threads:1]","disable_stats":false,"enable_queue_totals":false,"message_stats":{"ack":3736443,"ack_details":{"rate":0.0},"confirm":0,"confirm_details":{"rate":0.0},"deliver":3736446,"deliver_details":{"rate":0.0},"deliver_get":3736446,"deliver_get_details":{"rate":0.0},"deliver_no_ack":0,"deliver_no_ack_details":{"rate":0.0},"disk_reads":0,"disk_reads_details":{"rate":0.0},"disk_writes":55,"disk_writes_details":{"rate":0.0},"drop_unroutable":0,"drop_unroutable_details":{"rate":0.0},"get":0,"get_details":{"rate":0.0},"get_empty":0,"get_empty_details":{"rate":0.0},"get_no_ack":0,"get_no_ack_details":{"rate":0.0},"publish":770025,"publish_details":{"rate":0.0},"redeliver":1,"redeliver_details":{"rate":0.0},"return_unroutable":0,"return_unroutable_details":{"rate":0.0}},"churn_rates":{"channel_closed":2267,"channel_closed_details":{"rate":0.0},"channel_created":2310,"channel_created_details":{"rate":0.0},"connection_closed":2268,"connection_closed_details":{"rate":0.0},"connection_created":2310,"connection_created_details":{"rate":0.0},"queue_created":663,"queue_created_details":{"rate":0.0},"queue_declared":144281,"queue_declared_details":{"rate":0.0},"queue_deleted":629,"queue_deleted_details":{"rate":0.0}},"queue_totals":{"messages":30,"messages_details":{"rate":0.0},"messages_ready":30,"messages_ready_details":{"rate":0.0},"messages_unacknowledged":0,"messages_unacknowledged_details":{"rate":0.0}},"object_totals":{"channels":43,"connections":43,"consumers":37,"exchanges":8,"queues":34},"statistics_db_event_queue":0,"node":"rabbit@rmqserver","listeners":[{"node":"rabbit@rmqserver","protocol":"amqp","ip_address":"0.0.0.0","port":5672,"socket_opts":{"backlog":128,"nodelay":true,"linger":[true,0],"exit_on_close":false}},{"node":"rabbit@rmqserver","protocol":"amqp","ip_address":"::","port":5672,"socket_opts":{"backlog":128,"nodelay":true,"linger":[true,0],"exit_on_close":false}},{"node":"rabbit@rmqserver","protocol":"amqp/ssl","ip_address":"0.0.0.0","port":5671,"socket_opts":{"backlog":128,"nodelay":true,"linger":[true,0],"exit_on_close":false,"versions":["tlsv1.3","tlsv1.2","tlsv1.1","tlsv1"],"cacertfile":"C:\\ProgramData\\Chain.pem","certfile":"C:\\ProgramData\\server.crt","keyfile":"C:\\ProgramData\\server.key","verify":"verify_peer","depth":3,"fail_if_no_peer_cert":false}},{"node":"rabbit@rmqserver","protocol":"amqp/ssl","ip_address":"::","port":5671,"socket_opts":{"backlog":128,"nodelay":true,"linger":[true,0],"exit_on_close":false,"versions":["tlsv1.3","tlsv1.2","tlsv1.1","tlsv1"],"cacertfile":"C:\\ProgramData\\Chain.pem","certfile":"C:\\ProgramData\\server.crt","keyfile":"C:\\ProgramData\\server.key","verify":"verify_peer","depth":3,"fail_if_no_peer_cert":false}},{"node":"rabbit@rmqserver","protocol":"clustering","ip_address":"::","port":25672,"socket_opts":[]},{"node":"rabbit@rmqserver","protocol":"http","ip_address":"0.0.0.0","port":15672,"socket_opts":{"cowboy_opts":{"sendfile":false},"port":15672}},{"node":"rabbit@rmqserver","protocol":"http","ip_address":"::","port":15672,"socket_opts":{"cowboy_opts":{"sendfile":false},"port":15672}}],"contexts":[{"ssl_opts":[],"node":"rabbit@rmqserver","description":"RabbitMQ Management","path":"/","cowboy_opts":"[{sendfile,false}]","port":"15672"}]}
+{
+    "management_version": "3.8.14",
+    "rates_mode": "basic",
+    "sample_retention_policies": {
+        "global": [
+            600,
+            3600,
+            28800,
+            86400
+        ],
+        "basic": [
+            600,
+            3600
+        ],
+        "detailed": [
+            600
+        ]
+    },
+    "exchange_types": [
+        {
+            "name": "direct",
+            "description": "AMQP direct exchange, as per the AMQP specification",
+            "enabled": true
+        },
+        {
+            "name": "fanout",
+            "description": "AMQP fanout exchange, as per the AMQP specification",
+            "enabled": true
+        },
+        {
+            "name": "headers",
+            "description": "AMQP headers exchange, as per the AMQP specification",
+            "enabled": true
+        },
+        {
+            "name": "topic",
+            "description": "AMQP topic exchange, as per the AMQP specification",
+            "enabled": true
+        }
+    ],
+    "product_version": "3.8.14",
+    "product_name": "RabbitMQ",
+    "rabbitmq_version": "3.8.14",
+    "cluster_name": "rabbit@rmqserver",
+    "erlang_version": "23.2.7",
+    "erlang_full_version": "Erlang/OTP 23 [erts-11.1.8] [source] [64-bit] [smp:4:4] [ds:4:4:10] [async-threads:1]",
+    "disable_stats": false,
+    "enable_queue_totals": false,
+    "message_stats": {
+        "ack": 3736443,
+        "ack_details": {
+            "rate": 0.0
+        },
+        "confirm": 0,
+        "confirm_details": {
+            "rate": 0.0
+        },
+        "deliver": 3736446,
+        "deliver_details": {
+            "rate": 0.0
+        },
+        "deliver_get": 3736446,
+        "deliver_get_details": {
+            "rate": 0.0
+        },
+        "deliver_no_ack": 0,
+        "deliver_no_ack_details": {
+            "rate": 0.0
+        },
+        "disk_reads": 0,
+        "disk_reads_details": {
+            "rate": 0.0
+        },
+        "disk_writes": 55,
+        "disk_writes_details": {
+            "rate": 0.0
+        },
+        "drop_unroutable": 0,
+        "drop_unroutable_details": {
+            "rate": 0.0
+        },
+        "get": 0,
+        "get_details": {
+            "rate": 0.0
+        },
+        "get_empty": 0,
+        "get_empty_details": {
+            "rate": 0.0
+        },
+        "get_no_ack": 0,
+        "get_no_ack_details": {
+            "rate": 0.0
+        },
+        "publish": 770025,
+        "publish_details": {
+            "rate": 0.0
+        },
+        "redeliver": 1,
+        "redeliver_details": {
+            "rate": 0.0
+        },
+        "return_unroutable": 0,
+        "return_unroutable_details": {
+            "rate": 0.0
+        }
+    },
+    "churn_rates": {
+        "channel_closed": 2267,
+        "channel_closed_details": {
+            "rate": 0.0
+        },
+        "channel_created": 2310,
+        "channel_created_details": {
+            "rate": 0.0
+        },
+        "connection_closed": 2268,
+        "connection_closed_details": {
+            "rate": 0.0
+        },
+        "connection_created": 2310,
+        "connection_created_details": {
+            "rate": 0.0
+        },
+        "queue_created": 663,
+        "queue_created_details": {
+            "rate": 0.0
+        },
+        "queue_declared": 144281,
+        "queue_declared_details": {
+            "rate": 0.0
+        },
+        "queue_deleted": 629,
+        "queue_deleted_details": {
+            "rate": 0.0
+        }
+    },
+    "queue_totals": {
+        "messages": 30,
+        "messages_details": {
+            "rate": 0.0
+        },
+        "messages_ready": 30,
+        "messages_ready_details": {
+            "rate": 0.0
+        },
+        "messages_unacknowledged": 0,
+        "messages_unacknowledged_details": {
+            "rate": 0.0
+        }
+    },
+    "object_totals": {
+        "channels": 43,
+        "connections": 43,
+        "consumers": 40,
+        "exchanges": 8,
+        "queues": 37
+    },
+    "statistics_db_event_queue": 0,
+    "node": "rabbit@rmqserver",
+    "listeners": [
+        {
+            "node": "rabbit@rmqserver",
+            "protocol": "amqp",
+            "ip_address": "0.0.0.0",
+            "port": 5672,
+            "socket_opts": {
+                "backlog": 128,
+                "nodelay": true,
+                "linger": [
+                    true,
+                    0
+                ],
+                "exit_on_close": false
+            }
+        },
+        {
+            "node": "rabbit@rmqserver",
+            "protocol": "amqp",
+            "ip_address": "::",
+            "port": 5672,
+            "socket_opts": {
+                "backlog": 128,
+                "nodelay": true,
+                "linger": [
+                    true,
+                    0
+                ],
+                "exit_on_close": false
+            }
+        },
+        {
+            "node": "rabbit@rmqserver",
+            "protocol": "amqp/ssl",
+            "ip_address": "0.0.0.0",
+            "port": 5671,
+            "socket_opts": {
+                "backlog": 128,
+                "nodelay": true,
+                "linger": [
+                    true,
+                    0
+                ],
+                "exit_on_close": false,
+                "versions": [
+                    "tlsv1.3",
+                    "tlsv1.2",
+                    "tlsv1.1",
+                    "tlsv1"
+                ],
+                "cacertfile": "C:\\ProgramData\\Chain.pem",
+                "certfile": "C:\\ProgramData\\server.crt",
+                "keyfile": "C:\\ProgramData\\server.key",
+                "verify": "verify_peer",
+                "depth": 3,
+                "fail_if_no_peer_cert": false
+            }
+        },
+        {
+            "node": "rabbit@rmqserver",
+            "protocol": "amqp/ssl",
+            "ip_address": "::",
+            "port": 5671,
+            "socket_opts": {
+                "backlog": 128,
+                "nodelay": true,
+                "linger": [
+                    true,
+                    0
+                ],
+                "exit_on_close": false,
+                "versions": [
+                    "tlsv1.3",
+                    "tlsv1.2",
+                    "tlsv1.1",
+                    "tlsv1"
+                ],
+                "cacertfile": "C:\\ProgramData\\Chain.pem",
+                "certfile": "C:\\ProgramData\\server.crt",
+                "keyfile": "C:\\ProgramData\\server.key",
+                "verify": "verify_peer",
+                "depth": 3,
+                "fail_if_no_peer_cert": false
+            }
+        },
+        {
+            "node": "rabbit@rmqserver",
+            "protocol": "clustering",
+            "ip_address": "::",
+            "port": 25672,
+            "socket_opts": []
+        },
+        {
+            "node": "rabbit@rmqserver",
+            "protocol": "http",
+            "ip_address": "0.0.0.0",
+            "port": 15672,
+            "socket_opts": {
+                "cowboy_opts": {
+                    "sendfile": false
+                },
+                "port": 15672
+            }
+        },
+        {
+            "node": "rabbit@rmqserver",
+            "protocol": "http",
+            "ip_address": "::",
+            "port": 15672,
+            "socket_opts": {
+                "cowboy_opts": {
+                    "sendfile": false
+                },
+                "port": 15672
+            }
+        }
+    ],
+    "contexts": [
+        {
+            "ssl_opts": [],
+            "node": "rabbit@rmqserver",
+            "description": "RabbitMQ Management",
+            "path": "/",
+            "cowboy_opts": "[{sendfile,false}]",
+            "port": "15672"
+        }
+    ]
+}

--- a/plugins/inputs/rabbitmq/testdata/set2/queues.json
+++ b/plugins/inputs/rabbitmq/testdata/set2/queues.json
@@ -352,5 +352,241 @@
     "state": "running",
     "type": "classic",
     "vhost": "/"
+  },
+  {
+    "arguments": {
+      "x-expires": 300000
+    },
+    "auto_delete": false,
+    "backing_queue_status": {
+      "avg_ack_egress_rate": 0,
+      "avg_ack_ingress_rate": 0,
+      "avg_egress_rate": 0,
+      "avg_ingress_rate": 0,
+      "delta": [
+        "delta",
+        "undefined",
+        0,
+        0,
+        "undefined"
+      ],
+      "len": 0,
+      "mode": "default",
+      "next_seq_id": 100,
+      "q1": 0,
+      "q2": 0,
+      "q3": 0,
+      "q4": 0,
+      "target_ram_count": "infinity"
+    },
+    "consumer_capacity": 1,
+    "consumer_utilisation": 1,
+    "consumers": 1,
+    "durable": false,
+    "effective_policy_definition": {},
+    "exclusive": false,
+    "exclusive_consumer_tag": null,
+    "garbage_collection": {
+      "fullsweep_after": 65535,
+      "max_heap_size": 0,
+      "min_bin_vheap_size": 46422,
+      "min_heap_size": 233,
+      "minor_gcs": 1000
+    },
+    "head_message_timestamp": null,
+    "idle_since": "2021-06-28 15:54:17",
+    "memory": 12000,
+    "message_bytes": 0,
+    "message_bytes_paged_out": 0,
+    "message_bytes_persistent": 0,
+    "message_bytes_ram": 0,
+    "message_bytes_ready": 0,
+    "message_bytes_unacknowledged": 0,
+    "message_stats": {
+      "ack": 100,
+      "ack_details": {
+        "rate": 0
+      },
+      "deliver": 100,
+      "deliver_details": {
+        "rate": 0
+      },
+      "deliver_get": 100,
+      "deliver_get_details": {
+        "rate": 0
+      },
+      "deliver_no_ack": 0,
+      "deliver_no_ack_details": {
+        "rate": 0
+      },
+      "get": 0,
+      "get_details": {
+        "rate": 0
+      },
+      "get_empty": 0,
+      "get_empty_details": {
+        "rate": 0
+      },
+      "get_no_ack": 0,
+      "get_no_ack_details": {
+        "rate": 0
+      },
+      "publish": 100,
+      "publish_details": {
+        "rate": 0
+      },
+      "redeliver": 0,
+      "redeliver_details": {
+        "rate": 0
+      }
+    },
+    "messages": 0,
+    "messages_details": {
+      "rate": 0
+    },
+    "messages_paged_out": 0,
+    "messages_persistent": 0,
+    "messages_ram": 0,
+    "messages_ready": 0,
+    "messages_ready_details": {
+      "rate": 0
+    },
+    "messages_ready_ram": 0,
+    "messages_unacknowledged": 0,
+    "messages_unacknowledged_details": {
+      "rate": 0
+    },
+    "messages_unacknowledged_ram": 0,
+    "name": "no-type-queue-set2",
+    "node": "rabbit@rmqserver",
+    "operator_policy": null,
+    "policy": null,
+    "recoverable_slaves": null,
+    "reductions": 5000000,
+    "reductions_details": {
+      "rate": 0
+    },
+    "single_active_consumer_tag": null,
+    "state": "running",
+    "type": "",
+    "vhost": "/"
+  },
+  {
+    "arguments": {
+      "x-expires": 300000
+    },
+    "auto_delete": false,
+    "backing_queue_status": {
+      "avg_ack_egress_rate": 0,
+      "avg_ack_ingress_rate": 0,
+      "avg_egress_rate": 0,
+      "avg_ingress_rate": 0,
+      "delta": [
+        "delta",
+        "undefined",
+        0,
+        0,
+        "undefined"
+      ],
+      "len": 0,
+      "mode": "default",
+      "next_seq_id": 200,
+      "q1": 0,
+      "q2": 0,
+      "q3": 0,
+      "q4": 0,
+      "target_ram_count": "infinity"
+    },
+    "consumer_capacity": 1,
+    "consumer_utilisation": 1,
+    "consumers": 1,
+    "durable": false,
+    "effective_policy_definition": {},
+    "exclusive": false,
+    "exclusive_consumer_tag": null,
+    "garbage_collection": {
+      "fullsweep_after": 65535,
+      "max_heap_size": 0,
+      "min_bin_vheap_size": 46422,
+      "min_heap_size": 233,
+      "minor_gcs": 2000
+    },
+    "head_message_timestamp": null,
+    "idle_since": "2021-06-28 16:30:45",
+    "memory": 15000,
+    "message_bytes": 0,
+    "message_bytes_paged_out": 0,
+    "message_bytes_persistent": 0,
+    "message_bytes_ram": 0,
+    "message_bytes_ready": 0,
+    "message_bytes_unacknowledged": 0,
+    "message_stats": {
+      "ack": 200,
+      "ack_details": {
+        "rate": 0
+      },
+      "deliver": 200,
+      "deliver_details": {
+        "rate": 0
+      },
+      "deliver_get": 200,
+      "deliver_get_details": {
+        "rate": 0
+      },
+      "deliver_no_ack": 0,
+      "deliver_no_ack_details": {
+        "rate": 0
+      },
+      "get": 0,
+      "get_details": {
+        "rate": 0
+      },
+      "get_empty": 0,
+      "get_empty_details": {
+        "rate": 0
+      },
+      "get_no_ack": 0,
+      "get_no_ack_details": {
+        "rate": 0
+      },
+      "publish": 200,
+      "publish_details": {
+        "rate": 0
+      },
+      "redeliver": 0,
+      "redeliver_details": {
+        "rate": 0
+      }
+    },
+    "messages": 0,
+    "messages_details": {
+      "rate": 0
+    },
+    "messages_paged_out": 0,
+    "messages_persistent": 0,
+    "messages_ram": 0,
+    "messages_ready": 0,
+    "messages_ready_details": {
+      "rate": 0
+    },
+    "messages_ready_ram": 0,
+    "messages_unacknowledged": 0,
+    "messages_unacknowledged_details": {
+      "rate": 0
+    },
+    "messages_unacknowledged_ram": 0,
+    "name": "invalid-type-queue-set2",
+    "node": "rabbit@rmqserver",
+    "operator_policy": null,
+    "policy": null,
+    "recoverable_slaves": null,
+    "reductions": 10000000,
+    "reductions_details": {
+      "rate": 0
+    },
+    "single_active_consumer_tag": null,
+    "state": "running",
+    "type": "unknown_type",
+    "vhost": "/"
   }
 ]


### PR DESCRIPTION
## Summary
Add type tag to queue to be able to differentiate queues by type 

## Checklist
- [x] No AI generated code was used in this PR

## Related issues

resolves #17632

