### PR TITLE
chore(processors): Replace testutil.MustMetric with metric.New

### DIFF
--- a/plugins/processors/defaults/defaults_test.go
+++ b/plugins/processors/defaults/defaults_test.go
@@ -28,7 +28,7 @@ func TestDefaults(t *testing.T) {
 					"is_dead":   true,
 				},
 			},
-			input: testutil.MustMetric(
+			input: metric.New(
 				"CPU metrics",
 				map[string]string{},
 				map[string]interface{}{
@@ -39,7 +39,7 @@ func TestDefaults(t *testing.T) {
 				time.Unix(0, 0),
 			),
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"CPU metrics",
 					map[string]string{},
 					map[string]interface{}{
@@ -61,7 +61,7 @@ func TestDefaults(t *testing.T) {
 					"variance":      1.2,
 				},
 			},
-			input: testutil.MustMetric(
+			input: metric.New(
 				"CPU metrics",
 				map[string]string{},
 				map[string]interface{}{
@@ -71,7 +71,7 @@ func TestDefaults(t *testing.T) {
 				time.Unix(0, 0),
 			),
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"CPU metrics",
 					map[string]string{},
 					map[string]interface{}{
@@ -96,7 +96,7 @@ func TestDefaults(t *testing.T) {
 					"boost_enabled": false,
 				},
 			},
-			input: testutil.MustMetric(
+			input: metric.New(
 				"CPU metrics",
 				map[string]string{},
 				map[string]interface{}{
@@ -107,7 +107,7 @@ func TestDefaults(t *testing.T) {
 				time.Unix(0, 0),
 			),
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"CPU metrics",
 					map[string]string{},
 					map[string]interface{}{
@@ -147,7 +147,7 @@ func TestTagDefaults(t *testing.T) {
 					"wind_feel": "very chill",
 				},
 			},
-			input: testutil.MustMetric(
+			input: metric.New(
 				"CPU metrics",
 				map[string]string{
 					"wind_feel": "a dragon's breath",
@@ -159,7 +159,7 @@ func TestTagDefaults(t *testing.T) {
 				time.Unix(0, 0),
 			),
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"CPU metrics",
 					map[string]string{
 						"wind_feel": "a dragon's breath",
@@ -179,7 +179,7 @@ func TestTagDefaults(t *testing.T) {
 					"wind_feel": "Unknown",
 				},
 			},
-			input: testutil.MustMetric(
+			input: metric.New(
 				"CPU metrics",
 				map[string]string{},
 				map[string]interface{}{
@@ -189,7 +189,7 @@ func TestTagDefaults(t *testing.T) {
 				time.Unix(0, 0),
 			),
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"CPU metrics",
 					map[string]string{
 						"wind_feel": "Unknown",
@@ -211,7 +211,7 @@ func TestTagDefaults(t *testing.T) {
 					"boost_enabled": "false",
 				},
 			},
-			input: testutil.MustMetric(
+			input: metric.New(
 				"CPU metrics",
 				map[string]string{
 					"wind_feel":     " ",
@@ -224,7 +224,7 @@ func TestTagDefaults(t *testing.T) {
 				time.Unix(0, 0),
 			),
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"CPU metrics",
 					map[string]string{
 						"wind_feel":     "Unknown",

--- a/plugins/processors/strings/strings_test.go
+++ b/plugins/processors/strings/strings_test.go
@@ -961,7 +961,7 @@ func TestBase64Decode(t *testing.T) {
 				},
 			},
 			metric: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{},
 					map[string]interface{}{
@@ -971,7 +971,7 @@ func TestBase64Decode(t *testing.T) {
 				),
 			},
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{},
 					map[string]interface{}{
@@ -991,7 +991,7 @@ func TestBase64Decode(t *testing.T) {
 				},
 			},
 			metric: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{},
 					map[string]interface{}{
@@ -1001,7 +1001,7 @@ func TestBase64Decode(t *testing.T) {
 				),
 			},
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{},
 					map[string]interface{}{
@@ -1021,7 +1021,7 @@ func TestBase64Decode(t *testing.T) {
 				},
 			},
 			metric: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{},
 					map[string]interface{}{
@@ -1031,7 +1031,7 @@ func TestBase64Decode(t *testing.T) {
 				),
 			},
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{},
 					map[string]interface{}{
@@ -1069,7 +1069,7 @@ func TestValidUTF8(t *testing.T) {
 				},
 			},
 			metric: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{},
 					map[string]interface{}{
@@ -1079,7 +1079,7 @@ func TestValidUTF8(t *testing.T) {
 				),
 			},
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{},
 					map[string]interface{}{
@@ -1100,7 +1100,7 @@ func TestValidUTF8(t *testing.T) {
 				},
 			},
 			metric: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{},
 					map[string]interface{}{
@@ -1110,7 +1110,7 @@ func TestValidUTF8(t *testing.T) {
 				),
 			},
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{},
 					map[string]interface{}{
@@ -1131,7 +1131,7 @@ func TestValidUTF8(t *testing.T) {
 				},
 			},
 			metric: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{},
 					map[string]interface{}{
@@ -1141,7 +1141,7 @@ func TestValidUTF8(t *testing.T) {
 				),
 			},
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{},
 					map[string]interface{}{

--- a/plugins/processors/template/template_test.go
+++ b/plugins/processors/template/template_test.go
@@ -22,7 +22,7 @@ func TestName(t *testing.T) {
 	require.NoError(t, err)
 
 	input := []telegraf.Metric{
-		testutil.MustMetric(
+		metric.New(
 			"cpu",
 			map[string]string{},
 			map[string]interface{}{
@@ -34,7 +34,7 @@ func TestName(t *testing.T) {
 
 	actual := plugin.Apply(input...)
 	expected := []telegraf.Metric{
-		testutil.MustMetric(
+		metric.New(
 			"cpu",
 			map[string]string{
 				"measurement": "cpu",
@@ -58,7 +58,7 @@ func TestNameTemplate(t *testing.T) {
 	require.NoError(t, err)
 
 	input := []telegraf.Metric{
-		testutil.MustMetric(
+		metric.New(
 			"cpu",
 			map[string]string{"foo": "measurement"},
 			map[string]interface{}{
@@ -70,7 +70,7 @@ func TestNameTemplate(t *testing.T) {
 
 	actual := plugin.Apply(input...)
 	expected := []telegraf.Metric{
-		testutil.MustMetric(
+		metric.New(
 			"cpu",
 			map[string]string{
 				"foo":         "measurement",
@@ -98,14 +98,14 @@ func TestTagTemplateConcatenate(t *testing.T) {
 	}
 
 	// create metric for testing
-	input := []telegraf.Metric{testutil.MustMetric("Tags", map[string]string{"hostname": "localhost", "level": "debug"}, nil, now)}
+	input := []telegraf.Metric{metric.New("Tags", map[string]string{"hostname": "localhost", "level": "debug"}, nil, now)}
 
 	// act
 	actual := tmp.Apply(input[0])
 
 	// assert
 	expected := []telegraf.Metric{
-		testutil.MustMetric("Tags", map[string]string{"hostname": "localhost", "level": "debug", "topic": "localhost.debug"}, nil, now),
+		metric.New("Tags", map[string]string{"hostname": "localhost", "level": "debug", "topic": "localhost.debug"}, nil, now),
 	}
 	testutil.RequireMetricsEqual(t, expected, actual)
 }
@@ -123,8 +123,8 @@ func TestMetricMissingTagsIsNotLost(t *testing.T) {
 	}
 
 	// create metrics for testing
-	m1 := testutil.MustMetric("Works", map[string]string{"hostname": "localhost", "level": "debug"}, nil, now)
-	m2 := testutil.MustMetric("Fails", map[string]string{"hostname": "localhost"}, nil, now)
+	m1 := metric.New("Works", map[string]string{"hostname": "localhost", "level": "debug"}, nil, now)
+	m2 := metric.New("Fails", map[string]string{"hostname": "localhost"}, nil, now)
 
 	// act
 	actual := tmp.Apply(m1, m2)
@@ -147,14 +147,14 @@ func TestTagAndFieldConcatenate(t *testing.T) {
 	}
 
 	// create metric for testing
-	m1 := testutil.MustMetric("weather", map[string]string{"location": "us-midwest"}, map[string]interface{}{"temperature": "too warm"}, now)
+	m1 := metric.New("weather", map[string]string{"location": "us-midwest"}, map[string]interface{}{"temperature": "too warm"}, now)
 
 	// act
 	actual := tmp.Apply(m1)
 
 	// assert
 	expected := []telegraf.Metric{
-		testutil.MustMetric(
+		metric.New(
 			"weather",
 			map[string]string{"location": "us-midwest", "LocalTemp": "us-midwest is too warm"},
 			map[string]interface{}{"temperature": "too warm"},
@@ -286,7 +286,7 @@ func TestSprig(t *testing.T) {
 	require.NoError(t, err)
 
 	input := []telegraf.Metric{
-		testutil.MustMetric(
+		metric.New(
 			"cpu",
 			map[string]string{"foo": "MEASUREMENT"},
 			map[string]interface{}{
@@ -298,7 +298,7 @@ func TestSprig(t *testing.T) {
 
 	actual := plugin.Apply(input...)
 	expected := []telegraf.Metric{
-		testutil.MustMetric(
+		metric.New(
 			"cpu",
 			map[string]string{
 				"foo":         "MEASUREMENT",

--- a/plugins/processors/unpivot/unpivot_test.go
+++ b/plugins/processors/unpivot/unpivot_test.go
@@ -41,7 +41,7 @@ func TestOriginalMode(t *testing.T) {
 			tagKey:   "name",
 			valueKey: "value",
 			metrics: []telegraf.Metric{
-				testutil.MustMetric("cpu",
+				metric.New("cpu",
 					map[string]string{},
 					map[string]interface{}{
 						"idle_time": int64(42),
@@ -50,7 +50,7 @@ func TestOriginalMode(t *testing.T) {
 				),
 			},
 			expected: []telegraf.Metric{
-				testutil.MustMetric("cpu",
+				metric.New("cpu",
 					map[string]string{
 						"name": "idle_time",
 					},
@@ -66,7 +66,7 @@ func TestOriginalMode(t *testing.T) {
 			tagKey:   "name",
 			valueKey: "value",
 			metrics: []telegraf.Metric{
-				testutil.MustMetric("cpu",
+				metric.New("cpu",
 					map[string]string{},
 					map[string]interface{}{
 						"idle_time": int64(42),
@@ -76,7 +76,7 @@ func TestOriginalMode(t *testing.T) {
 				),
 			},
 			expected: []telegraf.Metric{
-				testutil.MustMetric("cpu",
+				metric.New("cpu",
 					map[string]string{
 						"name": "idle_time",
 					},
@@ -85,7 +85,7 @@ func TestOriginalMode(t *testing.T) {
 					},
 					now,
 				),
-				testutil.MustMetric("cpu",
+				metric.New("cpu",
 					map[string]string{
 						"name": "idle_user",
 					},
@@ -127,7 +127,7 @@ func TestFieldMode(t *testing.T) {
 			tagKey:      "name",
 			valueKey:    "value",
 			metrics: []telegraf.Metric{
-				testutil.MustMetric("cpu",
+				metric.New("cpu",
 					map[string]string{},
 					map[string]interface{}{
 						"idle_time": int64(42),
@@ -136,7 +136,7 @@ func TestFieldMode(t *testing.T) {
 				),
 			},
 			expected: []telegraf.Metric{
-				testutil.MustMetric("idle_time",
+				metric.New("idle_time",
 					map[string]string{},
 					map[string]interface{}{
 						"value": int64(42),
@@ -151,7 +151,7 @@ func TestFieldMode(t *testing.T) {
 			tagKey:      "name",
 			valueKey:    "value",
 			metrics: []telegraf.Metric{
-				testutil.MustMetric("cpu",
+				metric.New("cpu",
 					map[string]string{},
 					map[string]interface{}{
 						"idle_time": int64(42),
@@ -161,14 +161,14 @@ func TestFieldMode(t *testing.T) {
 				),
 			},
 			expected: []telegraf.Metric{
-				testutil.MustMetric("idle_time",
+				metric.New("idle_time",
 					map[string]string{},
 					map[string]interface{}{
 						"value": int64(42),
 					},
 					now,
 				),
-				testutil.MustMetric("idle_user",
+				metric.New("idle_user",
 					map[string]string{},
 					map[string]interface{}{
 						"value": int64(43),
@@ -183,7 +183,7 @@ func TestFieldMode(t *testing.T) {
 			tagKey:      "name",
 			valueKey:    "value",
 			metrics: []telegraf.Metric{
-				testutil.MustMetric("cpu",
+				metric.New("cpu",
 					map[string]string{
 						"building": "5a",
 					},
@@ -195,7 +195,7 @@ func TestFieldMode(t *testing.T) {
 				),
 			},
 			expected: []telegraf.Metric{
-				testutil.MustMetric("idle_time",
+				metric.New("idle_time",
 					map[string]string{
 						"building": "5a",
 					},
@@ -204,7 +204,7 @@ func TestFieldMode(t *testing.T) {
 					},
 					now,
 				),
-				testutil.MustMetric("idle_user",
+				metric.New("idle_user",
 					map[string]string{
 						"building": "5a",
 					},


### PR DESCRIPTION


## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Covers unpivot, strings, defaults, and template processors.

Part of #18495 - testutil.MustMetric is a trivial wrapper around metric.New that adds no value and misleads with its "Must" prefix.

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
