### PR TITLE
fix(agent): Reject negative collection_offset

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1693,7 +1693,7 @@ func (c *Config) buildInput(name, source string, tbl *ast.Table) (*models.InputC
 	cp.CollectionJitter, _ = c.getFieldDuration(tbl, "collection_jitter")
 	cp.CollectionOffset, _ = c.getFieldDuration(tbl, "collection_offset")
 	if cp.CollectionOffset < 0 {
-		return nil, fmt.Errorf("negative collection_offset %q is not allowed for input %s", cp.CollectionOffset, name)
+		return nil, fmt.Errorf("negative collection_offset %q is not allowed", cp.CollectionOffset)
 	}
 	cp.StartupErrorBehavior = c.getFieldString(tbl, "startup_error_behavior")
 	cp.TimeSource = c.getFieldString(tbl, "time_source")


### PR DESCRIPTION
## Summary

Based on the review feedback from @srebhan on #18178, this PR takes the simpler approach of **rejecting invalid offset values at startup** rather than normalizing them:

- **Negative agent-level collection_offset** → error at startup in `runAgent`
- **Negative per-input collection_offset** → error during config load in `buildInput`
- **Negative per-input interval** → error during config load in `buildInput`

This avoids the ambiguity of silently normalizing negative offsets, which could mean different things to different users.

## Changes

- Add agent-wide negative `collection_offset` check in `runAgent` (`cmd/telegraf/telegraf.go`), alongside existing interval/flush_interval checks
- Add per-input negative `interval` and `collection_offset` checks in `buildInput` (`config/config.go`)
- No changes to `NewTicker` signature or behavior

## Checklist

- [ ] No AI generated code was used in this PR
- [x] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

supersedes #18178
resolves #18175
