### PR TITLE
chore(outputs): Add error handling for creating a buffer

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1414,7 +1414,10 @@ func (c *Config) addOutput(name, source string, table *ast.Table) error {
 		}
 	}
 
-	ro := models.NewRunningOutput(output, outputConfig, c.Agent.MetricBatchSize, c.Agent.MetricBufferLimit)
+	ro, err := models.NewRunningOutput(output, outputConfig, c.Agent.MetricBatchSize, c.Agent.MetricBufferLimit)
+	if err != nil {
+		return err
+	}
 	c.Outputs = append(c.Outputs, ro)
 
 	return nil

--- a/models/buffer_disk.go
+++ b/models/buffer_disk.go
@@ -42,6 +42,9 @@ func NewDiskBuffer(id, path string, stats BufferStats, diskSync bool) (*DiskBuff
 		NoSync:     !diskSync,
 	})
 	if err != nil {
+		if errors.Is(err, wal.ErrCorrupt) {
+			return nil, fmt.Errorf("wal file is corrupt, you have to manually delete the wal at %q and restart Telegraf", filePath)
+		}
 		return nil, fmt.Errorf("failed to open wal file: %w", err)
 	}
 

--- a/models/running_output.go
+++ b/models/running_output.go
@@ -73,7 +73,7 @@ type RunningOutput struct {
 	aggMutex sync.Mutex
 }
 
