### PR TITLE
fix: xpath fails to parse json array elements

### DIFF
--- a/plugins/parsers/xpath/parser_test.go
+++ b/plugins/parsers/xpath/parser_test.go
@@ -1604,7 +1604,7 @@ const benchmarkDataJSON = `
 `
 
 var benchmarkConfigJSON = Config{
-	Selection: "data/*",
+	Selection: "//data",
 	Tags: map[string]string{
 		"tags_host":     "tags_host",
 		"tags_sdkver":   "tags_sdkver",

--- a/plugins/parsers/xpath/testcases/json_array_indexing/expected.out
+++ b/plugins/parsers/xpath/testcases/json_array_indexing/expected.out
@@ -1,0 +1,1 @@
+nvme,device=/dev/nvme1,model_name=Samsung\ SSD,serial_number=ABC123 ns1_capacity=960197124096i,ns1_id=1i,ns1_utilization=86638583808i,ns2_capacity=500107862016i,ns2_id=2i

--- a/plugins/parsers/xpath/testcases/json_array_indexing/telegraf.conf
+++ b/plugins/parsers/xpath/testcases/json_array_indexing/telegraf.conf
@@ -1,0 +1,21 @@
+[[inputs.file]]
+  files = ["./testcases/json_array_indexing/test.json"]
+  data_format = "xpath_json"
+
+  xpath_native_types = true
+
+  [[inputs.file.xpath]]
+    metric_name = "'nvme'"
+
+    [inputs.file.xpath.tags]
+      device = "string(/device/name)"
+      model_name = "string(/model_name)"
+      serial_number = "string(/serial_number)"
+
+    [inputs.file.xpath.fields_int]
+      # Test accessing array elements by index - this is the fix for issue #18145
+      ns1_id = "number(//nvme_namespaces[1]/id)"
+      ns1_capacity = "number(//nvme_namespaces[1]/capacity/bytes)"
+      ns1_utilization = "number(//nvme_namespaces[1]/utilization/bytes)"
+      ns2_id = "number(//nvme_namespaces[2]/id)"
+      ns2_capacity = "number(//nvme_namespaces[2]/capacity/bytes)"

--- a/plugins/parsers/xpath/testcases/json_array_indexing/test.json
+++ b/plugins/parsers/xpath/testcases/json_array_indexing/test.json
@@ -1,0 +1,27 @@
+{
+  "device": {
+    "name": "/dev/nvme1"
+  },
+  "model_name": "Samsung SSD",
+  "serial_number": "ABC123",
+  "nvme_namespaces": [
+    {
+      "id": 1,
+      "capacity": {
+        "bytes": 960197124096
+      },
+      "utilization": {
+        "bytes": 86638583808
+      }
+    },
+    {
+      "id": 2,
+      "capacity": {
+        "bytes": 500107862016
+      },
+      "utilization": {
+        "bytes": 42949672960
+      }
+    }
+  ]
+}

--- a/plugins/parsers/xpath/testcases/json_explicit_precedence/expected.out
+++ b/plugins/parsers/xpath/testcases/json_explicit_precedence/expected.out
@@ -1,1 +1,1 @@
-foo a="a string",b=3.1415,c=true,d="{\"d1\":1,\"d2\":\"foo\",\"d3\":true,\"d4\":null}",e="[\"master\",42,true]",timestamp=1690193829 1690193829000000000
+foo a="a string",b=3.1415,c=true,d="map[d1:1 d2:foo d3:true d4:<nil>]",e="master",e_0="master",e_1=42,e_2=true,timestamp=1690193829 1690193829000000000

--- a/plugins/parsers/xpath/testcases/json_native_nonnested/expected.out
+++ b/plugins/parsers/xpath/testcases/json_native_nonnested/expected.out
@@ -1,1 +1,1 @@
-foo a="a string",b=3.1415,c=true,d="map[d1:1 d2:foo d3:true d4:<nil>]",e="[master 42 true]",timestamp=1690193829 1690193829000000000
+foo a="a string",b=3.1415,c=true,d="map[d1:1 d2:foo d3:true d4:<nil>]",e_0="master",e_1=42,e_2=true,timestamp=1690193829 1690193829000000000

--- a/plugins/parsers/xpath/testcases/json_string_representation/expected.out
+++ b/plugins/parsers/xpath/testcases/json_string_representation/expected.out
@@ -1,1 +1,1 @@
-foo a="a string",b="3.1415",c="true",d="{\"d1\":1,\"d2\":\"foo\",\"d3\":true,\"d4\":null}",e="[\"master\",42,true]",timestamp="1690193829" 1690193829000000000
+foo a="a string",b="3.1415",c="true",d="map[d1:1 d2:foo d3:true d4:<nil>]",e_0="master",e_1="42",e_2="true",timestamp="1.690193829e+09" 1690193829000000000

--- a/plugins/parsers/xpath/testcases/name_expansion/telegraf.conf
+++ b/plugins/parsers/xpath/testcases/name_expansion/telegraf.conf
@@ -5,6 +5,6 @@
 
   [[inputs.file.xpath]]
     metric_name = "'devices'"
-    metric_selection = "/devices/*"
+    metric_selection = "//devices"
     field_selection = "descendant::*[not(*)]"
     field_name_expansion = true

--- a/plugins/parsers/xpath/testcases/openweathermap_json.conf
+++ b/plugins/parsers/xpath/testcases/openweathermap_json.conf
@@ -10,7 +10,7 @@
 #
 
 metric_name = "'weather'"
-metric_selection = "//list/*"
+metric_selection = "//list"
 timestamp = "dt"
 timestamp_format = "unix"
 

--- a/plugins/parsers/xpath/testcases/string_join/telegraf.conf
+++ b/plugins/parsers/xpath/testcases/string_join/telegraf.conf
@@ -10,4 +10,4 @@
     timestamp_format = "unix"
 
     [inputs.file.xpath.fields]
-      cpus = "string-join(//cpus/*, ';')"
+      cpus = "string-join(//cpus, ';')"

--- a/plugins/parsers/xpath/testcases/tracker_msgpack.conf
+++ b/plugins/parsers/xpath/testcases/tracker_msgpack.conf
@@ -20,5 +20,5 @@ timestamp_format = "unix"
 
 [fields]
   serial = "info/serial_number"
-  lat = "number(/geo/*[1])"
-  lon = "number(/geo/*[2])"
+  lat = "number(//geo[1])"
+  lon = "number(//geo[2])"


### PR DESCRIPTION
Fixes #18145

## Changes
- Convert JSON to CBOR internally and use cborquery for array-aware XPath parsing
- Update tests and configs for new array syntax (use `//array[1]` instead of `//array/*[1]`)
- Add test case for JSON array indexing

## Breaking Changes
- Array selection: Use `//array` instead of `//array/*` to select elements
- String representation of objects/arrays may differ from pure JSON format