### PR TITLE
fix(outputs): prevent retry storms on authentication failures

### DIFF
--- a/internal/errors.go
+++ b/internal/errors.go
@@ -1,6 +1,9 @@
 package internal
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+)
 
 var (
 	ErrNotConnected     = errors.New("not connected")
@@ -59,5 +62,25 @@ func (e *PartialWriteError) Error() string {
 }
 
 func (e *PartialWriteError) Unwrap() error {
+	return e.Err
+}
+
+// HTTPError represents an error from an HTTP API with retry information.
+// Use this for HTTP-based output plugins to indicate whether an error
+// is retryable (e.g., 5xx server errors) or not (e.g., 4xx client errors).
+type HTTPError struct {
+	Err        error
+	StatusCode int
+	Retryable  bool
+}
+
+func (e *HTTPError) Error() string {
+	if e.Err == nil {
+		return fmt.Sprintf("HTTP error: status %d", e.StatusCode)
+	}
+	return e.Err.Error()
+}
+
+func (e *HTTPError) Unwrap() error {
 	return e.Err
 }

--- a/plugins/outputs/influxdb_v2/http.go
+++ b/plugins/outputs/influxdb_v2/http.go
@@ -377,7 +377,11 @@ func (c *httpClient) writeBatch(ctx context.Context, b *batch) error {
 			StatusCode: resp.StatusCode,
 		}
 	case http.StatusUnauthorized, http.StatusForbidden:
-		return fmt.Errorf("failed to write metrics to %s (%s)%s", b.bucket, resp.Status, desc)
+		return &APIError{
+			Err:        fmt.Errorf("failed to write metrics to %s (will be dropped: %s)%s", b.bucket, resp.Status, desc),
+			StatusCode: resp.StatusCode,
+			Retryable:  false,
+		}
 	case http.StatusTooManyRequests,
 		http.StatusServiceUnavailable,
 		http.StatusBadGateway,

--- a/plugins/outputs/sumologic/sumologic_test.go
+++ b/plugins/outputs/sumologic/sumologic_test.go
@@ -162,11 +162,16 @@ func TestStatusCode(t *testing.T) {
 			},
 		},
 		{
-			name:       "4xx status is an error",
+			name:       "4xx status drops metrics without error",
 			plugin:     pluginFn(),
 			statusCode: http.StatusBadRequest,
 			errFunc: func(t *testing.T, err error) {
+				// 4xx client errors return HTTPError with Retryable: false
 				require.Error(t, err)
+				var httpErr *internal.HTTPError
+				require.ErrorAs(t, err, &httpErr)
+				require.Equal(t, http.StatusBadRequest, httpErr.StatusCode)
+				require.False(t, httpErr.Retryable, "4xx errors should not be retryable")
 			},
 		},
 	}


### PR DESCRIPTION
## Summary

When API tokens expire or get revoked, output plugins were retrying indefinitely, causing DDoS-like behavior against the target APIs. This issue was discovered with the warp10 plugin at Clever Cloud when token renewal failed - metrics kept retrying against endpoints returning authentication errors, creating excessive load on the Warp10 platform.

Add internal.HTTPError type to distinguish retryable errors (5xx server errors, rate limits) from non-retryable errors (4xx client errors like invalid/expired tokens). Plugins now properly drop metrics on authentication failures instead of retrying forever.

Updated plugins:
- warp10: parse response body to determine retryability (primary fix)
- azure_monitor: refactor send() to return HTTPError
- datadog: return HTTPError for 4xx/5xx responses
- dynatrace: return HTTPError for 4xx/5xx responses
- sumologic: return HTTPError for 4xx/5xx responses
- influxdb_v2: use APIError for 401/403 as non-retryable

## Checklist

- [ ] No AI generated code was used in this PR
- [x] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

resolves #18118