### PR TITLE
chore(outputs): Replace testutil.MustMetric with metric.New

### DIFF
--- a/plugins/outputs/prometheus_client/prometheus_client_v1_test.go
+++ b/plugins/outputs/prometheus_client/prometheus_client_v1_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/metric"
 	inputs "github.com/influxdata/telegraf/plugins/inputs/prometheus"
 	"github.com/influxdata/telegraf/plugins/serializers/prometheus"
 	"github.com/influxdata/telegraf/testutil"
@@ -37,7 +38,7 @@ func TestMetricVersion1(t *testing.T) {
 				Log:               logger,
 			},
 			metrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{
 						"host": "example.org",
@@ -64,7 +65,7 @@ cpu_time_idle{host="example.org"} 42
 				Log:               logger,
 			},
 			metrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"cpu_time_idle",
 					map[string]string{
 						"host": "example.org",
@@ -91,7 +92,7 @@ cpu_time_idle{host="example.org"} 42
 				Log:               logger,
 			},
 			metrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"cpu_time_idle",
 					map[string]string{
 						"host": "example.org",
@@ -120,7 +121,7 @@ cpu_time_idle{host="example.org"} 42
 				Log:               logger,
 			},
 			metrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"cpu_time_idle",
 					map[string]string{
 						"host": "example.org",
@@ -149,7 +150,7 @@ cpu_time_idle{host="example.org"} 42 1257894000000
 				Log:               logger,
 			},
 			metrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"cpu_time_idle",
 					map[string]string{},
 					map[string]interface{}{
@@ -177,7 +178,7 @@ cpu_time_idle{host_name="example.org"} 42
 				Log:               logger,
 			},
 			metrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"温度-指标",
 					map[string]string{
 						"主机-名": "example.org",
@@ -206,7 +207,7 @@ cpu_time_idle{host_name="example.org"} 42
 				Log:               logger,
 			},
 			metrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"cpu_time_idle",
 					map[string]string{
 						"host": "example.org",
@@ -234,7 +235,7 @@ cpu_time_idle{host="example.org"} 42
 				Log:               logger,
 			},
 			metrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"http_request_duration_seconds",
 					map[string]string{},
 					map[string]interface{}{
@@ -274,7 +275,7 @@ http_request_duration_seconds_count 144320
 				Log:               logger,
 			},
 			metrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"rpc_duration_seconds",
 					map[string]string{},
 					map[string]interface{}{
@@ -313,7 +314,7 @@ rpc_duration_seconds_count 2693
 				Log:               logger,
 			},
 			metrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"cpu_time_idle",
 					map[string]string{
 						"host": "example.org",
@@ -341,7 +342,7 @@ cpu_time_idle{host="example.org"} 42
 				Log:               logger,
 			},
 			metrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"cpu_time_idle",
 					map[string]string{
 						"host": "example.org",

--- a/plugins/outputs/prometheus_client/prometheus_client_v2_test.go
+++ b/plugins/outputs/prometheus_client/prometheus_client_v2_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/metric"
 	inputs "github.com/influxdata/telegraf/plugins/inputs/prometheus"
 	"github.com/influxdata/telegraf/plugins/serializers/prometheus"
 	"github.com/influxdata/telegraf/testutil"
@@ -37,7 +38,7 @@ func TestMetricVersion2(t *testing.T) {
 				Log:               logger,
 			},
 			metrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{
 						"host": "example.org",
@@ -64,7 +65,7 @@ cpu_time_idle{host="example.org"} 42
 				Log:               logger,
 			},
 			metrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"prometheus",
 					map[string]string{},
 					map[string]interface{}{
@@ -93,7 +94,7 @@ rpc_duration_seconds_count 2693
 				Log:               logger,
 			},
 			metrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{
 						"host": "example.org",
@@ -121,7 +122,7 @@ cpu_time_idle{host="example.org"} 42 0
 				Log:               logger,
 			},
 			metrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{},
 					map[string]interface{}{
@@ -148,7 +149,7 @@ cpu_time_idle{host="example.org"} 42
 				Log:               logger,
 			},
 			metrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{},
 					map[string]interface{}{
@@ -175,7 +176,7 @@ cpu_time_idle 42
 				Log:               logger,
 			},
 			metrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"温度-指标",
 					map[string]string{
 						"主机-名": "example.org",
@@ -203,7 +204,7 @@ cpu_time_idle 42
 				Log:               logger,
 			},
 			metrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"prometheus",
 					map[string]string{
 						"host": "example.org",
@@ -230,7 +231,7 @@ cpu_time_idle{host="example.org"} 42
 				Log:               logger,
 			},
 			metrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{
 						"cpu": "cpu1",
@@ -242,7 +243,7 @@ cpu_time_idle{host="example.org"} 42
 					time.Unix(0, 0),
 					telegraf.Histogram,
 				),
-				testutil.MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{
 						"cpu": "cpu1",
@@ -254,7 +255,7 @@ cpu_time_idle{host="example.org"} 42
 					time.Unix(0, 0),
 					telegraf.Histogram,
 				),
-				testutil.MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{
 						"cpu": "cpu1",
@@ -266,7 +267,7 @@ cpu_time_idle{host="example.org"} 42
 					time.Unix(0, 0),
 					telegraf.Histogram,
 				),
-				testutil.MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{
 						"cpu": "cpu1",
@@ -278,7 +279,7 @@ cpu_time_idle{host="example.org"} 42
 					time.Unix(0, 0),
 					telegraf.Histogram,
 				),
-				testutil.MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{
 						"cpu": "cpu1",
@@ -312,7 +313,7 @@ cpu_usage_idle_count{cpu="cpu1"} 20
 				Log:               logger,
 			},
 			metrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{
 						"cpu": "cpu1",
@@ -344,7 +345,7 @@ cpu_usage_idle_count{cpu="cpu1"} 20
 				Log:               logger,
 			},
 			metrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"prometheus",
 					map[string]string{
 						"host": "example.org",
@@ -372,7 +373,7 @@ cpu_time_idle{host="example.org"} 42
 				Log:               logger,
 			},
 			metrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"prometheus",
 					map[string]string{
 						"host": "example.org",

--- a/plugins/outputs/timestream/timestream_test.go
+++ b/plugins/outputs/timestream/timestream_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/metric"
 	common_aws "github.com/influxdata/telegraf/plugins/common/aws"
 	"github.com/influxdata/telegraf/testutil"
 )
@@ -240,7 +241,7 @@ func TestWriteMultiMeasuresSingleTableMode(t *testing.T) {
 
 		fieldName1 := "value_supported1" + strconv.Itoa(i)
 		fieldName2 := "value_supported2" + strconv.Itoa(i)
-		inputs = append(inputs, testutil.MustMetric(
+		inputs = append(inputs, metric.New(
 			"multi_measure_name",
 			map[string]string{"tag1": "value1"},
 			map[string]interface{}{
@@ -298,7 +299,7 @@ func TestWriteMultiMeasuresMultiTableMode(t *testing.T) {
 
 		fieldName1 := "value_supported1" + strconv.Itoa(i)
 		fieldName2 := "value_supported2" + strconv.Itoa(i)
-		inputs = append(inputs, testutil.MustMetric(
+		inputs = append(inputs, metric.New(
 			"multi_measure_name",
 			map[string]string{"tag1": "value1"},
 			map[string]interface{}{
@@ -349,7 +350,7 @@ func TestWriteMultiMeasuresMultiTableMode(t *testing.T) {
 }
 
 func TestBuildMultiMeasuresInSingleAndMultiTableMode(t *testing.T) {
-	input1 := testutil.MustMetric(
+	input1 := metric.New(
 		metricName1,
 		map[string]string{"tag1": "value1"},
 		map[string]interface{}{
@@ -358,7 +359,7 @@ func TestBuildMultiMeasuresInSingleAndMultiTableMode(t *testing.T) {
 		time1,
 	)
 
-	input2 := testutil.MustMetric(
+	input2 := metric.New(
 		metricName1,
 		map[string]string{"tag2": "value2"},
 		map[string]interface{}{
@@ -367,7 +368,7 @@ func TestBuildMultiMeasuresInSingleAndMultiTableMode(t *testing.T) {
 		time1,
 	)
 
-	input3 := testutil.MustMetric(
+	input3 := metric.New(
 		metricName1,
 		map[string]string{"tag3": "value3"},
 		map[string]interface{}{
@@ -376,7 +377,7 @@ func TestBuildMultiMeasuresInSingleAndMultiTableMode(t *testing.T) {
 		time1,
 	)
 
-	input4 := testutil.MustMetric(
+	input4 := metric.New(
 		metricName1,
 		map[string]string{"tag4": "value4"},
 		map[string]interface{}{
@@ -385,7 +386,7 @@ func TestBuildMultiMeasuresInSingleAndMultiTableMode(t *testing.T) {
 		time1,
 	)
 
-	input5 := testutil.MustMetric(
+	input5 := metric.New(
 		metricName1,
 		map[string]string{"tag5": "value5"},
 		map[string]interface{}{
@@ -394,7 +395,7 @@ func TestBuildMultiMeasuresInSingleAndMultiTableMode(t *testing.T) {
 		time1,
 	)
 
-	input6 := testutil.MustMetric(
+	input6 := metric.New(
 		metricName1,
 		map[string]string{"tag6": "value6"},
 		map[string]interface{}{
@@ -596,7 +597,7 @@ func TestThrottlingErrorIsReturnedToTelegraf(t *testing.T) {
 		Log:          testutil.Logger{},
 	}
 	require.NoError(t, plugin.Connect())
-	input := testutil.MustMetric(
+	input := metric.New(
 		metricName1,
 		map[string]string{"tag1": "value1"},
 		map[string]interface{}{"value": float64(1)},
@@ -622,7 +623,7 @@ func TestRejectedRecordsErrorResultsInMetricsBeingSkipped(t *testing.T) {
 		Log:          testutil.Logger{},
 	}
 	require.NoError(t, plugin.Connect())
-	input := testutil.MustMetric(
+	input := metric.New(
 		metricName1,
 		map[string]string{"tag1": "value1"},
 		map[string]interface{}{"value": float64(1)},
@@ -658,7 +659,7 @@ func TestWriteWhenRequestsGreaterThanMaxWriteGoRoutinesCount(t *testing.T) {
 	inputs := make([]telegraf.Metric, 0, totalRecords)
 	for i := 1; i <= totalRecords; i++ {
 		fieldName := "value_supported" + strconv.Itoa(i)
-		inputs = append(inputs, testutil.MustMetric(
+		inputs = append(inputs, metric.New(
 			metricName1,
 			map[string]string{"tag1": "value1"},
 			map[string]interface{}{
@@ -697,7 +698,7 @@ func TestWriteWhenRequestsLesserThanMaxWriteGoRoutinesCount(t *testing.T) {
 	inputs := make([]telegraf.Metric, 0, totalRecords)
 	for i := 1; i <= totalRecords; i++ {
 		fieldName := "value_supported" + strconv.Itoa(i)
-		inputs = append(inputs, testutil.MustMetric(
+		inputs = append(inputs, metric.New(
 			metricName1,
 			map[string]string{"tag1": "value1"},
 			map[string]interface{}{
@@ -713,13 +714,13 @@ func TestWriteWhenRequestsLesserThanMaxWriteGoRoutinesCount(t *testing.T) {
 }
 
 func TestTransformMetricsSkipEmptyMetric(t *testing.T) {
-	input1 := testutil.MustMetric(
+	input1 := metric.New(
 		metricName1,
 		map[string]string{"tag1": "value1"},
 		map[string]interface{}{}, // no fields here
 		time1,
 	)
-	input2 := testutil.MustMetric(
+	input2 := metric.New(
 		metricName1,
 		map[string]string{"tag2": "value2"},
 		map[string]interface{}{
@@ -727,7 +728,7 @@ func TestTransformMetricsSkipEmptyMetric(t *testing.T) {
 		},
 		time1,
 	)
-	input3 := testutil.MustMetric(
+	input3 := metric.New(
 		metricName1,
 		map[string]string{}, // record with no dimensions should appear in the results
 		map[string]interface{}{
@@ -796,7 +797,7 @@ func TestTransformMetricsRequestsAboveLimitAreSplit(t *testing.T) {
 	inputs := make([]telegraf.Metric, 0, maxRecordsInWriteRecordsCall+1)
 	for i := 1; i <= maxRecordsInWriteRecordsCall+1; i++ {
 		fieldName := "value_supported" + strconv.Itoa(i)
-		inputs = append(inputs, testutil.MustMetric(
+		inputs = append(inputs, metric.New(
 			metricName1,
 			map[string]string{"tag1": "value1"},
 			map[string]interface{}{
@@ -856,7 +857,7 @@ func TestTransformMetricsRequestsAboveLimitAreSplitSingleTable(t *testing.T) {
 		localTime++
 
 		fieldName := "value_supported" + strconv.Itoa(i)
-		inputs = append(inputs, testutil.MustMetric(
+		inputs = append(inputs, metric.New(
 			metricName1,
 			map[string]string{"tag1": "value1"},
 			map[string]interface{}{
@@ -913,7 +914,7 @@ func TestTransformMetricsRequestsAboveLimitAreSplitSingleTable(t *testing.T) {
 }
 
 func TestTransformMetricsDifferentDimensionsSameTimestampsAreWrittenSeparate(t *testing.T) {
-	input1 := testutil.MustMetric(
+	input1 := metric.New(
 		metricName1,
 		map[string]string{"tag1": "value1"},
 		map[string]interface{}{
@@ -922,7 +923,7 @@ func TestTransformMetricsDifferentDimensionsSameTimestampsAreWrittenSeparate(t *
 		time1,
 	)
 
-	input2 := testutil.MustMetric(
+	input2 := metric.New(
 		metricName2,
 		map[string]string{"tag2": "value2"},
 		map[string]interface{}{
@@ -977,7 +978,7 @@ func TestTransformMetricsDifferentDimensionsSameTimestampsAreWrittenSeparate(t *
 }
 
 func TestTransformMetricsSameDimensionsDifferentDimensionValuesAreWrittenSeparate(t *testing.T) {
-	input1 := testutil.MustMetric(
+	input1 := metric.New(
 		metricName1,
 		map[string]string{"tag1": "value1"},
 		map[string]interface{}{
@@ -985,7 +986,7 @@ func TestTransformMetricsSameDimensionsDifferentDimensionValuesAreWrittenSeparat
 		},
 		time1,
 	)
-	input2 := testutil.MustMetric(
+	input2 := metric.New(
 		metricName2,
 		map[string]string{"tag1": "value2"},
 		map[string]interface{}{
@@ -1039,7 +1040,7 @@ func TestTransformMetricsSameDimensionsDifferentDimensionValuesAreWrittenSeparat
 }
 
 func TestTransformMetricsSameDimensionsDifferentTimestampsAreWrittenSeparate(t *testing.T) {
-	input1 := testutil.MustMetric(
+	input1 := metric.New(
 		metricName1,
 		map[string]string{"tag1": "value1"},
 		map[string]interface{}{
@@ -1047,7 +1048,7 @@ func TestTransformMetricsSameDimensionsDifferentTimestampsAreWrittenSeparate(t *
 		},
 		time1,
 	)
-	input2 := testutil.MustMetric(
+	input2 := metric.New(
 		metricName1,
 		map[string]string{"tag1": "value1"},
 		map[string]interface{}{
@@ -1110,7 +1111,7 @@ func TestTransformMetricsSameDimensionsDifferentTimestampsAreWrittenSeparate(t *
 }
 
 func TestTransformMetricsSameDimensionsSameTimestampsAreWrittenTogether(t *testing.T) {
-	input1 := testutil.MustMetric(
+	input1 := metric.New(
 		metricName1,
 		map[string]string{"tag1": "value1"},
 		map[string]interface{}{
@@ -1118,7 +1119,7 @@ func TestTransformMetricsSameDimensionsSameTimestampsAreWrittenTogether(t *testi
 		},
 		time1,
 	)
-	input2 := testutil.MustMetric(
+	input2 := metric.New(
 		metricName1,
 		map[string]string{"tag1": "value1"},
 		map[string]interface{}{
@@ -1151,7 +1152,7 @@ func TestTransformMetricsSameDimensionsSameTimestampsAreWrittenTogether(t *testi
 }
 
 func TestTransformMetricsDifferentMetricsAreWrittenToDifferentTablesInMultiTableMapping(t *testing.T) {
-	input1 := testutil.MustMetric(
+	input1 := metric.New(
 		metricName1,
 		map[string]string{"tag1": "value1"},
 		map[string]interface{}{
@@ -1159,7 +1160,7 @@ func TestTransformMetricsDifferentMetricsAreWrittenToDifferentTablesInMultiTable
 		},
 		time1,
 	)
-	input2 := testutil.MustMetric(
+	input2 := metric.New(
 		metricName2,
 		map[string]string{"tag1": "value1"},
 		map[string]interface{}{
@@ -1213,7 +1214,7 @@ func TestTransformMetricsDifferentMetricsAreWrittenToDifferentTablesInMultiTable
 }
 
 func TestTransformMetricsUnsupportedFieldsAreSkipped(t *testing.T) {
-	metricWithUnsupportedField := testutil.MustMetric(
+	metricWithUnsupportedField := metric.New(
 		metricName1,
 		map[string]string{"tag1": "value1"},
 		map[string]interface{}{

--- a/plugins/outputs/yandex_cloud_monitoring/yandex_cloud_monitoring_test.go
+++ b/plugins/outputs/yandex_cloud_monitoring/yandex_cloud_monitoring_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/metric"
 	"github.com/influxdata/telegraf/testutil"
 )
 
@@ -65,7 +66,7 @@ func TestWrite(t *testing.T) {
 			name:   "metric is converted to json value",
 			plugin: &YandexCloudMonitoring{},
 			metrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"cluster",
 					map[string]string{},
 					map[string]interface{}{
@@ -86,7 +87,7 @@ func TestWrite(t *testing.T) {
 			name:   "int64 metric is converted to json value",
 			plugin: &YandexCloudMonitoring{},
 			metrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"cluster",
 					map[string]string{},
 					map[string]interface{}{
@@ -107,7 +108,7 @@ func TestWrite(t *testing.T) {
 			name:   "int metric is converted to json value",
 			plugin: &YandexCloudMonitoring{},
 			metrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"cluster",
 					map[string]string{},
 					map[string]interface{}{

--- a/plugins/outputs/zabbix/lld_test.go
+++ b/plugins/outputs/zabbix/lld_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
+	"github.com/influxdata/telegraf/metric"
 	"github.com/influxdata/telegraf/testutil"
 )
 
@@ -32,7 +33,7 @@ func TestAddAndPush(t *testing.T) {
 	tests := map[string][]Operations{
 		"metric without extra tags does not generate LLD metric": {
 			OperationAdd{
-				testutil.MustMetric(
+				metric.New(
 					"name",
 					map[string]string{"host": "hostA"},
 					map[string]interface{}{"value": 1},
@@ -42,7 +43,7 @@ func TestAddAndPush(t *testing.T) {
 		},
 		"simple Add, Push and check generated LLD metric": {
 			OperationAdd{
-				testutil.MustMetric(
+				metric.New(
 					"name",
 					map[string]string{"host": "hostA", "foo": "bar"},
 					map[string]interface{}{"value": 1},
@@ -50,7 +51,7 @@ func TestAddAndPush(t *testing.T) {
 			},
 			OperationPush{},
 			OperationCheck{
-				testutil.MustMetric(
+				metric.New(
 					lldName,
 					map[string]string{"host": "hostA"},
 					map[string]interface{}{"name.foo": `{"data":[{"{#FOO}":"bar"}]}`},
@@ -60,14 +61,14 @@ func TestAddAndPush(t *testing.T) {
 		},
 		"same metric with different tag values": {
 			OperationAdd{
-				testutil.MustMetric(
+				metric.New(
 					"name",
 					map[string]string{"host": "hostA", "foo": "bar1"},
 					map[string]interface{}{"value": 1},
 					time.Now()),
 			},
 			OperationAdd{
-				testutil.MustMetric(
+				metric.New(
 					"name",
 					map[string]string{"host": "hostA", "foo": "bar2"},
 					map[string]interface{}{"value": 1},
@@ -75,7 +76,7 @@ func TestAddAndPush(t *testing.T) {
 			},
 			OperationPush{},
 			OperationCheck{
-				testutil.MustMetric(
+				metric.New(
 					lldName,
 					map[string]string{"host": "hostA"},
 					map[string]interface{}{"name.foo": `{"data":[{"{#FOO}":"bar1"},{"{#FOO}":"bar2"}]}`},
@@ -85,12 +86,12 @@ func TestAddAndPush(t *testing.T) {
 		},
 		"add two metrics, Push and check generated LLD metric": {
 			OperationAdd{
-				testutil.MustMetric(
+				metric.New(
 					"nameA",
 					map[string]string{"host": "hostA", "foo": "bar"},
 					map[string]interface{}{"value": 1},
 					time.Now()),
-				testutil.MustMetric(
+				metric.New(
 					"nameB",
 					map[string]string{"host": "hostA", "foo": "bar"},
 					map[string]interface{}{"value": 1},
@@ -98,13 +99,13 @@ func TestAddAndPush(t *testing.T) {
 			},
 			OperationPush{},
 			OperationCheck{
-				testutil.MustMetric(
+				metric.New(
 					lldName,
 					map[string]string{"host": "hostA"},
 					map[string]interface{}{"nameA.foo": `{"data":[{"{#FOO}":"bar"}]}`},
 					time.Now(),
 				),
-				testutil.MustMetric(
+				metric.New(
 					lldName,
 					map[string]string{"host": "hostA"},
 					map[string]interface{}{"nameB.foo": `{"data":[{"{#FOO}":"bar"}]}`},
@@ -114,12 +115,12 @@ func TestAddAndPush(t *testing.T) {
 		},
 		"add two similar metrics, one with one more extra tag": {
 			OperationAdd{
-				testutil.MustMetric(
+				metric.New(
 					"nameA",
 					map[string]string{"host": "hostA", "foo1": "bar"},
 					map[string]interface{}{"value": 1},
 					time.Now()),
-				testutil.MustMetric(
+				metric.New(
 					"nameA",
 					map[string]string{"host": "hostA", "foo1": "bar", "foo2": "baz"},
 					map[string]interface{}{"value": 1},
@@ -127,13 +128,13 @@ func TestAddAndPush(t *testing.T) {
 			},
 			OperationPush{},
 			OperationCheck{
-				testutil.MustMetric(
+				metric.New(
 					lldName,
 					map[string]string{"host": "hostA"},
 					map[string]interface{}{"nameA.foo1": `{"data":[{"{#FOO1}":"bar"}]}`},
 					time.Now(),
 				),
-				testutil.MustMetric(
+				metric.New(
 					lldName,
 					map[string]string{"host": "hostA"},
 					map[string]interface{}{"nameA.foo1.foo2": `{"data":[{"{#FOO1}":"bar","{#FOO2}":"baz"}]}`},
@@ -143,19 +144,19 @@ func TestAddAndPush(t *testing.T) {
 		},
 		"same metric several times generate only one LLD": {
 			OperationAdd{
-				testutil.MustMetric(
+				metric.New(
 					"name",
 					map[string]string{"host": "hostA", "foo": "bar"},
 					map[string]interface{}{"value": 1},
 					time.Now(),
 				),
-				testutil.MustMetric(
+				metric.New(
 					"name",
 					map[string]string{"host": "hostA", "foo": "bar"},
 					map[string]interface{}{"value": 1},
 					time.Now(),
 				),
-				testutil.MustMetric(
+				metric.New(
 					"name",
 					map[string]string{"host": "hostA", "foo": "bar"},
 					map[string]interface{}{"value": 1},
@@ -164,7 +165,7 @@ func TestAddAndPush(t *testing.T) {
 			},
 			OperationPush{},
 			OperationCheck{
-				testutil.MustMetric(
+				metric.New(
 					lldName,
 					map[string]string{"host": "hostA"},
 					map[string]interface{}{"name.foo": `{"data":[{"{#FOO}":"bar"}]}`},
@@ -174,19 +175,19 @@ func TestAddAndPush(t *testing.T) {
 		},
 		"same metric several times, with different tag ordering, generate only one LLD": {
 			OperationAdd{
-				testutil.MustMetric(
+				metric.New(
 					"name",
 					map[string]string{"host": "hostA", "foo": "bar", "baz": "qux"},
 					map[string]interface{}{"value": 1},
 					time.Now(),
 				),
-				testutil.MustMetric(
+				metric.New(
 					"name",
 					map[string]string{"host": "hostA", "baz": "qux", "foo": "bar"},
 					map[string]interface{}{"value": 1},
 					time.Now(),
 				),
-				testutil.MustMetric(
+				metric.New(
 					"name",
 					map[string]string{"baz": "qux", "foo": "bar", "host": "hostA"},
 					map[string]interface{}{"value": 1},
@@ -195,7 +196,7 @@ func TestAddAndPush(t *testing.T) {
 			},
 			OperationPush{},
 			OperationCheck{
-				testutil.MustMetric(
+				metric.New(
 					lldName,
 					map[string]string{"host": "hostA"},
 					map[string]interface{}{"name.baz.foo": `{"data":[{"{#BAZ}":"qux","{#FOO}":"bar"}]}`},
@@ -204,7 +205,7 @@ func TestAddAndPush(t *testing.T) {
 			},
 		},
 		"after sending correctly an LLD, same tag values does not generate the same LLD": {
-			OperationAdd{testutil.MustMetric(
+			OperationAdd{metric.New(
 				"name",
 				map[string]string{"host": "hostA", "foo": "bar"},
 				map[string]interface{}{"value": 1},
@@ -212,14 +213,14 @@ func TestAddAndPush(t *testing.T) {
 			)},
 			OperationPush{},
 			OperationCheck{
-				testutil.MustMetric(
+				metric.New(
 					lldName,
 					map[string]string{"host": "hostA"},
 					map[string]interface{}{"name.foo": `{"data":[{"{#FOO}":"bar"}]}`},
 					time.Now(),
 				),
 			},
-			OperationAdd{testutil.MustMetric(
+			OperationAdd{metric.New(
 				"name",
 				map[string]string{"host": "hostA", "foo": "bar"},
 				map[string]interface{}{"value": 1},
@@ -228,7 +229,7 @@ func TestAddAndPush(t *testing.T) {
 			OperationPush{},
 		},
 		"after lld_clear_interval, already seen LLDs could be resend": {
-			OperationAdd{testutil.MustMetric(
+			OperationAdd{metric.New(
 				"name",
 				map[string]string{"host": "hostA", "foo": "bar"},
 				map[string]interface{}{"value": 1},
@@ -236,14 +237,14 @@ func TestAddAndPush(t *testing.T) {
 			)},
 			OperationPush{},
 			OperationCheck{
-				testutil.MustMetric(
+				metric.New(
 					lldName,
 					map[string]string{"host": "hostA"},
 					map[string]interface{}{"name.foo": `{"data":[{"{#FOO}":"bar"}]}`},
 					time.Now(),
 				),
 			},
-			OperationAdd{testutil.MustMetric(
+			OperationAdd{metric.New(
 				"name",
 				map[string]string{"host": "hostA", "foo": "bar"},
 				map[string]interface{}{"value": 1},
@@ -251,14 +252,14 @@ func TestAddAndPush(t *testing.T) {
 			)},
 			OperationPush{},
 			OperationCrossClearIntervalTime{}, // The clear of the previous LLD seen is done in the next push
-			OperationAdd{testutil.MustMetric(
+			OperationAdd{metric.New(
 				"name",
 				map[string]string{"host": "hostA", "foo": "bar"},
 				map[string]interface{}{"value": 1},
 				time.Now(),
 			)},
 			OperationPush{},
-			OperationAdd{testutil.MustMetric(
+			OperationAdd{metric.New(
 				"name",
 				map[string]string{"host": "hostA", "foo": "bar"},
 				map[string]interface{}{"value": 1},
@@ -266,7 +267,7 @@ func TestAddAndPush(t *testing.T) {
 			)},
 			OperationPush{},
 			OperationCheck{
-				testutil.MustMetric(
+				metric.New(
 					lldName,
 					map[string]string{"host": "hostA"},
 					map[string]interface{}{"name.foo": `{"data":[{"{#FOO}":"bar"}]}`},
@@ -275,7 +276,7 @@ func TestAddAndPush(t *testing.T) {
 			},
 		},
 		"clear interval does not interfere with the send of empty LLDs": {
-			OperationAdd{testutil.MustMetric(
+			OperationAdd{metric.New(
 				"name",
 				map[string]string{"host": "hostA", "foo": "bar"},
 				map[string]interface{}{"value": 1},
@@ -283,14 +284,14 @@ func TestAddAndPush(t *testing.T) {
 			)},
 			OperationPush{},
 			OperationCheck{
-				testutil.MustMetric(
+				metric.New(
 					lldName,
 					map[string]string{"host": "hostA"},
 					map[string]interface{}{"name.foo": `{"data":[{"{#FOO}":"bar"}]}`},
 					time.Now(),
 				),
 			},
-			OperationAdd{testutil.MustMetric(
+			OperationAdd{metric.New(
 				"name",
 				map[string]string{"host": "hostA", "foo": "bar"},
 				map[string]interface{}{"value": 1},
@@ -301,7 +302,7 @@ func TestAddAndPush(t *testing.T) {
 			OperationCrossClearIntervalTime{}, // The clear of the previous LLD seen is done in the next push
 			OperationPush{},
 			OperationCheck{
-				testutil.MustMetric(
+				metric.New(
 					lldName,
 					map[string]string{"host": "hostA"},
 					map[string]interface{}{"name.foo": `{"data":[]}`},
@@ -310,7 +311,7 @@ func TestAddAndPush(t *testing.T) {
 			},
 		},
 		"one metric changes the value of the tag, it should send the new value and not send and empty lld": {
-			OperationAdd{testutil.MustMetric(
+			OperationAdd{metric.New(
 				"name",
 				map[string]string{"host": "hostA", "foo": "bar1"},
 				map[string]interface{}{"value": 1},
@@ -318,14 +319,14 @@ func TestAddAndPush(t *testing.T) {
 			)},
 			OperationPush{},
 			OperationCheck{
-				testutil.MustMetric(
+				metric.New(
 					lldName,
 					map[string]string{"host": "hostA"},
 					map[string]interface{}{"name.foo": `{"data":[{"{#FOO}":"bar1"}]}`},
 					time.Now(),
 				),
 			},
-			OperationAdd{testutil.MustMetric(
+			OperationAdd{metric.New(
 				"name",
 				map[string]string{"host": "hostA", "foo": "bar2"},
 				map[string]interface{}{"value": 1},
@@ -333,7 +334,7 @@ func TestAddAndPush(t *testing.T) {
 			)},
 			OperationPush{},
 			OperationCheck{
-				testutil.MustMetric(
+				metric.New(
 					lldName,
 					map[string]string{"host": "hostA"},
 					map[string]interface{}{"name.foo": `{"data":[{"{#FOO}":"bar2"}]}`},
@@ -342,7 +343,7 @@ func TestAddAndPush(t *testing.T) {
 			},
 		},
 		"if one input stop sending metrics, an empty LLD is sent": {
-			OperationAdd{testutil.MustMetric(
+			OperationAdd{metric.New(
 				"name",
 				map[string]string{"host": "hostA", "foo": "bar"},
 				map[string]interface{}{"value": 1},
@@ -350,7 +351,7 @@ func TestAddAndPush(t *testing.T) {
 			)},
 			OperationPush{},
 			OperationCheck{
-				testutil.MustMetric(
+				metric.New(
 					lldName,
 					map[string]string{"host": "hostA"},
 					map[string]interface{}{"name.foo": `{"data":[{"{#FOO}":"bar"}]}`},
@@ -358,7 +359,7 @@ func TestAddAndPush(t *testing.T) {
 				),
 			},
 			OperationPush{},
-			OperationCheck{testutil.MustMetric(
+			OperationCheck{metric.New(
 				lldName,
 				map[string]string{"host": "hostA"},
 				map[string]interface{}{"name.foo": `{"data":[]}`},
@@ -367,13 +368,13 @@ func TestAddAndPush(t *testing.T) {
 		},
 		"from two inputs, one stop sending metrics, an empty LLD is sent just for that stopped input": {
 			OperationAdd{
-				testutil.MustMetric(
+				metric.New(
 					"name",
 					map[string]string{"host": "hostA", "foo": "bar"},
 					map[string]interface{}{"value": 1},
 					time.Now(),
 				),
-				testutil.MustMetric(
+				metric.New(
 					"name",
 					map[string]string{"host": "hostB", "foo": "bar"},
 					map[string]interface{}{"value": 1},
@@ -382,13 +383,13 @@ func TestAddAndPush(t *testing.T) {
 			},
 			OperationPush{},
 			OperationCheck{
-				testutil.MustMetric(
+				metric.New(
 					lldName,
 					map[string]string{"host": "hostA"},
 					map[string]interface{}{"name.foo": `{"data":[{"{#FOO}":"bar"}]}`},
 					time.Now(),
 				),
-				testutil.MustMetric(
+				metric.New(
 					lldName,
 					map[string]string{"host": "hostB"},
 					map[string]interface{}{"name.foo": `{"data":[{"{#FOO}":"bar"}]}`},
@@ -396,7 +397,7 @@ func TestAddAndPush(t *testing.T) {
 				),
 			},
 			OperationAdd{
-				testutil.MustMetric(
+				metric.New(
 					"name",
 					map[string]string{"host": "hostB", "foo": "bar"},
 					map[string]interface{}{"value": 1},
@@ -405,7 +406,7 @@ func TestAddAndPush(t *testing.T) {
 			},
 			OperationPush{},
 			OperationCheck{
-				testutil.MustMetric(
+				metric.New(
 					lldName,
 					map[string]string{"host": "hostA"},
 					map[string]interface{}{"name.foo": `{"data":[]}`},
@@ -414,13 +415,13 @@ func TestAddAndPush(t *testing.T) {
 			},
 		},
 		"different hosts sending the same metric should generate different LLDs": {
-			OperationAdd{testutil.MustMetric(
+			OperationAdd{metric.New(
 				"name",
 				map[string]string{"host": "hostA", "foo": "bar"},
 				map[string]interface{}{"value": 1},
 				time.Now(),
 			)},
-			OperationAdd{testutil.MustMetric(
+			OperationAdd{metric.New(
 				"name",
 				map[string]string{"host": "hostB", "foo": "bar"},
 				map[string]interface{}{"value": 1},
@@ -428,13 +429,13 @@ func TestAddAndPush(t *testing.T) {
 			)},
 			OperationPush{},
 			OperationCheck{
-				testutil.MustMetric(
+				metric.New(
 					lldName,
 					map[string]string{"host": "hostA"},
 					map[string]interface{}{"name.foo": `{"data":[{"{#FOO}":"bar"}]}`},
 					time.Now(),
 				),
-				testutil.MustMetric(
+				metric.New(
 					lldName,
 					map[string]string{"host": "hostB"},
 					map[string]interface{}{"name.foo": `{"data":[{"{#FOO}":"bar"}]}`},
@@ -443,14 +444,14 @@ func TestAddAndPush(t *testing.T) {
 			},
 		},
 		"same measurement with different tags should generate different LLDs": {
-			OperationAdd{testutil.MustMetric(
+			OperationAdd{metric.New(
 				"name",
 				map[string]string{"host": "hostA", "foo": "a"},
 				map[string]interface{}{"value": 1},
 				time.Now(),
 			)},
 			OperationAdd{
-				testutil.MustMetric(
+				metric.New(
 					"name",
 					map[string]string{"host": "hostA", "foo": "a", "bar": "b"},
 					map[string]interface{}{"value": 1},
@@ -459,13 +460,13 @@ func TestAddAndPush(t *testing.T) {
 			},
 			OperationPush{},
 			OperationCheck{
-				testutil.MustMetric(
+				metric.New(
 					lldName,
 					map[string]string{"host": "hostA"},
 					map[string]interface{}{"name.foo": `{"data":[{"{#FOO}":"a"}]}`},
 					time.Now(),
 				),
-				testutil.MustMetric(
+				metric.New(
 					lldName,
 					map[string]string{"host": "hostA"},
 					map[string]interface{}{"name.bar.foo": `{"data":[{"{#BAR}":"b","{#FOO}":"a"}]}`},
@@ -475,7 +476,7 @@ func TestAddAndPush(t *testing.T) {
 		},
 		"a set with a new combination of tag values already seen should generate a new lld": {
 			OperationAdd{
-				testutil.MustMetric(
+				metric.New(
 					"name",
 					map[string]string{"host": "hostA", "foo": "a", "bar": "b"},
 					map[string]interface{}{"value": 1},
@@ -483,7 +484,7 @@ func TestAddAndPush(t *testing.T) {
 				),
 			},
 			OperationAdd{
-				testutil.MustMetric(
+				metric.New(
 					"name",
 					map[string]string{"host": "hostA", "foo": "x", "bar": "y"},
 					map[string]interface{}{"value": 1},
@@ -491,7 +492,7 @@ func TestAddAndPush(t *testing.T) {
 				),
 			},
 			OperationAdd{
-				testutil.MustMetric(
+				metric.New(
 					"name",
 					map[string]string{"host": "hostA", "foo": "a", "bar": "y"},
 					map[string]interface{}{"value": 1},
@@ -500,7 +501,7 @@ func TestAddAndPush(t *testing.T) {
 			},
 			OperationPush{},
 			OperationCheck{
-				testutil.MustMetric(
+				metric.New(
 					lldName,
 					map[string]string{"host": "hostA"},
 					map[string]interface{}{
@@ -512,7 +513,7 @@ func TestAddAndPush(t *testing.T) {
 		},
 		"same host and metric with and without extra tag": {
 			OperationAdd{
-				testutil.MustMetric(
+				metric.New(
 					"name",
 					map[string]string{"host": "hostA", "foo": "a"},
 					map[string]interface{}{"value": 1},
@@ -520,7 +521,7 @@ func TestAddAndPush(t *testing.T) {
 				),
 			},
 			OperationAdd{
-				testutil.MustMetric(
+				metric.New(
 					"name",
 					map[string]string{"host": "hostA"},
 					map[string]interface{}{"value": 1},
@@ -529,7 +530,7 @@ func TestAddAndPush(t *testing.T) {
 			},
 			OperationPush{},
 			OperationCheck{
-				testutil.MustMetric(
+				metric.New(
 					lldName,
 					map[string]string{"host": "hostA"},
 					map[string]interface{}{
@@ -541,7 +542,7 @@ func TestAddAndPush(t *testing.T) {
 			OperationCrossClearIntervalTime{},
 			OperationPush{},
 			OperationAdd{
-				testutil.MustMetric(
+				metric.New(
 					"name",
 					map[string]string{"host": "hostA"},
 					map[string]interface{}{"value": 1},
@@ -549,7 +550,7 @@ func TestAddAndPush(t *testing.T) {
 				),
 			},
 			OperationAdd{
-				testutil.MustMetric(
+				metric.New(
 					"name",
 					map[string]string{"host": "hostA", "foo": "a"},
 					map[string]interface{}{"value": 1},
@@ -558,7 +559,7 @@ func TestAddAndPush(t *testing.T) {
 			},
 			OperationPush{},
 			OperationCheck{
-				testutil.MustMetric(
+				metric.New(
 					lldName,
 					map[string]string{"host": "hostA"},
 					map[string]interface{}{
@@ -568,7 +569,7 @@ func TestAddAndPush(t *testing.T) {
 				),
 			},
 			OperationAdd{
-				testutil.MustMetric(
+				metric.New(
 					"name",
 					map[string]string{"host": "hostA"},
 					map[string]interface{}{"value": 1},
@@ -578,7 +579,7 @@ func TestAddAndPush(t *testing.T) {
 			OperationPush{},
 			// Clean name.foo because it has not been since the last push
 			OperationCheck{
-				testutil.MustMetric(
+				metric.New(
 					lldName,
 					map[string]string{"host": "hostA"},
 					map[string]interface{}{
@@ -646,7 +647,7 @@ func TestPush(t *testing.T) {
 			},
 			PreviousReceivedData: map[uint64]lldInfo{},
 			Metrics: []telegraf.Metric{
-				testutil.MustMetric(lldName,
+				metric.New(lldName,
 					map[string]string{"host": "hostA"},
 					map[string]interface{}{"disk.foo": `{"data":[{"{#FOO}":"bar"}]}`},
 					time.Now(),
@@ -670,7 +671,7 @@ func TestPush(t *testing.T) {
 			},
 			PreviousReceivedData: map[uint64]lldInfo{},
 			Metrics: []telegraf.Metric{
-				testutil.MustMetric(lldName,
+				metric.New(lldName,
 					map[string]string{"host": "hostA"},
 					map[string]interface{}{"disk.foo": `{"data":[{"{#FOO}":"bar1"},{"{#FOO}":"bar2"}]}`},
 					time.Now(),
@@ -693,7 +694,7 @@ func TestPush(t *testing.T) {
 			},
 			PreviousReceivedData: map[uint64]lldInfo{},
 			Metrics: []telegraf.Metric{
-				testutil.MustMetric(lldName,
+				metric.New(lldName,
 					map[string]string{"host": "hostA"},
 					map[string]interface{}{"disk.fooA.fooB.fooC": `{"data":[{"{#FOOA}":"bar1","{#FOOB}":"bar2","{#FOOC}":"bar3"}]}`},
 					time.Now(),
@@ -732,17 +733,17 @@ func TestPush(t *testing.T) {
 			},
 			PreviousReceivedData: map[uint64]lldInfo{},
 			Metrics: []telegraf.Metric{
-				testutil.MustMetric(lldName,
+				metric.New(lldName,
 					map[string]string{"host": "hostA"},
 					map[string]interface{}{"proc.pid": `{"data":[{"{#PID}":"1234"}]}`},
 					time.Now(),
 				),
-				testutil.MustMetric(lldName,
+				metric.New(lldName,
 					map[string]string{"host": "hostA"},
 					map[string]interface{}{"disk.foo": `{"data":[{"{#FOO}":"bar"}]}`},
 					time.Now(),
 				),
-				testutil.MustMetric(lldName,
+				metric.New(lldName,
 					map[string]string{"host": "hostA"},
 					map[string]interface{}{"net.iface": `{"data":[{"{#IFACE}":"eth0"}]}`},
 					time.Now(),
@@ -772,12 +773,12 @@ func TestPush(t *testing.T) {
 			},
 			PreviousReceivedData: map[uint64]lldInfo{},
 			Metrics: []telegraf.Metric{
-				testutil.MustMetric(lldName,
+				metric.New(lldName,
 					map[string]string{"host": "hostA"},
 					map[string]interface{}{"disk.foo": `{"data":[{"{#FOO}":"bar"}]}`},
 					time.Now(),
 				),
-				testutil.MustMetric(lldName,
+				metric.New(lldName,
 					map[string]string{"host": "hostB"},
 					map[string]interface{}{"disk.foo": `{"data":[{"{#FOO}":"bar"}]}`},
 					time.Now(),
@@ -822,7 +823,7 @@ func TestPush(t *testing.T) {
 				},
 			},
 			Metrics: []telegraf.Metric{
-				testutil.MustMetric(lldName,
+				metric.New(lldName,
 					map[string]string{"host": "hostA"},
 					map[string]interface{}{"disk.foo": `{"data":[]}`},
 					time.Now(),
@@ -906,13 +907,13 @@ func TestAdd(t *testing.T) {
 	}{
 		"metric without tags is ignored": {
 			Metrics: []telegraf.Metric{
-				testutil.MustMetric("disk", map[string]string{}, map[string]interface{}{"a": 0}, time.Now()),
+				metric.New("disk", map[string]string{}, map[string]interface{}{"a": 0}, time.Now()),
 			},
 			Current: map[uint64]lldInfo{},
 		},
 		"metric with only the host tag is not used for LLD": {
 			Metrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"disk",
 					map[string]string{"host": "bar"},
 					map[string]interface{}{"a": 0},
@@ -923,7 +924,7 @@ func TestAdd(t *testing.T) {
 		},
 		"add one metric with one tag and not host tag, use the system hostname": {
 			Metrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"disk",
 					map[string]string{"foo": "bar"},
 					map[string]interface{}{"a": 0},
@@ -944,7 +945,7 @@ func TestAdd(t *testing.T) {
 		},
 		"add one metric with one extra tag": {
 			Metrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"disk",
 					map[string]string{"host": "bar", "foo": "bar"},
 					map[string]interface{}{"a": 0},
@@ -965,13 +966,13 @@ func TestAdd(t *testing.T) {
 		},
 		"same metric with different field values is only stored once": {
 			Metrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"disk",
 					map[string]string{"host": "bar", "foo": "bar"},
 					map[string]interface{}{"a": 0},
 					time.Now(),
 				),
-				testutil.MustMetric(
+				metric.New(
 					"disk",
 					map[string]string{"host": "bar", "foo": "bar"},
 					map[string]interface{}{"a": 999},
@@ -992,13 +993,13 @@ func TestAdd(t *testing.T) {
 		},
 		"for the same measurement and tags, the different combinations of tag values are stored under the same key": {
 			Metrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"disk",
 					map[string]string{"host": "bar", "foo": "bar1"},
 					map[string]interface{}{"a": 0},
 					time.Now(),
 				),
-				testutil.MustMetric(
+				metric.New(
 					"disk",
 					map[string]string{"host": "bar", "foo": "bar2"},
 					map[string]interface{}{"a": 0},
@@ -1022,13 +1023,13 @@ func TestAdd(t *testing.T) {
 		},
 		"same measurement and tags for different hosts are stored in different keys": {
 			Metrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"disk",
 					map[string]string{"host": "barA", "foo": "bar"},
 					map[string]interface{}{"a": 0},
 					time.Now(),
 				),
-				testutil.MustMetric(
+				metric.New(
 					"disk",
 					map[string]string{"host": "barB", "foo": "bar"},
 					map[string]interface{}{"a": 0},
@@ -1058,13 +1059,13 @@ func TestAdd(t *testing.T) {
 		},
 		"different number of tags for the same measurement are stored in different keys": {
 			Metrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"disk",
 					map[string]string{"host": "bar", "foo1": "bar", "foo2": "bar"},
 					map[string]interface{}{"a": 0},
 					time.Now(),
 				),
-				testutil.MustMetric(
+				metric.New(
 					"disk",
 					map[string]string{"host": "bar", "foo1": "bar"},
 					map[string]interface{}{"a": 0},


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Covers prometheus_client, timestream, yandex_cloud_monitoring, and zabbix outputs.

Part of #18495 - testutil.MustMetric is a trivial wrapper around metric.New that adds no value and misleads with its "Must" prefix.

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
