### PR TITLE
chore(outputs): Replace testutil.MustMetric with metric.New

### DIFF
--- a/plugins/outputs/azure_monitor/azure_monitor_test.go
+++ b/plugins/outputs/azure_monitor/azure_monitor_test.go
@@ -33,7 +33,7 @@ func TestAggregate(t *testing.T) {
 		{
 			name: "add metric outside window is dropped",
 			metrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{},
 					map[string]interface{}{
@@ -49,7 +49,7 @@ func TestAggregate(t *testing.T) {
 		{
 			name: "metric not sent until period expires",
 			metrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{},
 					map[string]interface{}{
@@ -65,7 +65,7 @@ func TestAggregate(t *testing.T) {
 			name:      "add strings as dimensions",
 			stringdim: true,
 			metrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{
 						"host": "localhost",
@@ -80,7 +80,7 @@ func TestAggregate(t *testing.T) {
 			addTime:  time.Unix(0, 0),
 			pushTime: time.Unix(3600, 0),
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"cpu-value",
 					map[string]string{
 						"host":    "localhost",
@@ -99,7 +99,7 @@ func TestAggregate(t *testing.T) {
 		{
 			name: "add metric to cache and push",
 			metrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{},
 					map[string]interface{}{
@@ -111,7 +111,7 @@ func TestAggregate(t *testing.T) {
 			addTime:  time.Unix(0, 0),
 			pushTime: time.Unix(3600, 0),
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"cpu-value",
 					map[string]string{},
 					map[string]interface{}{
@@ -127,7 +127,7 @@ func TestAggregate(t *testing.T) {
 		{
 			name: "added metric are aggregated",
 			metrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{},
 					map[string]interface{}{
@@ -135,7 +135,7 @@ func TestAggregate(t *testing.T) {
 					},
 					time.Unix(0, 0),
 				),
-				testutil.MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{},
 					map[string]interface{}{
@@ -143,7 +143,7 @@ func TestAggregate(t *testing.T) {
 					},
 					time.Unix(0, 0),
 				),
-				testutil.MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{},
 					map[string]interface{}{
@@ -155,7 +155,7 @@ func TestAggregate(t *testing.T) {
 			addTime:  time.Unix(0, 0),
 			pushTime: time.Unix(3600, 0),
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"cpu-value",
 					map[string]string{},
 					map[string]interface{}{
@@ -227,7 +227,7 @@ func TestWrite(t *testing.T) {
 		{
 			name: "if not an azure metric nothing is sent",
 			metrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{},
 					map[string]interface{}{
@@ -241,7 +241,7 @@ func TestWrite(t *testing.T) {
 		{
 			name: "single azure metric",
 			metrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"cpu-value",
 					map[string]string{},
 					map[string]interface{}{
@@ -259,7 +259,7 @@ func TestWrite(t *testing.T) {
 		{
 			name: "multiple azure metric",
 			metrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"cpu-value",
 					map[string]string{},
 					map[string]interface{}{
@@ -270,7 +270,7 @@ func TestWrite(t *testing.T) {
 					},
 					time.Unix(0, 0),
 				),
-				testutil.MustMetric(
+				metric.New(
 					"cpu-value",
 					map[string]string{},
 					map[string]interface{}{

--- a/plugins/outputs/clarify/clarify_test.go
+++ b/plugins/outputs/clarify/clarify_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
+	"github.com/influxdata/telegraf/metric"
 	"github.com/influxdata/telegraf/testutil"
 )
 
@@ -63,7 +64,7 @@ func TestGenerateID(t *testing.T) {
 		err      error
 	}{
 		{
-			testutil.MustMetric(
+			metric.New(
 				"cpu+='''..2!@#$abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890",
 				map[string]string{
 					"tag1": "78sx",
@@ -76,7 +77,7 @@ func TestGenerateID(t *testing.T) {
 			errIDTooLong,
 		},
 		{
-			testutil.MustMetric(
+			metric.New(
 				"cpu@@",
 				map[string]string{
 					"tag1": "78sx",
@@ -90,7 +91,7 @@ func TestGenerateID(t *testing.T) {
 			nil,
 		},
 		{
-			testutil.MustMetric(
+			metric.New(
 				"temperature",
 				map[string]string{},
 				map[string]interface{}{
@@ -102,7 +103,7 @@ func TestGenerateID(t *testing.T) {
 			nil,
 		},
 		{
-			testutil.MustMetric(
+			metric.New(
 				"legacy_measurement",
 				map[string]string{
 					"clarify_input_id": "e5e82f63-3700-4997-835d-eb366b7294a2",
@@ -141,7 +142,7 @@ func TestProcessMetrics(t *testing.T) {
 		outSignals map[string]views.SignalSave
 	}{
 		{
-			testutil.MustMetric(
+			metric.New(
 				"cpu1",
 				map[string]string{
 					"tag1": "78sx",
@@ -167,7 +168,7 @@ func TestProcessMetrics(t *testing.T) {
 			},
 		},
 		{
-			testutil.MustMetric(
+			metric.New(
 				"cpu2",
 				map[string]string{
 					"tag1": "78sx",
@@ -195,7 +196,7 @@ func TestProcessMetrics(t *testing.T) {
 			},
 		},
 		{
-			testutil.MustMetric(
+			metric.New(
 				"temperature",
 				map[string]string{},
 				map[string]interface{}{
@@ -225,7 +226,7 @@ func TestProcessMetrics(t *testing.T) {
 			},
 		},
 		{
-			testutil.MustMetric(
+			metric.New(
 				"legacy_measurement",
 				map[string]string{
 					"clarify_input_id": "e5e82f63-3700-4997-835d-eb366b7294a2",
@@ -253,7 +254,7 @@ func TestProcessMetrics(t *testing.T) {
 			},
 		},
 		{
-			testutil.MustMetric(
+			metric.New(
 				"opc_metric",
 				map[string]string{
 					"node_id": "ns=1;s=Omron PLC.Objects.new_Controller_0.GlobalVars.counter1",

--- a/plugins/outputs/cloudwatch_logs/cloudwatch_logs_test.go
+++ b/plugins/outputs/cloudwatch_logs/cloudwatch_logs_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/metric"
 	"github.com/influxdata/telegraf/plugins/common/aws"
 	"github.com/influxdata/telegraf/testutil"
 )
@@ -347,7 +348,7 @@ func TestWrite(t *testing.T) {
 			expectedMetricsOrder: map[int]int{0: 0, 1: 1},
 			expectedMetricsCount: 2,
 			metrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"docker_log",
 					map[string]string{
 						"container_name":    "telegraf",
@@ -362,7 +363,7 @@ func TestWrite(t *testing.T) {
 					},
 					time.Now().Add(-time.Minute),
 				),
-				testutil.MustMetric(
+				metric.New(
 					"docker_log",
 					map[string]string{
 						"container_name":    "telegraf",
@@ -385,7 +386,7 @@ func TestWrite(t *testing.T) {
 			expectedMetricsOrder: map[int]int{0: 1, 1: 0},
 			expectedMetricsCount: 2,
 			metrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"docker_log",
 					map[string]string{
 						"container_name":    "telegraf",
@@ -400,7 +401,7 @@ func TestWrite(t *testing.T) {
 					},
 					time.Now(),
 				),
-				testutil.MustMetric(
+				metric.New(
 					"docker_log",
 					map[string]string{
 						"container_name":    "telegraf",
@@ -422,7 +423,7 @@ func TestWrite(t *testing.T) {
 			logStreamName:        "deadbeef",
 			expectedMetricsCount: 0,
 			metrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"docker_log",
 					map[string]string{
 						"container_name":    "telegraf",
@@ -437,7 +438,7 @@ func TestWrite(t *testing.T) {
 					},
 					time.Now().Add(-maxPastLogEventTimeOffset).Add(-time.Hour),
 				),
-				testutil.MustMetric(
+				metric.New(
 					"docker_log",
 					map[string]string{
 						"container_name":    "telegraf",
@@ -459,7 +460,7 @@ func TestWrite(t *testing.T) {
 			logStreamName:        "deadbeef",
 			expectedMetricsCount: 0,
 			metrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"docker_log",
 					map[string]string{
 						"container_name":    "telegraf",
@@ -483,7 +484,7 @@ func TestWrite(t *testing.T) {
 			expectedMetricsOrder: map[int]int{0: 0, 1: 1, 2: 2, 3: 3, 4: 4},
 			expectedMetricsCount: 5,
 			metrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"docker_log",
 					map[string]string{
 						"container_name":    "telegraf",
@@ -499,7 +500,7 @@ func TestWrite(t *testing.T) {
 					},
 					time.Now().Add(-4*time.Minute),
 				),
-				testutil.MustMetric(
+				metric.New(
 					"docker_log",
 					map[string]string{
 						"container_name":    "telegraf",
@@ -515,7 +516,7 @@ func TestWrite(t *testing.T) {
 					},
 					time.Now().Add(-3*time.Minute),
 				),
-				testutil.MustMetric(
+				metric.New(
 					"docker_log",
 					map[string]string{
 						"container_name":    "telegraf",
@@ -531,7 +532,7 @@ func TestWrite(t *testing.T) {
 					},
 					time.Now().Add(-2*time.Minute),
 				),
-				testutil.MustMetric(
+				metric.New(
 					"docker_log",
 					map[string]string{
 						"container_name":    "telegraf",
@@ -547,7 +548,7 @@ func TestWrite(t *testing.T) {
 					},
 					time.Now().Add(-time.Minute),
 				),
-				testutil.MustMetric(
+				metric.New(
 					"docker_log",
 					map[string]string{
 						"container_name":    "telegraf",

--- a/plugins/outputs/datadog/datadog_test.go
+++ b/plugins/outputs/datadog/datadog_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
+	"github.com/influxdata/telegraf/metric"
 	"github.com/influxdata/telegraf/testutil"
 )
 
@@ -275,7 +276,7 @@ func TestNaNIsSkipped(t *testing.T) {
 	require.NoError(t, err)
 
 	err = plugin.Write([]telegraf.Metric{
-		testutil.MustMetric(
+		metric.New(
 			"cpu",
 			map[string]string{},
 			map[string]interface{}{
@@ -296,7 +297,7 @@ func TestInfIsSkipped(t *testing.T) {
 	require.NoError(t, err)
 
 	err = plugin.Write([]telegraf.Metric{
-		testutil.MustMetric(
+		metric.New(
 			"cpu",
 			map[string]string{},
 			map[string]interface{}{
@@ -321,7 +322,7 @@ func TestNonZeroRateIntervalConvertsRatesToCount(t *testing.T) {
 		{
 			"convert counter metrics to rate",
 			[]telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"count_metric",
 					map[string]string{
 						"metric_type": "counter",
@@ -353,7 +354,7 @@ func TestNonZeroRateIntervalConvertsRatesToCount(t *testing.T) {
 		{
 			"convert count value in timing metrics to rate",
 			[]telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"timing_metric",
 					map[string]string{
 						"metric_type": "timing",
@@ -475,7 +476,7 @@ func TestNonZeroRateIntervalConvertsRatesToCount(t *testing.T) {
 		{
 			"convert count value in histogram metrics to rate",
 			[]telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"histogram_metric",
 					map[string]string{
 						"metric_type": "histogram",
@@ -617,7 +618,7 @@ func TestZeroRateIntervalConvertsRatesToCount(t *testing.T) {
 		{
 			"does not convert counter metrics to rate",
 			[]telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"count_metric",
 					map[string]string{
 						"metric_type": "counter",
@@ -649,7 +650,7 @@ func TestZeroRateIntervalConvertsRatesToCount(t *testing.T) {
 		{
 			"does not convert count value in timing metrics to rate",
 			[]telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"timing_metric",
 					map[string]string{
 						"metric_type": "timing",
@@ -771,7 +772,7 @@ func TestZeroRateIntervalConvertsRatesToCount(t *testing.T) {
 		{
 			"does not convert count value in histogram metrics to rate",
 			[]telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"histogram_metric",
 					map[string]string{
 						"metric_type": "histogram",

--- a/plugins/outputs/execd/execd_test.go
+++ b/plugins/outputs/execd/execd_test.go
@@ -244,7 +244,7 @@ func runOutputConsumerProgram() {
 		}
 		numMetrics++
 
-		expected := testutil.MustMetric(metricName,
+		expected := metric.New(metricName,
 			map[string]string{"name": "cpu1"},
 			map[string]interface{}{"idle": 50, "sys": 30},
 			now,


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Covers azure_monitor, clarify, cloudwatch_logs, datadog, and execd outputs.

Part of #18495 - testutil.MustMetric is a trivial wrapper around metric.New that adds no value and misleads with its "Must" prefix.

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
