### PR TITLE
fix(inputs.procstat): Make port conversion more robust

### DIFF
--- a/plugins/inputs/procstat/process.go
+++ b/plugins/inputs/procstat/process.go
@@ -12,6 +12,7 @@ import (
 	gopsprocess "github.com/shirou/gopsutil/v4/process"
 
 	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/internal"
 	"github.com/influxdata/telegraf/metric"
 )
 
@@ -357,8 +358,11 @@ func (p *proc) metrics(prefix string, cfg *collectionConfig, t time.Time) ([]tel
 					delete(fields, "src")
 				}
 				if cfg.tagging["src_port"] && fields["src_port"] != nil {
-					port := uint64(fields["src_port"].(uint16))
-					p.tags["src_port"] = strconv.FormatUint(port, 10)
+					port, err := internal.ToString(fields["src_port"])
+					if err != nil {
+						return metrics, fmt.Errorf("converting source port to tag failed: %w", err)
+					}
+					p.tags["src_port"] = port
 					delete(fields, "src_port")
 				}
 				if cfg.tagging["dest"] && fields["dest"] != nil {
@@ -366,8 +370,11 @@ func (p *proc) metrics(prefix string, cfg *collectionConfig, t time.Time) ([]tel
 					delete(fields, "dest")
 				}
 				if cfg.tagging["dest_port"] && fields["dest_port"] != nil {
-					port := uint64(fields["dest_port"].(uint16))
-					p.tags["dest_port"] = strconv.FormatUint(port, 10)
+					port, err := internal.ToString(fields["dest_port"])
+					if err != nil {
+						return metrics, fmt.Errorf("converting destination port to tag failed: %w", err)
+					}
+					p.tags["dest_port"] = port
 					delete(fields, "dest_port")
 				}
 				if cfg.tagging["name"] && fields["name"] != nil {


### PR DESCRIPTION
## Summary

This PR fixes an issue where we try to convert the source and destination ports to tags using the wrong type. The fix uses the `internal.ToString` function which can handle types more robustly, helping to avoid those issues.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

resolves #18013 
