### PR TITLE
test(outputs.stackdriver): Add tests for secret token source

### DIFF
--- a/plugins/outputs/stackdriver/stackdriver_test.go
+++ b/plugins/outputs/stackdriver/stackdriver_test.go
@@ -1185,34 +1185,6 @@ func TestSecretTokenSource(t *testing.T) {
 	require.Equal(t, "Bearer", token.TokenType)
 }
 
-func TestWriteWithToken(t *testing.T) {
-	server := &mockServer{
-		resps: []proto.Message{&emptypb.Empty{}},
-	}
-	srv, client := startServer(t, server)
-	defer srv.GracefulStop()
-
-	plugin := &Stackdriver{
-		Token:     config.NewSecret([]byte("my-token")),
-		Project:   "projects/[PROJECT]",
-		Namespace: "test",
-		Log:       testutil.Logger{},
-		client:    client,
-	}
-	require.NoError(t, plugin.Init())
-	require.NoError(t, plugin.Connect())
-	require.NoError(t, plugin.Write(testutil.MockMetrics()))
-
-	require.Len(t, server.reqs, 1)
-	request, ok := server.reqs[0].(*monitoringpb.CreateTimeSeriesRequest)
-	require.Truef(t, ok, "Invalid request type %T", server.reqs[0])
-
-	require.Len(t, request.TimeSeries, 1)
-	ts := request.TimeSeries[0]
-	require.Equal(t, "global", ts.Resource.Type)
-	require.Equal(t, "projects/[PROJECT]", ts.Resource.Labels["project_id"])
-}
-
 func startServer(t *testing.T, mock *mockServer) (*grpc.Server, *monitoring.MetricClient) {
 	t.Helper()
 


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Add unit test for `secretTokenSource` introduced in #18339, verifying it correctly bridges `config.Secret` to `oauth2.TokenSource` by returning the expected `AccessToken` and `TokenType` values.

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
