### PR TITLE
docs(outputs): Fix line-length in READMEs

### DIFF
--- a/plugins/outputs/amon/README.md
+++ b/plugins/outputs/amon/README.md
@@ -1,8 +1,8 @@
 # Amon Output Plugin
 
 This plugin writes metrics to [Amon monitoring platform][amon]. It requires a
-`serverkey` and `amoninstance` URL which can be obtained [here][amon_monitoring]
-for your account.
+`serverkey` and `amoninstance` URL which can be obtained from the
+[website][amon_monitoring] for your account.
 
 > [!IMPORTANT]
 > If point values being sent cannot be converted to a `float64`, the metric is

--- a/plugins/outputs/datadog/README.md
+++ b/plugins/outputs/datadog/README.md
@@ -1,13 +1,17 @@
 # Datadog Output Plugin
 
 This plugin writes metrics to the [Datadog Metrics API][metrics] and requires an
-`apikey` which can be obtained [here][apikey] for the account.
+`apikey` which can be obtained on the [website][apikey] for the account.
+
 > [!NOTE]
 > This plugin supports the v1 API.
 
 ⭐ Telegraf v0.1.6
 🏷️ applications, cloud, datastore
 💻 all
+
+[metrics]: https://docs.datadoghq.com/api/v1/metrics/#submit-metrics
+[apikey]: https://app.datadoghq.com/account/settings#api
 
 ## Global configuration options <!-- @/docs/includes/plugin_config.md -->
 
@@ -65,6 +69,3 @@ intervals are the same (Datadog defaults to `10s`).
 Note that this only supports metrics ingested via `inputs.statsd` given
 the dependency on the `metric_type` tag it creates. There is only support for
 `counter` metrics, and `count` values from `timing` and `histogram` metrics.
-
-[metrics]: https://docs.datadoghq.com/api/v1/metrics/#submit-metrics
-[apikey]: https://app.datadoghq.com/account/settings#api

--- a/plugins/outputs/dynatrace/README.md
+++ b/plugins/outputs/dynatrace/README.md
@@ -94,9 +94,9 @@ The endpoint for the Dynatrace Metrics API v2 is
   api_token = "your API token here" // hard-coded for illustration only, should be read from environment
 ```
 
-You can learn more about how to use the Dynatrace API
-[here](https://docs.dynatrace.com/docs/shortlink/section-api).
+You can learn more about how to use the [Dynatrace API][api].
 
+[api]: https://docs.dynatrace.com/docs/shortlink/section-api
 [api-auth]: https://docs.dynatrace.com/docs/shortlink/api-authentication
 
 ## Global configuration options <!-- @/docs/includes/plugin_config.md -->

--- a/plugins/outputs/librato/README.md
+++ b/plugins/outputs/librato/README.md
@@ -1,8 +1,8 @@
 # Librato Output Plugin
 
 This plugin writes metrics to the [Librato][librato] service. It requires an
-`api_user` and `api_token` which can be obtained [here][tokens] for your
-account.
+`api_user` and `api_token` which can be obtained on the [website][tokens] for
+your account.
 
 The `source_tag` option in the Configuration file is used to send contextual
 information from Point Tags to the API. Besides from this, the plugin currently

--- a/plugins/outputs/nats/README.md
+++ b/plugins/outputs/nats/README.md
@@ -140,8 +140,8 @@ If you’re using JetStream the value of subject determines where messages
 are published.
 
 > [!IMPORTANT]
-> When using a dynamic subject template, Telegraf does not automatically register the
-> generated subjects with the JetStream stream.
+> When using a dynamic subject template, Telegraf does not automatically
+> register the generated subjects with the JetStream stream.
 
 For dynamic `subject`s you must explicitly define matching subjects in
 `outputs.nats.jetstream.subjects` to ensure your stream can receive and

--- a/plugins/outputs/timestream/README.md
+++ b/plugins/outputs/timestream/README.md
@@ -19,8 +19,12 @@ API endpoint. In the following order the plugin will attempt to authenticate.
 credentials are evaluated from subsequent rules). The `endpoint_url` attribute
 is used only for Timestream service. When fetching credentials, STS global
 endpoint will be used.
-1. Web identity provider credentials via STS if `role_arn` and `web_identity_token_file` are specified
-1. [Assumed credentials via STS][sts_credentials] if `role_arn` attribute is specified (source credentials are evaluated from subsequent rules). The `endpoint_url` attribute is used only for Timestream service. When fetching credentials, STS global endpoint will be used.
+1. Web identity provider credentials via STS if `role_arn` and
+   `web_identity_token_file` are specified
+1. [Assumed credentials via STS][sts_credentials] if `role_arn` attribute is
+   specified (source credentials are evaluated from subsequent rules). The
+   `endpoint_url` attribute is used only for Timestream service. When fetching
+   credentials, STS global endpoint will be used.
 1. Explicit credentials from `access_key`, `secret_key`, and `token` attributes
 1. Shared profile from `profile` attribute
 1. [Environment Variables][env_vars]

--- a/plugins/outputs/wavefront/README.md
+++ b/plugins/outputs/wavefront/README.md
@@ -172,8 +172,10 @@ The expected input for Wavefront is specified in the following way:
 <metric> <value> [<timestamp>] <source|host>=<sourceTagValue> [tagk1=tagv1 ...tagkN=tagvN]
 ```
 
-More information about the Wavefront data format is available
-[here](https://community.wavefront.com/docs/DOC-1031)
+More information about the Wavefront data format is available in the
+[documentation][docs].
+
+[docs]: https://community.wavefront.com/docs/DOC-1031
 
 ### Allowed values for metrics
 


### PR DESCRIPTION
## Summary

This fixes the line-length violations in the READMEs of the output plugins.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues
