### PR TITLE
chore(deps): Update golangci-lint to 2.7.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,7 +115,7 @@ jobs:
       - run: 'make check-deps'
       - run:
           name: "Install golangci-lint"
-          command: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.5.0
+          command: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.7.2
       - run:
           name: "golangci-lint/Linux"
           # There are only 4 vCPUs available for this executor, so use only 4 instead of the default number
@@ -129,7 +129,7 @@ jobs:
       - check-changed-files-or-halt
       - run:
           name: "Install golangci-lint"
-          command: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.5.0
+          command: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.7.2
       - run:
           name: "golangci-lint/macOS"
           # There are only 4 vCPUs available for this executor, so use only 4 instead of the default number
@@ -143,7 +143,7 @@ jobs:
       - check-changed-files-or-halt
       - run:
           name: "Install golangci-lint"
-          command: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.5.0
+          command: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.7.2
       - run:
           name: "golangci-lint/Windows"
           # There are only 4 vCPUs available for this executor, so use only 4 instead of the default number

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,12 +2,15 @@ version: "2"
 
 linters:
   # Default set of linters.
-  # The value can be: `standard`, `all`, `none`, or `fast`.
+  # The value can be:
+  # - `standard`: https://golangci-lint.run/docs/linters/#enabled-by-default
+  # - `all`: enables all linters by default.
+  # - `none`: disables all linters by default.
+  # - `fast`: enables only linters considered as "fast" (`golangci-lint help linters --json | jq '[ .[] | select(.fast==true) ] | map(.name)'`).
   # Default: standard
   default: none
 
   # Enable specific linter.
-  # https://golangci-lint.run/usage/linters/#enabled-by-default
   enable:
     - asasalint
     - asciicheck
@@ -45,6 +48,7 @@ linters:
     - unused
     - usetesting
 
+  # All available settings of specific linters.
   settings:
     depguard:
       # Rules to apply.
@@ -405,6 +409,7 @@ linters:
     staticcheck:
       # SAxxxx checks in https://staticcheck.dev/docs/configuration/options/#checks
       # Example (to disable some checks): [ "all", "-SA1000", "-SA1001"]
+      # Run `GL_DEBUG=staticcheck golangci-lint run --enable=staticcheck` to see all available checks and enabled by config checks.
       # Default: ["all", "-ST1000", "-ST1003", "-ST1016", "-ST1020", "-ST1021", "-ST1022"]
       checks:
         - all
@@ -516,6 +521,10 @@ linters:
       # revive:var-naming: Exclude mixed-caps packages in migrations, as these migrations are fixing the issues from before.
       - path: migrations/.*\.go$
         text: don't use MixedCaps in package name
+
+      # revive:var-naming: Exclude check for package names that conflict with standard library package names (e.g., "net", "json", "http", "os")
+      - path: (.*)\.go$
+        text: conflict with Go standard library package names
 
       # revive:exported
       - path: (.+)\.go$

--- a/Makefile
+++ b/Makefile
@@ -180,7 +180,7 @@ vet:
 .PHONY: lint-install
 lint-install:
 	@echo "Installing golangci-lint"
-	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.5.0
+	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.7.2
 
 	@echo "Installing markdownlint"
 	npm install -g markdownlint-cli

--- a/plugins/common/snmp/translator_netsnmp.go
+++ b/plugins/common/snmp/translator_netsnmp.go
@@ -225,6 +225,7 @@ func (n *netsnmpTranslator) snmpTranslateCall(oid string) (mibName string, oidNu
 		oidText = oidText[i+2:]
 	}
 
+	var b strings.Builder
 	for scanner.Scan() {
 		line := scanner.Text()
 
@@ -247,18 +248,21 @@ func (n *netsnmpTranslator) snmpTranslateCall(oid string) (mibName string, oidNu
 				if i := strings.Index(obj, "("); i != -1 {
 					obj = obj[i+1:]
 					if j := strings.Index(obj, ")"); j != -1 {
-						oidNum += "." + obj[:j]
+						b.WriteString(".")
+						b.WriteString(obj[:j])
 					} else {
 						return "", "", "", "", fmt.Errorf("getting OID number from: %s", obj)
 					}
 
 				} else {
-					oidNum += "." + obj
+					b.WriteString(".")
+					b.WriteString(obj)
 				}
 			}
 			break
 		}
 	}
