### PR TITLE
docs(specs): Changes to the labels and selector spec

### DIFF
--- a/docs/specs/tsd-010-labels-and-selectors.md
+++ b/docs/specs/tsd-010-labels-and-selectors.md
@@ -32,26 +32,26 @@ The Telegraf executable must accept one or more optional `--select` command-line
 flags. The passed value must be of the form:
 
 ```text
-<key>=<value>[,<key>=<value>]
+<key>=<value>[;<key>=<value>]
 ```
 
-The `key` part must not contain any wildcard characters but only
-alpha-numerical values (`[A-Za-z0-9]`), dots (`.`), dashes (`-`) or underscores
-(`_`).
+The `key` part must be non-empty and must not contain any wildcard characters
+but only contain alpha-numerical values (`[A-Za-z0-9]`), dots (`.`), dashes
+(`-`) or underscores (`_`).
 
-The `value` part might contain the wildcard characters asterix (`*`) for
-matching any number of characters or question mark (`?`) for matching a single
-character. Furthermore the value may contain alpha-numerical values
-(`[A-Za-z0-9]`), dots (`.`), dashes (`-`) or underscores (`_`).
+The `value` part must be non-empty and might contain the wildcard characters
+asterix (`*`) for matching any number of characters or question mark (`?`) for
+matching a single character. Furthermore, the value may contain alpha-numerical
+values (`[A-Za-z0-9]`), dots (`.`), dashes (`-`) or underscores (`_`).
 
 The `key` and `value` parts of a selector are separated by an equal sign (`=`).
-Multiple key-value pairs in a single selector are separated by commas.
+Multiple key-value pairs in a single selector are separated by semicolons.
 
 For example, users can start the telegraf instance with the following command
 line:
 
 ```console
-telegraf --config config.conf --config-directory directory/ --select="app=payments,region=us-*" --select="env=prod" --watch-config --print-plugin-config-source=true
+telegraf --config config.conf --config-directory directory/ --select="app=payments;region=us-*" --select="env=prod" --watch-config --print-plugin-config-source=true
 ```
 
 Specifying the same `key` multiple times within a single `--select` statement
@@ -65,13 +65,13 @@ setting must be available in all input, output, aggregator and processor
 plugins. The `labels` configuration setting must accept a map where each entry
 is a single key-value pair.
 
-The `key` part must not contain any wildcard characters but only
-alpha-numerical values (`[A-Za-z0-9]`), dots (`.`), dashes (`-`) or underscores
-(`_`).
+The `key` part must be non-empty and must not contain any wildcard characters
+but only alpha-numerical values (`[A-Za-z0-9]`), dots (`.`), dashes (`-`) or
+underscores (`_`).
 
-The `value` part must not contain any wildcard characters but only
-alpha-numerical values (`[A-Za-z0-9]`), dots (`.`), dashes (`-`) or underscores
-(`_`).
+The `value` part must be non-empty and must not contain any wildcard characters
+but only alpha-numerical values (`[A-Za-z0-9]`), dots (`.`), dashes (`-`) or
+underscores (`_`).
 
 ```toml
 [[inputs.cpu]]
@@ -95,8 +95,8 @@ determine if a plugin should be enabled. The matching behavior is as follows:
 Multiple `--select` command-line parameters are treated as a logical **OR**
 condition. If any select statement matches, the plugin will be enabled.
 Within each `--select` command-line parameter, multiple key-value pairs,
-separated by comma, are treated as a logical **AND** condition. All conditions
-within that select statement must match for a plugin to be selected.
+separated by a semicolon, are treated as a logical **AND** condition. All
+conditions within that select statement must match for a plugin to be selected.
 
 Selectors support exact matching as well as wildcard matching
 using `*` (multiple characters) and `?` (single character) in the selector


### PR DESCRIPTION
## Summary
Explicitly call out that they key and values must be non-empty and change the separator to `;`

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

related to #18105 
