### PR TITLE
docs(processors.lookup): Fix typo in csv_key_values header example

### DIFF
--- a/plugins/processors/lookup/README.md
+++ b/plugins/processors/lookup/README.md
@@ -105,7 +105,7 @@ This setting specifies comma-separated-value files with the following format
 
 ```csv
 # Optional comments
-ignored,tag-name1,...,tag-valueN
+ignored,tag-name1,...,tag-nameN
 keyA,tag-value1,...,,,,
 keyB,tag-value1,,,,...,
 ...


### PR DESCRIPTION
## Summary

The `csv_key_values` format example header on line 108 had `tag-valueN` as the last element, but the spec right below it says the header row contains tag-names. Changed it to `tag-nameN` to match the spec and the actual example at the bottom of the doc (which already uses tag-names correctly).

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

resolves #18421