### PR TITLE
feat(inputs.mysql): Support encryption algorithm statistics if present

### DIFF
--- a/plugins/inputs/mysql/mysql.go
+++ b/plugins/inputs/mysql/mysql.go
@@ -729,6 +729,7 @@ func gatherBinaryLogs(db *sql.DB, servtag string, acc telegraf.Accumulator) erro
 		fileSize  uint64
 		fileName  string
 		encrypted string
+		algorithm string
 	)
 
 	columns, err := rows.Columns()
@@ -739,11 +740,16 @@ func gatherBinaryLogs(db *sql.DB, servtag string, acc telegraf.Accumulator) erro
 
 	// iterate over rows and count the size and count of files
 	for rows.Next() {
-		if numColumns == 3 {
+		switch numColumns {
+		case 3:
 			if err := rows.Scan(&fileName, &fileSize, &encrypted); err != nil {
 				return err
 			}
-		} else {
+		case 4: // Compatible with versions that include encryption algorithms.
+			if err := rows.Scan(&fileName, &fileSize, &encrypted, &algorithm); err != nil {
+				return err
+			}
+		default:
 			if err := rows.Scan(&fileName, &fileSize); err != nil {
 				return err
 			}


### PR DESCRIPTION
## Summary

Enhanced the MySQL plugin to support newer MySQL versions that include encryption algorithm information in the SHOW BINARY LOGS output.

## Checklist
* [x]  No AI generated code was used in this PR
* [ ]  AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions](https://www.influxdata.com/ai-generated-code-contributions-policy) 

## Related issues

based on #18166 
