### PR TITLE
feat(agent): Add `structured_log_add_input_tags`. Adds the input tags into the logger JSON output.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -252,6 +252,10 @@ type AgentConfig struct {
 	// Ignored if "logformat" is not "structured".
 	StructuredLogMessageKey string `toml:"structured_log_message_key"`
 
+	// When set to true and using logformat = "structured", the tags of each
+	// input plugin are added to the log output as a "tags" JSON field.
+	LogAddInputTags bool `toml:"log_add_input_tags"`
+
 	// The file will be rotated after the time interval specified.  When set
 	// to 0 no time based rotation is performed.
 	LogfileRotationInterval Duration `toml:"logfile_rotation_interval"`
@@ -1690,6 +1694,7 @@ func (c *Config) buildInput(name, source string, tbl *ast.Table) (*models.InputC
 		Source:                  source,
 		AlwaysIncludeLocalTags:  c.Agent.AlwaysIncludeLocalTags,
 		AlwaysIncludeGlobalTags: c.Agent.AlwaysIncludeGlobalTags,
+		AddTagsToLogs:           c.Agent.LogAddInputTags,
 	}
 	cp.Interval, _ = c.getFieldDuration(tbl, "interval")
 	cp.Precision, _ = c.getFieldDuration(tbl, "precision")

--- a/config/config.go
+++ b/config/config.go
@@ -254,7 +254,7 @@ type AgentConfig struct {
 
 	// When set to true and using logformat = "structured", the tags of each
 	// input plugin are added to the log output as a "tags" JSON field.
-	LogAddInputTags bool `toml:"log_add_input_tags"`
+	StructuredLogAddInputTags bool `toml:"structured_log_add_input_tags"`
 
 	// The file will be rotated after the time interval specified.  When set
 	// to 0 no time based rotation is performed.
@@ -1694,7 +1694,7 @@ func (c *Config) buildInput(name, source string, tbl *ast.Table) (*models.InputC
 		Source:                  source,
 		AlwaysIncludeLocalTags:  c.Agent.AlwaysIncludeLocalTags,
 		AlwaysIncludeGlobalTags: c.Agent.AlwaysIncludeGlobalTags,
-		AddTagsToLogs:           c.Agent.LogAddInputTags,
+		AddTagsToStructuredLogs: c.Agent.StructuredLogAddInputTags,
 	}
 	cp.Interval, _ = c.getFieldDuration(tbl, "interval")
 	cp.Precision, _ = c.getFieldDuration(tbl, "precision")

--- a/config/config.go
+++ b/config/config.go
@@ -574,6 +574,19 @@ func (c *Config) LoadAll(configFiles ...string) error {
 		}
 	}
 
+	// When loading multiple config files (e.g. via --config-directory), the
+	// [agent] section may be parsed after some input files, meaning
+	// buildInput saw StructuredLogAddInputTags=false and skipped the logger
+	// attribute. Therefore, it needs to be parsed again after loading all configs.
+	if c.Agent.StructuredLogAddInputTags {
+		for _, input := range c.Inputs {
+			if !input.Config.AddTagsToStructuredLogs && len(input.Config.Tags) > 0 {
+				input.Config.AddTagsToStructuredLogs = true
+				input.Log().AddAttribute("tags", input.Config.Tags)
+			}
+		}
+	}
+
 	// Sort the processors according to their `order` setting while
 	// using a stable sort to keep the file loading / file position order.
 	sort.Stable(c.Processors)

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -330,7 +330,7 @@ The agent table configures Telegraf and the defaults used across all plugins.
         }
       }
     ```
-    
+
   Ignored if `logformat` is not "structured".
 
 - **logfile**:

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -313,7 +313,22 @@ The agent table configures Telegraf and the defaults used across all plugins.
 
 - **structured_log_add_input_tags**:
   To add input configuration tags to the log output.  
-  Example: `{"time":"2026-03-27T09:14:36.078389805Z","level":"INFO","msg":"Error connecting to target. Restarting in 10s...","category":"inputs","plugin":"execd","tags":{"server_host":"10.0.1.20","friendly_name":"friendly_server_name","log_source":"telegraf","metric_type":"logs"}}`  
+  Example:
+    ```
+      {
+        "time":"2026-03-27T09:14:36.078389805Z",
+        "level":"INFO",
+        "msg":"Error connecting to target. Restarting in 10s...",
+        "category":"inputs",
+        "plugin":"execd",
+        "tags":{
+          "server_host":"10.0.1.20",
+          "friendly_name":"friendly_server_name",
+          "log_source":"telegraf",
+          "metric_type":"logs"
+        }
+      }
+    ```
   Ignored if `logformat` is not "structured".
 
 - **logfile**:

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -311,6 +311,11 @@ The agent table configures Telegraf and the defaults used across all plugins.
   Message key for structured logs, to override the default of "msg".
   Ignored if `logformat` is not "structured".
 
+- **structured_log_add_input_tags**:
+  To add input configuration tags to the log output.  
+  Example: `{"time":"2026-03-27T09:14:36.078389805Z","level":"INFO","msg":"Error connecting to target. Restarting in 10s...","category":"inputs","plugin":"execd","tags":{"server_host":"10.0.1.20","friendly_name":"friendly_server_name","log_source":"telegraf","metric_type":"logs"}}`  
+  Ignored if `logformat` is not "structured".
+
 - **logfile**:
   Name of the file to be logged to or stderr if unset or empty. This
   setting is ignored for the "eventlog" format.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -314,7 +314,8 @@ The agent table configures Telegraf and the defaults used across all plugins.
 - **structured_log_add_input_tags**:
   To add input configuration tags to the log output.  
   Example:
-    ```
+
+    ```json
       {
         "time":"2026-03-27T09:14:36.078389805Z",
         "level":"INFO",
@@ -329,6 +330,7 @@ The agent table configures Telegraf and the defaults used across all plugins.
         }
       }
     ```
