### PR TITLE
fix(serializer): escape newline in string field values

### DIFF
--- a/plugins/serializers/influx/escape.go
+++ b/plugins/serializers/influx/escape.go
@@ -31,6 +31,7 @@ var (
 	stringFieldEscaper = strings.NewReplacer(
 		`"`, `\"`,
 		`\`, `\\`,
+		"\n", `\n`,
 	)
 )
 

--- a/plugins/serializers/influx/influx_test.go
+++ b/plugins/serializers/influx/influx_test.go
@@ -372,7 +372,7 @@ var tests = []struct {
 			},
 			time.Unix(0, 0),
 		),
-		output: []byte("cpu value=\"x\ny\" 0\n"),
+		output: []byte("cpu value=\"x\\ny\" 0\n"),
 	},
 	{
 		name:     "need more space",


### PR DESCRIPTION
## Summary

This PR improves robustness of the Influx Line Protocol serializer by
escaping raw newline characters (`\n`) inside string field values.

Currently, the serializer escapes:

-   double quotes `"`
-   backslashes `\`

However, newline characters inside quoted string fields are not
escaped.\
If a string field contains a literal newline byte, the generated line
protocol becomes physically split across multiple lines.

This breaks the fundamental assumption that one metric equals one
physical line and can lead to parsing failures in strict Line Protocol
parsers.

### Example

Input:

    value = "x\ny"

Current serialized output:

    cpu value="x
    y" 0

Expected serialized output:

    cpu value="x\\ny" 0

Escaping newline characters ensures:

-   A metric always remains on a single physical line
-   Downstream parsers do not encounter malformed LP
-   Improved compatibility across TSDB implementations
-   Safer behavior when ingesting data from sources like Jolokia

This change is minimal, backward compatible, and only affects string
field serialization.

Unit tests have been updated to validate the new behavior.

------------------------------------------------------------------------

## Implementation

The fix extends `stringFieldEscaper`:

``` go
stringFieldEscaper = strings.NewReplacer(
    `"`, `\"`,
    `\`, `\\`,
    "\n", `\n`,
)
```

------------------------------------------------------------------------

## Checklist

-   [x] No AI generated code was used in this PR
-   [ ] AI generated code used in this PR follows the InfluxData Policy
    on AI-Generated Code Contributions

------------------------------------------------------------------------

## Related issues

resolves #18350