### PR TITLE
fix(inputs.jenkins): Report all concurrent builds

### DIFF
--- a/plugins/inputs/jenkins/client.go
+++ b/plugins/inputs/jenkins/client.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 )
 
+const maxBuildsPerJob = 20
+
 type client struct {
 	baseURL       string
 	httpClient    *http.Client
@@ -132,7 +134,7 @@ func (c *client) getJobs(ctx context.Context, jr *jobRequest) (js *jobResponse, 
 	js = new(jobResponse)
 	url := jobPath
 	if jr != nil {
-		url = jr.url()
+		url = fmt.Sprintf("%s?tree=builds[number,url]{0,%d},lastBuild[number,url],jobs[name,url,color],name", jr.url(), maxBuildsPerJob)
 	}
 	err = c.doGet(ctx, url, js)
 	return js, err


### PR DESCRIPTION
## Summary
Report all concurrent builds, not just lastBuild. The plugin
previously only checked lastBuild for each job, missing builds
that completed alongside it. Now iterates over the builds array
from the Jenkins API, falling back to lastBuild when the array
is empty for backwards compatibility.

Bound build fetching by adding a tree query parameter to the
getJobs API call, limiting the builds array to 20 entries
server-side. This prevents unbounded HTTP requests for jobs
with thousands of historical builds.

Improve error resilience in the build fetch loop by replacing
return err with acc.AddError + continue. A single getBuild
failure no longer aborts the entire job; remaining builds are
still processed.

Replace break with continue for the MaxBuildAge check so an
out-of-order old build no longer stops iteration and silently
drops subsequent newer builds.

## Checklist
- [ ] No AI generated code was used in this PR
- [x] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
resolves #6966
resolves #18345
