### PR TITLE
fix(common.opcua): Include node ID in duplicate metric check

### DIFF
--- a/plugins/common/opcua/input/input_client.go
+++ b/plugins/common/opcua/input/input_client.go
@@ -332,8 +332,13 @@ type metricParts struct {
 }
 
 func newMP(n *NodeMetricMapping) metricParts {
-	keys := make([]string, 0, len(n.MetricTags))
-	for key := range n.MetricTags {
+	// Include the node ID as the "id" tag since MetricForNode always adds it
+	tags := map[string]string{"id": n.idStr}
+	for k, v := range n.MetricTags {
+		tags[k] = v
+	}
+	keys := make([]string, 0, len(tags))
+	for key := range tags {
 		keys = append(keys, key)
 	}
 	sort.Strings(keys)
@@ -344,14 +349,13 @@ func newMP(n *NodeMetricMapping) metricParts {
 		}
 		sb.WriteString(key)
 		sb.WriteString("=")
-		sb.WriteString(n.MetricTags[key])
+		sb.WriteString(tags[key])
 	}
-	x := metricParts{
+	return metricParts{
 		metricName: n.metricName,
 		fieldName:  n.Tag.FieldName,
 		tags:       sb.String(),
 	}
-	return x
 }
 
 func validateNodeToAdd(existing map[metricParts]struct{}, nmm *NodeMetricMapping) error {

--- a/plugins/common/opcua/input/input_client_test.go
+++ b/plugins/common/opcua/input/input_client_test.go
@@ -48,7 +48,7 @@ func TestValidateOPCTags(t *testing.T) {
 					},
 				},
 			},
-			errors.New(`name "fn" is duplicated (metric name "mn", tags "t1=v1, t2=v2")`),
+			errors.New(`name "fn" is duplicated (metric name "mn", tags "id=ns=2;s=i1, t1=v1, t2=v2")`),
 		},
 		{
 			"empty tag value not allowed",
@@ -179,6 +179,33 @@ func TestValidateOPCTags(t *testing.T) {
 						IdentifierType: "s",
 						Identifier:     "i1",
 						DefaultTags:    map[string]string{"t1": "v1", "t2": "v2"},
+					},
+				},
+			},
+			nil,
+		},
+		{
+			"same field name different node IDs",
+			InputClientConfig{
+				MetricName: "opcua",
+				RootNodes: []NodeSettings{
+					{
+						FieldName:      "breaker_amps",
+						Namespace:      "2",
+						IdentifierType: "s",
+						Identifier:     "AmpA/Value",
+					},
+					{
+						FieldName:      "breaker_amps",
+						Namespace:      "2",
+						IdentifierType: "s",
+						Identifier:     "AmpB/Value",
+					},
+					{
+						FieldName:      "breaker_amps",
+						Namespace:      "2",
+						IdentifierType: "s",
+						Identifier:     "AmpC/Value",
 					},
 				},
 			},
@@ -373,7 +400,7 @@ func TestValidateNodeToAdd(t *testing.T) {
 		{
 			name: "duplicate metric not allowed",
 			existing: map[metricParts]struct{}{
-				{metricName: "testmetric", fieldName: "f", tags: "t1=v1, t2=v2"}: {},
+				{metricName: "testmetric", fieldName: "f", tags: "id=ns=2;s=hf, t1=v1, t2=v2"}: {},
 			},
 			nmm: func() *NodeMetricMapping {
 				nmm, err := NewNodeMetricMapping("testmetric", NodeSettings{
@@ -386,7 +413,7 @@ func TestValidateNodeToAdd(t *testing.T) {
 				require.NoError(t, err)
 				return nmm
 			}(),
-			err: errors.New(`name "f" is duplicated (metric name "testmetric", tags "t1=v1, t2=v2")`),
+			err: errors.New(`name "f" is duplicated (metric name "testmetric", tags "id=ns=2;s=hf, t1=v1, t2=v2")`),
 		},
 		{
 			name:     "identifier type mismatch",


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
The duplicate node name validation only considered the metric name, field name, and user-configured default_tags for uniqueness. The "id" tag (OPC UA node ID) was added later at metric emission time but not included in the check, causing a false "name is duplicated" error when multiple nodes share the same field name but point to different OPC UA nodes.
## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #18375
