### PR TITLE
feat(outputs.stackdriver): Add credentials file support for stackdriver output plugin

### DIFF
--- a/plugins/outputs/stackdriver/README.md
+++ b/plugins/outputs/stackdriver/README.md
@@ -27,6 +27,14 @@ plugin ordering. See [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 [CONFIGURATION.md]: ../../../docs/CONFIGURATION.md#plugins
 
+## Secret-store support
+
+This plugin supports secrets from secret-stores for the `token` option.
+See the [secret-store documentation][SECRETSTORE] for more details on how
+to use them.
+
+[SECRETSTORE]: ../../../docs/CONFIGURATION.md#secret-store-secrets
+
 ## Configuration
 
 ```toml @sample.conf
@@ -35,11 +43,8 @@ plugin ordering. See [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## GCP Project
   project = "erudite-bloom-151019"
 
-  ## Optional. GCP access token for authorizing calls to Cloud Monitoring APIs.
-  ## Use with a secret-store to dynamically provide tokens, e.g. from the
-  ## googlecloud secret store: @{gcp_auth:token}
-  ## If not set, Telegraf will use Application Default Credentials (preferred).
-  # credentials_token = "@{gcp_auth:token}"
+  ## GCP access token for authorizing calls to Cloud Monitoring APIs
+  # token = "@{gcp_auth:token}"
 
   ## Quota Project
   ## Specifies the Google Cloud project that should be billed for metric ingestion.

--- a/plugins/outputs/stackdriver/sample.conf
+++ b/plugins/outputs/stackdriver/sample.conf
@@ -3,11 +3,8 @@
   ## GCP Project
   project = "erudite-bloom-151019"
 
-  ## Optional. GCP access token for authorizing calls to Cloud Monitoring APIs.
-  ## Use with a secret-store to dynamically provide tokens, e.g. from the
-  ## googlecloud secret store: @{gcp_auth:token}
-  ## If not set, Telegraf will use Application Default Credentials (preferred).
-  # credentials_token = "@{gcp_auth:token}"
+  ## GCP access token for authorizing calls to Cloud Monitoring APIs
+  # token = "@{gcp_auth:token}"
 
   ## Quota Project
   ## Specifies the Google Cloud project that should be billed for metric ingestion.

--- a/plugins/outputs/stackdriver/stackdriver.go
+++ b/plugins/outputs/stackdriver/stackdriver.go
@@ -34,7 +34,7 @@ var sampleConfig string
 
 // Stackdriver is the Google Stackdriver config info.
 type Stackdriver struct {
-	CredentialsToken     config.Secret     `toml:"credentials_token"`
+	Token                config.Secret     `toml:"token"`
 	Project              string            `toml:"project"`
 	QuotaProject         string            `toml:"quota_project"`
 	Namespace            string            `toml:"namespace"`
@@ -145,16 +145,12 @@ func (s *Stackdriver) Connect() error {
 
 		options := []option.ClientOption{
 			option.WithUserAgent(internal.ProductToken()),
+			option.WithQuotaProject(s.QuotaProject),
 		}
 
-		if !s.CredentialsToken.Empty() {
-			ts := &secretTokenSource{secret: &s.CredentialsToken}
+		if !s.Token.Empty() {
+			ts := &secretTokenSource{secret: &s.Token}
 			options = append(options, option.WithTokenSource(ts))
-		}
-
-		if s.QuotaProject != "" {
-			options = append(options, option.WithQuotaProject(s.QuotaProject))
-			s.Log.Infof("Using QuotaProject %s for quota attribution", s.QuotaProject)
 		}
 
 		client, err := monitoring.NewMetricClient(ctx, options...)
@@ -716,7 +712,6 @@ func (s *secretTokenSource) Token() (*oauth2.Token, error) {
 
 // Close will terminate the session to the backend, returning error if an issue arises.
 func (s *Stackdriver) Close() error {
-	s.CredentialsToken.Destroy()
 	return s.client.Close()
 }
 


### PR DESCRIPTION
## Summary
Adds GCP credential file support to the stackdriver output plugin. Follows the pattern from the GCP PubSub output plugin.
## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [ ] No AI generated code was used in this PR
- [x] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #16326
