### PR TITLE
chore(parsers): Replace testutil.MustMetric with metric.New (part 2)

### DIFF
--- a/plugins/parsers/csv/parser_test.go
+++ b/plugins/parsers/csv/parser_test.go
@@ -514,7 +514,7 @@ func TestParseStream(t *testing.T) {
 	m, err := p.ParseLine(csvBody)
 	require.NoError(t, err)
 	testutil.RequireMetricEqual(t,
-		testutil.MustMetric(
+		metric.New(
 			"csv",
 			map[string]string{},
 			map[string]interface{}{
@@ -544,7 +544,7 @@ func TestParseLineMultiMetricErrorMessage(t *testing.T) {
 	m, err := p.ParseLine(csvOneRow)
 	require.NoError(t, err)
 	testutil.RequireMetricEqual(t,
-		testutil.MustMetric(
+		metric.New(
 			"csv",
 			map[string]string{},
 			map[string]interface{}{
@@ -576,7 +576,7 @@ func TestTimestampUnixFloatPrecision(t *testing.T) {
 	data := `1551129661.95456123352050781250,42`
 
 	expected := []telegraf.Metric{
-		testutil.MustMetric(
+		metric.New(
 			"csv",
 			map[string]string{},
 			map[string]interface{}{
@@ -607,7 +607,7 @@ func TestSkipMeasurementColumn(t *testing.T) {
 		1,5,1551129661.954561233`
 
 	expected := []telegraf.Metric{
-		testutil.MustMetric(
+		metric.New(
 			"csv",
 			map[string]string{},
 			map[string]interface{}{
@@ -639,7 +639,7 @@ func TestSkipTimestampColumn(t *testing.T) {
 		1,5,1551129661.954561233`
 
 	expected := []telegraf.Metric{
-		testutil.MustMetric(
+		metric.New(
 			"csv",
 			map[string]string{},
 			map[string]interface{}{
@@ -694,7 +694,7 @@ func TestEmptyMeasurementName(t *testing.T) {
 	require.NoError(t, err)
 
 	expected := []telegraf.Metric{
-		testutil.MustMetric("csv",
+		metric.New("csv",
 			map[string]string{},
 			map[string]interface{}{
 				"b": 2,
@@ -721,7 +721,7 @@ func TestNumericMeasurementName(t *testing.T) {
 	require.NoError(t, err)
 
 	expected := []telegraf.Metric{
-		testutil.MustMetric("1",
+		metric.New("1",
 			map[string]string{},
 			map[string]interface{}{
 				"b": 2,
@@ -747,7 +747,7 @@ func TestStaticMeasurementName(t *testing.T) {
 	require.NoError(t, err)
 
 	expected := []telegraf.Metric{
-		testutil.MustMetric("csv",
+		metric.New("csv",
 			map[string]string{},
 			map[string]interface{}{
 				"a": 1,
@@ -775,7 +775,7 @@ func TestSkipEmptyStringValue(t *testing.T) {
 	require.NoError(t, err)
 
 	expected := []telegraf.Metric{
-		testutil.MustMetric("csv",
+		metric.New("csv",
 			map[string]string{},
 			map[string]interface{}{
 				"a": 1,
@@ -802,7 +802,7 @@ func TestSkipSpecifiedStringValue(t *testing.T) {
 	require.NoError(t, err)
 
 	expected := []telegraf.Metric{
-		testutil.MustMetric("csv",
+		metric.New("csv",
 			map[string]string{},
 			map[string]interface{}{
 				"a": 1,

--- a/plugins/parsers/opentsdb/parser_test.go
+++ b/plugins/parsers/opentsdb/parser_test.go
@@ -27,7 +27,7 @@ func TestParseLine(t *testing.T) {
 		{
 			name:  "minimal case",
 			input: "put sys.cpu.user " + strTimeSec + " 50",
-			expected: testutil.MustMetric(
+			expected: metric.New(
 				"sys.cpu.user",
 				map[string]string{},
 				map[string]interface{}{
@@ -39,7 +39,7 @@ func TestParseLine(t *testing.T) {
 		{
 			name:  "millisecond timestamp",
 			input: "put sys.cpu.user " + strTimeMilli + " 50",
-			expected: testutil.MustMetric(
+			expected: metric.New(
 				"sys.cpu.user",
 				map[string]string{},
 				map[string]interface{}{
@@ -51,7 +51,7 @@ func TestParseLine(t *testing.T) {
 		{
 			name:  "floating point value",
 			input: "put sys.cpu.user " + strTimeSec + " 42.5",
-			expected: testutil.MustMetric(
+			expected: metric.New(
 				"sys.cpu.user",
 				map[string]string{},
 				map[string]interface{}{
@@ -63,7 +63,7 @@ func TestParseLine(t *testing.T) {
 		{
 			name:  "single tag",
 			input: "put sys.cpu.user " + strTimeSec + " 42.5 host=webserver01",
-			expected: testutil.MustMetric(
+			expected: metric.New(
 				"sys.cpu.user",
 				map[string]string{
 					"host": "webserver01",
@@ -77,7 +77,7 @@ func TestParseLine(t *testing.T) {
 		{
 			name:  "double tags",
 			input: "put sys.cpu.user " + strTimeSec + " 42.5 host=webserver01 cpu=7",
-			expected: testutil.MustMetric(
+			expected: metric.New(
 				"sys.cpu.user",
 				map[string]string{
 					"host": "webserver01",
@@ -117,7 +117,7 @@ func TestParse(t *testing.T) {
 			name:  "single line with no newline",
 			input: []byte("put sys.cpu.user " + strTimeSec + " 42.5 host=webserver01 cpu=7"),
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"sys.cpu.user",
 					map[string]string{
 						"host": "webserver01",
@@ -134,7 +134,7 @@ func TestParse(t *testing.T) {
 			name:  "single line with LF",
 			input: []byte("put sys.cpu.user " + strTimeSec + " 42.5 host=webserver01 cpu=7\n"),
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"sys.cpu.user",
 					map[string]string{
 						"host": "webserver01",
@@ -151,7 +151,7 @@ func TestParse(t *testing.T) {
 			name:  "single line with CR+LF",
 			input: []byte("put sys.cpu.user " + strTimeSec + " 42.5 host=webserver01 cpu=7\r\n"),
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"sys.cpu.user",
 					map[string]string{
 						"host": "webserver01",
@@ -169,7 +169,7 @@ func TestParse(t *testing.T) {
 			input: []byte("put sys.cpu.user " + strTimeSec + " 42.5 host=webserver01 cpu=7\r\n" +
 				"put sys.cpu.user " + strTimeSec + " 53.5 host=webserver02 cpu=3\r\n"),
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"sys.cpu.user",
 					map[string]string{
 						"host": "webserver01",
@@ -180,7 +180,7 @@ func TestParse(t *testing.T) {
 					},
 					testTimeSec,
 				),
-				testutil.MustMetric(
+				metric.New(
 					"sys.cpu.user",
 					map[string]string{
 						"host": "webserver02",
@@ -201,7 +201,7 @@ func TestParse(t *testing.T) {
 					"put sys.cpu.user " + strTimeSec + " 53.5 host=webserver02 cpu=3\r\n",
 			),
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"sys.cpu.user",
 					map[string]string{
 						"host": "webserver01",
@@ -212,7 +212,7 @@ func TestParse(t *testing.T) {
 					},
 					testTimeSec,
 				),
-				testutil.MustMetric(
+				metric.New(
 					"sys.cpu.user",
 					map[string]string{
 						"host": "webserver02",
@@ -257,7 +257,7 @@ func TestParse_DefaultTags(t *testing.T) {
 				"foo": "bar",
 			},
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"sys.cpu.user",
 					map[string]string{
 						"foo":  "bar",
@@ -279,7 +279,7 @@ func TestParse_DefaultTags(t *testing.T) {
 				"foo2": "bar2",
 			},
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"sys.cpu.user",
 					map[string]string{
 						"foo1": "bar1",

--- a/plugins/parsers/prometheusremotewrite/parser_test.go
+++ b/plugins/parsers/prometheusremotewrite/parser_test.go
@@ -144,7 +144,7 @@ func TestParse(t *testing.T) {
 	require.NoError(t, err)
 
 	expected := []telegraf.Metric{
-		testutil.MustMetric(
+		metric.New(
 			"prometheus_remote_write",
 			map[string]string{
 				"quantile": "0.99",
@@ -154,7 +154,7 @@ func TestParse(t *testing.T) {
 			},
 			time.Unix(0, 0),
 		),
-		testutil.MustMetric(
+		metric.New(
 			"prometheus_remote_write",
 			map[string]string{
 				"job": "prometheus",
@@ -242,7 +242,7 @@ func TestHistograms(t *testing.T) {
 	require.NoError(t, err)
 
 	expected := []telegraf.Metric{
-		testutil.MustMetric(
+		metric.New(
 			"prometheus_remote_write",
 			map[string]string{},
 			map[string]interface{}{
@@ -250,7 +250,7 @@ func TestHistograms(t *testing.T) {
 			},
 			time.Unix(0, 0),
 		),
-		testutil.MustMetric(
+		metric.New(
 			"prometheus_remote_write",
 			map[string]string{},
 			map[string]interface{}{
@@ -258,7 +258,7 @@ func TestHistograms(t *testing.T) {
 			},
 			time.Unix(0, 0),
 		),
-		testutil.MustMetric(
+		metric.New(
 			"prometheus_remote_write",
 			map[string]string{},
 			map[string]interface{}{
@@ -266,7 +266,7 @@ func TestHistograms(t *testing.T) {
 			},
 			time.Unix(0, 0),
 		),
-		testutil.MustMetric(
+		metric.New(
 			"prometheus_remote_write",
 			map[string]string{},
 			map[string]interface{}{
@@ -304,7 +304,7 @@ func TestDefaultTags(t *testing.T) {
 	require.NoError(t, err)
 
 	expected := []telegraf.Metric{
-		testutil.MustMetric(
+		metric.New(
 			"prometheus_remote_write",
 			map[string]string{
 				"defaultTag": "defaultTagValue",
@@ -350,7 +350,7 @@ func TestMetricsWithTimestamp(t *testing.T) {
 	require.NoError(t, err)
 
 	expected := []telegraf.Metric{
-		testutil.MustMetric(
+		metric.New(
 			"prometheus_remote_write",
 			map[string]string{
 				"__eg__": "bar",

--- a/plugins/parsers/xpath/parser_test.go
+++ b/plugins/parsers/xpath/parser_test.go
@@ -207,7 +207,7 @@ func TestInvalidTypeQueries(t *testing.T) {
 				},
 			},
 			defaultTags: map[string]string{},
-			expected: testutil.MustMetric(
+			expected: metric.New(
 				"test",
 				map[string]string{},
 				map[string]interface{}{
@@ -228,7 +228,7 @@ func TestInvalidTypeQueries(t *testing.T) {
 				},
 			},
 			defaultTags: map[string]string{},
-			expected: testutil.MustMetric(
+			expected: metric.New(
 				"test",
 				map[string]string{},
 				map[string]interface{}{
@@ -274,7 +274,7 @@ func TestParseTimestamps(t *testing.T) {
 				},
 			},
 			defaultTags: map[string]string{},
-			expected: testutil.MustMetric(
+			expected: metric.New(
 				"test",
 				map[string]string{},
 				map[string]interface{}{},
@@ -291,7 +291,7 @@ func TestParseTimestamps(t *testing.T) {
 				},
 			},
 			defaultTags: map[string]string{},
-			expected: testutil.MustMetric(
+			expected: metric.New(
 				"test",
 				map[string]string{},
 				map[string]interface{}{},
@@ -308,7 +308,7 @@ func TestParseTimestamps(t *testing.T) {
 				},
 			},
 			defaultTags: map[string]string{},
-			expected: testutil.MustMetric(
+			expected: metric.New(
 				"test",
 				map[string]string{},
 				map[string]interface{}{},
@@ -325,7 +325,7 @@ func TestParseTimestamps(t *testing.T) {
 				},
 			},
 			defaultTags: map[string]string{},
-			expected: testutil.MustMetric(
+			expected: metric.New(
 				"test",
 				map[string]string{},
 				map[string]interface{}{},
@@ -342,7 +342,7 @@ func TestParseTimestamps(t *testing.T) {
 				},
 			},
 			defaultTags: map[string]string{},
-			expected: testutil.MustMetric(
+			expected: metric.New(
 				"test",
 				map[string]string{},
 				map[string]interface{}{},
@@ -359,7 +359,7 @@ func TestParseTimestamps(t *testing.T) {
 				},
 			},
 			defaultTags: map[string]string{},
-			expected: testutil.MustMetric(
+			expected: metric.New(
 				"test",
 				map[string]string{},
 				map[string]interface{}{},
@@ -409,7 +409,7 @@ func TestParseSingleValues(t *testing.T) {
 				},
 			},
 			defaultTags: map[string]string{},
-			expected: testutil.MustMetric(
+			expected: metric.New(
 				"test",
 				map[string]string{},
 				map[string]interface{}{
@@ -436,7 +436,7 @@ func TestParseSingleValues(t *testing.T) {
 				},
 			},
 			defaultTags: map[string]string{},
-			expected: testutil.MustMetric(
+			expected: metric.New(
 				"test",
 				map[string]string{},
 				map[string]interface{}{
@@ -465,7 +465,7 @@ func TestParseSingleValues(t *testing.T) {
 				},
 			},
 			defaultTags: map[string]string{},
-			expected: testutil.MustMetric(
+			expected: metric.New(
 				"test",
 				map[string]string{},
 				map[string]interface{}{
@@ -490,7 +490,7 @@ func TestParseSingleValues(t *testing.T) {
 				},
 			},
 			defaultTags: map[string]string{},
-			expected: testutil.MustMetric(
+			expected: metric.New(
 				"test",
 				map[string]string{},
 				map[string]interface{}{
@@ -513,7 +513,7 @@ func TestParseSingleValues(t *testing.T) {
 				},
 			},
 			defaultTags: map[string]string{},
-			expected: testutil.MustMetric(
+			expected: metric.New(
 				"test",
 				map[string]string{},
 				map[string]interface{}{
@@ -536,7 +536,7 @@ func TestParseSingleValues(t *testing.T) {
 				},
 			},
 			defaultTags: map[string]string{},
-			expected: testutil.MustMetric(
+			expected: metric.New(
 				"test",
 				map[string]string{},
 				map[string]interface{}{
@@ -559,7 +559,7 @@ func TestParseSingleValues(t *testing.T) {
 				},
 			},
 			defaultTags: map[string]string{},
-			expected: testutil.MustMetric(
+			expected: metric.New(
 				"test",
 				map[string]string{
 					"state": "ok",
@@ -606,7 +606,7 @@ func TestParseSingleAttributes(t *testing.T) {
 				},
 			},
 			defaultTags: map[string]string{},
-			expected: testutil.MustMetric(
+			expected: metric.New(
 				"test",
 				map[string]string{},
 				map[string]interface{}{},
@@ -623,7 +623,7 @@ func TestParseSingleAttributes(t *testing.T) {
 				},
 			},
 			defaultTags: map[string]string{},
-			expected: testutil.MustMetric(
+			expected: metric.New(
 				"test",
 				map[string]string{},
 				map[string]interface{}{},
@@ -645,7 +645,7 @@ func TestParseSingleAttributes(t *testing.T) {
 				},
 			},
 			defaultTags: map[string]string{},
-			expected: testutil.MustMetric(
+			expected: metric.New(
 				"test",
 				map[string]string{},
 				map[string]interface{}{
@@ -672,7 +672,7 @@ func TestParseSingleAttributes(t *testing.T) {
 				},
 			},
 			defaultTags: map[string]string{},
-			expected: testutil.MustMetric(
+			expected: metric.New(
 				"test",
 				map[string]string{},
 				map[string]interface{}{
@@ -701,7 +701,7 @@ func TestParseSingleAttributes(t *testing.T) {
 				},
 			},
 			defaultTags: map[string]string{},
-			expected: testutil.MustMetric(
+			expected: metric.New(
 				"test",
 				map[string]string{},
 				map[string]interface{}{
@@ -725,7 +725,7 @@ func TestParseSingleAttributes(t *testing.T) {
 				},
 			},
 			defaultTags: map[string]string{},
-			expected: testutil.MustMetric(
+			expected: metric.New(
 				"test",
 				map[string]string{},
 				map[string]interface{}{
@@ -747,7 +747,7 @@ func TestParseSingleAttributes(t *testing.T) {
 				},
 			},
 			defaultTags: map[string]string{},
-			expected: testutil.MustMetric(
+			expected: metric.New(
 				"test",
 				map[string]string{
 					"state": "ok",
@@ -769,7 +769,7 @@ func TestParseSingleAttributes(t *testing.T) {
 				},
 			},
 			defaultTags: map[string]string{},
-			expected: testutil.MustMetric(
+			expected: metric.New(
 				"test",
 				map[string]string{},
 				map[string]interface{}{
@@ -823,7 +823,7 @@ func TestParseMultiValues(t *testing.T) {
 				},
 			},
 			defaultTags: map[string]string{},
-			expected: testutil.MustMetric(
+			expected: metric.New(
 				"test",
 				map[string]string{},
 				map[string]interface{}{
@@ -854,7 +854,7 @@ func TestParseMultiValues(t *testing.T) {
 				},
 			},
 			defaultTags: map[string]string{},
-			expected: testutil.MustMetric(
+			expected: metric.New(
 				"test",
 				map[string]string{},
 				map[string]interface{}{
@@ -918,7 +918,7 @@ func TestParseMultiNodes(t *testing.T) {
 			},
 			defaultTags: map[string]string{},
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"test",
 					map[string]string{
 						"name":  "Device 1",
@@ -931,7 +931,7 @@ func TestParseMultiNodes(t *testing.T) {
 					},
 					time.Unix(1577923199, 0),
 				),
-				testutil.MustMetric(
+				metric.New(
 					"test",
 					map[string]string{
 						"name":  "Device 2",
@@ -944,7 +944,7 @@ func TestParseMultiNodes(t *testing.T) {
 					},
 					time.Unix(1577923199, 0),
 				),
-				testutil.MustMetric(
+				metric.New(
 					"test",
 					map[string]string{
 						"name":  "Device 3",
@@ -957,7 +957,7 @@ func TestParseMultiNodes(t *testing.T) {
 					},
 					time.Unix(1577923199, 0),
 				),
-				testutil.MustMetric(
+				metric.New(
 					"test",
 					map[string]string{
 						"name":  "Device 4",
@@ -970,7 +970,7 @@ func TestParseMultiNodes(t *testing.T) {
 					},
 					time.Unix(1577923199, 0),
 				),
-				testutil.MustMetric(
+				metric.New(
 					"test",
 					map[string]string{
 						"name":  "Device 5",
@@ -1026,7 +1026,7 @@ func TestParseMetricQuery(t *testing.T) {
 				},
 			},
 			defaultTags: map[string]string{},
-			expected: testutil.MustMetric(
+			expected: metric.New(
 				"state",
 				map[string]string{},
 				map[string]interface{}{
@@ -1048,7 +1048,7 @@ func TestParseMetricQuery(t *testing.T) {
 				},
 			},
 			defaultTags: map[string]string{},
-			expected: testutil.MustMetric(
+			expected: metric.New(
 				"the_metric",
 				map[string]string{},
 				map[string]interface{}{


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Covers csv, opentsdb, prometheusremotewrite, and xpath parsers.

`testutil.MustMetric` is a trivial wrapper around `metric.New` that adds no value and misleads with its "Must" prefix.

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

related to #18495
