### PR TITLE
fix(outputs.influxdb_v3): Remove duplicate timeout setting

### DIFF
--- a/plugins/outputs/influxdb_v3/influxdb_v3.go
+++ b/plugins/outputs/influxdb_v3/influxdb_v3.go
@@ -22,16 +22,15 @@ import (
 var sampleConfig string
 
 type clientConfig struct {
-	Token              config.Secret   `toml:"token"`
-	Database           string          `toml:"database"`
-	DatabaseTag        string          `toml:"database_tag"`
-	ExcludeDatabaseTag bool            `toml:"exclude_database_tag"`
-	Sync               *bool           `toml:"sync"`
-	ContentEncoding    string          `toml:"content_encoding"`
-	UserAgent          string          `toml:"user_agent"`
-	ConvertUint        bool            `toml:"convert_uint_to_int"`
-	OmitTimestamp      bool            `toml:"omit_timestamp"`
-	Timeout            config.Duration `toml:"timeout"`
+	Token              config.Secret `toml:"token"`
+	Database           string        `toml:"database"`
+	DatabaseTag        string        `toml:"database_tag"`
+	ExcludeDatabaseTag bool          `toml:"exclude_database_tag"`
+	Sync               *bool         `toml:"sync"`
+	ContentEncoding    string        `toml:"content_encoding"`
+	UserAgent          string        `toml:"user_agent"`
+	ConvertUint        bool          `toml:"convert_uint_to_int"`
+	OmitTimestamp      bool          `toml:"omit_timestamp"`
 	common_http.HTTPClientConfig
 	ratelimiter.RateLimitConfig
 }
@@ -123,7 +122,9 @@ func init() {
 	outputs.Add("influxdb_v3", func() telegraf.Output {
 		return &InfluxDB{
 			clientConfig: clientConfig{
-				Timeout: config.Duration(time.Second * 5),
+				HTTPClientConfig: common_http.HTTPClientConfig{
+					Timeout: config.Duration(5 * time.Second),
+				},
 			},
 		}
 	})

--- a/plugins/outputs/influxdb_v3/influxdb_v3_test.go
+++ b/plugins/outputs/influxdb_v3/influxdb_v3_test.go
@@ -33,6 +33,24 @@ func TestSampleConfig(t *testing.T) {
 	require.NotEmpty(t, plugin.SampleConfig())
 }
 
+func TestTimeoutTOMLParsing(t *testing.T) {
+	c := config.NewConfig()
+	cfg := []byte(`
+[[outputs.influxdb_v3]]
+  urls = ["http://localhost:8181"]
+  database = "test"
+  timeout = "120s"
+  response_timeout = "33s"
+`)
+	require.NoError(t, c.LoadConfigData(cfg, config.EmptySourcePath))
+	require.Len(t, c.Outputs, 1)
+
+	plugin, ok := c.Outputs[0].Output.(*InfluxDB)
+	require.True(t, ok)
+	require.Equal(t, config.Duration(120*time.Second), plugin.HTTPClientConfig.Timeout)
+	require.Equal(t, config.Duration(33*time.Second), plugin.HTTPClientConfig.ResponseHeaderTimeout)
+}
+
 func TestPluginRegistered(t *testing.T) {
 	require.Contains(t, outputs.Outputs, "influxdb_v3")
 }


### PR DESCRIPTION
## Summary

Fix TOML tag collision in outputs.influxdb_v3 configuration.

The `clientConfig` struct defines a `Timeout` field with `toml:"timeout"`, while the embedded `HTTPClientConfig` also defines the same TOML tag. This causes the TOML parser to detect multiple fields matching `timeout` and refuse to set the value.

This change removes the duplicated `Timeout` field and relies on the embedded `HTTPClientConfig.Timeout`, which already provides the same functionality.

## Checklist

- [x] No AI generated code was used in this PR

## Related Issues

resolves #18502