### PR TITLE
chore(inputs): Migrate testutil.MustMetric to metric.New

### DIFF
--- a/plugins/inputs/consul_agent/consul_agent_test.go
+++ b/plugins/inputs/consul_agent/consul_agent_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/metric"
 	"github.com/influxdata/telegraf/testutil"
 )
 
@@ -22,7 +23,7 @@ func TestConsulStats(t *testing.T) {
 		{
 			name: "Metrics",
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"consul.rpc.request",
 					map[string]string{},
 					map[string]interface{}{
@@ -37,7 +38,7 @@ func TestConsulStats(t *testing.T) {
 					time.Unix(1639218930, 0),
 					1,
 				),
-				testutil.MustMetric(
+				metric.New(
 					"consul.consul.members.clients",
 					map[string]string{
 						"datacenter": "dc1",
@@ -48,7 +49,7 @@ func TestConsulStats(t *testing.T) {
 					time.Unix(1639218930, 0),
 					2,
 				),
-				testutil.MustMetric(
+				metric.New(
 					"consul.api.http",
 					map[string]string{
 						"method": "GET",

--- a/plugins/inputs/disk/disk_test.go
+++ b/plugins/inputs/disk/disk_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/metric"
 	"github.com/influxdata/telegraf/plugins/common/psutil"
 	"github.com/influxdata/telegraf/testutil"
 )
@@ -572,7 +573,7 @@ func TestDiskUsageIssues(t *testing.T) {
 				InodesUsed:  2000,
 			},
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"disk",
 					map[string]string{
 						"device": "tmpfs",
@@ -593,7 +594,7 @@ func TestDiskUsageIssues(t *testing.T) {
 					time.Unix(0, 0),
 					telegraf.Gauge,
 				),
-				testutil.MustMetric(
+				metric.New(
 					"disk",
 					map[string]string{
 						"device": "nvme0n1p4",
@@ -628,7 +629,7 @@ func TestDiskUsageIssues(t *testing.T) {
 				InodesUsed:  2000,
 			},
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"disk",
 					map[string]string{
 						"device": "sda1",
@@ -650,7 +651,7 @@ func TestDiskUsageIssues(t *testing.T) {
 					time.Unix(0, 0),
 					telegraf.Gauge,
 				),
-				testutil.MustMetric(
+				metric.New(
 					"disk",
 					map[string]string{
 						"device": "sdb",

--- a/plugins/inputs/intel_dlb/intel_dlb_test.go
+++ b/plugins/inputs/intel_dlb/intel_dlb_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/metric"
 	"github.com/influxdata/telegraf/plugins/inputs/dpdk/mocks"
 	"github.com/influxdata/telegraf/testutil"
 )
@@ -480,7 +481,7 @@ func TestDLB_processCommandResult(t *testing.T) {
 		require.NoError(t, err)
 
 		expected := []telegraf.Metric{
-			testutil.MustMetric(
+			metric.New(
 				"intel_dlb",
 				map[string]string{
 					"command": "/eventdev/dev_xstats,0",
@@ -1036,7 +1037,7 @@ TOTAL_ERR_NONFATAL 9`
 
 var (
 	expectedRasMetrics = []telegraf.Metric{
-		testutil.MustMetric(
+		metric.New(
 			"intel_dlb_ras",
 			map[string]string{
 				"device":      "0000:00:00.0",
@@ -1055,7 +1056,7 @@ var (
 			},
 			time.Unix(0, 0),
 		),
-		testutil.MustMetric(
+		metric.New(
 			"intel_dlb_ras",
 			map[string]string{
 				"device":      "0000:00:00.0",
@@ -1084,7 +1085,7 @@ var (
 			},
 			time.Unix(0, 0),
 		),
-		testutil.MustMetric(
+		metric.New(
 			"intel_dlb_ras",
 			map[string]string{
 				"device":      "0000:00:00.0",
@@ -1116,7 +1117,7 @@ var (
 	}
 
 	expectedTelegrafMetrics = []telegraf.Metric{
-		testutil.MustMetric(
+		metric.New(
 			"intel_dlb",
 			map[string]string{
 				"command": "/eventdev/dev_xstats,0",

--- a/plugins/inputs/intel_pmt/intel_pmt_test.go
+++ b/plugins/inputs/intel_pmt/intel_pmt_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/metric"
 	"github.com/influxdata/telegraf/testutil"
 )
 
@@ -446,7 +447,7 @@ func TestGather(t *testing.T) {
 				},
 			},
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"intel_pmt",
 					map[string]string{
 						"guid":           "test-guid",
@@ -462,7 +463,7 @@ func TestGather(t *testing.T) {
 					},
 					time.Time{},
 				),
-				testutil.MustMetric(
+				metric.New(
 					"intel_pmt",
 					map[string]string{
 						"guid":           "test-guid2",
@@ -536,7 +537,7 @@ func TestGather(t *testing.T) {
 				},
 			},
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"intel_pmt",
 					map[string]string{
 						"guid":           "test-guid",

--- a/plugins/inputs/ipset/ipset_entries_test.go
+++ b/plugins/inputs/ipset/ipset_entries_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/metric"
 	"github.com/influxdata/telegraf/testutil"
 )
 
@@ -27,7 +28,7 @@ func TestIpsetEntries(t *testing.T) {
 	entries.commit(&acc)
 
 	expected := []telegraf.Metric{
-		testutil.MustMetric(
+		metric.New(
 			"ipset",
 			map[string]string{
 				"set": "mylist",
@@ -67,7 +68,7 @@ func TestIpsetEntriesCidr(t *testing.T) {
 	entries.commit(&acc)
 
 	expected := []telegraf.Metric{
-		testutil.MustMetric(
+		metric.New(
 			"ipset",
 			map[string]string{
 				"set": "mylist0",
@@ -79,7 +80,7 @@ func TestIpsetEntriesCidr(t *testing.T) {
 			time.Now().Add(time.Millisecond*0),
 			telegraf.Gauge,
 		),
-		testutil.MustMetric(
+		metric.New(
 			"ipset",
 			map[string]string{
 				"set": "mylist1",

--- a/plugins/inputs/kafka_consumer/kafka_consumer_test.go
+++ b/plugins/inputs/kafka_consumer/kafka_consumer_test.go
@@ -372,7 +372,7 @@ func TestConsumerGroupHandlerConsumeClaim(t *testing.T) {
 	require.NoError(t, err)
 
 	expected := []telegraf.Metric{
-		testutil.MustMetric(
+		metric.New(
 			"cpu",
 			map[string]string{},
 			map[string]interface{}{
@@ -401,7 +401,7 @@ func TestConsumerGroupHandlerHandle(t *testing.T) {
 				Value: []byte("42"),
 			},
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{},
 					map[string]interface{}{
@@ -436,7 +436,7 @@ func TestConsumerGroupHandlerHandle(t *testing.T) {
 				Value: []byte("42"),
 			},
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{
 						"topic": "telegraf",

--- a/plugins/inputs/nomad/nomad_test.go
+++ b/plugins/inputs/nomad/nomad_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/metric"
 	"github.com/influxdata/telegraf/testutil"
 )
 
@@ -22,7 +23,7 @@ func TestNomadStats(t *testing.T) {
 		{
 			name: "Metrics",
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"nomad.nomad.rpc.query",
 					map[string]string{
 						"host": "node1",
@@ -39,7 +40,7 @@ func TestNomadStats(t *testing.T) {
 					time.Unix(1636843140, 0),
 					1,
 				),
-				testutil.MustMetric(
+				metric.New(
 					"nomad.client.allocated.cpu",
 					map[string]string{
 						"node_scheduling_eligibility": "eligible",
@@ -55,7 +56,7 @@ func TestNomadStats(t *testing.T) {
 					time.Unix(1636843140, 0),
 					2,
 				),
-				testutil.MustMetric(
+				metric.New(
 					"nomad.memberlist.gossip",
 					map[string]string{
 						"host": "node1",

--- a/plugins/inputs/p4runtime/p4runtime_test.go
+++ b/plugins/inputs/p4runtime/p4runtime_test.go
@@ -14,6 +14,7 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/metric"
 	"github.com/influxdata/telegraf/testutil"
 )
 
@@ -129,7 +130,7 @@ func TestOneCounterRead(t *testing.T) {
 				5,
 				&p4.CounterData{ByteCount: 5, PacketCount: 1},
 			),
-			expected: []telegraf.Metric{testutil.MustMetric(
+			expected: []telegraf.Metric{metric.New(
 				"p4_runtime",
 				map[string]string{
 					"p4program_name": "P4Program",
@@ -160,7 +161,7 @@ func TestOneCounterRead(t *testing.T) {
 				5,
 				&p4.CounterData{ByteCount: 5},
 			),
-			expected: []telegraf.Metric{testutil.MustMetric(
+			expected: []telegraf.Metric{metric.New(
 				"p4_runtime",
 				map[string]string{
 					"p4program_name": "P4Program",
@@ -191,7 +192,7 @@ func TestOneCounterRead(t *testing.T) {
 				5,
 				&p4.CounterData{PacketCount: 1},
 			),
-			expected: []telegraf.Metric{testutil.MustMetric(
+			expected: []telegraf.Metric{metric.New(
 				"p4_runtime",
 				map[string]string{
 					"p4program_name": "P4Program",
@@ -290,7 +291,7 @@ func TestMultipleEntitiesSingleCounterRead(t *testing.T) {
 			}
 
 			entities = append(entities, counterEntry)
-			expected = append(expected, testutil.MustMetric(
+			expected = append(expected, metric.New(
 				"p4_runtime",
 				map[string]string{
 					"p4program_name": "P4Program",
@@ -372,7 +373,7 @@ func TestSingleEntitiesMultipleCounterRead(t *testing.T) {
 				),
 			)
 
-			expected = append(expected, testutil.MustMetric(
+			expected = append(expected, metric.New(
 				"p4_runtime",
 				map[string]string{
 					"p4program_name": "P4Program",

--- a/plugins/inputs/procstat/procstat_test.go
+++ b/plugins/inputs/procstat/procstat_test.go
@@ -251,7 +251,7 @@ func TestInitMissingPidMethod(t *testing.T) {
 
 func TestGather_CreateProcessErrorOk(t *testing.T) {
 	expected := []telegraf.Metric{
-		testutil.MustMetric(
+		metric.New(
 			"procstat_lookup",
 			map[string]string{
 				"exe":        "foo",
@@ -287,7 +287,7 @@ func TestGather_CreateProcessErrorOk(t *testing.T) {
 
 func TestGather_ProcessName(t *testing.T) {
 	expected := []telegraf.Metric{
-		testutil.MustMetric(
+		metric.New(
 			"procstat",
 			map[string]string{
 				"exe":          "foo",
@@ -323,7 +323,7 @@ func TestGather_ProcessName(t *testing.T) {
 			time.Unix(0, 0),
 			telegraf.Untyped,
 		),
-		testutil.MustMetric(
+		metric.New(
 			"procstat_lookup",
 			map[string]string{
 				"exe":        "foo",

--- a/plugins/inputs/sql/sql_test.go
+++ b/plugins/inputs/sql/sql_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
+	"github.com/influxdata/telegraf/metric"
 	"github.com/influxdata/telegraf/testutil"
 )
 
@@ -66,7 +67,7 @@ func TestMariaDBIntegration(t *testing.T) {
 				},
 			},
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"sql",
 					map[string]string{
 						"tag_one": "tag1",
@@ -164,7 +165,7 @@ func TestPostgreSQLIntegration(t *testing.T) {
 				},
 			},
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"sql",
 					map[string]string{
 						"tag_one": "tag1",
@@ -258,7 +259,7 @@ func TestClickHouseIntegration(t *testing.T) {
 				},
 			},
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"sql",
 					map[string]string{
 						"tag_one": "tag1",

--- a/plugins/inputs/vault/vault_test.go
+++ b/plugins/inputs/vault/vault_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/testcontainers/testcontainers-go/wait"
 
 	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/metric"
 	"github.com/influxdata/telegraf/testutil"
 )
 
@@ -25,7 +26,7 @@ func TestVaultStats(t *testing.T) {
 		{
 			name: "Metrics",
 			expected: []telegraf.Metric{
-				testutil.MustMetric(
+				metric.New(
 					"vault.raft.replication.appendEntries.logs",
 					map[string]string{
 						"peer_id": "clustnode-02",
@@ -42,7 +43,7 @@ func TestVaultStats(t *testing.T) {
 					time.Unix(1638287340, 0),
 					1,
 				),
-				testutil.MustMetric(
+				metric.New(
 					"vault.core.unsealed",
 					map[string]string{
 						"cluster": "vault-cluster-23b671c7",
@@ -53,7 +54,7 @@ func TestVaultStats(t *testing.T) {
 					time.Unix(1638287340, 0),
 					2,
 				),
-				testutil.MustMetric(
+				metric.New(
 					"vault.token.lookup",
 					map[string]string{},
 					map[string]interface{}{
@@ -111,7 +112,7 @@ func TestVaultStats(t *testing.T) {
 
 func TestRedirect(t *testing.T) {
 	expected := []telegraf.Metric{
-		testutil.MustMetric(
+		metric.New(
 			"vault.raft.replication.appendEntries.logs",
 			map[string]string{
 				"peer_id": "clustnode-02",
@@ -128,7 +129,7 @@ func TestRedirect(t *testing.T) {
 			time.Unix(1638287340, 0),
 			1,
 		),
-		testutil.MustMetric(
+		metric.New(
 			"vault.core.unsealed",
 			map[string]string{
 				"cluster": "vault-cluster-23b671c7",
@@ -139,7 +140,7 @@ func TestRedirect(t *testing.T) {
 			time.Unix(1638287340, 0),
 			2,
 		),
-		testutil.MustMetric(
+		metric.New(
 			"vault.token.lookup",
 			map[string]string{},
 			map[string]interface{}{


### PR DESCRIPTION


## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Migrate testutil.MustMetric to metric.New for: vault,p4runtime,intel_dlb,disk,sql,procstat,nomad,kafka_consumer,ipset,intel_pmt,consul_agent Part of #18495

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