-func NewRunningOutput(output telegraf.Output, config *OutputConfig, batchSize, bufferLimit int) *RunningOutput {
+func NewRunningOutput(output telegraf.Output, config *OutputConfig, batchSize, bufferLimit int) (*RunningOutput, error) {
 	tags := map[string]string{
 		"output": config.Name,
 		"_id":    config.ID,
@@ -108,7 +108,7 @@ func NewRunningOutput(output telegraf.Output, config *OutputConfig, batchSize, b
 
 	b, err := NewBuffer(config.Name, config.ID, config.Alias, bufferLimit, config.BufferStrategy, config.BufferDirectory, config.BufferDiskSync)
 	if err != nil {
-		panic(err)
+		return nil, fmt.Errorf("creating buffer failed: %w", err)
 	}
 
 	ro := &RunningOutput{
@@ -136,7 +136,7 @@ func NewRunningOutput(output telegraf.Output, config *OutputConfig, batchSize, b
 		log: logger,
 	}
 
-	return ro
+	return ro, nil
 }
 
 func (r *RunningOutput) LogName() string {

--- a/models/running_output_test.go
+++ b/models/running_output_test.go
@@ -43,7 +43,8 @@ func TestRunningOutputDropFilter(t *testing.T) {
 	require.NoError(t, conf.Filter.Compile())
 
 	m := &mockOutput{}
-	ro := NewRunningOutput(m, conf, 1000, 10000)
+	ro, err := NewRunningOutput(m, conf, 1000, 10000)
+	require.NoError(t, err)
 
 	for _, mt := range first5 {
 		ro.AddMetric(mt)
@@ -53,8 +54,7 @@ func TestRunningOutputDropFilter(t *testing.T) {
 	}
 	require.Empty(t, m.Metrics())
 
-	err := ro.Write()
-	require.NoError(t, err)
+	require.NoError(t, ro.Write())
 	require.Len(t, m.Metrics(), 8)
 }
 
@@ -68,7 +68,8 @@ func TestRunningOutputPassFilter(t *testing.T) {
 	require.NoError(t, conf.Filter.Compile())
 
 	m := &mockOutput{}
-	ro := NewRunningOutput(m, conf, 1000, 10000)
+	ro, err := NewRunningOutput(m, conf, 1000, 10000)
+	require.NoError(t, err)
 
 	for _, mt := range first5 {
 		ro.AddMetric(mt)
@@ -78,8 +79,7 @@ func TestRunningOutputPassFilter(t *testing.T) {
 	}
 	require.Empty(t, m.Metrics())
 
-	err := ro.Write()
-	require.NoError(t, err)
+	require.NoError(t, ro.Write())
 	require.Len(t, m.Metrics(), 10)
 }
 
@@ -93,13 +93,13 @@ func TestRunningOutputTagIncludeNoMatch(t *testing.T) {
 	require.NoError(t, conf.Filter.Compile())
 
 	m := &mockOutput{}
-	ro := NewRunningOutput(m, conf, 1000, 10000)
+	ro, err := NewRunningOutput(m, conf, 1000, 10000)
+	require.NoError(t, err)
 
 	ro.AddMetric(testutil.TestMetric(101, "metric1"))
 	require.Empty(t, m.Metrics())
 
-	err := ro.Write()
-	require.NoError(t, err)
+	require.NoError(t, ro.Write())
 	require.Len(t, m.Metrics(), 1)
 	require.Empty(t, m.Metrics()[0].Tags())
 }
@@ -114,13 +114,13 @@ func TestRunningOutputTagExcludeMatch(t *testing.T) {
 	require.NoError(t, conf.Filter.Compile())
 
 	m := &mockOutput{}
-	ro := NewRunningOutput(m, conf, 1000, 10000)
+	ro, err := NewRunningOutput(m, conf, 1000, 10000)
+	require.NoError(t, err)
 
 	ro.AddMetric(testutil.TestMetric(101, "metric1"))
 	require.Empty(t, m.Metrics())
 
-	err := ro.Write()
-	require.NoError(t, err)
+	require.NoError(t, ro.Write())
 	require.Len(t, m.Metrics(), 1)
 	require.Empty(t, m.Metrics()[0].Tags())
 }
@@ -135,13 +135,13 @@ func TestRunningOutputTagExcludeNoMatch(t *testing.T) {
 	require.NoError(t, conf.Filter.Compile())
 
 	m := &mockOutput{}
-	ro := NewRunningOutput(m, conf, 1000, 10000)
+	ro, err := NewRunningOutput(m, conf, 1000, 10000)
+	require.NoError(t, err)
 
 	ro.AddMetric(testutil.TestMetric(101, "metric1"))
 	require.Empty(t, m.Metrics())
 
-	err := ro.Write()
-	require.NoError(t, err)
+	require.NoError(t, ro.Write())
 	require.Len(t, m.Metrics(), 1)
 	require.Len(t, m.Metrics()[0].Tags(), 1)
 }
@@ -156,13 +156,13 @@ func TestRunningOutputTagIncludeMatch(t *testing.T) {
 	require.NoError(t, conf.Filter.Compile())
 
 	m := &mockOutput{}
-	ro := NewRunningOutput(m, conf, 1000, 10000)
+	ro, err := NewRunningOutput(m, conf, 1000, 10000)
+	require.NoError(t, err)
 
 	ro.AddMetric(testutil.TestMetric(101, "metric1"))
 	require.Empty(t, m.Metrics())
 
-	err := ro.Write()
-	require.NoError(t, err)
+	require.NoError(t, ro.Write())
 	require.Len(t, m.Metrics(), 1)
 	require.Len(t, m.Metrics()[0].Tags(), 1)
 }
@@ -174,13 +174,13 @@ func TestRunningOutputNameOverride(t *testing.T) {
 	}
 
 	m := &mockOutput{}
-	ro := NewRunningOutput(m, conf, 1000, 10000)
+	ro, err := NewRunningOutput(m, conf, 1000, 10000)
+	require.NoError(t, err)
 
 	ro.AddMetric(testutil.TestMetric(101, "metric1"))
 	require.Empty(t, m.Metrics())
 
-	err := ro.Write()
-	require.NoError(t, err)
+	require.NoError(t, ro.Write())
 	require.Len(t, m.Metrics(), 1)
 	require.Equal(t, "new_metric_name", m.Metrics()[0].Name())
 }
@@ -192,13 +192,13 @@ func TestRunningOutputNamePrefix(t *testing.T) {
 	}
 
 	m := &mockOutput{}
-	ro := NewRunningOutput(m, conf, 1000, 10000)
+	ro, err := NewRunningOutput(m, conf, 1000, 10000)
+	require.NoError(t, err)
 
 	ro.AddMetric(testutil.TestMetric(101, "metric1"))
 	require.Empty(t, m.Metrics())
 
-	err := ro.Write()
-	require.NoError(t, err)
+	require.NoError(t, ro.Write())
 	require.Len(t, m.Metrics(), 1)
 	require.Equal(t, "prefix_metric1", m.Metrics()[0].Name())
 }
@@ -210,13 +210,13 @@ func TestRunningOutputNameSuffix(t *testing.T) {
 	}
 
 	m := &mockOutput{}
-	ro := NewRunningOutput(m, conf, 1000, 10000)
+	ro, err := NewRunningOutput(m, conf, 1000, 10000)
+	require.NoError(t, err)
 
 	ro.AddMetric(testutil.TestMetric(101, "metric1"))
 	require.Empty(t, m.Metrics())
 
-	err := ro.Write()
-	require.NoError(t, err)
+	require.NoError(t, ro.Write())
 	require.Len(t, m.Metrics(), 1)
 	require.Equal(t, "metric1_suffix", m.Metrics()[0].Name())
 }
@@ -228,7 +228,8 @@ func TestRunningOutputDefault(t *testing.T) {
 	}
 
 	m := &mockOutput{}
-	ro := NewRunningOutput(m, conf, 1000, 10000)
+	ro, err := NewRunningOutput(m, conf, 1000, 10000)
+	require.NoError(t, err)
 
 	for _, mt := range first5 {
 		ro.AddMetric(mt)
@@ -238,8 +239,7 @@ func TestRunningOutputDefault(t *testing.T) {
 	}
 	require.Empty(t, m.Metrics())
 
-	err := ro.Write()
-	require.NoError(t, err)
+	require.NoError(t, ro.Write())
 	require.Len(t, m.Metrics(), 10)
 }
 
@@ -249,7 +249,8 @@ func TestRunningOutputWriteFail(t *testing.T) {
 	}
 
 	m := &mockOutput{batchAcceptSize: -1}
-	ro := NewRunningOutput(m, conf, 4, 12)
+	ro, err := NewRunningOutput(m, conf, 4, 12)
+	require.NoError(t, err)
 
 	// Fill buffer to limit twice
 	for _, mt := range first5 {
@@ -262,14 +263,12 @@ func TestRunningOutputWriteFail(t *testing.T) {
 	require.Empty(t, m.Metrics())
 
 	// manual write fails
-	err := ro.Write()
-	require.Error(t, err)
+	require.Error(t, ro.Write())
 	// no successful flush yet
 	require.Empty(t, m.Metrics())
 
 	m.batchAcceptSize = 0
-	err = ro.Write()
-	require.NoError(t, err)
+	require.NoError(t, ro.Write())
 
 	require.Len(t, m.Metrics(), 10)
 }
@@ -281,7 +280,8 @@ func TestRunningOutputWriteFailOrder(t *testing.T) {
 	}
 
 	m := &mockOutput{batchAcceptSize: -1}
-	ro := NewRunningOutput(m, conf, 100, 1000)
+	ro, err := NewRunningOutput(m, conf, 100, 1000)
+	require.NoError(t, err)
 
 	// add 5 metrics
 	for _, mt := range first5 {
@@ -291,8 +291,7 @@ func TestRunningOutputWriteFailOrder(t *testing.T) {
 	require.Empty(t, m.Metrics())
 
 	// Write fails
-	err := ro.Write()
-	require.Error(t, err)
+	require.Error(t, ro.Write())
 	// no successful flush yet
 	require.Empty(t, m.Metrics())
 
@@ -302,8 +301,7 @@ func TestRunningOutputWriteFailOrder(t *testing.T) {
 	for _, mt := range next5 {
 		ro.AddMetric(mt)
 	}
-	err = ro.Write()
-	require.NoError(t, err)
+	require.NoError(t, ro.Write())
 
 	// Verify that 10 metrics were written
 	require.Len(t, m.Metrics(), 10)
@@ -319,15 +317,15 @@ func TestRunningOutputWriteFailOrder2(t *testing.T) {
 	}
 
 	m := &mockOutput{batchAcceptSize: -1}
-	ro := NewRunningOutput(m, conf, 5, 100)
+	ro, err := NewRunningOutput(m, conf, 5, 100)
+	require.NoError(t, err)
 
 	// add 5 metrics
 	for _, mt := range first5 {
 		ro.AddMetric(mt)
 	}
 	// Write fails
-	err := ro.Write()
-	require.Error(t, err)
+	require.Error(t, ro.Write())
 	// no successful flush yet
 	require.Empty(t, m.Metrics())
 
@@ -336,8 +334,7 @@ func TestRunningOutputWriteFailOrder2(t *testing.T) {
 		ro.AddMetric(mt)
 	}
 	// Write fails
-	err = ro.Write()
-	require.Error(t, err)
+	require.Error(t, ro.Write())
 	// no successful flush yet
 	require.Empty(t, m.Metrics())
 
@@ -346,8 +343,7 @@ func TestRunningOutputWriteFailOrder2(t *testing.T) {
 		ro.AddMetric(mt)
 	}
 	// Write fails
-	err = ro.Write()
-	require.Error(t, err)
+	require.Error(t, ro.Write())
 	// no successful flush yet
 	require.Empty(t, m.Metrics())
 
@@ -356,14 +352,12 @@ func TestRunningOutputWriteFailOrder2(t *testing.T) {
 		ro.AddMetric(mt)
 	}
 	// Write fails
-	err = ro.Write()
-	require.Error(t, err)
+	require.Error(t, ro.Write())
 	// no successful flush yet
 	require.Empty(t, m.Metrics())
 
 	m.batchAcceptSize = 0
-	err = ro.Write()
-	require.NoError(t, err)
+	require.NoError(t, ro.Write())
 
 	// Verify that 20 metrics were written
 	require.Len(t, m.Metrics(), 20)
@@ -382,7 +376,8 @@ func TestRunningOutputWriteFailOrder3(t *testing.T) {
 	}
 
 	m := &mockOutput{batchAcceptSize: -1}
-	ro := NewRunningOutput(m, conf, 5, 1000)
+	ro, err := NewRunningOutput(m, conf, 5, 1000)
+	require.NoError(t, err)
 
 	// add 5 metrics
 	for _, mt := range first5 {
@@ -392,21 +387,17 @@ func TestRunningOutputWriteFailOrder3(t *testing.T) {
 	require.Empty(t, m.Metrics())
 
 	// Write fails
-	err := ro.Write()
-	require.Error(t, err)
+	require.Error(t, ro.Write())
 	// no successful flush yet
 	require.Empty(t, m.Metrics())
 
 	// add and attempt to write a single metric:
 	ro.AddMetric(next5[0])
-	err = ro.Write()
-	require.Error(t, err)
+	require.Error(t, ro.Write())
 
 	// unset fail and write metrics
 	m.batchAcceptSize = 0
-
-	err = ro.Write()
-	require.NoError(t, err)
+	require.NoError(t, ro.Write())
 
 	// Verify that 6 metrics were written
 	require.Len(t, m.Metrics(), 6)
@@ -440,7 +431,8 @@ func TestRunningOutputBufferFullyDrained(t *testing.T) {
 		},
 	}
 	const batchSize = 5
-	ro := NewRunningOutput(plugin, conf, batchSize, 100)
+	ro, err := NewRunningOutput(plugin, conf, batchSize, 100)
+	require.NoError(t, err)
 
 	// Create a multiple of batch size many metrics beyond the batch size
 	const totalMetrics = 10 * batchSize
@@ -523,7 +515,8 @@ func TestRunningOutputBufferImmediateRestartOnContinuousWrite(t *testing.T) {
 			return nil
 		},
 	}
-	ro := NewRunningOutput(plugin, conf, batchSize, 100)
+	ro, err := NewRunningOutput(plugin, conf, batchSize, 100)
+	require.NoError(t, err)
 
 	// Create a multiple of batch size many metrics beyond the batch size
 	const totalMetrics = 10 * batchSize
@@ -591,7 +584,8 @@ func TestRunningOutputNoRetriggerOnError(t *testing.T) {
 		},
 	}
 	const batchSize = 5
-	ro := NewRunningOutput(plugin, conf, batchSize, 100)
+	ro, err := NewRunningOutput(plugin, conf, batchSize, 100)
+	require.NoError(t, err)
 
 	// Create a multiple of batch size many metrics beyond the batch size
 	const totalMetrics = 10 * batchSize
@@ -661,7 +655,8 @@ func TestRunningOutputNoRetriggerOnSuccessfulPartialWriteError(t *testing.T) {
 		},
 	}
 	const batchSize = 5
-	ro := NewRunningOutput(plugin, conf, batchSize, 100)
+	ro, err := NewRunningOutput(plugin, conf, batchSize, 100)
+	require.NoError(t, err)
 
 	// Create a multiple of batch size many metrics beyond the batch size
 	const batchCount = 10
@@ -729,7 +724,8 @@ func TestRunningOutputNoRetriggerOnUnsuccessfulPartialWriteError(t *testing.T) {
 		},
 	}
 	const batchSize = 5
-	ro := NewRunningOutput(plugin, conf, batchSize, 100)
+	ro, err := NewRunningOutput(plugin, conf, batchSize, 100)
+	require.NoError(t, err)
 
 	// Create a multiple of batch size many metrics beyond the batch size
 	const batchCount = 10
@@ -779,7 +775,7 @@ func TestRunningOutputNoRetriggerOnUnsuccessfulPartialWriteError(t *testing.T) {
 }
 
 func TestRunningOutputInternalMetrics(t *testing.T) {
-	_ = NewRunningOutput(
+	_, err := NewRunningOutput(
 		&mockOutput{},
 		&OutputConfig{
 			Filter: Filter{},
@@ -787,7 +783,9 @@ func TestRunningOutputInternalMetrics(t *testing.T) {
 			Alias:  "test_alias",
 		},
 		5,
-		10)
+		10,
+	)
+	require.NoError(t, err)
 
 	expected := []telegraf.Metric{
 		metric.New(
@@ -824,7 +822,7 @@ func TestRunningOutputInternalMetrics(t *testing.T) {
 }
 
 func TestRunningOutputStartupBehaviorInvalid(t *testing.T) {
-	ro := NewRunningOutput(
+	ro, err := NewRunningOutput(
 		&mockOutput{},
 		&OutputConfig{
 			Filter:               Filter{},
@@ -834,6 +832,7 @@ func TestRunningOutputStartupBehaviorInvalid(t *testing.T) {
 		},
 		5, 10,
 	)
+	require.NoError(t, err)
 	require.ErrorContains(t, ro.Init(), "invalid 'startup_error_behavior'")
 }
 
@@ -842,7 +841,7 @@ func TestRunningOutputRetryableStartupBehaviorDefault(t *testing.T) {
 		Err:   errors.New("retryable err"),
 		Retry: true,
 	}
-	ro := NewRunningOutput(
+	ro, err := NewRunningOutput(
 		&mockOutput{
 			startupErrorCount: 1,
 			startupError:      serr,
@@ -854,6 +853,7 @@ func TestRunningOutputRetryableStartupBehaviorDefault(t *testing.T) {
 		},
 		5, 10,
 	)
+	require.NoError(t, err)
 	require.NoError(t, ro.Init())
 
 	// If Connect() fails, the agent will stop
@@ -866,7 +866,7 @@ func TestRunningOutputRetryableStartupBehaviorError(t *testing.T) {
 		Err:   errors.New("retryable err"),
 		Retry: true,
 	}
-	ro := NewRunningOutput(
+	ro, err := NewRunningOutput(
 		&mockOutput{
 			startupErrorCount: 1,
 			startupError:      serr,
@@ -879,6 +879,7 @@ func TestRunningOutputRetryableStartupBehaviorError(t *testing.T) {
 		},
 		5, 10,
 	)
+	require.NoError(t, err)
 	require.NoError(t, ro.Init())
 
 	// If Connect() fails, the agent will stop
@@ -895,7 +896,7 @@ func TestRunningOutputRetryableStartupBehaviorRetry(t *testing.T) {
 		startupErrorCount: 2,
 		startupError:      serr,
 	}
-	ro := NewRunningOutput(
+	ro, err := NewRunningOutput(
 		mo,
 		&OutputConfig{
 			Filter:               Filter{},
@@ -905,6 +906,7 @@ func TestRunningOutputRetryableStartupBehaviorRetry(t *testing.T) {
 		},
 		5, 10,
 	)
+	require.NoError(t, err)
 	require.NoError(t, ro.Init())
 
 	// For retry, Connect() should succeed even though there is an error but
@@ -936,7 +938,7 @@ func TestRunningOutputRetryableStartupBehaviorIgnore(t *testing.T) {
 		startupErrorCount: 2,
 		startupError:      serr,
 	}
-	ro := NewRunningOutput(
+	ro, err := NewRunningOutput(
 		mo,
 		&OutputConfig{
 			Filter:               Filter{},
@@ -946,6 +948,7 @@ func TestRunningOutputRetryableStartupBehaviorIgnore(t *testing.T) {
 		},
 		5, 10,
 	)
+	require.NoError(t, err)
 	require.NoError(t, ro.Init())
 
 	// For ignore, Connect() should return a fatal error if connection fails.
@@ -968,7 +971,7 @@ func TestRunningOutputNonRetryableStartupBehaviorDefault(t *testing.T) {
 				startupErrorCount: 2,
 				startupError:      serr,
 			}
-			ro := NewRunningOutput(
+			ro, err := NewRunningOutput(
 				mo,
 				&OutputConfig{
 					Filter:               Filter{},
@@ -978,6 +981,7 @@ func TestRunningOutputNonRetryableStartupBehaviorDefault(t *testing.T) {
 				},
 				5, 10,
 			)
+			require.NoError(t, err)
 			require.NoError(t, ro.Init())
 
 			// Non-retryable error should pass through and in turn the agent
@@ -997,7 +1001,7 @@ func TestRunningOutputUntypedStartupBehaviorIgnore(t *testing.T) {
 				startupErrorCount: 2,
 				startupError:      serr,
 			}
-			ro := NewRunningOutput(
+			ro, err := NewRunningOutput(
 				mo,
 				&OutputConfig{
 					Filter:               Filter{},
@@ -1007,6 +1011,7 @@ func TestRunningOutputUntypedStartupBehaviorIgnore(t *testing.T) {
 				},
 				5, 10,
 			)
+			require.NoError(t, err)
 			require.NoError(t, ro.Init())
 
 			// Untyped error should pass through and in turn the agent will
@@ -1027,7 +1032,7 @@ func TestRunningOutputPartiallyStarted(t *testing.T) {
 		startupErrorCount: 2,
 		startupError:      serr,
 	}
-	ro := NewRunningOutput(
+	ro, err := NewRunningOutput(
 		mo,
 		&OutputConfig{
 			Filter:               Filter{},
@@ -1037,6 +1042,7 @@ func TestRunningOutputPartiallyStarted(t *testing.T) {
 		},
 		5, 10,
 	)
+	require.NoError(t, err)
 	require.NoError(t, ro.Init())
 
 	// For retry, Connect() should succeed even though there is an error but
@@ -1064,7 +1070,8 @@ func TestRunningOutputWritePartialSuccess(t *testing.T) {
 	plugin := &mockOutput{
 		batchAcceptSize: 4,
 	}
-	model := NewRunningOutput(plugin, &OutputConfig{}, 5, 10)
+	model, err := NewRunningOutput(plugin, &OutputConfig{}, 5, 10)
+	require.NoError(t, err)
 	require.NoError(t, model.Init())
 	require.NoError(t, model.Connect())
 	defer model.Close()
@@ -1105,7 +1112,8 @@ func TestRunningOutputWritePartialSuccessAndLoss(t *testing.T) {
 		batchAcceptSize:  4,
 		metricFatalIndex: &lost,
 	}
-	model := NewRunningOutput(plugin, &OutputConfig{}, 5, 10)
+	model, err := NewRunningOutput(plugin, &OutputConfig{}, 5, 10)
+	require.NoError(t, err)
 	require.NoError(t, model.Init())
 	require.NoError(t, model.Connect())
 	defer model.Close()
@@ -1149,7 +1157,8 @@ func TestRunningOutputWriteBatchPartialSuccess(t *testing.T) {
 	plugin := &mockOutput{
 		batchAcceptSize: 4,
 	}
-	model := NewRunningOutput(plugin, &OutputConfig{}, 5, 10)
+	model, err := NewRunningOutput(plugin, &OutputConfig{}, 5, 10)
+	require.NoError(t, err)
 	require.NoError(t, model.Init())
 	require.NoError(t, model.Connect())
 	defer model.Close()
@@ -1190,7 +1199,8 @@ func TestRunningOutputWriteBatchPartialSuccessAndLoss(t *testing.T) {
 		batchAcceptSize:  4,
 		metricFatalIndex: &lost,
 	}
-	model := NewRunningOutput(plugin, &OutputConfig{}, 5, 10)
+	model, err := NewRunningOutput(plugin, &OutputConfig{}, 5, 10)
+	require.NoError(t, err)
 	require.NoError(t, model.Init())
 	require.NoError(t, model.Connect())
 	defer model.Close()
@@ -1236,7 +1246,8 @@ func BenchmarkRunningOutputAddWrite(b *testing.B) {
 		Filter: Filter{},
 	}
 	m := &perfOutput{}
-	ro := NewRunningOutput(m, conf, 1000, 10000)
+	ro, err := NewRunningOutput(m, conf, 1000, 10000)
+	require.NoError(b, err)
 
 	for n := 0; n < b.N; n++ {
 		ro.AddMetric(testutil.TestMetric(101, "metric1"))
@@ -1250,7 +1261,8 @@ func BenchmarkRunningOutputAddWriteEvery100(b *testing.B) {
 		Filter: Filter{},
 	}
 	m := &perfOutput{}
-	ro := NewRunningOutput(m, conf, 1000, 10000)
+	ro, err := NewRunningOutput(m, conf, 1000, 10000)
+	require.NoError(b, err)
 
 	for n := 0; n < b.N; n++ {
 		ro.AddMetric(testutil.TestMetric(101, "metric1"))
@@ -1266,7 +1278,9 @@ func BenchmarkRunningOutputAddFailWrites(b *testing.B) {
 		Filter: Filter{},
 	}
 	m := &perfOutput{failWrite: true}
-	ro := NewRunningOutput(m, conf, 1000, 10000)
+	ro, err := NewRunningOutput(m, conf, 1000, 10000)
+	require.NoError(b, err)
+
 	for n := 0; n < b.N; n++ {
 		ro.AddMetric(testutil.TestMetric(101, "metric1"))
 	}

--- a/plugins/inputs/cloud_pubsub_push/cloud_pubsub_push_test.go
+++ b/plugins/inputs/cloud_pubsub_push/cloud_pubsub_push_test.go
@@ -181,7 +181,8 @@ func TestServeHTTP(t *testing.T) {
 		pubPush.SetParser(p)
 
 		dst := make(chan telegraf.Metric, 1)
-		ro := models.NewRunningOutput(&testOutput{failWrite: test.fail}, &models.OutputConfig{}, 1, 1)
+		ro, err := models.NewRunningOutput(&testOutput{failWrite: test.fail}, &models.OutputConfig{}, 1, 1)
+		require.NoError(t, err)
 		pubPush.acc = agent.NewAccumulator(&testMetricMaker{}, dst).WithTracking(1)
 
 		wg.Add(1)

--- a/plugins/outputs/cratedb/cratedb_test.go
+++ b/plugins/outputs/cratedb/cratedb_test.go
@@ -110,7 +110,7 @@ func TestConnectionIssueAtStartup(t *testing.T) {
 		Timeout:     config.Duration(time.Second * 5),
 		TableCreate: true,
 	}
-	model := models.NewRunningOutput(
+	model, err := models.NewRunningOutput(
 		plugin,
 		&models.OutputConfig{
 			Name:                 "cratedb",
@@ -118,6 +118,7 @@ func TestConnectionIssueAtStartup(t *testing.T) {
 		},
 		1000, 1000,
 	)
+	require.NoError(t, err)
 	require.NoError(t, model.Init())
 
 	// The connect call should succeed even though the table creation was not

--- a/plugins/outputs/postgresql/postgresql_test.go
+++ b/plugins/outputs/postgresql/postgresql_test.go
@@ -353,7 +353,7 @@ func TestConnectionIssueAtStartup(t *testing.T) {
 	plugin.Connection = dsn
 	plugin.Logger = testutil.Logger{}
 	plugin.LogLevel = "debug"
-	model := models.NewRunningOutput(
+	model, err := models.NewRunningOutput(
 		plugin,
 		&models.OutputConfig{
 			Name:                 "postgres",
@@ -361,6 +361,7 @@ func TestConnectionIssueAtStartup(t *testing.T) {
 		},
 		1000, 1000,
 	)
+	require.NoError(t, err)
 	require.NoError(t, model.Init())
 
 	// The connect call should succeed even though the table creation was not

--- a/plugins/outputs/syslog/syslog_test.go
+++ b/plugins/outputs/syslog/syslog_test.go
@@ -268,13 +268,14 @@ func TestStartupErrorBehaviorDefault(t *testing.T) {
 		DefaultAppname:      "Telegraf",
 	}
 
-	model := models.NewRunningOutput(
+	model, err := models.NewRunningOutput(
 		plugin,
 		&models.OutputConfig{
 			Name: "syslog",
 		},
 		10, 100,
 	)
+	require.NoError(t, err)
 	require.NoError(t, model.Init())
 
 	// Starting the plugin will fail with an error because the server does not listen
@@ -301,7 +302,7 @@ func TestStartupErrorBehaviorError(t *testing.T) {
 		DefaultAppname:      "Telegraf",
 	}
 
-	model := models.NewRunningOutput(
+	model, err := models.NewRunningOutput(
 		plugin,
 		&models.OutputConfig{
 			Name:                 "syslog",
@@ -309,6 +310,7 @@ func TestStartupErrorBehaviorError(t *testing.T) {
 		},
 		10, 100,
 	)
+	require.NoError(t, err)
 	require.NoError(t, model.Init())
 
 	// Starting the plugin will fail with an error because the server does not listen
@@ -335,7 +337,7 @@ func TestStartupErrorBehaviorIgnore(t *testing.T) {
 		DefaultAppname:      "Telegraf",
 	}
 
-	model := models.NewRunningOutput(
+	model, err := models.NewRunningOutput(
 		plugin,
 		&models.OutputConfig{
 			Name:                 "syslog",
@@ -343,6 +345,7 @@ func TestStartupErrorBehaviorIgnore(t *testing.T) {
 		},
 		10, 100,
 	)
+	require.NoError(t, err)
 	require.NoError(t, model.Init())
 
 	// Starting the plugin will fail because the server does not accept connections.
@@ -371,7 +374,7 @@ func TestStartupErrorBehaviorRetry(t *testing.T) {
 		DefaultAppname:      "Telegraf",
 	}
 
-	model := models.NewRunningOutput(
+	model, err := models.NewRunningOutput(
 		plugin,
 		&models.OutputConfig{
 			Name:                 "syslog",
@@ -379,6 +382,7 @@ func TestStartupErrorBehaviorRetry(t *testing.T) {
 		},
 		10, 100,
 	)
+	require.NoError(t, err)
 	require.NoError(t, model.Init())
 
 	// Starting the plugin will return no error because the plugin will


### PR DESCRIPTION
## Summary

When using disk-based buffering, creating a new buffer instance can fail, e.g. due to permission issues or corrupted existing WAL files. This PR passes potential errors up from the `NewRunningOutput` to the `addOutput` function to do proper error reporting instead of panicking.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

resolves #18082
resolves #18528
