### PR TITLE
docs(linter): Switch to markdownlint for line-length lint

### DIFF
--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -1,0 +1,12 @@
+{
+  "MD013": {
+    "code_blocks": false,
+    "tables": false,
+    "heading_line_length": 90
+  },
+  "MD033": {
+    "allowed_elements": [
+      "br"
+    ]
+  }
+}

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,6 +1,0 @@
-{
-    "MD013": false,
-    "MD033": {
-      "allowed_elements": ["br"]
-    }
-}

--- a/tools/readme_linter/assert.go
+++ b/tools/readme_linter/assert.go
@@ -30,7 +30,10 @@ func (t *T) printFailedAssertf(n ast.Node, format string, args ...interface{}) {
 
 // Assert function that doesnt involve a node, for example if something is missing
 func (t *T) assertf(format string, args ...interface{}) {
-	t.assertLine2f(0, format, args...) // There's no line number associated, so use the first
+	t.printFileLine(0) // There's no line number associated, so use the first
+	fmt.Printf(format+"\n", args...)
+	t.printRule(3)
+	t.fails++
 }
 
 func (t *T) assertNodef(n ast.Node, format string, args ...interface{}) {
@@ -39,20 +42,6 @@ func (t *T) assertNodef(n ast.Node, format string, args ...interface{}) {
 
 func (t *T) assertNodeLineOffsetf(n ast.Node, offset int, format string, args ...interface{}) {
 	t.printFileOffset(n, offset)
-	fmt.Printf(format+"\n", args...)
-	t.printRule(3)
-	t.fails++
-}
-
-func (t *T) assertLinef(line int, format string, args ...interface{}) {
-	// this func only exists to make the call stack to t.printRule the same depth
-	// as when called through assertf
-
-	t.assertLine2f(line, format, args...)
-}
-
-func (t *T) assertLine2f(line int, format string, args ...interface{}) {
-	t.printFileLine(line)
 	fmt.Printf(format+"\n", args...)
 	t.printRule(3)
 	t.fails++

--- a/tools/readme_linter/main.go
+++ b/tools/readme_linter/main.go
@@ -49,7 +49,6 @@ func init() {
 		firstSection,
 		configSection,
 		relativeTelegrafLinks,
-		noLongLinesInParagraphs(80),
 	}
 	for i := pluginInput; i <= pluginParser; i++ {
 		rules[i] = all


### PR DESCRIPTION
## Summary

This PR activates the [line-length check](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md013---line-length) of markdownlint and removes the hand-crafted linter for this purpose from `tools/readme_linter`.

The PR additionally renames the markdownlint configuration file to use the correct file-format suffix.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues
