### PR TITLE
feat(inputs.sqlserver): Set pool size and idle connection

### DIFF
--- a/plugins/inputs/sqlserver/README.md
+++ b/plugins/inputs/sqlserver/README.md
@@ -168,14 +168,11 @@ to use them.
   ## - SQLServerAvailabilityReplicaStates
   ## - SQLServerDatabaseReplicaStates
 
-  ## Connection pool configuration.
-  ## Set the maximum number of open connections to the database.
-  ## Default is 0 (unlimited)
+  ## Maximum number of open connections to the database, 0 allows the driver to decide.
   # max_open_connections = 0
 
-  ## Set the maximum number of connections in the idle connection pool.
-  ## Default is 2
-  # max_idle_connections = 2
+  ## Maximum number of idle connections in the connection pool, 0 allows the driver to decide.
+  # max_idle_connections = 0
 ```
 
 ### Additional Setup

--- a/plugins/inputs/sqlserver/sample.conf
+++ b/plugins/inputs/sqlserver/sample.conf
@@ -130,11 +130,8 @@
   ## - SQLServerAvailabilityReplicaStates
   ## - SQLServerDatabaseReplicaStates
 
-  ## Connection pool configuration.
-  ## Set the maximum number of open connections to the database.
-  ## Default is 0 (unlimited)
+  ## Maximum number of open connections to the database, 0 allows the driver to decide.
   # max_open_connections = 0
 
-  ## Set the maximum number of connections in the idle connection pool.
-  ## Default is 2
-  # max_idle_connections = 2
+  ## Maximum number of idle connections in the connection pool, 0 allows the driver to decide.
+  # max_idle_connections = 0

--- a/plugins/inputs/sqlserver/sqlserver.go
+++ b/plugins/inputs/sqlserver/sqlserver.go
@@ -173,15 +173,11 @@ func (s *SQLServer) Start(acc telegraf.Accumulator) error {
 		// Use max_open_connections if any
 		if s.MaxOpenConnections > 0 {
 			pool.SetMaxOpenConns(s.MaxOpenConnections)
-		} else {
-			pool.SetMaxOpenConns(0)
 		}
 
 		// Use max_idle_connections if any
 		if s.MaxIdleConnections > 0 {
 			pool.SetMaxIdleConns(s.MaxIdleConnections)
-		} else {
-			pool.SetMaxIdleConns(2)
 		}
 
 		s.pools = append(s.pools, pool)


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
`[[inputs.sqlserver]]` do not support connection pooling. Hence it created multiple connection to the database. This PR is to add the connection pool.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #17781
