### PR TITLE
fix(inputs): Add startup-errors of input models to gather statistics

### DIFF
--- a/models/running_input.go
+++ b/models/running_input.go
@@ -76,7 +76,7 @@ func NewRunningInput(input telegraf.Input, config *InputConfig) *RunningInput {
 			tags,
 		),
 		StartupErrors: selfstat.Register(
-			"write",
+			"gather",
 			"startup_errors",
 			tags,
 		),


### PR DESCRIPTION
## Summary

Issue #18559 uncovered that `startup_errors` of input models were added to the `internal_write` statistic instead of the `internal_gather` statistic accidentally. This PR fixes the issue and assigns the the statistic to the correct metric.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

resolves #18559 
