### PR TITLE
feat(inputs.statsd): Improve performance

### DIFF
--- a/plugins/inputs/statsd/statsd.go
+++ b/plugins/inputs/statsd/statsd.go
@@ -567,7 +567,7 @@ func (s *Statsd) udpListen(conn *net.UDPConn) error {
 // packet into statsd strings and then calls parseStatsdLine, which parses a
 // single statsd metric into a struct.
 func (s *Statsd) parser() error {
-	p, err := newGraphiteParser(s)
+	p, err := s.newGraphiteParser()
 	if err != nil {
 		return err
 	}
@@ -1056,7 +1056,7 @@ func (s *Statsd) expireCachedMetrics() {
 
 // newGraphiteParser initializes and returns a new graphite.Parser. graphite.Parser returned is not safe to be used in
 // multiple goroutines.
-func newGraphiteParser(s *Statsd) (*graphite.Parser, error) {
+func (s *Statsd) newGraphiteParser() (*graphite.Parser, error) {
 	p := &graphite.Parser{Separator: s.MetricSeparator, Templates: s.Templates}
 	err := p.Init()
 	if err != nil {

--- a/plugins/inputs/statsd/statsd_test.go
+++ b/plugins/inputs/statsd/statsd_test.go
@@ -133,7 +133,7 @@ func BenchmarkParser(b *testing.B) {
 		AllowedPendingMessages: 250000,
 		NumberWorkerThreads:    5,
 	}
-	parser, err := newGraphiteParser(&plugin)
+	parser, err := plugin.newGraphiteParser()
 	require.NoError(b, err)
 
 	acc := &testutil.Accumulator{Discard: true}
@@ -343,7 +343,7 @@ func BenchmarkTCP(b *testing.B) {
 // Valid lines should be parsed and their values should be cached
 func TestParse_ValidLines(t *testing.T) {
 	s := newTestStatsd()
-	parser, err := newGraphiteParser(s)
+	parser, err := s.newGraphiteParser()
 	require.NoError(t, err)
 
 	validLines := []string{
@@ -362,7 +362,7 @@ func TestParse_ValidLines(t *testing.T) {
 // Tests low-level functionality of gauges
 func TestParse_Gauges(t *testing.T) {
 	s := newTestStatsd()
-	parser, err := newGraphiteParser(s)
+	parser, err := s.newGraphiteParser()
 	require.NoError(t, err)
 
 	// Test that gauge +- values work
@@ -434,7 +434,7 @@ func TestParse_Gauges(t *testing.T) {
 // Tests low-level functionality of sets
 func TestParse_Sets(t *testing.T) {
 	s := newTestStatsd()
-	parser, err := newGraphiteParser(s)
+	parser, err := s.newGraphiteParser()
 	require.NoError(t, err)
 
 	// Test that sets work
@@ -493,7 +493,7 @@ func TestParse_Sets_SetsAsFloat(t *testing.T) {
 	s := newTestStatsd()
 	s.FloatSets = true
 
-	parser, err := newGraphiteParser(s)
+	parser, err := s.newGraphiteParser()
 	require.NoError(t, err)
 
 	// Test that sets work
@@ -540,7 +540,7 @@ func TestParse_Sets_SetsAsFloat(t *testing.T) {
 // Tests low-level functionality of counters
 func TestParse_Counters(t *testing.T) {
 	s := newTestStatsd()
-	parser, err := newGraphiteParser(s)
+	parser, err := s.newGraphiteParser()
 	require.NoError(t, err)
 
 	// Test that counters work
@@ -602,7 +602,7 @@ func TestParse_CountersAsFloat(t *testing.T) {
 	s := newTestStatsd()
 	s.FloatCounters = true
 
-	parser, err := newGraphiteParser(s)
+	parser, err := s.newGraphiteParser()
 	require.NoError(t, err)
 
 	// Test that counters work
@@ -715,7 +715,7 @@ func TestParse_Timings(t *testing.T) {
 	s := newTestStatsd()
 	s.Percentiles = []number{90.0}
 
-	parser, err := newGraphiteParser(s)
+	parser, err := s.newGraphiteParser()
 	require.NoError(t, err)
 
 	acc := &testutil.Accumulator{}
@@ -754,7 +754,7 @@ func TestParse_Timings_TimingsAsFloat(t *testing.T) {
 	s.FloatTimings = true
 	s.Percentiles = []number{90.0}
 
-	parser, err := newGraphiteParser(s)
+	parser, err := s.newGraphiteParser()
 	require.NoError(t, err)
 
 	acc := &testutil.Accumulator{}
@@ -788,7 +788,7 @@ func TestParse_Timings_TimingsAsFloat(t *testing.T) {
 func TestParse_Distributions(t *testing.T) {
 	s := newTestStatsd()
 
-	parser, err := newGraphiteParser(s)
+	parser, err := s.newGraphiteParser()
 	require.NoError(t, err)
 
 	acc := &testutil.Accumulator{}
@@ -845,7 +845,7 @@ func TestParse_Distributions(t *testing.T) {
 func TestParseScientificNotation(t *testing.T) {
 	s := newTestStatsd()
 
-	parser, err := newGraphiteParser(s)
+	parser, err := s.newGraphiteParser()
 	require.NoError(t, err)
 
 	sciNotationLines := []string{
@@ -863,7 +863,7 @@ func TestParseScientificNotation(t *testing.T) {
 func TestParse_InvalidLines(t *testing.T) {
 	s := newTestStatsd()
 
-	parser, err := newGraphiteParser(s)
+	parser, err := s.newGraphiteParser()
 	require.NoError(t, err)
 
 	invalidLines := []string{
@@ -886,7 +886,7 @@ func TestParse_InvalidLines(t *testing.T) {
 func TestParse_InvalidSampleRate(t *testing.T) {
 	s := newTestStatsd()
 
-	parser, err := newGraphiteParser(s)
+	parser, err := s.newGraphiteParser()
 	require.NoError(t, err)
 
 	invalidLines := []string{
@@ -930,7 +930,7 @@ func TestParse_InvalidSampleRate(t *testing.T) {
 func TestParse_DefaultNameParsing(t *testing.T) {
 	s := newTestStatsd()
 
-	parser, err := newGraphiteParser(s)
+	parser, err := s.newGraphiteParser()
 	require.NoError(t, err)
 
 	validLines := []string{
@@ -968,7 +968,7 @@ func TestParse_Template(t *testing.T) {
 		"measurement.measurement.host.service",
 	}
 
-	parser, err := newGraphiteParser(s)
+	parser, err := s.newGraphiteParser()
 	require.NoError(t, err)
 
 	lines := []string{
@@ -1007,7 +1007,7 @@ func TestParse_TemplateFilter(t *testing.T) {
 		"cpu.idle.* measurement.measurement.host",
 	}
 
-	parser, err := newGraphiteParser(s)
+	parser, err := s.newGraphiteParser()
 	require.NoError(t, err)
 
 	lines := []string{
@@ -1047,7 +1047,7 @@ func TestParse_TemplateSpecificity(t *testing.T) {
 		"cpu.idle.* measurement.measurement.host",
 	}
 
-	parser, err := newGraphiteParser(s)
+	parser, err := s.newGraphiteParser()
 	require.NoError(t, err)
 
 	lines := []string{
@@ -1081,7 +1081,7 @@ func TestParse_TemplateFields(t *testing.T) {
 		"* measurement.measurement.field",
 	}
 
-	parser, err := newGraphiteParser(s)
+	parser, err := s.newGraphiteParser()
 	require.NoError(t, err)
 
 	lines := []string{
@@ -1183,7 +1183,7 @@ func TestParse_Fields(t *testing.T) {
 func TestParse_Tags(t *testing.T) {
 	s := newTestStatsd()
 
-	parser, err := newGraphiteParser(s)
+	parser, err := s.newGraphiteParser()
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -1340,7 +1340,7 @@ func TestParse_DataDogTags(t *testing.T) {
 			s := newTestStatsd()
 			s.DataDogExtensions = true
 
-			parser, err := newGraphiteParser(s)
+			parser, err := s.newGraphiteParser()
 			require.NoError(t, err)
 
 			require.NoError(t, s.parseStatsdLine(parser, tt.line))
@@ -1494,7 +1494,7 @@ func TestParse_DataDogContainerID(t *testing.T) {
 			s.DataDogExtensions = true
 			s.DataDogKeepContainerTag = tt.keep
 
-			parser, err := newGraphiteParser(s)
+			parser, err := s.newGraphiteParser()
 			require.NoError(t, err)
 
 			require.NoError(t, s.parseStatsdLine(parser, tt.line))
@@ -1510,7 +1510,7 @@ func TestParse_DataDogContainerID(t *testing.T) {
 func TestParseName(t *testing.T) {
 	s := newTestStatsd()
 
-	parser, err := newGraphiteParser(s)
+	parser, err := s.newGraphiteParser()
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -1539,7 +1539,7 @@ func TestParseName(t *testing.T) {
 	// Test with separator == "."
 	s.MetricSeparator = "."
 
-	parser, err = newGraphiteParser(s)
+	parser, err = s.newGraphiteParser()
 	require.NoError(t, err)
 
 	tests = []struct {
@@ -1571,7 +1571,7 @@ func TestParseName(t *testing.T) {
 func TestParse_MeasurementsWithSameName(t *testing.T) {
 	s := newTestStatsd()
 
-	parser, err := newGraphiteParser(s)
+	parser, err := s.newGraphiteParser()
 	require.NoError(t, err)
 
 	// Test that counters work
@@ -1592,7 +1592,7 @@ func TestCachesExpireAfterMaxTTL(t *testing.T) {
 	s := newTestStatsd()
 	s.MaxTTL = config.Duration(10 * time.Millisecond)
 
-	parser, err := newGraphiteParser(s)
+	parser, err := s.newGraphiteParser()
 	require.NoError(t, err)
 
 	acc := &testutil.Accumulator{}
@@ -1691,11 +1691,11 @@ func TestParse_MeasurementsWithMultipleValues(t *testing.T) {
 	}
 
 	sSingle := newTestStatsd()
-	sParser, err := newGraphiteParser(sSingle)
+	sParser, err := sSingle.newGraphiteParser()
 	require.NoError(t, err)
 
 	sMultiple := newTestStatsd()
-	mParser, err := newGraphiteParser(sMultiple)
+	mParser, err := sMultiple.newGraphiteParser()
 	require.NoError(t, err)
 
 	for _, line := range singleLines {
@@ -1754,7 +1754,7 @@ func TestParse_TimingsMultipleFieldsWithTemplate(t *testing.T) {
 	s.Templates = []string{"measurement.field"}
 	s.Percentiles = []number{90.0}
 
-	parser, err := newGraphiteParser(s)
+	parser, err := s.newGraphiteParser()
 	require.NoError(t, err)
 
 	acc := &testutil.Accumulator{}
@@ -1808,7 +1808,7 @@ func TestParse_TimingsMultipleFieldsWithoutTemplate(t *testing.T) {
 	s.Templates = make([]string, 0)
 	s.Percentiles = []number{90.0}
 
-	parser, err := newGraphiteParser(s)
+	parser, err := s.newGraphiteParser()
 	require.NoError(t, err)
 
 	acc := &testutil.Accumulator{}
@@ -1859,7 +1859,7 @@ func TestParse_TimingsMultipleFieldsWithoutTemplate(t *testing.T) {
 func BenchmarkParse(b *testing.B) {
 	s := newTestStatsd()
 
-	parser, err := newGraphiteParser(s)
+	parser, err := s.newGraphiteParser()
 	if err != nil {
 		b.Errorf("Error initializing parser: %v", err)
 	}
@@ -1889,7 +1889,7 @@ func BenchmarkParse(b *testing.B) {
 func BenchmarkParseWithTemplate(b *testing.B) {
 	s := newTestStatsd()
 
-	parser, err := newGraphiteParser(s)
+	parser, err := s.newGraphiteParser()
 	if err != nil {
 		b.Errorf("Error initializing parser: %v", err)
 	}
@@ -1920,7 +1920,7 @@ func BenchmarkParseWithTemplate(b *testing.B) {
 func BenchmarkParseWithTemplateAndFilter(b *testing.B) {
 	s := newTestStatsd()
 
-	parser, err := newGraphiteParser(s)
+	parser, err := s.newGraphiteParser()
 	if err != nil {
 		b.Errorf("Error initializing parser: %v", err)
 	}
@@ -1951,7 +1951,7 @@ func BenchmarkParseWithTemplateAndFilter(b *testing.B) {
 func BenchmarkParseWith2TemplatesAndFilter(b *testing.B) {
 	s := newTestStatsd()
 
-	parser, err := newGraphiteParser(s)
+	parser, err := s.newGraphiteParser()
 	if err != nil {
 		b.Errorf("Error initializing parser: %v", err)
 	}
@@ -1985,7 +1985,7 @@ func BenchmarkParseWith2TemplatesAndFilter(b *testing.B) {
 func BenchmarkParseWith2Templates3TagsAndFilter(b *testing.B) {
 	s := newTestStatsd()
 
-	parser, err := newGraphiteParser(s)
+	parser, err := s.newGraphiteParser()
 	if err != nil {
 		b.Errorf("Error initializing parser: %v", err)
 	}
@@ -2020,7 +2020,7 @@ func TestParse_Timings_Delete(t *testing.T) {
 	s := newTestStatsd()
 	s.DeleteTimings = true
 
-	parser, err := newGraphiteParser(s)
+	parser, err := s.newGraphiteParser()
 	require.NoError(t, err)
 
 	fakeacc := &testutil.Accumulator{}
@@ -2040,7 +2040,7 @@ func TestParse_Gauges_Delete(t *testing.T) {
 	s := newTestStatsd()
 	s.DeleteGauges = true
 
-	parser, err := newGraphiteParser(s)
+	parser, err := s.newGraphiteParser()
 	require.NoError(t, err)
 	fakeacc := &testutil.Accumulator{}
 
@@ -2059,7 +2059,7 @@ func TestParse_Sets_Delete(t *testing.T) {
 	s := newTestStatsd()
 	s.DeleteSets = true
 
-	parser, err := newGraphiteParser(s)
+	parser, err := s.newGraphiteParser()
 	require.NoError(t, err)
 
 	fakeacc := &testutil.Accumulator{}
@@ -2079,7 +2079,7 @@ func TestParse_Counters_Delete(t *testing.T) {
 	s := newTestStatsd()
 	s.DeleteCounters = true
 
-	parser, err := newGraphiteParser(s)
+	parser, err := s.newGraphiteParser()
 	require.NoError(t, err)
 
 	fakeacc := &testutil.Accumulator{}
@@ -2362,7 +2362,7 @@ func TestParseSanitize(t *testing.T) {
 	s := newTestStatsd()
 	s.SanitizeNamesMethod = "upstream"
 
-	parser, err := newGraphiteParser(s)
+	parser, err := s.newGraphiteParser()
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -2397,7 +2397,7 @@ func TestParseNoSanitize(t *testing.T) {
 	s := newTestStatsd()
 	s.SanitizeNamesMethod = ""
 
-	parser, err := newGraphiteParser(s)
+	parser, err := s.newGraphiteParser()
 	require.NoError(t, err)
 
 	tests := []struct {


### PR DESCRIPTION
## Summary
Avoid using the mutex in each metric name parse by passing each worker goroutine its own `graphite.Parser`.

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR

## Related issues
resolves #12313 

## Benchmark
There is a big difference in the overall throughput when using multiple threads

### Old code
```
BenchmarkParser-10                               	  305120	      3939 ns/op
BenchmarkUDP-10                                  	       1	2014095375 ns/op
BenchmarkUDPThreads4-10                          	     128	   8014808 ns/op
BenchmarkUDPThreads8-10                          	     126	   7963413 ns/op
BenchmarkUDPThreads16-10                         	     123	   8457920 ns/op
BenchmarkTCP-10                                  	       1	1583591084 ns/op
BenchmarkParse-10                                	   29188	     41003 ns/op
BenchmarkParseWithTemplate-10                    	   32236	     36990 ns/op
BenchmarkParseWithTemplateAndFilter-10           	   31557	     37952 ns/op
BenchmarkParseWith2TemplatesAndFilter-10         	   31798	     37983 ns/op
BenchmarkParseWith2Templates3TagsAndFilter-10    	   25666	     46949 ns/op
PASS
```

### New code
```
BenchmarkParser-10                               	  324426	      3748 ns/op
BenchmarkUDP-10                                  	       1	1545554250 ns/op
BenchmarkUDPThreads4-10                          	     235	   4815471 ns/op
BenchmarkUDPThreads8-10                          	     247	   4646433 ns/op
BenchmarkUDPThreads16-10                         	     220	   4568423 ns/op
BenchmarkTCP-10                                  	       1	1590451042 ns/op
BenchmarkParse-10                                	   31209	     38400 ns/op
BenchmarkParseWithTemplate-10                    	   31294	     38442 ns/op
BenchmarkParseWithTemplateAndFilter-10           	   30872	     38969 ns/op
BenchmarkParseWith2TemplatesAndFilter-10         	   30714	     39148 ns/op
BenchmarkParseWith2Templates3TagsAndFilter-10    	   22514	     53415 ns/op
PASS
```
