### PR TITLE
test(models): Fix tests

### DIFF
--- a/models/running_output_test.go
+++ b/models/running_output_test.go
@@ -1251,11 +1251,12 @@ func TestRunningOutputStatisticsErrorsCount(t *testing.T) {
 	plugin := &mockOutput{
 		preWriteHook: func([]telegraf.Metric) error { return expectedErr },
 	}
-	model := NewRunningOutput(plugin, &OutputConfig{
+	model, err := NewRunningOutput(plugin, &OutputConfig{
 		Name:  "mock",
 		Alias: "TestRunningOutputStatisticsErrorCount",
 		ID:    id.String(),
 	}, 5, 10)
+	require.NoError(t, err)
 	require.NoError(t, model.Init())
 	require.NoError(t, model.Connect())
 	defer model.Close()
@@ -1297,11 +1298,12 @@ func TestRunningOutputStatisticsWriteErrorsCount(t *testing.T) {
 	plugin := &mockOutput{
 		preWriteHook: func([]telegraf.Metric) error { return expectedErr },
 	}
-	model := NewRunningOutput(plugin, &OutputConfig{
+	model, err := NewRunningOutput(plugin, &OutputConfig{
 		Name:  "mock",
 		Alias: "TestRunningOutputStatisticsErrorCount",
 		ID:    id.String(),
 	}, 5, 10)
+	require.NoError(t, err)
 	require.NoError(t, model.Init())
 	require.NoError(t, model.Connect())
 	defer model.Close()


### PR DESCRIPTION
## Summary

Fix unit-tests using the old `NewRunningOutput` signature.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
