### PR TITLE
test(circleci): Remove govuln workflow due to permanent timeout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -212,13 +212,6 @@ jobs:
       - check-changed-files-or-halt
       - run: 'make build_tools'
       - run: './tools/license_checker/license_checker -whitelist ./tools/license_checker/data/whitelist'
-  test-govulncheck:
-    executor: telegraf-ci
-    steps:
-      - checkout
-      - check-changed-files-or-halt
-      - run: 'make vuln-install'
-      - run: 'make vuln'
   windows-package:
     parameters:
       nightly:
@@ -800,7 +793,6 @@ workflows:
       - 'test-go-mac'
       - 'test-go-windows'
       - 'test-licenses'
-      - 'test-govulncheck'
       - 'windows-package':
           name: 'windows-package-nightly'
           nightly: true


### PR DESCRIPTION
## Summary

The govuln-workflow times out in almost all runs and therefore makes the CircleCI job fail. This PR removes the workflow and relies on regular manual checks for vulnerabilities instead.
 
## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
