### PR TITLE
fix(inputs.sip): Use local_address for Via header hostname

### DIFF
--- a/plugins/inputs/sip/sip.go
+++ b/plugins/inputs/sip/sip.go
@@ -200,8 +200,12 @@ func (s *SIP) Start(telegraf.Accumulator) error {
 	}
 	s.ua = ua
 
-	// Create SIP client
-	client, err := sipgo.NewClient(ua)
+	// Create SIP client with local address for Via header if configured
+	var clientOpts []sipgo.ClientOption
+	if s.LocalAddress != "" {
+		clientOpts = append(clientOpts, sipgo.WithClientHostname(s.LocalAddress))
+	}
+	client, err := sipgo.NewClient(ua, clientOpts...)
 	if err != nil {
 		s.Stop()
 		return fmt.Errorf("creating SIP client failed: %w", err)


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Pass WithClientHostname to sipgo.NewClient when local_address is configured so the Via header contains the correct host instead of defaulting to 0.0.0.0.

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #18564
