### PR TITLE
chore(inputs.nginx_upstream_check): Migrate to common http package

### DIFF
--- a/plugins/inputs/nginx_upstream_check/README.md
+++ b/plugins/inputs/nginx_upstream_check/README.md
@@ -29,6 +29,8 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## An URL where Nginx Upstream check module is enabled
   ## It should be set to return a JSON formatted response
   url = "http://127.0.0.1/status?format=json"
+  ## You can also point it at a unix socket too
+  # url = "http+unix:///var/run/nginx.sock:/status?format=json"
 
   ## HTTP method
   # method = "GET"

--- a/plugins/inputs/nginx_upstream_check/sample.conf
+++ b/plugins/inputs/nginx_upstream_check/sample.conf
@@ -3,6 +3,8 @@
   ## An URL where Nginx Upstream check module is enabled
   ## It should be set to return a JSON formatted response
   url = "http://127.0.0.1/status?format=json"
+  ## You can also point it at a unix socket too
+  # url = "http+unix:///var/run/nginx.sock:/status?format=json"
 
   ## HTTP method
   # method = "GET"


### PR DESCRIPTION
## Summary
This PR changes how inputs.nginx_upstream_check instantiates the HTTP client to act as a probe for metrics. Specifically, it changes from the native HTTP library to the common telegraf HTTP library which has "unix://" schema support.

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #17986 
