### PR TITLE
feat(inputs.win_perf_counters): Remove deprecated options

### DIFF
--- a/plugins/inputs/win_perf_counters/README.md
+++ b/plugins/inputs/win_perf_counters/README.md
@@ -285,21 +285,6 @@ Set it to `0s` to disable periodic refreshing.
 Example:
 `CountersRefreshInterval=1m`
 
-##### PreVistaSupport
-
-(Deprecated in 1.7; Necessary features on Windows Vista and newer are checked
-dynamically)
-
-Bool, if set to `true`, the plugin will use the localized PerfCounter interface
-that has been present since before Vista for backwards compatibility.
-
-It is recommended NOT to use this on OSes starting with Vista and newer because
-it requires more configuration to use this than the newer interface present
-since Vista.
-
-Example for Windows Server 2003, this would be set to true:
-`PreVistaSupport=true`
-
 ##### UsePerfCounterTime
 
 Bool, if set to `true` will request a timestamp along with the PerfCounter data.

--- a/plugins/inputs/win_perf_counters/README.md
+++ b/plugins/inputs/win_perf_counters/README.md
@@ -377,8 +377,9 @@ is set to `true`.
 
 ##### Sources (Object) (Optional)
 
-Overrides the [Sources](#sources-optional) global parameter for current performance
-object. See [Sources](#sources-optional) description for more details.
+Overrides the [Sources](#sources-optional) global parameter for current
+performance object. See [Sources](#sources-optional) description for more
+details.
 
 ##### Measurement (Optional)
 

--- a/plugins/inputs/win_perf_counters/win_perf_counters.go
+++ b/plugins/inputs/win_perf_counters/win_perf_counters.go
@@ -30,7 +30,6 @@ const emptyInstance = "------"
 
 type WinPerfCounters struct {
 	PrintValid                 bool            `toml:"PrintValid"`
-	PreVistaSupport            bool            `toml:"PreVistaSupport" deprecated:"1.7.0;1.35.0;determined dynamically"`
 	UsePerfCounterTime         bool            `toml:"UsePerfCounterTime"`
 	Object                     []perfObject    `toml:"object"`
 	CountersRefreshInterval    config.Duration `toml:"CountersRefreshInterval"`


### PR DESCRIPTION
## Summary

Remove `PreVistaSupport` option which was stated to be removed in 1.35.0.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

