### PR TITLE
chore(serializers.json): Replace testutil.MustMetric with metric.New

### DIFF
--- a/plugins/serializers/json/json_test.go
+++ b/plugins/serializers/json/json_test.go
@@ -205,7 +205,7 @@ func TestSerializeBatch(t *testing.T) {
 
 func TestSerializeBatchSkipInf(t *testing.T) {
 	metrics := []telegraf.Metric{
-		testutil.MustMetric(
+		metric.New(
 			"cpu",
 			map[string]string{},
 			map[string]interface{}{
@@ -225,7 +225,7 @@ func TestSerializeBatchSkipInf(t *testing.T) {
 
 func TestSerializeBatchSkipInfAllFields(t *testing.T) {
 	metrics := []telegraf.Metric{
-		testutil.MustMetric(
+		metric.New(
 			"cpu",
 			map[string]string{},
 			map[string]interface{}{


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
`testutil.MustMetric` is a trivial wrapper around `metric.New` that adds no value and misleads with its "Must" prefix.


## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

related to #18495 
