### PR TITLE
feat(outputs.nats): Add secret-support for credentials

### DIFF
--- a/plugins/outputs/nats/README.md
+++ b/plugins/outputs/nats/README.md
@@ -21,11 +21,9 @@ See the [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 ## Secret-store support
 
-This plugin supports secrets from secret-stores for the `username` and
-`password` option. Since telegraf 1.37 the plugin also supports the secret
-store for the `credentials` option, while specifying a path was deprecated.
-See the [secret-store documentation][SECRETSTORE] for more details on how
-to use them.
+This plugin supports secrets from secret-stores for the `username`, `password`
+and `credential` option. See the [secret-store documentation][SECRETSTORE] for
+more details on how to use them.
 
 [SECRETSTORE]: ../../../docs/CONFIGURATION.md#secret-store-secrets
 
@@ -45,7 +43,6 @@ to use them.
   # password = ""
 
   ## Optional NATS 2.0 and NATS NGS compatible user credentials
-  ## Using a path to a credential file is deprecated and will be removed in 1.40.
   # credentials = ""
 
   ## Optional authentication with nkey seed file (NATS 2.0)

--- a/plugins/outputs/nats/nats.go
+++ b/plugins/outputs/nats/nats.go
@@ -120,22 +120,22 @@ func (n *NATS) Connect() error {
 	}
 
 	if !n.Credentials.Empty() {
-		credentials, secretsErr := n.Credentials.Get()
+		credentialsRaw, secretsErr := n.Credentials.Get()
 		if secretsErr != nil {
 			return fmt.Errorf("getting credentials secret failed: %w", secretsErr)
 		}
+		credentials := credentialsRaw.String()
+		credentialsRaw.Destroy()
 
-		credentialsSecret := credentials.String()
-
-		_, statsErr := os.Stat(credentialsSecret)
+		_, statsErr := os.Stat(credentials)
 		if errors.Is(statsErr, os.ErrNotExist) || errors.Is(statsErr, syscall.ENAMETOOLONG) {
-			opts = append(opts, nats.UserCredentialBytes([]byte(credentialsSecret)))
+			opts = append(opts, nats.UserCredentialBytes([]byte(credentials)))
 		} else {
 			n.Log.Warn(
 				"Using a file for 'credentials' is deprecated since v1.37.0 and will be removed with v1.40.0! " +
 					"Use a secret-store instead to securely handle your credentials.",
 			)
-			opts = append(opts, nats.UserCredentials(credentialsSecret))
+			opts = append(opts, nats.UserCredentials(credentials))
 		}
 	}
 

--- a/plugins/outputs/nats/sample.conf
+++ b/plugins/outputs/nats/sample.conf
@@ -11,7 +11,6 @@
   # password = ""
 
   ## Optional NATS 2.0 and NATS NGS compatible user credentials
-  ## Using a path to a credential file is deprecated and will be removed in 1.40.
   # credentials = ""
 
   ## Optional authentication with nkey seed file (NATS 2.0)


### PR DESCRIPTION
## Summary

This PR adds a new config option `credentials_bytes` to the nats output, to make it easier to distribute the credentials directly with the config file, or with a secret store.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #18047
