### PR TITLE
chore(ci): Switch to m4pro.medium resource class for mac tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ executors:
       GOFLAGS: -p=4
   mac:
     working_directory: '~/go/src/github.com/influxdata/telegraf'
-    resource_class: macos.m1.medium.gen1
+    resource_class: m4pro.medium
     macos:
       xcode: 15.4.0
     environment:


### PR DESCRIPTION
## Summary
Switches from the `macos.m1.medium.gen1` resource class to `m4pro.medium` as the older resource class is deprecated and being removed early next year.

Deprecation notice: https://circleci.com/changelog/deprecation-of-mac-m1-and-m2-resource-classes/
MacOS resource classes: https://circleci.com/docs/guides/execution-managed/using-macos/#available-resource-classes

I chose `m4pro.medium` as following the deprecation removals, this is the cheaper of the two options, though is still a considerable upgrade compared to our previous resource class in terms of specs

## Checklist
- [x] No AI generated code was used in this PR

## Related issues
resolves #
