### PR TITLE
chore(models): Replace testutil.MustMetric with metric.New

### DIFF
--- a/models/filter_test.go
+++ b/models/filter_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/metric"
-	"github.com/influxdata/telegraf/testutil"
 )
 
 func TestFilterApplyEmpty(t *testing.T) {
@@ -545,7 +544,7 @@ func TestFilterTagsPassAndDrop(t *testing.T) {
 }
 
 func TestFilterMetricPass(t *testing.T) {
-	m := testutil.MustMetric("cpu",
+	m := metric.New("cpu",
 		map[string]string{
 			"host":   "Hugin",
 			"source": "myserver@mycompany.com",
@@ -655,7 +654,7 @@ func BenchmarkFilter(b *testing.B) {
 		{
 			name:   "empty filter",
 			filter: Filter{},
-			metric: testutil.MustMetric("cpu",
+			metric: metric.New("cpu",
 				map[string]string{},
 				map[string]interface{}{
 					"value": 42,
@@ -668,7 +667,7 @@ func BenchmarkFilter(b *testing.B) {
 			filter: Filter{
 				NamePass: []string{"cpu"},
 			},
-			metric: testutil.MustMetric("cpu",
+			metric: metric.New("cpu",
 				map[string]string{},
 				map[string]interface{}{
 					"value": 42,
@@ -681,7 +680,7 @@ func BenchmarkFilter(b *testing.B) {
 			filter: Filter{
 				MetricPass: `name == "cpu"`,
 			},
-			metric: testutil.MustMetric("cpu",
+			metric: metric.New("cpu",
 				map[string]string{},
 				map[string]interface{}{
 					"value": 42,
@@ -694,7 +693,7 @@ func BenchmarkFilter(b *testing.B) {
 			filter: Filter{
 				MetricPass: `name.matches("^c[a-z]*$")`,
 			},
-			metric: testutil.MustMetric("cpu",
+			metric: metric.New("cpu",
 				map[string]string{},
 				map[string]interface{}{
 					"value": 42,
@@ -707,7 +706,7 @@ func BenchmarkFilter(b *testing.B) {
 			filter: Filter{
 				MetricPass: `time >= timestamp("2023-04-25T00:00:00Z") - duration("24h")`,
 			},
-			metric: testutil.MustMetric("cpu",
+			metric: metric.New("cpu",
 				map[string]string{},
 				map[string]interface{}{
 					"value": 42,
@@ -722,7 +721,7 @@ func BenchmarkFilter(b *testing.B) {
 					` && fields.exists(f, type(fields[f]) in [int, uint, double] && fields[f] > 20.0)` +
 					` && time >= timestamp("2023-04-25T00:00:00Z") - duration("24h")`,
 			},
-			metric: testutil.MustMetric("cpu",
+			metric: metric.New("cpu",
 				map[string]string{},
 				map[string]interface{}{
 					"value": 42,

--- a/models/running_aggregator_test.go
+++ b/models/running_aggregator_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/metric"
 	"github.com/influxdata/telegraf/testutil"
 )
 
@@ -25,7 +26,7 @@ func TestRunningAggregatorAdd(t *testing.T) {
 	now := time.Now()
 	ra.UpdateWindow(now, now.Add(ra.Config.Period))
 
-	m := testutil.MustMetric("RITest",
+	m := metric.New("RITest",
 		map[string]string{},
 		map[string]interface{}{
 			"value": int64(101),
@@ -53,7 +54,7 @@ func TestRunningAggregatorAddMetricsOutsideCurrentPeriod(t *testing.T) {
 	now := time.Now()
 	ra.UpdateWindow(now, now.Add(ra.Config.Period))
 
-	m := testutil.MustMetric("RITest",
+	m := metric.New("RITest",
 		map[string]string{},
 		map[string]interface{}{
 			"value": int64(101),
@@ -64,7 +65,7 @@ func TestRunningAggregatorAddMetricsOutsideCurrentPeriod(t *testing.T) {
 	require.False(t, ra.Add(m))
 
 	// metric after current period
-	m = testutil.MustMetric("RITest",
+	m = metric.New("RITest",
 		map[string]string{},
 		map[string]interface{}{
 			"value": int64(101),
@@ -75,7 +76,7 @@ func TestRunningAggregatorAddMetricsOutsideCurrentPeriod(t *testing.T) {
 	require.False(t, ra.Add(m))
 
 	// "now" metric
-	m = testutil.MustMetric("RITest",
+	m = metric.New("RITest",
 		map[string]string{},
 		map[string]interface{}{
 			"value": int64(101),
@@ -104,7 +105,7 @@ func TestRunningAggregatorAddMetricsOutsideCurrentPeriodWithGrace(t *testing.T) 
 	now := time.Now()
 	ra.UpdateWindow(now, now.Add(ra.Config.Period))
 
-	m := testutil.MustMetric("RITest",
+	m := metric.New("RITest",
 		map[string]string{},
 		map[string]interface{}{
 			"value": int64(101),
@@ -115,7 +116,7 @@ func TestRunningAggregatorAddMetricsOutsideCurrentPeriodWithGrace(t *testing.T) 
 	require.False(t, ra.Add(m))
 
 	// metric before current period (late)
-	m = testutil.MustMetric("RITest",
+	m = metric.New("RITest",
 		map[string]string{},
 		map[string]interface{}{
 			"value": int64(100),
@@ -126,7 +127,7 @@ func TestRunningAggregatorAddMetricsOutsideCurrentPeriodWithGrace(t *testing.T) 
 	require.False(t, ra.Add(m))
 
 	// metric before current period, but within grace period (late)
-	m = testutil.MustMetric("RITest",
+	m = metric.New("RITest",
 		map[string]string{},
 		map[string]interface{}{
 			"value": int64(102),
@@ -137,7 +138,7 @@ func TestRunningAggregatorAddMetricsOutsideCurrentPeriodWithGrace(t *testing.T) 
 	require.False(t, ra.Add(m))
 
 	// "now" metric
-	m = testutil.MustMetric("RITest",
+	m = metric.New("RITest",
 		map[string]string{},
 		map[string]interface{}{
 			"value": int64(101),
@@ -166,7 +167,7 @@ func TestRunningAggregatorAddAndPushOnePeriod(t *testing.T) {
 	now := time.Now()
 	ra.UpdateWindow(now, now.Add(ra.Config.Period))
 
-	m := testutil.MustMetric("RITest",
+	m := metric.New("RITest",
 		map[string]string{},
 		map[string]interface{}{
 			"value": int64(101),
@@ -193,7 +194,7 @@ func TestRunningAggregatorAddDropOriginal(t *testing.T) {
 	now := time.Now()
 	ra.UpdateWindow(now, now.Add(ra.Config.Period))
 
-	m := testutil.MustMetric("RITest",
+	m := metric.New("RITest",
 		map[string]string{},
 		map[string]interface{}{
 			"value": int64(101),
@@ -203,7 +204,7 @@ func TestRunningAggregatorAddDropOriginal(t *testing.T) {
 	require.True(t, ra.Add(m))
 
 	// this metric name doesn't match the filter, so Add will return false
-	m2 := testutil.MustMetric("foobar",
+	m2 := metric.New("foobar",
 		map[string]string{},
 		map[string]interface{}{
 			"value": int64(101),
@@ -225,7 +226,7 @@ func TestRunningAggregatorAddDoesNotModifyMetric(t *testing.T) {
 
 	now := time.Now()
 
-	m := testutil.MustMetric(
+	m := metric.New(
 		"cpu",
 		map[string]string{},
 		map[string]interface{}{

--- a/models/running_input_test.go
+++ b/models/running_input_test.go
@@ -96,7 +96,7 @@ func TestRunningInputMakeMetricWithPluginTags(t *testing.T) {
 		},
 	})
 
-	m := testutil.MustMetric("RITest",
+	m := metric.New("RITest",
 		map[string]string{},
 		map[string]interface{}{
 			"value": int64(101),
@@ -149,7 +149,7 @@ func TestRunningInputMakeMetricWithDaemonTags(t *testing.T) {
 		"foo": "bar",
 	})
 
-	m := testutil.MustMetric("RITest",
+	m := metric.New("RITest",
 		map[string]string{},
 		map[string]interface{}{
 			"value": int64(101),
@@ -287,7 +287,7 @@ func TestRunningInputMakeMetricWithAlwaysKeepingPluginTagsDisabled(t *testing.T)
 	ri.SetDefaultTags(map[string]string{"logic": "rulez"})
 	require.NoError(t, ri.Config.Filter.Compile())
 
-	m := testutil.MustMetric("RITest",
+	m := metric.New("RITest",
 		map[string]string{
 			"b": "test",
 		},
@@ -325,7 +325,7 @@ func TestRunningInputMakeMetricWithAlwaysKeepingLocalPluginTagsEnabled(t *testin
 	ri.SetDefaultTags(map[string]string{"logic": "rulez"})
 	require.NoError(t, ri.Config.Filter.Compile())
 
-	m := testutil.MustMetric("RITest",
+	m := metric.New("RITest",
 		map[string]string{
 			"b": "test",
 		},
@@ -364,7 +364,7 @@ func TestRunningInputMakeMetricWithAlwaysKeepingGlobalPluginTagsEnabled(t *testi
 	ri.SetDefaultTags(map[string]string{"logic": "rulez"})
 	require.NoError(t, ri.Config.Filter.Compile())
 
-	m := testutil.MustMetric("RITest",
+	m := metric.New("RITest",
 		map[string]string{
 			"b": "test",
 		},
@@ -404,7 +404,7 @@ func TestRunningInputMakeMetricWithAlwaysKeepingPluginTagsEnabled(t *testing.T) 
 	ri.SetDefaultTags(map[string]string{"logic": "rulez"})
 	require.NoError(t, ri.Config.Filter.Compile())
 
-	m := testutil.MustMetric("RITest",
+	m := metric.New("RITest",
 		map[string]string{
 			"b": "test",
 		},

--- a/models/running_output_test.go
+++ b/models/running_output_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/internal"
+	"github.com/influxdata/telegraf/metric"
 	"github.com/influxdata/telegraf/selfstat"
 	"github.com/influxdata/telegraf/testutil"
 )
@@ -789,7 +790,7 @@ func TestRunningOutputInternalMetrics(t *testing.T) {
 		10)
 
 	expected := []telegraf.Metric{
-		testutil.MustMetric(
+		metric.New(
 			"internal_write",
 			map[string]string{
 				"_id":    "",

--- a/models/running_processor_test.go
+++ b/models/running_processor_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/metric"
 	"github.com/influxdata/telegraf/models"
 	"github.com/influxdata/telegraf/plugins/processors"
 	"github.com/influxdata/telegraf/testutil"
@@ -52,7 +53,7 @@ func TestRunningProcessorApply(t *testing.T) {
 				},
 			},
 			input: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{},
 					map[string]interface{}{
@@ -62,7 +63,7 @@ func TestRunningProcessorApply(t *testing.T) {
 				),
 			},
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{
 						"apply": "true",
@@ -94,7 +95,7 @@ func TestRunningProcessorApply(t *testing.T) {
 				},
 			},
 			input: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{},
 					map[string]interface{}{
@@ -104,7 +105,7 @@ func TestRunningProcessorApply(t *testing.T) {
 				),
 			},
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{
 						"apply": "true",
@@ -136,7 +137,7 @@ func TestRunningProcessorApply(t *testing.T) {
 				},
 			},
 			input: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{},
 					map[string]interface{}{
@@ -146,7 +147,7 @@ func TestRunningProcessorApply(t *testing.T) {
 				),
 			},
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{},
 					map[string]interface{}{


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Part of #18495 - testutil.MustMetric is a trivial wrapper around metric.New that adds no value and misleads with its "Must" prefix.

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
