### PR TITLE
fix(inputs.fibaro): Handle numeric value2 field from HC3 devices

### DIFF
--- a/plugins/inputs/fibaro/fibaro_test.go
+++ b/plugins/inputs/fibaro/fibaro_test.go
@@ -290,6 +290,7 @@ func TestHC3JSON(t *testing.T) {
 				"energy": float64(4.33),
 				"power":  float64(0.7),
 				"value":  float64(34),
+				"value2": float64(75),
 			},
 			time.Unix(0, 0),
 		),

--- a/plugins/inputs/fibaro/hc3/parser.go
+++ b/plugins/inputs/fibaro/hc3/parser.go
@@ -74,6 +74,15 @@ func Parse(acc telegraf.Accumulator, sectionBytes, roomBytes, devicesBytes []byt
 			}
 		}
 
+		if device.Properties.Value2 != nil {
+			v, err := internal.ToFloat64(device.Properties.Value2)
+			if err != nil {
+				acc.AddError(fmt.Errorf("unable to convert value2: %w", err))
+			} else {
+				fields["value2"] = v
+			}
+		}
+
 		acc.AddFields("fibaro", fields, tags)
 	}
 

--- a/plugins/inputs/fibaro/hc3/types.go
+++ b/plugins/inputs/fibaro/hc3/types.go
@@ -32,6 +32,6 @@ type Devices struct {
 		Energy       *float64    `json:"energy"`
 		Power        *float64    `json:"power"`
 		Value        interface{} `json:"value"`
-		Value2       *string     `json:"value2"`
+		Value2       interface{} `json:"value2"`
 	} `json:"properties"`
 }

--- a/plugins/inputs/fibaro/testdata/device_hc3.json
+++ b/plugins/inputs/fibaro/testdata/device_hc3.json
@@ -58,7 +58,8 @@
             "energy": 4.33,
             "power": 0.7,
             "dead": false,
-            "value": 34
+            "value": 34,
+            "value2": 75
         },
         "sortOrder": 5
     }


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
The HC3 API returns the value2 property as a JSON number, but the struct defined it as *string, causing json.Unmarshal to fail. Change the type to interface{} (matching the value field) and add value2 processing to the HC3 parser, which was previously missing entirely.

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #18380
