### PR TITLE
fix(common.jolokia2): Add Jolokia 2.x compatibility for proxy target tag

### DIFF
--- a/plugins/common/jolokia2/client_test.go
+++ b/plugins/common/jolokia2/client_test.go
@@ -1,0 +1,161 @@
+package jolokia2
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMakeReadResponses_Jolokia1xTarget(t *testing.T) {
+	// Jolokia 1.x returns target directly in request.target
+	jresponses := []jolokiaResponse{
+		{
+			Request: jolokiaResponseRequest{
+				jolokiaRequest: jolokiaRequest{
+					Type:      "read",
+					Mbean:     "java.lang:type=Runtime",
+					Attribute: "Uptime",
+					Target: &jolokiaTarget{
+						URL: "service:jmx:rmi:///jndi/rmi://target:9010/jmxrmi",
+					},
+				},
+			},
+			Value:  1214083,
+			Status: 200,
+		},
+	}
+
+	responses := makeReadResponses(jresponses)
+
+	require.Len(t, responses, 1)
+	require.Equal(t, "service:jmx:rmi:///jndi/rmi://target:9010/jmxrmi", responses[0].RequestTarget)
+	require.Equal(t, "java.lang:type=Runtime", responses[0].RequestMbean)
+	require.Equal(t, 200, responses[0].Status)
+}
+
+func TestMakeReadResponses_Jolokia2xTarget(t *testing.T) {
+	// Jolokia 2.x returns target in request.options.target
+	jresponses := []jolokiaResponse{
+		{
+			Request: jolokiaResponseRequest{
+				jolokiaRequest: jolokiaRequest{
+					Type:      "read",
+					Mbean:     "java.lang:type=Runtime",
+					Attribute: "Uptime",
+				},
+				Options: &jolokiaOptions{
+					Target: &jolokiaTarget{
+						URL: "service:jmx:rmi:///jndi/rmi://target:9010/jmxrmi",
+					},
+				},
+			},
+			Value:  1214083,
+			Status: 200,
+		},
+	}
+
+	responses := makeReadResponses(jresponses)
+
+	require.Len(t, responses, 1)
+	require.Equal(t, "service:jmx:rmi:///jndi/rmi://target:9010/jmxrmi", responses[0].RequestTarget)
+	require.Equal(t, "java.lang:type=Runtime", responses[0].RequestMbean)
+	require.Equal(t, 200, responses[0].Status)
+}
+
+func TestMakeReadResponses_NoTarget(t *testing.T) {
+	// No target (direct agent connection, not proxy)
+	jresponses := []jolokiaResponse{
+		{
+			Request: jolokiaResponseRequest{
+				jolokiaRequest: jolokiaRequest{
+					Type:      "read",
+					Mbean:     "java.lang:type=Runtime",
+					Attribute: "Uptime",
+				},
+			},
+			Value:  1214083,
+			Status: 200,
+		},
+	}
+
+	responses := makeReadResponses(jresponses)
+
+	require.Len(t, responses, 1)
+	require.Empty(t, responses[0].RequestTarget)
+	require.Equal(t, "java.lang:type=Runtime", responses[0].RequestMbean)
+}
+
+func TestMakeReadResponses_Jolokia1xTakesPrecedence(t *testing.T) {
+	// If both locations have a target, Jolokia 1.x location takes precedence
+	jresponses := []jolokiaResponse{
+		{
+			Request: jolokiaResponseRequest{
+				jolokiaRequest: jolokiaRequest{
+					Type:      "read",
+					Mbean:     "java.lang:type=Runtime",
+					Attribute: "Uptime",
+					Target: &jolokiaTarget{
+						URL: "service:jmx:rmi:///jndi/rmi://target1:9010/jmxrmi",
+					},
+				},
+				Options: &jolokiaOptions{
+					Target: &jolokiaTarget{
+						URL: "service:jmx:rmi:///jndi/rmi://target2:9010/jmxrmi",
+					},
+				},
+			},
+			Value:  1214083,
+			Status: 200,
+		},
+	}
+
+	responses := makeReadResponses(jresponses)
+
+	require.Len(t, responses, 1)
+	// Jolokia 1.x location (request.target) takes precedence
+	require.Equal(t, "service:jmx:rmi:///jndi/rmi://target1:9010/jmxrmi", responses[0].RequestTarget)
+}
+
+func TestMakeReadResponses_MultipleTargets(t *testing.T) {
+	// Multiple responses with different targets (Jolokia 2.x format)
+	jresponses := []jolokiaResponse{
+		{
+			Request: jolokiaResponseRequest{
+				jolokiaRequest: jolokiaRequest{
+					Type:      "read",
+					Mbean:     "java.lang:type=Runtime",
+					Attribute: "Uptime",
+				},
+				Options: &jolokiaOptions{
+					Target: &jolokiaTarget{
+						URL: "service:jmx:rmi:///jndi/rmi://host1:9010/jmxrmi",
+					},
+				},
+			},
+			Value:  1000,
+			Status: 200,
+		},
+		{
+			Request: jolokiaResponseRequest{
+				jolokiaRequest: jolokiaRequest{
+					Type:      "read",
+					Mbean:     "java.lang:type=Runtime",
+					Attribute: "Uptime",
+				},
+				Options: &jolokiaOptions{
+					Target: &jolokiaTarget{
+						URL: "service:jmx:rmi:///jndi/rmi://host2:9010/jmxrmi",
+					},
+				},
+			},
+			Value:  2000,
+			Status: 200,
+		},
+	}
+
+	responses := makeReadResponses(jresponses)
+
+	require.Len(t, responses, 2)
+	require.Equal(t, "service:jmx:rmi:///jndi/rmi://host1:9010/jmxrmi", responses[0].RequestTarget)
+	require.Equal(t, "service:jmx:rmi:///jndi/rmi://host2:9010/jmxrmi", responses[1].RequestTarget)
+}


### PR DESCRIPTION
## Summary

Jolokia 2.x changed the response format for proxy requests. The target URL is now returned under `request.options.target` instead of `request.target` (Jolokia 1.x format).

This change adds support for both formats by checking both locations when extracting the target URL for the `jolokia_agent_url` tag.

Without this fix, metrics from `jolokia2_proxy` plugin using Jolokia 2.x are missing the `jolokia_agent_url` tag, making it impossible to distinguish metrics from different proxy targets.

## Checklist

- [x] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

resolves #18194