### PR TITLE
fix(inputs.ping): Do not show warning when timeout not set

### DIFF
--- a/plugins/inputs/ping/ping.go
+++ b/plugins/inputs/ping/ping.go
@@ -83,15 +83,12 @@ func (p *Ping) Init() error {
 		p.calcInterval = time.Duration(p.PingInterval * float64(time.Second))
 	}
 
-	// If no timeout is given default to 5 seconds, matching original implementation
-	if p.Timeout == 0 {
-		p.calcTimeout = time.Duration(5) * time.Second
-	} else {
-		p.calcTimeout = time.Duration(p.Timeout) * time.Second
-	}
-
 	if p.Method == "native" && p.Timeout > 0 {
 		p.Log.Warn(`"timeout" is ignored when method = "native"; use "deadline" to control the total runtime`)
+	} else if p.Timeout == 0 {
+		p.calcTimeout = time.Duration(1) * time.Second
+	} else {
+		p.calcTimeout = time.Duration(p.Timeout) * time.Second
 	}
 
 	return nil
@@ -304,7 +301,6 @@ func init() {
 			pingHost:     hostPinger,
 			PingInterval: 1.0,
 			Count:        1,
-			Timeout:      1.0,
 			Deadline:     10,
 			Method:       "exec",
 			Binary:       "ping",


### PR DESCRIPTION
## Summary

PR #18455 introduced a warning when a timeout is set and using the native method. However the timeout is always set by means of default value for the plugin. This PR re-arranges this so the warning is not shown when not setting timeout in the config.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues


resolves #18455
