### PR TITLE
fix(outputs.mongodb): Remove incorrect HTTP wait strategy from integration tests

### DIFF
--- a/plugins/outputs/mongodb/mongodb_test.go
+++ b/plugins/outputs/mongodb/mongodb_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/docker/go-connections/nat"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go/wait"
 
@@ -24,10 +23,7 @@ func TestConnectAndWriteIntegrationNoAuth(t *testing.T) {
 	container := testutil.Container{
 		Image:        "mongo",
 		ExposedPorts: []string{servicePort},
-		WaitingFor: wait.ForAll(
-			wait.NewHTTPStrategy("/").WithPort(nat.Port(servicePort)),
-			wait.ForLog("Waiting for connections"),
-		),
+		WaitingFor:   wait.ForLog("Waiting for connections"),
 	}
 	err := container.Start()
 	require.NoError(t, err, "failed to start container")
@@ -66,10 +62,7 @@ func TestConnectAndWriteIntegrationSCRAMAuth(t *testing.T) {
 		Files: map[string]string{
 			"/docker-entrypoint-initdb.d/setup.js": initdb,
 		},
-		WaitingFor: wait.ForAll(
-			wait.NewHTTPStrategy("/").WithPort(nat.Port(servicePort)),
-			wait.ForLog("Waiting for connections").WithOccurrence(2),
-		),
+		WaitingFor: wait.ForLog("Waiting for connections").WithOccurrence(2),
 	}
 	err = container.Start()
 	require.NoError(t, err, "failed to start container")
@@ -169,10 +162,7 @@ func TestConnectAndWriteIntegrationX509Auth(t *testing.T) {
 			"--tlsCAFile", "/cacert.pem",
 			"--tlsCertificateKeyFile", "/server.pem",
 		},
-		WaitingFor: wait.ForAll(
-			wait.NewHTTPStrategy("/").WithPort(nat.Port(servicePort)),
-			wait.ForLog("Waiting for connections").WithOccurrence(2),
-		),
+		WaitingFor: wait.ForLog("Waiting for connections").WithOccurrence(2),
 	}
 	err = container.Start()
 	require.NoError(t, err, "failed to start container")


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Fixed flaky MongoDB [integration tests](https://app.circleci.com/pipelines/github/influxdata/telegraf/27905/workflows/61f83066-6947-45d1-a46e-aae18e8231c7/jobs/444124) (exit code 48) by replacing the incorrect HTTP wait strategy with a log-based strategy. MongoDB doesn’t use HTTP on port 27017, so the HTTP checks failed; the log-based approach reliably waits for the ‘Waiting for connections’ message.



## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->


- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
