### PR TITLE
fix(inputs.mem): Use vm.Cached as vm.Buffers on OpenBSD

### DIFF
--- a/plugins/inputs/mem/mem.go
+++ b/plugins/inputs/mem/mem.go
@@ -50,7 +50,7 @@ func (ms *Mem) Gather(acc telegraf.Accumulator) error {
 		fields["wired"] = vm.Wired
 	case "openbsd":
 		fields["active"] = vm.Active
-		fields["cached"] = vm.Cached
+		fields["cached"] = vm.Buffers
 		fields["free"] = vm.Free
 		fields["inactive"] = vm.Inactive
 		fields["wired"] = vm.Wired


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

The problem is that vm.Cached is unavailable on OpenBSD and the nearest equivalent to Linux cache memory is vm.Buffers.

I've been testing the change on my OpenBSD server for the last month and here is how it looks like:

<img width="1855" height="1111" alt="image" src="https://github.com/user-attachments/assets/bca18d0d-029b-49a8-8fe0-1d615a402a9a" />

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #18382
