### PR TITLE
fix(secretstores.systemd): Handle dash version separator correctly

### DIFF
--- a/plugins/secretstores/systemd/systemd.go
+++ b/plugins/secretstores/systemd/systemd.go
@@ -126,7 +126,9 @@ func getSystemdMajorVersion() (int, error) {
 		return 0, err
 	}
 	fullVersion = strings.Trim(fullVersion, "\"")
-	return strconv.Atoi(strings.SplitN(fullVersion, ".", 2)[0])
+	major, _, _ := strings.Cut(fullVersion, ".")
+	major, _, _ = strings.Cut(major, "-")
+	return strconv.Atoi(major)
 }
 
 func init() {


### PR DESCRIPTION
## Summary

Systemd versions might contain a dash separator in the version instead of dots. This PR fixes parsing such versions by accounting for dash-separators.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #17734 
