### PR TITLE
chore(inputs.amd_rocm_smi): Rename type metric struct to gpuMetric

### DIFF
--- a/plugins/inputs/amd_rocm_smi/amd_rocm_smi.go
+++ b/plugins/inputs/amd_rocm_smi/amd_rocm_smi.go
@@ -101,7 +101,7 @@ type sysInfo struct {
 	DriverVersion string `json:"Driver version"`
 }
 
-type metric struct {
+type gpuMetric struct {
 	tags   map[string]string
 	fields map[string]interface{}
 }
@@ -179,8 +179,8 @@ func (rsmi *ROCmSMI) pollROCmSMI() ([]byte, error) {
 	return internal.StdOutputTimeout(cmd, time.Duration(rsmi.Timeout))
 }
 
-func genTagsFields(gpus map[string]gpu, system map[string]sysInfo) []metric {
-	metrics := make([]metric, 0, len(gpus))
+func genTagsFields(gpus map[string]gpu, system map[string]sysInfo) []gpuMetric {
+	metrics := make([]gpuMetric, 0, len(gpus))
 	for cardID := range gpus {
 		if strings.Contains(cardID, "card") {
 			tags := map[string]string{
@@ -224,7 +224,7 @@ func genTagsFields(gpus map[string]gpu, system map[string]sysInfo) []metric {
 			setIfUsed("str", fields, "card_model", payload.GpuCardModel)
 			setIfUsed("str", fields, "card_vendor", payload.GpuCardVendor)
 
-			metrics = append(metrics, metric{tags, fields})
+			metrics = append(metrics, gpuMetric{tags, fields})
 		}
 	}
 	return metrics


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
  Rename the unexported metric struct to gpuMetric to avoid conflict
  with the telegraf/metric package import. This is a prerequisite for
  migrating testutil.MustMetric to metric.New (#18495).

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
