### PR TITLE
fix(config): Add missing validation for labels in plugins

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1990,7 +1990,7 @@ func (c *Config) matchesLabelSelection(tbl *ast.Table) (bool, error) {
 	// Get the label definitions for the plugin and check them
 	labels := c.getFieldMap(tbl, "labels")
 	for k, v := range labels {
-		if err := CheckSelectionKeyValuePairs(k, v); err != nil {
+		if err := CheckLabelKeyValuePairs(k, v); err != nil {
 			return false, err
 		}
 	}

--- a/config/plugin_selector_test.go
+++ b/config/plugin_selector_test.go
@@ -169,6 +169,8 @@ func TestSelectorValueRegex(t *testing.T) {
 			err := CheckSelectionKeyValuePairs("key", tt.input)
 			if tt.wantErr {
 				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
 			}
 		})
 	}
@@ -212,6 +214,8 @@ func TestLabelValueRegex(t *testing.T) {
 			err := CheckLabelKeyValuePairs("key", tt.input)
 			if tt.wantErr {
 				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
In the last related PR #18108, we missed calling the label syntax check function. This PR addresses that issue.

Addressing the following comments:
https://github.com/influxdata/telegraf/issues/18105#issuecomment-3654482698
https://github.com/influxdata/telegraf/pull/18108#discussion_r2618510581 


## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #18105

