### PR TITLE
feat(parsers.xpath): Remove deprecated options

### DIFF
--- a/plugins/parsers/xpath/parser.go
+++ b/plugins/parsers/xpath/parser.go
@@ -17,7 +17,6 @@ import (
 	"github.com/srebhan/protobufquery"
 
 	"github.com/influxdata/telegraf"
-	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/filter"
 	"github.com/influxdata/telegraf/internal"
 	"github.com/influxdata/telegraf/metric"
@@ -45,17 +44,11 @@ type Parser struct {
 	PrintDocument        bool              `toml:"xpath_print_document"`
 	AllowEmptySelection  bool              `toml:"xpath_allow_empty_selection"`
 	NativeTypes          bool              `toml:"xpath_native_types"`
-	Trace                bool              `toml:"xpath_trace" deprecated:"1.35.0;use 'log_level' 'trace' instead"`
+	Trace                bool              `toml:"xpath_trace" deprecated:"1.35.0;1.40.0;use 'log_level' 'trace' instead"`
 	Configs              []Config          `toml:"xpath"`
 	DefaultMetricName    string            `toml:"-"`
 	DefaultTags          map[string]string `toml:"-"`
 	Log                  telegraf.Logger   `toml:"-"`
-
-	// Required for backward compatibility
-	ConfigsXML     []Config `toml:"xml" deprecated:"1.23.1;1.35.0;use 'xpath' instead"`
-	ConfigsJSON    []Config `toml:"xpath_json" deprecated:"1.23.1;1.35.0;use 'xpath' instead"`
-	ConfigsMsgPack []Config `toml:"xpath_msgpack" deprecated:"1.23.1;1.35.0;use 'xpath' instead"`
-	ConfigsProto   []Config `toml:"xpath_protobuf" deprecated:"1.23.1;1.35.0;use 'xpath' instead"`
 
 	document dataDocument
 }
@@ -91,42 +84,12 @@ func (p *Parser) Init() error {
 	switch p.Format {
 	case "", "xml":
 		p.document = &xmlDocument{}
-
-		// Required for backward compatibility
-		if len(p.ConfigsXML) > 0 {
-			p.Configs = append(p.Configs, p.ConfigsXML...)
-			config.PrintOptionDeprecationNotice("parsers.xpath", "xml", telegraf.DeprecationInfo{
-				Since:     "1.23.1",
-				RemovalIn: "1.35.0",
-				Notice:    "use 'xpath' instead",
-			})
-		}
 	case "xpath_cbor":
 		p.document = &cborDocument{}
 	case "xpath_json":
 		p.document = &jsonDocument{}
-
-		// Required for backward compatibility
-		if len(p.ConfigsJSON) > 0 {
-			p.Configs = append(p.Configs, p.ConfigsJSON...)
-			config.PrintOptionDeprecationNotice("parsers.xpath", "xpath_json", telegraf.DeprecationInfo{
-				Since:     "1.23.1",
-				RemovalIn: "1.35.0",
-				Notice:    "use 'xpath' instead",
-			})
-		}
 	case "xpath_msgpack":
 		p.document = &msgpackDocument{}
-
-		// Required for backward compatibility
-		if len(p.ConfigsMsgPack) > 0 {
-			p.Configs = append(p.Configs, p.ConfigsMsgPack...)
-			config.PrintOptionDeprecationNotice("parsers.xpath", "xpath_msgpack", telegraf.DeprecationInfo{
-				Since:     "1.23.1",
-				RemovalIn: "1.35.0",
-				Notice:    "use 'xpath' instead",
-			})
-		}
 	case "xpath_protobuf":
 		if p.ProtobufMessageDef != "" && !slices.Contains(p.ProtobufMessageFiles, p.ProtobufMessageDef) {
 			p.ProtobufMessageFiles = append(p.ProtobufMessageFiles, p.ProtobufMessageDef)
@@ -142,16 +105,6 @@ func (p *Parser) Init() error {
 			return err
 		}
 		p.document = &pbdoc
-
-		// Required for backward compatibility
-		if len(p.ConfigsProto) > 0 {
-			p.Configs = append(p.Configs, p.ConfigsProto...)
-			config.PrintOptionDeprecationNotice("parsers.xpath", "xpath_proto", telegraf.DeprecationInfo{
-				Since:     "1.23.1",
-				RemovalIn: "1.35.0",
-				Notice:    "use 'xpath' instead",
-			})
-		}
 	default:
 		return fmt.Errorf("unknown data-format %q for xpath parser", p.Format)
 	}

--- a/plugins/parsers/xpath/parser_test.go
+++ b/plugins/parsers/xpath/parser_test.go
@@ -1357,12 +1357,12 @@ func TestTestCases(t *testing.T) {
 				metricName = fileformat
 			}
 			parser := &Parser{
-				DefaultMetricName:   metricName,
-				Format:              fileformat,
-				ProtobufMessageDef:  pbmsgdef,
-				ProtobufMessageType: pbmsgtype,
-				Configs:             []Config{*cfg},
-				Log:                 testutil.Logger{Name: "parsers.xml"},
+				DefaultMetricName:    metricName,
+				Format:               fileformat,
+				ProtobufMessageFiles: []string{pbmsgdef},
+				ProtobufMessageType:  pbmsgtype,
+				Configs:              []Config{*cfg},
+				Log:                  testutil.Logger{Name: "parsers.xml"},
 			}
 			require.NoError(t, parser.Init())
 			outputs, err := parser.Parse(content)
@@ -1383,12 +1383,12 @@ func TestTestCases(t *testing.T) {
 func TestProtobufImporting(t *testing.T) {
 	// Setup the parser and run it.
 	parser := &Parser{
-		DefaultMetricName:   "xpath_protobuf",
-		Format:              "xpath_protobuf",
-		ProtobufMessageDef:  "person.proto",
-		ProtobufMessageType: "importtest.Person",
-		ProtobufImportPaths: []string{"testcases/protos"},
-		Log:                 testutil.Logger{Name: "parsers.protobuf"},
+		DefaultMetricName:    "xpath_protobuf",
+		Format:               "xpath_protobuf",
+		ProtobufMessageFiles: []string{"person.proto"},
+		ProtobufMessageType:  "importtest.Person",
+		ProtobufImportPaths:  []string{"testcases/protos"},
+		Log:                  testutil.Logger{Name: "parsers.protobuf"},
 	}
 	require.NoError(t, parser.Init())
 }
@@ -1648,12 +1648,12 @@ func BenchmarkParsingJSON(b *testing.B) {
 
 func BenchmarkParsingProtobuf(b *testing.B) {
 	plugin := &Parser{
-		DefaultMetricName:   "benchmark",
-		Format:              "xpath_protobuf",
-		ProtobufMessageDef:  "benchmark.proto",
-		ProtobufMessageType: "benchmark.BenchmarkData",
-		ProtobufImportPaths: []string{".", "./testcases/protobuf_benchmark"},
-		NativeTypes:         true,
+		DefaultMetricName:    "benchmark",
+		Format:               "xpath_protobuf",
+		ProtobufMessageFiles: []string{"benchmark.proto"},
+		ProtobufMessageType:  "benchmark.BenchmarkData",
+		ProtobufImportPaths:  []string{".", "./testcases/protobuf_benchmark"},
+		NativeTypes:          true,
 		Configs: []Config{
 			{
 				Selection:    "//data",


### PR DESCRIPTION
## Summary

Remove options `xml`, `xpath_json`, `xpath_msgpack` and `xpath_protobuf` which were stated to be removed in 1.35.0.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues
