### PR TITLE
feat(inputs.s7comm): Add option idle_timeout

### DIFF
--- a/plugins/inputs/s7comm/README.md
+++ b/plugins/inputs/s7comm/README.md
@@ -54,6 +54,9 @@ using the `startup_error_behavior` setting. Available values are:
   ## Timeout for requests
   # timeout = "10s"
 
+  ## Idle timeout for requests
+  # idle_timeout = "60s"
+
   ## Log detailed connection messages for tracing issues
   # log_level = "trace"
 

--- a/plugins/inputs/s7comm/s7comm.go
+++ b/plugins/inputs/s7comm/s7comm.go
@@ -69,6 +69,7 @@ type S7comm struct {
 	ConnectionType  string             `toml:"connection_type"`
 	BatchMaxSize    int                `toml:"pdu_size"`
 	Timeout         config.Duration    `toml:"timeout"`
+	IdleTimeout     config.Duration    `toml:"idle_timeout"`
 	DebugConnection bool               `toml:"debug_connection" deprecated:"1.35.0;use 'log_level' 'trace' instead"`
 	Configs         []metricDefinition `toml:"metric"`
 	Log             telegraf.Logger    `toml:"-"`
@@ -140,6 +141,7 @@ func (s *S7comm) Init() error {
 	// Create handler for the connection
 	s.handler = gos7.NewTCPClientHandlerWithConnectType(s.Server, s.Rack, s.Slot, connectionTypeMap[s.ConnectionType])
 	s.handler.Timeout = time.Duration(s.Timeout)
+	s.handler.IdleTimeout = time.Duration(s.IdleTimeout)
 	if s.Log.Level().Includes(telegraf.Trace) || s.DebugConnection { // for backward compatibility
 		s.handler.Logger = log.New(&tracelogger{log: s.Log}, "", 0)
 	}
@@ -431,6 +433,7 @@ func init() {
 			Slot:         -1,
 			BatchMaxSize: 20,
 			Timeout:      config.Duration(10 * time.Second),
+			IdleTimeout:  config.Duration(60 * time.Second),
 		}
 	})
 }

--- a/plugins/inputs/s7comm/sample.conf
+++ b/plugins/inputs/s7comm/sample.conf
@@ -17,6 +17,9 @@
   ## Timeout for requests
   # timeout = "10s"
 
+  ## Idle timeout for requests
+  # idle_timeout = "60s"
+
   ## Log detailed connection messages for tracing issues
   # log_level = "trace"
 


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

The gos7 library has a default idle timeout of 60 seconds. In some scenarios, data collection intervals exceed 60 seconds, causing unwanted reconnection attempts.
This PR exposes an `idle_timeout` configuration option to allow users to customize the timeout duration based on their specific requirements.

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->
