### PR TITLE
chore(ci): Temporarily disable race testing on Windows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,11 +41,21 @@ commands:
           condition:
             equal: [ "386", << parameters.arch >> ]
           steps:
+      # Disable -race on Windows due to issues with CGO in the test-go-windows CI job.
+      # See https://github.com/influxdata/telegraf/pull/17789
+      #      - run: echo 'export RACE="-race"' >> $BASH_ENV
             - unless:
                 condition:
                   equal: [ windows, << parameters.os >> ]
                 steps:
                   - run: echo 'export RACE="-race"' >> $BASH_ENV
+
+      # Disable CGO on Windows for the same reason as above.
+      #- when:
+      #    condition:
+      #      equal: [ windows, << parameters.os >> ]
+      #    steps:
+      #      - run: echo 'export CGO_ENABLED=1' >> $BASH_ENV
       - when:
           condition:
             equal: [ darwin, << parameters.os >> ]


### PR DESCRIPTION
## Summary
Temporarily disables race testing (`-race`) and CGO on the `test-go-windows` CI task so that tests can run again. Still investigating how to re-enable this long-term

## Checklist
- [x] No AI generated code was used in this PR

## Related issues
resolves #
