### PR TITLE
chore(deps): Bump cloud.google.com/go/auth from 0.17.0 to 0.18.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.3
 godebug x509negativeserial=1
 
 require (
-	cloud.google.com/go/auth v0.17.0
+	cloud.google.com/go/auth v0.18.0
 	cloud.google.com/go/bigquery v1.72.0
 	cloud.google.com/go/monitoring v1.24.3
 	cloud.google.com/go/pubsub/v2 v2.3.0

--- a/go.sum
+++ b/go.sum
@@ -103,8 +103,8 @@ cloud.google.com/go/assuredworkloads v1.7.0/go.mod h1:z/736/oNmtGAyU47reJgGN+KVo
 cloud.google.com/go/assuredworkloads v1.8.0/go.mod h1:AsX2cqyNCOvEQC8RMPnoc0yEarXQk6WEKkxYfL6kGIo=
 cloud.google.com/go/assuredworkloads v1.9.0/go.mod h1:kFuI1P78bplYtT77Tb1hi0FMxM0vVpRC7VVoJC3ZoT0=
 cloud.google.com/go/assuredworkloads v1.10.0/go.mod h1:kwdUQuXcedVdsIaKgKTp9t0UJkE5+PAVNhdQm4ZVq2E=
-cloud.google.com/go/auth v0.17.0 h1:74yCm7hCj2rUyyAocqnFzsAYXgJhrG26XCFimrc/Kz4=
-cloud.google.com/go/auth v0.17.0/go.mod h1:6wv/t5/6rOPAX4fJiRjKkJCvswLwdet7G8+UGXt7nCQ=
+cloud.google.com/go/auth v0.18.0 h1:wnqy5hrv7p3k7cShwAU/Br3nzod7fxoqG+k0VZ+/Pk0=
+cloud.google.com/go/auth v0.18.0/go.mod h1:wwkPM1AgE1f2u6dG443MiWoD8C3BtOywNsUMcUTVDRo=
 cloud.google.com/go/auth/oauth2adapt v0.2.8 h1:keo8NaayQZ6wimpNSmW5OPc283g65QNIiLpZnkHRbnc=
 cloud.google.com/go/auth/oauth2adapt v0.2.8/go.mod h1:XQ9y31RkqZCcwJWNSx2Xvric3RrU88hAYYbjDWYDL+c=
 cloud.google.com/go/automl v1.5.0/go.mod h1:34EjfoFGMZ5sgJ9EoLsRtdPSNZLcfflJR39VbVNS2M0=

--- a/plugins/secretstores/googlecloud/googlecloud_test.go
+++ b/plugins/secretstores/googlecloud/googlecloud_test.go
@@ -40,7 +40,7 @@ func TestInitFail(t *testing.T) {
 				Log:             testutil.Logger{},
 				CredentialsFile: "non-existent-file.json",
 			},
-			expected: "credentials search failed:",
+			expected: "cannot load the credential file:",
 		},
 		{
 			name: "invalid service account file json should fail",
@@ -49,7 +49,7 @@ func TestInitFail(t *testing.T) {
 				Log:             testutil.Logger{},
 				CredentialsFile: "./testdata/invalid-json-sa-key.json",
 			},
-			expected: "credentials search failed: invalid character",
+			expected: "cannot parse the credential file: invalid character",
 		},
 		{
 			name: "missing service account type should fail",
@@ -67,6 +67,15 @@ func TestInitFail(t *testing.T) {
 				CredentialsFile: "./testdata/gdch.json",
 			},
 			expected: "credentials search failed: credentials: STSAudience must be set for the GDCH auth flows",
+		},
+		{
+			name: "missing ca cert path should fail",
+			plugin: &GoogleCloud{
+				Log:             testutil.Logger{},
+				CredentialsFile: "./testdata/gdch-missing-ca-cert-path.json",
+				STSAudience:     "https://localhost",
+			},
+			expected: "credentials search failed: credentials: failed to read certificate:",
 		},
 	}
 

