### PR TITLE
fix(inputs.kapacitor): add instance identity tags

### DIFF
--- a/plugins/inputs/kapacitor/kapacitor.go
+++ b/plugins/inputs/kapacitor/kapacitor.go
@@ -203,6 +203,9 @@ func (k *Kapacitor) gatherURL(
 
 	if s.Kapacitor != nil {
 		for _, obj := range *s.Kapacitor {
+			obj.Tags["kap_version"] = s.Version
+			obj.Tags["url"] = url
+
 			// Strip out high-cardinality or duplicative tags
 			excludeTags := []string{"host", "cluster_id", "server_id"}
 			for _, key := range excludeTags {


### PR DESCRIPTION
## Summary
Add Kapacitor instance identity tags (`url`, `kap_version`) for dynamically gathered metrics.

Dynamically gathered Kapacitor metrics such as `kapacitor_ingress` were missing instance-specific tags making metrics from multiple monitored Kapacitor instances indistinguishable.

## Checklist
- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

resolves #18645 
