### PR TITLE
feat(inputs.nftables): Monitor set element counts

### DIFF
--- a/plugins/inputs/nftables/README.md
+++ b/plugins/inputs/nftables/README.md
@@ -1,11 +1,11 @@
 # Nftables Plugin
 
 This plugin gathers packets and bytes counters for rules within
-Linux's [nftables][nftables] firewall.
+Linux's [nftables][nftables] firewall, as well as set element counts.
 
 > [!IMPORTANT]
-> Rules are identified by the associated comment so those **comments have to be unique**!
-> Rules without comment are ignored.
+> Rules are identified by the associated comment so those **comments have to be
+> unique**! Rules without comment are ignored.
 
 ⭐ Telegraf v1.37.0
 🏷️ network, system
@@ -28,10 +28,11 @@ plugin ordering. See [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## Use the specified binary which will be looked-up in PATH
   # binary = "nft"
 
-  ## Use sudo for command execution, can be restricted to "nft --json list table"
+  ## Use sudo for command execution, can be restricted to
+  ## "nft --json list table"
   # use_sudo = false
 
-  ## Tables to monitor containing both a counter and comment declaration
+  ## Tables to monitor (may use "family table" format, e.g., "inet filter")
   # tables = [ "filter" ]
 ```
 
@@ -48,6 +49,8 @@ telegraf ALL=(root) NOPASSWD: /usr/bin/nft *
 
 ## Metrics
 
+Rules:
+
 * nftables
   * tags:
     * table
@@ -57,9 +60,19 @@ telegraf ALL=(root) NOPASSWD: /usr/bin/nft *
     * pkts (integer, count)
     * bytes (integer, bytes)
 
+Sets:
+
+* nftables
+  * tags:
+    * table
+    * set
+  * field:
+    * count (integer, count)
+
 ## Example Output
 
 ```text
 > nftables,chain=incoming,host=my_hostname,rule=comment_val_1,table=filter bytes=66435845i,pkts=133882i 1757367516000000000
 > nftables,chain=outgoing,host=my_hostname,rule=comment_val2,table=filter bytes=25596512i,pkts=145129i 1757367516000000000
+> nftables,host=my_hostname,set=my_set,table=filter count=10i 1757367516000000000
 ```

--- a/plugins/inputs/nftables/nftables.go
+++ b/plugins/inputs/nftables/nftables.go
@@ -99,6 +99,16 @@ func (n *Nftables) gatherTable(acc telegraf.Accumulator, name string) error {
 			acc.AddFields("nftables", fields, tags)
 		}
 	}
+	for _, set := range nftable.Sets {
+		fields := map[string]interface{}{
+			"count": len(set.Elem),
+		}
+		tags := map[string]string{
+			"table": set.Table,
+			"set":   set.Name,
+		}
+		acc.AddFields("nftables", fields, tags)
+	}
 	return nil
 }
 

--- a/plugins/inputs/nftables/sample.conf
+++ b/plugins/inputs/nftables/sample.conf
@@ -2,8 +2,9 @@
   ## Use the specified binary which will be looked-up in PATH
   # binary = "nft"
 
-  ## Use sudo for command execution, can be restricted to "nft --json list table"
+  ## Use sudo for command execution, can be restricted to
+  ## "nft --json list table"
   # use_sudo = false
 
-  ## Tables to monitor containing both a counter and comment declaration
+  ## Tables to monitor (may use "family table" format, e.g., "inet filter")
   # tables = [ "filter" ]

--- a/plugins/inputs/nftables/testcases/valid/expected.out
+++ b/plugins/inputs/nftables/testcases/valid/expected.out
@@ -1,2 +1,4 @@
 nftables,chain=test-chain,rule=test1,table=test bytes=2i,pkts=1i 1763040447356073265
 nftables,chain=test-chain,rule=test2,table=test bytes=1412296i,pkts=24468i 1763040447356078375
+nftables,set=non_empty_set,table=test count=5i 1763040447356078375
+nftables,set=empty_set,table=test count=0i 1763040447356078375

--- a/plugins/inputs/nftables/testcases/valid/table_test.json
+++ b/plugins/inputs/nftables/testcases/valid/table_test.json
@@ -24,7 +24,9 @@
         "hook": "input",
         "prio": 0,
         "policy": "accept"
-      } }, {
+      }
+    },
+    {
       "rule": {
         "family": "inet",
         "table": "test",
@@ -137,6 +139,63 @@
             "accept": null
           }
         ]
+      }
+    },
+    {
+      "set": {
+        "family": "inet",
+        "name": "non_empty_set",
+        "table": "test",
+        "type": "ipv6_addr",
+        "handle": 6,
+        "size": 65536,
+        "flags": ["timeout"],
+        "timeout": 300,
+        "elem": [
+          {
+            "elem": {
+              "val": "::1",
+              "expires": 99
+            }
+          },
+          {
+            "elem": {
+              "val": "::2",
+              "expires": 277
+            }
+          },
+          {
+            "elem": {
+              "val": "::3",
+              "expires": 280
+            }
+          },
+          {
+            "elem": {
+              "val": "::4",
+              "expires": 284
+            }
+          },
+          {
+            "elem": {
+              "val": "::5",
+              "expires": 287
+            }
+          }
+        ]
+      }
+    },
+    {
+      "set": {
+        "family": "inet",
+        "name": "empty_set",
+        "table": "test",
+        "type": "ipv4_addr",
+        "handle": 7,
+        "comment": "comment",
+        "size": 65536,
+        "flags": ["timeout"],
+        "timeout": 300
       }
     }
   ]

--- a/plugins/inputs/nftables/types.go
+++ b/plugins/inputs/nftables/types.go
@@ -10,6 +10,7 @@ import (
 type table struct {
 	Metainfo          *metainfo
 	Rules             []*rule
+	Sets              []*set
 	JSONSchemaVersion int `json:"json_schema_version"`
 }
 
@@ -36,6 +37,12 @@ func (nftable *table) UnmarshalJSON(b []byte) error {
 				return fmt.Errorf("unable to parse rule: %w", err)
 			}
 			nftable.Rules = append(nftable.Rules, &r)
+		} else if _, found := nfthing["set"]; found {
+			var s set
+			if err := json.Unmarshal(nfthing["set"], &s); err != nil {
+				return fmt.Errorf("unable to parse set: %w", err)
+			}
+			nftable.Sets = append(nftable.Sets, &s)
 		}
 	}
 	return nil
@@ -62,3 +69,12 @@ type counter struct {
 	Packets int64 `json:"packets"`
 	Bytes   int64 `json:"bytes"`
 }
+
+type set struct {
+	Family string `json:"family"`
+	Name   string `json:"name"`
+	Table  string `json:"table"`
+	Elem   []elem `json:"elem,omitempty"`
+}
+
+type elem struct{}


### PR DESCRIPTION
## Summary

Named sets are often modified dynamically (for example by a firewall to ban ip addresses), and thus useful to monitor.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #18133
