### PR TITLE
chore(inputs.nginx_plus_api): Migrate to common http package

### DIFF
--- a/plugins/inputs/nginx_plus_api/README.md
+++ b/plugins/inputs/nginx_plus_api/README.md
@@ -32,7 +32,7 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 # Read Nginx Plus API advanced status information
 [[inputs.nginx_plus_api]]
   ## An array of Nginx API URIs to gather stats.
-  urls = ["http://localhost/api"]
+  urls = ["http://localhost/api", "http+unix:///var/run/nginx.sock:/api"]
   # Nginx API version, default: 3
   # api_version = 3
 

--- a/plugins/inputs/nginx_plus_api/sample.conf
+++ b/plugins/inputs/nginx_plus_api/sample.conf
@@ -1,7 +1,7 @@
 # Read Nginx Plus API advanced status information
 [[inputs.nginx_plus_api]]
   ## An array of Nginx API URIs to gather stats.
-  urls = ["http://localhost/api"]
+  urls = ["http://localhost/api", "http+unix:///var/run/nginx.sock:/api"]
   # Nginx API version, default: 3
   # api_version = 3
 


### PR DESCRIPTION
## Summary
This PR changes how inputs.nginx_plus_api instantiates the HTTP client to act as a probe for metrics. Specifically, it changes from the native HTTP library to the common telegraf HTTP library which has "unix://" schema support.

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #17986 
