### PR TITLE
test(inputs.tail): Avoid race when editing file

### DIFF
--- a/plugins/inputs/tail/tail_test.go
+++ b/plugins/inputs/tail/tail_test.go
@@ -1117,6 +1117,9 @@ func TestTailNoLeak(t *testing.T) {
 			"Expected exactly one tailer after Gather #%d, but found %d", i+1, currentTailerCount)
 	}
 
+	// Reset metrics to make it easier to test for the new value
+	acc.ClearMetrics()
+
 	// Append new content to the file to verify the tailer is still working
 	appendContent := "cpu usage_idle=200\r\n"
 	f, err := os.OpenFile(logFile, os.O_APPEND|os.O_WRONLY, 0600)
@@ -1124,9 +1127,6 @@ func TestTailNoLeak(t *testing.T) {
 	_, err = f.WriteString(appendContent)
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
-
-	// Reset metrics to make it easier to test for the new value
-	acc.ClearMetrics()
 
 	// Call Gather to pick up the new content
 	require.NoError(t, acc.GatherError(tt.Gather))


### PR DESCRIPTION
## Summary

This PR tries to fix

```
=== FAIL: plugins/inputs/tail TestTailNoLeak (3.10s)
    tail_test.go:1135: 
                Error Trace:    /go/src/github.com/influxdata/telegraf/plugins/inputs/tail/tail_test.go:1135
                Error:          Condition never satisfied
                Test:           TestTailNoLeak
                Messages:       Did not receive metric after appending to file
```

by clearing the accumulator _before_ writing new data to avoid a race between the `acc` being cleared and data is picked up by the plugin's internal tailer.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues
