### PR TITLE
feat(config): Allow specifying env-handling mode for config check

### DIFF
--- a/cmd/telegraf/cmd_config.go
+++ b/cmd/telegraf/cmd_config.go
@@ -57,6 +57,18 @@ func getConfigCommands(configHandlingFlags []cli.Flag, outputBuffer io.Writer) [
 							return err
 						}
 
+						// Set the environment variables handling mode
+						if cCtx.Bool("strict-env-handling") && cCtx.Bool("non-strict-env-handling") {
+							return errors.New("flags --strict-env-handling and --non-strict-env-handling cannot be used together")
+						}
+						if !cCtx.Bool("strict-env-handling") && !cCtx.Bool("non-strict-env-handling") {
+							msg := "Strict environment variable handling will be the new default starting with v1.38.0! " +
+								"If your configuration works with strict handling or you don't use environment variables it is safe " +
+								"to ignore this warning. Otherwise please explicitly add the --non-strict-env-handling flag!"
+							log.Println("W! " + color.YellowString(msg))
+						}
+						config.NonStrictEnvVarHandling = !cCtx.Bool("strict-env-handling")
+
 						// Collect the given configuration files
 						configFiles := cCtx.StringSlice("config")
 						configDir := cCtx.StringSlice("config-directory")

--- a/cmd/telegraf/main.go
+++ b/cmd/telegraf/main.go
@@ -135,6 +135,14 @@ func runApp(args []string, outputBuffer io.Writer, pprof Server, c TelegrafConfi
 			Name:  "secretstore-filter",
 			Usage: "filter the secret-stores to enable, separator is ':'",
 		},
+		&cli.BoolFlag{
+			Name:  "strict-env-handling",
+			Usage: "enforces strict and secure handling of environment variables; will not work with non-string settings",
+		},
+		&cli.BoolFlag{
+			Name:  "non-strict-env-handling",
+			Usage: "allow unsafe non-strict handling of environment variables to replace non-string settings",
+		},
 	}
 
 	mainFlags := append(configHandlingFlags, cliFlags()...)
@@ -332,14 +340,6 @@ func runApp(args []string, outputBuffer io.Writer, pprof Server, c TelegrafConfi
 				&cli.BoolFlag{
 					Name:  "old-env-behavior",
 					Usage: "switch back to pre v1.27 environment replacement behavior",
-				},
-				&cli.BoolFlag{
-					Name:  "strict-env-handling",
-					Usage: "enforces strict and secure handling of environment variables; will not work with non-string settings",
-				},
-				&cli.BoolFlag{
-					Name:  "non-strict-env-handling",
-					Usage: "allow unsafe non-strict handling of environment variables to replace non-string settings",
 				},
 				&cli.BoolFlag{
 					Name:  "print-plugin-config-source",


### PR DESCRIPTION
## Summary

This PR allows to specify `--strict-env-handling` or `--non-strict-env-handling` for the `config check` command. This is helpful to check if the configuration work in strict mode.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