+	oidNum = b.String()
 
 	return mibName, oidNum, oidText, conversion, nil
 }

--- a/plugins/inputs/intel_rdt/intel_rdt.go
+++ b/plugins/inputs/intel_rdt/intel_rdt.go
@@ -355,20 +355,22 @@ func shutDownPqos(pqos *exec.Cmd) error {
 
 func createArgCores(cores []string) string {
 	allGroupsArg := "--mon-core="
+	var b strings.Builder
 	for _, coreGroup := range cores {
 		argGroup := createArgsForGroups(strings.Split(coreGroup, ","))
-		allGroupsArg = allGroupsArg + argGroup
+		b.WriteString(argGroup)
 	}
-	return allGroupsArg
+	return allGroupsArg + b.String()
 }
 
 func createArgProcess(processPIDs map[string]string) string {
 	allPIDsArg := "--mon-pid="
+	var b strings.Builder
 	for _, PIDs := range processPIDs {
 		argPIDs := createArgsForGroups(strings.Split(PIDs, ","))
-		allPIDsArg = allPIDsArg + argPIDs
+		b.WriteString(argPIDs)
 	}
-	return allPIDsArg
+	return allPIDsArg + b.String()
 }
 
 func createArgsForGroups(coresOrPIDs []string) string {

--- a/plugins/inputs/modbus/modbus.go
+++ b/plugins/inputs/modbus/modbus.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"time"
 
 	mb "github.com/grid-x/modbus"
@@ -118,13 +119,15 @@ func (m *Modbus) SampleConfig() string {
 		&m.configurationPerMetric,
 	}
 
-	totalConfig := sampleConfigStart
+	var b strings.Builder
+	b.WriteString(sampleConfigStart)
 	for _, c := range configs {
-		totalConfig += c.sampleConfigPart() + "\n"
+		b.WriteString(c.sampleConfigPart())
+		b.WriteString("\n")
 	}
-	totalConfig += "\n"
-	totalConfig += sampleConfigEnd
-	return totalConfig
+	b.WriteString("\n")
+	b.WriteString(sampleConfigEnd)
+	return b.String()
 }
 
 func (m *Modbus) Init() error {

--- a/plugins/inputs/opcua_listener/opcua_listener_test.go
+++ b/plugins/inputs/opcua_listener/opcua_listener_test.go
@@ -3,6 +3,7 @@ package opcua_listener
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -230,12 +231,12 @@ func TestSubscribeClientIntegration(t *testing.T) {
 			}
 
 		case <-ctx.Done():
-			msg := ""
+			var sb strings.Builder
 			for _, tag := range tagsRemaining {
-				msg += tag + ", "
+				sb.WriteString(tag)
+				sb.WriteString(", ")
 			}
-
-			t.Errorf("Tags %s are remaining without a received value", msg)
+			t.Errorf("Tags %s are remaining without a received value", sb.String())
 			return
 		}
 	}
@@ -371,12 +372,12 @@ func TestSubscribeClientIntegrationAdditionalFields(t *testing.T) {
 			}
 
 		case <-ctx.Done():
-			msg := ""
+			var sb strings.Builder
 			for _, tag := range tagsRemaining {
-				msg += tag + ", "
+				sb.WriteString(tag)
+				sb.WriteString(", ")
 			}
-
-			t.Errorf("Tags %s are remaining without a received value", msg)
+			t.Errorf("Tags %s are remaining without a received value", sb.String())
 			return
 		}
 	}

--- a/plugins/inputs/passenger/passenger_test.go
+++ b/plugins/inputs/passenger/passenger_test.go
@@ -17,10 +17,14 @@ func fakePassengerStatus(stat string) (string, error) {
 	var fileExtension, content string
 	if runtime.GOOS == "windows" {
 		fileExtension = ".bat"
-		content = "@echo off\n"
+		var sb strings.Builder
+		sb.WriteString("@echo off\n")
 		for _, line := range strings.Split(strings.TrimSuffix(stat, "\n"), "\n") {
-			content += "for /f \"delims=\" %%A in (\"" + line + "\") do echo %%~A\n" // my eyes are bleeding
+			sb.WriteString("for /f \"delims=\" %%A in (\"")
+			sb.WriteString(line)
+			sb.WriteString("\") do echo %%~A\n")
 		}
+		content = sb.String()
 	} else {
 		content = fmt.Sprintf("#!/bin/sh\ncat << EOF\n%s\nEOF", stat)
 	}

--- a/plugins/inputs/phpfpm/fcgi.go
+++ b/plugins/inputs/phpfpm/fcgi.go
@@ -213,6 +213,7 @@ func encodeSize(b []byte, size uint32) int {
 		binary.BigEndian.PutUint32(b, size)
 		return 4
 	}
+	//nolint:gosec // G602: False positive — all callers allocate b with length >= 1 (e.g., make([]byte,4) or make([]byte,8)), so indexing b[0] is safe.
 	b[0] = byte(size)
 	return 1
 }

