### PR TITLE
fix(inputs.opcua): Add private key for certificate-based user authentication

### DIFF
--- a/plugins/common/opcua/opcua_util.go
+++ b/plugins/common/opcua/opcua_util.go
@@ -222,16 +222,18 @@ func (o *OpcUAClient) generateClientOpts(endpoints []*ua.EndpointDescription) ([
 	}
 
 	var cert []byte
+	var pk *rsa.PrivateKey
 	if certFile != "" && keyFile != "" {
 		debug.Printf("Loading cert/key from %s/%s", certFile, keyFile)
 		c, err := tls.LoadX509KeyPair(certFile, keyFile)
 		if err != nil {
 			o.Log.Warnf("Failed to load certificate: %s", err)
 		} else {
-			pk, ok := c.PrivateKey.(*rsa.PrivateKey)
+			pkTemp, ok := c.PrivateKey.(*rsa.PrivateKey)
 			if !ok {
 				return nil, errors.New("invalid private key")
 			}
+			pk = pkTemp
 			cert = c.Certificate[0]
 			opts = append(opts, opcua.PrivateKey(pk), opcua.Certificate(cert))
 		}
@@ -258,12 +260,12 @@ func (o *OpcUAClient) generateClientOpts(endpoints []*ua.EndpointDescription) ([
 	o.Log.Debugf("security policy from configuration %s", secPolicy)
 
 	// Select the most appropriate authentication mode from server capabilities and user input
-	authMode, authOption, err := o.generateAuth(o.Config.AuthMethod, cert, o.Config.Username, o.Config.Password)
+	authMode, authOptions, err := o.generateAuth(o.Config.AuthMethod, cert, pk, o.Config.Username, o.Config.Password)
 	if err != nil {
 		return nil, err
 	}
 
-	opts = append(opts, authOption)
+	opts = append(opts, authOptions...)
 
 	var secMode ua.MessageSecurityMode
 	switch strings.ToLower(mode) {
@@ -359,13 +361,13 @@ func (o *OpcUAClient) generateClientOpts(endpoints []*ua.EndpointDescription) ([
 	return opts, nil
 }
 
-func (o *OpcUAClient) generateAuth(a string, cert []byte, user, passwd config.Secret) (ua.UserTokenType, opcua.Option, error) {
+func (o *OpcUAClient) generateAuth(a string, cert []byte, pk *rsa.PrivateKey, user, passwd config.Secret) (ua.UserTokenType, []opcua.Option, error) {
 	var authMode ua.UserTokenType
-	var authOption opcua.Option
+	var authOptions []opcua.Option
 	switch strings.ToLower(a) {
 	case "anonymous":
 		authMode = ua.UserTokenTypeAnonymous
-		authOption = opcua.AuthAnonymous()
+		authOptions = []opcua.Option{opcua.AuthAnonymous()}
 	case "username":
 		authMode = ua.UserTokenTypeUserName
 
@@ -393,25 +395,29 @@ func (o *OpcUAClient) generateAuth(a string, cert []byte, user, passwd config.Se
 			defer psecret.Destroy()
 			password = psecret.Bytes()
 		}
-		authOption = opcua.AuthUsername(string(username), string(password))
+		authOptions = []opcua.Option{opcua.AuthUsername(string(username), string(password))}
 	case "certificate":
 		authMode = ua.UserTokenTypeCertificate
-		authOption = opcua.AuthCertificate(cert)
+		authOptions = []opcua.Option{opcua.AuthCertificate(cert)}
+		if pk != nil {
+			o.Log.Debug("Setting private key for certificate-based user authentication")
+			authOptions = append(authOptions, opcua.AuthPrivateKey(pk))
+		}
 	case "issuedtoken":
 		// TODO: this is unsupported, should we fail here or let the opcua package handle it?
 		authMode = ua.UserTokenTypeIssuedToken
-		authOption = opcua.AuthIssuedToken([]byte(nil))
+		authOptions = []opcua.Option{opcua.AuthIssuedToken([]byte(nil))}
 	case "":
 		// Default to anonymous when auth method is not specified
 		authMode = ua.UserTokenTypeAnonymous
-		authOption = opcua.AuthAnonymous()
+		authOptions = []opcua.Option{opcua.AuthAnonymous()}
 	default:
 		o.Log.Warnf("unknown auth method %q, defaulting to Anonymous", a)
 		authMode = ua.UserTokenTypeAnonymous
-		authOption = opcua.AuthAnonymous()
+		authOptions = []opcua.Option{opcua.AuthAnonymous()}
 	}
 
-	return authMode, authOption, nil
+	return authMode, authOptions, nil
 }
 
 func validateEndpointConfig(endpoints []*ua.EndpointDescription, secPolicy string, secMode ua.MessageSecurityMode, authMode ua.UserTokenType) error {


### PR DESCRIPTION
# Fix Certificate-Based User Authentication in Telegraf OPC UA Plugin

## Problem

Certificate-based user authentication (`auth_method = "certificate"`) fails with errors even after PR [#17825](https://github.com/influxdata/telegraf/pull/17825):
- `StatusBadSecurityChecksFailed (0x80120000)`
- `StatusBadIdentityTokenRejected (0x80210000)`

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [ ] No AI generated code was used in this PR
- [x] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

It was used AI coding, not vibe coding. The test was done against two different OPC UA server as described later.

## Root Cause

PR [#17825](https://github.com/influxdata/telegraf/pull/17825) added `remote_certificate` for server certificate trust (transport layer), but the private key was not being provided for **user identity token signing** (session layer).

OPC UA uses certificates in two contexts:
1. **SecureChannel encryption** - `opcua.PrivateKey()` ✅ Working
2. **User identity token signing** - `opcua.AuthPrivateKey()` ❌ **MISSING**

The client couldn't sign the user identity token without the private key, causing authentication failures.

## Solution

Add `opcua.AuthPrivateKey(pk)` to the certificate authentication case in `plugins/common/opcua/opcua_util.go`.

### Key Changes

**File:** `plugins/common/opcua/opcua_util.go`

1. Capture private key at function scope (line 220-228)
2. Pass private key to `generateAuth()` (line 263)
3. Update `generateAuth()` signature to accept `pk *rsa.PrivateKey` and return `[]opcua.Option` (line 364)
4. Add private key for certificate auth (lines 401-405):
```go
case "certificate":
    authMode = ua.UserTokenTypeCertificate
    authOptions = []opcua.Option{opcua.AuthCertificate(cert)}
    if pk != nil {
        o.Log.Debug("Setting private key for certificate-based user authentication")
        authOptions = append(authOptions, opcua.AuthPrivateKey(pk))  // THE FIX
    }
```
5. Spread auth options array (line 268): `opts = append(opts, authOptions...)`

**Lines changed:** 18 insertions(+), 12 deletions(-)

## Testing Results

### Test Environment
- Telegraf 1.37.0-034523f6 (master with PR [#17825](https://github.com/influxdata/telegraf/pull/17825))
- Security: Basic256Sha256/SignAndEncrypt
- Certificate: RSA 2048-bit, thumbprint `02E273A867AF5B339DC22831D27212DC4DF27980`

### Microsoft OPC PLC (mcr.microsoft.com/iotedge/opc-plc:latest)

**Before:**
```
StatusBadSecurityChecksFailed
User: Anonymous
```

**After:**
```
Setting private key for certificate-based user authentication ✅
Connected to OPC UA Server ✅
Subscribed with subscription ID 2774778660 ✅
User: X509v3 Subject Alternative Name="URI:urn:freeopcua:client" ✅
```

### Prosys OPC UA Simulation Server v5.4.x

**Before:**
```
Certificate added to rejected certificates ❌
Session NOT activated - Bad_IdentityTokenRejected ❌
```

**After:**
```
Certificate added to trusted certificates ✅
Session activated: gopcua-1762500152149986269 ✅
SecurityPolicy: Basic256Sha256
Subscribed with subscription ID 1762500128 ✅
```

## Impact
- **Breaking Changes:** None
- **Backward Compatibility:** Fully maintained
- **Security:** Certificate authentication now functional
- **Performance:** Negligible impact

## Relationship to PR [#17825](https://github.com/influxdata/telegraf/pull/17825)

PR [#17825](https://github.com/influxdata/telegraf/pull/17825) enabled server certificate trust. This fix completes certificate support by enabling **client certificate authentication**.

Together:
- ✅ Trust self-signed server certificates (PR [#17825](https://github.com/influxdata/telegraf/pull/17825))
- ✅ Authenticate with client certificates (This fix)

## Acceptance Criteria
- [x] Certificate authentication works with Microsoft OPC PLC
- [x] Certificate authentication works with Prosys OPC UA Simulator
- [x] No regression in other authentication methods (anonymous, username)
- [x] Debug logging shows "Setting private key for certificate-based user authentication"
- [x] Sessions activated successfully (not rejected)
- [x] Subscriptions created successfully

## Technical Details

OPC UA Specification (Part 4 - Services, Section 5.6.3):
- **OpenSecureChannel** uses `opcua.PrivateKey()` for transport encryption
- **ActivateSession** requires `opcua.AuthPrivateKey()` to sign user identity token

Without `AuthPrivateKey()`, the server cannot verify the user's identity because the identity token isn't properly signed.

## Files Changed
- `plugins/common/opcua/opcua_util.go`
  - Functions: `generateClientOpts()`, `generateAuth()`

## References
- OPC UA Spec Part 4 Section 5.6.3 (ActivateSession)
- [gopcua library](https://github.com/gopcua/opcua) `opcua.AuthPrivateKey()` documentation
- Related: PR [#17825](https://github.com/influxdata/telegraf/pull/17825) (remote_certificate)
- Repository: https://github.com/influxdata/telegraf
