### PR TITLE
docs: Ignore long-lines in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-<!-- markdownlint-disable MD024 -->
+<!-- markdownlint-disable MD013 MD024 -->
 # Changelog
 
 ## v1.36.4 [2025-11-17]


### PR DESCRIPTION
## Summary

Ignore long lines in `CHANGELOG.md` by disabling rule MD013. This is necessary to satisfy the markdown linter.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
