### PR TITLE
feat(inputs.zookeeper): Remove deprecated option

### DIFF
--- a/plugins/inputs/zookeeper/README.md
+++ b/plugins/inputs/zookeeper/README.md
@@ -46,12 +46,30 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   # parse_floats = "string"
 
   ## Optional TLS Config
-  # enable_tls = false
-  # tls_ca = "/etc/telegraf/ca.pem"
-  # tls_cert = "/etc/telegraf/cert.pem"
-  # tls_key = "/etc/telegraf/key.pem"
-  ## If false, skip chain & host verification
-  # insecure_skip_verify = true
+  ## Set to true/false to enforce TLS being enabled/disabled. If not set,
+  ## enable TLS only if any of the other options are specified.
+  # tls_enable =
+  ## Trusted root certificates for server
+  # tls_ca = "/path/to/cafile"
+  ## Used for TLS client certificate authentication
+  # tls_cert = "/path/to/certfile"
+  ## Used for TLS client certificate authentication
+  # tls_key = "/path/to/keyfile"
+  ## Password for the key file if it is encrypted
+  # tls_key_pwd = ""
+  ## Send the specified TLS server name via SNI
+  # tls_server_name = "kubernetes.example.com"
+  ## Minimal TLS version to accept by the client
+  # tls_min_version = "TLS12"
+  ## List of ciphers to accept, by default all secure ciphers will be accepted
+  ## See https://pkg.go.dev/crypto/tls#pkg-constants for supported values.
+  ## Use "all", "secure" and "insecure" to add all support ciphers, secure
+  ## suites or insecure suites respectively.
+  # tls_cipher_suites = ["secure"]
+  ## Renegotiation method, "never", "once" or "freely"
+  # tls_renegotiation_method = "never"
+  ## Use TLS but skip chain & host verification
+  # insecure_skip_verify = false
 ```
 
 ## Troubleshooting

--- a/plugins/inputs/zookeeper/sample.conf
+++ b/plugins/inputs/zookeeper/sample.conf
@@ -17,9 +17,27 @@
   # parse_floats = "string"
 
   ## Optional TLS Config
-  # enable_tls = false
-  # tls_ca = "/etc/telegraf/ca.pem"
-  # tls_cert = "/etc/telegraf/cert.pem"
-  # tls_key = "/etc/telegraf/key.pem"
-  ## If false, skip chain & host verification
-  # insecure_skip_verify = true
+  ## Set to true/false to enforce TLS being enabled/disabled. If not set,
+  ## enable TLS only if any of the other options are specified.
+  # tls_enable =
+  ## Trusted root certificates for server
+  # tls_ca = "/path/to/cafile"
+  ## Used for TLS client certificate authentication
+  # tls_cert = "/path/to/certfile"
+  ## Used for TLS client certificate authentication
+  # tls_key = "/path/to/keyfile"
+  ## Password for the key file if it is encrypted
+  # tls_key_pwd = ""
+  ## Send the specified TLS server name via SNI
+  # tls_server_name = "kubernetes.example.com"
+  ## Minimal TLS version to accept by the client
+  # tls_min_version = "TLS12"
+  ## List of ciphers to accept, by default all secure ciphers will be accepted
+  ## See https://pkg.go.dev/crypto/tls#pkg-constants for supported values.
+  ## Use "all", "secure" and "insecure" to add all support ciphers, secure
+  ## suites or insecure suites respectively.
+  # tls_cipher_suites = ["secure"]
+  ## Renegotiation method, "never", "once" or "freely"
+  # tls_renegotiation_method = "never"
+  ## Use TLS but skip chain & host verification
+  # insecure_skip_verify = false

--- a/plugins/inputs/zookeeper/sample.conf.in
+++ b/plugins/inputs/zookeeper/sample.conf.in
@@ -1,0 +1,20 @@
+# Reads 'mntr' stats from one or many zookeeper servers
+[[inputs.zookeeper]]
+  ## An array of address to gather stats about. Specify an ip or hostname
+  ## with port. ie localhost:2181, 10.0.0.1:2181, etc.
+
+  ## If no servers are specified, then localhost is used as the host.
+  ## If no port is specified, 2181 is used
+  servers = [":2181"]
+
+  ## Timeout for metric collections from all servers.  Minimum timeout is "1s".
+  # timeout = "5s"
+
+  ## Float Parsing - the initial implementation forced any value unable to be
+  ## parsed as an int to be a string. Setting this to "float" will attempt to
+  ## parse float values as floats and not strings. This would break existing
+  ## metrics and may cause issues if a value switches between a float and int.
+  # parse_floats = "string"
+
+  ## Optional TLS Config
+{{template "/plugins/common/tls/client.conf"}}

--- a/plugins/inputs/zookeeper/zookeeper_test.go
+++ b/plugins/inputs/zookeeper/zookeeper_test.go
@@ -56,6 +56,8 @@ func TestZookeeperGeneratesMetricsIntegration(t *testing.T) {
 	}
 	for _, tt := range testset {
 		t.Run(tt.name, func(t *testing.T) {
+			require.NoError(t, tt.zookeeper.Init())
+
 			var acc testutil.Accumulator
 			require.NoError(t, acc.GatherError(tt.zookeeper.Gather))
 

--- a/plugins/inputs/zookeeper/zookeeper_test.go
+++ b/plugins/inputs/zookeeper/zookeeper_test.go
@@ -3,13 +3,28 @@ package zookeeper
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/docker/go-connections/nat"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go/wait"
 
+	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/testutil"
 )
+
+func TestInit(t *testing.T) {
+	plugin := &Zookeeper{}
+
+	require.NoError(t, plugin.Init())
+
+	require.Len(t, plugin.Servers, 1)
+	require.Equal(t, ":2181", plugin.Servers[0])
+
+	require.Equal(t, config.Duration(5*time.Second), plugin.Timeout)
+
+	require.Nil(t, plugin.tlsConfig)
+}
 
 func TestZookeeperGeneratesMetricsIntegration(t *testing.T) {
 	if testing.Short() {


### PR DESCRIPTION
## Summary

Remove `enable_ssl` option which was stated to be removed in 1.35.0.

Meanwhile also deprecate `enable_tls` to use `tls_enable` instead.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues
