### PR TITLE
test(outputs.signalfx): Ensure value fields are not appended to event or datapoint name

### DIFF
--- a/plugins/outputs/signalfx/signalfx_test.go
+++ b/plugins/outputs/signalfx/signalfx_test.go
@@ -409,6 +409,61 @@ func TestSignalFx_SignalFx(t *testing.T) {
 				events:     make([]*event.Event, 0),
 			},
 		},
+		{
+			name: "add event for value field",
+			fields: fields{
+				IncludedEvents: []string{"event.value", "event"},
+			},
+			measurements: []*measurement{
+				{
+					name:   "event",
+					tags:   map[string]string{"host": "192.168.0.1"},
+					fields: map[string]interface{}{"value": "hello world"},
+					time:   time.Date(2010, time.November, 10, 23, 0, 0, 0, time.UTC),
+					tp:     telegraf.Untyped,
+				},
+			},
+			want: errorsink{
+				datapoints: make([]*datapoint.Datapoint, 0),
+				events: []*event.Event{
+					event.NewWithProperties(
+						"event",
+						event.AGENT,
+						map[string]string{
+							"host": "192.168.0.1",
+						},
+						map[string]interface{}{
+							"message": "hello world",
+						},
+						time.Date(2010, time.November, 10, 23, 0, 0, 0, time.UTC)),
+				},
+			},
+		},
+		{
+			name:   "add datapoint for value field",
+			fields: fields{},
+			measurements: []*measurement{
+				{
+					name:   "data",
+					tags:   map[string]string{"host": "192.168.0.1"},
+					fields: map[string]interface{}{"value": 3.14},
+					time:   time.Date(2010, time.November, 10, 23, 0, 0, 0, time.UTC),
+					tp:     telegraf.Untyped,
+				},
+			},
+			want: errorsink{
+				datapoints: []*datapoint.Datapoint{
+					datapoint.New(
+						"data",
+						map[string]string{"host": "192.168.0.1"},
+						datapoint.NewFloatValue(3.14),
+						datapoint.Gauge,
+						time.Date(2010, time.November, 10, 23, 0, 0, 0, time.UTC),
+					),
+				},
+				events: make([]*event.Event, 0),
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

Verify that `value` fields do not append `.value` to the SignalFX event or data-point names.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

resolves #17204 
