### PR TITLE
fix(serializers.template): Unwrap tracking metrics

### DIFF
--- a/plugins/serializers/template/template.go
+++ b/plugins/serializers/template/template.go
@@ -76,7 +76,11 @@ func (s *Serializer) SerializeBatch(metrics []telegraf.Metric) ([]byte, error) {
 	newMetrics := make([]telegraf.TemplateMetric, 0, len(metrics))
 
 	for _, metric := range metrics {
-		m, ok := metric.(telegraf.TemplateMetric)
+		metricPlain := metric
+		if wm, ok := metric.(telegraf.UnwrappableMetric); ok {
+			metricPlain = wm.Unwrap()
+		}
+		m, ok := metricPlain.(telegraf.TemplateMetric)
 		if !ok {
 			s.Log.Errorf("metric of type %T is not a template metric", metric)
 			return nil, nil


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
SerializeBatch failed with "metric of type *metric.trackingMetric is not a template metric" when use_batch_format was enabled because it did not unwrap tracking metrics before type-checking against TemplateMetric.

The Serialize method already handled this correctly; apply the same unwrapping pattern to SerializeBatch.
## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #18224
