### PR TITLE
fix(inputs.docker_log): Remove pre-filtering of states

### DIFF
--- a/plugins/inputs/docker_log/docker_log_test.go
+++ b/plugins/inputs/docker_log/docker_log_test.go
@@ -74,6 +74,7 @@ func Test(t *testing.T) {
 							ID:    "deadbeef",
 							Names: []string{"/telegraf"},
 							Image: "influxdata/telegraf:1.11.0",
+							State: "running",
 						},
 					}, nil
 				},
@@ -115,6 +116,7 @@ func Test(t *testing.T) {
 							ID:    "deadbeef",
 							Names: []string{"/telegraf"},
 							Image: "influxdata/telegraf:1.11.0",
+							State: "running",
 						},
 					}, nil
 				},


### PR DESCRIPTION
## Summary

When using Podman with the `docker_log` input plugin configured with `container_state_include = ["*"]`, the metrics collection fails with an error like:

```
E! [inputs.docker_log] Error in plugin: Error response from daemon: unknown container state: restarting: invalid argument
```

The `docker_log` input plugin implements the container state filter by querying the `ContainerList` API with a `filter` parameter containing a `status` filter. The values provided in this status filter are constructed by iterating over a statically defined list of all Docker container states and keeping only those which match the configured container state filter.

However, the container state are different in Docker and Podman:
- In [Docker](https://github.com/moby/moby/blob/f222c1ed0532b338c9761729bd6a6d1779fa4698/api/types/container/state.go#L11-L19), the states are `created`, `running`, `paused`, `restarting`, `removing`, `exited`, and `dead`.
- In [Podman](https://github.com/containers/podman/blob/ec0f63c6e59785142d9996bbaa91a4865613f0a6/libpod/define/containerstate.go#L39-L70), the states are `created`, `initialized`, `running`, `stopped`, `paused`, `exited`, `removing`, `stopping`, and `unknown`.

So, when using Podman with the `docker_log` input plugin configured with `container_state_include = ["*"]`, the `filter` parameter will contain a `status` filter with status value that are not valid, and produce the error above.

This PR changes the container state filter implementation to be a post-filter, similar to the implementation of the container name filter. This implementation avoids the need to enumerate all the possible state values, which may be different in different container runtimes and may change over time, and thus makes the `docker_log` input plugin a bit more robust.

_Also see https://github.com/influxdata/telegraf/pull/18374_

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy