### PR TITLE
docs(parsers): Fix line-length in READMEs

### DIFF
--- a/plugins/parsers/collectd/README.md
+++ b/plugins/parsers/collectd/README.md
@@ -4,19 +4,20 @@ The collectd format parses the collectd binary network protocol.  Tags are
 created for host, instance, type, and type instance.  All collectd values are
 added as float64 fields.
 
-For more information about the binary network protocol see
-[here](https://collectd.org/wiki/index.php/Binary_protocol).
+For more information check the [binary network protocol documentation][proto].
 
 You can control the cryptographic settings with parser options.  Create an
 authentication file and set `collectd_auth_file` to the path of the file, then
 set the desired security level in `collectd_security_level`.
 
-Additional information including client setup can be found [here][1].
+Additional information including client setup can be found in the setup
+[documentation][setup].
 
 You can also change the path to the typesdb or add additional typesdb using
 `collectd_typesdb`.
 
-[1]: https://collectd.org/wiki/index.php/Networking_introduction#Cryptographic_setup
+[proto]: https://collectd.org/wiki/index.php/Binary_protocol
+[setup]: https://collectd.org/wiki/index.php/Networking_introduction#Cryptographic_setup
 
 ## Configuration
 

--- a/plugins/parsers/grok/README.md
+++ b/plugins/parsers/grok/README.md
@@ -1,10 +1,8 @@
 # Grok Parser Plugin
 
 The grok data format parses line delimited data using a regular expression like
-language.
-
-The best way to get acquainted with grok patterns is to read the logstash docs,
-which are available [here][1].
+language. The best way to get acquainted with grok patterns is to read the
+[logstash documentation][logstash].
 
 The grok parser uses a slightly modified version of logstash "grok"
 patterns, with the format:
@@ -58,24 +56,26 @@ CUSTOM time layouts must be within quotes and be the representation of the
 comma decimal point you can use a period.  For example
 `%{TIMESTAMP:timestamp:ts-"2006-01-02 15:04:05.000"}` can be used to match
 `"2018-01-02 15:04:05,000"` To match a comma decimal point you can use a period
-in the pattern string.  See [Goloang Time
-docs](https://golang.org/pkg/time/#Parse) for more details.
+in the pattern string. See the [Golang Time documentation][gotime] for more
+details.
 
-Telegraf has many of its own [built-in patterns][] as well as support for most
-of the Logstash builtin patterns using [these Go compatible
-patterns][grok-patterns].
+Telegraf has many of its own [built-in patterns][builtin] as well as support for
+most of the Logstash builtin patterns using
+[these Go-compatible patterns][gopatterns].
 
-**Note:** Golang regular expressions do not support lookahead or lookbehind.
-Logstash patterns that use these features may not be supported, or may use a Go
-friendly pattern that is not fully compatible with the Logstash pattern.
+> [!NOTE]
+> Golang regular expressions do not support lookahead or lookbehind.
+> Logstash patterns that use these features may not be supported, or may use a
+> Go friendly pattern that is not fully compatible with the Logstash pattern.
 
-[built-in patterns]: /plugins/parsers/grok/influx_patterns.go
-[grok-patterns]: https://github.com/vjeantet/grok/blob/master/patterns/grok-patterns
+If you need help building patterns to match your logs, you will find the
+[Grok Debug application][debugger] quite useful!
 
-If you need help building patterns to match your logs, you will find the [Grok
-Debug](https://grokdebug.herokuapp.com) application quite useful!
-
-[1]: https://www.elastic.co/guide/en/logstash/current/plugins-filters-grok.html
+[logstash]: https://www.elastic.co/guide/en/logstash/current/plugins-filters-grok.html
+[gotime]: https://golang.org/pkg/time/#Parse
+[builtin]: /plugins/parsers/grok/influx_patterns.go
+[gopatterns]: https://github.com/vjeantet/grok/blob/master/patterns/grok-patterns
+[debugger]: https://grokdebug.herokuapp.com
 
 ## Configuration
 

--- a/plugins/parsers/prometheusremotewrite/README.md
+++ b/plugins/parsers/prometheusremotewrite/README.md
@@ -1,8 +1,10 @@
 # Prometheus Remote Write Parser Plugin
 
 Converts prometheus remote write samples directly into Telegraf metrics. It can
-be used with [http_listener_v2](/plugins/inputs/http_listener_v2). There are no
-additional configuration options for Prometheus Remote Write Samples.
+be used with [http_listener_v2][http_listener_v2]. There are no additional
+configuration options for Prometheus Remote Write Samples.
+
+[http_listener_v2]: /plugins/inputs/http_listener_v2
 
 ## Configuration
 
@@ -54,7 +56,16 @@ go_gc_duration_seconds,instance=localhost:9090,job=prometheus,quantile=0.99 valu
 prometheus_remote_write,instance=localhost:9090,job=prometheus,quantile=0.99 go_gc_duration_seconds=4.63 1614889298859000000
 ```
 
-## For alignment with the [InfluxDB v1.x Prometheus Remote Write Spec](https://docs.influxdata.com/influxdb/v1.8/supported_protocols/prometheus/#how-prometheus-metrics-are-parsed-in-influxdb)
+## Alignment with Prometheus Remote Write Specification
 
-- V1: already aligned, it parses metrics according to the spec.
-- V2: Use the [Starlark processor rename prometheus remote write script](https://github.com/influxdata/telegraf/blob/master/plugins/processors/starlark/testdata/rename_prometheus_remote_write.star) to rename the measurement name to the fieldname and rename the fieldname to value.
+To align the output with the [InfluxDB v1.x Prometheus Remote Write Specification][spec]
+use
+
+- V1: already aligned, it parses metrics according to the spec
+- V2: use the [Starlark processor][starlark] with the
+      [rename prometheus remote write script][rename_script] to rename the
+      measurement to the field-name and rename the field-name to value
+
+[spec]: https://docs.influxdata.com/influxdb/v1.8/supported_protocols/prometheus/#how-prometheus-metrics-are-parsed-in-influxdb
+[starlark]: /plugins/processors/starlark/README.md
+[rename_script]: https://github.com/influxdata/telegraf/blob/master/plugins/processors/starlark/testdata/rename_prometheus_remote_write.star

--- a/plugins/parsers/wavefront/README.md
+++ b/plugins/parsers/wavefront/README.md
@@ -1,8 +1,9 @@
 # Wavefront Parser Plugin
 
 Wavefront Data Format is metrics are parsed directly into Telegraf metrics.
-For more information about the Wavefront Data Format see
-[here](https://docs.wavefront.com/wavefront_data_format.html).
+For more information check the [Wavefront Data Format documentation][docs].
+
+[docs]: https://docs.wavefront.com/wavefront_data_format.html
 
 ## Configuration
 


### PR DESCRIPTION
## Summary

This fixes the line-length violations in the READMEs of the parser plugins.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues
