### PR TITLE
chore(outputs): Replace testutil.MustMetric with metric.New

### DIFF
--- a/plugins/outputs/health/compares_test.go
+++ b/plugins/outputs/health/compares_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/metric"
 	"github.com/influxdata/telegraf/plugins/outputs/health"
-	"github.com/influxdata/telegraf/testutil"
 )
 
 func addr(v float64) *float64 {
@@ -17,7 +17,7 @@ func addr(v float64) *float64 {
 
 func TestFieldNotFoundIsSuccess(t *testing.T) {
 	metrics := []telegraf.Metric{
-		testutil.MustMetric(
+		metric.New(
 			"cpu",
 			map[string]string{},
 			map[string]interface{}{},
@@ -34,7 +34,7 @@ func TestFieldNotFoundIsSuccess(t *testing.T) {
 
 func TestStringFieldIsFailure(t *testing.T) {
 	metrics := []telegraf.Metric{
-		testutil.MustMetric(
+		metric.New(
 			"cpu",
 			map[string]string{},
 			map[string]interface{}{
@@ -60,7 +60,7 @@ func TestFloatConvert(t *testing.T) {
 		{
 			name: "int64 field",
 			metrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{},
 					map[string]interface{}{
@@ -73,7 +73,7 @@ func TestFloatConvert(t *testing.T) {
 		{
 			name: "uint64 field",
 			metrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{},
 					map[string]interface{}{
@@ -86,7 +86,7 @@ func TestFloatConvert(t *testing.T) {
 		{
 			name: "float64 field",
 			metrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{},
 					map[string]interface{}{
@@ -99,7 +99,7 @@ func TestFloatConvert(t *testing.T) {
 		{
 			name: "bool field true",
 			metrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{},
 					map[string]interface{}{
@@ -112,7 +112,7 @@ func TestFloatConvert(t *testing.T) {
 		{
 			name: "bool field false",
 			metrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{},
 					map[string]interface{}{
@@ -125,7 +125,7 @@ func TestFloatConvert(t *testing.T) {
 		{
 			name: "string field",
 			metrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{},
 					map[string]interface{}{
@@ -254,7 +254,7 @@ func TestOperators(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			metrics := []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{},
 					map[string]interface{}{

--- a/plugins/outputs/health/contains_test.go
+++ b/plugins/outputs/health/contains_test.go
@@ -7,13 +7,13 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/metric"
 	"github.com/influxdata/telegraf/plugins/outputs/health"
-	"github.com/influxdata/telegraf/testutil"
 )
 
 func TestFieldFound(t *testing.T) {
 	metrics := []telegraf.Metric{
-		testutil.MustMetric(
+		metric.New(
 			"cpu",
 			map[string]string{},
 			map[string]interface{}{
@@ -31,7 +31,7 @@ func TestFieldFound(t *testing.T) {
 
 func TestFieldNotFound(t *testing.T) {
 	metrics := []telegraf.Metric{
-		testutil.MustMetric(
+		metric.New(
 			"cpu",
 			map[string]string{},
 			map[string]interface{}{},
@@ -47,12 +47,12 @@ func TestFieldNotFound(t *testing.T) {
 
 func TestOneMetricWithFieldIsSuccess(t *testing.T) {
 	metrics := []telegraf.Metric{
-		testutil.MustMetric(
+		metric.New(
 			"cpu",
 			map[string]string{},
 			map[string]interface{}{},
 			time.Now()),
-		testutil.MustMetric(
+		metric.New(
 			"cpu",
 			map[string]string{},
 			map[string]interface{}{

--- a/plugins/outputs/health/health_test.go
+++ b/plugins/outputs/health/health_test.go
@@ -45,7 +45,7 @@ func TestHealth(t *testing.T) {
 				},
 			},
 			metrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{},
 					map[string]interface{}{
@@ -66,7 +66,7 @@ func TestHealth(t *testing.T) {
 				},
 			},
 			metrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{},
 					map[string]interface{}{
@@ -92,7 +92,7 @@ func TestHealth(t *testing.T) {
 				},
 			},
 			metrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{},
 					map[string]interface{}{
@@ -244,14 +244,14 @@ func TestTimeBetweenMetrics(t *testing.T) {
 			name:                  "healthy when disabled and old metric",
 			maxTimeBetweenMetrics: config.Duration(0),
 			metrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{},
 					map[string]any{
 						"time_idle": 42,
 					},
 					arbitraryTime),
-				testutil.MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{},
 					map[string]any{
@@ -266,7 +266,7 @@ func TestTimeBetweenMetrics(t *testing.T) {
 			name:                  "healthy when enabled and recent metric",
 			maxTimeBetweenMetrics: config.Duration(5 * time.Second),
 			metrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{},
 					map[string]any{
@@ -281,14 +281,14 @@ func TestTimeBetweenMetrics(t *testing.T) {
 			name:                  "unhealthy when enabled and old metric",
 			maxTimeBetweenMetrics: config.Duration(5 * time.Millisecond),
 			metrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{},
 					map[string]any{
 						"time_idle": 42,
 					},
 					arbitraryTime),
-				testutil.MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{},
 					map[string]any{

--- a/plugins/outputs/influxdb/http_test.go
+++ b/plugins/outputs/influxdb/http_test.go
@@ -783,7 +783,7 @@ func TestHTTP_WriteDatabaseTagWorksOnRetry(t *testing.T) {
 	require.NoError(t, err)
 
 	metrics := []telegraf.Metric{
-		testutil.MustMetric(
+		metric.New(
 			"cpu",
 			map[string]string{
 				"database": "foo",
@@ -822,7 +822,7 @@ func TestDBRPTags(t *testing.T) {
 				Database: "telegraf",
 			},
 			metrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{
 						"database": "foo",
@@ -847,7 +847,7 @@ func TestDBRPTags(t *testing.T) {
 				RetentionPolicy: "foo",
 			},
 			metrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{},
 					map[string]interface{}{
@@ -872,7 +872,7 @@ func TestDBRPTags(t *testing.T) {
 				Log:                  testutil.Logger{},
 			},
 			metrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{
 						"rp": "foo",
@@ -903,7 +903,7 @@ func TestDBRPTags(t *testing.T) {
 				Log:                  testutil.Logger{},
 			},
 			metrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{},
 					map[string]interface{}{
@@ -928,7 +928,7 @@ func TestDBRPTags(t *testing.T) {
 				Log:                  testutil.Logger{},
 			},
 			metrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{},
 					map[string]interface{}{
@@ -954,7 +954,7 @@ func TestDBRPTags(t *testing.T) {
 				Log:                       testutil.Logger{},
 			},
 			metrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{
 						"rp": "foo",
@@ -985,7 +985,7 @@ func TestDBRPTags(t *testing.T) {
 				Log:                  testutil.Logger{},
 			},
 			metrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{
 						"rp": "foo",
@@ -1095,7 +1095,7 @@ func TestDBRPTagsCreateDatabaseNotCalledOnRetryAfterForbidden(t *testing.T) {
 	ts.Config.Handler = handlers
 
 	metrics := []telegraf.Metric{
-		testutil.MustMetric(
+		metric.New(
 			"cpu",
 			map[string]string{},
 			map[string]interface{}{
@@ -1191,7 +1191,7 @@ func TestDBRPTagsCreateDatabaseCalledOnDatabaseNotFound(t *testing.T) {
 	ts.Config.Handler = handlers
 
 	metrics := []telegraf.Metric{
-		testutil.MustMetric(
+		metric.New(
 			"cpu",
 			map[string]string{},
 			map[string]interface{}{
@@ -1249,7 +1249,7 @@ func TestDBNotFoundShouldDropMetricWhenSkipDatabaseCreateIsTrue(t *testing.T) {
 	ts.Config.Handler = http.HandlerFunc(f)
 
 	metrics := []telegraf.Metric{
-		testutil.MustMetric(
+		metric.New(
 			"cpu",
 			map[string]string{},
 			map[string]interface{}{

--- a/plugins/outputs/influxdb_v2/influxdb_v2_test.go
+++ b/plugins/outputs/influxdb_v2/influxdb_v2_test.go
@@ -201,7 +201,7 @@ func TestWrite(t *testing.T) {
 
 	// Test writing
 	metrics := []telegraf.Metric{
-		testutil.MustMetric(
+		metric.New(
 			"cpu",
 			map[string]string{
 				"bucket": "foobar",
@@ -262,7 +262,7 @@ func TestWriteWithPartialSerializationError(t *testing.T) {
 
 	metrics := []telegraf.Metric{
 		// Metric which cannot be serialized
-		testutil.MustMetric(
+		metric.New(
 			"cpu",
 			map[string]string{
 				"type": "invalid",
@@ -273,7 +273,7 @@ func TestWriteWithPartialSerializationError(t *testing.T) {
 			time.Unix(0, 0),
 		),
 		// Valid metric
-		testutil.MustMetric(
+		metric.New(
 			"cpu",
 			map[string]string{
 				"type": "valid",
@@ -284,7 +284,7 @@ func TestWriteWithPartialSerializationError(t *testing.T) {
 			time.Unix(0, 0),
 		),
 		// Metric which cannot be serialized
-		testutil.MustMetric(
+		metric.New(
 			"cpu",
 			map[string]string{
 				"type": "invalid",
@@ -352,7 +352,7 @@ func TestWriteWithPartialSerializationAndSendError(t *testing.T) {
 
 	metrics := []telegraf.Metric{
 		// Metric which cannot be serialized
-		testutil.MustMetric(
+		metric.New(
 			"cpu",
 			map[string]string{
 				"type": "invalid",
@@ -363,7 +363,7 @@ func TestWriteWithPartialSerializationAndSendError(t *testing.T) {
 			time.Unix(0, 0),
 		),
 		// Valid metric
-		testutil.MustMetric(
+		metric.New(
 			"cpu",
 			map[string]string{
 				"type": "valid",
@@ -374,7 +374,7 @@ func TestWriteWithPartialSerializationAndSendError(t *testing.T) {
 			time.Unix(0, 0),
 		),
 		// Metric which cannot be serialized
-		testutil.MustMetric(
+		metric.New(
 			"cpu",
 			map[string]string{
 				"type": "invalid",
@@ -452,7 +452,7 @@ func TestWriteBucketTagWorksOnRetry(t *testing.T) {
 
 	// Send the metrics which should be succeed if sent twice
 	metrics := []telegraf.Metric{
-		testutil.MustMetric(
+		metric.New(
 			"cpu",
 			map[string]string{
 				"bucket": "foo",

--- a/plugins/outputs/influxdb_v3/influxdb_v3_test.go
+++ b/plugins/outputs/influxdb_v3/influxdb_v3_test.go
@@ -205,7 +205,7 @@ func TestWrite(t *testing.T) {
 
 	// Test writing
 	metrics := []telegraf.Metric{
-		testutil.MustMetric(
+		metric.New(
 			"cpu",
 			map[string]string{
 				"database": "foobar",
@@ -254,7 +254,7 @@ func TestWriteDefaultSync(t *testing.T) {
 
 	// Test writing
 	metrics := []telegraf.Metric{
-		testutil.MustMetric(
+		metric.New(
 			"cpu",
 			map[string]string{
 				"database": "foobar",
@@ -304,7 +304,7 @@ func TestWriteExplicitSync(t *testing.T) {
 
 	// Test writing
 	metrics := []telegraf.Metric{
-		testutil.MustMetric(
+		metric.New(
 			"cpu",
 			map[string]string{
 				"database": "foobar",
@@ -366,7 +366,7 @@ func TestWriteNotConvertUint(t *testing.T) {
 
 	// Test writing
 	metrics := []telegraf.Metric{
-		testutil.MustMetric(
+		metric.New(
 			"cpu",
 			map[string]string{},
 			map[string]interface{}{
@@ -427,7 +427,7 @@ func TestWriteConvertUint(t *testing.T) {
 
 	// Test writing
 	metrics := []telegraf.Metric{
-		testutil.MustMetric(
+		metric.New(
 			"cpu",
 			map[string]string{},
 			map[string]interface{}{
@@ -475,7 +475,7 @@ func TestWriteExplicitNoSync(t *testing.T) {
 
 	// Test writing
 	metrics := []telegraf.Metric{
-		testutil.MustMetric(
+		metric.New(
 			"cpu",
 			map[string]string{
 				"database": "foobar",
@@ -545,7 +545,7 @@ func TestWriteDatabaseTagWorksOnRetry(t *testing.T) {
 
 	// Send the metrics which should be succeed if sent twice
 	metrics := []telegraf.Metric{
-		testutil.MustMetric(
+		metric.New(
 			"cpu",
 			map[string]string{
 				"database": "foo",


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Covers health, influxdb, influxdb_v2, and influxdb_v3 outputs.

Part of #18495 - testutil.MustMetric is a trivial wrapper around metric.New that adds no value and misleads with its "Must" prefix.

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
