### PR TITLE
fix(outputs.opentelemetry): Prevent goroutine leak on gzip write failure

### DIFF
--- a/plugins/outputs/opentelemetry/client_http.go
+++ b/plugins/outputs/opentelemetry/client_http.go
@@ -72,9 +72,8 @@ func (h *httpClient) Export(ctx context.Context, request pmetricotlp.ExportReque
 	reader = bytes.NewReader(requestBytes)
 
 	if h.compress != "" && h.compress != "none" {
-		rc := internal.CompressWithGzip(reader)
-		defer rc.Close()
-		reader = rc
+		reader = internal.CompressWithGzip(reader)
+		defer reader.(io.ReadCloser).Close()
 	}
 
 	httpRequest, err := http.NewRequestWithContext(ctx, http.MethodPost, h.url, reader)


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Close the gzip pipe reader returned by `CompressWithGzip` in `Export`.
If the HTTP request fails or the server responds before consuming the full body, the gzip goroutine can block on `PipeWriter.Write`, causing a memory leak.

While reviewing #18416 (which fixed this in `outputs.influxdb`), I checked other `CompressWithGzip` call sites. `outputs.opentelemetry` was the only remaining caller missing the close. Other plugins (`outputs.http`, `outputs.sensu`, `outputs.loki`) already use `defer rc.Close()`.

Related to #18413, #18416


## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
