### PR TITLE
feat(outputs.influxdb_v2): Add trace logging for write request timing

### DIFF
--- a/plugins/outputs/influxdb_v2/http.go
+++ b/plugins/outputs/influxdb_v2/http.go
@@ -367,6 +367,10 @@ func (c *httpClient) writeBatch(ctx context.Context, b *batch) error {
 	}
 
 	// We got an error and now try to decode further
+	c.log.Tracef(
+		"Request returned error status in %s: metrics=%d, size=%d bytes, bucket=%q, status=%s",
+		elapsed, metricCount, payloadSize, b.bucket, resp.Status,
+	)
 	var desc string
 	writeResp := &genericRespError{}
 	if json.NewDecoder(resp.Body).Decode(writeResp) == nil {


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Added trace logging for write request timing and payload details in the influxdb_v2 output plugin.                                                                                                                                 
   
#### How This Helps Diagnose Issues                                                                                                                                                                                                
                                                            
  1. If elapsed ≈ timeout: Server isn't responding at all (network or server-side issue)
  2. If elapsed < timeout but fails: Connection reset, server error, etc.
  3. Payload sizes: Reveals actual payload size being sent (after encoding) - helps identify unexpectedly large payloads

#### New Trace Logs

  Before sending:
  
`  T! [outputs.influxdb_v2::<alias>] Sending batch: metrics=<count>, size=<bytes> bytes (<KB> KB), bucket="<bucket>", timeout=<timeout>`
  

  On failure:
  
`  T! [outputs.influxdb_v2::<alias>] Request failed after <elapsed> (timeout=<timeout>): metrics=<count>, size=<bytes> bytes, bucket="<bucket>", error=<error_message>`
  

  On success:
  
`  T! [outputs.influxdb_v2::<alias>] Request succeeded in <elapsed>: metrics=<count>, size=<bytes> bytes (<KB> KB), bucket="<bucket>"`
  


## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
