### PR TITLE
chore(config): Add option for non-strict envvar handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
 <!-- markdownlint-disable MD013 MD024 -->
 # Changelog
 
+## Unreleased
+
+### Important Changes
+
+- PR [#17966](https://github.com/influxdata/telegraf/pull/17966) introduced the strict handling of environment variables
+  to prevent security issues. However, strict handling prevents using environment variables for non-string settings as
+  the configuration before replacing the variables must be TOML conform. To provide security-by-default, we will change
+  the **default behavior of Telegraf to the strict environment variable handling with v1.38.0**!
+  Please make sure your configuration works in the now conditions by using the `--strict-env-handling` flag! If your
+  configuration works in strict mode or you are not using environment variables, **do not** add the flag as it will be
+  removed later and ignore the new warning at startup. In case you need the current behavior please add
+  `--non-strict-env-handling` when starting Telegraf to prepare for the upcoming change!
+
 ## v1.36.4 [2025-11-17]
 
 ### Bugfixes

--- a/cmd/telegraf/main.go
+++ b/cmd/telegraf/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -9,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/awnumar/memguard"
+	"github.com/fatih/color"
 	"github.com/urfave/cli/v2"
 
 	"github.com/influxdata/telegraf/config"
@@ -221,6 +223,16 @@ func runApp(args []string, outputBuffer io.Writer, pprof Server, c TelegrafConfi
 			pprof.Start(cCtx.String("pprof-addr"))
 		}
 
+		if cCtx.Bool("strict-env-handling") && cCtx.Bool("non-strict-env-handling") {
+			return errors.New("flags --strict-env-handling and --non-strict-env-handling cannot be used together")
+		}
+		if !cCtx.Bool("strict-env-handling") && !cCtx.Bool("non-strict-env-handling") {
+			msg := "Strict environment variable handling will be the new default starting with v1.38.0! " +
+				"If your configuration works with strict handling or you don't use environment variables it is safe " +
+				"to ignore this warning. Otherwise please explicitly add the --non-strict-env-handling flag!"
+			log.Println("W! " + color.YellowString(msg))
+		}
+
 		if err := config.SetPluginLabelSelections(cCtx.StringSlice("select")); err != nil {
 			return err
 		}
@@ -324,6 +336,10 @@ func runApp(args []string, outputBuffer io.Writer, pprof Server, c TelegrafConfi
 				&cli.BoolFlag{
 					Name:  "strict-env-handling",
 					Usage: "enforces strict and secure handling of environment variables; will not work with non-string settings",
+				},
+				&cli.BoolFlag{
+					Name:  "non-strict-env-handling",
+					Usage: "allow unsafe non-strict handling of environment variables to replace non-string settings",
 				},
 				&cli.BoolFlag{
 					Name:  "print-plugin-config-source",


### PR DESCRIPTION
## Summary

This PR warns about the fact that **we will change the default behavior** for environment variable parsing
to **strict**  parsing with **v1.38.0**! To prepare for the change we provide a `--non-strict-env-handling`
flag to explicitly opt-out from strict environment variable parsing for users that need the current behavior.

> [!NOTE]
> This PR is not breaking the current behavior but only warns about the upcoming break!

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
