### PR TITLE
chore(aggregators): Replace testutil.MustMetric with metric.New

### DIFF
--- a/plugins/aggregators/final/final_test.go
+++ b/plugins/aggregators/final/final_test.go
@@ -36,7 +36,7 @@ func TestSimple(t *testing.T) {
 	final.Push(&acc)
 
 	expected := []telegraf.Metric{
-		testutil.MustMetric(
+		metric.New(
 			"m1",
 			tags,
 			map[string]interface{}{
@@ -74,7 +74,7 @@ func TestTwoTags(t *testing.T) {
 	final.Push(&acc)
 
 	expected := []telegraf.Metric{
-		testutil.MustMetric(
+		metric.New(
 			"m1",
 			tags2,
 			map[string]interface{}{
@@ -82,7 +82,7 @@ func TestTwoTags(t *testing.T) {
 			},
 			time.Unix(1530939937, 0),
 		),
-		testutil.MustMetric(
+		metric.New(
 			"m1",
 			tags1,
 			map[string]interface{}{
@@ -128,7 +128,7 @@ func TestLongDifference(t *testing.T) {
 	final.Push(&acc)
 
 	expected := []telegraf.Metric{
-		testutil.MustMetric(
+		metric.New(
 			"m",
 			tags,
 			map[string]interface{}{
@@ -136,7 +136,7 @@ func TestLongDifference(t *testing.T) {
 			},
 			now.Add(time.Second*-275),
 		),
-		testutil.MustMetric(
+		metric.New(
 			"m",
 			tags,
 			map[string]interface{}{
@@ -192,7 +192,7 @@ func TestOutputStrategyTimeout(t *testing.T) {
 	final.Push(&acc)
 
 	expected := []telegraf.Metric{
-		testutil.MustMetric(
+		metric.New(
 			"m",
 			tags,
 			map[string]interface{}{
@@ -200,7 +200,7 @@ func TestOutputStrategyTimeout(t *testing.T) {
 			},
 			now.Add(time.Second*-275),
 		),
-		testutil.MustMetric(
+		metric.New(
 			"m",
 			tags,
 			map[string]interface{}{

--- a/plugins/aggregators/merge/merge_test.go
+++ b/plugins/aggregators/merge/merge_test.go
@@ -17,7 +17,7 @@ func TestSimple(t *testing.T) {
 	require.NoError(t, plugin.Init())
 
 	plugin.Add(
-		testutil.MustMetric(
+		metric.New(
 			"cpu",
 			map[string]string{
 				"cpu": "cpu0",
@@ -29,7 +29,7 @@ func TestSimple(t *testing.T) {
 		),
 	)
 	plugin.Add(
-		testutil.MustMetric(
+		metric.New(
 			"cpu",
 			map[string]string{
 				"cpu": "cpu0",
@@ -45,7 +45,7 @@ func TestSimple(t *testing.T) {
 	plugin.Push(&acc)
 
 	expected := []telegraf.Metric{
-		testutil.MustMetric(
+		metric.New(
 			"cpu",
 			map[string]string{
 				"cpu": "cpu0",
@@ -66,7 +66,7 @@ func TestNanosecondPrecision(t *testing.T) {
 	require.NoError(t, plugin.Init())
 
 	plugin.Add(
-		testutil.MustMetric(
+		metric.New(
 			"cpu",
 			map[string]string{
 				"cpu": "cpu0",
@@ -79,7 +79,7 @@ func TestNanosecondPrecision(t *testing.T) {
 	)
 
 	plugin.Add(
-		testutil.MustMetric(
+		metric.New(
 			"cpu",
 			map[string]string{
 				"cpu": "cpu0",
@@ -96,7 +96,7 @@ func TestNanosecondPrecision(t *testing.T) {
 	plugin.Push(&acc)
 
 	expected := []telegraf.Metric{
-		testutil.MustMetric(
+		metric.New(
 			"cpu",
 			map[string]string{
 				"cpu": "cpu0",
@@ -117,7 +117,7 @@ func TestNoRounding(t *testing.T) {
 	require.NoError(t, plugin.Init())
 
 	plugin.Add(
-		testutil.MustMetric(
+		metric.New(
 			"cpu",
 			map[string]string{
 				"cpu": "cpu0",
@@ -130,7 +130,7 @@ func TestNoRounding(t *testing.T) {
 	)
 
 	plugin.Add(
-		testutil.MustMetric(
+		metric.New(
 			"cpu",
 			map[string]string{
 				"cpu": "cpu0",
@@ -147,7 +147,7 @@ func TestNoRounding(t *testing.T) {
 	plugin.Push(&acc)
 
 	expected := []telegraf.Metric{
-		testutil.MustMetric(
+		metric.New(
 			"cpu",
 			map[string]string{
 				"cpu": "cpu0",
@@ -157,7 +157,7 @@ func TestNoRounding(t *testing.T) {
 			},
 			time.Unix(0, 1),
 		),
-		testutil.MustMetric(
+		metric.New(
 			"cpu",
 			map[string]string{
 				"cpu": "cpu0",
@@ -177,7 +177,7 @@ func TestWithRounding(t *testing.T) {
 	require.NoError(t, plugin.Init())
 
 	plugin.Add(
-		testutil.MustMetric(
+		metric.New(
 			"cpu",
 			map[string]string{
 				"cpu": "cpu0",
@@ -190,7 +190,7 @@ func TestWithRounding(t *testing.T) {
 	)
 
 	plugin.Add(
-		testutil.MustMetric(
+		metric.New(
 			"cpu",
 			map[string]string{
 				"cpu": "cpu0",
@@ -207,7 +207,7 @@ func TestWithRounding(t *testing.T) {
 	plugin.Push(&acc)
 
 	expected := []telegraf.Metric{
-		testutil.MustMetric(
+		metric.New(
 			"cpu",
 			map[string]string{
 				"cpu": "cpu0",
@@ -228,7 +228,7 @@ func TestReset(t *testing.T) {
 	require.NoError(t, plugin.Init())
 
 	plugin.Add(
-		testutil.MustMetric(
+		metric.New(
 			"cpu",
 			map[string]string{
 				"cpu": "cpu0",
@@ -246,7 +246,7 @@ func TestReset(t *testing.T) {
 	plugin.Reset()
 
 	plugin.Add(
-		testutil.MustMetric(
+		metric.New(
 			"cpu",
 			map[string]string{
 				"cpu": "cpu0",
@@ -261,7 +261,7 @@ func TestReset(t *testing.T) {
 	plugin.Push(&acc)
 
 	expected := []telegraf.Metric{
-		testutil.MustMetric(
+		metric.New(
 			"cpu",
 			map[string]string{
 				"cpu": "cpu0",
@@ -271,7 +271,7 @@ func TestReset(t *testing.T) {
 			},
 			time.Unix(0, 0),
 		),
-		testutil.MustMetric(
+		metric.New(
 			"cpu",
 			map[string]string{
 				"cpu": "cpu0",

--- a/plugins/aggregators/quantile/quantile_test.go
+++ b/plugins/aggregators/quantile/quantile_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/metric"
 	"github.com/influxdata/telegraf/testutil"
 )
 
@@ -54,7 +55,7 @@ func TestSingleMetricTDigest(t *testing.T) {
 	require.NoError(t, err)
 
 	expected := []telegraf.Metric{
-		testutil.MustMetric(
+		metric.New(
 			"test",
 			map[string]string{"foo": "bar"},
 			map[string]interface{}{
@@ -86,7 +87,7 @@ func TestSingleMetricTDigest(t *testing.T) {
 
 	metrics := make([]telegraf.Metric, 0, 100)
 	for i := 0; i < 100; i++ {
-		metrics = append(metrics, testutil.MustMetric(
+		metrics = append(metrics, metric.New(
 			"test",
 			map[string]string{"foo": "bar"},
 			map[string]interface{}{
@@ -124,7 +125,7 @@ func TestMultipleMetricsTDigest(t *testing.T) {
 	require.NoError(t, err)
 
 	expected := []telegraf.Metric{
-		testutil.MustMetric(
+		metric.New(
 			"test",
 			map[string]string{"series": "foo"},
 			map[string]interface{}{
@@ -133,7 +134,7 @@ func TestMultipleMetricsTDigest(t *testing.T) {
 			},
 			time.Now(),
 		),
-		testutil.MustMetric(
+		metric.New(
 			"test",
 			map[string]string{"series": "bar"},
 			map[string]interface{}{
@@ -147,14 +148,14 @@ func TestMultipleMetricsTDigest(t *testing.T) {
 	metricsA := make([]telegraf.Metric, 0, 100)
 	metricsB := make([]telegraf.Metric, 0, 100)
 	for i := 0; i < 100; i++ {
-		metricsA = append(metricsA, testutil.MustMetric(
+		metricsA = append(metricsA, metric.New(
 			"test",
 			map[string]string{"series": "foo"},
 			map[string]interface{}{"a": int64(i), "b": float64(i), "x1": "string", "x2": true},
 			time.Now(),
 		))
 
-		metricsB = append(metricsB, testutil.MustMetric(
+		metricsB = append(metricsB, metric.New(
 			"test",
 			map[string]string{"series": "bar"},
 			map[string]interface{}{"a": int64(2 * i), "b": float64(2 * i), "x1": "string", "x2": true},
@@ -186,7 +187,7 @@ func TestSingleMetricExactR7(t *testing.T) {
 	require.NoError(t, err)
 
 	expected := []telegraf.Metric{
-		testutil.MustMetric(
+		metric.New(
 			"test",
 			map[string]string{"foo": "bar"},
 			map[string]interface{}{
@@ -218,7 +219,7 @@ func TestSingleMetricExactR7(t *testing.T) {
 
 	metrics := make([]telegraf.Metric, 0, 100)
 	for i := 0; i < 100; i++ {
-		metrics = append(metrics, testutil.MustMetric(
+		metrics = append(metrics, metric.New(
 			"test",
 			map[string]string{"foo": "bar"},
 			map[string]interface{}{
@@ -256,7 +257,7 @@ func TestMultipleMetricsExactR7(t *testing.T) {
 	require.NoError(t, err)
 
 	expected := []telegraf.Metric{
-		testutil.MustMetric(
+		metric.New(
 			"test",
 			map[string]string{"series": "foo"},
 			map[string]interface{}{
@@ -265,7 +266,7 @@ func TestMultipleMetricsExactR7(t *testing.T) {
 			},
 			time.Now(),
 		),
-		testutil.MustMetric(
+		metric.New(
 			"test",
 			map[string]string{"series": "bar"},
 			map[string]interface{}{
@@ -279,14 +280,14 @@ func TestMultipleMetricsExactR7(t *testing.T) {
 	metricsA := make([]telegraf.Metric, 0, 100)
 	metricsB := make([]telegraf.Metric, 0, 100)
 	for i := 0; i < 100; i++ {
-		metricsA = append(metricsA, testutil.MustMetric(
+		metricsA = append(metricsA, metric.New(
 			"test",
 			map[string]string{"series": "foo"},
 			map[string]interface{}{"a": int64(i), "b": float64(i), "x1": "string", "x2": true},
 			time.Now(),
 		))
 
-		metricsB = append(metricsB, testutil.MustMetric(
+		metricsB = append(metricsB, metric.New(
 			"test",
 			map[string]string{"series": "bar"},
 			map[string]interface{}{"a": int64(2 * i), "b": float64(2 * i), "x1": "string", "x2": true},
@@ -318,7 +319,7 @@ func TestSingleMetricExactR8(t *testing.T) {
 	require.NoError(t, err)
 
 	expected := []telegraf.Metric{
-		testutil.MustMetric(
+		metric.New(
 			"test",
 			map[string]string{"foo": "bar"},
 			map[string]interface{}{
@@ -350,7 +351,7 @@ func TestSingleMetricExactR8(t *testing.T) {
 
 	metrics := make([]telegraf.Metric, 0, 100)
 	for i := 0; i < 100; i++ {
-		metrics = append(metrics, testutil.MustMetric(
+		metrics = append(metrics, metric.New(
 			"test",
 			map[string]string{"foo": "bar"},
 			map[string]interface{}{
@@ -388,7 +389,7 @@ func TestMultipleMetricsExactR8(t *testing.T) {
 	require.NoError(t, err)
 
 	expected := []telegraf.Metric{
-		testutil.MustMetric(
+		metric.New(
 			"test",
 			map[string]string{"series": "foo"},
 			map[string]interface{}{
@@ -397,7 +398,7 @@ func TestMultipleMetricsExactR8(t *testing.T) {
 			},
 			time.Now(),
 		),
-		testutil.MustMetric(
+		metric.New(
 			"test",
 			map[string]string{"series": "bar"},
 			map[string]interface{}{
@@ -411,14 +412,14 @@ func TestMultipleMetricsExactR8(t *testing.T) {
 	metricsA := make([]telegraf.Metric, 0, 100)
 	metricsB := make([]telegraf.Metric, 0, 100)
 	for i := 0; i < 100; i++ {
-		metricsA = append(metricsA, testutil.MustMetric(
+		metricsA = append(metricsA, metric.New(
 			"test",
 			map[string]string{"series": "foo"},
 			map[string]interface{}{"a": int64(i), "b": float64(i), "x1": "string", "x2": true},
 			time.Now(),
 		))
 
-		metricsB = append(metricsB, testutil.MustMetric(
+		metricsB = append(metricsB, metric.New(
 			"test",
 			map[string]string{"series": "bar"},
 			map[string]interface{}{"a": int64(2 * i), "b": float64(2 * i), "x1": "string", "x2": true},
@@ -442,7 +443,7 @@ func TestMultipleMetricsExactR8(t *testing.T) {
 func BenchmarkDefaultTDigest(b *testing.B) {
 	metrics := make([]telegraf.Metric, 0, 100)
 	for i := 0; i < 100; i++ {
-		metrics = append(metrics, testutil.MustMetric(
+		metrics = append(metrics, metric.New(
 			"test",
 			map[string]string{"foo": "bar"},
 			map[string]interface{}{
@@ -478,7 +479,7 @@ func BenchmarkDefaultTDigest(b *testing.B) {
 func BenchmarkDefaultTDigest100Q(b *testing.B) {
 	metrics := make([]telegraf.Metric, 0, 100)
 	for i := 0; i < 100; i++ {
-		metrics = append(metrics, testutil.MustMetric(
+		metrics = append(metrics, metric.New(
 			"test",
 			map[string]string{"foo": "bar"},
 			map[string]interface{}{
@@ -519,7 +520,7 @@ func BenchmarkDefaultTDigest100Q(b *testing.B) {
 func BenchmarkDefaultExactR7(b *testing.B) {
 	metrics := make([]telegraf.Metric, 0, 100)
 	for i := 0; i < 100; i++ {
-		metrics = append(metrics, testutil.MustMetric(
+		metrics = append(metrics, metric.New(
 			"test",
 			map[string]string{"foo": "bar"},
 			map[string]interface{}{
@@ -555,7 +556,7 @@ func BenchmarkDefaultExactR7(b *testing.B) {
 func BenchmarkDefaultExactR7100Q(b *testing.B) {
 	metrics := make([]telegraf.Metric, 0, 100)
 	for i := 0; i < 100; i++ {
-		metrics = append(metrics, testutil.MustMetric(
+		metrics = append(metrics, metric.New(
 			"test",
 			map[string]string{"foo": "bar"},
 			map[string]interface{}{
@@ -596,7 +597,7 @@ func BenchmarkDefaultExactR7100Q(b *testing.B) {
 func BenchmarkDefaultExactR8(b *testing.B) {
 	metrics := make([]telegraf.Metric, 0, 100)
 	for i := 0; i < 100; i++ {
-		metrics = append(metrics, testutil.MustMetric(
+		metrics = append(metrics, metric.New(
 			"test",
 			map[string]string{"foo": "bar"},
 			map[string]interface{}{
@@ -632,7 +633,7 @@ func BenchmarkDefaultExactR8(b *testing.B) {
 func BenchmarkDefaultExactR8100Q(b *testing.B) {
 	metrics := make([]telegraf.Metric, 0, 100)
 	for i := 0; i < 100; i++ {
-		metrics = append(metrics, testutil.MustMetric(
+		metrics = append(metrics, metric.New(
 			"test",
 			map[string]string{"foo": "bar"},
 			map[string]interface{}{

--- a/plugins/aggregators/starlark/starlark_test.go
+++ b/plugins/aggregators/starlark/starlark_test.go
@@ -181,7 +181,7 @@ func TestSimple(t *testing.T) {
 	require.NoError(t, err)
 
 	plugin.Add(
-		testutil.MustMetric(
+		metric.New(
 			"cpu",
 			map[string]string{
 				"cpu": "cpu0",
@@ -195,7 +195,7 @@ func TestSimple(t *testing.T) {
 	require.NoError(t, err)
 
 	plugin.Add(
-		testutil.MustMetric(
+		metric.New(
 			"cpu",
 			map[string]string{
 				"cpu": "cpu0",
@@ -212,7 +212,7 @@ func TestSimple(t *testing.T) {
 	plugin.Push(&acc)
 
 	expected := []telegraf.Metric{
-		testutil.MustMetric(
+		metric.New(
 			"cpu",
 			map[string]string{
 				"cpu": "cpu0",
@@ -234,7 +234,7 @@ func TestNanosecondPrecision(t *testing.T) {
 	require.NoError(t, err)
 
 	plugin.Add(
-		testutil.MustMetric(
+		metric.New(
 			"cpu",
 			map[string]string{
 				"cpu": "cpu0",
@@ -248,7 +248,7 @@ func TestNanosecondPrecision(t *testing.T) {
 	require.NoError(t, err)
 
 	plugin.Add(
-		testutil.MustMetric(
+		metric.New(
 			"cpu",
 			map[string]string{
 				"cpu": "cpu0",
@@ -266,7 +266,7 @@ func TestNanosecondPrecision(t *testing.T) {
 	plugin.Push(&acc)
 
 	expected := []telegraf.Metric{
-		testutil.MustMetric(
+		metric.New(
 			"cpu",
 			map[string]string{
 				"cpu": "cpu0",
@@ -288,7 +288,7 @@ func TestReset(t *testing.T) {
 	require.NoError(t, err)
 
 	plugin.Add(
-		testutil.MustMetric(
+		metric.New(
 			"cpu",
 			map[string]string{
 				"cpu": "cpu0",
@@ -307,7 +307,7 @@ func TestReset(t *testing.T) {
 	plugin.Reset()
 
 	plugin.Add(
-		testutil.MustMetric(
+		metric.New(
 			"cpu",
 			map[string]string{
 				"cpu": "cpu0",
@@ -323,7 +323,7 @@ func TestReset(t *testing.T) {
 	plugin.Push(&acc)
 
 	expected := []telegraf.Metric{
-		testutil.MustMetric(
+		metric.New(
 			"cpu",
 			map[string]string{
 				"cpu": "cpu0",
@@ -333,7 +333,7 @@ func TestReset(t *testing.T) {
 			},
 			time.Unix(0, 0),
 		),
-		testutil.MustMetric(
+		metric.New(
 			"cpu",
 			map[string]string{
 				"cpu": "cpu0",
@@ -367,7 +367,7 @@ def reset():
 `)
 	require.NoError(t, err)
 	plugin.Add(
-		testutil.MustMetric(
+		metric.New(
 			"cpu",
 			map[string]string{
 				"cpu": "cpu0",
@@ -380,7 +380,7 @@ def reset():
 	)
 	require.NoError(t, err)
 	plugin.Add(
-		testutil.MustMetric(
+		metric.New(
 			"cpu",
 			map[string]string{
 				"cpu": "cpu2",


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
`testutil.MustMetric` is a trivial wrapper around `metric.New` that adds no value and misleads with its "Must" prefix.

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

related to #18495