### PR TITLE
fix(inputs.tail): Fix flaky test

### DIFF
--- a/plugins/inputs/tail/tail_test.go
+++ b/plugins/inputs/tail/tail_test.go
@@ -1131,10 +1131,10 @@ func TestTailNoLeak(t *testing.T) {
 	// Call Gather to pick up the new content
 	require.NoError(t, acc.GatherError(tt.Gather))
 
-	// Wait for the new metric
+	// Wait for the new metric (increased timeout for slower environments like ARM64 CircleCI)
 	require.Eventually(t, func() bool {
 		return acc.NMetrics() >= 1
-	}, time.Second, 100*time.Millisecond, "Did not receive metric after appending to file")
+	}, 3*time.Second, 100*time.Millisecond, "Did not receive metric after appending to file")
 
 	// Verify we got the new metric
 	acc.AssertContainsFields(t, "cpu",


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Increase timeout in TestTailNoLeak for slower environments. 
The test was flaky on [ARM64 CircleCI](https://app.circleci.com/pipelines/github/influxdata/telegraf/27887/workflows/d215a104-f530-476e-9cae-6968043e1c75/jobs/443755) due to insufficient time for the tail plugin to detect and process file changes. Increased timeout from 1s to 3s.



## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
