### PR TITLE
feat(inputs.openntpd): Add sensor and status metrics

### DIFF
--- a/plugins/inputs/openntpd/README.md
+++ b/plugins/inputs/openntpd/README.md
@@ -78,22 +78,50 @@ Please use the solution you see as most appropriate.
 
 ## Metrics
 
-- ntpctl
+- openntpd
   - tags:
-    - remote (remote peer for synchorization)
+    - remote (remote peer address or hostname)
     - stratum (remote peer stratum)
+    - state_prefix (ntpctl state indicator, e.g. `*` for active peer;
+      omitted when absent)
   - fields:
     - delay (round trip delay to the remote peer in milliseconds; `float`)
-    - jitter (mean deviation (jitter) for remote peer; `float`)
+    - jitter (mean deviation (jitter) for remote peer in milliseconds; `float`)
     - offset (mean offset (phase) to remote peer in milliseconds; `float`)
     - poll (polling interval in seconds; `int`)
     - next (number of seconds until the next poll; `int`)
     - wt (peer weight; `int`)
     - tl (peer trust level; `int`)
 
+- openntpd_sensors (one metric per hardware/GPS sensor)
+  - tags:
+    - sensor (sensor device name, e.g. `nmea0`)
+    - refid (sensor reference ID, e.g. `GPS`)
+    - state_prefix (ntpctl state indicator, e.g. `*` for active sensor;
+      omitted when absent)
+  - fields:
+    - wt (sensor weight; `int`)
+    - gd (sensor good count; `int`)
+    - st (sensor stratum; `int`)
+    - next (seconds until next poll; `int`)
+    - poll (polling interval in seconds; `int`)
+    - offset (sensor offset in milliseconds; `float`)
+    - correction (sensor correction in milliseconds; `float`)
+
+- openntpd_status (one metric per gather, system-level summary)
+  - fields:
+    - peers_valid (number of currently valid peers; `int`)
+    - peers_total (total number of configured peers; `int`)
+    - sensors_valid (number of currently valid sensors; `int`)
+    - sensors_total (total number of configured sensors; `int`)
+    - constraint_offset_s (constraint offset in seconds; `int`)
+    - clock_synced (1 if the local clock is synced, 0 otherwise; `int`)
+    - stratum (local clock stratum; `int`)
+
 ## Example Output
 
 ```text
-openntpd,remote=194.57.169.1,stratum=2,host=localhost tl=10i,poll=1007i,
-offset=2.295,jitter=3.896,delay=53.766,next=266i,wt=1i 1514454299000000000
+openntpd,remote=194.57.169.1,stratum=2 tl=10i,poll=1007i,offset=2.295,jitter=3.896,delay=53.766,next=266i,wt=1i 1514454299000000000
+openntpd_sensors,sensor=nmea0,refid=GPS,state_prefix=* wt=10i,gd=1i,st=0i,next=1i,poll=15i,offset=-0.673,correction=0.6 1514454299000000000
+openntpd_status peers_valid=12i,peers_total=12i,sensors_valid=1i,sensors_total=1i,constraint_offset_s=-1i,clock_synced=1i,stratum=1i 1514454299000000000
 ```

--- a/plugins/inputs/openntpd/openntpd.go
+++ b/plugins/inputs/openntpd/openntpd.go
@@ -201,6 +201,9 @@ func parsePeer(scanner *bufio.Scanner, headerLine string, acc telegraf.Accumulat
 	}
 	statsLine := scanner.Text()
 	statsFields := strings.Fields(statsLine)
+	if len(statsFields) == 0 {
+		return
+	}
 
 	// Optional state prefix (e.g. "*")
 	if strings.ContainsAny(statsFields[0], "*") {

--- a/plugins/inputs/openntpd/openntpd.go
+++ b/plugins/inputs/openntpd/openntpd.go
@@ -275,6 +275,9 @@ func parseSensor(scanner *bufio.Scanner, headerLine string, acc telegraf.Accumul
 	}
 	statsLine := scanner.Text()
 	statsFields := strings.Fields(statsLine)
+	if len(statsFields) == 0 {
+		return
+	}
 
 	// Optional state prefix (e.g. "*")
 	if len(statsFields) > 0 && strings.ContainsAny(statsFields[0], "*") {

--- a/plugins/inputs/openntpd/openntpd.go
+++ b/plugins/inputs/openntpd/openntpd.go
@@ -186,7 +186,7 @@ func parseFraction(s string) (num, den int64, ok bool) {
 func parsePeer(scanner *bufio.Scanner, headerLine string, acc telegraf.Accumulator) {
 	headerFields := strings.Fields(headerLine)
 
-	mFields := make(map[string]interface{})
+	mFields := make(map[string]interface{}, 7)
 	tags := make(map[string]string)
 
 	// DNS resolution error → keep DNS name as remote

--- a/plugins/inputs/openntpd/openntpd.go
+++ b/plugins/inputs/openntpd/openntpd.go
@@ -185,9 +185,9 @@ func parseFraction(s string) (num, den int64, ok bool) {
 // (peer address / DNS name); the second line is read from scanner.
 func parsePeer(scanner *bufio.Scanner, headerLine string, acc telegraf.Accumulator) {
 	headerFields := strings.Fields(headerLine)
-    if len(headerFields) == 0 {                                                                                                                                                                                      
-        return
-    }
+	if len(headerFields) == 0 {
+		return
+	}
 
 	mFields := make(map[string]interface{}, 7)
 	tags := make(map[string]string, 3)

--- a/plugins/inputs/openntpd/openntpd.go
+++ b/plugins/inputs/openntpd/openntpd.go
@@ -164,7 +164,7 @@ func parseStatusLine(line string, acc telegraf.Accumulator) {
 		fields["clock_synced"] = int64(0)
 	}
 
-	acc.AddFields("openntpd_status", fields, make(map[string]string))
+	acc.AddFields("openntpd_status", fields, nil)
 }
 
 // parseFraction splits "12/12" into (numerator, denominator, ok).

--- a/plugins/inputs/openntpd/openntpd.go
+++ b/plugins/inputs/openntpd/openntpd.go
@@ -185,6 +185,9 @@ func parseFraction(s string) (num, den int64, ok bool) {
 // (peer address / DNS name); the second line is read from scanner.
 func parsePeer(scanner *bufio.Scanner, headerLine string, acc telegraf.Accumulator) {
 	headerFields := strings.Fields(headerLine)
+    if len(headerFields) == 0 {                                                                                                                                                                                      
+        return
+    }
 
 	mFields := make(map[string]interface{}, 7)
 	tags := make(map[string]string, 3)
@@ -280,7 +283,7 @@ func parseSensor(scanner *bufio.Scanner, headerLine string, acc telegraf.Accumul
 	}
 
 	// Optional state prefix (e.g. "*")
-	if len(statsFields) > 0 && strings.ContainsAny(statsFields[0], "*") {
+	if strings.ContainsAny(statsFields[0], "*") {
 		tags["state_prefix"] = statsFields[0]
 		statsFields = statsFields[1:]
 	}

--- a/plugins/inputs/openntpd/openntpd.go
+++ b/plugins/inputs/openntpd/openntpd.go
@@ -187,7 +187,7 @@ func parsePeer(scanner *bufio.Scanner, headerLine string, acc telegraf.Accumulat
 	headerFields := strings.Fields(headerLine)
 
 	mFields := make(map[string]interface{}, 7)
-	tags := make(map[string]string)
+	tags := make(map[string]string, 3)
 
 	// DNS resolution error → keep DNS name as remote
 	if headerFields[0] != "not" {

--- a/plugins/inputs/openntpd/openntpd.go
+++ b/plugins/inputs/openntpd/openntpd.go
@@ -24,22 +24,33 @@ var (
 	defaultBinary  = "/usr/sbin/ntpctl"
 	defaultTimeout = config.Duration(5 * time.Second)
 
-	// Mapping of the ntpctl tag key to the index in the command output
-	tagI = map[string]int{
+	// Peer column index mappings
+	peerTagI = map[string]int{
 		"stratum": 2,
 	}
-	// Mapping of float metrics to their index in the command output
-	floatI = map[string]int{
+	peerFloatI = map[string]int{
 		"offset": 5,
 		"delay":  6,
 		"jitter": 7,
 	}
-	// Mapping of int metrics to their index in the command output
-	intI = map[string]int{
+	peerIntI = map[string]int{
 		"wt":   0,
 		"tl":   1,
 		"next": 3,
 		"poll": 4,
+	}
+
+	// Sensor column index mappings
+	sensorIntI = map[string]int{
+		"wt":   0,
+		"gd":   1,
+		"st":   2,
+		"next": 3,
+		"poll": 4,
+	}
+	sensorFloatI = map[string]int{
+		"offset":     5,
+		"correction": 6,
 	}
 )
 
@@ -63,114 +74,251 @@ func (n *Openntpd) Gather(acc telegraf.Accumulator) error {
 		return fmt.Errorf("error gathering metrics: %w", err)
 	}
 
-	lineCounter := 0
+	// section tracks which part of the output we are in:
+	// "" = before first section header (status line area)
+	// "peer" = inside peer section
+	// "sensor" = inside sensor section
+	section := ""
+	skipNext := false
+
 	scanner := bufio.NewScanner(out)
 	for scanner.Scan() {
-		// skip first (peer) and second (field list) line
-		if lineCounter < 2 {
-			lineCounter++
+		line := scanner.Text()
+		trimmed := strings.TrimSpace(line)
+
+		if trimmed == "" {
 			continue
 		}
 
-		line := scanner.Text()
-
-		fields := strings.Fields(line)
-
-		mFields := make(map[string]interface{})
-		tags := make(map[string]string)
-
-		// Even line ---> ntp server info
-		if lineCounter%2 == 0 {
-			// DNS resolution error ---> keep DNS name as remote name
-			if fields[0] != "not" {
-				tags["remote"] = fields[0]
-			} else {
-				tags["remote"] = fields[len(fields)-1]
-			}
+		if trimmed == "peer" {
+			section = "peer"
+			skipNext = true
+			continue
 		}
 
-		// Read next line - Odd line ---> ntp server stats
-		scanner.Scan()
-		line = scanner.Text()
-		lineCounter++
-
-		fields = strings.Fields(line)
-
-		// if there is an ntpctl state prefix, remove it and make it it's own tag
-		if strings.ContainsAny(fields[0], "*") {
-			tags["state_prefix"] = fields[0]
-			fields = fields[1:]
+		if trimmed == "sensor" {
+			section = "sensor"
+			skipNext = true
+			continue
 		}
 
-		// Get tags from output
-		for key, index := range tagI {
-			if index >= len(fields) {
-				continue
-			}
-			tags[key] = fields[index]
+		// Skip the column-header line that follows each section header
+		if skipNext {
+			skipNext = false
+			continue
 		}
 
-		// Get integer metrics from output
-		for key, index := range intI {
-			if index >= len(fields) {
-				continue
-			}
-			if fields[index] == "-" {
-				continue
-			}
-
-			if key == "next" || key == "poll" {
-				m, err := strconv.ParseInt(strings.TrimSuffix(fields[index], "s"), 10, 64)
-				if err != nil {
-					acc.AddError(fmt.Errorf("integer value expected, got: %s", fields[index]))
-					continue
-				}
-				mFields[key] = m
-			} else {
-				m, err := strconv.ParseInt(fields[index], 10, 64)
-				if err != nil {
-					acc.AddError(fmt.Errorf("integer value expected, got: %s", fields[index]))
-					continue
-				}
-				mFields[key] = m
-			}
+		switch section {
+		case "":
+			parseStatusLine(trimmed, acc)
+		case "peer":
+			parsePeer(scanner, line, acc)
+		case "sensor":
+			parseSensor(scanner, line, acc)
 		}
-
-		// get float metrics from output
-		for key, index := range floatI {
-			if len(fields) <= index {
-				continue
-			}
-			if fields[index] == "-" || fields[index] == "----" || fields[index] == "peer" || fields[index] == "not" || fields[index] == "valid" {
-				continue
-			}
-
-			if key == "offset" || key == "delay" || key == "jitter" {
-				m, err := strconv.ParseFloat(strings.TrimSuffix(fields[index], "ms"), 64)
-				if err != nil {
-					acc.AddError(fmt.Errorf("float value expected, got: %s", fields[index]))
-					continue
-				}
-				mFields[key] = m
-			} else {
-				m, err := strconv.ParseFloat(fields[index], 64)
-				if err != nil {
-					acc.AddError(fmt.Errorf("float value expected, got: %s", fields[index]))
-					continue
-				}
-				mFields[key] = m
-			}
-		}
-		acc.AddFields("openntpd", mFields, tags)
-
-		lineCounter++
 	}
+
 	return nil
+}
+
+// parseStatusLine parses the summary line produced by `ntpctl -s all`, e.g.:
+//
+//	12/12 peers valid, 1/1 sensors valid, constraint offset -1s, clock synced, stratum 1
+func parseStatusLine(line string, acc telegraf.Accumulator) {
+	fields := make(map[string]interface{})
+
+	parts := strings.Split(line, ", ")
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		switch {
+		case strings.HasSuffix(part, "peers valid"):
+			fraction := strings.Fields(part)[0]
+			pv, pt, ok := parseFraction(fraction)
+			if ok {
+				fields["peers_valid"] = pv
+				fields["peers_total"] = pt
+			}
+		case strings.HasSuffix(part, "sensors valid"):
+			fraction := strings.Fields(part)[0]
+			sv, st, ok := parseFraction(fraction)
+			if ok {
+				fields["sensors_valid"] = sv
+				fields["sensors_total"] = st
+			}
+		case strings.HasPrefix(part, "constraint offset "):
+			val := strings.TrimPrefix(part, "constraint offset ")
+			val = strings.TrimSuffix(val, "s")
+			if v, err := strconv.ParseInt(val, 10, 64); err == nil {
+				fields["constraint_offset_s"] = v
+			}
+		case part == "clock synced":
+			fields["clock_synced"] = int64(1)
+		case strings.HasPrefix(part, "stratum "):
+			val := strings.TrimPrefix(part, "stratum ")
+			if v, err := strconv.ParseInt(val, 10, 64); err == nil {
+				fields["stratum"] = v
+			}
+		}
+	}
+
+	if _, hasSynced := fields["clock_synced"]; !hasSynced {
+		fields["clock_synced"] = int64(0)
+	}
+
+	if len(fields) > 0 {
+		acc.AddFields("openntpd_status", fields, make(map[string]string))
+	}
+}
+
+// parseFraction splits "12/12" into (numerator, denominator, ok).
+func parseFraction(s string) (num, den int64, ok bool) {
+	idx := strings.Index(s, "/")
+	if idx < 0 {
+		return 0, 0, false
+	}
+	num, err1 := strconv.ParseInt(s[:idx], 10, 64)
+	den, err2 := strconv.ParseInt(s[idx+1:], 10, 64)
+	if err1 != nil || err2 != nil {
+		return 0, 0, false
+	}
+	return num, den, true
+}
+
+// parsePeer parses a two-line peer entry. headerLine is the first line
+// (peer address / DNS name); the second line is read from scanner.
+func parsePeer(scanner *bufio.Scanner, headerLine string, acc telegraf.Accumulator) {
+	headerFields := strings.Fields(headerLine)
+
+	mFields := make(map[string]interface{})
+	tags := make(map[string]string)
+
+	// DNS resolution error → keep DNS name as remote
+	if headerFields[0] != "not" {
+		tags["remote"] = headerFields[0]
+	} else {
+		tags["remote"] = headerFields[len(headerFields)-1]
+	}
+
+	if !scanner.Scan() {
+		return
+	}
+	statsLine := scanner.Text()
+	statsFields := strings.Fields(statsLine)
+
+	// Optional state prefix (e.g. "*")
+	if strings.ContainsAny(statsFields[0], "*") {
+		tags["state_prefix"] = statsFields[0]
+		statsFields = statsFields[1:]
+	}
+
+	for key, index := range peerTagI {
+		if index < len(statsFields) {
+			tags[key] = statsFields[index]
+		}
+	}
+
+	for key, index := range peerIntI {
+		if index >= len(statsFields) || statsFields[index] == "-" {
+			continue
+		}
+		raw := statsFields[index]
+		if key == "next" || key == "poll" {
+			raw = strings.TrimSuffix(raw, "s")
+		}
+		v, err := strconv.ParseInt(raw, 10, 64)
+		if err != nil {
+			acc.AddError(fmt.Errorf("integer value expected, got: %s", statsFields[index]))
+			continue
+		}
+		mFields[key] = v
+	}
+
+	for key, index := range peerFloatI {
+		if index >= len(statsFields) {
+			continue
+		}
+		raw := statsFields[index]
+		if raw == "-" || raw == "----" || raw == "peer" ||
+			raw == "not" || raw == "valid" {
+			continue
+		}
+		if key == "offset" || key == "delay" || key == "jitter" {
+			raw = strings.TrimSuffix(raw, "ms")
+		}
+		v, err := strconv.ParseFloat(raw, 64)
+		if err != nil {
+			acc.AddError(fmt.Errorf("float value expected, got: %s", statsFields[index]))
+			continue
+		}
+		mFields[key] = v
+	}
+
+	acc.AddFields("openntpd", mFields, tags)
+}
+
+// parseSensor parses a two-line sensor entry. headerLine is the first line
+// (sensor name and refid); the second line is read from scanner.
+func parseSensor(scanner *bufio.Scanner, headerLine string, acc telegraf.Accumulator) {
+	headerFields := strings.Fields(headerLine)
+	if len(headerFields) < 1 {
+		return
+	}
+
+	tags := make(map[string]string)
+	tags["sensor"] = headerFields[0]
+	if len(headerFields) >= 2 {
+		tags["refid"] = headerFields[1]
+	}
+
+	if !scanner.Scan() {
+		return
+	}
+	statsLine := scanner.Text()
+	statsFields := strings.Fields(statsLine)
+
+	// Optional state prefix (e.g. "*")
+	if len(statsFields) > 0 && strings.ContainsAny(statsFields[0], "*") {
+		tags["state_prefix"] = statsFields[0]
+		statsFields = statsFields[1:]
+	}
+
+	mFields := make(map[string]interface{})
+
+	for key, index := range sensorIntI {
+		if index >= len(statsFields) || statsFields[index] == "-" {
+			continue
+		}
+		raw := statsFields[index]
+		if key == "next" || key == "poll" {
+			raw = strings.TrimSuffix(raw, "s")
+		}
+		v, err := strconv.ParseInt(raw, 10, 64)
+		if err != nil {
+			acc.AddError(fmt.Errorf("integer value expected, got: %s", statsFields[index]))
+			continue
+		}
+		mFields[key] = v
+	}
+
+	for key, index := range sensorFloatI {
+		if index >= len(statsFields) || statsFields[index] == "-" {
+			continue
+		}
+		raw := strings.TrimSuffix(statsFields[index], "ms")
+		v, err := strconv.ParseFloat(raw, 64)
+		if err != nil {
+			acc.AddError(fmt.Errorf("float value expected, got: %s", statsFields[index]))
+			continue
+		}
+		mFields[key] = v
+	}
+
+	acc.AddFields("openntpd_sensors", mFields, tags)
 }
 
 // Shell out to ntpctl and return the output
 func openntpdRunner(cmdName string, timeout config.Duration, useSudo bool) (*bytes.Buffer, error) {
-	cmdArgs := []string{"-s", "peers"}
+	cmdArgs := []string{"-s", "all"}
 
 	cmd := exec.Command(cmdName, cmdArgs...)
 

--- a/plugins/inputs/openntpd/openntpd.go
+++ b/plugins/inputs/openntpd/openntpd.go
@@ -125,7 +125,7 @@ func (n *Openntpd) Gather(acc telegraf.Accumulator) error {
 //
 //	12/12 peers valid, 1/1 sensors valid, constraint offset -1s, clock synced, stratum 1
 func parseStatusLine(line string, acc telegraf.Accumulator) {
-	fields := make(map[string]interface{})
+	fields := make(map[string]interface{}, 7)
 
 	parts := strings.Split(line, ", ")
 	for _, part := range parts {
@@ -133,15 +133,13 @@ func parseStatusLine(line string, acc telegraf.Accumulator) {
 		switch {
 		case strings.HasSuffix(part, "peers valid"):
 			fraction := strings.Fields(part)[0]
-			pv, pt, ok := parseFraction(fraction)
-			if ok {
+			if pv, pt, ok := parseFraction(fraction); ok {
 				fields["peers_valid"] = pv
 				fields["peers_total"] = pt
 			}
 		case strings.HasSuffix(part, "sensors valid"):
 			fraction := strings.Fields(part)[0]
-			sv, st, ok := parseFraction(fraction)
-			if ok {
+			if sv, st, ok := parseFraction(fraction); ok {
 				fields["sensors_valid"] = sv
 				fields["sensors_total"] = st
 			}
@@ -161,23 +159,22 @@ func parseStatusLine(line string, acc telegraf.Accumulator) {
 		}
 	}
 
-	if _, hasSynced := fields["clock_synced"]; !hasSynced {
+	// Make sure we always provide the clock_synced field
+	if _, found := fields["clock_synced"]; !found {
 		fields["clock_synced"] = int64(0)
 	}
 
-	if len(fields) > 0 {
-		acc.AddFields("openntpd_status", fields, make(map[string]string))
-	}
+	acc.AddFields("openntpd_status", fields, make(map[string]string))
 }
 
 // parseFraction splits "12/12" into (numerator, denominator, ok).
 func parseFraction(s string) (num, den int64, ok bool) {
-	idx := strings.Index(s, "/")
-	if idx < 0 {
+	n, d, found := strings.Cut(s, "/")
+	if !found {
 		return 0, 0, false
 	}
-	num, err1 := strconv.ParseInt(s[:idx], 10, 64)
-	den, err2 := strconv.ParseInt(s[idx+1:], 10, 64)
+	num, err1 := strconv.ParseInt(n, 10, 64)
+	den, err2 := strconv.ParseInt(d, 10, 64)
 	if err1 != nil || err2 != nil {
 		return 0, 0, false
 	}
@@ -264,7 +261,7 @@ func parseSensor(scanner *bufio.Scanner, headerLine string, acc telegraf.Accumul
 		return
 	}
 
-	tags := make(map[string]string)
+	tags := make(map[string]string, 3)
 	tags["sensor"] = headerFields[0]
 	if len(headerFields) >= 2 {
 		tags["refid"] = headerFields[1]
@@ -282,7 +279,7 @@ func parseSensor(scanner *bufio.Scanner, headerLine string, acc telegraf.Accumul
 		statsFields = statsFields[1:]
 	}
 
-	mFields := make(map[string]interface{})
+	mFields := make(map[string]interface{}, 7)
 
 	for key, index := range sensorIntI {
 		if index >= len(statsFields) || statsFields[index] == "-" {

--- a/plugins/inputs/openntpd/openntpd_test.go
+++ b/plugins/inputs/openntpd/openntpd_test.go
@@ -257,6 +257,82 @@ func TestParseFullOutput(t *testing.T) {
 	acc.AssertContainsTaggedFields(t, "openntpd", fourthpeerfields, fourthpeertags)
 }
 
+func TestParseFullOutputAll(t *testing.T) {
+	acc := &testutil.Accumulator{}
+	v := &Openntpd{
+		run: openntpdCTL(fullOutputAll),
+	}
+	err := v.Gather(acc)
+	require.NoError(t, err)
+
+	// Peers
+	require.True(t, acc.HasMeasurement("openntpd"))
+
+	firstpeerfields := map[string]interface{}{
+		"wt":     int64(1),
+		"tl":     int64(10),
+		"next":   int64(56),
+		"poll":   int64(63),
+		"offset": float64(9.271),
+		"delay":  float64(44.662),
+		"jitter": float64(2.678),
+	}
+	firstpeertags := map[string]string{
+		"remote":  "212.129.9.36",
+		"stratum": "3",
+	}
+	acc.AssertContainsTaggedFields(t, "openntpd", firstpeerfields, firstpeertags)
+
+	// Status
+	require.True(t, acc.HasMeasurement("openntpd_status"))
+	statusFields := map[string]interface{}{
+		"peers_valid":         int64(12),
+		"peers_total":         int64(12),
+		"sensors_valid":       int64(1),
+		"sensors_total":       int64(1),
+		"constraint_offset_s": int64(-1),
+		"clock_synced":        int64(1),
+		"stratum":             int64(1),
+	}
+	acc.AssertContainsFields(t, "openntpd_status", statusFields)
+
+	// Sensors
+	require.True(t, acc.HasMeasurement("openntpd_sensors"))
+	sensorFields := map[string]interface{}{
+		"wt":         int64(10),
+		"gd":         int64(1),
+		"st":         int64(0),
+		"next":       int64(1),
+		"poll":       int64(15),
+		"offset":     float64(-0.673),
+		"correction": float64(0.600),
+	}
+	sensorTags := map[string]string{
+		"sensor":       "nmea0",
+		"refid":        "GPS",
+		"state_prefix": "*",
+	}
+	acc.AssertContainsTaggedFields(t, "openntpd_sensors", sensorFields, sensorTags)
+}
+
+func TestParseStatusLineClockNotSynced(t *testing.T) {
+	acc := &testutil.Accumulator{}
+	v := &Openntpd{
+		run: openntpdCTL(outputNoSync),
+	}
+	err := v.Gather(acc)
+	require.NoError(t, err)
+
+	require.True(t, acc.HasMeasurement("openntpd_status"))
+	statusFields := map[string]interface{}{
+		"peers_valid":         int64(0),
+		"peers_total":         int64(4),
+		"constraint_offset_s": int64(0),
+		"clock_synced":        int64(0),
+	}
+	acc.AssertContainsFields(t, "openntpd_status", statusFields)
+}
+
 var simpleOutput = `peer
 wt tl st  next  poll          offset       delay      jitter
 212.129.9.36 from pool 0.debian.pool.ntp.org
@@ -325,3 +401,31 @@ wt tl st  next  poll          offset       delay      jitter
 1  2  -  105s  300s             ---- peer not valid ----
 194.57.169.1 from pool 3.debian.pool.ntp.org
 1 10  2   32s   63s         6.589ms    52.051ms     2.057ms`
+
+// fullOutputAll represents the output of `ntpctl -s all` with status line,
+// peers and a sensor section.
+var fullOutputAll = `12/12 peers valid, 1/1 sensors valid, constraint offset -1s, clock synced, stratum 1
+
+peer
+   wt tl st  next  poll          offset       delay      jitter
+212.129.9.36 from pool 0.debian.pool.ntp.org
+    1 10  3   56s   63s         9.271ms    44.662ms     2.678ms
+163.172.25.19 from pool 0.debian.pool.ntp.org
+    1 10  2   21s   64s        -0.103ms    53.199ms     9.046ms
+92.243.6.5 from pool 0.debian.pool.ntp.org
+ *  1 10  2   45s  980s        -9.901ms    67.573ms    29.350ms
+178.33.111.49 from pool 0.debian.pool.ntp.org
+    1  2  -  203s  300s             ---- peer not valid ----
+
+sensor
+   wt gd st  next  poll          offset  correction
+nmea0  GPS
+ * 10  1  0    1s   15s        -0.673ms     0.600ms`
+
+// outputNoSync represents a status line where the clock is not yet synced.
+var outputNoSync = `0/4 peers valid, constraint offset 0s, clock unsynced
+
+peer
+   wt tl st  next  poll          offset       delay      jitter
+212.129.9.36 from pool 0.debian.pool.ntp.org
+    1  2  -    5s   15s             ---- peer not valid ----`

--- a/plugins/inputs/openntpd/openntpd_test.go
+++ b/plugins/inputs/openntpd/openntpd_test.go
@@ -3,10 +3,13 @@ package openntpd
 import (
 	"bytes"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
+	"github.com/influxdata/telegraf/metric"
 	"github.com/influxdata/telegraf/testutil"
 )
 
@@ -258,79 +261,164 @@ func TestParseFullOutput(t *testing.T) {
 }
 
 func TestParseFullOutputAll(t *testing.T) {
-	acc := &testutil.Accumulator{}
-	v := &Openntpd{
+	plugin := &Openntpd{
 		run: openntpdCTL(fullOutputAll),
 	}
-	err := v.Gather(acc)
-	require.NoError(t, err)
 
-	// Peers
-	require.True(t, acc.HasMeasurement("openntpd"))
+	var acc testutil.Accumulator
+	require.NoError(t, plugin.Gather(&acc))
 
-	firstpeerfields := map[string]interface{}{
-		"wt":     int64(1),
-		"tl":     int64(10),
-		"next":   int64(56),
-		"poll":   int64(63),
-		"offset": float64(9.271),
-		"delay":  float64(44.662),
-		"jitter": float64(2.678),
+	expected := []telegraf.Metric{
+		metric.New(
+			"openntpd_status",
+			map[string]string{},
+			map[string]interface{}{
+				"peers_valid":         int64(12),
+				"peers_total":         int64(12),
+				"sensors_valid":       int64(1),
+				"sensors_total":       int64(1),
+				"constraint_offset_s": int64(-1),
+				"clock_synced":        int64(1),
+				"stratum":             int64(1),
+			},
+			time.Unix(0, 0),
+		),
+		metric.New(
+			"openntpd",
+			map[string]string{
+				"remote":  "212.129.9.36",
+				"stratum": "3",
+			},
+			map[string]interface{}{
+				"wt":     int64(1),
+				"tl":     int64(10),
+				"next":   int64(56),
+				"poll":   int64(63),
+				"offset": float64(9.271),
+				"delay":  float64(44.662),
+				"jitter": float64(2.678),
+			},
+			time.Unix(0, 0),
+		),
+		metric.New(
+			"openntpd",
+			map[string]string{
+				"remote":  "163.172.25.19",
+				"stratum": "2",
+			},
+			map[string]interface{}{
+				"wt":     int64(1),
+				"tl":     int64(10),
+				"next":   int64(21),
+				"poll":   int64(64),
+				"offset": float64(-0.103),
+				"delay":  float64(53.199),
+				"jitter": float64(9.046),
+			},
+			time.Unix(0, 0),
+		),
+		metric.New(
+			"openntpd",
+			map[string]string{
+				"remote":       "92.243.6.5",
+				"stratum":      "2",
+				"state_prefix": "*",
+			},
+			map[string]interface{}{
+				"wt":     int64(1),
+				"tl":     int64(10),
+				"next":   int64(45),
+				"poll":   int64(980),
+				"offset": float64(-9.901),
+				"delay":  float64(67.573),
+				"jitter": float64(29.350),
+			},
+			time.Unix(0, 0),
+		),
+		metric.New(
+			"openntpd",
+			map[string]string{
+				"remote":  "178.33.111.49",
+				"stratum": "-",
+			},
+			map[string]interface{}{
+				"wt":   int64(1),
+				"tl":   int64(2),
+				"next": int64(203),
+				"poll": int64(300),
+			},
+			time.Unix(0, 0),
+		),
+		metric.New(
+			"openntpd_sensors",
+			map[string]string{
+				"sensor":       "nmea0",
+				"refid":        "GPS",
+				"state_prefix": "*",
+			},
+			map[string]interface{}{
+				"wt":         int64(10),
+				"gd":         int64(1),
+				"st":         int64(0),
+				"next":       int64(1),
+				"poll":       int64(15),
+				"offset":     float64(-0.673),
+				"correction": float64(0.600),
+			},
+			time.Unix(0, 0),
+		),
 	}
-	firstpeertags := map[string]string{
-		"remote":  "212.129.9.36",
-		"stratum": "3",
-	}
-	acc.AssertContainsTaggedFields(t, "openntpd", firstpeerfields, firstpeertags)
 
-	// Status
-	require.True(t, acc.HasMeasurement("openntpd_status"))
-	statusFields := map[string]interface{}{
-		"peers_valid":         int64(12),
-		"peers_total":         int64(12),
-		"sensors_valid":       int64(1),
-		"sensors_total":       int64(1),
-		"constraint_offset_s": int64(-1),
-		"clock_synced":        int64(1),
-		"stratum":             int64(1),
-	}
-	acc.AssertContainsFields(t, "openntpd_status", statusFields)
-
-	// Sensors
-	require.True(t, acc.HasMeasurement("openntpd_sensors"))
-	sensorFields := map[string]interface{}{
-		"wt":         int64(10),
-		"gd":         int64(1),
-		"st":         int64(0),
-		"next":       int64(1),
-		"poll":       int64(15),
-		"offset":     float64(-0.673),
-		"correction": float64(0.600),
-	}
-	sensorTags := map[string]string{
-		"sensor":       "nmea0",
-		"refid":        "GPS",
-		"state_prefix": "*",
-	}
-	acc.AssertContainsTaggedFields(t, "openntpd_sensors", sensorFields, sensorTags)
+	actual := acc.GetTelegrafMetrics()
+	testutil.RequireMetricsEqual(t,
+		expected, actual,
+		testutil.SortMetrics(),
+		testutil.IgnoreTime(),
+	)
 }
 
 func TestParseStatusLineClockNotSynced(t *testing.T) {
-	acc := &testutil.Accumulator{}
-	v := &Openntpd{
+	plugin := &Openntpd{
 		run: openntpdCTL(outputNoSync),
 	}
-	err := v.Gather(acc)
-	require.NoError(t, err)
 
-	require.True(t, acc.HasMeasurement("openntpd_status"))
-	statusFields := map[string]interface{}{
-		"peers_valid":         int64(0),
-		"peers_total":         int64(4),
-		"constraint_offset_s": int64(0),
-		"clock_synced":        int64(0),
+	var acc testutil.Accumulator
+	require.NoError(t, plugin.Gather(&acc))
+
+	expected := []telegraf.Metric{
+		metric.New(
+			"openntpd_status",
+			map[string]string{},
+			map[string]interface{}{
+				"peers_valid":         int64(0),
+				"peers_total":         int64(4),
+				"constraint_offset_s": int64(0),
+				"clock_synced":        int64(0),
+			},
+			time.Unix(0, 0),
+		),
+		metric.New(
+			"openntpd",
+			map[string]string{
+				"remote":  "212.129.9.36",
+				"stratum": "-",
+			},
+			map[string]interface{}{
+				"wt":   int64(1),
+				"tl":   int64(2),
+				"next": int64(5),
+				"poll": int64(15),
+			},
+			time.Unix(0, 0),
+		),
 	}
-	acc.AssertContainsFields(t, "openntpd_status", statusFields)
+
+	actual := acc.GetTelegrafMetrics()
+	testutil.RequireMetricsEqual(t,
+		expected, actual,
+		testutil.SortMetrics(),
+		testutil.IgnoreTime(),
+	)
 }
 
 var simpleOutput = `peer


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

Switch from ntpctl -s peers to ntpctl -s all to collect openntpd_sensors (per-sensor offset and correction) and openntpd_status (peers valid, clock synced, local stratum). Existing openntpd peer metrics are unchanged.

I've been running this change for the last few weeks on my OpenBSD server and it works very well. Here is an example graph I made to track my OpenNTPd instance:

<img width="1829" height="1007" alt="image" src="https://github.com/user-attachments/assets/2d3218ba-4856-4dcd-b561-fbfe2e49f7ef" />

Questions or comments are appresiated.

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [ ] No AI generated code was used in this PR
- [x] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #18467
