### PR TITLE
chore(inputs): Migrate testutil.MustMetric to metric.New

### DIFF
--- a/plugins/inputs/docker/docker_test.go
+++ b/plugins/inputs/docker/docker_test.go
@@ -750,7 +750,7 @@ func TestContainerStatus(t *testing.T) {
 			},
 			inspect: containerInspect(),
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"docker_container_status",
 					map[string]string{
 						"container_name":    "etcd",
@@ -787,7 +787,7 @@ func TestContainerStatus(t *testing.T) {
 				return i
 			}(),
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"docker_container_status",
 					map[string]string{
 						"container_name":    "etcd",
@@ -826,7 +826,7 @@ func TestContainerStatus(t *testing.T) {
 				return i
 			}(),
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"docker_container_status",
 					map[string]string{
 						"container_name":    "etcd",
@@ -863,7 +863,7 @@ func TestContainerStatus(t *testing.T) {
 				return i
 			}(),
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"docker_container_status",
 					map[string]string{
 						"container_name":    "etcd",
@@ -1439,7 +1439,7 @@ func Test_parseContainerStatsPerDeviceAndTotal(t *testing.T) {
 
 	var (
 		testDate       = time.Date(2018, 6, 14, 5, 51, 53, 266176036, time.UTC)
-		metricCPUTotal = testutil.MustMetric(
+		metricCPUTotal = metric.New(
 			"docker_container_cpu",
 			map[string]string{
 				"cpu": "cpu-total",
@@ -1447,14 +1447,14 @@ func Test_parseContainerStatsPerDeviceAndTotal(t *testing.T) {
 			map[string]interface{}{},
 			testDate)
 
-		metricCPU0 = testutil.MustMetric(
+		metricCPU0 = metric.New(
 			"docker_container_cpu",
 			map[string]string{
 				"cpu": "cpu0",
 			},
 			map[string]interface{}{},
 			testDate)
-		metricCPU1 = testutil.MustMetric(
+		metricCPU1 = metric.New(
 			"docker_container_cpu",
 			map[string]string{
 				"cpu": "cpu1",
@@ -1462,7 +1462,7 @@ func Test_parseContainerStatsPerDeviceAndTotal(t *testing.T) {
 			map[string]interface{}{},
 			testDate)
 
-		metricNetworkTotal = testutil.MustMetric(
+		metricNetworkTotal = metric.New(
 			"docker_container_net",
 			map[string]string{
 				"network": "total",
@@ -1470,7 +1470,7 @@ func Test_parseContainerStatsPerDeviceAndTotal(t *testing.T) {
 			map[string]interface{}{},
 			testDate)
 
-		metricNetworkEth0 = testutil.MustMetric(
+		metricNetworkEth0 = metric.New(
 			"docker_container_net",
 			map[string]string{
 				"network": "eth0",
@@ -1478,28 +1478,28 @@ func Test_parseContainerStatsPerDeviceAndTotal(t *testing.T) {
 			map[string]interface{}{},
 			testDate)
 
-		metricNetworkEth1 = testutil.MustMetric(
+		metricNetworkEth1 = metric.New(
 			"docker_container_net",
 			map[string]string{
 				"network": "eth0",
 			},
 			map[string]interface{}{},
 			testDate)
-		metricBlkioTotal = testutil.MustMetric(
+		metricBlkioTotal = metric.New(
 			"docker_container_blkio",
 			map[string]string{
 				"device": "total",
 			},
 			map[string]interface{}{},
 			testDate)
-		metricBlkio6_0 = testutil.MustMetric(
+		metricBlkio6_0 = metric.New(
 			"docker_container_blkio",
 			map[string]string{
 				"device": "6:0",
 			},
 			map[string]interface{}{},
 			testDate)
-		metricBlkio6_1 = testutil.MustMetric(
+		metricBlkio6_1 = metric.New(
 			"docker_container_blkio",
 			map[string]string{
 				"device": "6:1",

--- a/plugins/inputs/dpdk/dpdk_cmds_test.go
+++ b/plugins/inputs/dpdk/dpdk_cmds_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/metric"
 	"github.com/influxdata/telegraf/testutil"
 )
 
@@ -21,7 +22,7 @@ func Test_LinkStatusCommand(t *testing.T) {
 		dpdkConn.processCommand(mockAcc, testutil.Logger{}, ethdevLinkStatusCommand+",1", nil)
 
 		expected := []telegraf.Metric{
-			testutil.MustMetric(
+			metric.New(
 				"dpdk",
 				map[string]string{
 					"command": ethdevLinkStatusCommand,
@@ -48,7 +49,7 @@ func Test_LinkStatusCommand(t *testing.T) {
 		dpdkConn.processCommand(mockAcc, testutil.Logger{}, ethdevLinkStatusCommand+",1", nil)
 
 		expected := []telegraf.Metric{
-			testutil.MustMetric(
+			metric.New(
 				"dpdk",
 				map[string]string{
 					"command": ethdevLinkStatusCommand,
@@ -86,7 +87,7 @@ func Test_LinkStatusCommand(t *testing.T) {
 		dpdkConn := dpdk.connectors[0]
 		dpdkConn.processCommand(mockAcc, testutil.Logger{}, ethdevLinkStatusCommand+",1", nil)
 		expected := []telegraf.Metric{
-			testutil.MustMetric(
+			metric.New(
 				"dpdk",
 				map[string]string{
 					"command": ethdevLinkStatusCommand,
@@ -112,7 +113,7 @@ func Test_LinkStatusCommand(t *testing.T) {
 		dpdkConn.processCommand(mockAcc, testutil.Logger{}, ethdevLinkStatusCommand+",1", nil)
 
 		expected := []telegraf.Metric{
-			testutil.MustMetric(
+			metric.New(
 				"dpdk",
 				map[string]string{
 					"command": ethdevLinkStatusCommand,

--- a/plugins/inputs/dpdk/dpdk_test.go
+++ b/plugins/inputs/dpdk/dpdk_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/filter"
 	"github.com/influxdata/telegraf/internal/globpath"
+	"github.com/influxdata/telegraf/metric"
 	"github.com/influxdata/telegraf/plugins/inputs/dpdk/mocks"
 	"github.com/influxdata/telegraf/testutil"
 )
@@ -630,7 +631,7 @@ func Test_Gather(t *testing.T) {
 		require.Empty(t, mockAcc.Errors)
 
 		expected := []telegraf.Metric{
-			testutil.MustMetric(
+			metric.New(
 				"dpdk",
 				map[string]string{
 					"command": "/endpoint1",
@@ -658,7 +659,7 @@ func Test_Gather(t *testing.T) {
 		require.Empty(t, mockAcc.Errors)
 
 		expected := []telegraf.Metric{
-			testutil.MustMetric(
+			metric.New(
 				"dpdk",
 				map[string]string{
 					"command": "/endpoint1",
@@ -695,7 +696,7 @@ func Test_Gather(t *testing.T) {
 		require.Empty(t, mockAcc.Errors)
 
 		expected := []telegraf.Metric{
-			testutil.MustMetric(
+			metric.New(
 				"dpdk",
 				map[string]string{
 					"command": "/endpoint1",
@@ -732,7 +733,7 @@ func Test_Gather(t *testing.T) {
 		require.Empty(t, mockAcc.Errors)
 
 		expected := []telegraf.Metric{
-			testutil.MustMetric(
+			metric.New(
 				"dpdk",
 				map[string]string{
 					"command": "/endpoint1",
@@ -767,7 +768,7 @@ func Test_Gather(t *testing.T) {
 		require.Empty(t, mockAcc.Errors)
 
 		expected := []telegraf.Metric{
-			testutil.MustMetric(
+			metric.New(
 				"dpdk",
 				map[string]string{
 					"command": "/endpoint1",
@@ -805,7 +806,7 @@ func Test_Gather_MultiSocket(t *testing.T) {
 		require.Empty(t, mockAcc.Errors)
 
 		expected := []telegraf.Metric{
-			testutil.MustMetric(
+			metric.New(
 				"dpdk",
 				map[string]string{
 					"command": "/endpoint1",
@@ -816,7 +817,7 @@ func Test_Gather_MultiSocket(t *testing.T) {
 				},
 				time.Unix(0, 0),
 			),
-			testutil.MustMetric(
+			metric.New(
 				"dpdk",
 				map[string]string{
 					"command": "/endpoint1",

--- a/plugins/inputs/monit/monit_test.go
+++ b/plugins/inputs/monit/monit_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/metric"
 	"github.com/influxdata/telegraf/testutil"
 )
 
@@ -34,7 +35,7 @@ func TestServiceType(t *testing.T) {
 			name:     "check filesystem service type",
 			filename: "testdata/response_servicetype_0.xml",
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"monit_filesystem",
 					map[string]string{
 						"version":           "5.17.1",
@@ -67,7 +68,7 @@ func TestServiceType(t *testing.T) {
 			name:     "check directory service type",
 			filename: "testdata/response_servicetype_1.xml",
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"monit_directory",
 					map[string]string{
 						"version":           "5.17.1",
@@ -94,7 +95,7 @@ func TestServiceType(t *testing.T) {
 			name:     "check file service type",
 			filename: "testdata/response_servicetype_2.xml",
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"monit_file",
 					map[string]string{
 						"version":           "5.17.1",
@@ -122,7 +123,7 @@ func TestServiceType(t *testing.T) {
 			name:     "check process service type",
 			filename: "testdata/response_servicetype_3.xml",
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"monit_process",
 					map[string]string{
 						"version":           "5.17.1",
@@ -158,7 +159,7 @@ func TestServiceType(t *testing.T) {
 			name:     "check remote host service type",
 			filename: "testdata/response_servicetype_4.xml",
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"monit_remote_host",
 					map[string]string{
 						"version":           "5.17.1",
@@ -190,7 +191,7 @@ func TestServiceType(t *testing.T) {
 			name:     "check system service type",
 			filename: "testdata/response_servicetype_5.xml",
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"monit_system",
 					map[string]string{
 						"version":           "5.17.1",
@@ -226,7 +227,7 @@ func TestServiceType(t *testing.T) {
 			name:     "check fifo service type",
 			filename: "testdata/response_servicetype_6.xml",
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"monit_fifo",
 					map[string]string{
 						"version":           "5.17.1",
@@ -253,7 +254,7 @@ func TestServiceType(t *testing.T) {
 			name:     "check program service type",
 			filename: "testdata/response_servicetype_7.xml",
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"monit_program",
 					map[string]string{
 						"version":           "5.17.1",
@@ -281,7 +282,7 @@ func TestServiceType(t *testing.T) {
 			name:     "check network service type",
 			filename: "testdata/response_servicetype_8.xml",
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"monit_network",
 					map[string]string{
 						"version":           "5.17.1",
@@ -355,7 +356,7 @@ func TestMonitFailure(t *testing.T) {
 			name:     "check monit failure status",
 			filename: "testdata/response_servicetype_8_failure.xml",
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"monit_network",
 					map[string]string{
 						"version":           "5.17.1",
@@ -396,7 +397,7 @@ func TestMonitFailure(t *testing.T) {
 			name:     "check passive mode",
 			filename: "testdata/response_servicetype_8_passivemode.xml",
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"monit_network",
 					map[string]string{
 						"version":           "5.17.1",
@@ -437,7 +438,7 @@ func TestMonitFailure(t *testing.T) {
 			name:     "check initializing status",
 			filename: "testdata/response_servicetype_8_initializingmode.xml",
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"monit_network",
 					map[string]string{
 						"version":           "5.17.1",
@@ -478,7 +479,7 @@ func TestMonitFailure(t *testing.T) {
 			name:     "check pending action",
 			filename: "testdata/response_servicetype_8_pendingaction.xml",
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"monit_network",
 					map[string]string{
 						"version":           "5.17.1",

--- a/plugins/inputs/mqtt_consumer/mqtt_consumer_test.go
+++ b/plugins/inputs/mqtt_consumer/mqtt_consumer_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/internal"
+	"github.com/influxdata/telegraf/metric"
 	"github.com/influxdata/telegraf/models"
 	"github.com/influxdata/telegraf/plugins/parsers/influx"
 	"github.com/influxdata/telegraf/testutil"
@@ -216,7 +217,7 @@ func TestTopicTag(t *testing.T) {
 				return nil
 			},
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{
 						"topic": "telegraf",
@@ -236,7 +237,7 @@ func TestTopicTag(t *testing.T) {
 				return &tag
 			},
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{
 						"topic_tag": "telegraf",
@@ -256,7 +257,7 @@ func TestTopicTag(t *testing.T) {
 				return &tag
 			},
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{},
 					map[string]interface{}{
@@ -285,7 +286,7 @@ func TestTopicTag(t *testing.T) {
 				},
 			},
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"test",
 					map[string]string{
 						"testTag": "telegraf",
@@ -317,7 +318,7 @@ func TestTopicTag(t *testing.T) {
 				},
 			},
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"test",
 					map[string]string{
 						"testTag": "telegraf",
@@ -351,7 +352,7 @@ func TestTopicTag(t *testing.T) {
 				},
 			},
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"test",
 					map[string]string{
 						"testTag": "telegraf",
@@ -383,7 +384,7 @@ func TestTopicTag(t *testing.T) {
 				},
 			},
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"test",
 					map[string]string{
 						"testTag": "telegraf",
@@ -413,7 +414,7 @@ func TestTopicTag(t *testing.T) {
 				},
 			},
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{
 						"testTag": "telegraf",
@@ -446,7 +447,7 @@ func TestTopicTag(t *testing.T) {
 				},
 			},
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"test",
 					map[string]string{
 						"testTag": "telegraf",
@@ -479,7 +480,7 @@ func TestTopicTag(t *testing.T) {
 				},
 			},
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"test",
 					map[string]string{
 						"testTag": "telegraf",
@@ -513,7 +514,7 @@ func TestTopicTag(t *testing.T) {
 				},
 			},
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{},
 					map[string]interface{}{

--- a/plugins/inputs/prometheus/prometheus_test.go
+++ b/plugins/inputs/prometheus/prometheus_test.go
@@ -467,7 +467,7 @@ go_gc_duration_seconds_count 42`
 	require.NoError(t, err)
 
 	expected := []telegraf.Metric{
-		testutil.MustMetric(
+		metric.New(
 			"prometheus",
 			map[string]string{
 				"quantile": "0",
@@ -478,7 +478,7 @@ go_gc_duration_seconds_count 42`
 			time.Unix(0, 0),
 			telegraf.Summary,
 		),
-		testutil.MustMetric(
+		metric.New(
 			"prometheus",
 			map[string]string{
 				"quantile": "1",
@@ -489,7 +489,7 @@ go_gc_duration_seconds_count 42`
 			time.Unix(0, 0),
 			telegraf.Summary,
 		),
-		testutil.MustMetric(
+		metric.New(
 			"prometheus",
 			map[string]string{},
 			map[string]interface{}{
@@ -498,7 +498,7 @@ go_gc_duration_seconds_count 42`
 			time.Unix(0, 0),
 			telegraf.Summary,
 		),
-		testutil.MustMetric(
+		metric.New(
 			"prometheus_request",
 			map[string]string{},
 			map[string]interface{}{
@@ -800,21 +800,21 @@ go_memstats_heap_alloc_bytes 1.581062048e+09
 	require.NoError(t, p.Gather(&acc))
 
 	expected := []telegraf.Metric{
-		testutil.MustMetric(
+		metric.New(
 			"openmetric",
 			map[string]string{},
 			map[string]interface{}{"go_memstats_gc_cpu_fraction": float64(-0.00014404354379774563)},
 			time.Unix(0, 0),
 			telegraf.Gauge,
 		),
-		testutil.MustMetric(
+		metric.New(
 			"openmetric",
 			map[string]string{},
 			map[string]interface{}{"go_memstats_gc_sys_bytes": 6.0936192e+07},
 			time.Unix(0, 0),
 			telegraf.Gauge,
 		),
-		testutil.MustMetric(
+		metric.New(
 			"openmetric",
 			map[string]string{},
 			map[string]interface{}{"go_memstats_heap_alloc_bytes": 1.581062048e+09},
@@ -852,21 +852,21 @@ func TestOpenmetricsProtobuf(t *testing.T) {
 	require.NoError(t, p.Gather(&acc))
 
 	expected := []telegraf.Metric{
-		testutil.MustMetric(
+		metric.New(
 			"openmetric",
 			map[string]string{},
 			map[string]interface{}{"go_memstats_gc_cpu_fraction": float64(-0.00014404354379774563)},
 			time.Unix(0, 0),
 			telegraf.Gauge,
 		),
-		testutil.MustMetric(
+		metric.New(
 			"openmetric",
 			map[string]string{},
 			map[string]interface{}{"go_memstats_gc_sys_bytes": 6.0936192e+07},
 			time.Unix(0, 0),
 			telegraf.Gauge,
 		),
-		testutil.MustMetric(
+		metric.New(
 			"openmetric",
 			map[string]string{},
 			map[string]interface{}{"go_memstats_heap_alloc_bytes": 1.581062048e+09},
@@ -915,21 +915,21 @@ go_memstats_heap_alloc_bytes 1.581062048e+09
 	require.NoError(t, p.Gather(&acc))
 
 	expected := []telegraf.Metric{
-		testutil.MustMetric(
+		metric.New(
 			"openmetric",
 			map[string]string{},
 			map[string]interface{}{"go_memstats_gc_cpu_fraction": float64(-0.00014404354379774563)},
 			time.Unix(0, 0),
 			telegraf.Gauge,
 		),
-		testutil.MustMetric(
+		metric.New(
 			"openmetric",
 			map[string]string{},
 			map[string]interface{}{"go_memstats_gc_sys_bytes": 6.0936192e+07},
 			time.Unix(0, 0),
 			telegraf.Gauge,
 		),
-		testutil.MustMetric(
+		metric.New(
 			"openmetric",
 			map[string]string{},
 			map[string]interface{}{"go_memstats_heap_alloc_bytes": 1.581062048e+09},

--- a/plugins/inputs/tail/tail_test.go
+++ b/plugins/inputs/tail/tail_test.go
@@ -349,7 +349,7 @@ cpu,42
 	require.NoError(t, plugin.Init())
 
 	expected := []telegraf.Metric{
-		testutil.MustMetric("cpu",
+		metric.New("cpu",
 			map[string]string{
 				"path": tmpfile,
 			},
@@ -357,7 +357,7 @@ cpu,42
 				"time_idle": 42,
 			},
 			time.Unix(0, 0)),
-		testutil.MustMetric("cpu",
+		metric.New("cpu",
 			map[string]string{
 				"path": tmpfile,
 			},
@@ -389,7 +389,7 @@ skip2,mem,100
 	require.NoError(t, os.WriteFile(tmpfile, []byte(content), 0600))
 
 	expected := []telegraf.Metric{
-		testutil.MustMetric("cpu",
+		metric.New("cpu",
 			map[string]string{
 				"path": tmpfile,
 			},
@@ -397,7 +397,7 @@ skip2,mem,100
 				"value2": 42,
 			},
 			time.Unix(0, 0)),
-		testutil.MustMetric("mem",
+		metric.New("mem",
 			map[string]string{
 				"path": tmpfile,
 			},
@@ -447,7 +447,7 @@ func TestMultipleMetricsOnFirstLine(t *testing.T) {
 	require.NoError(t, os.WriteFile(tmpfile, []byte(content), 0600))
 
 	expected := []telegraf.Metric{
-		testutil.MustMetric("cpu",
+		metric.New("cpu",
 			map[string]string{
 				"customPathTagMyFile": tmpfile,
 			},
@@ -455,7 +455,7 @@ func TestMultipleMetricsOnFirstLine(t *testing.T) {
 				"time_idle": 42.0,
 			},
 			time.Unix(0, 0)),
-		testutil.MustMetric("cpu",
+		metric.New("cpu",
 			map[string]string{
 				"customPathTagMyFile": tmpfile,
 			},
@@ -492,7 +492,7 @@ func TestMultipleMetricsOnFirstLine(t *testing.T) {
 
 func TestCharacterEncoding(t *testing.T) {
 	full := []telegraf.Metric{
-		testutil.MustMetric("cpu",
+		metric.New("cpu",
 			map[string]string{
 				"cpu": "cpu0",
 			},
@@ -501,7 +501,7 @@ func TestCharacterEncoding(t *testing.T) {
 			},
 			time.Unix(0, 0),
 		),
-		testutil.MustMetric("cpu",
+		metric.New("cpu",
 			map[string]string{
 				"cpu": "cpu1",
 			},
@@ -510,7 +510,7 @@ func TestCharacterEncoding(t *testing.T) {
 			},
 			time.Unix(0, 0),
 		),
-		testutil.MustMetric("cpu",
+		metric.New("cpu",
 			map[string]string{
 				"cpu": "cpu2",
 			},
@@ -519,7 +519,7 @@ func TestCharacterEncoding(t *testing.T) {
 			},
 			time.Unix(0, 0),
 		),
-		testutil.MustMetric("cpu",
+		metric.New("cpu",
 			map[string]string{
 				"cpu": "cpu3",
 			},
@@ -528,7 +528,7 @@ func TestCharacterEncoding(t *testing.T) {
 			},
 			time.Unix(0, 0),
 		),
-		testutil.MustMetric("cpu",
+		metric.New("cpu",
 			map[string]string{
 				"cpu": "cpu-total",
 			},


### PR DESCRIPTION


## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Migrate testutil.MustMetric to metric.New for: prometheus,monit,docker,tail,mqtt_consumer,dpdk Part of #18495

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
