### PR TITLE
feat(inputs.mysql): Add replication latency fields

### DIFF
--- a/plugins/inputs/mysql/README.md
+++ b/plugins/inputs/mysql/README.md
@@ -247,6 +247,13 @@ measurement name.
 ## Metrics
 
 * Global statuses - all numeric and boolean values of `SHOW GLOBAL STATUSES`
+  * wsrep_evs_repl_latency - a complex field containing multiple values is split
+      into separate fields
+    * wsrep_evs_repl_latency_min(float, seconds)
+    * wsrep_evs_repl_latency_avg(float, seconds)
+    * wsrep_evs_repl_latency_max(float, seconds)
+    * wsrep_evs_repl_latency_stdev(float, seconds)
+    * wsrep_evs_repl_latency_sample_size(float, number)
 * Global variables - all numeric and boolean values of `SHOW GLOBAL VARIABLES`
 * Slave status - metrics from `SHOW SLAVE STATUS` the metrics are gathered when
 the single-source replication is on. If the multi-source replication is set,

--- a/plugins/inputs/mysql/v2/convert_test.go
+++ b/plugins/inputs/mysql/v2/convert_test.go
@@ -37,6 +37,19 @@ func TestConvertGlobalStatus(t *testing.T) {
 			expected:    nil,
 			expectedErr: nil,
 		},
+		{
+			name:  "multiple values in one metric converted to a map",
+			key:   "wsrep_evs_repl_latency",
+			value: []byte("0.000160108/0.000386178/0.00964884/0.000488261/816"),
+			expected: map[string]interface{}{
+				"min":         0.000160108,
+				"avg":         0.000386178,
+				"max":         0.00964884,
+				"stdev":       0.000488261,
+				"sample_size": 816.0,
+			},
+			expectedErr: nil,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

#### feat(inputs.mysql): Add replication latency fields

The `wsrep_evs_repl_latency` global status field contains 5 separate
metrics delimited by a forward slash. This commit adds parsing for that
field.

---------
## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->
