### PR TITLE
chore(processors): Replace testutil.MustMetric with metric.New

### DIFF
--- a/plugins/processors/date/date_test.go
+++ b/plugins/processors/date/date_test.go
@@ -215,7 +215,7 @@ func TestDateOffset(t *testing.T) {
 	}
 	require.NoError(t, plugin.Init())
 
-	input := testutil.MustMetric(
+	input := metric.New(
 		"cpu",
 		map[string]string{},
 		map[string]interface{}{
@@ -225,7 +225,7 @@ func TestDateOffset(t *testing.T) {
 	)
 
 	expected := []telegraf.Metric{
-		testutil.MustMetric(
+		metric.New(
 			"cpu",
 			map[string]string{
 				"hour": "23",

--- a/plugins/processors/filepath/filepath_test.go
+++ b/plugins/processors/filepath/filepath_test.go
@@ -23,7 +23,7 @@ func TestOptions_Apply(t *testing.T) {
 			o:            newOptions("/my/test/"),
 			inputMetrics: getSmokeTestInputMetrics(samplePath),
 			expectedMetrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					smokeMetricName,
 					map[string]string{
 						"baseTag":  "file.log",
@@ -55,14 +55,14 @@ func TestOptions_Apply(t *testing.T) {
 					},
 				}},
 			inputMetrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"testMetric",
 					map[string]string{"sourcePath": samplePath},
 					map[string]interface{}{"sourcePath": samplePath},
 					time.Now()),
 			},
 			expectedMetrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"testMetric",
 					map[string]string{"sourcePath": samplePath, "basePath": "file.log"},
 					map[string]interface{}{"sourcePath": samplePath, "basePath": "file.log"},

--- a/plugins/processors/filepath/filepath_test_helpers.go
+++ b/plugins/processors/filepath/filepath_test_helpers.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/metric"
 	"github.com/influxdata/telegraf/testutil"
 )
 
@@ -85,7 +86,7 @@ func getSampleMetricFields(path string) map[string]interface{} {
 
 func getSmokeTestInputMetrics(path string) []telegraf.Metric {
 	return []telegraf.Metric{
-		testutil.MustMetric(smokeMetricName, getSampleMetricTags(path), getSampleMetricFields(path),
+		metric.New(smokeMetricName, getSampleMetricTags(path), getSampleMetricFields(path),
 			time.Now()),
 	}
 }

--- a/plugins/processors/filepath/filepath_windows_test.go
+++ b/plugins/processors/filepath/filepath_windows_test.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/influxdata/telegraf"
-	"github.com/influxdata/telegraf/testutil"
+	"github.com/influxdata/telegraf/metric"
 )
 
 var samplePath = "c:\\my\\test\\\\c\\..\\path\\file.log"
@@ -17,7 +17,7 @@ func TestOptions_Apply(t *testing.T) {
 			o:            newOptions("c:\\my\\test\\"),
 			inputMetrics: getSmokeTestInputMetrics(samplePath),
 			expectedMetrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					smokeMetricName,
 					map[string]string{
 						"baseTag":  "file.log",

--- a/plugins/processors/ifname/ifname_test.go
+++ b/plugins/processors/ifname/ifname_test.go
@@ -70,7 +70,7 @@ func TestIfNameIntegration(t *testing.T) {
 
 	require.NoError(t, err)
 
-	m := testutil.MustMetric(
+	m := metric.New(
 		"cpu",
 		map[string]string{
 			"ifIndex": "1",
@@ -80,7 +80,7 @@ func TestIfNameIntegration(t *testing.T) {
 		time.Unix(0, 0),
 	)
 
-	expected := testutil.MustMetric(
+	expected := metric.New(
 		"cpu",
 		map[string]string{
 			"ifIndex": "1",

--- a/plugins/processors/pivot/pivot_test.go
+++ b/plugins/processors/pivot/pivot_test.go
@@ -27,7 +27,7 @@ func TestPivot(t *testing.T) {
 				ValueKey: "value",
 			},
 			metrics: []telegraf.Metric{
-				testutil.MustMetric("cpu",
+				metric.New("cpu",
 					map[string]string{
 						"name": "idle_time",
 					},
@@ -38,7 +38,7 @@ func TestPivot(t *testing.T) {
 				),
 			},
 			expected: []telegraf.Metric{
-				testutil.MustMetric("cpu",
+				metric.New("cpu",
 					map[string]string{},
 					map[string]interface{}{
 						"idle_time": int64(42),
@@ -54,7 +54,7 @@ func TestPivot(t *testing.T) {
 				ValueKey: "value",
 			},
 			metrics: []telegraf.Metric{
-				testutil.MustMetric("cpu",
+				metric.New("cpu",
 					map[string]string{
 						"foo": "idle_time",
 					},
@@ -65,7 +65,7 @@ func TestPivot(t *testing.T) {
 				),
 			},
 			expected: []telegraf.Metric{
-				testutil.MustMetric("cpu",
+				metric.New("cpu",
 					map[string]string{
 						"foo": "idle_time",
 					},
@@ -83,7 +83,7 @@ func TestPivot(t *testing.T) {
 				ValueKey: "value",
 			},
 			metrics: []telegraf.Metric{
-				testutil.MustMetric("cpu",
+				metric.New("cpu",
 					map[string]string{
 						"name": "idle_time",
 					},
@@ -94,7 +94,7 @@ func TestPivot(t *testing.T) {
 				),
 			},
 			expected: []telegraf.Metric{
-				testutil.MustMetric("cpu",
+				metric.New("cpu",
 					map[string]string{
 						"name": "idle_time",
 					},

--- a/plugins/processors/s2geo/s2geo_test.go
+++ b/plugins/processors/s2geo/s2geo_test.go
@@ -27,7 +27,7 @@ func TestGeo(t *testing.T) {
 	err := plugin.Init()
 	require.NoError(t, err)
 
-	m := testutil.MustMetric(
+	m := metric.New(
 		"mta",
 		map[string]string{},
 		map[string]interface{}{
@@ -38,7 +38,7 @@ func TestGeo(t *testing.T) {
 	)
 
 	expected := []telegraf.Metric{
-		testutil.MustMetric(
+		metric.New(
 			"mta",
 			map[string]string{
 				"s2_cell_id": "89e8ed4",


### PR DESCRIPTION


## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Covers pivot, filepath, s2geo, date, and ifname processors.

Part of #18495 - testutil.MustMetric is a trivial wrapper around metric.New that adds no value and misleads with its "Must" prefix.

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
