### PR TITLE
docs(outputs.execd): Document error handling limitations

### DIFF
--- a/plugins/outputs/execd/README.md
+++ b/plugins/outputs/execd/README.md
@@ -57,6 +57,24 @@ plugin ordering. See [CONFIGURATION.md][CONFIGURATION.md] for more details.
   data_format = "influx"
 ```
 
+## Error Handling
+
+This plugin uses a fire-and-forget communication model. Metrics are considered
+successfully written once they are written to the external process's `stdin`
+pipe, not when the external plugin actually processes them. Due to OS pipe
+buffering (typically ~64KB), writes to `stdin` are non-blocking until the
+buffer fills.
+
+If the external plugin encounters an error while processing metrics, it may
+write error messages to `stderr`, which Telegraf will log. However, these
+errors do not trigger Telegraf's retry mechanism or prevent metrics from being
+removed from the buffer.
+
+This means metrics can be lost if the external plugin fails to process them.
+For use cases requiring guaranteed delivery, consider using a built-in output
+plugin or implementing your own acknowledgment mechanism within the external
+plugin.
+
 ## Example
 
 see [examples][]


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
  - Documents the fire-and-forget communication model used by `outputs.execd`
  - Clarifies that metrics are considered "written" once they reach the stdin pipe, not when processed by the external plugin
  - Explains that errors from external plugins are logged but don't trigger Telegraf's retry mechanism
  - Warns users about potential metric loss and suggests alternatives for guaranteed delivery


## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #17828
resolves #17845
