### PR TITLE
chore(tools): Add license check to make check-deps

### DIFF
--- a/docs/LICENSE_OF_DEPENDENCIES.md
+++ b/docs/LICENSE_OF_DEPENDENCIES.md
@@ -490,7 +490,7 @@ following works:
 - gopkg.in/tomb.v2 [BSD 3-Clause Clear License](https://github.com/go-tomb/tomb/blob/v2/LICENSE)
 - gopkg.in/yaml.v2 [Apache License 2.0](https://github.com/go-yaml/yaml/blob/v2.2.2/LICENSE)
 - gopkg.in/yaml.v3 [MIT License](https://github.com/go-yaml/yaml/blob/v3/LICENSE)
-- howett.net/plist [BSD 2-Clause with views sentence](https://github.com/DHowett/go-plist/blob/main/LICENSE)
+- howett.net/plist [BSD-2-Clause-Views, BSD-3-Clause](https://github.com/DHowett/go-plist/blob/main/LICENSE)
 - k8s.io/api [Apache License 2.0](https://github.com/kubernetes/client-go/blob/master/LICENSE)
 - k8s.io/apimachinery [Apache License 2.0](https://github.com/kubernetes/client-go/blob/master/LICENSE)
 - k8s.io/client-go [Apache License 2.0](https://github.com/kubernetes/client-go/blob/master/LICENSE)


### PR DESCRIPTION
## Summary
~~Fixes a nightly error we have after #17375 merged ([pipeline](https://app.circleci.com/pipelines/github/influxdata/telegraf/28415/workflows/d30cf7c0-7a38-4f80-bebe-1bcfd694db2e/jobs/454293))~~ Now handled in #17837

Adds the license checker to make check-deps since it is in my opinion valuable to check more often and does not take long to run. Let me know if there is a reason this wasn't done before and I can revert this PR to only include the license of dependencies file change.

## Checklist
- [x] No AI generated code was used in this PR

## Related issues
resolves #
