### PR TITLE
test(processors.snmp_lookup): Fix flaky test

### DIFF
--- a/plugins/processors/snmp_lookup/store_test.go
+++ b/plugins/processors/snmp_lookup/store_test.go
@@ -57,10 +57,7 @@ func TestLookup(t *testing.T) {
 	// Initial lookup should cache entries
 	s.lookup("127.0.0.1", "999")
 	require.Eventually(t, func() bool {
-		return s.cache.Contains("127.0.0.1")
-	}, time.Second, time.Millisecond)
-	require.Eventually(t, func() bool {
-		return notifyCount.Load() == 1
+		return s.cache.Contains("127.0.0.1") && notifyCount.Load() == 1
 	}, time.Second, time.Millisecond)
 
 	entries, _ := s.cache.Get("127.0.0.1")


### PR DESCRIPTION
## Summary
Attempts to fix the flaky test in snmp_lookup by adding some more loose timing to checks. Went from consistently failing at `-count=1000` to consistently passing at `-count=10000`

## Checklist
- [x] No AI generated code was used in this PR

## Related issues
resolves #
