### PR TITLE
chore(inputs.nginx): Migrate to common http package

### DIFF
--- a/plugins/inputs/nginx/README.md
+++ b/plugins/inputs/nginx/README.md
@@ -26,7 +26,7 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 # Read Nginx's basic status information (ngx_http_stub_status_module)
 [[inputs.nginx]]
   ## An array of Nginx stub_status URI to gather stats.
-  urls = ["http://localhost/server_status"]
+  urls = ["http://localhost/server_status", "http+unix:///var/run/nginx.sock:/server_status"]
 
   ## Optional TLS Config
   # tls_ca = "/etc/telegraf/ca.pem"

--- a/plugins/inputs/nginx/nginx.go
+++ b/plugins/inputs/nginx/nginx.go
@@ -3,6 +3,7 @@ package nginx
 
 import (
 	"bufio"
+	"context"
 	_ "embed"
 	"fmt"
 	"net"
@@ -15,7 +16,7 @@ import (
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
-	"github.com/influxdata/telegraf/plugins/common/tls"
+	common_http "github.com/influxdata/telegraf/plugins/common/http"
 	"github.com/influxdata/telegraf/plugins/inputs"
 )
 
@@ -23,9 +24,9 @@ import (
 var sampleConfig string
 
 type Nginx struct {
-	Urls            []string        `toml:"urls"`
-	ResponseTimeout config.Duration `toml:"response_timeout"`
-	tls.ClientConfig
+	Urls []string        `toml:"urls"`
+	Log  telegraf.Logger `toml:"-"`
+	common_http.HTTPClientConfig
 
 	// HTTP client
 	client *http.Client
@@ -67,20 +68,15 @@ func (n *Nginx) Gather(acc telegraf.Accumulator) error {
 }
 
 func (n *Nginx) createHTTPClient() (*http.Client, error) {
-	tlsCfg, err := n.ClientConfig.TLSConfig()
+	if n.HTTPClientConfig.ResponseHeaderTimeout < config.Duration(time.Second) {
+		n.HTTPClientConfig.ResponseHeaderTimeout = config.Duration(time.Second * 5)
+	}
+
+	// Create the client
+	ctx := context.Background()
+	client, err := n.HTTPClientConfig.CreateClient(ctx, n.Log)
 	if err != nil {
-		return nil, err
-	}
-
-	if n.ResponseTimeout < config.Duration(time.Second) {
-		n.ResponseTimeout = config.Duration(time.Second * 5)
-	}
-
-	client := &http.Client{
-		Transport: &http.Transport{
-			TLSClientConfig: tlsCfg,
-		},
-		Timeout: time.Duration(n.ResponseTimeout),
+		return nil, fmt.Errorf("creating client failed: %w", err)
 	}
 
 	return client, nil

--- a/plugins/inputs/nginx/nginx_test.go
+++ b/plugins/inputs/nginx/nginx_test.go
@@ -28,7 +28,7 @@ Reading: 8 Writing: 125 Waiting: 946
 
 // Verify that nginx tags are properly parsed based on the server
 func TestNginxTags(t *testing.T) {
-	urls := []string{"http://localhost/endpoint", "http://localhost:80/endpoint"}
+	urls := []string{"http://localhost/endpoint", "http://localhost:80/endpoint", "http+unix://localhost/endpoint"}
 	for _, url1 := range urls {
 		addr, err := url.Parse(url1)
 		require.NoError(t, err)

--- a/plugins/inputs/nginx/sample.conf
+++ b/plugins/inputs/nginx/sample.conf
@@ -1,7 +1,7 @@
 # Read Nginx's basic status information (ngx_http_stub_status_module)
 [[inputs.nginx]]
   ## An array of Nginx stub_status URI to gather stats.
-  urls = ["http://localhost/server_status"]
+  urls = ["http://localhost/server_status", "http+unix:///var/run/nginx.sock:/server_status"]
 
   ## Optional TLS Config
   # tls_ca = "/etc/telegraf/ca.pem"


### PR DESCRIPTION
## Summary
This PR changes how input.nginx instantiates the HTTP client to act as a probe for metrics. Specifically, it changes from the native HTTP library to the common telegraf HTTP library which has "unix://" schema support.

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #17986 
