### PR TITLE
feat(config): Remove deprecated options

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -215,16 +215,6 @@ type AgentConfig struct {
 	// not be less than 2 times MetricBatchSize.
 	MetricBufferLimit int
 
-	// FlushBufferWhenFull tells Telegraf to flush the metric buffer whenever
-	// it fills up, regardless of FlushInterval. Setting this option to true
-	// does _not_ deactivate FlushInterval.
-	FlushBufferWhenFull bool `toml:"flush_buffer_when_full" deprecated:"0.13.0;1.35.0;option is ignored"`
-
-	// TODO(cam): Remove UTC and parameter, they are no longer
-	// valid for the agent config. Leaving them here for now for backwards-
-	// compatibility
-	UTC bool `toml:"utc" deprecated:"1.0.0;1.35.0;option is ignored"`
-
 	// Debug is the option for running in debug mode
 	Debug bool `toml:"debug"`
 


### PR DESCRIPTION
## Summary

Remove deprecated options `flush_buffer_when_full` and `utc` which were stated to be removed in 1.35.0

## Checklist

- [x] No AI generated code was used in this PR

## Related issues
