### PR TITLE
fix(outputs.sql): Mark table as found during initial existence check 

### DIFF
--- a/plugins/outputs/sql/sql.go
+++ b/plugins/outputs/sql/sql.go
@@ -271,9 +271,11 @@ func (p *SQL) createTable(metric telegraf.Metric) error {
 	}
 	// Ensure compatibility: set the table cache to an empty map
 	p.tables[tablename] = make(map[string]bool)
-	// Update cache
-	if err := p.updateTableCache(tablename); err != nil {
-		return fmt.Errorf("updating table cache failed: %w", err)
+	// Modifying the table schema is opt-in
+	if p.TableUpdateTemplate != "" {
+		if err := p.updateTableCache(tablename); err != nil {
+			return fmt.Errorf("updating table cache failed: %w", err)
+		}
 	}
 	return nil
 }
@@ -305,25 +307,19 @@ func (p *SQL) createColumn(tablename, column, columnType string) error {
 	return nil
 }
 
-func (p *SQL) ensureTable(metric telegraf.Metric) error {
-	tableName := metric.Name()
-
-	if _, found := p.tables[tableName]; found {
-		return nil
-	}
-
-	if !p.tableExists(tableName) {
-		return p.createTable(metric)
-	}
-
-	return p.updateTableCache(tableName)
-}
-
 func (p *SQL) tableExists(tableName string) bool {
 	stmt := strings.ReplaceAll(p.TableExistsTemplate, "{TABLE}", quoteIdent(tableName))
 
 	_, err := p.db.Exec(stmt)
-	return err == nil
+
+	// Make sure to update the table cache to not query the table existence in
+	// every write cycle
+	exists := err == nil
+	if _, found := p.tables[tableName]; exists && !found {
+		p.tables[tableName] = make(map[string]bool)
+	}
+
+	return exists
 }
 
 func (p *SQL) updateTableCache(tablename string) error {
@@ -446,8 +442,10 @@ func (p *SQL) Write(metrics []telegraf.Metric) error {
 	for _, metric := range metrics {
 		tablename := metric.Name()
 		// create table if needed
-		if err := p.ensureTable(metric); err != nil {
-			return err
+		if _, found := p.tables[tablename]; !found && !p.tableExists(tablename) {
+			if err := p.createTable(metric); err != nil {
+				return err
+			}
 		}
 		cacheKey, columns, values := p.processMetric(metric)
 		sql, found := p.queryCache[cacheKey]


### PR DESCRIPTION
## Summary

This PR aims to fix incorrect table existence check. When table exists in database at Telegraf startup table cache is empty and is not updated when ensuring table existence. This leads to tons of table existence checks and fails to complete within the flush interval.

#17985 for more details and profiling.

```
Current:
2025-11-10T23:43:33Z D! [outputs.sql] Wrote batch of 205 metrics in 607.680145ms

New:
2025-11-10T23:50:53Z D! [outputs.sql] Wrote batch of 89 metrics in 7.583714ms
```

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #17985
