### PR TITLE
fix(config): Reject invalid tagpass and tagdrop types

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1982,11 +1982,11 @@ func (c *Config) getFieldStringSlice(tbl *ast.Table, fieldName string) []string 
 func (c *Config) getFieldTagFilter(tbl *ast.Table, fieldName string) []models.TagFilter {
 	var target []models.TagFilter
 	if node, ok := tbl.Fields[fieldName]; ok {
-		if _, ok := node.(*ast.Table); !ok {
+		subTbl, ok := node.(*ast.Table)
+		if !ok {
 			c.addError(tbl, fmt.Errorf("invalid syntax for %q: expected a table of key=[values]", fieldName))
 			return nil
-		}
-		if subTbl, ok := node.(*ast.Table); ok {
+		} else {
 			for name, val := range subTbl.Fields {
 				if kv, ok := val.(*ast.KeyValue); ok {
 					ary, ok := kv.Value.(*ast.Array)

--- a/config/config.go
+++ b/config/config.go
@@ -1994,7 +1994,7 @@ func (c *Config) getFieldTagFilter(tbl *ast.Table, fieldName string) []models.Ta
 						c.addError(tbl, fmt.Errorf("found unexpected format while parsing %q, expecting string array/slice format on each entry", fieldName))
 						return nil
 					}
-					
+
 					tagFilter := models.TagFilter{Name: name}
 					for _, elem := range ary.Value {
 						if str, ok := elem.(*ast.String); ok {

--- a/config/config.go
+++ b/config/config.go
@@ -1981,28 +1981,33 @@ func (c *Config) getFieldStringSlice(tbl *ast.Table, fieldName string) []string 
 
 func (c *Config) getFieldTagFilter(tbl *ast.Table, fieldName string) []models.TagFilter {
 	var target []models.TagFilter
+
 	if node, ok := tbl.Fields[fieldName]; ok {
 		subTbl, ok := node.(*ast.Table)
 		if !ok {
 			c.addError(tbl, fmt.Errorf("invalid syntax for %q: expected a table of key=[values]", fieldName))
 			return nil
-		} else {
-			for name, val := range subTbl.Fields {
-				if kv, ok := val.(*ast.KeyValue); ok {
-					ary, ok := kv.Value.(*ast.Array)
-					if !ok {
-						c.addError(tbl, fmt.Errorf("found unexpected format while parsing %q, expecting string array/slice format on each entry", fieldName))
-						return nil
-					}
+		}
 
-					tagFilter := models.TagFilter{Name: name}
-					for _, elem := range ary.Value {
-						if str, ok := elem.(*ast.String); ok {
-							tagFilter.Values = append(tagFilter.Values, str.Value)
-						}
-					}
-					target = append(target, tagFilter)
+		for name, val := range subTbl.Fields {
+			if kv, ok := val.(*ast.KeyValue); ok {
+				ary, ok := kv.Value.(*ast.Array)
+				if !ok {
+					c.addError(tbl, fmt.Errorf(
+						"found unexpected format while parsing %q, expecting string array/slice format on each entry",
+						fieldName,
+					))
+					return nil
 				}
+
+				tagFilter := models.TagFilter{Name: name}
+				for _, elem := range ary.Value {
+					if str, ok := elem.(*ast.String); ok {
+						tagFilter.Values = append(tagFilter.Values, str.Value)
+					}
+				}
+
+				target = append(target, tagFilter)
 			}
 		}
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -1982,6 +1982,10 @@ func (c *Config) getFieldStringSlice(tbl *ast.Table, fieldName string) []string 
 func (c *Config) getFieldTagFilter(tbl *ast.Table, fieldName string) []models.TagFilter {
 	var target []models.TagFilter
 	if node, ok := tbl.Fields[fieldName]; ok {
+		if _, ok := node.(*ast.Table); !ok {
+			c.addError(tbl, fmt.Errorf("invalid syntax for %q: expected a table of key=[values]", fieldName))
+			return nil
+		}
 		if subTbl, ok := node.(*ast.Table); ok {
 			for name, val := range subTbl.Fields {
 				if kv, ok := val.(*ast.KeyValue); ok {
@@ -1990,7 +1994,7 @@ func (c *Config) getFieldTagFilter(tbl *ast.Table, fieldName string) []models.Ta
 						c.addError(tbl, fmt.Errorf("found unexpected format while parsing %q, expecting string array/slice format on each entry", fieldName))
 						return nil
 					}
-
+					
 					tagFilter := models.TagFilter{Name: name}
 					for _, elem := range ary.Value {
 						if str, ok := elem.(*ast.String); ok {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1480,6 +1480,29 @@ func TestConfigEnvVarsNonStrictMalicious(t *testing.T) {
 
 	// We expect too plugins due to malicious environment setting
 	require.Len(t, c.Inputs, 2)
+
+func TestInvalidTagpassSyntaxFromFile(t *testing.T) {
+	c := config.NewConfig()
+	err := c.LoadConfig("testdata/tagfilter_invalid.toml")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), `invalid syntax for "tagpass"`)
+}
+
+func TestValidTagpassAndTagdropSyntaxFromFile(t *testing.T) {
+	c := config.NewConfig()
+	require.NoError(t, c.LoadConfig("testdata/tagfilter_valid.toml"))
+
+	require.NotEmpty(t, c.Inputs)
+
+	plugin := c.Inputs[0].Config
+	require.Len(t, plugin.Filter.TagPassFilters, 1)
+	require.Len(t, plugin.Filter.TagDropFilters, 1)
+
+	require.Equal(t, "host", plugin.Filter.TagPassFilters[0].Name)
+	require.Equal(t, []string{"server1", "server2"}, plugin.Filter.TagPassFilters[0].Values)
+
+	require.Equal(t, "region", plugin.Filter.TagDropFilters[0].Name)
+	require.Equal(t, []string{"us-west"}, plugin.Filter.TagDropFilters[0].Values)
 }
 
 // Mockup INPUT plugin for (new) parser testing to avoid cyclic dependencies

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1484,9 +1484,7 @@ func TestConfigEnvVarsNonStrictMalicious(t *testing.T) {
 
 func TestInvalidTagpassSyntaxFromFile(t *testing.T) {
 	c := config.NewConfig()
-	err := c.LoadConfig("testdata/tagfilter_invalid.toml")
-	require.Error(t, err)
-	require.Contains(t, err.Error(), `invalid syntax for "tagpass"`)
+	require.ErrorContains(t, c.LoadConfig("testdata/tagfilter_invalid.toml"), `invalid syntax for "tagpass"`)
 }
 
 func TestValidTagpassAndTagdropSyntaxFromFile(t *testing.T) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1480,6 +1480,7 @@ func TestConfigEnvVarsNonStrictMalicious(t *testing.T) {
 
 	// We expect too plugins due to malicious environment setting
 	require.Len(t, c.Inputs, 2)
+}
 
 func TestInvalidTagpassSyntaxFromFile(t *testing.T) {
 	c := config.NewConfig()

--- a/config/testdata/tagfilter_invalid.toml
+++ b/config/testdata/tagfilter_invalid.toml
@@ -1,0 +1,2 @@
+[[inputs.http_listener_v2]]
+  tagpass = ["foo"]

--- a/config/testdata/tagfilter_valid.toml
+++ b/config/testdata/tagfilter_valid.toml
@@ -1,0 +1,6 @@
+[[inputs.http_listener_v2]]
+  [inputs.http_listener_v2.tagpass]
+    host = ["server1", "server2"]
+
+  [inputs.http_listener_v2.tagdrop]
+    region = ["us-west"]


### PR DESCRIPTION
## Summary
Address open issue: #16398 

People work sloppily and try to match metrics with a tagpass = ["mymarkertag"] when the correct version would be tagpass = { "markertag" = ["mymarkertag"] } or similar.
Telegraf doesn't error out, though, and processors and outputs still process and put out the affected metrics because no working tagpass means matching every metric.

But it also matches metrics it shouldn't match and those end up in databases where they shouldn't end up.

Expected behavior
Error out with a config syntax error because tagpass expects a dictionary

Actual behavior
No erroring out and just matching everything leading to metrics in places where they don't belong.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #16398 
