### PR TITLE
chore(outputs): Replace testutil.MustMetric with metric.New

### DIFF
--- a/plugins/outputs/kafka/kafka_test.go
+++ b/plugins/outputs/kafka/kafka_test.go
@@ -218,7 +218,7 @@ func TestTopicTag(t *testing.T) {
 
 	// Define an input metric for writing
 	input := []telegraf.Metric{
-		testutil.MustMetric(
+		metric.New(
 			"cpu",
 			map[string]string{
 				"topic": "xyzzy",

--- a/plugins/outputs/loki/loki_test.go
+++ b/plugins/outputs/loki/loki_test.go
@@ -17,11 +17,11 @@ import (
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/internal"
-	"github.com/influxdata/telegraf/testutil"
+	"github.com/influxdata/telegraf/metric"
 )
 
 func getMetric() telegraf.Metric {
-	return testutil.MustMetric(
+	return metric.New(
 		"log",
 		map[string]string{
 			"key1": "value1",
@@ -36,7 +36,7 @@ func getMetric() telegraf.Metric {
 
 func getOutOfOrderMetrics() []telegraf.Metric {
 	return []telegraf.Metric{
-		testutil.MustMetric(
+		metric.New(
 			"log",
 			map[string]string{
 				"key1": "value1",
@@ -47,7 +47,7 @@ func getOutOfOrderMetrics() []telegraf.Metric {
 			},
 			time.Unix(1230, 0),
 		),
-		testutil.MustMetric(
+		metric.New(
 			"log",
 			map[string]string{
 				"key1": "value1",

--- a/plugins/outputs/nebius_cloud_monitoring/nebius_cloud_monitoring_test.go
+++ b/plugins/outputs/nebius_cloud_monitoring/nebius_cloud_monitoring_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/metric"
 	"github.com/influxdata/telegraf/testutil"
 )
 
@@ -64,7 +65,7 @@ func TestWrite(t *testing.T) {
 			name:   "metric is converted to json value",
 			plugin: &NebiusCloudMonitoring{},
 			metrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"cluster",
 					map[string]string{},
 					map[string]interface{}{
@@ -86,7 +87,7 @@ func TestWrite(t *testing.T) {
 			name:   "int64 metric is converted to json value",
 			plugin: &NebiusCloudMonitoring{},
 			metrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"cluster",
 					map[string]string{},
 					map[string]interface{}{
@@ -108,7 +109,7 @@ func TestWrite(t *testing.T) {
 			name:   "int metric is converted to json value",
 			plugin: &NebiusCloudMonitoring{},
 			metrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"cluster",
 					map[string]string{},
 					map[string]interface{}{
@@ -130,7 +131,7 @@ func TestWrite(t *testing.T) {
 			name:   "label with name 'name' is replaced with '_name'",
 			plugin: &NebiusCloudMonitoring{},
 			metrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"cluster",
 					map[string]string{
 						"name": "accounts-daemon.service",

--- a/plugins/outputs/opentelemetry/opentelemetry_test.go
+++ b/plugins/outputs/opentelemetry/opentelemetry_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
+	"github.com/influxdata/telegraf/metric"
 	"github.com/influxdata/telegraf/testutil"
 )
 
@@ -59,7 +60,7 @@ func TestOpenTelemetry(t *testing.T) {
 		Log: testutil.Logger{},
 	}
 
-	input := testutil.MustMetric(
+	input := metric.New(
 		"cpu_temp",
 		map[string]string{
 			"foo":               "bar",
@@ -158,7 +159,7 @@ func TestOpenTelemetryHTTPProtobuf(t *testing.T) {
 	}
 	require.NoError(t, plugin.Connect())
 
-	input := testutil.MustMetric(
+	input := metric.New(
 		"cpu_temp",
 		map[string]string{
 			"foo":               "bar",
@@ -256,7 +257,7 @@ func TestOpenTelemetryHTTPJSON(t *testing.T) {
 	}
 	require.NoError(t, plugin.Connect())
 
-	input := testutil.MustMetric(
+	input := metric.New(
 		"cpu_temp",
 		map[string]string{
 			"foo":               "bar",

--- a/plugins/outputs/parquet/parquet_test.go
+++ b/plugins/outputs/parquet/parquet_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
-	"github.com/influxdata/telegraf/testutil"
+	"github.com/influxdata/telegraf/metric"
 )
 
 func TestCases(t *testing.T) {
@@ -26,7 +26,7 @@ func TestCases(t *testing.T) {
 		{
 			name: "basic single metric",
 			metrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"test",
 					map[string]string{},
 					map[string]interface{}{
@@ -41,7 +41,7 @@ func TestCases(t *testing.T) {
 		{
 			name: "mix of tags and fields",
 			metrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"test",
 					map[string]string{
 						"tag": "tag",
@@ -51,7 +51,7 @@ func TestCases(t *testing.T) {
 					},
 					time.Now(),
 				),
-				testutil.MustMetric(
+				metric.New(
 					"test",
 					map[string]string{
 						"tag": "tag2",
@@ -68,7 +68,7 @@ func TestCases(t *testing.T) {
 		{
 			name: "null values",
 			metrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"test",
 					map[string]string{
 						"host": "tag",
@@ -78,7 +78,7 @@ func TestCases(t *testing.T) {
 					},
 					time.Now(),
 				),
-				testutil.MustMetric(
+				metric.New(
 					"test",
 					map[string]string{
 						"tag": "tag2",
@@ -95,7 +95,7 @@ func TestCases(t *testing.T) {
 		{
 			name: "data types",
 			metrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"test",
 					map[string]string{},
 					map[string]interface{}{
@@ -151,7 +151,7 @@ func TestCases(t *testing.T) {
 
 func TestRotation(t *testing.T) {
 	metrics := []telegraf.Metric{
-		testutil.MustMetric(
+		metric.New(
 			"test",
 			map[string]string{},
 			map[string]interface{}{
@@ -181,7 +181,7 @@ func TestRotation(t *testing.T) {
 
 func TestOmitTimestamp(t *testing.T) {
 	metrics := []telegraf.Metric{
-		testutil.MustMetric(
+		metric.New(
 			"test",
 			map[string]string{},
 			map[string]interface{}{
@@ -214,7 +214,7 @@ func TestOmitTimestamp(t *testing.T) {
 
 func TestTimestampDifferentName(t *testing.T) {
 	metrics := []telegraf.Metric{
-		testutil.MustMetric(
+		metric.New(
 			"test",
 			map[string]string{},
 			map[string]interface{}{

--- a/plugins/outputs/postgresql/postgresql_test.go
+++ b/plugins/outputs/postgresql/postgresql_test.go
@@ -387,7 +387,7 @@ func newMetric(
 	tags map[string]string,
 	fields map[string]interface{},
 ) telegraf.Metric {
-	return testutil.MustMetric(t.Name()+suffix, tags, fields, time.Now())
+	return metric.New(t.Name()+suffix, tags, fields, time.Now())
 }
 
 type MSS = map[string]string


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Covers kafka, loki, nebius_cloud_monitoring, opentelemetry, parquet, and postgresql outputs.

Part of #18495 - testutil.MustMetric is a trivial wrapper around metric.New that adds no value and misleads with its "Must" prefix.

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
