### PR TITLE
chore(processors): Replace testutil.MustMetric with metric.New

### DIFF
--- a/plugins/processors/port_name/port_name_test.go
+++ b/plugins/processors/port_name/port_name_test.go
@@ -47,7 +47,7 @@ func TestTable(t *testing.T) {
 			dest: "service",
 			prot: "tcp",
 			input: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"meas",
 					map[string]string{
 						"port": "443",
@@ -57,7 +57,7 @@ func TestTable(t *testing.T) {
 				),
 			},
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"meas",
 					map[string]string{
 						"port":    "443",
@@ -74,7 +74,7 @@ func TestTable(t *testing.T) {
 			dest: "service",
 			prot: "udp",
 			input: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"meas",
 					map[string]string{
 						"port": "69",
@@ -84,7 +84,7 @@ func TestTable(t *testing.T) {
 				),
 			},
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"meas",
 					map[string]string{
 						"port":    "69",
@@ -101,7 +101,7 @@ func TestTable(t *testing.T) {
 			dest: "service",
 			prot: "foobar",
 			input: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"meas",
 					map[string]string{
 						"port": "80/tcp",
@@ -111,7 +111,7 @@ func TestTable(t *testing.T) {
 				),
 			},
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"meas",
 					map[string]string{
 						"port":    "80/tcp",
@@ -128,7 +128,7 @@ func TestTable(t *testing.T) {
 			dest: "service",
 			prot: "tcp",
 			input: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"meas",
 					map[string]string{
 						"port": "80",
@@ -136,7 +136,7 @@ func TestTable(t *testing.T) {
 					map[string]interface{}{},
 					time.Unix(0, 0),
 				),
-				testutil.MustMetric(
+				metric.New(
 					"meas",
 					map[string]string{
 						"port": "69/udp",
@@ -146,7 +146,7 @@ func TestTable(t *testing.T) {
 				),
 			},
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"meas",
 					map[string]string{
 						"port":    "80",
@@ -155,7 +155,7 @@ func TestTable(t *testing.T) {
 					map[string]interface{}{},
 					time.Unix(0, 0),
 				),
-				testutil.MustMetric(
+				metric.New(
 					"meas",
 					map[string]string{
 						"port":    "69/udp",
@@ -172,7 +172,7 @@ func TestTable(t *testing.T) {
 			dest: "bar",
 			prot: "tcp",
 			input: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"meas",
 					map[string]string{
 						"foo": "80",
@@ -182,7 +182,7 @@ func TestTable(t *testing.T) {
 				),
 			},
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"meas",
 					map[string]string{
 						"foo": "80",
@@ -199,7 +199,7 @@ func TestTable(t *testing.T) {
 			dest: "service",
 			prot: "tcp",
 			input: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"meas",
 					map[string]string{
 						"port": "9999",
@@ -209,7 +209,7 @@ func TestTable(t *testing.T) {
 				),
 			},
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"meas",
 					map[string]string{
 						"port": "9999",
@@ -225,7 +225,7 @@ func TestTable(t *testing.T) {
 			dest: "service",
 			prot: "udp",
 			input: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"meas",
 					map[string]string{
 						"port": "80",
@@ -235,7 +235,7 @@ func TestTable(t *testing.T) {
 				),
 			},
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"meas",
 					map[string]string{
 						"port": "80",
@@ -251,7 +251,7 @@ func TestTable(t *testing.T) {
 			dest:  "bar",
 			prot:  "tcp",
 			input: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"meas",
 					map[string]string{},
 					map[string]interface{}{
@@ -261,7 +261,7 @@ func TestTable(t *testing.T) {
 				),
 			},
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"meas",
 					map[string]string{},
 					map[string]interface{}{
@@ -279,7 +279,7 @@ func TestTable(t *testing.T) {
 			prot:      "udp",
 			protField: "proto",
 			input: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"meas",
 					map[string]string{},
 					map[string]interface{}{
@@ -290,7 +290,7 @@ func TestTable(t *testing.T) {
 				),
 			},
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"meas",
 					map[string]string{},
 					map[string]interface{}{
@@ -309,7 +309,7 @@ func TestTable(t *testing.T) {
 			prot:    "udp",
 			protTag: "proto",
 			input: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"meas",
 					map[string]string{
 						"foo":   "80",
@@ -320,7 +320,7 @@ func TestTable(t *testing.T) {
 				),
 			},
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"meas",
 					map[string]string{
 						"foo":   "80",

--- a/plugins/processors/scale/scale_test.go
+++ b/plugins/processors/scale/scale_test.go
@@ -53,44 +53,44 @@ func TestMinMax(t *testing.T) {
 				},
 			},
 			inputs: []telegraf.Metric{
-				testutil.MustMetric("Name1", map[string]string{},
+				metric.New("Name1", map[string]string{},
 					map[string]interface{}{
 						"test1": int64(0),
 						"test2": uint64(1),
 					}, time.Unix(0, 0)),
-				testutil.MustMetric("Name2", map[string]string{},
+				metric.New("Name2", map[string]string{},
 					map[string]interface{}{
 						"test1": "0.5",
 						"test2": float32(-0.5),
 					}, time.Unix(0, 0)),
-				testutil.MustMetric("Name3", map[string]string{},
+				metric.New("Name3", map[string]string{},
 					map[string]interface{}{
 						"test3": int64(-3),
 						"test4": uint64(0),
 					}, time.Unix(0, 0)),
-				testutil.MustMetric("Name4", map[string]string{},
+				metric.New("Name4", map[string]string{},
 					map[string]interface{}{
 						"test3": int64(-5),
 						"test4": float32(-0.5),
 					}, time.Unix(0, 0)),
 			},
 			expected: []telegraf.Metric{
-				testutil.MustMetric("Name1", map[string]string{},
+				metric.New("Name1", map[string]string{},
 					map[string]interface{}{
 						"test1": float64(50),
 						"test2": float64(100),
 					}, time.Unix(0, 0)),
-				testutil.MustMetric("Name2", map[string]string{},
+				metric.New("Name2", map[string]string{},
 					map[string]interface{}{
 						"test1": float64(75),
 						"test2": float32(25),
 					}, time.Unix(0, 0)),
-				testutil.MustMetric("Name3", map[string]string{},
+				metric.New("Name3", map[string]string{},
 					map[string]interface{}{
 						"test3": float64(4.6),
 						"test4": float64(10),
 					}, time.Unix(0, 0)),
-				testutil.MustMetric("Name4", map[string]string{},
+				metric.New("Name4", map[string]string{},
 					map[string]interface{}{
 						"test3": float64(1),
 						"test4": float64(9.1),
@@ -109,7 +109,7 @@ func TestMinMax(t *testing.T) {
 				},
 			},
 			inputs: []telegraf.Metric{
-				testutil.MustMetric("Name1", map[string]string{},
+				metric.New("Name1", map[string]string{},
 					map[string]interface{}{
 						"test1": int64(0),
 						"test2": uint64(1),
@@ -117,7 +117,7 @@ func TestMinMax(t *testing.T) {
 					}, time.Unix(0, 0)),
 			},
 			expected: []telegraf.Metric{
-				testutil.MustMetric("Name1", map[string]string{},
+				metric.New("Name1", map[string]string{},
 					map[string]interface{}{
 						"test1": float64(50),
 						"test2": float64(100),
@@ -137,14 +137,14 @@ func TestMinMax(t *testing.T) {
 				},
 			},
 			inputs: []telegraf.Metric{
-				testutil.MustMetric("Name1", map[string]string{},
+				metric.New("Name1", map[string]string{},
 					map[string]interface{}{
 						"test1": int64(-2),
 						"test2": uint64(2),
 					}, time.Unix(0, 0)),
 			},
 			expected: []telegraf.Metric{
-				testutil.MustMetric("Name1", map[string]string{},
+				metric.New("Name1", map[string]string{},
 					map[string]interface{}{
 						"test1": float64(-50),
 						"test2": float64(150),
@@ -163,13 +163,13 @@ func TestMinMax(t *testing.T) {
 				},
 			},
 			inputs: []telegraf.Metric{
-				testutil.MustMetric("Name1", map[string]string{},
+				metric.New("Name1", map[string]string{},
 					map[string]interface{}{
 						"test1": int64(0),
 					}, time.Unix(0, 0)),
 			},
 			expected: []telegraf.Metric{
-				testutil.MustMetric("Name1", map[string]string{},
+				metric.New("Name1", map[string]string{},
 					map[string]interface{}{
 						"test1": float64(50),
 					}, time.Unix(0, 0)),
@@ -222,44 +222,44 @@ func TestFactor(t *testing.T) {
 				},
 			},
 			inputs: []telegraf.Metric{
-				testutil.MustMetric("Name1", map[string]string{},
+				metric.New("Name1", map[string]string{},
 					map[string]interface{}{
 						"test1": int64(0),
 						"test2": uint64(1),
 					}, time.Unix(0, 0)),
-				testutil.MustMetric("Name2", map[string]string{},
+				metric.New("Name2", map[string]string{},
 					map[string]interface{}{
 						"test1": "0.5",
 						"test2": float32(-0.5),
 					}, time.Unix(0, 0)),
-				testutil.MustMetric("Name3", map[string]string{},
+				metric.New("Name3", map[string]string{},
 					map[string]interface{}{
 						"test3": int64(-3),
 						"test4": uint64(0),
 					}, time.Unix(0, 0)),
-				testutil.MustMetric("Name4", map[string]string{},
+				metric.New("Name4", map[string]string{},
 					map[string]interface{}{
 						"test3": int64(-5),
 						"test4": float32(-0.5),
 					}, time.Unix(0, 0)),
 			},
 			expected: []telegraf.Metric{
-				testutil.MustMetric("Name1", map[string]string{},
+				metric.New("Name1", map[string]string{},
 					map[string]interface{}{
 						"test1": float64(50),
 						"test2": float64(100),
 					}, time.Unix(0, 0)),
-				testutil.MustMetric("Name2", map[string]string{},
+				metric.New("Name2", map[string]string{},
 					map[string]interface{}{
 						"test1": float64(75),
 						"test2": float32(25),
 					}, time.Unix(0, 0)),
-				testutil.MustMetric("Name3", map[string]string{},
+				metric.New("Name3", map[string]string{},
 					map[string]interface{}{
 						"test3": float64(4.2),
 						"test4": float64(9),
 					}, time.Unix(0, 0)),
-				testutil.MustMetric("Name4", map[string]string{},
+				metric.New("Name4", map[string]string{},
 					map[string]interface{}{
 						"test3": float64(1),
 						"test4": float64(8.2),
@@ -276,7 +276,7 @@ func TestFactor(t *testing.T) {
 				},
 			},
 			inputs: []telegraf.Metric{
-				testutil.MustMetric("Name1", map[string]string{},
+				metric.New("Name1", map[string]string{},
 					map[string]interface{}{
 						"test1": int64(0),
 						"test2": uint64(1),
@@ -284,7 +284,7 @@ func TestFactor(t *testing.T) {
 					}, time.Unix(0, 0)),
 			},
 			expected: []telegraf.Metric{
-				testutil.MustMetric("Name1", map[string]string{},
+				metric.New("Name1", map[string]string{},
 					map[string]interface{}{
 						"test1": float64(50),
 						"test2": float64(100),
@@ -302,13 +302,13 @@ func TestFactor(t *testing.T) {
 				},
 			},
 			inputs: []telegraf.Metric{
-				testutil.MustMetric("Name1", map[string]string{},
+				metric.New("Name1", map[string]string{},
 					map[string]interface{}{
 						"test1": int64(0),
 					}, time.Unix(0, 0)),
 			},
 			expected: []telegraf.Metric{
-				testutil.MustMetric("Name1", map[string]string{},
+				metric.New("Name1", map[string]string{},
 					map[string]interface{}{
 						"test1": float64(50),
 					}, time.Unix(0, 0)),
@@ -323,13 +323,13 @@ func TestFactor(t *testing.T) {
 				},
 			},
 			inputs: []telegraf.Metric{
-				testutil.MustMetric("Name1", map[string]string{},
+				metric.New("Name1", map[string]string{},
 					map[string]interface{}{
 						"test1": int64(1),
 					}, time.Unix(0, 0)),
 			},
 			expected: []telegraf.Metric{
-				testutil.MustMetric("Name1", map[string]string{},
+				metric.New("Name1", map[string]string{},
 					map[string]interface{}{
 						"test1": float64(50),
 					}, time.Unix(0, 0)),
@@ -344,13 +344,13 @@ func TestFactor(t *testing.T) {
 				},
 			},
 			inputs: []telegraf.Metric{
-				testutil.MustMetric("Name1", map[string]string{},
+				metric.New("Name1", map[string]string{},
 					map[string]interface{}{
 						"test1": int64(1),
 					}, time.Unix(0, 0)),
 			},
 			expected: []telegraf.Metric{
-				testutil.MustMetric("Name1", map[string]string{},
+				metric.New("Name1", map[string]string{},
 					map[string]interface{}{
 						"test1": float64(51),
 					}, time.Unix(0, 0)),

--- a/plugins/processors/snmp_lookup/lookup_test.go
+++ b/plugins/processors/snmp_lookup/lookup_test.go
@@ -137,7 +137,7 @@ func TestGetConnection(t *testing.T) {
 	}{
 		{
 			name: "agent error",
-			input: testutil.MustMetric(
+			input: metric.New(
 				"test",
 				map[string]string{
 					"source": "test://127.0.0.1",
@@ -149,7 +149,7 @@ func TestGetConnection(t *testing.T) {
 		},
 		{
 			name: "v2 trap",
-			input: testutil.MustMetric(
+			input: metric.New(
 				"test",
 				map[string]string{
 					"source":    "127.0.0.1",
@@ -268,7 +268,7 @@ func TestAdd(t *testing.T) {
 		},
 		{
 			name: "no index tag",
-			input: testutil.MustMetric(
+			input: metric.New(
 				"test",
 				map[string]string{
 					"source": "127.0.0.1",
@@ -277,7 +277,7 @@ func TestAdd(t *testing.T) {
 				time.Unix(0, 0),
 			),
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"test",
 					map[string]string{
 						"source": "127.0.0.1",
@@ -289,7 +289,7 @@ func TestAdd(t *testing.T) {
 		},
 		{
 			name: "cached",
-			input: testutil.MustMetric(
+			input: metric.New(
 				"test",
 				map[string]string{
 					"source": "127.0.0.1",
@@ -299,7 +299,7 @@ func TestAdd(t *testing.T) {
 				time.Unix(0, 0),
 			),
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"test",
 					map[string]string{
 						"source": "127.0.0.1",
@@ -313,7 +313,7 @@ func TestAdd(t *testing.T) {
 		},
 		{
 			name: "non-existing index",
-			input: testutil.MustMetric(
+			input: metric.New(
 				"test",
 				map[string]string{
 					"source": "127.0.0.1",
@@ -323,7 +323,7 @@ func TestAdd(t *testing.T) {
 				time.Unix(0, 0),
 			),
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"test",
 					map[string]string{
 						"source": "127.0.0.1",
@@ -397,7 +397,7 @@ func TestExpiry(t *testing.T) {
 			".1.3.6.1.2.1.31.1.1.1.1.1": "eth1",
 		},
 	}
-	m := testutil.MustMetric(
+	m := metric.New(
 		"test",
 		map[string]string{"source": "127.0.0.1"},
 		map[string]interface{}{"value": 1.0},
@@ -662,7 +662,7 @@ func TestNoReenqueAfterStop(t *testing.T) {
 
 	// Send two metrics for the
 	for range 2 {
-		m := testutil.MustMetric(
+		m := metric.New(
 			"test",
 			map[string]string{
 				"source": "127.0.0.1",
@@ -741,7 +741,7 @@ func TestStopWithTaskInWorkerPool(t *testing.T) {
 	var acc testutil.Accumulator
 	require.NoError(t, plugin.Start(&acc))
 
-	m := testutil.MustMetric(
+	m := metric.New(
 		"test",
 		map[string]string{
 			"source": "127.0.0.1",
@@ -833,7 +833,7 @@ func TestStopWithTaskInWorkerPoolWithGoTimeout(t *testing.T) {
 	var acc testutil.Accumulator
 	require.NoError(t, plugin.Start(&acc))
 
-	m := testutil.MustMetric(
+	m := metric.New(
 		"test",
 		map[string]string{
 			"source": "127.0.0.1",


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Covers scale, port_name, and snmp_lookup processors.

Part of #18495 - testutil.MustMetric is a trivial wrapper around metric.New that adds no value and misleads with its "Must" prefix.

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
