### PR TITLE
test(outputs.stackdriver): Fix interval test

### DIFF
--- a/plugins/outputs/stackdriver/stackdriver_test.go
+++ b/plugins/outputs/stackdriver/stackdriver_test.go
@@ -761,7 +761,7 @@ func TestIntervalEndpoints(t *testing.T) {
 					// times are backdated 1ms from the end time.
 					require.GreaterOrEqual(t, startTime.AsTime().UTC().Unix(), earlier.UTC().Unix())
 				} else {
-					require.GreaterOrEqual(t, startTime.AsTime().UTC().Unix(), later.UTC().Unix())
+					require.LessOrEqual(t, startTime.AsTime().UTC().Unix(), later.UTC().Unix())
 				}
 			}
 


### PR DESCRIPTION
## Summary

The current code uses the wrong condition for evaluating the start-time against the later metric time where the start should be **less or equal**!

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
