### PR TITLE
fix(inputs.cisco_telemetry_mdt): Handle DME events correctly

### DIFF
--- a/plugins/inputs/cisco_telemetry_mdt/cisco_telemetry_mdt.go
+++ b/plugins/inputs/cisco_telemetry_mdt/cisco_telemetry_mdt.go
@@ -771,14 +771,12 @@ func (c *CiscoTelemetryMDT) parseContentField(
 	// DME structure: https://developer.cisco.com/site/nxapi-dme-model-reference-api/
 	rn := ""
 	dn := false
-	dnstr := ""
 
 	for _, subfield := range nxAttributes.Fields {
 		if subfield.Name == "rn" {
 			rn = decodeTag(subfield)
 		} else if subfield.Name == "dn" {
 			dn = true
-			dnstr = decodeTag(subfield)
 		}
 	}
 
@@ -787,8 +785,6 @@ func (c *CiscoTelemetryMDT) parseContentField(
 	} else if !dn { // Check for distinguished name being present
 		c.acc.AddError(errors.New("failed while decoding NX-OS: missing 'dn' field"))
 		return
-	} else if dn {
-		tags["dn"] = dnstr
 	}
 
 	for _, subfield := range nxAttributes.Fields {

--- a/plugins/inputs/cisco_telemetry_mdt/cisco_telemetry_mdt_test.go
+++ b/plugins/inputs/cisco_telemetry_mdt/cisco_telemetry_mdt_test.go
@@ -1527,7 +1527,6 @@ func TestHandleNXDMEEventListWithDn(t *testing.T) {
 	tags := map[string]string{
 		"path":         "EVENT-LIST",
 		"EVENT_LIST":   "EVENT-LIST",
-		"dn":           "sys/intf/phys-[eth1/11]/phys",
 		"source":       "NX-PGBL-GX2",
 		"subscription": "1",
 	}


### PR DESCRIPTION
## Summary
Currently the event based telemetry data from cisco NXOS switch is not properly parsed by the cisco_telemetry_mdt plugin and is silently getting dropped. Also, the DN needs to be added as a tag for all the event telemetry data received.

## Checklist
- [ ] No AI generated code was used in this PR
- [x] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves # https://github.com/influxdata/telegraf/issues/18255
