### PR TITLE
fix(inputs.turbostat): Allow floating point intervals

### DIFF
--- a/plugins/inputs/turbostat/turbostat.go
+++ b/plugins/inputs/turbostat/turbostat.go
@@ -92,8 +92,8 @@ func (t *Turbostat) Init() error {
 	if t.UseSudo {
 		t.command = append(t.command, "sudo")
 	}
-	s := int(time.Duration(t.Interval).Seconds())
-	t.command = append(t.command, t.Path, "--quiet", "--interval", strconv.Itoa(s), "--show", "all")
+	interval := strconv.FormatFloat(time.Duration(t.Interval).Seconds(), 'f', -1, 64)
+	t.command = append(t.command, t.Path, "--quiet", "--interval", interval, "--show", "all")
 
 	return nil
 }


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

### Interval `< 1s`

Since `turbostat` supports intervals smaller than `1s`, I've fixed the error that arises in case of intervals less than 1s, which results in truncating every interval to 0. Moreover, I've converted the interval into floating-point seconds, which now correctly affects the sampling of `turbostat`. 

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #17957
