### PR TITLE
test(incus): Update image list

### DIFF
--- a/tools/package_incus_test/main.go
+++ b/tools/package_incus_test/main.go
@@ -12,7 +12,7 @@ import (
 var imagesRPM = []string{
 	"fedora/42",
 	"fedora/41",
-	"centos/9-Stream",
+	"centos/10-Stream",
 }
 
 var imagesDEB = []string{
@@ -23,7 +23,7 @@ var imagesDEB = []string{
 	// LTS
 	"ubuntu/noble",
 	// Latest
-	"ubuntu/questing",
+	"ubuntu/plucky",
 }
 
 func main() {


### PR DESCRIPTION
## Summary
`fedora/40` is no longer available: [pipeline](https://app.circleci.com/pipelines/github/influxdata/telegraf/28415/workflows/d30cf7c0-7a38-4f80-bebe-1bcfd694db2e/jobs/454304)

Also updates CentOS to 10, and Debian and Ubuntu to include the latest LTS and latest release versions, (though Ubuntu 25.10 (Questing) is not on linuxcontainers yet, so I left it at Plucky) as well as comments to show intention here. Let me know if there is a different scheme we should do for these images instead

## Checklist
- [x] No AI generated code was used in this PR

## Related issues
resolves #
