### PR TITLE
test(inputs.syslog): Fix test failures with 2025 timestamps

### DIFF
--- a/plugins/inputs/syslog/testcases/rfc3164_best_effort_udp/expected.out
+++ b/plugins/inputs/syslog/testcases/rfc3164_best_effort_udp/expected.out
@@ -1,1 +1,1 @@
-syslog,appname=app,facility=user,hostname=host,severity=notice,source=127.0.0.1 facility_code=1i,message="Test",severity_code=5i,timestamp=1764693063000000000i 0
+syslog,appname=app,facility=user,hostname=host,severity=notice,source=127.0.0.1 facility_code=1i,message="Test",severity_code=5i,timestamp=1796229063000000000i 0

--- a/plugins/inputs/syslog/testcases/rfc3164_non_transparent_strict_tcp/expected.out
+++ b/plugins/inputs/syslog/testcases/rfc3164_non_transparent_strict_tcp/expected.out
@@ -1,1 +1,1 @@
-syslog,appname=app,facility=user,hostname=host,severity=notice,source=127.0.0.1 facility_code=1i,message="Test",severity_code=5i,timestamp=1764693063000000000i 0
+syslog,appname=app,facility=user,hostname=host,severity=notice,source=127.0.0.1 facility_code=1i,message="Test",severity_code=5i,timestamp=1796229063000000000i 0

--- a/plugins/inputs/syslog/testcases/rfc3164_octet_counting_strict_tcp/expected.out
+++ b/plugins/inputs/syslog/testcases/rfc3164_octet_counting_strict_tcp/expected.out
@@ -1,1 +1,1 @@
-syslog,appname=app,facility=user,hostname=host,severity=notice,source=127.0.0.1 facility_code=1i,message="Test",severity_code=5i,timestamp=1764693063000000000i 0
+syslog,appname=app,facility=user,hostname=host,severity=notice,source=127.0.0.1 facility_code=1i,message="Test",severity_code=5i,timestamp=1796229063000000000i 0

--- a/plugins/inputs/syslog/testcases/rfc3164_strict_udp/expected.out
+++ b/plugins/inputs/syslog/testcases/rfc3164_strict_udp/expected.out
@@ -1,1 +1,1 @@
-syslog,appname=app,facility=user,hostname=host,severity=notice,source=127.0.0.1 facility_code=1i,message="Test",severity_code=5i,timestamp=1764693063000000000i 0
+syslog,appname=app,facility=user,hostname=host,severity=notice,source=127.0.0.1 facility_code=1i,message="Test",severity_code=5i,timestamp=1796229063000000000i 0


### PR DESCRIPTION
## Summary
Fixes test failures due to the expected output expecting a 2025 timestamp, and now getting a 2026 timestamp

## Checklist
- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
resolves #
