### PR TITLE
fix(inputs.prometheus): Cleanup shared informers on stop

### DIFF
--- a/plugins/inputs/prometheus/prometheus.go
+++ b/plugins/inputs/prometheus/prometheus.go
@@ -312,6 +312,10 @@ func (p *Prometheus) Stop() {
 	p.cancel()
 	p.wg.Wait()
 
+	if p.MonitorPods && !p.isNodeScrapeScope {
+		delete(informerfactory, p.PodNamespace)
+	}
+
 	if p.client != nil {
 		p.client.CloseIdleConnections()
 	}


### PR DESCRIPTION


## Summary
When telegraf configuration is reloaded, Stop() for every plugin is called followed by Start() for all plugins.

Prometheus plugin's Stop() cancels context used to initialize shared informer in the `watchPod`, which then cause
informer to stop.

Stopped informers cannot be restarted, so we need to remove informers from the global map. This will allow subsequent Start() to initialize fresh informer.

## Checklist
- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
resolves #18303 