### PR TITLE
fix(outputs.influxdb_v2): Correct calculation of amount of batches for concurrent writes

### DIFF
--- a/plugins/outputs/influxdb_v2/batching.go
+++ b/plugins/outputs/influxdb_v2/batching.go
@@ -22,6 +22,9 @@ type batch struct {
 
 func createBatches(metrics []telegraf.Metric, bucket string, size int) []*batch {
 	number := len(metrics) / size
+	if len(metrics)%size > 0 {
+		number++
+	}
 	batches := make([]*batch, 0, number)
 	for i := range number {
 		begin := i * size


### PR DESCRIPTION
## Summary
in influxdb_v2 output with `concurrent_writes` > 1 part of data may be dropped
[here](https://github.com/influxdata/telegraf/blob/ea2cb48a2e001aa068b1d8ad3168b35179c18389/plugins/outputs/influxdb_v2/http.go#L148) algorithm calculates a size of buffer dividing amount of metrics by workers count and increments by one if remainder is > 0, but this is not taken into account during calculation of batches count inside `createBatches`.

In current implementation with metrics slice of size `100k` and concurrent_writes set to`13` telegraf drops `7684` items
`(100000 // ⌈100000/13⌉) * ⌈100000/13⌉= (100000//7693) * 7693 = 12 * 7693 = 92316`

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy
