### PR TITLE
fix(internal): Extract go version even more robustly

### DIFF
--- a/internal/internal.go
+++ b/internal/internal.go
@@ -34,7 +34,7 @@ var (
 	ErrNotImplemented = errors.New("not implemented yet")
 
 	// Regexp for extracting the go version from runtime information
-	reGoVer = regexp.MustCompile(`go([^\s]+).*`)
+	reGoVer = regexp.MustCompile(`go(\d+\.\d+\.\d+).*`)
 )
 
 // Set via LDFLAGS -X

--- a/internal/internal_test.go
+++ b/internal/internal_test.go
@@ -907,6 +907,34 @@ func TestTimestampAbbrevWarning(t *testing.T) {
 	require.Contains(t, buf.String(), "Your config is using abbreviated timezones and parsing was changed in v1.27.0")
 }
 
+func TestGoVersion(t *testing.T) {
+	tests := []struct {
+		version  string
+		expected string
+	}{
+		{
+			version:  "go version go1.24.0 linux/amd64",
+			expected: "1.24.0",
+		},
+		{
+			version:  "go version go1.25.2 X:nodwarf5 linux/amd64",
+			expected: "1.25.2",
+		},
+		{
+			version:  "go version go1.26.1-X:nodwarf5 linux/amd64",
+			expected: "1.26.1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.version, func(t *testing.T) {
+			match := reGoVer.FindStringSubmatch(tt.version)
+			require.Len(t, match, 2)
+			require.Equal(t, tt.expected, match[1])
+		})
+	}
+}
+
 func TestProductToken(t *testing.T) {
 	token := ProductToken()
 	// Telegraf version depends on the call to SetVersion, it cannot be set


### PR DESCRIPTION
## Summary

This PR constraints the go version extraction pattern even more to be able to handle the next formatting change in the go compiler. Previously the version was one of the patterns in the tests like
```
go version go1.25.7 linux/amd64
```
or a version with added linker information like
```
go version go1.25.7 X:nodwarf5 linux/amd64
```

However, with go 1.26 the format changed to
```
go version go1.26.1-X:nodwarf5 linux/amd64
```

extracting `1.26.1-X:nodwarf5` as version where we expect `1.26.1`.

This PR fixes the regular expression in the hope we now catch all future changes and adds a unit-test to cover older versions of the go compiler.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
