### PR TITLE
fix(inputs.procstat): Handle newer versions of systemd correctly

### DIFF
--- a/plugins/inputs/procstat/procstat.go
+++ b/plugins/inputs/procstat/procstat.go
@@ -599,7 +599,11 @@ func (p *Procstat) supervisorPIDs() ([]string, map[string]map[string]string, err
 
 func (p *Procstat) systemdUnitPIDs() ([]pidsTags, error) {
 	if p.IncludeSystemdChildren {
+		// Adapt the path for newer versions of systemd
 		p.CGroup = "systemd/system.slice/" + p.SystemdUnit
+		if _, err := os.Stat("/sys/fs/cgroup/systemd/system.slice"); errors.Is(err, os.ErrNotExist) {
+			p.CGroup = "system.slice/" + p.SystemdUnit
+		}
 		return p.cgroupPIDs()
 	}
 


### PR DESCRIPTION
## Summary

This PR adapts the `/sys/fs` path for newer systemd versions and uses the correct filtering for systemd units when using the new filter scheme.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

resolves #17904 
