### PR TITLE
chore(tools): Extend license checker to handle mixed-license whitelist entries

### DIFF
--- a/tools/license_checker/data/whitelist
+++ b/tools/license_checker/data/whitelist
@@ -1,2 +1,3 @@
 <github.com/couchbase/goutils@v0.1.2 Apache-2.0
 <=github.com/segmentio/asm@v1.2.0 MIT
+howett.net/plist BSD-2-Clause-Views,BSD-3-Clause

--- a/tools/license_checker/main.go
+++ b/tools/license_checker/main.go
@@ -171,6 +171,9 @@ func main() {
 				ignored++
 				continue
 			}
+			if info.spdx == "" {
+				info.spdx = strings.ReplaceAll(info.license, " ", "")
+			}
 			debugf("adding %q with license %q (%s) and version %q at %q...", info.name, info.license, info.spdx, info.version, info.url)
 			packageInfos = append(packageInfos, info)
 		}

--- a/tools/license_checker/whitelist.go
+++ b/tools/license_checker/whitelist.go
@@ -19,7 +19,7 @@ type whitelistEntry struct {
 	License  string
 }
 
-var re = regexp.MustCompile(`^([<=>]+\s*)?([-\.\/\w]+)(@v[\d\.]+)?\s+([-\.\w]+)$`)
+var re = regexp.MustCompile(`^([<=>]+\s*)?([-\.\/\w]+)(@v[\d\.]+)?\s+([-\.,\w]+)$`)
 
 func (w *whitelist) Parse(filename string) error {
 	file, err := os.Open(filename)


### PR DESCRIPTION
## Summary

This PR fixes an issue with the license-checking tool being unable to handle mixed licenses like

```
- howett.net/plist [BSD-2-Clause-Views, BSD-3-Clause](https://github.com/DHowett/go-plist/blob/main/LICENSE)
```

It does so by extending the code to pass on raw license text (the one in square brackets) to the whitelist check and allow to add comma-separated licenses to the whitelist.

Furthermore, the PR whitelists `howett.net/plist` (the entry above) after a manual check.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues
