### PR TITLE
fix(common.opcua): Skip file permission check on Windows

### DIFF
--- a/plugins/common/opcua/opcua_util_test.go
+++ b/plugins/common/opcua/opcua_util_test.go
@@ -3,6 +3,7 @@ package opcua
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -45,9 +46,12 @@ func TestGenerateCertPersistentPaths(t *testing.T) {
 	require.FileExists(t, keyPath)
 
 	// Verify file permissions (key should be 0600)
-	info, err := os.Stat(keyPath)
-	require.NoError(t, err)
-	require.Equal(t, os.FileMode(0600), info.Mode().Perm())
+	// Skip permission check on Windows as Unix-style permissions don't apply
+	if runtime.GOOS != "windows" {
+		info, err := os.Stat(keyPath)
+		require.NoError(t, err)
+		require.Equal(t, os.FileMode(0600), info.Mode().Perm())
+	}
 }
 
 func TestGenerateCertCreatesParentDirectory(t *testing.T) {


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
  Windows does not support Unix-style file permissions, causing TestGenerateCertPersistentPaths to fail when checking for 0600 permissions. The test expects 0x180 (0600) but Windows returns 0x1b6 (0666).

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