--- a/plugins/secretstores/googlecloud/testdata/gdch-missing-ca-cert-path.json
+++ b/plugins/secretstores/googlecloud/testdata/gdch-missing-ca-cert-path.json
@@ -1,0 +1,9 @@
+{
+    "type":"gdch_service_account",
+    "format_version":"1",
+    "project":"itia-test",
+    "private_key_id":"b02a10dd-a1c8-4d39-aeca-00d8791d6fc1",
+    "private_key": "-----BEGIN PRIVATE KEY-----\nMIICdgIBADANBgkqhkiG9w0BAQEFAASCAmAwggJcAgEAAoGBALX0PQoe1igW12ikv1bN/r9lN749y2ijmbc/mFHPyS3hNTyOCjDvBbXYbDhQJzWVUikh4mvGBA07qTj79Xc3yBDfKP2IeyYQIFe0t0zkd7R9Zdn98Y2rIQC47aAbDfubtkU1U72t4zL11kHvoa0/RuFZjncvlr42X7be7lYh4p3NAgMBAAECgYASk5wDw4Az2ZkmeuN6Fk/y9H+Lcb2pskJIXjrL533vrDWGOC48LrsThMQPv8cxBky8HFSEklPpkfTF95tpD43iVwJRB/GrCtGTw65IfJ4/tI09h6zGc4yqvIo1cHX/LQ+SxKLGyir/dQM925rGt/VojxY5ryJR7GLbCzxPnJm/oQJBANwOCO6D2hy1LQYJhXh7O+RLtA/tSnT1xyMQsGT+uUCMiKS2bSKx2wxo9k7h3OegNJIu1q6nZ6AbxDK8H3+d0dUCQQDTrPSXagBxzp8PecbaCHjzNRSQE2in81qYnrAFNB4o3DpHyMMY6s5ALLeHKscEWnqP8Ur6X4PvzZecCWU9BKAZAkAutLPknAuxSCsUOvUfS1i87ex77Ot+w6POp34pEX+UWb+u5iFn2cQacDTHLV1LtE80L8jVLSbrbrlH43H0DjU5AkEAgidhycxS86dxpEljnOMCw8CKoUBd5I880IUahEiUltk7OLJYS/Ts1wbn3kPOVX3wyJs8WBDtBkFrDHW2ezth2QJADj3e1YhMVdjJW5jqwlD/VNddGjgzyunmiZg0uOXsHXbytYmsA545S8KRQFaJKFXYYFo2kOjqOiC1T2cAzMDjCQ==\n-----END PRIVATE KEY-----\n",
+    "name":"itia-test-sa",
+    "token_uri":"https://service-account/authenticate"
+}


### PR DESCRIPTION
# PR Summary: Google Cloud Secret Store Refactoring

## Overview
This PR updates the Google Cloud secret store plugin to improve credential file handling with explicit type detection.

## Changes

### Code Refactoring
**File: `plugins/secretstores/googlecloud/googlecloud.go`**

- **Replaced API**: Changed from `credentials.DetectDefault()` to `credentials.NewCredentialsFromJSON()` for more explicit credential handling
- **Remove deprecated variables**: The variable `DetectOptions` **CredentialsFile** is [deprecated](https://github.com/googleapis/google-cloud-go/blob/2a546c0cf9330ddc97dbb60c3b8d21be2b929221/auth/credentials/detect.go#L238), and the functionality has been removed.
- **Added credential file parsing**: Now manually reads and parses the service account JSON file instead of relying on auto-detection
- **New helper function**: Added `parseFileType()` to extract the `type` field from the service account JSON, which is required to instantiate credentials correctly
- **Improved error handling**: Separate error messages for file reading vs. JSON parsing failures

### Test Updates
**File: `plugins/secretstores/googlecloud/googlecloud_test.go`**

- Updated error message assertions to reflect new parsing flow
- Added test case for missing CA certificate path in GDCH (Google Distributed Cloud Hosted) service accounts

### Test Data
**New file: `plugins/secretstores/googlecloud/testdata/gdch-missing-ca-cert-path.json`**

- Added test fixture for GDCH service account credentials with incomplete configuration

## Benefits
- More explicit and debuggable credential initialization
- Better error messages for troubleshooting credential file issues
- Compatibility with the latest Google Cloud auth library
- Improved support for GDCH (Google Distributed Cloud Hosted) authentication flows

## Checklist

- [x] No AI generated code was used in this PR
