### PR TITLE
fix(inputs.docker_log): Remove hard-coded API version

### DIFF
--- a/plugins/inputs/docker_log/client.go
+++ b/plugins/inputs/docker_log/client.go
@@ -35,6 +35,7 @@ func newClient(host string, tlsConfig *tls.Config) (dockerClient, error) {
 	client, err := docker.NewClientWithOpts(
 		docker.WithHTTPHeaders(map[string]string{"User-Agent": "engine-api-cli-1.0"}),
 		docker.WithHTTPClient(httpClient),
+		docker.WithAPIVersionNegotiation(),
 		docker.WithHost(host))
 
 	if err != nil {


### PR DESCRIPTION
## Summary

Remove too old hard-coded API version to allow access to newer server instances.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

resolves #18010 
