### PR TITLE
fix(parsers.dropwizard): Correct sample config setting name for tag path

### DIFF
--- a/plugins/parsers/dropwizard/README.md
+++ b/plugins/parsers/dropwizard/README.md
@@ -51,7 +51,7 @@ pattern][templates]. All field value types are supported, `string`, `number` and
   # dropwizard_tags_path = "tags"
 
   ## You may even use tag paths per tag
-  # [inputs.exec.dropwizard_tag_paths]
+  # [inputs.exec.dropwizard_tag_paths_map]
   #   tag1 = "tags.tag1"
   #   tag2 = "tags.tag2"
 ```
@@ -171,7 +171,7 @@ dropwizard_time_path = "time"
 dropwizard_time_format = "2006-01-02T15:04:05Z07:00"
 dropwizard_tags_path = "tags"
 ## tag paths per tag are supported too, eg.
-#[inputs.yourinput.dropwizard_tag_paths]
+#[inputs.yourinput.dropwizard_tag_paths_map]
 #  tag1 = "tags.tag1"
 #  tag2 = "tags.tag2"
 ```


### PR DESCRIPTION
## Summary

In the `dropwizard` parser sample configuration, the `dropwizard_tag_paths` TOML key doesn't match what's defined in the `parser.go`:

```go
TagPathsMap        map[string]string `toml:"dropwizard_tag_paths_map"`
```

This updates the README to include the correct TOML key in the sample configuration.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

resolves #18277
