### PR TITLE
fix(inputs.kinesis_consumer): Ignore expired parent shards

### DIFF
--- a/plugins/inputs/kinesis_consumer/consumer.go
+++ b/plugins/inputs/kinesis_consumer/consumer.go
@@ -283,7 +283,7 @@ func (c *consumer) updateShardConsumers(ctx context.Context) error {
 				c.log.Tracef("shard %s has parent %s which is expired...", id, pid)
 			}
 		}
-		if shard.AdjacentParentShardId != nil && *shard.AdjacentParentShardId != "" && availableShardIDs[*shard.AdjacentParentShardId] {
+		if shard.AdjacentParentShardId != nil && *shard.AdjacentParentShardId != "" {
 			pid := *shard.AdjacentParentShardId
 			// The parent shard might be expired and thus not available anymore.
 			// In those cases, we need to start consuming the child shard


### PR DESCRIPTION
## Summary

When consuming Kinesis shards the code tries to begin as early as possible which, when resharding occured, means to start at the parent shards. However, in some cases the parent shards are already expired and therefore not accessible anymore (see [documentation](https://docs.aws.amazon.com/streams/latest/dev/kinesis-using-sdk-java-after-resharding.html#kinesis-using-sdk-java-resharding-data-routing)).

In the current code, this case is not handled and we rely on the parent shard being among the listed available shards. This assumption does not hold true for expired parent shards and thus the complete shard subgraph is not consumed.

This PR checks for expired parent shards and start consuming the present child shard in those cases.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #17871 
