### PR TITLE
chore(parsers): Replace testutil.MustMetric with metric.New (part 1)

### DIFF
--- a/plugins/parsers/graphite/parser_test.go
+++ b/plugins/parsers/graphite/parser_test.go
@@ -421,7 +421,7 @@ func TestParseNaN(t *testing.T) {
 	m, err := p.ParseLine("servers.localhost.cpu_load NaN 1435077219")
 	require.NoError(t, err)
 
-	expected := testutil.MustMetric(
+	expected := metric.New(
 		"servers.localhost.cpu_load",
 		map[string]string{},
 		map[string]interface{}{
@@ -440,7 +440,7 @@ func TestParseInf(t *testing.T) {
 	m, err := p.ParseLine("servers.localhost.cpu_load +Inf 1435077219")
 	require.NoError(t, err)
 
-	expected := testutil.MustMetric(
+	expected := metric.New(
 		"servers.localhost.cpu_load",
 		map[string]string{},
 		map[string]interface{}{

--- a/plugins/parsers/grok/parser_test.go
+++ b/plugins/parsers/grok/parser_test.go
@@ -642,7 +642,7 @@ func TestParseErrors_WrongIntegerType(t *testing.T) {
 	require.NoError(t, err)
 	testutil.RequireMetricEqual(t,
 		m,
-		testutil.MustMetric("grok", map[string]string{}, map[string]interface{}{}, time.Unix(0, 0)))
+		metric.New("grok", map[string]string{}, map[string]interface{}{}, time.Unix(0, 0)))
 }
 
 func TestParseErrors_WrongFloatType(t *testing.T) {
@@ -659,7 +659,7 @@ func TestParseErrors_WrongFloatType(t *testing.T) {
 	require.NoError(t, err)
 	testutil.RequireMetricEqual(t,
 		m,
-		testutil.MustMetric("grok", map[string]string{}, map[string]interface{}{}, time.Unix(0, 0)))
+		metric.New("grok", map[string]string{}, map[string]interface{}{}, time.Unix(0, 0)))
 }
 
 func TestParseErrors_WrongDurationType(t *testing.T) {
@@ -676,7 +676,7 @@ func TestParseErrors_WrongDurationType(t *testing.T) {
 	require.NoError(t, err)
 	testutil.RequireMetricEqual(t,
 		m,
-		testutil.MustMetric("grok", map[string]string{}, map[string]interface{}{}, time.Unix(0, 0)))
+		metric.New("grok", map[string]string{}, map[string]interface{}{}, time.Unix(0, 0)))
 }
 
 func TestParseErrors_WrongTimeLayout(t *testing.T) {
@@ -693,7 +693,7 @@ func TestParseErrors_WrongTimeLayout(t *testing.T) {
 	require.NoError(t, err)
 	testutil.RequireMetricEqual(t,
 		m,
-		testutil.MustMetric("grok", map[string]string{}, map[string]interface{}{}, time.Unix(0, 0)))
+		metric.New("grok", map[string]string{}, map[string]interface{}{}, time.Unix(0, 0)))
 }
 
 func TestParseInteger_Base16(t *testing.T) {
@@ -1159,7 +1159,7 @@ func TestTrimRegression(t *testing.T) {
 	actual, err := p.ParseLine(`level=info msg="ok"`)
 	require.NoError(t, err)
 
-	expected := testutil.MustMetric(
+	expected := metric.New(
 		"",
 		map[string]string{},
 		map[string]interface{}{

--- a/plugins/parsers/json/parser_test.go
+++ b/plugins/parsers/json/parser_test.go
@@ -896,7 +896,7 @@ func TestParse(t *testing.T) {
 			},
 			input: []byte(`{"metric": {"__name__": "howdy", "time_idle": 42}}`),
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"json",
 					map[string]string{
 						"metric___name__": "howdy",
@@ -930,7 +930,7 @@ func TestParse(t *testing.T) {
 			},
 			input: []byte(`[{"answer": 42}]`),
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"json",
 					map[string]string{},
 					map[string]interface{}{
@@ -953,7 +953,7 @@ func TestParse(t *testing.T) {
 }
 `),
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"json",
 					map[string]string{},
 					map[string]interface{}{
@@ -978,7 +978,7 @@ func TestParse(t *testing.T) {
 }
 `),
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"json",
 					map[string]string{},
 					map[string]interface{}{
@@ -1017,7 +1017,7 @@ func TestParseWithWildcardTagKeys(t *testing.T) {
 			},
 			input: []byte(validJSONTags),
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"json_test",
 					map[string]string{
 						"tags_object_mytag":    "foobar",
@@ -1039,7 +1039,7 @@ func TestParseWithWildcardTagKeys(t *testing.T) {
 			},
 			input: []byte(validJSONTags),
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"json_test",
 					map[string]string{
 						"mytag":                "foobar",
@@ -1063,7 +1063,7 @@ func TestParseWithWildcardTagKeys(t *testing.T) {
 			},
 			input: []byte(validJSONTags),
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"json_test",
 					map[string]string{
 						"tags_object_mytag":    "foobar",
@@ -1085,7 +1085,7 @@ func TestParseWithWildcardTagKeys(t *testing.T) {
 			},
 			input: []byte(validJSONTags),
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"json_test",
 					map[string]string{
 						"mytag":                "foobar",
@@ -1127,7 +1127,7 @@ func TestParseLineWithWildcardTagKeys(t *testing.T) {
 				TagKeys:    []string{"tags_object_*"},
 			},
 			input: validJSONTags,
-			expected: testutil.MustMetric(
+			expected: metric.New(
 				"json_test",
 				map[string]string{
 					"tags_object_mytag":    "foobar",
@@ -1147,7 +1147,7 @@ func TestParseLineWithWildcardTagKeys(t *testing.T) {
 				TagKeys:    []string{"*tag"},
 			},
 			input: validJSONTags,
-			expected: testutil.MustMetric(
+			expected: metric.New(
 				"json_test",
 				map[string]string{
 					"mytag":                "foobar",
@@ -1169,7 +1169,7 @@ func TestParseLineWithWildcardTagKeys(t *testing.T) {
 				TagKeys:    []string{"wrongtagkey", "tags_object_*"},
 			},
 			input: validJSONTags,
-			expected: testutil.MustMetric(
+			expected: metric.New(
 				"json_test",
 				map[string]string{
 					"tags_object_mytag":    "foobar",
@@ -1189,7 +1189,7 @@ func TestParseLineWithWildcardTagKeys(t *testing.T) {
 				TagKeys:    []string{"mytag", "tags_object_*"},
 			},
 			input: validJSONTags,
-			expected: testutil.MustMetric(
+			expected: metric.New(
 				"json_test",
 				map[string]string{
 					"mytag":                "foobar",
@@ -1233,7 +1233,7 @@ func TestParseArrayWithWildcardTagKeys(t *testing.T) {
 			},
 			input: []byte(validJSONArrayTags),
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"json_array_test",
 					map[string]string{
 						"mytag":                 "foo",
@@ -1247,7 +1247,7 @@ func TestParseArrayWithWildcardTagKeys(t *testing.T) {
 					},
 					time.Unix(0, 0),
 				),
-				testutil.MustMetric(
+				metric.New(
 					"json_array_test",
 					map[string]string{
 						"mytag":                 "bar",
@@ -1271,7 +1271,7 @@ func TestParseArrayWithWildcardTagKeys(t *testing.T) {
 			},
 			input: []byte(validJSONArrayTags),
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"json_array_test",
 					map[string]string{
 						"tags_array_0_mytag":    "foo",
@@ -1283,7 +1283,7 @@ func TestParseArrayWithWildcardTagKeys(t *testing.T) {
 					},
 					time.Unix(0, 0),
 				),
-				testutil.MustMetric(
+				metric.New(
 					"json_array_test",
 					map[string]string{
 						"tags_array_0_mytag":    "bar",
@@ -1305,7 +1305,7 @@ func TestParseArrayWithWildcardTagKeys(t *testing.T) {
 			},
 			input: []byte(validJSONArrayTags),
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"json_array_test",
 					map[string]string{
 						"mytag":                 "foo",
@@ -1319,7 +1319,7 @@ func TestParseArrayWithWildcardTagKeys(t *testing.T) {
 					},
 					time.Unix(0, 0),
 				),
-				testutil.MustMetric(
+				metric.New(
 					"json_array_test",
 					map[string]string{
 						"mytag":                 "bar",
@@ -1343,7 +1343,7 @@ func TestParseArrayWithWildcardTagKeys(t *testing.T) {
 			},
 			input: []byte(validJSONArrayTags),
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"json_array_test",
 					map[string]string{
 						"anothert":              "foo",
@@ -1358,7 +1358,7 @@ func TestParseArrayWithWildcardTagKeys(t *testing.T) {
 					},
 					time.Unix(0, 0),
 				),
-				testutil.MustMetric(
+				metric.New(
 					"json_array_test",
 					map[string]string{
 						"anothert":              "bar",

--- a/plugins/parsers/logfmt/parser_test.go
+++ b/plugins/parsers/logfmt/parser_test.go
@@ -27,7 +27,7 @@ func TestParse(t *testing.T) {
 			bytes:       []byte("foo=\"bar\""),
 			measurement: "testlog",
 			want: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"testlog",
 					map[string]string{},
 					map[string]interface{}{
@@ -42,7 +42,7 @@ func TestParse(t *testing.T) {
 			bytes:       []byte("foo=\"bar\"\n"),
 			measurement: "testlog",
 			want: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"testlog",
 					map[string]string{},
 					map[string]interface{}{
@@ -57,7 +57,7 @@ func TestParse(t *testing.T) {
 			bytes:       []byte(`ts=2018-07-24T19:43:40.275Z lvl=info msg="http request" method=POST`),
 			measurement: "testlog",
 			want: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"testlog",
 					map[string]string{},
 					map[string]interface{}{
@@ -77,7 +77,7 @@ func TestParse(t *testing.T) {
 			),
 			measurement: "testlog",
 			want: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"testlog",
 					map[string]string{},
 					map[string]interface{}{
@@ -88,7 +88,7 @@ func TestParse(t *testing.T) {
 					},
 					time.Unix(0, 0),
 				),
-				testutil.MustMetric(
+				metric.New(
 					"testlog",
 					map[string]string{},
 					map[string]interface{}{
@@ -156,7 +156,7 @@ func TestParseLine(t *testing.T) {
 			name:        "Log parser fmt returns all fields",
 			measurement: "testlog",
 			s:           `ts=2018-07-24T19:43:35.207268Z lvl=5 msg="Write failed" log_id=09R4e4Rl000`,
-			want: testutil.MustMetric(
+			want: metric.New(
 				"testlog",
 				map[string]string{},
 				map[string]interface{}{
@@ -173,7 +173,7 @@ func TestParseLine(t *testing.T) {
 			measurement: "testlog",
 			s: "ts=2018-07-24T19:43:35.207268Z lvl=5 msg=\"Write failed\" log_id=09R4e4Rl000\nmethod=POST " +
 				"parent_id=088876RL000 duration=7.45 log_id=09R4e4Rl000",
-			want: testutil.MustMetric(
+			want: metric.New(
 				"testlog",
 				map[string]string{},
 				map[string]interface{}{
@@ -214,7 +214,7 @@ func TestTags(t *testing.T) {
 			measurement: "testlog",
 			tagKeys:     []string{"lvl"},
 			s:           "ts=2018-07-24T19:43:40.275Z lvl=info msg=\"http request\" method=POST",
-			want: testutil.MustMetric(
+			want: metric.New(
 				"testlog",
 				map[string]string{
 					"lvl": "info",
@@ -232,7 +232,7 @@ func TestTags(t *testing.T) {
 			measurement: "testlog",
 			tagKeys:     []string{"lvl"},
 			s:           "lvl=info",
-			want: testutil.MustMetric(
+			want: metric.New(
 				"testlog",
 				map[string]string{
 					"lvl": "info",
@@ -246,7 +246,7 @@ func TestTags(t *testing.T) {
 			measurement: "testlog",
 			tagKeys:     []string{"*"},
 			s:           "ts=2018-07-24T19:43:40.275Z lvl=info msg=\"http request\" method=POST",
-			want: testutil.MustMetric(
+			want: metric.New(
 				"testlog",
 				map[string]string{
 					"lvl":    "info",


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Covers graphite, json, grok, and logfmt parsers.

`testutil.MustMetric` is a trivial wrapper around `metric.New` that adds no value and misleads with its "Must" prefix.

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

related to #18495
