### PR TITLE
feat(inputs.mysql): Add wsrep provider options fields

### DIFF
--- a/plugins/inputs/mysql/README.md
+++ b/plugins/inputs/mysql/README.md
@@ -255,6 +255,9 @@ measurement name.
     * wsrep_evs_repl_latency_stdev(float, seconds)
     * wsrep_evs_repl_latency_sample_size(float, number)
 * Global variables - all numeric and boolean values of `SHOW GLOBAL VARIABLES`
+  * wsrep_provider_options - a complex field containing multiple values is split
+      into separate fields
+    * gcache_size(int, bytes)
 * Slave status - metrics from `SHOW SLAVE STATUS` the metrics are gathered when
 the single-source replication is on. If the multi-source replication is set,
 then everything works differently, this metric does not work with multi-source

--- a/plugins/inputs/mysql/mysql.go
+++ b/plugins/inputs/mysql/mysql.go
@@ -597,7 +597,8 @@ func (m *Mysql) gatherGlobalVariables(db *sql.DB, servtag string, acc telegraf.A
 				acc.AddError(errString)
 			}
 		} else {
-			fields[key] = value
+			// v2.ConvertGlobalVariables can parse "complex" multi-value fields, e.g. wsrep_provider_options
+			parseKeyValues(fields, key, value)
 		}
 
 		// Send 20 fields at a time

--- a/plugins/inputs/mysql/v2/convert_test.go
+++ b/plugins/inputs/mysql/v2/convert_test.go
@@ -89,6 +89,34 @@ func TestConvertGlobalVariables(t *testing.T) {
 			expected:    nil,
 			expectedErr: nil,
 		},
+		{
+			name: "multiple values in one metric converted to a map",
+			key:  "wsrep_provider_options",
+			value: []byte(
+				"allocator.disk_pages_encryption = no; allocator.encryption_cache_page_size = 32K; allocator.encryption_cache_size = 16777216; " +
+					"base_dir = /var/lib/mysql; base_host = 192.168.1.1; base_port = 4567; cert.log_conflicts = no; cert.optimistic_pa = NO; debug = no; " +
+					"evs.auto_evict = 0; evs.causal_keepalive_period = PT1S; evs.debug_log_mask = 0x1; evs.delay_margin = PT1S; " +
+					"evs.delayed_keep_period = PT30S; evs.inactive_check_period = PT0.5S; evs.inactive_timeout = PT15S; evs.info_log_mask = 0; " +
+					"evs.install_timeout = PT7.5S; evs.join_retrans_period = PT1S; evs.keepalive_period = PT1S; evs.max_install_timeouts = 3; " +
+					"evs.send_window = 10; evs.stats_report_period = PT1M; evs.suspect_timeout = PT5S; evs.use_aggregate = true; evs.user_send_window = 4; " +
+					"evs.version = 1; evs.view_forget_timeout = P1D; gcache.dir = /var/lib/mysql; gcache.encryption = no; " +
+					"gcache.encryption_cache_page_size = 32K; gcache.encryption_cache_size = 16777216; gcache.freeze_purge_at_seqno = -1; " +
+					"gcache.keep_pages_count = 0; gcache.keep_pages_size = 0; gcache.mem_size = 0; gcache.name = galera.cache; gcache.page_size = 128M; " +
+					"gcache.recover = yes; gcache.size = 128M; gcomm.thread_prio = ; gcs.fc_auto_evict_threshold = 0.75; gcs.fc_auto_evict_window = 0; " +
+					"gcs.fc_debug = 0; gcs.fc_factor = 1.0; gcs.fc_limit = 100; gcs.fc_master_slave = no; gcs.fc_single_primary = no; " +
+					"gcs.max_packet_size = 64500; gcs.max_throttle = 0.25; gcs.recv_q_hard_limit = 9223372036854775807; gcs.recv_q_soft_limit = 0.25; " +
+					"gcs.sync_donor = no; gmcast.listen_addr = tcp://0.0.0.0:4567; gmcast.mcast_addr = ; gmcast.mcast_ttl = 1; gmcast.peer_timeout = PT3S; " +
+					"gmcast.segment = 0; gmcast.time_wait = PT5S; gmcast.version = 0; ist.recv_addr = 192.168.1.1; pc.announce_timeout = PT3S; " +
+					"pc.checksum = false; pc.ignore_quorum = false; pc.ignore_sb = false; pc.linger = PT20S; pc.npvo = false; pc.recovery = true; " +
+					"pc.version = 0; pc.wait_prim = true; pc.wait_prim_timeout = PT30S; pc.wait_restored_prim_timeout = PT0S; pc.weight = 1; " +
+					"protonet.backend = asio; protonet.version = 0; repl.causal_read_timeout = PT30S; repl.commit_order = 3; repl.key_format = FLAT8; " +
+					"repl.max_ws_size = 2147483647; repl.proto_max = 11; socket.checksum = 2; socket.recv_buf_size = auto; socket.send_buf_size = auto; ",
+			),
+			expected: map[string]interface{}{
+				"gcache_size": uint64(134217728),
+			},
+			expectedErr: nil,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary
The `wsrep_provider_options` variable contains optional settings the node passes to the wsrep Provider.

This field contains multiple metrics however, delimited by `; `. This commit adds parsing for that field.

For the time being the only metric parsed is `gcache.size`, as it's used for Percona xtradb cluster monitoring dashboards.

see:
https://galeracluster.com/documentation/html_docs_proto-12/documentation/mysql-wsrep-options.html#wsrep-provider-options

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy