### PR TITLE
chore(inputs): Migrate testutil.MustMetric to metric.New

### DIFF
--- a/plugins/inputs/elasticsearch_query/elasticsearch_query_test.go
+++ b/plugins/inputs/elasticsearch_query/elasticsearch_query_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
+	"github.com/influxdata/telegraf/metric"
 	common_http "github.com/influxdata/telegraf/plugins/common/http"
 	"github.com/influxdata/telegraf/testutil"
 )
@@ -65,7 +66,7 @@ var testEsAggregationData = []esAggregationQueryTest{
 			},
 		},
 		[]telegraf.Metric{
-			testutil.MustMetric(
+			metric.New(
 				"measurement1",
 				map[string]string{"URI_keyword": "/downloads/product_1"},
 				map[string]interface{}{"size_avg": float64(202.30038022813687), "doc_count": int64(263)},
@@ -100,13 +101,13 @@ var testEsAggregationData = []esAggregationQueryTest{
 			},
 		},
 		[]telegraf.Metric{
-			testutil.MustMetric(
+			metric.New(
 				"measurement2",
 				map[string]string{"URI_keyword": "/downloads/product_1"},
 				map[string]interface{}{"size_max": float64(3301), "doc_count": int64(263)},
 				time.Date(2018, 6, 14, 5, 51, 53, 266176036, time.UTC),
 			),
-			testutil.MustMetric(
+			metric.New(
 				"measurement2",
 				map[string]string{"URI_keyword": "/downloads/product_2"},
 				map[string]interface{}{"size_max": float64(3318), "doc_count": int64(237)},
@@ -141,19 +142,19 @@ var testEsAggregationData = []esAggregationQueryTest{
 			},
 		},
 		[]telegraf.Metric{
-			testutil.MustMetric(
+			metric.New(
 				"measurement3",
 				map[string]string{"response_keyword": "200"},
 				map[string]interface{}{"size_sum": float64(22790), "doc_count": int64(22)},
 				time.Date(2018, 6, 14, 5, 51, 53, 266176036, time.UTC),
 			),
-			testutil.MustMetric(
+			metric.New(
 				"measurement3",
 				map[string]string{"response_keyword": "304"},
 				map[string]interface{}{"size_sum": float64(0), "doc_count": int64(219)},
 				time.Date(2018, 6, 14, 5, 51, 53, 266176036, time.UTC),
 			),
-			testutil.MustMetric(
+			metric.New(
 				"measurement3",
 				map[string]string{"response_keyword": "404"},
 				map[string]interface{}{"size_sum": float64(86932), "doc_count": int64(259)},
@@ -202,49 +203,49 @@ var testEsAggregationData = []esAggregationQueryTest{
 			},
 		},
 		[]telegraf.Metric{
-			testutil.MustMetric(
+			metric.New(
 				"measurement4",
 				map[string]string{"response_keyword": "404", "URI_keyword": "/downloads/product_1", "method_keyword": "GET"},
 				map[string]interface{}{"size_min": float64(318), "response_time_min": float64(126), "doc_count": int64(146)},
 				time.Date(2018, 6, 14, 5, 51, 53, 266176036, time.UTC),
 			),
-			testutil.MustMetric(
+			metric.New(
 				"measurement4",
 				map[string]string{"response_keyword": "304", "URI_keyword": "/downloads/product_1", "method_keyword": "GET"},
 				map[string]interface{}{"size_min": float64(0), "response_time_min": float64(71), "doc_count": int64(113)},
 				time.Date(2018, 6, 14, 5, 51, 53, 266176036, time.UTC),
 			),
-			testutil.MustMetric(
+			metric.New(
 				"measurement4",
 				map[string]string{"response_keyword": "200", "URI_keyword": "/downloads/product_1", "method_keyword": "GET"},
 				map[string]interface{}{"size_min": float64(490), "response_time_min": float64(1514), "doc_count": int64(3)},
 				time.Date(2018, 6, 14, 5, 51, 53, 266176036, time.UTC),
 			),
-			testutil.MustMetric(
+			metric.New(
 				"measurement4",
 				map[string]string{"response_keyword": "404", "URI_keyword": "/downloads/product_2", "method_keyword": "GET"},
 				map[string]interface{}{"size_min": float64(318), "response_time_min": float64(237), "doc_count": int64(113)},
 				time.Date(2018, 6, 14, 5, 51, 53, 266176036, time.UTC),
 			),
-			testutil.MustMetric(
+			metric.New(
 				"measurement4",
 				map[string]string{"response_keyword": "304", "URI_keyword": "/downloads/product_2", "method_keyword": "GET"},
 				map[string]interface{}{"size_min": float64(0), "response_time_min": float64(134), "doc_count": int64(106)},
 				time.Date(2018, 6, 14, 5, 51, 53, 266176036, time.UTC),
 			),
-			testutil.MustMetric(
+			metric.New(
 				"measurement4",
 				map[string]string{"response_keyword": "200", "URI_keyword": "/downloads/product_2", "method_keyword": "GET"},
 				map[string]interface{}{"size_min": float64(490), "response_time_min": float64(2), "doc_count": int64(13)},
 				time.Date(2018, 6, 14, 5, 51, 53, 266176036, time.UTC),
 			),
-			testutil.MustMetric(
+			metric.New(
 				"measurement4",
 				map[string]string{"response_keyword": "200", "URI_keyword": "/downloads/product_1", "method_keyword": "HEAD"},
 				map[string]interface{}{"size_min": float64(0), "response_time_min": float64(8479), "doc_count": int64(1)},
 				time.Date(2018, 6, 14, 5, 51, 53, 266176036, time.UTC),
 			),
-			testutil.MustMetric(
+			metric.New(
 				"measurement4",
 				map[string]string{"response_keyword": "200", "URI_keyword": "/downloads/product_2", "method_keyword": "HEAD"},
 				map[string]interface{}{"size_min": float64(0), "response_time_min": float64(1059), "doc_count": int64(5)},
@@ -273,7 +274,7 @@ var testEsAggregationData = []esAggregationQueryTest{
 			},
 		},
 		[]telegraf.Metric{
-			testutil.MustMetric(
+			metric.New(
 				"measurement5",
 				map[string]string{"URI_keyword": "/downloads/product_2"},
 				map[string]interface{}{"doc_count": int64(237)},
@@ -306,13 +307,13 @@ var testEsAggregationData = []esAggregationQueryTest{
 			},
 		},
 		[]telegraf.Metric{
-			testutil.MustMetric(
+			metric.New(
 				"measurement6",
 				map[string]string{"response_keyword": "200", "URI_keyword": "/downloads/product_1"},
 				map[string]interface{}{"doc_count": int64(4)},
 				time.Date(2018, 6, 14, 5, 51, 53, 266176036, time.UTC),
 			),
-			testutil.MustMetric(
+			metric.New(
 				"measurement6",
 				map[string]string{"response_keyword": "200", "URI_keyword": "/downloads/product_2"},
 				map[string]interface{}{"doc_count": int64(18)},
@@ -335,7 +336,7 @@ var testEsAggregationData = []esAggregationQueryTest{
 		},
 		nil,
 		[]telegraf.Metric{
-			testutil.MustMetric(
+			metric.New(
 				"measurement7",
 				map[string]string{},
 				map[string]interface{}{"doc_count": int64(22)},
@@ -365,7 +366,7 @@ var testEsAggregationData = []esAggregationQueryTest{
 			},
 		},
 		[]telegraf.Metric{
-			testutil.MustMetric(
+			metric.New(
 				"measurement8",
 				map[string]string{},
 				map[string]interface{}{"size_max": float64(3318)},
@@ -443,7 +444,7 @@ var testEsAggregationData = []esAggregationQueryTest{
 			},
 		},
 		[]telegraf.Metric{
-			testutil.MustMetric(
+			metric.New(
 				"measurement12",
 				map[string]string{},
 				map[string]interface{}{"size_avg": float64(0)},

--- a/plugins/inputs/nvidia_smi/nvidia_smi_test.go
+++ b/plugins/inputs/nvidia_smi/nvidia_smi_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/internal"
+	"github.com/influxdata/telegraf/metric"
 	"github.com/influxdata/telegraf/models"
 	"github.com/influxdata/telegraf/testutil"
 )
@@ -149,7 +150,7 @@ func TestGatherValidXML(t *testing.T) {
 			name:     "GeForce GTX 1070 Ti",
 			filename: "gtx-1070-ti.xml",
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"nvidia_smi",
 					map[string]string{
 						"name":         "GeForce GTX 1070 Ti",
@@ -183,7 +184,7 @@ func TestGatherValidXML(t *testing.T) {
 			name:     "GeForce GTX 1660 Ti",
 			filename: "gtx-1660-ti.xml",
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"nvidia_smi",
 					map[string]string{
 						"compute_mode": "Default",
@@ -229,7 +230,7 @@ func TestGatherValidXML(t *testing.T) {
 			name:     "Quadro P400",
 			filename: "quadro-p400.xml",
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"nvidia_smi",
 					map[string]string{
 						"compute_mode": "Default",
@@ -274,7 +275,7 @@ func TestGatherValidXML(t *testing.T) {
 			name:     "Quadro P2000",
 			filename: "quadro-p2000-v12.xml",
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"nvidia_smi",
 					map[string]string{
 						"arch":         "Pascal",
@@ -324,7 +325,7 @@ func TestGatherValidXML(t *testing.T) {
 			name:     "Tesla T4",
 			filename: "tesla-t4.xml",
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"nvidia_smi",
 					map[string]string{
 						"compute_mode": "Default",
@@ -376,7 +377,7 @@ func TestGatherValidXML(t *testing.T) {
 			name:     "A10G",
 			filename: "a10g.xml",
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"nvidia_smi",
 					map[string]string{
 						"compute_mode": "Default",
@@ -429,7 +430,7 @@ func TestGatherValidXML(t *testing.T) {
 			name:     "RTC 3060 schema v12",
 			filename: "rtx-3060-v12.xml",
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"nvidia_smi",
 					map[string]string{
 						"compute_mode": "Default",
@@ -479,7 +480,7 @@ func TestGatherValidXML(t *testing.T) {
 			name:     "RTC 3080 schema v12",
 			filename: "rtx-3080-v12.xml",
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"nvidia_smi",
 					map[string]string{
 						"compute_mode": "Default",
@@ -522,7 +523,7 @@ func TestGatherValidXML(t *testing.T) {
 						"vbios_version":                 "94.02.71.40.72",
 					},
 					time.Unix(1689872450, 0)),
-				testutil.MustMetric(
+				metric.New(
 					"nvidia_smi_process",
 					map[string]string{
 						"name": "/usr/lib/Xorg",
@@ -533,7 +534,7 @@ func TestGatherValidXML(t *testing.T) {
 						"used_memory": int64(550),
 					},
 					time.Unix(1689872450, 0)),
-				testutil.MustMetric(
+				metric.New(
 					"nvidia_smi_process",
 					map[string]string{
 						"name": "/usr/bin/gnome-shell",
@@ -544,7 +545,7 @@ func TestGatherValidXML(t *testing.T) {
 						"used_memory": int64(18),
 					},
 					time.Unix(1689872450, 0)),
-				testutil.MustMetric(
+				metric.New(
 					"nvidia_smi_process",
 					map[string]string{
 						"name": "/opt/microsoft/msedge/msedge --type=gpu-process " +
@@ -562,7 +563,7 @@ func TestGatherValidXML(t *testing.T) {
 						"used_memory": int64(79),
 					},
 					time.Unix(1689872450, 0)),
-				testutil.MustMetric(
+				metric.New(
 					"nvidia_smi_process",
 					map[string]string{
 						"name": "/usr/lib/firefox/firefox",
@@ -573,7 +574,7 @@ func TestGatherValidXML(t *testing.T) {
 						"used_memory": int64(541),
 					},
 					time.Unix(1689872450, 0)),
-				testutil.MustMetric(
+				metric.New(
 					"nvidia_smi_process",
 					map[string]string{
 						"name": "/opt/visual-studio-code/code --type=gpu-process " +
@@ -598,7 +599,7 @@ func TestGatherValidXML(t *testing.T) {
 			name:     "RTC 3090 schema v12",
 			filename: "rtx-3090-v12.xml",
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"nvidia_smi",
 					map[string]string{
 						"compute_mode": "Default",
@@ -646,7 +647,7 @@ func TestGatherValidXML(t *testing.T) {
 			name:     "A100-SXM4 schema v12",
 			filename: "a100-sxm4-v12.xml",
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"nvidia_smi",
 					map[string]string{
 						"compute_mode": "Default",
@@ -684,7 +685,7 @@ func TestGatherValidXML(t *testing.T) {
 						"vbios_version":                 "92.00.36.00.02",
 					},
 					time.Unix(1689872450, 0)),
-				testutil.MustMetric(
+				metric.New(
 					"nvidia_smi_mig",
 					map[string]string{
 						"compute_mode":  "Default",
@@ -707,7 +708,7 @@ func TestGatherValidXML(t *testing.T) {
 						"sram_uncorrectable": 0,
 					},
 					time.Unix(1689872450, 0)),
-				testutil.MustMetric(
+				metric.New(
 					"nvidia_smi_mig",
 					map[string]string{
 						"compute_mode":  "Default",
@@ -730,7 +731,7 @@ func TestGatherValidXML(t *testing.T) {
 						"sram_uncorrectable": 0,
 					},
 					time.Unix(1689872450, 0)),
-				testutil.MustMetric(
+				metric.New(
 					"nvidia_smi_mig",
 					map[string]string{
 						"compute_mode":  "Default",
@@ -753,7 +754,7 @@ func TestGatherValidXML(t *testing.T) {
 						"sram_uncorrectable": 0,
 					},
 					time.Unix(1689872450, 0)),
-				testutil.MustMetric(
+				metric.New(
 					"nvidia_smi_mig",
 					map[string]string{
 						"compute_mode":  "Default",

--- a/plugins/inputs/sflow/decoder_test.go
+++ b/plugins/inputs/sflow/decoder_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/metric"
 	"github.com/influxdata/telegraf/testutil"
 )
 
@@ -75,7 +76,7 @@ func TestIPv4SW(t *testing.T) {
 	require.NoError(t, err)
 
 	expected := []telegraf.Metric{
-		testutil.MustMetric(
+		metric.New(
 			"sflow",
 			map[string]string{
 				"agent_address":    "192.168.1.2",
@@ -109,7 +110,7 @@ func TestIPv4SW(t *testing.T) {
 			},
 			time.Unix(0, 0),
 		),
-		testutil.MustMetric(
+		metric.New(
 			"sflow",
 			map[string]string{
 				"agent_address":    "192.168.1.2",
@@ -194,7 +195,7 @@ func TestExpandFlow(t *testing.T) {
 	actual := makeMetrics(p)
 
 	expected := []telegraf.Metric{
-		testutil.MustMetric(
+		metric.New(
 			"sflow",
 			map[string]string{
 				"agent_address":    "10.0.1.80",
@@ -230,7 +231,7 @@ func TestExpandFlow(t *testing.T) {
 			},
 			time.Unix(0, 0),
 		),
-		testutil.MustMetric(
+		metric.New(
 			"sflow",
 			map[string]string{
 				"agent_address":    "10.0.1.80",
@@ -266,7 +267,7 @@ func TestExpandFlow(t *testing.T) {
 			},
 			time.Unix(0, 0),
 		),
-		testutil.MustMetric(
+		metric.New(
 			"sflow",
 			map[string]string{
 				"agent_address":    "10.0.1.80",
@@ -335,7 +336,7 @@ func TestIPv4SWRT(t *testing.T) {
 	actual := makeMetrics(p)
 
 	expected := []telegraf.Metric{
-		testutil.MustMetric(
+		metric.New(
 			"sflow",
 			map[string]string{
 				"agent_address":    "137.221.79.1",
@@ -369,7 +370,7 @@ func TestIPv4SWRT(t *testing.T) {
 			},
 			time.Unix(0, 0),
 		),
-		testutil.MustMetric(
+		metric.New(
 			"sflow",
 			map[string]string{
 				"agent_address":    "137.221.79.1",
@@ -403,7 +404,7 @@ func TestIPv4SWRT(t *testing.T) {
 			},
 			time.Unix(0, 0),
 		),
-		testutil.MustMetric(
+		metric.New(
 			"sflow",
 			map[string]string{
 				"agent_address":    "137.221.79.1",
@@ -437,7 +438,7 @@ func TestIPv4SWRT(t *testing.T) {
 			},
 			time.Unix(0, 0),
 		),
-		testutil.MustMetric(
+		metric.New(
 			"sflow",
 			map[string]string{
 				"agent_address":    "137.221.79.1",
@@ -473,7 +474,7 @@ func TestIPv4SWRT(t *testing.T) {
 			},
 			time.Unix(0, 0),
 		),
-		testutil.MustMetric(
+		metric.New(
 			"sflow",
 			map[string]string{
 				"agent_address":    "137.221.79.1",
@@ -507,7 +508,7 @@ func TestIPv4SWRT(t *testing.T) {
 			},
 			time.Unix(0, 0),
 		),
-		testutil.MustMetric(
+		metric.New(
 			"sflow",
 			map[string]string{
 				"agent_address":    "137.221.79.1",
@@ -563,7 +564,7 @@ func TestIPv6SW(t *testing.T) {
 
 	expected := []telegraf.Metric{
 
-		testutil.MustMetric(
+		metric.New(
 			"sflow",
 			map[string]string{
 				"agent_address":    "10.224.100.129",
@@ -633,7 +634,7 @@ func TestExpandFlowCounter(t *testing.T) {
 	actual := makeMetrics(p)
 
 	expected := []telegraf.Metric{
-		testutil.MustMetric(
+		metric.New(
 			"sflow",
 			map[string]string{
 				"agent_address":    "10.0.1.80",
@@ -669,7 +670,7 @@ func TestExpandFlowCounter(t *testing.T) {
 			},
 			time.Unix(0, 0),
 		),
-		testutil.MustMetric(
+		metric.New(
 			"sflow",
 			map[string]string{
 				"agent_address":    "10.0.1.80",
@@ -705,7 +706,7 @@ func TestExpandFlowCounter(t *testing.T) {
 			},
 			time.Unix(0, 0),
 		),
-		testutil.MustMetric(
+		metric.New(
 			"sflow",
 			map[string]string{
 				"agent_address":    "10.0.1.80",
@@ -741,7 +742,7 @@ func TestExpandFlowCounter(t *testing.T) {
 			},
 			time.Unix(0, 0),
 		),
-		testutil.MustMetric(
+		metric.New(
 			"sflow",
 			map[string]string{
 				"agent_address":    "10.0.1.80",
@@ -777,7 +778,7 @@ func TestExpandFlowCounter(t *testing.T) {
 			},
 			time.Unix(0, 0),
 		),
-		testutil.MustMetric(
+		metric.New(
 			"sflow",
 			map[string]string{
 				"agent_address":    "10.0.1.80",

--- a/plugins/inputs/sflow/sflow_test.go
+++ b/plugins/inputs/sflow/sflow_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/metric"
 	"github.com/influxdata/telegraf/testutil"
 )
 
@@ -45,7 +46,7 @@ func TestSFlow(t *testing.T) {
 	acc.Wait(2)
 
 	expected := []telegraf.Metric{
-		testutil.MustMetric(
+		metric.New(
 			"sflow",
 			map[string]string{
 				"agent_address":    "192.168.1.2",
@@ -79,7 +80,7 @@ func TestSFlow(t *testing.T) {
 			},
 			time.Unix(0, 0),
 		),
-		testutil.MustMetric(
+		metric.New(
 			"sflow",
 			map[string]string{
 				"agent_address":    "192.168.1.2",


### PR DESCRIPTION


## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Migrate testutil.MustMetric to metric.New for: elasticsearch_query,sflow,nvidia_smi Part of #18495

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
