### PR TITLE
fix(outputs.loki): Sanitize colons in label names

### DIFF
--- a/plugins/outputs/loki/README.md
+++ b/plugins/outputs/loki/README.md
@@ -61,7 +61,7 @@ to use them.
 
   ## Sanitize Tag Names
   ## If true, all tag names will have invalid characters replaced with
-  ## underscores that do not match the regex: ^[a-zA-Z_:][a-zA-Z0-9_:]*.
+  ## underscores that do not match the regex: ^[a-zA-Z_][a-zA-Z0-9_]*.
   # sanitize_label_names = false
 
   ## Metric Name Label

--- a/plugins/outputs/loki/loki.go
+++ b/plugins/outputs/loki/loki.go
@@ -208,12 +208,12 @@ func (l *Loki) writeMetrics(s Streams) error {
 	return nil
 }
 
-// Verify the label name matches the regex [a-zA-Z_:][a-zA-Z0-9_:]*
+// Verify the label name matches the regex [a-zA-Z_][a-zA-Z0-9_]*
 func sanitizeLabelName(name string) string {
-	re := regexp.MustCompile(`^[^a-zA-Z_:]`)
+	re := regexp.MustCompile(`^[^a-zA-Z_]`)
 	result := re.ReplaceAllString(name, "_")
 
-	re = regexp.MustCompile(`[^a-zA-Z0-9_:]`)
+	re = regexp.MustCompile(`[^a-zA-Z0-9_]`)
 	return re.ReplaceAllString(result, "_")
 }
 

--- a/plugins/outputs/loki/loki_test.go
+++ b/plugins/outputs/loki/loki_test.go
@@ -620,6 +620,11 @@ func TestSanitizeLabelName(t *testing.T) {
 			input:    "foobar.foobar.2002",
 			expected: "foobar_foobar_2002",
 		},
+		{
+			name:     "replace colon",
+			input:    "foo:bar",
+			expected: "foo_bar",
+		},
 	}
 
 	for _, tt := range tests {

--- a/plugins/outputs/loki/sample.conf
+++ b/plugins/outputs/loki/sample.conf
@@ -26,7 +26,7 @@
 
   ## Sanitize Tag Names
   ## If true, all tag names will have invalid characters replaced with
-  ## underscores that do not match the regex: ^[a-zA-Z_:][a-zA-Z0-9_:]*.
+  ## underscores that do not match the regex: ^[a-zA-Z_][a-zA-Z0-9_]*.
   # sanitize_label_names = false
 
   ## Metric Name Label


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
This change fixes the issue that loki output plugin does not replace colons with underscores.

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #17919
