### PR TITLE
feat(cpu): add clamp_percentages option

### DIFF
--- a/plugins/inputs/cpu/README.md
+++ b/plugins/inputs/cpu/README.md
@@ -25,6 +25,8 @@ plugin ordering. See [CONFIGURATION.md][CONFIGURATION.md] for more details.
   totalcpu = true
   ## If true, collect raw CPU time metrics
   collect_cpu_time = false
+  ## If true, clamp usage percent fields into the range [0,100]
+  clamp_percentages = false
   ## If true, compute and report the sum of all non-idle CPU states
   ## NOTE: The resulting 'time_active' field INCLUDES 'iowait'!
   report_active = false

--- a/plugins/inputs/cpu/sample.conf
+++ b/plugins/inputs/cpu/sample.conf
@@ -6,6 +6,8 @@
   totalcpu = true
   ## If true, collect raw CPU time metrics
   collect_cpu_time = false
+  ## If true, clamp usage percent fields into the range [0,100]
+  clamp_percentages = false
   ## If true, compute and report the sum of all non-idle CPU states
   ## NOTE: The resulting 'time_active' field INCLUDES 'iowait'!
   report_active = false


### PR DESCRIPTION
- add clamp_percentages configuration option
- implement usagePercent helper function with clamping logic
- clamp CPU usage percentages to [0,100] range when enabled

## Summary
cpu in windows can show non 0-100 values
check [issue](https://github.com/influxdata/telegraf/issues/18141)

## Checklist

- [x ] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

resolves [issue](https://github.com/influxdata/telegraf/issues/18141)
