### PR TITLE
chore(inputs): Migrate testutil.MustMetric to metric.New

### DIFF
--- a/plugins/inputs/amd_rocm_smi/amd_rocm_smi_test.go
+++ b/plugins/inputs/amd_rocm_smi/amd_rocm_smi_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/internal"
+	"github.com/influxdata/telegraf/metric"
 	"github.com/influxdata/telegraf/models"
 	"github.com/influxdata/telegraf/testutil"
 )
@@ -99,7 +100,7 @@ func TestGatherValidJSON(t *testing.T) {
 			name:     "Vega 10 XT",
 			filename: "vega-10-XT.json",
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"amd_rocm_smi",
 					map[string]string{
 						"gpu_id":        "0x6861",
@@ -131,7 +132,7 @@ func TestGatherValidJSON(t *testing.T) {
 			name:     "Vega 20 WKS GL-XE [Radeon Pro VII]",
 			filename: "vega-20-WKS-GL-XE.json",
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"amd_rocm_smi",
 					map[string]string{
 						"gpu_id":        "0x66a1",
@@ -167,7 +168,7 @@ func TestGatherValidJSON(t *testing.T) {
 			name:     "mi100 + ROCm 571",
 			filename: "mi100_rocm571.json",
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"amd_rocm_smi",
 					map[string]string{
 						"gpu_id":        "0x738c",
@@ -195,7 +196,7 @@ func TestGatherValidJSON(t *testing.T) {
 					},
 					time.Unix(0, 0),
 				),
-				testutil.MustMetric(
+				metric.New(
 					"amd_rocm_smi",
 					map[string]string{
 						"gpu_id":        "0x738c",
@@ -223,7 +224,7 @@ func TestGatherValidJSON(t *testing.T) {
 					},
 					time.Unix(0, 0),
 				),
-				testutil.MustMetric(
+				metric.New(
 					"amd_rocm_smi",
 					map[string]string{
 						"gpu_id":        "0x738c",
@@ -251,7 +252,7 @@ func TestGatherValidJSON(t *testing.T) {
 					},
 					time.Unix(0, 0),
 				),
-				testutil.MustMetric(
+				metric.New(
 					"amd_rocm_smi",
 					map[string]string{
 						"gpu_id":        "0x738c",
@@ -279,7 +280,7 @@ func TestGatherValidJSON(t *testing.T) {
 					},
 					time.Unix(0, 0),
 				),
-				testutil.MustMetric(
+				metric.New(
 					"amd_rocm_smi",
 					map[string]string{
 						"gpu_id":        "0x738c",
@@ -307,7 +308,7 @@ func TestGatherValidJSON(t *testing.T) {
 					},
 					time.Unix(0, 0),
 				),
-				testutil.MustMetric(
+				metric.New(
 					"amd_rocm_smi",
 					map[string]string{
 						"gpu_id":        "0x738c",
@@ -341,7 +342,7 @@ func TestGatherValidJSON(t *testing.T) {
 			name:     "mi100 + ROCm 602",
 			filename: "mi100_rocm602.json",
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"amd_rocm_smi",
 					map[string]string{
 						"gpu_id":        "0x738c",
@@ -369,7 +370,7 @@ func TestGatherValidJSON(t *testing.T) {
 					},
 					time.Unix(0, 0),
 				),
-				testutil.MustMetric(
+				metric.New(
 					"amd_rocm_smi",
 					map[string]string{
 						"gpu_id":        "0x738c",
@@ -397,7 +398,7 @@ func TestGatherValidJSON(t *testing.T) {
 					},
 					time.Unix(0, 0),
 				),
-				testutil.MustMetric(
+				metric.New(
 					"amd_rocm_smi",
 					map[string]string{
 						"gpu_id":        "0x738c",
@@ -425,7 +426,7 @@ func TestGatherValidJSON(t *testing.T) {
 					},
 					time.Unix(0, 0),
 				),
-				testutil.MustMetric(
+				metric.New(
 					"amd_rocm_smi",
 					map[string]string{
 						"gpu_id":        "0x738c",
@@ -459,7 +460,7 @@ func TestGatherValidJSON(t *testing.T) {
 			name:     "rx6700xt + ROCm 430",
 			filename: "rx6700xt_rocm430.json",
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"amd_rocm_smi",
 					map[string]string{
 						"gpu_id":        "0x73df",
@@ -494,7 +495,7 @@ func TestGatherValidJSON(t *testing.T) {
 			name:     "rx6700xt + ROCm 571",
 			filename: "rx6700xt_rocm571.json",
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"amd_rocm_smi",
 					map[string]string{
 						"gpu_id":        "0x73df",
@@ -529,7 +530,7 @@ func TestGatherValidJSON(t *testing.T) {
 			name:     "rx6700xt + ROCm 602",
 			filename: "rx6700xt_rocm602.json",
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"amd_rocm_smi",
 					map[string]string{
 						"gpu_id":        "0x73df",
@@ -563,7 +564,7 @@ func TestGatherValidJSON(t *testing.T) {
 			name:     "rx6700xt + ROCm 612",
 			filename: "rx6700xt_rocm612.json",
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"amd_rocm_smi",
 					map[string]string{
 						"gpu_id":        "0x73df",

--- a/plugins/inputs/example/example_test.go
+++ b/plugins/inputs/example/example_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
+	"github.com/influxdata/telegraf/metric"
 	"github.com/influxdata/telegraf/testutil"
 )
 
@@ -85,7 +86,7 @@ func TestFixedValue(t *testing.T) {
 				NumberFields: 1,
 			},
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"example",
 					map[string]string{
 						"device": "test",
@@ -95,7 +96,7 @@ func TestFixedValue(t *testing.T) {
 					},
 					time.Unix(0, 0),
 				),
-				testutil.MustMetric(
+				metric.New(
 					"example",
 					map[string]string{
 						"device": "test",
@@ -105,7 +106,7 @@ func TestFixedValue(t *testing.T) {
 					},
 					time.Unix(0, 0),
 				),
-				testutil.MustMetric(
+				metric.New(
 					"example",
 					map[string]string{
 						"device": "test",
@@ -123,7 +124,7 @@ func TestFixedValue(t *testing.T) {
 				DeviceName: "test",
 			},
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"example",
 					map[string]string{
 						"device": "test",
@@ -134,7 +135,7 @@ func TestFixedValue(t *testing.T) {
 					},
 					time.Unix(0, 0),
 				),
-				testutil.MustMetric(
+				metric.New(
 					"example",
 					map[string]string{
 						"device": "test",
@@ -145,7 +146,7 @@ func TestFixedValue(t *testing.T) {
 					},
 					time.Unix(0, 0),
 				),
-				testutil.MustMetric(
+				metric.New(
 					"example",
 					map[string]string{
 						"device": "test",
@@ -165,7 +166,7 @@ func TestFixedValue(t *testing.T) {
 				NumberFields: 4,
 			},
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"example",
 					map[string]string{
 						"device": "test",
@@ -178,7 +179,7 @@ func TestFixedValue(t *testing.T) {
 					},
 					time.Unix(0, 0),
 				),
-				testutil.MustMetric(
+				metric.New(
 					"example",
 					map[string]string{
 						"device": "test",
@@ -191,7 +192,7 @@ func TestFixedValue(t *testing.T) {
 					},
 					time.Unix(0, 0),
 				),
-				testutil.MustMetric(
+				metric.New(
 					"example",
 					map[string]string{
 						"device": "test",
@@ -249,7 +250,7 @@ func TestRandomValue(t *testing.T) {
 				NumberFields:         1,
 				EnableRandomVariable: true,
 			},
-			template: testutil.MustMetric(
+			template: metric.New(
 				"example",
 				map[string]string{
 					"device": "test",
@@ -266,7 +267,7 @@ func TestRandomValue(t *testing.T) {
 				DeviceName:           "test",
 				EnableRandomVariable: true,
 			},
-			template: testutil.MustMetric(
+			template: metric.New(
 				"example",
 				map[string]string{
 					"device": "test",
@@ -285,7 +286,7 @@ func TestRandomValue(t *testing.T) {
 				NumberFields:         4,
 				EnableRandomVariable: true,
 			},
-			template: testutil.MustMetric(
+			template: metric.New(
 				"example",
 				map[string]string{
 					"device": "test",
@@ -389,7 +390,7 @@ func TestRandomValueFailPartial(t *testing.T) {
 				EnableRandomVariable: true,
 			},
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"example",
 					map[string]string{
 						"device": "flappy",
@@ -399,7 +400,7 @@ func TestRandomValueFailPartial(t *testing.T) {
 					},
 					time.Unix(0, 0),
 				),
-				testutil.MustMetric(
+				metric.New(
 					"example",
 					map[string]string{
 						"device": "flappy",

--- a/plugins/inputs/modbus/configuration_register_test.go
+++ b/plugins/inputs/modbus/configuration_register_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/tbrandon/mbserver"
 
 	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/metric"
 	"github.com/influxdata/telegraf/testutil"
 )
 
@@ -188,7 +189,7 @@ func TestRegisterCoils(t *testing.T) {
 			}
 
 			expected := []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"modbus",
 					map[string]string{
 						"type":     cCoils,
@@ -825,7 +826,7 @@ func TestRegisterHoldingRegisters(t *testing.T) {
 			}
 
 			expected := []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"modbus",
 					map[string]string{
 						"type":     cHoldingRegisters,
@@ -912,7 +913,7 @@ func TestRegisterReadMultipleCoilWithHole(t *testing.T) {
 	modbus.Coils = fcs
 
 	expected := []telegraf.Metric{
-		testutil.MustMetric(
+		metric.New(
 			"modbus",
 			map[string]string{
 				"type":     cCoils,
@@ -971,7 +972,7 @@ func TestRegisterReadMultipleCoilLimit(t *testing.T) {
 	modbus.Coils = fcs
 
 	expected := []telegraf.Metric{
-		testutil.MustMetric(
+		metric.New(
 			"modbus",
 			map[string]string{
 				"type":     cCoils,
@@ -1045,7 +1046,7 @@ func TestRegisterReadMultipleHoldingRegisterWithHole(t *testing.T) {
 	modbus.HoldingRegisters = fcs
 
 	expected := []telegraf.Metric{
-		testutil.MustMetric(
+		metric.New(
 			"modbus",
 			map[string]string{
 				"type":     cHoldingRegisters,
@@ -1102,7 +1103,7 @@ func TestRegisterReadMultipleHoldingRegisterLimit(t *testing.T) {
 	modbus.HoldingRegisters = fcs
 
 	expected := []telegraf.Metric{
-		testutil.MustMetric(
+		metric.New(
 			"modbus",
 			map[string]string{
 				"type":     cHoldingRegisters,
@@ -1170,7 +1171,7 @@ func TestRegisterHighAddresses(t *testing.T) {
 	}
 
 	expected := []telegraf.Metric{
-		testutil.MustMetric(
+		metric.New(
 			"modbus",
 			map[string]string{
 				"type":     cHoldingRegisters,

--- a/plugins/inputs/modbus/configuration_request_test.go
+++ b/plugins/inputs/modbus/configuration_request_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/tbrandon/mbserver"
 
 	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/metric"
 	"github.com/influxdata/telegraf/testutil"
 )
 
@@ -430,7 +431,7 @@ func TestRequestTypesCoil(t *testing.T) {
 			}
 
 			expected := []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"modbus",
 					map[string]string{
 						"type":     cCoils,
@@ -1059,7 +1060,7 @@ func TestRequestTypesHoldingABCD(t *testing.T) {
 			}
 
 			expected := []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"modbus",
 					map[string]string{
 						"type":     cHoldingRegisters,
@@ -1679,7 +1680,7 @@ func TestRequestTypesHoldingDCBA(t *testing.T) {
 			}
 
 			expected := []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"modbus",
 					map[string]string{
 						"type":     cHoldingRegisters,
@@ -2138,7 +2139,7 @@ func TestRequestStartingWithOmits(t *testing.T) {
 	require.NoError(t, err)
 
 	expected := []telegraf.Metric{
-		testutil.MustMetric(
+		metric.New(
 			"modbus",
 			map[string]string{
 				"type":     cHoldingRegisters,
@@ -2327,7 +2328,7 @@ func TestRequestMultipleSlavesOneFail(t *testing.T) {
 	)
 
 	expected := []telegraf.Metric{
-		testutil.MustMetric(
+		metric.New(
 			"modbus",
 			map[string]string{
 				"type":     cHoldingRegisters,
@@ -2337,7 +2338,7 @@ func TestRequestMultipleSlavesOneFail(t *testing.T) {
 			map[string]interface{}{"holding-0": int16(0x42)},
 			time.Unix(0, 0),
 		),
-		testutil.MustMetric(
+		metric.New(
 			"modbus",
 			map[string]string{
 				"type":     cHoldingRegisters,

--- a/plugins/inputs/modbus/modbus_test.go
+++ b/plugins/inputs/modbus/modbus_test.go
@@ -186,7 +186,7 @@ func TestRetrySuccessful(t *testing.T) {
 	}
 
 	expected := []telegraf.Metric{
-		testutil.MustMetric(
+		metric.New(
 			"modbus",
 			map[string]string{
 				"type":     cCoils,

--- a/plugins/inputs/neptune_apex/neptune_apex_test.go
+++ b/plugins/inputs/neptune_apex/neptune_apex_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/metric"
 	"github.com/influxdata/telegraf/testutil"
 )
 
@@ -69,7 +70,7 @@ func TestParseXML(t *testing.T) {
 			name:        "Good test",
 			xmlResponse: []byte(apex2016),
 			wantMetrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					Measurement,
 					map[string]string{
 						"source":   "apex",
@@ -84,7 +85,7 @@ func TestParseXML(t *testing.T) {
 					},
 					goodTime,
 				),
-				testutil.MustMetric(
+				metric.New(
 					Measurement,
 					map[string]string{
 						"source":      "apex",
@@ -99,7 +100,7 @@ func TestParseXML(t *testing.T) {
 					map[string]interface{}{"state": "PF1"},
 					goodTime,
 				),
-				testutil.MustMetric(
+				metric.New(
 					Measurement,
 					map[string]string{
 						"source":      "apex",
@@ -114,7 +115,7 @@ func TestParseXML(t *testing.T) {
 					map[string]interface{}{"state": "AOF"},
 					goodTime,
 				),
-				testutil.MustMetric(
+				metric.New(
 					Measurement,
 					map[string]string{
 						"source":      "apex",
@@ -133,7 +134,7 @@ func TestParseXML(t *testing.T) {
 					},
 					goodTime,
 				),
-				testutil.MustMetric(
+				metric.New(
 					Measurement,
 					map[string]string{
 						"source":      "apex",
@@ -151,7 +152,7 @@ func TestParseXML(t *testing.T) {
 					},
 					goodTime,
 				),
-				testutil.MustMetric(
+				metric.New(
 					Measurement,
 					map[string]string{
 						"source":      "apex",
@@ -166,7 +167,7 @@ func TestParseXML(t *testing.T) {
 					map[string]interface{}{"state": "AOF"},
 					goodTime,
 				),
-				testutil.MustMetric(
+				metric.New(
 					Measurement,
 					map[string]string{
 						"source":      "apex",
@@ -181,7 +182,7 @@ func TestParseXML(t *testing.T) {
 					map[string]interface{}{"state": "AOF"},
 					goodTime,
 				),
-				testutil.MustMetric(
+				metric.New(
 					Measurement,
 					map[string]string{
 						"source":     "apex",
@@ -194,7 +195,7 @@ func TestParseXML(t *testing.T) {
 					map[string]interface{}{"value": 30.1},
 					goodTime,
 				),
-				testutil.MustMetric(
+				metric.New(
 					Measurement,
 					map[string]string{
 						"source":   "apex",
@@ -225,7 +226,7 @@ func TestParseXML(t *testing.T) {
 				<timezone>-8.0</timezone><power><failed>a</failed>
 				<restored>12/22/2018 22:55:37</restored></power></status>`),
 			wantMetrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					Measurement,
 					map[string]string{
 						"source":   "",
@@ -248,7 +249,7 @@ func TestParseXML(t *testing.T) {
 				<timezone>-8.0</timezone><power><restored>a</restored>
 				<failed>12/22/2018 22:55:37</failed></power></status>`),
 			wantMetrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					Measurement,
 					map[string]string{
 						"source":   "",
@@ -282,7 +283,7 @@ func TestParseXML(t *testing.T) {
 				</probes></status>`),
 			wantAccErr: true,
 			wantMetrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					Measurement,
 					map[string]string{
 						"source":   "",
@@ -311,7 +312,7 @@ func TestParseXML(t *testing.T) {
 				</probes></status>`),
 			wantAccErr: true,
 			wantMetrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					Measurement,
 					map[string]string{
 						"source":   "",
@@ -339,7 +340,7 @@ func TestParseXML(t *testing.T) {
 				</probes></status>`),
 			wantAccErr: true,
 			wantMetrics: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					Measurement,
 					map[string]string{
 						"source":   "",


### PR DESCRIPTION


## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Migrate testutil.MustMetric to metric.New for: amd_rocm_smi,neptune_apex,modbus,example Part of #18495

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
