### PR TITLE
chore(packaging): Add dependency to "influxdata-archive-keyring" package for RPM and DEB packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -394,6 +394,7 @@ $(include_packages):
 			--rpm-posttrans scripts/rpm/post-install.sh \
 			--rpm-os ${GOOS} \
 			--rpm-tag "Requires(pre): /usr/sbin/useradd" \
+			--rpm-tag "Recommends: influxdata-archive-keyring" \
 			--name telegraf \
 			--version $(version) \
 			--iteration $(rpm_iteration) \
@@ -416,6 +417,7 @@ $(include_packages):
 			--after-remove scripts/deb/post-remove.sh \
 			--before-remove scripts/deb/pre-remove.sh \
 			--description "Plugin-driven server agent for reporting metrics into InfluxDB." \
+			--deb-recommends "influxdata-archive-keyring" \
 			--name telegraf \
 			--version $(version) \
 			--iteration $(deb_iteration) \


### PR DESCRIPTION
## Summary
This adds the "influxdata-archive-keyring" package as a suggested package. This should make signing key rotations easier in the future.

```sh
$ dpkg -I build/dist/telegraf_1.37.0~c66f2b3c-0_amd64.deb
 new Debian package, version 2.0.
 size 78279352 bytes: control archive=1958 bytes.
      61 bytes,     2 lines      conffiles
     345 bytes,    12 lines      control
     391 bytes,     6 lines      md5sums
    1967 bytes,    79 lines   *  postinst             #!/bin/bash
     672 bytes,    33 lines   *  postrm               #!/bin/bash
     885 bytes,    24 lines   *  preinst              #!/bin/bash
     176 bytes,    10 lines   *  prerm                #!/bin/bash
 Package: telegraf
 Version: 1.37.0-0
 License: MIT
 Vendor: InfluxData
 Architecture: amd64
 Maintainer: support@influxdb.com
 Installed-Size: 293665
 Recommends: influxdata-archive-keyring
 Section: default
 Priority: optional
 Homepage: https://github.com/influxdata/telegraf
 Description: Plugin-driven server agent for reporting metrics into InfluxDB.
```
```sh
$ rpm -q --recommends build/dist/telegraf-1.37.0~c66f2b3c-0.amd64.rpm
influxdata-archive-keyring
```

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [X] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
