### PR TITLE
chore: Fix invalid pre-allocation

### DIFF
--- a/cmd/telegraf/main.go
+++ b/cmd/telegraf/main.go
@@ -101,7 +101,6 @@ func deleteEmpty(s []string) []string {
 // runApp defines all the subcommands and flags for Telegraf
 // this abstraction is used for testing, so outputBuffer and args can be changed
 func runApp(args []string, outputBuffer io.Writer, pprof Server, c TelegrafConfig, m App) error {
-	//nolint:prealloc // False positive as this has a fixed, known-in-advance size
 	configHandlingFlags := []cli.Flag{
 		&cli.StringSliceFlag{
 			Name:  "config",


### PR DESCRIPTION
## Summary

This reverts an invalid pre-allocation in the telegraf command code that triggers on Windows only. The pre-allocation is done for the wrong variable and is unnecessary because the `configurationHandlingFlags` variable has a fixed set of entries known at initialization time so a pre-allocation doesn't provide any benefit!

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
