### PR TITLE
feat(parsers.binary): Remove deprecated options

### DIFF
--- a/plugins/parsers/binary/parser.go
+++ b/plugins/parsers/binary/parser.go
@@ -16,10 +16,8 @@ import (
 
 type Parser struct {
 	AllowNoMatch bool            `toml:"allow_no_match"`
-	Endianess    string          `toml:"endianess" deprecated:"1.27.4;1.35.0;use 'endianness' instead"`
 	Endianness   string          `toml:"endianness"`
 	Configs      []Config        `toml:"binary"`
-	HexEncoding  bool            `toml:"hex_encoding" deprecated:"1.30.0;1.35.0;use 'binary_encoding' instead"`
 	Encoding     string          `toml:"binary_encoding"`
 	Log          telegraf.Logger `toml:"-"`
 
@@ -29,17 +27,6 @@ type Parser struct {
 }
 
 func (p *Parser) Init() error {
-	// Keep backward compatibility
-	if p.Endianess != "" && p.Endianness == "" {
-		p.Endianness = p.Endianess
-	}
-	if p.HexEncoding {
-		if p.Encoding != "" && p.Encoding != "hex" {
-			return errors.New("conflicting settings between 'hex_encoding' and 'binary_encoding'")
-		}
-		p.Encoding = "hex"
-	}
-
 	switch p.Endianness {
 	case "le":
 		p.converter = binary.LittleEndian


### PR DESCRIPTION
## Summary

Remove `endianess` and `hex_encoding` options which were stated to be removed in 1.35.0.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues
