### PR TITLE
test(inputs.openldap): Reduce container starts in OpenLDAP input tests

### DIFF
--- a/plugins/inputs/openldap/openldap_test.go
+++ b/plugins/inputs/openldap/openldap_test.go
@@ -39,7 +39,7 @@ func TestOpenldapMockResult(t *testing.T) {
 	commonTests(t, o, &acc)
 }
 
-func TestOpenldapNoConnectionIntegration(t *testing.T) {
+func TestIntegrationOpenldapNoConnection(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
@@ -50,10 +50,9 @@ func TestOpenldapNoConnectionIntegration(t *testing.T) {
 	}
 
 	var acc testutil.Accumulator
-	err := o.Gather(&acc)
-	require.NoError(t, err)         // test that we didn't return an error
-	require.Zero(t, acc.NFields())  // test that we didn't return any fields
-	require.NotEmpty(t, acc.Errors) // test that we set an error
+	require.NoError(t, o.Gather(&acc)) // test that we didn't return an error
+	require.Zero(t, acc.NFields())     // test that we didn't return any fields
+	require.NotEmpty(t, acc.Errors)    // test that we set an error
 }
 
 func TestIntegrationOpenldap(t *testing.T) {


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
  - Consolidate 6 integration test containers into 2 by grouping tests
    into `TestIntegrationOpenldap` (basic LDAP, port 1389) and
    `TestIntegrationOpenldapTLS` (TLS-enabled, ports 1389+1636)
  - TLS container now exposes both ports and waits for both to be ready,
    which is more robust than the original per-test setup
  - All test logic within each subtest is preserved as-is

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