+    
   Ignored if `logformat` is not "structured".
 
 - **logfile**:

--- a/models/running_input.go
+++ b/models/running_input.go
@@ -54,6 +54,9 @@ func NewRunningInput(input telegraf.Input, config *InputConfig) *RunningInput {
 	if err := logger.SetLogLevel(config.LogLevel); err != nil {
 		logger.Error(err)
 	}
+	if config.AddTagsToLogs && len(config.Tags) > 0 {
+		logger.AddAttribute("tags", config.Tags)
+	}
 	SetLoggerOnPlugin(input, logger)
 	SetStatisticsOnPlugin(input, logger, tags)
 
@@ -110,6 +113,10 @@ type InputConfig struct {
 	Filter                  Filter
 	AlwaysIncludeLocalTags  bool
 	AlwaysIncludeGlobalTags bool
+
+	// When true and using logformat = "structured", the input's tags are
+	// added to the log output as a "tags" JSON field.
+	AddTagsToLogs bool
 }
 
 func (*RunningInput) metricFiltered(metric telegraf.Metric) {

--- a/models/running_input.go
+++ b/models/running_input.go
@@ -54,7 +54,7 @@ func NewRunningInput(input telegraf.Input, config *InputConfig) *RunningInput {
 	if err := logger.SetLogLevel(config.LogLevel); err != nil {
 		logger.Error(err)
 	}
-	if config.AddTagsToLogs && len(config.Tags) > 0 {
+	if config.AddTagsToStructuredLogs && len(config.Tags) > 0 {
 		logger.AddAttribute("tags", config.Tags)
 	}
 	SetLoggerOnPlugin(input, logger)
@@ -116,7 +116,7 @@ type InputConfig struct {
 
 	// When true and using logformat = "structured", the input's tags are
 	// added to the log output as a "tags" JSON field.
-	AddTagsToLogs bool
+	AddTagsToStructuredLogs bool
 }
 
 func (*RunningInput) metricFiltered(metric telegraf.Metric) {


### PR DESCRIPTION
## Summary
When using a lot of different configurations, it can be hard to differentiate which checks are failing when they do. We have many input.execd which are using an SSH connection (and other) to perform remote operations (getting content of files, disk space, etc).
This PR adds a setting at the [agent] level to add the inputs.* tags to the logger output if using `logformat = "structured"`.

It's useful for us, because we can then query the log output by looking up a particular set of tags and get the error logs.

In the `[agent]` section, a new setting `structured_log_add_input_tags` can be set to true. When it's the case, the JSON output becomes the following : 
`{"time":"2026-03-27T09:14:36.078389805Z","level":"INFO","msg":"Error connecting to target. Restarting in 10s...","category":"inputs","plugin":"execd","tags":{"server_host":"10.0.1.20","friendly_name":"friendly_server_name","log_source":"telegraf","metric_type":"logs"}}`  

I've also updated the documentation in `docs/CONFIGURATION.md`.

I've used only a little bit of LLM (Claude Sonnet 4.6 via Github Copilot) to understand better the codebase and get some insights as to where the changes should go. I've then manually implemented those changes.

## Checklist
- [ ] No AI generated code was used in this PR
- [x] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
resolves #18610 
