### PR TITLE
test(CI): Make sure to use sort binary with unique flag capabilities

### DIFF
--- a/scripts/check-plugin-changes.sh
+++ b/scripts/check-plugin-changes.sh
@@ -23,7 +23,7 @@ if [[ -n "${MODIFIED_NONPLUGINS}" ]]; then
 fi
 
 # Get the plugins modified and selectively run that plugin if only one is touched
-MODIFIED_PLUGINS=$(IFS='' git diff --name-only "$(git merge-base HEAD origin/master)" | grep -E "${PLUGINS}" | awk -F'/' '{print $1"/"$2"/"$3}' | sort -u)
+MODIFIED_PLUGINS=$(IFS='' git diff --name-only "$(git merge-base HEAD origin/master)" | grep -E "${PLUGINS}" | awk -F'/' '{print $1"/"$2"/"$3}' | /usr/bin/sort -u)
 echo "=== Changed plugins ===" >&2
 echo "${MODIFIED_PLUGINS}" >&2
 echo "=====================" >&2


### PR DESCRIPTION
## Summary

This PR fixes the script checking for changed file on Windows by using the GNU binary supporting the `-u` (unique) flag instead of the Windows `sort` command being in path by default. The latter is very limited and does not support the `-u` flag required for the script to work.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
