### PR TITLE
fix(outputs.nats): Unwrap wrapped metrics to avoid panic on missing Field method

### DIFF
--- a/plugins/outputs/nats/nats.go
+++ b/plugins/outputs/nats/nats.go
@@ -341,9 +341,13 @@ func (n *NATS) Write(metrics []telegraf.Metric) error {
 		}
 	} else {
 		var subject bytes.Buffer
-		for i, m := range metrics {
+		for i, raw := range metrics {
+			m := raw
+			if wm, ok := m.(telegraf.UnwrappableMetric); ok {
+				m = wm.Unwrap()
+			}
 			subject.Reset()
-			if err := n.tplSubject.Execute(&subject, m.(telegraf.TemplateMetric)); err != nil {
+			if err := n.tplSubject.Execute(&subject, m); err != nil {
 				return fmt.Errorf("failed to execute subject template: %w", err)
 			}
 			sub := subject.String()


### PR DESCRIPTION
## Summary
Fixes a panic caused by a cast to TemplateMetric in the templating step of writing to the output. Also adds a new check to unwrap tracking metrics before applying to the template

## Checklist
- [x] No AI generated code was used in this PR

## Related issues
resolves #17780
