### PR TITLE
feat(inputs.opcua): Remove deprecated options

### DIFF
--- a/plugins/common/opcua/input/input_client.go
+++ b/plugins/common/opcua/input/input_client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"sort"
 	"strconv"
 	"strings"
@@ -52,9 +53,6 @@ type NodeSettings struct {
 	Namespace        string               `toml:"namespace"`
 	IdentifierType   string               `toml:"identifier_type"`
 	Identifier       string               `toml:"identifier"`
-	DataType         string               `toml:"data_type" deprecated:"1.17.0;1.35.0;option is ignored"`
-	Description      string               `toml:"description" deprecated:"1.17.0;1.35.0;option is ignored"`
-	TagsSlice        [][]string           `toml:"tags" deprecated:"1.25.0;1.35.0;use 'default_tags' instead"`
 	DefaultTags      map[string]string    `toml:"default_tags"`
 	MonitoringParams MonitoringParameters `toml:"monitoring_params"`
 }
@@ -70,7 +68,6 @@ type NodeGroupSettings struct {
 	Namespace        string            `toml:"namespace"`       // Can be overridden by node setting
 	IdentifierType   string            `toml:"identifier_type"` // Can be overridden by node setting
 	Nodes            []NodeSettings    `toml:"nodes"`
-	TagsSlice        [][]string        `toml:"tags" deprecated:"1.26.0;1.35.0;use default_tags"`
 	DefaultTags      map[string]string `toml:"default_tags"`
 	SamplingInterval config.Duration   `toml:"sampling_interval"` // Can be overridden by monitoring parameters
 }
