### PR TITLE
fix(config): Make labels and selectors conform to specification

### DIFF
--- a/config/plugin_selector.go
+++ b/config/plugin_selector.go
@@ -14,19 +14,33 @@ const (
 )
 
 var (
-	reKey   = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`)
-	reValue = regexp.MustCompile(`^[a-z0-9\*\?]([-a-z0-9\*\?]*[a-z0-9\*\?])?$`)
+	// keyRegex matches a non empty string with A-Z, a-z, 0-9, -, _, .
+	keyRegex = regexp.MustCompile(`^[A-Za-z0-9._-]+$`)
+	// selectorValueRegex matches a non empty string A-Z, a-z, 0-9, -, _, ., *, ?
+	selectorValueRegex = regexp.MustCompile(`^[A-Za-z0-9._\-*?]+$`)
+	// labelValueRegex matches a non empty string with A-Z, a-z, 0-9, -, _, .
+	labelValueRegex = regexp.MustCompile(`^[A-Za-z0-9._-]+$`)
 
 	pluginLabelSelector labelSelector
 )
 
-// CheckSelectionKeyValuePairs checks the key and value of a selector or
-// label pair
+// CheckSelectionKeyValuePairs checks the key and value of a selector.
 func CheckSelectionKeyValuePairs(k, v string) error {
-	if !reKey.MatchString(k) {
+	if !keyRegex.MatchString(k) {
 		return fmt.Errorf("invalid key %q", k)
 	}
-	if !reValue.MatchString(v) {
+	if !selectorValueRegex.MatchString(v) {
+		return fmt.Errorf("invalid value %q", v)
+	}
+	return nil
+}
+
+// CheckLabelKeyValuePairs checks the key and value of a label.
+func CheckLabelKeyValuePairs(k, v string) error {
+	if !keyRegex.MatchString(k) {
+		return fmt.Errorf("invalid key %q", k)
+	}
+	if !labelValueRegex.MatchString(v) {
 		return fmt.Errorf("invalid value %q", v)
 	}
 	return nil

--- a/config/plugin_selector_test.go
+++ b/config/plugin_selector_test.go
@@ -58,6 +58,21 @@ func TestSetPluginLabelSelections(t *testing.T) {
 			selections: []string{"env=prod;app=web;invalid=value&()"},
 			wantErr:    true,
 		},
+		{
+			name:       "empty value",
+			selections: []string{"env=prod;app="},
+			wantErr:    true,
+		},
+		{
+			name:           "contains only _,-,*,?",
+			selections:     []string{"env=__-_*?"},
+			expectedGroups: []int{1},
+		},
+		{
+			name:           "regex check- character set",
+			selections:     []string{"Env123=456prOd;123=*456?", "p0-p1_p2.=_?*Env234_-"},
+			expectedGroups: []int{2, 1},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -70,6 +85,133 @@ func TestSetPluginLabelSelections(t *testing.T) {
 			require.NoError(t, err)
 			for i, group := range pluginSelector.groups {
 				require.Equal(t, len(group), tt.expectedGroups[i])
+			}
+		})
+	}
+}
+
+func TestKeyRegex(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		// Valid
+		{name: "simple", input: "abc"},
+		{name: "alphanumeric", input: "abc123"},
+		{name: "with-dash", input: "abc-123"},
+		{name: "with-dot", input: "abc.123"},
+		{name: "with-underscore", input: "abc_123"},
+		{name: "mixed", input: "A_z-9.X"},
+		{name: "single-char", input: "a"},
+		{name: "long-key", input: "abc.def-ghi_jkl.mno_123"},
+		{name: "starts-with-dot", input: ".abc"},
+		{name: "ends-with-dot", input: "abc."},
+		{name: "two-dots", input: "a..b"},
+		// Invalid
+		{name: "empty", input: "", wantErr: true},
+		{name: "wildcard-star", input: "abc*", wantErr: true},
+		{name: "wildcard-question", input: "abc?", wantErr: true},
+		{name: "space", input: "abc def", wantErr: true},
+		{name: "unicode", input: "ümlaut", wantErr: true},
+		{name: "symbols", input: "abc$", wantErr: true},
+		{name: "slash", input: "abc/def", wantErr: true},
+		{name: "colon", input: "abc:def", wantErr: true},
+		{name: "comma", input: "abc,def", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := CheckSelectionKeyValuePairs(tt.input, "value")
+			if tt.wantErr {
+				require.Error(t, err)
+			}
+		})
+	}
+}
+
+func TestSelectorValueRegex(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		// Valid
+		{name: "simple", input: "abc"},
+		{name: "with-wildcards", input: "a*b?c"},
+		{name: "only-star", input: "*"},
+		{name: "only-question", input: "?"},
+		{name: "mixed-wildcards", input: "*a?b*c*"},
+		{name: "alphanumeric", input: "abc123"},
+		{name: "combo", input: "A_z-9.X*?foo"},
+		{name: "dash-dot-underscore-wildcards", input: "a_b-c.d*?"},
+		{name: "ends-with-wildcard", input: "abc*"},
+		{name: "starts-with-wildcard", input: "*abc"},
+		{name: "wildcard-middle", input: "ab*cd?ef"},
+		{name: "long-value", input: "abc.def-ghi*jkl?mno_123"},
+
+		// Invalid
+		{name: "empty", input: "", wantErr: true},
+		{name: "space", input: "abc def", wantErr: true},
+		{name: "unicode", input: "ümlaut", wantErr: true},
+		{name: "control-char", input: "abc\x00def", wantErr: true},
+		{name: "symbols", input: "abc$", wantErr: true},
+		{name: "slash", input: "abc/def", wantErr: true},
+		{name: "colon", input: "abc:def", wantErr: true},
+		{name: "comma", input: "abc,def", wantErr: true},
+		{name: "plus", input: "abc+def", wantErr: true},
+		{name: "pipe", input: "abc|def", wantErr: true},
+		{name: "caret", input: "abc^def", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := CheckSelectionKeyValuePairs("key", tt.input)
+			if tt.wantErr {
+				require.Error(t, err)
+			}
+		})
+	}
+}
+
+func TestLabelValueRegex(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		// Valid
+		{name: "simple", input: "abc"},
+		{name: "alphanumeric", input: "abc123"},
+		{name: "with-dash", input: "abc-123"},
+		{name: "with-dot", input: "abc.123"},
+		{name: "with-underscore", input: "abc_123"},
+		{name: "mixed", input: "A_z-9.X"},
+		{name: "single-char", input: "a"},
+		{name: "long", input: "abc.def-ghi_jkl.mno_123"},
+		{name: "starts-with-dot", input: ".abc"},
+		{name: "ends-with-dot", input: "abc."},
+		{name: "two-dots", input: "a..b"},
+
+		// Invalid
+		{name: "empty", input: "", wantErr: true},
+		{name: "wildcard-star", input: "abc*", wantErr: true},
+		{name: "wildcard-question", input: "abc?", wantErr: true},
+		{name: "space", input: "abc def", wantErr: true},
+		{name: "unicode", input: "香港", wantErr: true},
+		{name: "symbols", input: "abc$", wantErr: true},
+		{name: "slash", input: "abc/def", wantErr: true},
+		{name: "comma", input: "abc,def", wantErr: true},
+		{name: "plus", input: "abc+def", wantErr: true},
+		{name: "caret", input: "abc^def", wantErr: true},
+		{name: "pipe", input: "abc|def", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := CheckLabelKeyValuePairs("key", tt.input)
+			if tt.wantErr {
+				require.Error(t, err)
 			}
 		})
 	}
@@ -187,6 +329,15 @@ func TestMatches(t *testing.T) {
 				"region": "dc-23",
 				"extra":  "value",
 				"extra2": "value2",
+			},
+			expected: true,
+		},
+		{
+			name:      "complex charset match",
+			selectors: []string{"Env-123=prOd456;Env_456=_123prOd-", "Env-123=?456*;Env_456=_???pr0D*"},
+			labels: map[string]string{
+				"Env-123": "X456",
+				"Env_456": "____pr0D123",
 			},
 			expected: true,
 		},


### PR DESCRIPTION
## Summary
Adds support for uppercase characters and `_` as defined in the original spec.

Added many unit tests for the same.

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
resolves #18105
