### PR TITLE
fix(inputs.docker): Fix incorrect CPU usage_percent for Podman containers

### DIFF
--- a/plugins/inputs/docker/README.md
+++ b/plugins/inputs/docker/README.md
@@ -59,6 +59,12 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## Timeout for docker list, info, and stats commands
   timeout = "5s"
 
+  ## Podman compatibility settings (auto-enabled when Podman detected)
+  ## Cache TTL for accurate CPU percentage calculation (default: 60s)
+  ## Set higher than your collection interval for accurate measurements
+  ## Set to 0 to keep cache entries forever (not recommended for dynamic environments)
+  # podman_cache_ttl = "60s"
+
   ## Specifies for which classes a per-device metric should be issued
   ## Possible values are 'cpu' (cpu0, cpu1, ...), 'blkio' (8:0, 8:1, ...) and 'network' (eth0, eth1, ...)
   # perdevice_include = ["cpu"]
@@ -98,6 +104,17 @@ could result in an attacker gaining root access to a machine. This is especially
 relevant if the telegraf configuration can be changed by untrusted users.
 
 [4]: https://docs.docker.com/engine/security/security/#docker-daemon-attack-surface
+
+### Podman Compatibility
+
+This plugin is compatible with Podman through its Docker-compatible API.
+When connected to Podman:
+
+- The plugin automatically detects Podman by examining the server version and
+  endpoint
+- Uses an intelligent caching mechanism to calculate accurate CPU percentages
+- Configure Podman socket endpoint, for example:
+  `endpoint = "unix:///run/podman/podman.sock"`
 
 ### Docker Daemon Permissions
 

--- a/plugins/inputs/docker/sample.conf
+++ b/plugins/inputs/docker/sample.conf
@@ -32,6 +32,12 @@
   ## Timeout for docker list, info, and stats commands
   timeout = "5s"
 
+  ## Podman compatibility settings (auto-enabled when Podman detected)
+  ## Cache TTL for accurate CPU percentage calculation (default: 60s)
+  ## Set higher than your collection interval for accurate measurements
+  ## Set to 0 to keep cache entries forever (not recommended for dynamic environments)
+  # podman_cache_ttl = "60s"
+
   ## Specifies for which classes a per-device metric should be issued
   ## Possible values are 'cpu' (cpu0, cpu1, ...), 'blkio' (8:0, 8:1, ...) and 'network' (eth0, eth1, ...)
   # perdevice_include = ["cpu"]


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Fixes incorrect CPU `usage_percent` metrics when using the Docker input plugin with Podman containers. The plugin now automatically detects Podman and implements an efficient caching mechanism to calculate accurate CPU percentages.

**Issue:**
Podman's Docker-compatible API behaves differently from Docker's native API:
  - **Docker**: Returns `PreCPUStats` from the previous collection interval (~1 second ago)
  - **Podman**: Returns `PreCPUStats` from when the container started

This caused Telegraf to report the average CPU usage since container start rather than current CPU usage, making the metrics essentially useless for monitoring actual container load.
Related to Podman issue: containers/podman#25709

**Solution:**
This PR implements an intelligent caching mechanism that:
  1. Automatically detects Podman using multiple heuristics (version strings, endpoint patterns, runtime indicators)
  2. Caches previous stats readings to calculate accurate interval-based CPU percentages
  3. Zero impact on Docker users - cache is only allocated when Podman is detected


## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #17379
