### PR TITLE
Fixes a panic in the outputs.heartbeat plugin introduced in v1.38.0.

### DIFF
--- a/plugins/outputs/heartbeat/statistics.go
+++ b/plugins/outputs/heartbeat/statistics.go
@@ -83,10 +83,13 @@ func (s *statistics) snapshot() *statistics {
 					entry[k] = v
 				}
 			}
-			if limit := entry["buffer_limit"].(int64); limit != 0 {
-				entry["buffer_fullness"] = float64(entry["buffer_size"].(int64)) / float64(limit)
+
+			limit, lok := entry["buffer_limit"].(int64)
+			size, sok := entry["buffer_size"].(int64)
+			if lok && sok && limit != 0 {
+				entry["buffer_fullness"] = float64(size) / float64(limit)
 			} else {
-				entry["buffer_fullness"] = float64(1.0) // output 100% if no limit
+				entry["buffer_fullness"] = 1.0 // output 100% if no limit
 			}
 			out.currentOutputs[name] = append(out.currentOutputs[name], entry)
 		case "agent":


### PR DESCRIPTION
 ## Summary

Fix a panic in the outputs.heartbeat plugin introduced in v1.38.0.

The issue was caused by unsafe type assertions in snapshot():

    entry["buffer_limit"].(int64)
    entry["buffer_size"].(int64)

This could lead to runtime panics when:
- fields are missing
- values are not int64 (e.g. float64 from decoded metrics)

The fix replaces these assertions with safe type checks and falls back
to a default buffer_fullness of 1.0 when values are invalid.

Additionally, selfstat.Metrics() is now wrapped in a package-level variable
to allow proper mocking in unit tests, improving testability.


## Related issues

resolves #18559