### PR TITLE
test(internal.clock): Fix flaky TestUnalignedTicker race condition

### DIFF
--- a/internal/clock/ticker_unaligned_test.go
+++ b/internal/clock/ticker_unaligned_test.go
@@ -16,9 +16,6 @@ func TestUnalignedTicker(t *testing.T) {
 	clk := clock.NewMock()
 	clk.Add(1 * time.Second)
 
-	start := clk.Now()
-	end := start.Add(60 * time.Second)
-
 	startup := make(chan bool, 1)
 
 	ticker := NewTicker(interval, jitter, offset, WithClock(clk), WithStartupNotification(startup))
@@ -39,14 +36,16 @@ func TestUnalignedTicker(t *testing.T) {
 	// Wait for the ticker to startup
 	<-startup
 
-	// Advance the clock and collect all ticks on the way
-	for !clk.Now().After(end) {
-		select {
-		case ts := <-ticker.C:
-			actual = append(actual, ts.UTC())
-		default:
-			clk.Add(1 * time.Second)
-		}
+	// The first tick fires immediately inside the Timer() constructor
+	// (Timer(0) with deadline == now), so no clock advance is needed.
+	// Blocking on each read ensures the ticker goroutine has called
+	// timer.Reset() before the next clock advance, preventing the
+	// race between clk.Add() and timer.Reset() that causes flaky
+	// deadline shifts.
+	actual = append(actual, (<-ticker.C).UTC())
+	for i := 1; i < len(expected); i++ {
+		clk.Add(interval)
+		actual = append(actual, (<-ticker.C).UTC())
 	}
 	require.Equal(t, expected, actual)
 }


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
The select/default loop with clk.Add(1s) raced with the ticker goroutine's timer.Reset() call, causing the mock clock to advance between clk.Until() and timer.Reset(), shifting the timer deadline by 1 second.

Replace the select/default loop with blocking channel reads. Since Timer(0) fires immediately inside the constructor, no clock advance is needed for the first tick. Blocking on each subsequent read ensures timer.Reset() completes before the next clk.Add().

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