--- a/plugins/inputs/postgresql/postgresql_test.go
+++ b/plugins/inputs/postgresql/postgresql_test.go
@@ -110,6 +110,7 @@ func TestPostgresqlGeneratesMetricsIntegration(t *testing.T) {
 		metricsCounted++
 	}
 
+	//nolint:gosec // G602: False positive — this is a safe range iteration over a slice (it may be empty)
 	for _, metric := range int32Metrics {
 		require.True(t, acc.HasInt32Field("postgresql", metric), "%q not found in int32 metrics", metric)
 		metricsCounted++

--- a/plugins/inputs/postgresql_extensible/postgresql_extensible_test.go
+++ b/plugins/inputs/postgresql_extensible/postgresql_extensible_test.go
@@ -106,6 +106,7 @@ func TestPostgresqlGeneratesMetricsIntegration(t *testing.T) {
 		metricsCounted++
 	}
 
+	//nolint:gosec // G602: False positive — this is a safe range iteration over a slice (it may be empty)
 	for _, metric := range int32Metrics {
 		require.True(t, acc.HasInt32Field("postgresql", metric))
 		metricsCounted++
@@ -221,6 +222,7 @@ func TestPostgresqlFieldOutputIntegration(t *testing.T) {
 		require.Truef(t, found, "expected %s to be an integer", field)
 	}
 
+	//nolint:gosec // G602: False positive — this is a safe range iteration over a slice (it may be empty)
 	for _, field := range int32Metrics {
 		_, found := acc.Int32Field(measurement, field)
 		require.Truef(t, found, "expected %s to be an int32", field)

--- a/plugins/inputs/ravendb/ravendb.go
+++ b/plugins/inputs/ravendb/ravendb.go
@@ -376,12 +376,15 @@ func prepareDBNamesURLPart(dbNames []string) string {
 	if len(dbNames) == 0 {
 		return ""
 	}
-	result := "?" + dbNames[0]
+	var b strings.Builder
+	b.WriteString("?")
+	b.WriteString(dbNames[0])
 	for _, db := range dbNames[1:] {
-		result += "&name=" + url.QueryEscape(db)
+		b.WriteString("&name=")
+		b.WriteString(url.QueryEscape(db))
 	}
 
-	return result
+	return b.String()
 }
 
 func init() {

--- a/plugins/outputs/loki/loki.go
+++ b/plugins/outputs/loki/loki.go
@@ -135,10 +135,11 @@ func (l *Loki) Write(metrics []telegraf.Metric) error {
 			}
 		}
 
-		var line string
+		var lineBuilder strings.Builder
 		for _, f := range m.FieldList() {
-			line += fmt.Sprintf("%s=\"%v\" ", f.Key, f.Value)
+			lineBuilder.WriteString(fmt.Sprintf("%s=\"%v\" ", f.Key, f.Value))
 		}
+		line := lineBuilder.String()
 
 		s.insertLog(tags, Log{strconv.FormatInt(m.Time().UnixNano(), 10), line})
 	}

--- a/plugins/outputs/loki/stream.go
+++ b/plugins/outputs/loki/stream.go
@@ -46,14 +46,14 @@ func (s Streams) MarshalJSON() ([]byte, error) {
 }
 
 func uniqKeyFromTagList(ts []*telegraf.Tag) (k string) {
+	var b strings.Builder
 	for _, t := range ts {
-		k += fmt.Sprintf("%s-%s-",
+		b.WriteString(fmt.Sprintf("%s-%s-",
 			strings.ReplaceAll(t.Key, "-", "--"),
 			strings.ReplaceAll(t.Value, "-", "--"),
-		)
+		))
 	}
-
-	return k
+	return b.String()
 }
 
 func newStream(ts []*telegraf.Tag) *Stream {

--- a/plugins/outputs/newrelic/newrelic.go
+++ b/plugins/outputs/newrelic/newrelic.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/newrelic/newrelic-telemetry-sdk-go/cumulative"
@@ -58,12 +59,12 @@ func (nr *NewRelic) Connect() error {
 			cfg.HarvestTimeout = time.Duration(nr.Timeout)
 			cfg.Client = &nr.client
 			cfg.ErrorLogger = func(e map[string]interface{}) {
-				var errorString string
+				var b strings.Builder
 				for k, v := range e {
-					errorString += fmt.Sprintf("%s = %s ", k, v)
+					b.WriteString(fmt.Sprintf("%s = %s ", k, v))
 				}
 				nr.errorCount++
-				nr.savedErrors[nr.errorCount] = errorString
+				nr.savedErrors[nr.errorCount] = b.String()
 			}
 			if nr.MetricURL != "" {
 				cfg.MetricsURLOverride = nr.MetricURL

--- a/plugins/parsers/csv/parser_test.go
+++ b/plugins/parsers/csv/parser_test.go
@@ -1019,7 +1019,9 @@ timestamp,type,name,status
 	rowIndex++
 	m, err = p.ParseLine(testCSVRows[rowIndex])
 	require.NoError(t, err)
+	//nolint:gosec // G602: False positive — length is known to be == 2
 	require.Equal(t, expectedFields[0], m.Fields())
+	//nolint:gosec // G602: False positive — length is known to be == 2
 	require.Equal(t, expectedTags[0], m.Tags())
 	rowIndex++
 	m, err = p.ParseLine(testCSVRows[rowIndex])
@@ -1028,7 +1030,9 @@ timestamp,type,name,status
 	rowIndex++
 	m, err = p.ParseLine(testCSVRows[rowIndex])
 	require.NoError(t, err)
+	//nolint:gosec // G602: False positive — length is known to be == 2
 	require.Equal(t, expectedFields[1], m.Fields())
+	//nolint:gosec // G602: False positive — length is known to be == 2
 	require.Equal(t, expectedTags[1], m.Tags())
 }
 

--- a/plugins/serializers/graphite/graphite.go
+++ b/plugins/serializers/graphite/graphite.go
@@ -325,16 +325,15 @@ func buildTags(tags map[string]string) string {
 	}
 	sort.Strings(keys)
 
-	var tagStr string
+	var b strings.Builder
 	for i, k := range keys {
 		tagValue := strings.ReplaceAll(tags[k], ".", "_")
-		if i == 0 {
-			tagStr += tagValue
-		} else {
-			tagStr += "." + tagValue
+		if i > 0 {
+			b.WriteByte('.')
 		}
+		b.WriteString(tagValue)
 	}
-	return tagStr
+	return b.String()
 }
 
 func (s *Serializer) strictSanitize(value string) string {

--- a/plugins/serializers/prometheusremotewrite/prometheusremotewrite_test.go
+++ b/plugins/serializers/prometheusremotewrite/prometheusremotewrite_test.go
@@ -879,20 +879,22 @@ func prompbToHistogramText(data []byte) ([]byte, error) {
 		// There is no text representation for native histogram and it has to be written out as proto exposition.
 		// For test purpose we format a reasonable string for verification. Labels are sorted to make it deterministic.
 		nameString := ""
-		labelString := "{"
+		var lb strings.Builder
+		lb.WriteByte('{')
 		firstLabel := true
 		for _, l := range ts.Labels {
 			if l.Name == model.MetricNameLabel {
 				nameString = l.Value
 			} else {
 				if !firstLabel {
-					labelString += ", "
+					lb.WriteString(", ")
 				}
-				labelString += fmt.Sprintf("%s=%q", l.Name, l.Value)
+				fmt.Fprintf(&lb, "%s=%q", l.Name, l.Value)
 				firstLabel = false
 			}
 		}
-		labelString += "}"
+		lb.WriteByte('}')
+		labelString := lb.String()
 		for _, h := range ts.Histograms {
 			fh := *h.ToFloatHistogram()
 			buf.WriteString(nameString)


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

In this PR: 
- I bumped the `.golangci-lint` from `v2.5.0` to `v2.7.2`.
- I refined the current config to make it look as close as possible to https://github.com/golangci/golangci-lint/blob/main/.golangci.reference.yml to facilitate future diffs.  
- I fixed new findings:
```
plugins/common/snmp/translator_netsnmp.go:256:6                                perfsprint  concat-loop: string concatenation in a loop
plugins/inputs/gnmi/path.go:279:4                                              perfsprint  concat-loop: string concatenation in a loop
plugins/inputs/gnmi/path.go:319:4                                              perfsprint  concat-loop: string concatenation in a loop
plugins/inputs/gnmi/path.go:345:3                                              perfsprint  concat-loop: string concatenation in a loop
plugins/inputs/gnmi/path.go:362:4                                              perfsprint  concat-loop: string concatenation in a loop
plugins/inputs/http/http.go:3:9                                                revive      var-naming: avoid package names that conflict with Go standard library package names
plugins/inputs/intel_rdt/intel_rdt.go:360:3                                    perfsprint  concat-loop: string concatenation in a loop
plugins/inputs/intel_rdt/intel_rdt.go:369:3                                    perfsprint  concat-loop: string concatenation in a loop
plugins/inputs/modbus/modbus.go:123:3                                          perfsprint  concat-loop: string concatenation in a loop
plugins/inputs/mysql/mysql.go:1420:4                                           perfsprint  concat-loop: string concatenation in a loop
plugins/inputs/net/net_test.go:1:9                                             revive      var-naming: avoid package names that conflict with Go standard library package names
plugins/inputs/opcua_listener/opcua_listener_test.go:235:5                     perfsprint  concat-loop: string concatenation in a loop
plugins/inputs/opcua_listener/opcua_listener_test.go:376:5                     perfsprint  concat-loop: string concatenation in a loop
plugins/inputs/passenger/passenger_test.go:22:4                                perfsprint  concat-loop: string concatenation in a loop
plugins/inputs/phpfpm/fcgi.go:216:3                                            gosec       G602: slice index out of range
plugins/inputs/postgresql/postgresql_test.go:113:25                            gosec       G602: slice index out of range
plugins/inputs/postgresql_extensible/postgresql_extensible_test.go:109:25      gosec       G602: slice index out of range
plugins/inputs/postgresql_extensible/postgresql_extensible_test.go:224:24      gosec       G602: slice index out of range
plugins/inputs/ravendb/ravendb.go:381:3                                        perfsprint  concat-loop: string concatenation in a loop
plugins/outputs/http/http_test.go:1:9                                          revive      var-naming: avoid package names that conflict with Go standard library package names
plugins/outputs/loki/loki.go:140:4                                             perfsprint  concat-loop: string concatenation in a loop
plugins/outputs/loki/stream.go:50:3                                            perfsprint  concat-loop: string concatenation in a loop
plugins/outputs/newrelic/newrelic.go:63:6                                      perfsprint  concat-loop: string concatenation in a loop
plugins/parsers/csv/parser_test.go:1022:33                                     gosec       G602: slice index out of range
plugins/parsers/csv/parser_test.go:1023:31                                     gosec       G602: slice index out of range
plugins/parsers/csv/parser_test.go:1031:33                                     gosec       G602: slice index out of range
plugins/parsers/csv/parser_test.go:1032:31                                     gosec       G602: slice index out of range
plugins/parsers/json/parser_test.go:1:9                                        revive      var-naming: avoid package names that conflict with Go standard library package names
plugins/processors/topk/topk.go:142:4                                          perfsprint  concat-loop: string concatenation in a loop
plugins/secretstores/http/key_derivation_test.go:1:9                           revive      var-naming: avoid package names that conflict with Go standard library package names
plugins/secretstores/os/os_test.go:3:9                                         revive      var-naming: avoid package names that conflict with Go standard library package names
plugins/serializers/graphite/graphite.go:332:4                                 perfsprint  concat-loop: string concatenation in a loop
plugins/serializers/json/json_test.go:1:9                                      revive      var-naming: avoid package names that conflict with Go standard library package names
plugins/serializers/prometheusremotewrite/prometheusremotewrite_test.go:891:5  perfsprint  concat-loop: string concatenation in a loop
```

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [x] No AI generated code was used in this PR
