### PR TITLE
chore(inputs.statsd): Fix typo in comment

### DIFF
--- a/plugins/inputs/statsd/statsd.go
+++ b/plugins/inputs/statsd/statsd.go
@@ -151,8 +151,8 @@ type internalStats struct {
 
 // Number will get parsed as an int or float depending on what is passed
 //
-// This type needs to be exported so that the plugin can be configured when using the TOML config file. i.e. It's being
-// used as a library.
+// This type needs to be exported so that the plugin can be configured when not using the TOML config file.
+// i.e. It's being used as a library.
 type Number float64
 
 // UnmarshalTOML is a custom TOML unmarshalling function for the number type.


### PR DESCRIPTION
## Summary
I wrote this comment initially and meant it to say this.

## Checklist

- [x] No AI generated code was used in this PR

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

https://github.com/influxdata/telegraf/pull/18249
