### PR TITLE
chore: Unify endianness setting in binary parser and serializer

### DIFF
--- a/plugins/parsers/binary/README.md
+++ b/plugins/parsers/binary/README.md
@@ -19,8 +19,9 @@ user-specified configurations.
   # allow_no_match = false
 
   ## Specify the endianness of the data.
-  ## Available values are "be" (big-endian), "le" (little-endian) and "host",
-  ## where "host" means the same endianness as the machine running Telegraf.
+  ## Available values are "big" or "be" for big-endian, "little" or "le" for
+  ## little-endian and "host" for using the same endianness as the machine
+  ## running Telegraf.
   # endianness = "host"
 
   ## Interpret input using the specified encoding

--- a/plugins/parsers/binary/parser.go
+++ b/plugins/parsers/binary/parser.go
@@ -28,9 +28,9 @@ type Parser struct {
 
 func (p *Parser) Init() error {
 	switch p.Endianness {
-	case "le":
+	case "little", "le":
 		p.converter = binary.LittleEndian
-	case "be":
+	case "big", "be":
 		p.converter = binary.BigEndian
 	case "", "host":
 		p.converter = internal.HostEndianness

--- a/plugins/serializers/binary/README.md
+++ b/plugins/serializers/binary/README.md
@@ -17,8 +17,9 @@ using user-specified configurations.
   data_format = "binary"
 
   ## Specify the endianness of the data.
-  ## Available values are "little" (little-endian), "big" (big-endian) and "host",
-  ## where "host" means the same endianness as the machine running Telegraf.
+  ## Available values are "big" or "be" for big-endian, "little" or "le" for
+  ## little-endian and "host" for using the same endianness as the machine
+  ## running Telegraf.
   # endianness = "host"
 
   ## Definition of the message format and the serialized data.

--- a/plugins/serializers/binary/binary.go
+++ b/plugins/serializers/binary/binary.go
@@ -18,9 +18,9 @@ type Serializer struct {
 
 func (s *Serializer) Init() error {
 	switch s.Endianness {
-	case "big":
+	case "big", "be":
 		s.converter = binary.BigEndian
-	case "little":
+	case "little", "le":
 		s.converter = binary.LittleEndian
 	case "", "host":
 		s.Endianness = "host"


### PR DESCRIPTION
## Summary

Unify available values for the endianness setting in both the binary parser and serializer.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

resolves #18274
