### PR TITLE
fix(inputs.exec): log stderr output when command exits successfully

### DIFF
--- a/plugins/inputs/exec/exec.go
+++ b/plugins/inputs/exec/exec.go
@@ -2,6 +2,7 @@
 package exec
 
 import (
+	"bufio"
 	"bytes"
 	_ "embed"
 	"fmt"
@@ -161,7 +162,41 @@ func (e *Exec) processCommand(acc telegraf.Accumulator, cmd string) error {
 		acc.AddMetric(m)
 	}
 
+	if len(errBuf) > 0 {
+		e.cmdReadErr(errBuf)
+	}
+
+	if runErr == nil && len(errBuf) > 0 && !e.IgnoreError {
+		return fmt.Errorf("exec: command %q wrote to stderr: %s", cmd, string(errBuf))
+	}
+
 	return nil
+}
+
+func (e *Exec) cmdReadErr(out []byte) {
+	scanner := bufio.NewScanner(bytes.NewReader(out))
+
+	for scanner.Scan() {
+		msg := scanner.Text()
+		switch {
+		case strings.HasPrefix(msg, "E! "):
+			e.Log.Error(msg[3:])
+		case strings.HasPrefix(msg, "W! "):
+			e.Log.Warn(msg[3:])
+		case strings.HasPrefix(msg, "I! "):
+			e.Log.Info(msg[3:])
+		case strings.HasPrefix(msg, "D! "):
+			e.Log.Debug(msg[3:])
+		case strings.HasPrefix(msg, "T! "):
+			e.Log.Trace(msg[3:])
+		default:
+			e.Log.Errorf("stderr: %q", msg)
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		e.Log.Errorf("error reading stderr: %v", err)
+	}
 }
 
 func truncate(buf *bytes.Buffer) {

--- a/plugins/inputs/exec/exec_test.go
+++ b/plugins/inputs/exec/exec_test.go
@@ -175,6 +175,69 @@ func TestCommandIgnoreError(t *testing.T) {
 	testutil.RequireMetricsEqual(t, expected, acc.GetTelegrafMetrics(), testutil.IgnoreTime())
 }
 
+func TestCommandStderrWithSuccessExit(t *testing.T) {
+	// Setup parser
+	parser := &json.Parser{MetricName: "exec"}
+	require.NoError(t, parser.Init())
+
+	// Setup plugin
+	plugin := &Exec{
+		Commands: []string{"testcommand"},
+		Log:      testutil.Logger{},
+	}
+	plugin.SetParser(parser)
+	require.NoError(t, plugin.Init())
+	plugin.runner = &runnerMock{
+		out:    []byte(validJSON),
+		errout: []byte("Error alarm from this script"),
+	}
+
+	// Gather the metrics and check the result
+	var acc testutil.Accumulator
+	err := acc.GatherError(plugin.Gather)
+	require.ErrorContains(t, err, "wrote to stderr")
+	require.ErrorContains(t, err, "Error alarm from this script")
+	require.Equal(t, 8, acc.NFields(), "Metrics should still be parsed and added")
+}
+
+func TestCommandStderrWithSuccessExitIgnoreError(t *testing.T) {
+	// Setup parser
+	parser := &json.Parser{MetricName: "exec"}
+	require.NoError(t, parser.Init())
+
+	// Setup plugin
+	log := &testutil.CaptureLogger{Name: "exec"}
+	plugin := &Exec{
+		Commands:    []string{"testcommand"},
+		IgnoreError: true,
+		Log:         log,
+	}
+	plugin.SetParser(parser)
+	require.NoError(t, plugin.Init())
+	plugin.runner = &runnerMock{
+		out:    []byte(validJSON),
+		errout: []byte("W! warning\nI! info\nD! debug\nT! trace\nplain stderr line"),
+	}
+
+	// Gather the metrics and check the result
+	var acc testutil.Accumulator
+	require.NoError(t, acc.GatherError(plugin.Gather))
+	require.Equal(t, 8, acc.NFields(), "Metrics should still be parsed and added")
+
+	messages := log.Messages()
+	require.Len(t, messages, 5)
+	require.Equal(t, testutil.LevelWarn, messages[0].Level)
+	require.Equal(t, "warning", messages[0].Text)
+	require.Equal(t, testutil.LevelInfo, messages[1].Level)
+	require.Equal(t, "info", messages[1].Text)
+	require.Equal(t, testutil.LevelDebug, messages[2].Level)
+	require.Equal(t, "debug", messages[2].Text)
+	require.Equal(t, testutil.LevelTrace, messages[3].Level)
+	require.Equal(t, "trace", messages[3].Text)
+	require.Equal(t, testutil.LevelError, messages[4].Level)
+	require.Equal(t, `stderr: "plain stderr line"`, messages[4].Text)
+}
+
 func TestExecCommandWithGlob(t *testing.T) {
 	// Setup parser
 	parser := value.Parser{


### PR DESCRIPTION
## Summary

Currently the `inputs.exec` plugin ignores stderr output when the executed command exits successfully.

This change ensures that stderr output is surfaced as an error so users can detect script warnings or failures even if the exit code is zero.

## Changes

- Return an error when stderr output is produced even if the command exits successfully
- Add unit test `TestCommandStderrWithSuccessExit`
- Ensure metrics are still parsed and added to the accumulator

## Checklist

- [x] No AI generated code was used in this PR

## Related Issues

Fixes #18508