### PR TITLE
chore(serializers.prometheus): Replace testutil.MustMetric with metric.New

### DIFF
--- a/plugins/serializers/prometheus/prometheus_test.go
+++ b/plugins/serializers/prometheus/prometheus_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/metric"
 	"github.com/influxdata/telegraf/plugins/serializers"
-	"github.com/influxdata/telegraf/testutil"
 )
 
 func TestSerialize(t *testing.T) {
@@ -21,7 +21,7 @@ func TestSerialize(t *testing.T) {
 	}{
 		{
 			name: "simple",
-			metric: testutil.MustMetric(
+			metric: metric.New(
 				"cpu",
 				map[string]string{
 					"host": "example.org",
@@ -39,7 +39,7 @@ cpu_time_idle{host="example.org"} 42
 		},
 		{
 			name: "prometheus input untyped",
-			metric: testutil.MustMetric(
+			metric: metric.New(
 				"prometheus",
 				map[string]string{
 					"code":   "400",
@@ -59,7 +59,7 @@ http_requests_total{code="400",method="post"} 3
 		},
 		{
 			name: "prometheus input counter",
-			metric: testutil.MustMetric(
+			metric: metric.New(
 				"prometheus",
 				map[string]string{
 					"code":   "400",
@@ -79,7 +79,7 @@ http_requests_total{code="400",method="post"} 3
 		},
 		{
 			name: "prometheus input gauge",
-			metric: testutil.MustMetric(
+			metric: metric.New(
 				"prometheus",
 				map[string]string{
 					"code":   "400",
@@ -99,7 +99,7 @@ http_requests_total{code="400",method="post"} 3
 		},
 		{
 			name: "prometheus input histogram no buckets",
-			metric: testutil.MustMetric(
+			metric: metric.New(
 				"prometheus",
 				map[string]string{},
 				map[string]interface{}{
@@ -119,7 +119,7 @@ http_request_duration_seconds_count 144320
 		},
 		{
 			name: "prometheus input histogram only bucket",
-			metric: testutil.MustMetric(
+			metric: metric.New(
 				"prometheus",
 				map[string]string{
 					"le": "0.5",
@@ -144,7 +144,7 @@ http_request_duration_seconds_count 0
 			config: FormatConfig{
 				ExportTimestamp: true,
 			},
-			metric: testutil.MustMetric(
+			metric: metric.New(
 				"cpu",
 				map[string]string{
 					"host": "example.org",
@@ -165,7 +165,7 @@ cpu_time_idle{host="example.org"} 42 1574279268000
 			config: FormatConfig{
 				CompactEncoding: true,
 			},
-			metric: testutil.MustMetric(
+			metric: metric.New(
 				"cpu",
 				map[string]string{
 					"host": "example.org",
@@ -185,7 +185,7 @@ cpu_time_idle{host="example.org"} 42
 			config: FormatConfig{
 				TypeMappings: MetricTypes{Counter: []string{"cpu_time_idle"}},
 			},
-			metric: testutil.MustMetric(
+			metric: metric.New(
 				"cpu",
 				map[string]string{
 					"host": "example.org",
@@ -206,7 +206,7 @@ cpu_time_idle{host="example.org"} 42
 			config: FormatConfig{
 				TypeMappings: MetricTypes{Gauge: []string{"cpu_time_idle"}},
 			},
-			metric: testutil.MustMetric(
+			metric: metric.New(
 				"cpu",
 				map[string]string{
 					"host": "example.org",
@@ -256,7 +256,7 @@ func TestSerializeBatch(t *testing.T) {
 		{
 			name: "simple",
 			metrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{
 						"host": "one.example.org",
@@ -266,7 +266,7 @@ func TestSerializeBatch(t *testing.T) {
 					},
 					time.Unix(0, 0),
 				),
-				testutil.MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{
 						"host": "two.example.org",
@@ -287,7 +287,7 @@ cpu_time_idle{host="two.example.org"} 42
 		{
 			name: "multiple metric families",
 			metrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{
 						"host": "one.example.org",
@@ -311,7 +311,7 @@ cpu_time_idle{host="one.example.org"} 42
 		{
 			name: "histogram",
 			metrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"prometheus",
 					map[string]string{},
 					map[string]interface{}{
@@ -321,7 +321,7 @@ cpu_time_idle{host="one.example.org"} 42
 					time.Unix(0, 0),
 					telegraf.Histogram,
 				),
-				testutil.MustMetric(
+				metric.New(
 					"prometheus",
 					map[string]string{"le": "0.05"},
 					map[string]interface{}{
@@ -330,7 +330,7 @@ cpu_time_idle{host="one.example.org"} 42
 					time.Unix(0, 0),
 					telegraf.Histogram,
 				),
-				testutil.MustMetric(
+				metric.New(
 					"prometheus",
 					map[string]string{"le": "0.1"},
 					map[string]interface{}{
@@ -339,7 +339,7 @@ cpu_time_idle{host="one.example.org"} 42
 					time.Unix(0, 0),
 					telegraf.Histogram,
 				),
-				testutil.MustMetric(
+				metric.New(
 					"prometheus",
 					map[string]string{"le": "0.2"},
 					map[string]interface{}{
@@ -348,7 +348,7 @@ cpu_time_idle{host="one.example.org"} 42
 					time.Unix(0, 0),
 					telegraf.Histogram,
 				),
-				testutil.MustMetric(
+				metric.New(
 					"prometheus",
 					map[string]string{"le": "0.5"},
 					map[string]interface{}{
@@ -357,7 +357,7 @@ cpu_time_idle{host="one.example.org"} 42
 					time.Unix(0, 0),
 					telegraf.Histogram,
 				),
-				testutil.MustMetric(
+				metric.New(
 					"prometheus",
 					map[string]string{"le": "1.0"},
 					map[string]interface{}{
@@ -366,7 +366,7 @@ cpu_time_idle{host="one.example.org"} 42
 					time.Unix(0, 0),
 					telegraf.Histogram,
 				),
-				testutil.MustMetric(
+				metric.New(
 					"prometheus",
 					map[string]string{"le": "+Inf"},
 					map[string]interface{}{
@@ -392,7 +392,7 @@ http_request_duration_seconds_count 144320
 		{
 			name: "",
 			metrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"prometheus",
 					map[string]string{},
 					map[string]interface{}{
@@ -402,7 +402,7 @@ http_request_duration_seconds_count 144320
 					time.Unix(0, 0),
 					telegraf.Summary,
 				),
-				testutil.MustMetric(
+				metric.New(
 					"prometheus",
 					map[string]string{"quantile": "0.01"},
 					map[string]interface{}{
@@ -411,7 +411,7 @@ http_request_duration_seconds_count 144320
 					time.Unix(0, 0),
 					telegraf.Summary,
 				),
-				testutil.MustMetric(
+				metric.New(
 					"prometheus",
 					map[string]string{"quantile": "0.05"},
 					map[string]interface{}{
@@ -420,7 +420,7 @@ http_request_duration_seconds_count 144320
 					time.Unix(0, 0),
 					telegraf.Summary,
 				),
-				testutil.MustMetric(
+				metric.New(
 					"prometheus",
 					map[string]string{"quantile": "0.5"},
 					map[string]interface{}{
@@ -429,7 +429,7 @@ http_request_duration_seconds_count 144320
 					time.Unix(0, 0),
 					telegraf.Summary,
 				),
-				testutil.MustMetric(
+				metric.New(
 					"prometheus",
 					map[string]string{"quantile": "0.9"},
 					map[string]interface{}{
@@ -438,7 +438,7 @@ http_request_duration_seconds_count 144320
 					time.Unix(0, 0),
 					telegraf.Summary,
 				),
-				testutil.MustMetric(
+				metric.New(
 					"prometheus",
 					map[string]string{"quantile": "0.99"},
 					map[string]interface{}{
@@ -463,7 +463,7 @@ rpc_duration_seconds_count 2693
 		{
 			name: "newer sample",
 			metrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{},
 					map[string]interface{}{
@@ -471,7 +471,7 @@ rpc_duration_seconds_count 2693
 					},
 					time.Unix(1, 0),
 				),
-				testutil.MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{},
 					map[string]interface{}{
@@ -489,7 +489,7 @@ cpu_time_idle 43
 		{
 			name: "colons are not replaced in metric name from measurement",
 			metrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"cpu::xyzzy",
 					map[string]string{},
 					map[string]interface{}{
@@ -507,7 +507,7 @@ cpu::xyzzy_time_idle 42
 		{
 			name: "colons are not replaced in metric name from field",
 			metrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{},
 					map[string]interface{}{
@@ -525,7 +525,7 @@ cpu_time:idle 42
 		{
 			name: "invalid label",
 			metrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{
 						"host-name": "example.org",
@@ -545,7 +545,7 @@ cpu_time_idle{host_name="example.org"} 42
 		{
 			name: "colons are replaced in label name",
 			metrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{
 						"host:name": "example.org",
@@ -565,7 +565,7 @@ cpu_time_idle{host_name="example.org"} 42
 		{
 			name: "discard strings",
 			metrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{},
 					map[string]interface{}{
@@ -587,7 +587,7 @@ cpu_time_idle 42
 				StringAsLabel: true,
 			},
 			metrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{},
 					map[string]interface{}{
@@ -609,7 +609,7 @@ cpu_time_idle{cpu="cpu0"} 42
 				StringAsLabel: true,
 			},
 			metrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{
 						"cpu": "cpu0",
@@ -633,7 +633,7 @@ cpu_time_idle{cpu="cpu0"} 42
 				StringAsLabel: true,
 			},
 			metrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{},
 					map[string]interface{}{
@@ -652,7 +652,7 @@ cpu_time_idle{host_name="example.org"} 42
 		{
 			name: "multiple fields grouping",
 			metrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{
 						"cpu": "cpu0",
@@ -664,7 +664,7 @@ cpu_time_idle{host_name="example.org"} 42
 					},
 					time.Unix(0, 0),
 				),
-				testutil.MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{
 						"cpu": "cpu1",
@@ -676,7 +676,7 @@ cpu_time_idle{host_name="example.org"} 42
 					},
 					time.Unix(0, 0),
 				),
-				testutil.MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{
 						"cpu": "cpu2",
@@ -688,7 +688,7 @@ cpu_time_idle{host_name="example.org"} 42
 					},
 					time.Unix(0, 0),
 				),
-				testutil.MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{
 						"cpu": "cpu3",
@@ -725,7 +725,7 @@ cpu_time_user{cpu="cpu3"} 94148
 		{
 			name: "summary with no quantile",
 			metrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"prometheus",
 					map[string]string{},
 					map[string]interface{}{


### PR DESCRIPTION
## Summary
- Replace all 41 occurrences of `testutil.MustMetric` with `metric.New` in `prometheus_test.go`
- Remove unused `testutil` import, add `metric` import

Part of #18495

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues



