### PR TITLE
fix(inputs.jenkins): Report all concurrent builds

### DIFF
--- a/plugins/inputs/jenkins/jenkins.go
+++ b/plugins/inputs/jenkins/jenkins.go
@@ -290,31 +290,37 @@ func (j *Jenkins) getJobDetail(jr jobRequest, acc telegraf.Accumulator) error {
 	}
 
 	// collect build info
-	number := js.LastBuild.Number
-	if number < 1 {
-		// no build info
-		return nil
-	}
-	build, err := j.client.getBuild(context.Background(), jr, number)
-	if err != nil {
-		return err
+	builds := js.Builds
+	if len(builds) == 0 {
+		if js.LastBuild.Number < 1 {
+			return nil
+		}
+		builds = []jobBuild{js.LastBuild}
 	}
 
-	if build.Building {
-		j.Log.Debugf("Ignore running build on %s, build %v", jr.name, number)
-		return nil
-	}
-
-	// stop if build is too old
-	// Higher up in gatherJobs
 	cutoff := time.Now().Add(-1 * time.Duration(j.MaxBuildAge))
 
-	// Here we just test
-	if build.getTimestamp().Before(cutoff) {
-		return nil
-	}
+	for _, jb := range builds {
+		if jb.Number < 1 {
+			continue
+		}
 
-	j.gatherJobBuild(jr, build, acc)
+		build, err := j.client.getBuild(context.Background(), jr, jb.Number)
+		if err != nil {
+			return err
+		}
+
+		if build.Building {
+			j.Log.Debugf("Ignore running build on %s, build %v", jr.name, jb.Number)
+			continue
+		}
+
+		if build.getTimestamp().Before(cutoff) {
+			break // builds are newest-first, so all remaining are older
+		}
+
+		j.gatherJobBuild(jr, build, acc)
+	}
 	return nil
 }
 
@@ -362,6 +368,7 @@ type swapSpaceMonitor struct {
 
 type jobResponse struct {
 	LastBuild jobBuild   `json:"lastBuild"`
+	Builds    []jobBuild `json:"builds"`
 	Jobs      []innerJob `json:"jobs"`
 	Name      string     `json:"name"`
 }


### PR DESCRIPTION
Report all concurrent builds, not just lastBuild. The plugin previously only checked lastBuild for each job, missing concurrent builds that completed alongside it. Now iterates over the builds array from the Jenkins API, falling back to lastBuild when the array is empty for backwards compatibility.

## Summary
The Jenkins input plugin only inspects the lastBuild field from the Jenkins API when collecting build metrics. This means only a single build per job is ever evaluated per gather cycle. When a job has multiple builds — whether running concurrently or queued — completed builds are silently dropped.

## Checklist
- [ ] No AI generated code was used in this PR
- [x] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
https://github.com/influxdata/telegraf/issues/18345
https://github.com/influxdata/telegraf/issues/6966

resolves #18345 #6966 
