### PR TITLE
fix(inputs.docker): Remove pre-filtering of states

### DIFF
--- a/plugins/inputs/docker/docker_testdata.go
+++ b/plugins/inputs/docker/docker_testdata.go
@@ -86,6 +86,7 @@ var containerList = []container.Summary{
 		Image:   "quay.io/coreos/etcd:v3.3.25",
 		Command: "/etcd -name etcd0 -advertise-client-urls http://localhost:2379 -listen-client-urls http://0.0.0.0:2379",
 		Created: 1455941930,
+		State:   "running",
 		Status:  "Up 4 hours",
 		Ports: []container.Port{
 			{
@@ -123,6 +124,7 @@ var containerList = []container.Summary{
 		Image:   "quay.io:4443/coreos/etcd:v3.3.25",
 		Command: "/etcd -name etcd2 -advertise-client-urls http://localhost:2379 -listen-client-urls http://0.0.0.0:2379",
 		Created: 1455941933,
+		State:   "running",
 		Status:  "Up 4 hours",
 		Ports: []container.Port{
 			{
@@ -157,14 +159,17 @@ var containerList = []container.Summary{
 	{
 		ID:    "e8a713dd90604f5a257b97c15945e047ab60ed5b2c4397c5a6b5bf40e1bd2791",
 		Names: []string{"/acme"},
+		State: "running",
 	},
 	{
 		ID:    "9bc6faf9ba8106fae32e8faafd38a1dd6f6d262bec172398cc10bc03c0d6841a",
 		Names: []string{"/acme-test"},
+		State: "running",
 	},
 	{
 		ID:    "d4ccced494a1d5fe8ebdb0a86335a0dab069319912221e5838a132ab18a8bc84",
 		Names: []string{"/foo"},
+		State: "running",
 	},
 }
 


### PR DESCRIPTION
## Summary

When using Podman with the `docker` input plugin configured with `container_state_include = ["*"]`, the metrics collection fails with an error like:

```
E! [inputs.docker] Error in plugin: Error response from daemon: unknown container state: restarting: invalid argument
```

The `docker` input plugin implements the container state filter by querying the `ContainerList` API with a `filter` parameter containing a `status` filter. The values provided in this status filter are constructed by iterating over a statically defined list of all Docker container states and keeping only those which match the configured container state filter.

However, the container state are different in Docker and Podman:
- In [Docker](https://github.com/moby/moby/blob/f222c1ed0532b338c9761729bd6a6d1779fa4698/api/types/container/state.go#L11-L19), the states are `created`, `running`, `paused`, `restarting`, `removing`, `exited`, and `dead`.
- In [Podman](https://github.com/containers/podman/blob/ec0f63c6e59785142d9996bbaa91a4865613f0a6/libpod/define/containerstate.go#L39-L70), the states are `created`, `initialized`, `running`, `stopped`, `paused`, `exited`, `removing`, `stopping`, and `unknown`.

So, when using Podman with the `docker` input plugin configured with `container_state_include = ["*"]`, the `filter` parameter will contain a `status` filter with status value that are not valid, and produce the error above.

This PR changes the container state filter implementation to be a post-filter, similar to the implementation of the container name filter. This implementation avoids the need to enumerate all the possible state values, which may be different in different container runtimes and may change over time, and thus makes the `docker` input plugin a bit more robust.

This PR also makes a similar fix to the `docker_log` input plugin.

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy