### PR TITLE
feat(inputs.mem): Add extended memory statistics

### DIFF
--- a/plugins/inputs/mem/README.md
+++ b/plugins/inputs/mem/README.md
@@ -25,7 +25,9 @@ plugin ordering. See [CONFIGURATION.md][CONFIGURATION.md] for more details.
 ```toml @sample.conf
 # Read metrics about memory usage
 [[inputs.mem]]
-  # no configuration
+  ## Collect extended memory statistics from /proc/meminfo (Linux)
+  ## or from performance counters (Windows).
+  # collect_extended = false
 ```
 
 ## Metrics
@@ -71,8 +73,42 @@ Available fields are dependent on platform.
     - write_back (integer, Linux)
     - write_back_tmp (integer, Linux)
 
+### Extended fields (`collect_extended = true`)
+
+These fields are only collected when `collect_extended` is set to `true`.
+
+#### Linux
+
+- mem
+  - fields:
+    - active_anon (integer)
+    - active_file (integer)
+    - inactive_anon (integer)
+    - inactive_file (integer)
+    - percpu (integer)
+    - unevictable (integer)
+
+#### Windows
+
+- mem
+  - fields:
+    - commit_limit (integer)
+    - commit_total (integer)
+    - page_file_avail (integer)
+    - page_file_total (integer)
+    - phys_avail (integer)
+    - phys_total (integer)
+    - virtual_avail (integer)
+    - virtual_total (integer)
+
 ## Example Output
 
 ```text
-mem active=9299595264i,available=16818249728i,available_percent=80.41654254645131,buffered=2383761408i,cached=13316689920i,commit_limit=14751920128i,committed_as=11781156864i,dirty=122880i,free=1877688320i,high_free=0i,high_total=0i,huge_page_size=2097152i,huge_pages_free=0i,huge_pages_total=0i,inactive=7549939712i,low_free=0i,low_total=0i,mapped=416763904i,page_tables=19787776i,shared=670679040i,slab=2081071104i,sreclaimable=1923395584i,sunreclaim=157675520i,swap_cached=1302528i,swap_free=4286128128i,swap_total=4294963200i,total=20913917952i,used=3335778304i,used_percent=15.95004011996231,vmalloc_chunk=0i,vmalloc_total=35184372087808i,vmalloc_used=0i,wired=0i,write_back=0i,write_back_tmp=0i 1574712869000000000
+mem active=9299595264i,available=16818249728i,available_percent=80.41654254645131,buffered=2383761408i,cached=13316689920i,commit_limit=14751920128i,committed_as=11781156864i,dirty=122880i,free=1877688320i,high_free=0i,high_total=0i,huge_page_size=2097152i,huge_pages_free=0i,huge_pages_total=0i,inactive=7549939712i,low_free=0i,low_total=0i,mapped=416763904i,page_tables=19787776i,shared=670679040i,slab=2081071104i,sreclaimable=1923395584i,sunreclaim=157675520i,swap_cached=1302528i,swap_free=4286128128i,swap_total=4294963200i,total=20913917952i,used=3335778304i,used_percent=15.95004011996231,vmalloc_chunk=0i,vmalloc_total=35184372087808i,vmalloc_used=0i,write_back=0i,write_back_tmp=0i 1574712869000000000
+```
+
+With `collect_extended = true` on Linux:
+
+```text
+mem active=9299595264i,active_anon=5765169152i,active_file=3534426112i,available=16818249728i,available_percent=80.41654254645131,buffered=2383761408i,cached=13316689920i,commit_limit=14751920128i,committed_as=11781156864i,dirty=122880i,free=1877688320i,high_free=0i,high_total=0i,huge_page_size=2097152i,huge_pages_free=0i,huge_pages_total=0i,inactive=7549939712i,inactive_anon=1081245696i,inactive_file=6468694016i,low_free=0i,low_total=0i,mapped=416763904i,page_tables=19787776i,percpu=5765120i,shared=670679040i,slab=2081071104i,sreclaimable=1923395584i,sunreclaim=157675520i,swap_cached=1302528i,swap_free=4286128128i,swap_total=4294963200i,total=20913917952i,unevictable=143360i,used=3335778304i,used_percent=15.95004011996231,vmalloc_chunk=0i,vmalloc_total=35184372087808i,vmalloc_used=0i,write_back=0i,write_back_tmp=0i 1574712869000000000
 ```

--- a/plugins/inputs/mem/mem.go
+++ b/plugins/inputs/mem/mem.go
@@ -15,6 +15,10 @@ import (
 var sampleConfig string
 
 type Mem struct {
+	CollectExtended bool `toml:"collect_extended"`
+
+	Log telegraf.Logger `toml:"-"`
+
 	ps       psutil.PS
 	platform string
 }
@@ -25,6 +29,10 @@ func (*Mem) SampleConfig() string {
 
 func (ms *Mem) Init() error {
 	ms.platform = runtime.GOOS
+	if ms.CollectExtended && !extendedMemorySupported {
+		ms.Log.Warn("collect_extended is not supported on this platform, ignoring")
+		ms.CollectExtended = false
+	}
 	return nil
 }
 
@@ -92,6 +100,16 @@ func (ms *Mem) Gather(acc telegraf.Accumulator) error {
 		fields["vmalloc_used"] = vm.VmallocUsed
 		fields["write_back_tmp"] = vm.WriteBackTmp
 		fields["write_back"] = vm.WriteBack
+	}
+
+	if ms.CollectExtended {
+		if extended, err := getExtendedMemoryFields(); err == nil {
+			for k, v := range extended {
+				fields[k] = v
+			}
+		} else {
+			acc.AddError(fmt.Errorf("getting extended virtual memory info failed: %w", err))
+		}
 	}
 
 	acc.AddGauge("mem", fields, nil)

--- a/plugins/inputs/mem/mem_linux.go
+++ b/plugins/inputs/mem/mem_linux.go
@@ -1,0 +1,24 @@
+//go:build linux
+
+package mem
+
+import (
+	"github.com/shirou/gopsutil/v4/mem"
+)
+
+const extendedMemorySupported = true
+
+func getExtendedMemoryFields() (map[string]interface{}, error) {
+	exVM, err := mem.NewExLinux().VirtualMemory()
+	if err != nil {
+		return nil, err
+	}
+	return map[string]interface{}{
+		"active_file":   exVM.ActiveFile,
+		"inactive_file": exVM.InactiveFile,
+		"active_anon":   exVM.ActiveAnon,
+		"inactive_anon": exVM.InactiveAnon,
+		"unevictable":   exVM.Unevictable,
+		"percpu":        exVM.Percpu,
+	}, nil
+}

--- a/plugins/inputs/mem/mem_other.go
+++ b/plugins/inputs/mem/mem_other.go
@@ -1,0 +1,9 @@
+//go:build !linux && !windows
+
+package mem
+
+const extendedMemorySupported = false
+
+func getExtendedMemoryFields() (map[string]interface{}, error) {
+	return nil, nil
+}

--- a/plugins/inputs/mem/mem_test.go
+++ b/plugins/inputs/mem/mem_test.go
@@ -1,6 +1,8 @@
 package mem
 
 import (
+	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
@@ -114,4 +116,107 @@ func TestMemStats(t *testing.T) {
 	}
 
 	testutil.RequireMetricsEqual(t, expected, acc.GetTelegrafMetrics(), testutil.IgnoreTime())
+}
+
+func TestMemStatsCollectExtended(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("Skipping Linux-specific extended memory test")
+	}
+
+	tests := []struct {
+		name           string
+		testdataDir    string
+		extendedFields map[string]interface{}
+	}{
+		{
+			name:        "normal",
+			testdataDir: "normal",
+			extendedFields: map[string]interface{}{
+				"active_anon":   uint64(5765169152),
+				"inactive_anon": uint64(1082245120),
+				"active_file":   uint64(3535425536),
+				"inactive_file": uint64(4421992448),
+				"unevictable":   uint64(143360),
+				"percpu":        uint64(5767168),
+			},
+		},
+		{
+			name:        "missing fields",
+			testdataDir: "missing_fields",
+			extendedFields: map[string]interface{}{
+				"active_anon":   uint64(5765169152),
+				"inactive_anon": uint64(1082245120),
+				"active_file":   uint64(3535425536),
+				"inactive_file": uint64(4421992448),
+				"unevictable":   uint64(0),
+				"percpu":        uint64(0),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hostProc, err := filepath.Abs(filepath.Join("testdata", tt.testdataDir, "proc"))
+			require.NoError(t, err)
+			t.Setenv("HOST_PROC", hostProc)
+
+			var mps psutil.MockPS
+			defer mps.AssertExpectations(t)
+			var acc testutil.Accumulator
+
+			vms := &mem.VirtualMemoryStat{
+				Total:     12400,
+				Available: 7600,
+				Used:      5000,
+				Free:      1235,
+			}
+
+			mps.On("VMStat").Return(vms, nil)
+			plugin := &Mem{
+				ps:              &mps,
+				CollectExtended: true,
+			}
+
+			require.NoError(t, plugin.Init())
+			plugin.platform = "linux"
+
+			require.NoError(t, plugin.Gather(&acc))
+
+			fields := acc.GetTelegrafMetrics()[0].Fields()
+			for k, v := range tt.extendedFields {
+				require.Equal(t, v, fields[k], "field %q mismatch", k)
+			}
+		})
+	}
+}
+
+func TestMemStatsCollectExtendedDisabled(t *testing.T) {
+	var mps psutil.MockPS
+	defer mps.AssertExpectations(t)
+	var acc testutil.Accumulator
+
+	vms := &mem.VirtualMemoryStat{
+		Total:     12400,
+		Available: 7600,
+		Used:      5000,
+	}
+
+	mps.On("VMStat").Return(vms, nil)
+	plugin := &Mem{
+		ps:              &mps,
+		CollectExtended: false,
+	}
+
+	err := plugin.Init()
+	require.NoError(t, err)
+
+	plugin.platform = "linux"
+
+	err = plugin.Gather(&acc)
+	require.NoError(t, err)
+
+	fields := acc.GetTelegrafMetrics()[0].Fields()
+	for _, key := range []string{"active_anon", "inactive_anon", "active_file", "inactive_file", "unevictable", "percpu"} {
+		require.Nil(t, fields[key], "field %q should not be present when collect_extended is false", key)
+	}
 }

--- a/plugins/inputs/mem/mem_test.go
+++ b/plugins/inputs/mem/mem_test.go
@@ -118,6 +118,43 @@ func TestMemStats(t *testing.T) {
 	testutil.RequireMetricsEqual(t, expected, acc.GetTelegrafMetrics(), testutil.IgnoreTime())
 }
 
+var linuxBaseFields = map[string]interface{}{
+	"total":             uint64(12400),
+	"available":         uint64(7600),
+	"used":              uint64(5000),
+	"used_percent":      100 * float64(5000) / float64(12400),
+	"available_percent": 100 * float64(7600) / float64(12400),
+	"free":              uint64(1235),
+	"active":            uint64(0),
+	"buffered":          uint64(0),
+	"cached":            uint64(0),
+	"commit_limit":      uint64(0),
+	"committed_as":      uint64(0),
+	"dirty":             uint64(0),
+	"high_free":         uint64(0),
+	"high_total":        uint64(0),
+	"huge_pages_free":   uint64(0),
+	"huge_page_size":    uint64(0),
+	"huge_pages_total":  uint64(0),
+	"inactive":          uint64(0),
+	"low_free":          uint64(0),
+	"low_total":         uint64(0),
+	"mapped":            uint64(0),
+	"page_tables":       uint64(0),
+	"shared":            uint64(0),
+	"slab":              uint64(0),
+	"sreclaimable":      uint64(0),
+	"sunreclaim":        uint64(0),
+	"swap_cached":       uint64(0),
+	"swap_free":         uint64(0),
+	"swap_total":        uint64(0),
+	"vmalloc_chunk":     uint64(0),
+	"vmalloc_total":     uint64(0),
+	"vmalloc_used":      uint64(0),
+	"write_back_tmp":    uint64(0),
+	"write_back":        uint64(0),
+}
+
 func TestMemStatsCollectExtended(t *testing.T) {
 	if runtime.GOOS != "linux" {
 		t.Skip("Skipping Linux-specific extended memory test")
@@ -154,6 +191,8 @@ func TestMemStatsCollectExtended(t *testing.T) {
 		},
 	}
 
+	baseFields := linuxBaseFields
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			hostProc, err := filepath.Abs(filepath.Join("testdata", tt.testdataDir, "proc"))
@@ -182,10 +221,18 @@ func TestMemStatsCollectExtended(t *testing.T) {
 
 			require.NoError(t, plugin.Gather(&acc))
 
-			fields := acc.GetTelegrafMetrics()[0].Fields()
-			for k, v := range tt.extendedFields {
-				require.Equal(t, v, fields[k], "field %q mismatch", k)
+			fields := make(map[string]interface{}, len(baseFields)+len(tt.extendedFields))
+			for k, v := range baseFields {
+				fields[k] = v
 			}
+			for k, v := range tt.extendedFields {
+				fields[k] = v
+			}
+
+			expected := []telegraf.Metric{
+				testutil.MustMetric("mem", map[string]string{}, fields, time.Unix(0, 0), telegraf.Gauge),
+			}
+			testutil.RequireMetricsEqual(t, expected, acc.GetTelegrafMetrics(), testutil.IgnoreTime())
 		})
 	}
 }
@@ -199,6 +246,7 @@ func TestMemStatsCollectExtendedDisabled(t *testing.T) {
 		Total:     12400,
 		Available: 7600,
 		Used:      5000,
+		Free:      1235,
 	}
 
 	mps.On("VMStat").Return(vms, nil)
@@ -215,8 +263,8 @@ func TestMemStatsCollectExtendedDisabled(t *testing.T) {
 	err = plugin.Gather(&acc)
 	require.NoError(t, err)
 
-	fields := acc.GetTelegrafMetrics()[0].Fields()
-	for _, key := range []string{"active_anon", "inactive_anon", "active_file", "inactive_file", "unevictable", "percpu"} {
-		require.Nil(t, fields[key], "field %q should not be present when collect_extended is false", key)
+	expected := []telegraf.Metric{
+		testutil.MustMetric("mem", map[string]string{}, linuxBaseFields, time.Unix(0, 0), telegraf.Gauge),
 	}
+	testutil.RequireMetricsEqual(t, expected, acc.GetTelegrafMetrics(), testutil.IgnoreTime())
 }

--- a/plugins/inputs/mem/mem_test.go
+++ b/plugins/inputs/mem/mem_test.go
@@ -118,43 +118,6 @@ func TestMemStats(t *testing.T) {
 	testutil.RequireMetricsEqual(t, expected, acc.GetTelegrafMetrics(), testutil.IgnoreTime())
 }
 
-var linuxBaseFields = map[string]interface{}{
-	"total":             uint64(12400),
-	"available":         uint64(7600),
-	"used":              uint64(5000),
-	"used_percent":      100 * float64(5000) / float64(12400),
-	"available_percent": 100 * float64(7600) / float64(12400),
-	"free":              uint64(1235),
-	"active":            uint64(0),
-	"buffered":          uint64(0),
-	"cached":            uint64(0),
-	"commit_limit":      uint64(0),
-	"committed_as":      uint64(0),
-	"dirty":             uint64(0),
-	"high_free":         uint64(0),
-	"high_total":        uint64(0),
-	"huge_pages_free":   uint64(0),
-	"huge_page_size":    uint64(0),
-	"huge_pages_total":  uint64(0),
-	"inactive":          uint64(0),
-	"low_free":          uint64(0),
-	"low_total":         uint64(0),
-	"mapped":            uint64(0),
-	"page_tables":       uint64(0),
-	"shared":            uint64(0),
-	"slab":              uint64(0),
-	"sreclaimable":      uint64(0),
-	"sunreclaim":        uint64(0),
-	"swap_cached":       uint64(0),
-	"swap_free":         uint64(0),
-	"swap_total":        uint64(0),
-	"vmalloc_chunk":     uint64(0),
-	"vmalloc_total":     uint64(0),
-	"vmalloc_used":      uint64(0),
-	"write_back_tmp":    uint64(0),
-	"write_back":        uint64(0),
-}
-
 func TestMemStatsCollectExtended(t *testing.T) {
 	if runtime.GOOS != "linux" {
 		t.Skip("Skipping Linux-specific extended memory test")
@@ -191,8 +154,6 @@ func TestMemStatsCollectExtended(t *testing.T) {
 		},
 	}
 
-	baseFields := linuxBaseFields
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			hostProc, err := filepath.Abs(filepath.Join("testdata", tt.testdataDir, "proc"))
@@ -201,7 +162,6 @@ func TestMemStatsCollectExtended(t *testing.T) {
 
 			var mps psutil.MockPS
 			defer mps.AssertExpectations(t)
-			var acc testutil.Accumulator
 
 			vms := &mem.VirtualMemoryStat{
 				Total:     12400,
@@ -215,15 +175,46 @@ func TestMemStatsCollectExtended(t *testing.T) {
 				ps:              &mps,
 				CollectExtended: true,
 			}
-
 			require.NoError(t, plugin.Init())
-			plugin.platform = "linux"
 
+			var acc testutil.Accumulator
 			require.NoError(t, plugin.Gather(&acc))
 
-			fields := make(map[string]interface{}, len(baseFields)+len(tt.extendedFields))
-			for k, v := range baseFields {
-				fields[k] = v
+			fields := map[string]interface{}{
+				"total":             uint64(12400),
+				"available":         uint64(7600),
+				"used":              uint64(5000),
+				"used_percent":      100 * float64(5000) / float64(12400),
+				"available_percent": 100 * float64(7600) / float64(12400),
+				"free":              uint64(1235),
+				"active":            uint64(0),
+				"buffered":          uint64(0),
+				"cached":            uint64(0),
+				"commit_limit":      uint64(0),
+				"committed_as":      uint64(0),
+				"dirty":             uint64(0),
+				"high_free":         uint64(0),
+				"high_total":        uint64(0),
+				"huge_pages_free":   uint64(0),
+				"huge_page_size":    uint64(0),
+				"huge_pages_total":  uint64(0),
+				"inactive":          uint64(0),
+				"low_free":          uint64(0),
+				"low_total":         uint64(0),
+				"mapped":            uint64(0),
+				"page_tables":       uint64(0),
+				"shared":            uint64(0),
+				"slab":              uint64(0),
+				"sreclaimable":      uint64(0),
+				"sunreclaim":        uint64(0),
+				"swap_cached":       uint64(0),
+				"swap_free":         uint64(0),
+				"swap_total":        uint64(0),
+				"vmalloc_chunk":     uint64(0),
+				"vmalloc_total":     uint64(0),
+				"vmalloc_used":      uint64(0),
+				"write_back_tmp":    uint64(0),
+				"write_back":        uint64(0),
 			}
 			for k, v := range tt.extendedFields {
 				fields[k] = v
@@ -237,34 +228,37 @@ func TestMemStatsCollectExtended(t *testing.T) {
 	}
 }
 
-func TestMemStatsCollectExtendedDisabled(t *testing.T) {
-	var mps psutil.MockPS
-	defer mps.AssertExpectations(t)
-	var acc testutil.Accumulator
-
-	vms := &mem.VirtualMemoryStat{
-		Total:     12400,
-		Available: 7600,
-		Used:      5000,
-		Free:      1235,
+func TestMemStatsCollectExtendedWindows(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Skipping Windows-specific extended memory test")
 	}
 
-	mps.On("VMStat").Return(vms, nil)
 	plugin := &Mem{
-		ps:              &mps,
-		CollectExtended: false,
+		ps:              psutil.NewSystemPS(),
+		CollectExtended: true,
 	}
+	require.NoError(t, plugin.Init())
 
-	err := plugin.Init()
-	require.NoError(t, err)
-
-	plugin.platform = "linux"
-
-	err = plugin.Gather(&acc)
-	require.NoError(t, err)
+	var acc testutil.Accumulator
+	require.NoError(t, plugin.Gather(&acc))
 
 	expected := []telegraf.Metric{
-		testutil.MustMetric("mem", map[string]string{}, linuxBaseFields, time.Unix(0, 0), telegraf.Gauge),
+		testutil.MustMetric("mem", map[string]string{}, map[string]interface{}{
+			"total":             uint64(0),
+			"available":         uint64(0),
+			"used":              uint64(0),
+			"used_percent":      float64(0),
+			"available_percent": float64(0),
+			"free":              uint64(0),
+			"commit_limit":      uint64(0),
+			"commit_total":      uint64(0),
+			"virtual_total":     uint64(0),
+			"virtual_avail":     uint64(0),
+			"phys_total":        uint64(0),
+			"phys_avail":        uint64(0),
+			"page_file_total":   uint64(0),
+			"page_file_avail":   uint64(0),
+		}, time.Unix(0, 0), telegraf.Gauge),
 	}
-	testutil.RequireMetricsEqual(t, expected, acc.GetTelegrafMetrics(), testutil.IgnoreTime())
+	testutil.RequireMetricsStructureEqual(t, expected, acc.GetTelegrafMetrics(), testutil.IgnoreTime())
 }

--- a/plugins/inputs/mem/mem_test.go
+++ b/plugins/inputs/mem/mem_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/metric"
 	"github.com/influxdata/telegraf/plugins/common/psutil"
 	"github.com/influxdata/telegraf/testutil"
 )
@@ -124,32 +125,116 @@ func TestMemStatsCollectExtended(t *testing.T) {
 	}
 
 	tests := []struct {
-		name           string
-		testdataDir    string
-		extendedFields map[string]interface{}
+		name        string
+		testdataDir string
+		expected    []telegraf.Metric
 	}{
 		{
 			name:        "normal",
 			testdataDir: "normal",
-			extendedFields: map[string]interface{}{
-				"active_anon":   uint64(5765169152),
-				"inactive_anon": uint64(1082245120),
-				"active_file":   uint64(3535425536),
-				"inactive_file": uint64(4421992448),
-				"unevictable":   uint64(143360),
-				"percpu":        uint64(5767168),
+			expected: []telegraf.Metric{
+				metric.New(
+					"mem",
+					map[string]string{},
+					map[string]interface{}{
+						"total":             uint64(12400),
+						"available":         uint64(7600),
+						"used":              uint64(5000),
+						"used_percent":      100 * float64(5000) / float64(12400),
+						"available_percent": 100 * float64(7600) / float64(12400),
+						"free":              uint64(1235),
+						"active":            uint64(0),
+						"buffered":          uint64(0),
+						"cached":            uint64(0),
+						"commit_limit":      uint64(0),
+						"committed_as":      uint64(0),
+						"dirty":             uint64(0),
+						"high_free":         uint64(0),
+						"high_total":        uint64(0),
+						"huge_pages_free":   uint64(0),
+						"huge_page_size":    uint64(0),
+						"huge_pages_total":  uint64(0),
+						"inactive":          uint64(0),
+						"low_free":          uint64(0),
+						"low_total":         uint64(0),
+						"mapped":            uint64(0),
+						"page_tables":       uint64(0),
+						"shared":            uint64(0),
+						"slab":              uint64(0),
+						"sreclaimable":      uint64(0),
+						"sunreclaim":        uint64(0),
+						"swap_cached":       uint64(0),
+						"swap_free":         uint64(0),
+						"swap_total":        uint64(0),
+						"vmalloc_chunk":     uint64(0),
+						"vmalloc_total":     uint64(0),
+						"vmalloc_used":      uint64(0),
+						"write_back_tmp":    uint64(0),
+						"write_back":        uint64(0),
+						"active_anon":       uint64(5765169152),
+						"inactive_anon":     uint64(1082245120),
+						"active_file":       uint64(3535425536),
+						"inactive_file":     uint64(4421992448),
+						"unevictable":       uint64(143360),
+						"percpu":            uint64(5767168),
+					},
+					time.Unix(0, 0),
+					telegraf.Gauge,
+				),
 			},
 		},
 		{
 			name:        "missing fields",
 			testdataDir: "missing_fields",
-			extendedFields: map[string]interface{}{
-				"active_anon":   uint64(5765169152),
-				"inactive_anon": uint64(1082245120),
-				"active_file":   uint64(3535425536),
-				"inactive_file": uint64(4421992448),
-				"unevictable":   uint64(0),
-				"percpu":        uint64(0),
+			expected: []telegraf.Metric{
+				metric.New(
+					"mem",
+					map[string]string{},
+					map[string]interface{}{
+						"total":             uint64(12400),
+						"available":         uint64(7600),
+						"used":              uint64(5000),
+						"used_percent":      100 * float64(5000) / float64(12400),
+						"available_percent": 100 * float64(7600) / float64(12400),
+						"free":              uint64(1235),
+						"active":            uint64(0),
+						"buffered":          uint64(0),
+						"cached":            uint64(0),
+						"commit_limit":      uint64(0),
+						"committed_as":      uint64(0),
+						"dirty":             uint64(0),
+						"high_free":         uint64(0),
+						"high_total":        uint64(0),
+						"huge_pages_free":   uint64(0),
+						"huge_page_size":    uint64(0),
+						"huge_pages_total":  uint64(0),
+						"inactive":          uint64(0),
+						"low_free":          uint64(0),
+						"low_total":         uint64(0),
+						"mapped":            uint64(0),
+						"page_tables":       uint64(0),
+						"shared":            uint64(0),
+						"slab":              uint64(0),
+						"sreclaimable":      uint64(0),
+						"sunreclaim":        uint64(0),
+						"swap_cached":       uint64(0),
+						"swap_free":         uint64(0),
+						"swap_total":        uint64(0),
+						"vmalloc_chunk":     uint64(0),
+						"vmalloc_total":     uint64(0),
+						"vmalloc_used":      uint64(0),
+						"write_back_tmp":    uint64(0),
+						"write_back":        uint64(0),
+						"active_anon":       uint64(5765169152),
+						"inactive_anon":     uint64(1082245120),
+						"active_file":       uint64(3535425536),
+						"inactive_file":     uint64(4421992448),
+						"unevictable":       uint64(0),
+						"percpu":            uint64(0),
+					},
+					time.Unix(0, 0),
+					telegraf.Gauge,
+				),
 			},
 		},
 	}
@@ -180,50 +265,7 @@ func TestMemStatsCollectExtended(t *testing.T) {
 			var acc testutil.Accumulator
 			require.NoError(t, plugin.Gather(&acc))
 
-			fields := map[string]interface{}{
-				"total":             uint64(12400),
-				"available":         uint64(7600),
-				"used":              uint64(5000),
-				"used_percent":      100 * float64(5000) / float64(12400),
-				"available_percent": 100 * float64(7600) / float64(12400),
-				"free":              uint64(1235),
-				"active":            uint64(0),
-				"buffered":          uint64(0),
-				"cached":            uint64(0),
-				"commit_limit":      uint64(0),
-				"committed_as":      uint64(0),
-				"dirty":             uint64(0),
-				"high_free":         uint64(0),
-				"high_total":        uint64(0),
-				"huge_pages_free":   uint64(0),
-				"huge_page_size":    uint64(0),
-				"huge_pages_total":  uint64(0),
-				"inactive":          uint64(0),
-				"low_free":          uint64(0),
-				"low_total":         uint64(0),
-				"mapped":            uint64(0),
-				"page_tables":       uint64(0),
-				"shared":            uint64(0),
-				"slab":              uint64(0),
-				"sreclaimable":      uint64(0),
-				"sunreclaim":        uint64(0),
-				"swap_cached":       uint64(0),
-				"swap_free":         uint64(0),
-				"swap_total":        uint64(0),
-				"vmalloc_chunk":     uint64(0),
-				"vmalloc_total":     uint64(0),
-				"vmalloc_used":      uint64(0),
-				"write_back_tmp":    uint64(0),
-				"write_back":        uint64(0),
-			}
-			for k, v := range tt.extendedFields {
-				fields[k] = v
-			}
-
-			expected := []telegraf.Metric{
-				testutil.MustMetric("mem", map[string]string{}, fields, time.Unix(0, 0), telegraf.Gauge),
-			}
-			testutil.RequireMetricsEqual(t, expected, acc.GetTelegrafMetrics(), testutil.IgnoreTime())
+			testutil.RequireMetricsEqual(t, tt.expected, acc.GetTelegrafMetrics(), testutil.IgnoreTime())
 		})
 	}
 }
@@ -243,21 +285,27 @@ func TestMemStatsCollectExtendedWindows(t *testing.T) {
 	require.NoError(t, plugin.Gather(&acc))
 
 	expected := []telegraf.Metric{
-		testutil.MustMetric("mem", map[string]string{}, map[string]interface{}{
-			"total":             uint64(0),
-			"available":         uint64(0),
-			"used":              uint64(0),
-			"used_percent":      float64(0),
-			"available_percent": float64(0),
-			"commit_limit":      uint64(0),
-			"commit_total":      uint64(0),
-			"virtual_total":     uint64(0),
-			"virtual_avail":     uint64(0),
-			"phys_total":        uint64(0),
-			"phys_avail":        uint64(0),
-			"page_file_total":   uint64(0),
-			"page_file_avail":   uint64(0),
-		}, time.Unix(0, 0), telegraf.Gauge),
+		metric.New(
+			"mem",
+			map[string]string{},
+			map[string]interface{}{
+				"total":             uint64(0),
+				"available":         uint64(0),
+				"used":              uint64(0),
+				"used_percent":      float64(0),
+				"available_percent": float64(0),
+				"commit_limit":      uint64(0),
+				"commit_total":      uint64(0),
+				"virtual_total":     uint64(0),
+				"virtual_avail":     uint64(0),
+				"phys_total":        uint64(0),
+				"phys_avail":        uint64(0),
+				"page_file_total":   uint64(0),
+				"page_file_avail":   uint64(0),
+			},
+			time.Unix(0, 0),
+			telegraf.Gauge,
+		),
 	}
 	testutil.RequireMetricsStructureEqual(t, expected, acc.GetTelegrafMetrics(), testutil.IgnoreTime())
 }

--- a/plugins/inputs/mem/mem_test.go
+++ b/plugins/inputs/mem/mem_test.go
@@ -249,7 +249,6 @@ func TestMemStatsCollectExtendedWindows(t *testing.T) {
 			"used":              uint64(0),
 			"used_percent":      float64(0),
 			"available_percent": float64(0),
-			"free":              uint64(0),
 			"commit_limit":      uint64(0),
 			"commit_total":      uint64(0),
 			"virtual_total":     uint64(0),

--- a/plugins/inputs/mem/mem_windows.go
+++ b/plugins/inputs/mem/mem_windows.go
@@ -1,0 +1,26 @@
+//go:build windows
+
+package mem
+
+import (
+	"github.com/shirou/gopsutil/v4/mem"
+)
+
+const extendedMemorySupported = true
+
+func getExtendedMemoryFields() (map[string]interface{}, error) {
+	exVM, err := mem.NewExWindows().VirtualMemory()
+	if err != nil {
+		return nil, err
+	}
+	return map[string]interface{}{
+		"commit_limit":    exVM.CommitLimit,
+		"commit_total":    exVM.CommitTotal,
+		"virtual_total":   exVM.VirtualTotal,
+		"virtual_avail":   exVM.VirtualAvail,
+		"phys_total":      exVM.PhysTotal,
+		"phys_avail":      exVM.PhysAvail,
+		"page_file_total": exVM.PageFileTotal,
+		"page_file_avail": exVM.PageFileAvail,
+	}, nil
+}

--- a/plugins/inputs/mem/sample.conf
+++ b/plugins/inputs/mem/sample.conf
@@ -1,3 +1,5 @@
 # Read metrics about memory usage
 [[inputs.mem]]
-  # no configuration
+  ## Collect extended memory statistics from /proc/meminfo (Linux)
+  ## or from performance counters (Windows).
+  # collect_extended = false

--- a/plugins/inputs/mem/testdata/missing_fields/proc/meminfo
+++ b/plugins/inputs/mem/testdata/missing_fields/proc/meminfo
@@ -1,0 +1,49 @@
+MemTotal:       16201888 kB
+MemFree:        1834660 kB
+MemAvailable:   14221924 kB
+Buffers:         2328512 kB
+Cached:         10074816 kB
+SwapCached:         1272 kB
+Active:          9082612 kB
+Inactive:        5375232 kB
+Active(anon):    5630048 kB
+Inactive(anon):  1056880 kB
+Active(file):    3452564 kB
+Inactive(file):  4318352 kB
+Mlocked:             140 kB
+SwapTotal:       4194300 kB
+SwapFree:        4186844 kB
+Dirty:               120 kB
+Writeback:             0 kB
+AnonPages:       2681888 kB
+Mapped:           407004 kB
+Shmem:            655156 kB
+KReclaimable:    1878340 kB
+Slab:            2032296 kB
+SReclaimable:    1878340 kB
+SUnreclaim:       153956 kB
+KernelStack:       16544 kB
+PageTables:        19324 kB
+NFS_Unstable:          0 kB
+Bounce:                0 kB
+WritebackTmp:          0 kB
+CommitLimit:    12295244 kB
+Committed_AS:   11505536 kB
+VmallocTotal:   34359738368 kB
+VmallocUsed:           0 kB
+VmallocChunk:          0 kB
+HardwareCorrupted:     0 kB
+AnonHugePages:         0 kB
+ShmemHugePages:        0 kB
+ShmemPmdMapped:        0 kB
+FileHugePages:         0 kB
+FilePmdMapped:         0 kB
+HugePages_Total:       0
+HugePages_Free:        0
+HugePages_Rsvd:        0
+HugePages_Surp:        0
+Hugepagesize:       2048 kB
+Hugetlb:               0 kB
+DirectMap4k:      382656 kB
+DirectMap2M:    14297088 kB
+DirectMap1G:     2097152 kB

--- a/plugins/inputs/mem/testdata/normal/proc/meminfo
+++ b/plugins/inputs/mem/testdata/normal/proc/meminfo
@@ -1,0 +1,51 @@
+MemTotal:       16201888 kB
+MemFree:        1834660 kB
+MemAvailable:   14221924 kB
+Buffers:         2328512 kB
+Cached:         10074816 kB
+SwapCached:         1272 kB
+Active:          9082612 kB
+Inactive:        5375232 kB
+Active(anon):    5630048 kB
+Inactive(anon):  1056880 kB
+Active(file):    3452564 kB
+Inactive(file):  4318352 kB
+Unevictable:         140 kB
+Mlocked:             140 kB
+SwapTotal:       4194300 kB
+SwapFree:        4186844 kB
+Dirty:               120 kB
+Writeback:             0 kB
+AnonPages:       2681888 kB
+Mapped:           407004 kB
+Shmem:            655156 kB
+KReclaimable:    1878340 kB
+Slab:            2032296 kB
+SReclaimable:    1878340 kB
+SUnreclaim:       153956 kB
+KernelStack:       16544 kB
+PageTables:        19324 kB
+NFS_Unstable:          0 kB
+Bounce:                0 kB
+WritebackTmp:          0 kB
+CommitLimit:    12295244 kB
+Committed_AS:   11505536 kB
+VmallocTotal:   34359738368 kB
+VmallocUsed:           0 kB
+VmallocChunk:          0 kB
+Percpu:             5632 kB
+HardwareCorrupted:     0 kB
+AnonHugePages:         0 kB
+ShmemHugePages:        0 kB
+ShmemPmdMapped:        0 kB
+FileHugePages:         0 kB
+FilePmdMapped:         0 kB
+HugePages_Total:       0
+HugePages_Free:        0
+HugePages_Rsvd:        0
+HugePages_Surp:        0
+Hugepagesize:       2048 kB
+Hugetlb:               0 kB
+DirectMap4k:      382656 kB
+DirectMap2M:    14297088 kB
+DirectMap1G:     2097152 kB


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

Add platform-specific extended memory fields behind a `collect_extended` config option (default: false). Linux provides active_file, inactive_file, active_anon, inactive_anon, unevictable, and percpu fields via /proc/meminfo. Windows provides commit, virtual, physical, and page file counters.

This is a rewrite of the previous closed pull request, #18281, which takes into account all the comments provided: the code has been simplified, current tests have not changed, etc.

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [ ] No AI generated code was used in this PR
- [x] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #17925
