### PR TITLE
fix(outputs.influxdb): Prevent goroutine leak on gzip write failure

### DIFF
--- a/plugins/outputs/influxdb/http.go
+++ b/plugins/outputs/influxdb/http.go
@@ -496,12 +496,15 @@ func (c *httpClient) makeWriteRequest(address string, body io.Reader) (*http.Req
 // side of the connection in case of error
 func (c *httpClient) requestBodyReader(metrics []telegraf.Metric) *wrappedReader {
 	reader := influx.NewReader(metrics, c.config.Serializer)
+	var rc io.ReadCloser
 	if c.config.ContentEncoding == "gzip" {
-		reader = internal.CompressWithGzip(reader)
+		rc = internal.CompressWithGzip(reader)
+	} else {
+		rc = io.NopCloser(reader)
 	}
 
 	// Create a wrapper to be able to able to extract the number of bytes written
-	return &wrappedReader{r: io.NopCloser(reader)}
+	return &wrappedReader{r: rc}
 }
 
 func (c *httpClient) addHeaders(req *http.Request) error {


### PR DESCRIPTION
## Summary

Fix goroutine leak in outputs.influxdb when gzip compression is enabled and write fails.

The gzip reader returned by CompressWithGzip must preserve its Close()
behavior. Previously it was wrapped by io.NopCloser, preventing the
pipe reader from closing and leaving the gzip goroutine blocked.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #18413