### PR TITLE
docs(inputs.logql): Clarify sorting and limit example

### DIFF
--- a/plugins/inputs/logql/README.md
+++ b/plugins/inputs/logql/README.md
@@ -139,8 +139,8 @@ returned results.
 
 Vector and metric results will produce one or more metrics with the metric named
 being either `logql` or the `name` specified in the query.
-Labels of the results will be kept as tags if they are not internal i.e. they
-are not starting and ending with a double underscore (`__<label>__`).
+Labels of the results will be kept as tags if they are not internal (not
+starting and ending with a double underscore `__<label>__`).
 The returned value for each sample will be stored in a field called `value` and
 the provided Loki timestamp will be used as metric timestamp.
 
@@ -148,8 +148,8 @@ the provided Loki timestamp will be used as metric timestamp.
 
 A stream result will produce one or more metrics with the metric named being
 either `logql` or the `name` specified in the query.
-Labels of the results will be kept as tags if they are not internal i.e. they
-are not starting and ending with a double underscore (`__<label>__`).
+Labels of the results will be kept as tags if they are not internal (not
+starting and ending with a double underscore `__<label>__`).
 The returned log-line for each sample will be stored in a field called `message`
 and the provided Loki timestamp will be used as metric timestamp.
 
@@ -196,13 +196,13 @@ logql,detected_level=unknown,host=Hugin value=1 1762943400000000000
 logql,detected_level=unknown,host=Hugin value=1 1762943460000000000
 ```
 
-When quering raw log entries (i.e. stream results) e.g. via
+When querying raw log entries (stream results), for example:
 
 ```logql
 {job="varlogs", filename="/var/log/Xorg.0.log"}
 ```
 
-with sorting forward and limiting the number of returned values to 5 you get
+with `sorting = "forward"` and `limit = 5`, the plugin returns the following:
 
 ```text
 logql,detected_level=unknown,filename=/var/log/Xorg.0.log,host=Hugin,job=varlogs,service_name=varlogs message="[     6.806] (--) Log file renamed from \"/var/log/Xorg.pid-693.log\" to \"/var/log/Xorg.0.log\"" 1762943173000000000


### PR DESCRIPTION
## Summary

- Replace `i.e.` abbreviations with clearer parenthetical explanations
- Fix typo: `quering` → `querying`
- Clarify sorting and limit example with explicit config parameter references (`sorting = "forward"` and `limit = 5`)
- Use active voice per Google Developer Documentation style

## Test plan

- [x] `make docs` runs successfully
- [x] Review rendered README for clarity