### PR TITLE
chore(ci): Add debug flag to windows go install to avoid context deadline

### DIFF
--- a/scripts/installgo_windows.sh
+++ b/scripts/installgo_windows.sh
@@ -5,7 +5,7 @@ set -eux
 GO_VERSION="1.25.3"
 
 setup_go () {
-    choco upgrade golang --allow-downgrade --version=${GO_VERSION}
+    choco upgrade golang -d --allow-downgrade --version=${GO_VERSION}
 }
 
 if command -v go >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
Should help to avoid the `test-go-windows` CI job failing occasionally because of timing out due to no log output when installing Go ([example](https://app.circleci.com/pipelines/github/influxdata/telegraf/28412/workflows/616738ba-3400-4412-9f48-8abd2fff87c0/jobs/454252)) (or, if this actually did fail silently, may help to show why instead of just being silent)

## Checklist
- [x] No AI generated code was used in this PR

## Related issues
resolves #
