### PR TITLE
feat(inputs.ldap): Support external SASL bind (#17477)

### DIFF
--- a/plugins/inputs/ldap/README.md
+++ b/plugins/inputs/ldap/README.md
@@ -38,6 +38,12 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## Server dialect, can be "openldap" or "389ds"
   # dialect = "openldap"
 
+  # What sort of Bind to use
+  ## Empty or "simple" means to use a simple LDAP bind, otherwise use a
+  ## specified SASL mechanism (only EXTERNAL currently supported - for TLS
+  ## client certs or UNIX credentials)
+  # bind_mechanism = "simple"
+
   # DN and password to bind with
   ## If bind_dn is empty an anonymous bind is performed.
   bind_dn = ""

--- a/plugins/inputs/ldap/sample.conf
+++ b/plugins/inputs/ldap/sample.conf
@@ -13,6 +13,12 @@
   ## Server dialect, can be "openldap" or "389ds"
   # dialect = "openldap"
 
+  # What sort of Bind to use
+  ## Empty or "simple" means to use a simple LDAP bind, otherwise use a
+  ## specified SASL mechanism (only EXTERNAL currently supported - for TLS
+  ## client certs or UNIX credentials)
+  # bind_mechanism = "simple"
+
   # DN and password to bind with
   ## If bind_dn is empty an anonymous bind is performed.
   bind_dn = ""

--- a/plugins/inputs/ldap/sample.conf.in
+++ b/plugins/inputs/ldap/sample.conf.in
@@ -13,6 +13,12 @@
   ## Server dialect, can be "openldap" or "389ds"
   # dialect = "openldap"
 
+  # What sort of Bind to use
+  ## Empty or "simple" means to use a simple LDAP bind, otherwise use a
+  ## specified SASL mechanism (only EXTERNAL currently supported - for TLS
+  ## client certs or UNIX credentials)
+  # bind_mechanism = "simple"
+
   # DN and password to bind with
   ## If bind_dn is empty an anonymous bind is performed.
   bind_dn = ""


### PR DESCRIPTION
## Summary
Allow an EXTERNAL SASL Bind for authentication (splitting from #17478 as requested)

## Checklist
- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

Partially resolves #17477 (The SASL Bind part)
