### PR TITLE
chore(inputs): Migrate testutil.MustMetric to metric.New

### DIFF
--- a/plugins/inputs/opensearch_query/opensearch_query_test.go
+++ b/plugins/inputs/opensearch_query/opensearch_query_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
+	"github.com/influxdata/telegraf/metric"
 	"github.com/influxdata/telegraf/plugins/common/tls"
 	"github.com/influxdata/telegraf/testutil"
 )
@@ -52,7 +53,7 @@ func testData() []osAggregationQueryTest {
 				mapMetricFields: map[string]string{"size": "long"},
 			},
 			expectedMetrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"measurement1",
 					map[string]string{"URI_keyword": "/downloads/product_1"},
 					map[string]interface{}{"size_avg_value": float64(202.30038022813687), "doc_count": int64(263)},
@@ -74,13 +75,13 @@ func testData() []osAggregationQueryTest {
 				mapMetricFields: map[string]string{"size": "long"},
 			},
 			expectedMetrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"measurement2",
 					map[string]string{"URI_keyword": "/downloads/product_1"},
 					map[string]interface{}{"size_max_value": float64(3301), "doc_count": int64(263)},
 					time.Date(2018, 6, 14, 5, 51, 53, 266176036, time.UTC),
 				),
-				testutil.MustMetric(
+				metric.New(
 					"measurement2",
 					map[string]string{"URI_keyword": "/downloads/product_2"},
 					map[string]interface{}{"size_max_value": float64(3318), "doc_count": int64(237)},
@@ -102,19 +103,19 @@ func testData() []osAggregationQueryTest {
 				mapMetricFields: map[string]string{"size": "long"},
 			},
 			expectedMetrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"measurement3",
 					map[string]string{"response_keyword": "200"},
 					map[string]interface{}{"size_sum_value": float64(22790), "doc_count": int64(22)},
 					time.Date(2018, 6, 14, 5, 51, 53, 266176036, time.UTC),
 				),
-				testutil.MustMetric(
+				metric.New(
 					"measurement3",
 					map[string]string{"response_keyword": "304"},
 					map[string]interface{}{"size_sum_value": float64(0), "doc_count": int64(219)},
 					time.Date(2018, 6, 14, 5, 51, 53, 266176036, time.UTC),
 				),
-				testutil.MustMetric(
+				metric.New(
 					"measurement3",
 					map[string]string{"response_keyword": "404"},
 					map[string]interface{}{"size_sum_value": float64(86932), "doc_count": int64(259)},
@@ -138,49 +139,49 @@ func testData() []osAggregationQueryTest {
 				mapMetricFields:   map[string]string{"size": "long", "response_time": "long"},
 			},
 			expectedMetrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"measurement4",
 					map[string]string{"response_keyword": "404", "URI_keyword": "/downloads/product_1", "method_keyword": "GET"},
 					map[string]interface{}{"size_min_value": float64(318), "response_time_min_value": float64(126), "doc_count": int64(146)},
 					time.Date(2018, 6, 14, 5, 51, 53, 266176036, time.UTC),
 				),
-				testutil.MustMetric(
+				metric.New(
 					"measurement4",
 					map[string]string{"response_keyword": "304", "URI_keyword": "/downloads/product_1", "method_keyword": "GET"},
 					map[string]interface{}{"size_min_value": float64(0), "response_time_min_value": float64(71), "doc_count": int64(113)},
 					time.Date(2018, 6, 14, 5, 51, 53, 266176036, time.UTC),
 				),
-				testutil.MustMetric(
+				metric.New(
 					"measurement4",
 					map[string]string{"response_keyword": "200", "URI_keyword": "/downloads/product_1", "method_keyword": "GET"},
 					map[string]interface{}{"size_min_value": float64(490), "response_time_min_value": float64(1514), "doc_count": int64(3)},
 					time.Date(2018, 6, 14, 5, 51, 53, 266176036, time.UTC),
 				),
-				testutil.MustMetric(
+				metric.New(
 					"measurement4",
 					map[string]string{"response_keyword": "404", "URI_keyword": "/downloads/product_2", "method_keyword": "GET"},
 					map[string]interface{}{"size_min_value": float64(318), "response_time_min_value": float64(237), "doc_count": int64(113)},
 					time.Date(2018, 6, 14, 5, 51, 53, 266176036, time.UTC),
 				),
-				testutil.MustMetric(
+				metric.New(
 					"measurement4",
 					map[string]string{"response_keyword": "304", "URI_keyword": "/downloads/product_2", "method_keyword": "GET"},
 					map[string]interface{}{"size_min_value": float64(0), "response_time_min_value": float64(134), "doc_count": int64(106)},
 					time.Date(2018, 6, 14, 5, 51, 53, 266176036, time.UTC),
 				),
-				testutil.MustMetric(
+				metric.New(
 					"measurement4",
 					map[string]string{"response_keyword": "200", "URI_keyword": "/downloads/product_2", "method_keyword": "GET"},
 					map[string]interface{}{"size_min_value": float64(490), "response_time_min_value": float64(2), "doc_count": int64(13)},
 					time.Date(2018, 6, 14, 5, 51, 53, 266176036, time.UTC),
 				),
-				testutil.MustMetric(
+				metric.New(
 					"measurement4",
 					map[string]string{"response_keyword": "200", "URI_keyword": "/downloads/product_1", "method_keyword": "HEAD"},
 					map[string]interface{}{"size_min_value": float64(0), "response_time_min_value": float64(8479), "doc_count": int64(1)},
 					time.Date(2018, 6, 14, 5, 51, 53, 266176036, time.UTC),
 				),
-				testutil.MustMetric(
+				metric.New(
 					"measurement4",
 					map[string]string{"response_keyword": "200", "URI_keyword": "/downloads/product_2", "method_keyword": "HEAD"},
 					map[string]interface{}{"size_min_value": float64(0), "response_time_min_value": float64(1059), "doc_count": int64(5)},
@@ -200,7 +201,7 @@ func testData() []osAggregationQueryTest {
 				mapMetricFields: map[string]string{},
 			},
 			expectedMetrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"measurement5",
 					map[string]string{"URI_keyword": "/downloads/product_2"},
 					map[string]interface{}{"doc_count": int64(237)},
@@ -220,13 +221,13 @@ func testData() []osAggregationQueryTest {
 				mapMetricFields: map[string]string{},
 			},
 			expectedMetrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"measurement6",
 					map[string]string{"response_keyword": "200", "URI_keyword": "/downloads/product_1"},
 					map[string]interface{}{"doc_count": int64(4)},
 					time.Date(2018, 6, 14, 5, 51, 53, 266176036, time.UTC),
 				),
-				testutil.MustMetric(
+				metric.New(
 					"measurement6",
 					map[string]string{"response_keyword": "200", "URI_keyword": "/downloads/product_2"},
 					map[string]interface{}{"doc_count": int64(18)},
@@ -245,7 +246,7 @@ func testData() []osAggregationQueryTest {
 				mapMetricFields: map[string]string{},
 			},
 			expectedMetrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"measurement7",
 					map[string]string{},
 					map[string]interface{}{"doc_count": int64(22)},
@@ -266,7 +267,7 @@ func testData() []osAggregationQueryTest {
 				mapMetricFields: map[string]string{"size": "long"},
 			},
 			expectedMetrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"measurement8",
 					map[string]string{},
 					map[string]interface{}{"size_max_value": float64(3318), "doc_count": int64(500)},
@@ -324,7 +325,7 @@ func testData() []osAggregationQueryTest {
 				mapMetricFields: map[string]string{"size": "long"},
 			},
 			expectedMetrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"measurement12",
 					map[string]string{},
 					map[string]interface{}{"doc_count": int64(0)},
@@ -372,7 +373,7 @@ func testData() []osAggregationQueryTest {
 				mapMetricFields: map[string]string{"size": "long"},
 			},
 			expectedMetrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"measurement15",
 					map[string]string{"URI_keyword": "/downloads/product_1"},
 					map[string]interface{}{
@@ -384,7 +385,7 @@ func testData() []osAggregationQueryTest {
 						"doc_count":        int64(263)},
 					time.Date(2018, 6, 14, 5, 51, 53, 266176036, time.UTC),
 				),
-				testutil.MustMetric(
+				metric.New(
 					"measurement15",
 					map[string]string{"URI_keyword": "/downloads/product_2"},
 					map[string]interface{}{
@@ -412,7 +413,7 @@ func testData() []osAggregationQueryTest {
 				mapMetricFields: map[string]string{"size": "long"},
 			},
 			expectedMetrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"measurement16",
 					map[string]string{"URI_keyword": "/downloads/product_1"},
 					map[string]interface{}{
@@ -437,7 +438,7 @@ func testData() []osAggregationQueryTest {
 						"doc_count":                                                 int64(263)},
 					time.Date(2018, 6, 14, 5, 51, 53, 266176036, time.UTC),
 				),
-				testutil.MustMetric(
+				metric.New(
 					"measurement16",
 					map[string]string{"URI_keyword": "/downloads/product_2"},
 					map[string]interface{}{
@@ -478,7 +479,7 @@ func testData() []osAggregationQueryTest {
 				mapMetricFields: map[string]string{"size": "long"},
 			},
 			expectedMetrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"measurement16",
 					map[string]string{"URI_keyword": "/downloads/product_1"},
 					map[string]interface{}{
@@ -492,7 +493,7 @@ func testData() []osAggregationQueryTest {
 						"doc_count":                    int64(263)},
 					time.Date(2018, 6, 14, 5, 51, 53, 266176036, time.UTC),
 				),
-				testutil.MustMetric(
+				metric.New(
 					"measurement16",
 					map[string]string{"URI_keyword": "/downloads/product_2"},
 					map[string]interface{}{

--- a/plugins/inputs/stackdriver/stackdriver_test.go
+++ b/plugins/inputs/stackdriver/stackdriver_test.go
@@ -14,6 +14,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/metric"
 	"github.com/influxdata/telegraf/plugins/inputs"
 	"github.com/influxdata/telegraf/testutil"
 )
@@ -120,7 +121,7 @@ func TestGather(t *testing.T) {
 				metricpb.MetricDescriptor_DISTRIBUTION,
 			),
 			expected: []telegraf.Metric{
-				testutil.MustMetric("",
+				metric.New("",
 					map[string]string{
 						"project_id":    "test",
 						"resource_type": "global",
@@ -156,7 +157,7 @@ func TestGather(t *testing.T) {
 				metricpb.MetricDescriptor_INT64,
 			),
 			expected: []telegraf.Metric{
-				testutil.MustMetric("telegraf/cpu",
+				metric.New("telegraf/cpu",
 					map[string]string{
 						"resource_type": "global",
 						"project_id":    "test",
@@ -189,7 +190,7 @@ func TestGather(t *testing.T) {
 				metricpb.MetricDescriptor_DOUBLE,
 			),
 			expected: []telegraf.Metric{
-				testutil.MustMetric("telegraf/cpu",
+				metric.New("telegraf/cpu",
 					map[string]string{
 						"resource_type": "global",
 						"project_id":    "test",
@@ -222,7 +223,7 @@ func TestGather(t *testing.T) {
 				metricpb.MetricDescriptor_INT64,
 			),
 			expected: []telegraf.Metric{
-				testutil.MustMetric("telegraf/cpu",
+				metric.New("telegraf/cpu",
 					map[string]string{
 						"resource_type": "global",
 						"project_id":    "test",
@@ -255,7 +256,7 @@ func TestGather(t *testing.T) {
 				metricpb.MetricDescriptor_BOOL,
 			),
 			expected: []telegraf.Metric{
-				testutil.MustMetric("telegraf/cpu",
+				metric.New("telegraf/cpu",
 					map[string]string{
 						"resource_type": "global",
 						"project_id":    "test",
@@ -288,7 +289,7 @@ func TestGather(t *testing.T) {
 				metricpb.MetricDescriptor_STRING,
 			),
 			expected: []telegraf.Metric{
-				testutil.MustMetric("telegraf/cpu",
+				metric.New("telegraf/cpu",
 					map[string]string{
 						"resource_type": "global",
 						"project_id":    "test",
@@ -334,7 +335,7 @@ func TestGather(t *testing.T) {
 				ValueType: metricpb.MetricDescriptor_DOUBLE,
 			},
 			expected: []telegraf.Metric{
-				testutil.MustMetric("telegraf/cpu",
+				metric.New("telegraf/cpu",
 					map[string]string{
 						"resource_type": "instance",
 						"project_id":    "test",
@@ -385,7 +386,7 @@ func TestGather(t *testing.T) {
 				metricpb.MetricDescriptor_DISTRIBUTION,
 			),
 			expected: []telegraf.Metric{
-				testutil.MustMetric("telegraf/cpu",
+				metric.New("telegraf/cpu",
 					map[string]string{
 						"resource_type": "global",
 						"project_id":    "test",
@@ -398,7 +399,7 @@ func TestGather(t *testing.T) {
 						"usage_sum_of_squared_deviation": 1.0,
 					},
 					now),
-				testutil.MustMetric("telegraf/cpu",
+				metric.New("telegraf/cpu",
 					map[string]string{
 						"resource_type": "global",
 						"project_id":    "test",
@@ -408,7 +409,7 @@ func TestGather(t *testing.T) {
 						"usage_bucket": int64(0),
 					},
 					now),
-				testutil.MustMetric("telegraf/cpu",
+				metric.New("telegraf/cpu",
 					map[string]string{
 						"resource_type": "global",
 						"project_id":    "test",
@@ -418,7 +419,7 @@ func TestGather(t *testing.T) {
 						"usage_bucket": int64(1),
 					},
 					now),
-				testutil.MustMetric("telegraf/cpu",
+				metric.New("telegraf/cpu",
 					map[string]string{
 						"resource_type": "global",
 						"project_id":    "test",
@@ -428,7 +429,7 @@ func TestGather(t *testing.T) {
 						"usage_bucket": int64(4),
 					},
 					now),
-				testutil.MustMetric("telegraf/cpu",
+				metric.New("telegraf/cpu",
 					map[string]string{
 						"resource_type": "global",
 						"project_id":    "test",
@@ -480,7 +481,7 @@ func TestGather(t *testing.T) {
 				metricpb.MetricDescriptor_DISTRIBUTION,
 			),
 			expected: []telegraf.Metric{
-				testutil.MustMetric("telegraf/cpu",
+				metric.New("telegraf/cpu",
 					map[string]string{
 						"resource_type": "global",
 						"project_id":    "test",
@@ -493,7 +494,7 @@ func TestGather(t *testing.T) {
 						"usage_sum_of_squared_deviation": 1.0,
 					},
 					now),
-				testutil.MustMetric("telegraf/cpu",
+				metric.New("telegraf/cpu",
 					map[string]string{
 						"resource_type": "global",
 						"project_id":    "test",
@@ -503,7 +504,7 @@ func TestGather(t *testing.T) {
 						"usage_bucket": int64(0),
 					},
 					now),
-				testutil.MustMetric("telegraf/cpu",
+				metric.New("telegraf/cpu",
 					map[string]string{
 						"resource_type": "global",
 						"project_id":    "test",
@@ -513,7 +514,7 @@ func TestGather(t *testing.T) {
 						"usage_bucket": int64(1),
 					},
 					now),
-				testutil.MustMetric("telegraf/cpu",
+				metric.New("telegraf/cpu",
 					map[string]string{
 						"resource_type": "global",
 						"project_id":    "test",
@@ -523,7 +524,7 @@ func TestGather(t *testing.T) {
 						"usage_bucket": int64(4),
 					},
 					now),
-				testutil.MustMetric("telegraf/cpu",
+				metric.New("telegraf/cpu",
 					map[string]string{
 						"resource_type": "global",
 						"project_id":    "test",
@@ -573,7 +574,7 @@ func TestGather(t *testing.T) {
 				metricpb.MetricDescriptor_DISTRIBUTION,
 			),
 			expected: []telegraf.Metric{
-				testutil.MustMetric("telegraf/cpu",
+				metric.New("telegraf/cpu",
 					map[string]string{
 						"resource_type": "global",
 						"project_id":    "test",
@@ -586,7 +587,7 @@ func TestGather(t *testing.T) {
 						"usage_sum_of_squared_deviation": 1.0,
 					},
 					now),
-				testutil.MustMetric("telegraf/cpu",
+				metric.New("telegraf/cpu",
 					map[string]string{
 						"resource_type": "global",
 						"project_id":    "test",
@@ -596,7 +597,7 @@ func TestGather(t *testing.T) {
 						"usage_bucket": int64(0),
 					},
 					now),
-				testutil.MustMetric("telegraf/cpu",
+				metric.New("telegraf/cpu",
 					map[string]string{
 						"resource_type": "global",
 						"project_id":    "test",
@@ -606,7 +607,7 @@ func TestGather(t *testing.T) {
 						"usage_bucket": int64(1),
 					},
 					now),
-				testutil.MustMetric("telegraf/cpu",
+				metric.New("telegraf/cpu",
 					map[string]string{
 						"resource_type": "global",
 						"project_id":    "test",
@@ -658,7 +659,7 @@ func TestGather(t *testing.T) {
 				metricpb.MetricDescriptor_DISTRIBUTION,
 			),
 			expected: []telegraf.Metric{
-				testutil.MustMetric("telegraf/cpu",
+				metric.New("telegraf/cpu",
 					map[string]string{
 						"resource_type": "global",
 						"project_id":    "test",
@@ -671,7 +672,7 @@ func TestGather(t *testing.T) {
 						"usage_sum_of_squared_deviation": 1.0,
 					},
 					now),
-				testutil.MustMetric("telegraf/cpu",
+				metric.New("telegraf/cpu",
 					map[string]string{
 						"resource_type": "global",
 						"project_id":    "test",
@@ -681,7 +682,7 @@ func TestGather(t *testing.T) {
 						"usage_bucket": int64(0),
 					},
 					now),
-				testutil.MustMetric("telegraf/cpu",
+				metric.New("telegraf/cpu",
 					map[string]string{
 						"resource_type": "global",
 						"project_id":    "test",
@@ -691,7 +692,7 @@ func TestGather(t *testing.T) {
 						"usage_bucket": int64(1),
 					},
 					now),
-				testutil.MustMetric("telegraf/cpu",
+				metric.New("telegraf/cpu",
 					map[string]string{
 						"resource_type": "global",
 						"project_id":    "test",
@@ -701,7 +702,7 @@ func TestGather(t *testing.T) {
 						"usage_bucket": int64(1),
 					},
 					now),
-				testutil.MustMetric("telegraf/cpu",
+				metric.New("telegraf/cpu",
 					map[string]string{
 						"resource_type": "global",
 						"project_id":    "test",
@@ -822,7 +823,7 @@ func TestGatherAlign(t *testing.T) {
 				),
 			},
 			expected: []telegraf.Metric{
-				testutil.MustMetric("telegraf/cpu",
+				metric.New("telegraf/cpu",
 					map[string]string{
 						"resource_type": "global",
 						"project_id":    "test",


### PR DESCRIPTION


## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Migrate testutil.MustMetric to metric.New for: stackdriver,opensearch_query Part of #18495

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
