### PR TITLE
feat(inputs.net): Remove deprecated plugin option value

### DIFF
--- a/plugins/inputs/net/net.go
+++ b/plugins/inputs/net/net.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 
 	"github.com/influxdata/telegraf"
-	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/filter"
 	"github.com/influxdata/telegraf/internal"
 	"github.com/influxdata/telegraf/plugins/common/psutil"
@@ -23,7 +22,7 @@ var sampleConfig string
 
 type Net struct {
 	Interfaces          []string `toml:"interfaces"`
-	IgnoreProtocolStats bool     `toml:"ignore_protocol_stats"`
+	IgnoreProtocolStats bool     `toml:"ignore_protocol_stats" deprecated:"1.37.0;1.45.0;use the 'inputs.nstat' plugin instead for protocol stats"`
 
 	filter     filter.Filter
 	ps         psutil.PS
@@ -35,16 +34,6 @@ func (*Net) SampleConfig() string {
 }
 
 func (n *Net) Init() error {
-	if !n.IgnoreProtocolStats {
-		config.PrintOptionValueDeprecationNotice("inputs.net", "ignore_protocol_stats", "false",
-			telegraf.DeprecationInfo{
-				Since:     "1.27.3",
-				RemovalIn: "1.36.0",
-				Notice:    "use the 'inputs.nstat' plugin instead for protocol stats",
-			},
-		)
-	}
-
 	// So not use the interface list of the system if the HOST_PROC variable is
 	// set as the interfaces are determined by a syscall and therefore might
 	// differ especially in container environments.
@@ -116,25 +105,6 @@ func (n *Net) Gather(acc telegraf.Accumulator) error {
 			"speed":        getInterfaceSpeed(io.Name),
 		}
 		acc.AddCounter("net", fields, tags)
-	}
-
-	// Get system wide stats for different network protocols
-	// (ignore these stats if the call fails)
-	if !n.IgnoreProtocolStats {
-		//nolint:errcheck // stats ignored on fail
-		netprotos, _ := n.ps.NetProto()
-		fields := make(map[string]interface{})
-		for _, proto := range netprotos {
-			for stat, value := range proto.Stats {
-				name := fmt.Sprintf("%s_%s", strings.ToLower(proto.Protocol),
-					strings.ToLower(stat))
-				fields[name] = value
-			}
-		}
-		tags := map[string]string{
-			"interface": "all",
-		}
-		acc.AddFields("net", fields, tags)
 	}
 
 	return nil

--- a/plugins/inputs/net/net_test.go
+++ b/plugins/inputs/net/net_test.go
@@ -32,17 +32,6 @@ func TestNetIOStats(t *testing.T) {
 
 	mps.On("NetIO").Return([]net.IOCountersStat{netio}, nil)
 
-	netprotos := []net.ProtoCountersStat{
-		{
-			Protocol: "Udp",
-			Stats: map[string]int64{
-				"InDatagrams": 4655,
-				"NoPorts":     892592,
-			},
-		},
-	}
-	mps.On("NetProto").Return(netprotos, nil)
-
 	t.Setenv("HOST_SYS", filepath.Join("testdata", "general", "sys"))
 
 	plugin := &Net{ps: &mps, skipChecks: true}
@@ -68,15 +57,6 @@ func TestNetIOStats(t *testing.T) {
 			time.Unix(0, 0),
 			telegraf.Counter,
 		),
-		metric.New(
-			"net",
-			map[string]string{"interface": "all"},
-			map[string]interface{}{
-				"udp_noports":     int64(892592),
-				"udp_indatagrams": int64(4655),
-			},
-			time.Unix(0, 0),
-		),
 	}
 	testutil.RequireMetricsEqual(t, expected, acc.GetTelegrafMetrics(), testutil.IgnoreTime())
 }
@@ -98,17 +78,6 @@ func TestNetIOStatsSpeedUnsupported(t *testing.T) {
 	}
 
 	mps.On("NetIO").Return([]net.IOCountersStat{netio}, nil)
-
-	netprotos := []net.ProtoCountersStat{
-		{
-			Protocol: "Udp",
-			Stats: map[string]int64{
-				"InDatagrams": 4655,
-				"NoPorts":     892592,
-			},
-		},
-	}
-	mps.On("NetProto").Return(netprotos, nil)
 
 	t.Setenv("HOST_SYS", filepath.Join("testdata", "general", "sys"))
 
@@ -135,15 +104,6 @@ func TestNetIOStatsSpeedUnsupported(t *testing.T) {
 			time.Unix(0, 0),
 			telegraf.Counter,
 		),
-		metric.New(
-			"net",
-			map[string]string{"interface": "all"},
-			map[string]interface{}{
-				"udp_noports":     int64(892592),
-				"udp_indatagrams": int64(4655),
-			},
-			time.Unix(0, 0),
-		),
 	}
 	testutil.RequireMetricsEqual(t, expected, acc.GetTelegrafMetrics(), testutil.IgnoreTime())
 }
@@ -165,17 +125,6 @@ func TestNetIOStatsNoSpeedFile(t *testing.T) {
 	}
 
 	mps.On("NetIO").Return([]net.IOCountersStat{netio}, nil)
-
-	netprotos := []net.ProtoCountersStat{
-		{
-			Protocol: "Udp",
-			Stats: map[string]int64{
-				"InDatagrams": 4655,
-				"NoPorts":     892592,
-			},
-		},
-	}
-	mps.On("NetProto").Return(netprotos, nil)
 
 	t.Setenv("HOST_SYS", filepath.Join("testdata", "general", "sys"))
 
@@ -201,15 +150,6 @@ func TestNetIOStatsNoSpeedFile(t *testing.T) {
 			},
 			time.Unix(0, 0),
 			telegraf.Counter,
-		),
-		metric.New(
-			"net",
-			map[string]string{"interface": "all"},
-			map[string]interface{}{
-				"udp_noports":     int64(892592),
-				"udp_indatagrams": int64(4655),
-			},
-			time.Unix(0, 0),
 		),
 	}
 	testutil.RequireMetricsEqual(t, expected, acc.GetTelegrafMetrics(), testutil.IgnoreTime())


### PR DESCRIPTION
## Summary

Remove config option `ignore_protocol_stats = false` which was stated to be removed in `1.36.0`, but wasn't.

This deprecates the `ignore_protocol_stats` config option as a whole since it's not used anymore.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

