### PR TITLE
fix(inputs.statsd): Handle negative lengths

### DIFF
--- a/plugins/inputs/statsd/datadog.go
+++ b/plugins/inputs/statsd/datadog.go
@@ -59,6 +59,9 @@ func (s *Statsd) parseEventMessage(now time.Time, message, defaultHostname strin
 	if err != nil {
 		return fmt.Errorf("invalid message format, could not parse text.length: %q", rawLen[0])
 	}
+	if titleLen < 0 || textLen < 0 {
+		return errors.New("invalid message format, title.length and text.length must be positive integer")
+	}
 	if titleLen+textLen+1 > int64(len(message)) {
 		return errors.New("invalid message format, title.length and text.length exceed total message length")
 	}

--- a/plugins/inputs/statsd/datadog_test.go
+++ b/plugins/inputs/statsd/datadog_test.go
@@ -456,6 +456,12 @@ func TestEventError(t *testing.T) {
 	err = s.parseEventMessage(now, "_e{,}:title|text", "default-hostname")
 	require.Error(t, err)
 
+	err = s.parseEventMessage(now, "_e{-5,5}:title|text", "default-hostname")
+	require.Error(t, err)
+
+	err = s.parseEventMessage(now, "_e{0,-5}:title|text", "default-hostname")
+	require.Error(t, err)
+
 	// not enough information
 	err = s.parseEventMessage(now, "_e|text", "default-hostname")
 	require.Error(t, err)


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Currently when parsing DataDog events both `titleLen` and `textLen` could be supplied as negative integer, which would yield an uncaught exception and crash telegraf in lines:

https://github.com/donmahallem/telegraf/blob/538478fee14258a2944f37c61e18a530c635cb10/plugins/inputs/statsd/datadog.go#L69-L70


Example input: "_e{-5,5}:title|text" would cause `titleLen` be -5 and cause issues in line https://github.com/donmahallem/telegraf/blob/538478fee14258a2944f37c61e18a530c635cb10/plugins/inputs/statsd/datadog.go#L69

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