@@ -244,25 +241,8 @@ type NodeMetricMapping struct {
 // NewNodeMetricMapping builds a new NodeMetricMapping from the given argument
 func NewNodeMetricMapping(metricName string, node NodeSettings, groupTags map[string]string) (*NodeMetricMapping, error) {
 	mergedTags := make(map[string]string)
-	for n, t := range groupTags {
-		mergedTags[n] = t
-	}
-
-	nodeTags := make(map[string]string)
-	if len(node.DefaultTags) > 0 {
-		nodeTags = node.DefaultTags
-	} else if len(node.TagsSlice) > 0 {
-		// fixme: once the TagsSlice has been removed (after deprecation), remove this if else logic
-		var err error
-		nodeTags, err = tagsSliceToMap(node.TagsSlice)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	for n, t := range nodeTags {
-		mergedTags[n] = t
-	}
+	maps.Copy(mergedTags, groupTags)
+	maps.Copy(mergedTags, node.DefaultTags)
 
 	return &NodeMetricMapping{
 		Tag:        node,
@@ -349,28 +329,6 @@ func newMP(n *NodeMetricMapping) metricParts {
 	return x
 }
 
-// fixme: once the TagsSlice has been removed (after deprecation), remove this
-// tagsSliceToMap takes an array of pairs of strings and creates a map from it
-func tagsSliceToMap(tags [][]string) (map[string]string, error) {
-	m := make(map[string]string)
-	for i, tag := range tags {
-		if len(tag) != 2 {
-			return nil, fmt.Errorf("tag %d needs 2 values, has %d: %v", i+1, len(tag), tag)
-		}
-		if tag[0] == "" {
-			return nil, fmt.Errorf("tag %d has empty name", i+1)
-		}
-		if tag[1] == "" {
-			return nil, fmt.Errorf("tag %d has empty value", i+1)
-		}
-		if _, ok := m[tag[0]]; ok {
-			return nil, fmt.Errorf("tag %d has duplicate key: %v", i+1, tag[0])
-		}
-		m[tag[0]] = tag[1]
-	}
-	return m, nil
-}
-
 func validateNodeToAdd(existing map[metricParts]struct{}, nmm *NodeMetricMapping) error {
 	if nmm.Tag.FieldName == "" {
 		return fmt.Errorf("empty name in %q", nmm.Tag.FieldName)
@@ -382,6 +340,15 @@ func validateNodeToAdd(existing map[metricParts]struct{}, nmm *NodeMetricMapping
 
 	if len(nmm.Tag.Identifier) == 0 {
 		return errors.New("empty node identifier not allowed")
+	}
+
+	for k, v := range nmm.MetricTags {
+		if k == "" {
+			return fmt.Errorf("empty tag name in tags for %q", nmm.Tag.FieldName)
+		}
+		if v == "" {
+			return fmt.Errorf("empty tag value for tag %q in %q", k, nmm.Tag.FieldName)
+		}
 	}
 
 	mp := newMP(nmm)
@@ -425,22 +392,6 @@ func (o *OpcUAInputClient) InitNodeMetricMapping() error {
 			group.MetricName = o.Config.MetricName
 		}
 
-		if len(group.DefaultTags) > 0 && len(group.TagsSlice) > 0 {
-			o.Log.Warn("Tags found in both `tags` and `default_tags`, only using tags defined in `default_tags`")
-		}
-
-		groupTags := make(map[string]string)
-		if len(group.DefaultTags) > 0 {
-			groupTags = group.DefaultTags
-		} else if len(group.TagsSlice) > 0 {
-			// fixme: once the TagsSlice has been removed (after deprecation), remove this if else logic
-			var err error
-			groupTags, err = tagsSliceToMap(group.TagsSlice)
-			if err != nil {
-				return err
-			}
-		}
-
 		for _, node := range group.Nodes {
 			if node.Namespace == "" {
 				node.Namespace = group.Namespace
@@ -452,7 +403,7 @@ func (o *OpcUAInputClient) InitNodeMetricMapping() error {
 				node.MonitoringParams.SamplingInterval = group.SamplingInterval
 			}
 
-			nmm, err := NewNodeMetricMapping(group.MetricName, node, groupTags)
+			nmm, err := NewNodeMetricMapping(group.MetricName, node, group.DefaultTags)
 			if err != nil {
 				return err
 			}

--- a/plugins/inputs/opcua/opcua_test.go
+++ b/plugins/inputs/opcua/opcua_test.go
@@ -76,10 +76,8 @@ func TestGetDataBadNodeContainerIntegration(t *testing.T) {
 	}
 
 	g := input.NodeGroupSettings{
-		MetricName: "anodic_current",
-		TagsSlice: [][]string{
-			{"pot", "2002"},
-		},
+		MetricName:  "anodic_current",
+		DefaultTags: map[string]string{"pot": "2002"},
 	}
 
 	for _, tags := range testopctags {
@@ -320,32 +318,33 @@ optional_fields = ["DataType"]
   namespace = "1"
   identifier_type = "s"
   identifier="one"
-  tags=[["tag0", "val0"]]
+  default_tags = { tag0 = "val0" }
 
 [[inputs.opcua.nodes]]
   name="name2"
   namespace="2"
   identifier_type="s"
   identifier="two"
-  tags=[["tag0", "val0"], ["tag00", "val00"]]
-  default_tags = {tag6 = "val6"}
+  default_tags={tag6="val6"}
 
 [[inputs.opcua.group]]
 name = "foo"
 namespace = "3"
 identifier_type = "i"
-tags = [["tag1", "val1"], ["tag2", "val2"]]
-nodes = [{name="name3", identifier="3000", tags=[["tag3", "val3"]]}]
+default_tags = { tag1 = "val1", tag2 = "val2"}
+[[inputs.opcua.group.nodes]]
+  name = "name3"
+  identifier = "3000"
+  default_tags = { tag3 = "val3" }
 
 [[inputs.opcua.group]]
 name = "bar"
 namespace = "0"
 identifier_type = "i"
-tags = [["tag1", "val1"], ["tag2", "val2"]]
+default_tags = { tag1 = "val1", tag2 = "val2"}
 [[inputs.opcua.group.nodes]]
   name = "name4"
   identifier = "4000"
-  tags=[["tag4", "val4"]]
   default_tags = { tag1 = "override" }
 
 [[inputs.opcua.group.nodes]]
@@ -386,14 +385,13 @@ use_unregistered_reads = true
 			Namespace:      "1",
 			IdentifierType: "s",
 			Identifier:     "one",
-			TagsSlice:      [][]string{{"tag0", "val0"}},
+			DefaultTags:    map[string]string{"tag0": "val0"},
 		},
 		{
 			FieldName:      "name2",
 			Namespace:      "2",
 			IdentifierType: "s",
 			Identifier:     "two",
-			TagsSlice:      [][]string{{"tag0", "val0"}, {"tag00", "val00"}},
 			DefaultTags:    map[string]string{"tag6": "val6"},
 		},
 	}, o.readClientConfig.RootNodes)
@@ -402,22 +400,21 @@ use_unregistered_reads = true
 			MetricName:     "foo",
 			Namespace:      "3",
 			IdentifierType: "i",
-			TagsSlice:      [][]string{{"tag1", "val1"}, {"tag2", "val2"}},
+			DefaultTags:    map[string]string{"tag1": "val1", "tag2": "val2"},
 			Nodes: []input.NodeSettings{{
-				FieldName:  "name3",
-				Identifier: "3000",
-				TagsSlice:  [][]string{{"tag3", "val3"}},
+				FieldName:   "name3",
+				Identifier:  "3000",
+				DefaultTags: map[string]string{"tag3": "val3"},
 			}},
 		},
 		{
 			MetricName:     "bar",
 			Namespace:      "0",
 			IdentifierType: "i",
-			TagsSlice:      [][]string{{"tag1", "val1"}, {"tag2", "val2"}},
+			DefaultTags:    map[string]string{"tag1": "val1", "tag2": "val2"},
 			Nodes: []input.NodeSettings{{
 				FieldName:   "name4",
 				Identifier:  "4000",
-				TagsSlice:   [][]string{{"tag4", "val4"}},
 				DefaultTags: map[string]string{"tag1": "override"},
 			}, {
 				FieldName:  "name5",

--- a/plugins/inputs/opcua_listener/opcua_listener_test.go
+++ b/plugins/inputs/opcua_listener/opcua_listener_test.go
@@ -411,15 +411,21 @@ nodes = [
 name = "foo"
 namespace = "3"
 identifier_type = "i"
-tags = [["tag1", "val1"], ["tag2", "val2"]]
-nodes = [{name="name3", identifier="3000", tags=[["tag3", "val3"]]}]
+default_tags = {tag1="val1", tag2="val2"}
+[[inputs.opcua_listener.group.nodes]]
+  name = "name3"
+  identifier = "3000"
+  default_tags = {tag3="val3"}
 
 [[inputs.opcua_listener.group]]
 name = "bar"
 namespace = "0"
 identifier_type = "i"
-tags = [["tag1", "val1"], ["tag2", "val2"]]
-nodes = [{name="name4", identifier="4000", tags=[["tag1", "override"]]}]
+default_tags = {tag1="val1", tag2="val2"}
+[[inputs.opcua_listener.group.nodes]]
+  name = "name4"
+  identifier = "4000"
+  default_tags = {tag1="override"}
 
 [inputs.opcua_listener.workarounds]
 additional_valid_status_codes = ["0xC0"]
@@ -466,22 +472,22 @@ additional_valid_status_codes = ["0xC0"]
 			MetricName:     "foo",
 			Namespace:      "3",
 			IdentifierType: "i",
-			TagsSlice:      [][]string{{"tag1", "val1"}, {"tag2", "val2"}},
+			DefaultTags:    map[string]string{"tag1": "val1", "tag2": "val2"},
 			Nodes: []input.NodeSettings{{
-				FieldName:  "name3",
-				Identifier: "3000",
-				TagsSlice:  [][]string{{"tag3", "val3"}},
+				FieldName:   "name3",
+				Identifier:  "3000",
+				DefaultTags: map[string]string{"tag3": "val3"},
 			}},
 		},
 		{
 			MetricName:     "bar",
 			Namespace:      "0",
 			IdentifierType: "i",
-			TagsSlice:      [][]string{{"tag1", "val1"}, {"tag2", "val2"}},
+			DefaultTags:    map[string]string{"tag1": "val1", "tag2": "val2"},
 			Nodes: []input.NodeSettings{{
-				FieldName:  "name4",
-				Identifier: "4000",
-				TagsSlice:  [][]string{{"tag1", "override"}},
+				FieldName:   "name4",
+				Identifier:  "4000",
+				DefaultTags: map[string]string{"tag1": "override"},
 			}},
 		},
 	}, o.subscribeClientConfig.Groups)
@@ -500,8 +506,11 @@ subscription_interval = "200ms"
 name = "foo"
 namespace = "3"
 identifier_type = "i"
-tags = [["tag1", "val1"], ["tag2", "val2"]]
-nodes = [{name="name3", identifier="3000", tags=[["tag3", "val3"]]}]
+default_tags = {tag1="val1", tag2="val2"}
+[[inputs.opcua_listener.group.nodes]]
+  name = "name3"
+  identifier = "3000"
+  default_tags = {tag3="val3"}
 
 [inputs.opcua_listener.group.nodes.monitoring_params]
 sampling_interval = "50ms"
@@ -531,11 +540,11 @@ deadband_value = 100.0
 			MetricName:     "foo",
 			Namespace:      "3",
 			IdentifierType: "i",
-			TagsSlice:      [][]string{{"tag1", "val1"}, {"tag2", "val2"}},
+			DefaultTags:    map[string]string{"tag1": "val1", "tag2": "val2"},
 			Nodes: []input.NodeSettings{{
-				FieldName:  "name3",
-				Identifier: "3000",
-				TagsSlice:  [][]string{{"tag3", "val3"}},
+				FieldName:   "name3",
+				Identifier:  "3000",
+				DefaultTags: map[string]string{"tag3": "val3"},
 				MonitoringParams: input.MonitoringParameters{
 					SamplingInterval: 50000000,
 					QueueSize:        &queueSize,


### PR DESCRIPTION
## Summary

Removes the `data_type`, `description` and `tags` options which were stated to be removed in 1.35.0.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues
