### PR TITLE
fix(inputs.redis_sentinel): Pin Docker image to specific version for reliability

### DIFF
--- a/plugins/inputs/redis_sentinel/redis_sentinel_test.go
+++ b/plugins/inputs/redis_sentinel/redis_sentinel_test.go
@@ -362,7 +362,7 @@ func createRedisContainer(networkName string) testutil.Container {
 
 func createSentinelContainer(redisAddress, networkName string, waitingFor wait.Strategy) testutil.Container {
 	return testutil.Container{
-		Image:        "bitnami/redis-sentinel:7.0",
+		Image:        "bitnami/redis-sentinel:7.4.3",
 		ExposedPorts: []string{sentinelServicePort},
 		Networks:     []string{networkName},
 		Env: map[string]string{


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
The integration test `TestRedisSentinelConnectIntegration` has been failing on CircleCI with the error:

```
Error response from daemon: manifest for bitnami/redis-sentinel:7.0 not found
```

The problem is that we’re using a generic Docker tag (`:7.0`). These tags are mutable; they change whenever a new patch version comes out (e.g. `7.0.9` → `7.0.10`). When Docker Hub updates the tag but CI runners still have cached metadata pointing to the old manifest, we get “manifest not found” errors.

To avoid these flaky failures, this PR switches to using specific patch versions (e.g. `:7.4.3`).

### Trade-offs

* Using **generic tags** (`:7.0`) keeps things updated automatically and requires less maintenance, but makes tests unreliable and non-reproducible.
* Using **specific tags** (`:7.0.9`) ensures stability and reproducibility, but means we need to bump versions manually when security or bug-fix releases come out.


## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
