### PR TITLE
feat(inputs.mqtt_consumer): Add option for maximum reconnect interval

### DIFF
--- a/plugins/inputs/mqtt_consumer/README.md
+++ b/plugins/inputs/mqtt_consumer/README.md
@@ -90,6 +90,12 @@ to use them.
   ## Connection timeout for initial connection in seconds
   # connection_timeout = "30s"
 
+  ## Maximum interval between reconnection attempts after a connection loss.
+  ## The MQTT library uses exponential backoff starting at 1 second up to this
+  ## ceiling. The library default is 10 minutes, which can cause long delays
+  ## before message flow resumes after a network outage.
+  # max_reconnect_interval = "30s"
+
   ## Interval and ping timeout for keep-alive messages
   ## The sum of those options defines when a connection loss is detected.
   ## Note: The keep-alive interval needs to be greater or equal one second and

--- a/plugins/inputs/mqtt_consumer/mqtt_consumer.go
+++ b/plugins/inputs/mqtt_consumer/mqtt_consumer.go
@@ -28,6 +28,7 @@ var (
 	once sync.Once
 	// 30 Seconds is the default used by paho.mqtt.golang
 	defaultConnectionTimeout      = config.Duration(30 * time.Second)
+	defaultMaxReconnectInterval   = config.Duration(30 * time.Second)
 	defaultMaxUndeliveredMessages = 1000
 )
 
@@ -40,6 +41,7 @@ type MQTTConsumer struct {
 	Password               config.Secret        `toml:"password"`
 	QoS                    int                  `toml:"qos"`
 	ConnectionTimeout      config.Duration      `toml:"connection_timeout"`
+	MaxReconnectInterval   config.Duration      `toml:"max_reconnect_interval"`
 	KeepAliveInterval      config.Duration      `toml:"keepalive"`
 	PingTimeout            config.Duration      `toml:"ping_timeout"`
 	MaxUndeliveredMessages int                  `toml:"max_undelivered_messages"`
@@ -329,6 +331,7 @@ func (m *MQTTConsumer) createOpts() (*mqtt.ClientOptions, error) {
 		opts.AddBroker(server)
 	}
 	opts.SetAutoReconnect(true)
+	opts.SetMaxReconnectInterval(time.Duration(m.MaxReconnectInterval))
 	opts.SetKeepAlive(time.Duration(m.KeepAliveInterval))
 	opts.SetPingTimeout(time.Duration(m.PingTimeout))
 	opts.SetCleanSession(!m.PersistentSession)
@@ -343,6 +346,7 @@ func newMQTTConsumer(factory clientFactory) *MQTTConsumer {
 		Servers:                []string{"tcp://127.0.0.1:1883"},
 		MaxUndeliveredMessages: defaultMaxUndeliveredMessages,
 		ConnectionTimeout:      defaultConnectionTimeout,
+		MaxReconnectInterval:   defaultMaxReconnectInterval,
 		KeepAliveInterval:      config.Duration(60 * time.Second),
 		PingTimeout:            config.Duration(10 * time.Second),
 		clientFactory:          factory,

--- a/plugins/inputs/mqtt_consumer/sample.conf
+++ b/plugins/inputs/mqtt_consumer/sample.conf
@@ -30,6 +30,12 @@
   ## Connection timeout for initial connection in seconds
   # connection_timeout = "30s"
 
+  ## Maximum interval between reconnection attempts after a connection loss.
+  ## The MQTT library uses exponential backoff starting at 1 second up to this
+  ## ceiling. The library default is 10 minutes, which can cause long delays
+  ## before message flow resumes after a network outage.
+  # max_reconnect_interval = "30s"
+
   ## Interval and ping timeout for keep-alive messages
   ## The sum of those options defines when a connection loss is detected.
   ## Note: The keep-alive interval needs to be greater or equal one second and


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
  - Add a dedicated `max_reconnect_interval` config option (default 30s) to cap paho's exponential reconnect backoff
  - The paho library default is 10 minutes, which causes users to wait up to 10 minutes for message flow to resume after a network outage
  - Community testing by @SofieF2005 in #18452 confirmed the issue with `client_trace` logs showing `Reconnect failed, slept for600seconds`

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

Follow-up to #18452
