### PR TITLE
feat(outputs.amon): Deprecate plugin

### DIFF
--- a/plugins/outputs/amon/README.md
+++ b/plugins/outputs/amon/README.md
@@ -9,6 +9,8 @@ This plugin writes metrics to [Amon monitoring platform][amon]. It requires a
 > skipped.
 
 ⭐ Telegraf v0.2.1
+🚩 Telegraf v1.37.0
+🔥 Telegraf v1.40.0
 🏷️ datastore
 💻 all
 

--- a/plugins/outputs/deprecations.go
+++ b/plugins/outputs/deprecations.go
@@ -9,4 +9,9 @@ var Deprecations = map[string]telegraf.DeprecationInfo{
 		RemovalIn: "1.30.0",
 		Notice:    "use 'outputs.riemann' instead (see https://github.com/influxdata/telegraf/issues/1878)",
 	},
+	"amon": {
+		Since:     "1.37.0",
+		RemovalIn: "1.40.0",
+		Notice:    "service doesn't exist anymore and platform code is unmaintained",
+	},
 }


### PR DESCRIPTION
## Summary

The service and the domain at https://www.amon.cx no longer exists and the [platform code](https://github.com/amonapp/amon) is not maintained for more than 6 years. Therefore, this PR deprecates the plugin as it is of no use anymore...

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
