### PR TITLE
chore(dependabot): Add group for AWS dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,3 +18,8 @@ updates:
       - dependency-name: "*.v*"
     labels:
       - "dependencies"
+    groups:
+      aws-sdk-go-v2:
+        applies-to: version-updates
+        patterns:
+          - "github.com/aws/aws-sdk-go-v2*"


### PR DESCRIPTION
## Summary
Adds a dependabot group for AWS dependencies to reduce how many PRs dependabot opens for AWS, reducing merge conflicts

## Checklist
- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
resolves #
