### PR TITLE
fix(inputs.diskio): Sanitize newline characters in serial tag

### DIFF
--- a/plugins/inputs/diskio/diskio.go
+++ b/plugins/inputs/diskio/diskio.go
@@ -20,7 +20,8 @@ import (
 var sampleConfig string
 
 var (
-	varRegex = regexp.MustCompile(`\$(?:\w+|\{\w+\})`)
+	varRegex           = regexp.MustCompile(`\$(?:\w+|\{\w+\})`)
+	serialTagSanitizer = strings.NewReplacer("\n", "", "\r", "")
 )
 
 type DiskIO struct {
@@ -106,8 +107,9 @@ func (d *DiskIO) Gather(acc telegraf.Accumulator) error {
 		}
 
 		if !d.SkipSerialNumber {
-			if len(io.SerialNumber) != 0 {
-				tags["serial"] = io.SerialNumber
+			serial := sanitizeSerialNumber(io.SerialNumber)
+			if len(serial) != 0 {
+				tags["serial"] = serial
 			} else {
 				tags["serial"] = "unknown"
 			}
@@ -158,6 +160,10 @@ func (d *DiskIO) Gather(acc telegraf.Accumulator) error {
 // hasMeta reports whether s contains any special glob characters.
 func hasMeta(s string) bool {
 	return strings.ContainsAny(s, "*?[")
+}
+
+func sanitizeSerialNumber(serial string) string {
+	return strings.TrimSpace(serialTagSanitizer.Replace(serial))
 }
 
 func (d *DiskIO) diskName(devName string) (string, []string) {

--- a/plugins/inputs/diskio/diskio_test.go
+++ b/plugins/inputs/diskio/diskio_test.go
@@ -72,6 +72,32 @@ func TestDiskIO(t *testing.T) {
 			},
 		},
 		{
+			name: "sanitize serial newlines",
+			result: Result{
+				stats: map[string]disk.IOCountersStat{
+					"sdb": {
+						ReadCount:    1,
+						WriteCount:   2,
+						Name:         "sdb",
+						SerialNumber: "INTEL SSDPE21K100GA \n_PHKE831600AC100EGN \n",
+					},
+				},
+				err: nil,
+			},
+			err: nil,
+			metrics: []Metric{
+				{
+					tags: map[string]string{
+						"name":   "sdb",
+						"serial": "INTEL SSDPE21K100GA _PHKE831600AC100EGN",
+					},
+					fields: map[string]interface{}{
+						"reads": uint64(1),
+					},
+				},
+			},
+		},
+		{
 			name:    "glob device",
 			devices: []string{"sd*"},
 			result: Result{


### PR DESCRIPTION
## Summary

Fix disk serial tag values containing embedded newline characters.

Some Linux devices may return serial numbers with trailing or embedded `\n` / `\r`, which end up in the `serial` tag value. This causes problems for downstream systems because tag values should not contain newlines.

This change sanitizes serial numbers before writing them as tags and adds a regression test covering multiline serial values.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #18470