### PR TITLE
feat(outputs.nats): Support nkey seed authentication

### DIFF
--- a/plugins/outputs/nats/README.md
+++ b/plugins/outputs/nats/README.md
@@ -46,6 +46,9 @@ to use them.
   ## Optional NATS 2.0 and NATS NGS compatible user credentials
   # credentials = "/etc/telegraf/nats.creds"
 
+  ## Optional authentication with nkey seed file (NATS 2.0)
+  # nkey_seed = "/etc/telegraf/seed.txt"
+
   ## NATS subject for producer messages.
   ## This field can be a static string or a Go template, see README for details.
   ## Incompatible with `use_batch_format

--- a/plugins/outputs/nats/nats.go
+++ b/plugins/outputs/nats/nats.go
@@ -31,6 +31,7 @@ type NATS struct {
 	Username       config.Secret `toml:"username"`
 	Password       config.Secret `toml:"password"`
 	Credentials    string        `toml:"credentials"`
+	NkeySeed       string        `toml:"nkey_seed"`
 	Subject        string        `toml:"subject"`
 	UseBatchFormat bool          `toml:"use_batch_format"`
 	Jetstream      *StreamConfig `toml:"jetstream"`
@@ -118,6 +119,14 @@ func (n *NATS) Connect() error {
 
 	if n.Credentials != "" {
 		opts = append(opts, nats.UserCredentials(n.Credentials))
+	}
+
+	if n.NkeySeed != "" {
+		opt, err := nats.NkeyOptionFromSeed(n.NkeySeed)
+		if err != nil {
+			return err
+		}
+		opts = append(opts, opt)
 	}
 
 	if n.Name != "" {

--- a/plugins/outputs/nats/sample.conf
+++ b/plugins/outputs/nats/sample.conf
@@ -13,6 +13,9 @@
   ## Optional NATS 2.0 and NATS NGS compatible user credentials
   # credentials = "/etc/telegraf/nats.creds"
 
+  ## Optional authentication with nkey seed file (NATS 2.0)
+  # nkey_seed = "/etc/telegraf/seed.txt"
+
   ## NATS subject for producer messages.
   ## This field can be a static string or a Go template, see README for details.
   ## Incompatible with `use_batch_format


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

Adds `nkey_seed` authentication option to the NATS output plugin for feature parity with the NATS input plugin.

The NATS input plugin already supports nkey seed authentication, but the output plugin doesn't. This PR adds the same functionality to maintain consistency between both plugins.

Changes:


- Added nkey_seed configuration option
- Implemented authentication using `nats.NkeyOptionFromSeed()` (same as input plugin)
- Updated `README.md` and `sample.conf`

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #18006
