### PR TITLE
chore(outputs.cloudwatch): Cleanup unit-tests

### DIFF
--- a/plugins/outputs/cloudwatch/cloudwatch_test.go
+++ b/plugins/outputs/cloudwatch/cloudwatch_test.go
@@ -57,8 +57,8 @@ func TestBuildDimensions(t *testing.T) {
 
 	// Wrapper for later cleanup
 	tags := make(map[string]string, len(input))
-	for _, t := range input {
-		tags[t.Key] = t.Value
+	for _, tag := range input {
+		tags[tag.Key] = tag.Value
 	}
 
 	for _, tt := range tests {
@@ -172,7 +172,8 @@ func TestBuildMetricDatums(t *testing.T) {
 				map[string]string{"tag1": "value1"},
 				map[string]interface{}{
 					"valueA": float64(10),
-					"valueB": float64(0), "valueC": float64(100),
+					"valueB": float64(0),
+					"valueC": float64(100),
 					"valueD": float64(20),
 				},
 				time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC),


### PR DESCRIPTION
## Summary

This PR cleans the unit-tests of the cloudwatch output plugin for a later code cleanup. No functional changes.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

in preparation of fixing #16286