### PR TITLE
feat(outputs.opentelemetry): Support dot-separated OpenTelemetry metric names

### DIFF
--- a/plugins/outputs/opentelemetry/README.md
+++ b/plugins/outputs/opentelemetry/README.md
@@ -30,6 +30,11 @@ plugin ordering. See [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## protobuf, json
   # encoding_type = "protobuf"
 
+  ## Override the default (prometheus) metric name format
+  ## prometheus: converts dots to underscores (default, Prometheus-compatible)
+  ## otel: preserves dot-separated names (OpenTelemetry semantic conventions)
+  # metric_name_format = "prometheus"
+
   ## Override the default (5s) request timeout
   # timeout = "5s"
 
@@ -73,6 +78,15 @@ plugin ordering. See [CONFIGURATION.md][CONFIGURATION.md] for more details.
   # [outputs.opentelemetry.headers]
   # key1 = "value1"
 ```
+
+## Metric Name Format
+
+The plugin supports two metric name formats:
+
+- **prometheus** (default): Converts dots (`.`) to underscores (`_`) in metric names. This is the default behavior and maintains compatibility with Prometheus naming conventions.
+- **otel**: Preserves dot-separated metric names as-is. This is useful when working with OpenTelemetry semantic conventions (e.g., `http.server.duration`, `http.client.request.count`) and ensures consistency across the OpenTelemetry ecosystem.
+
+To use OpenTelemetry semantic conventions, set `metric_name_format = "otel"` in your configuration.
 
 ## Supported dialects
 

--- a/plugins/outputs/opentelemetry/README.md
+++ b/plugins/outputs/opentelemetry/README.md
@@ -83,10 +83,16 @@ plugin ordering. See [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 The plugin supports two metric name formats:
 
-- **prometheus** (default): Converts dots (`.`) to underscores (`_`) in metric names. This is the default behavior and maintains compatibility with Prometheus naming conventions.
-- **otel**: Preserves dot-separated metric names as-is. This is useful when working with OpenTelemetry semantic conventions (e.g., `http.server.duration`, `http.client.request.count`) and ensures consistency across the OpenTelemetry ecosystem.
+- **prometheus** (default): Converts dots (`.`) to underscores (`_`) in metric names.
+  This is the default behavior and maintains compatibility with Prometheus naming
+  conventions.
+- **otel**: Preserves dot-separated metric names as-is. This is useful when working
+  with OpenTelemetry semantic conventions (e.g., `http.server.duration`,
+  `http.client.request.count`) and ensures consistency across the OpenTelemetry
+  ecosystem.
 
-To use OpenTelemetry semantic conventions, set `metric_name_format = "otel"` in your configuration.
+To use OpenTelemetry semantic conventions, set `metric_name_format = "otel"` in
+your configuration.
 
 ## Supported dialects
 

--- a/plugins/outputs/opentelemetry/opentelemetry.go
+++ b/plugins/outputs/opentelemetry/opentelemetry.go
@@ -28,9 +28,9 @@ var userAgent = internal.ProductToken()
 var sampleConfig string
 
 type OpenTelemetry struct {
-	ServiceAddress    string `toml:"service_address"`
-	EncodingType      string `toml:"encoding_type"`
-	MetricNameFormat  string `toml:"metric_name_format"`
+	ServiceAddress   string `toml:"service_address"`
+	EncodingType     string `toml:"encoding_type"`
+	MetricNameFormat string `toml:"metric_name_format"`
 
 	tls.ClientConfig
 	Timeout     config.Duration   `toml:"timeout"`
@@ -238,9 +238,9 @@ func (o *OpenTelemetry) transformMetricName(name string) string {
 }
 
 const (
-	defaultServiceAddress  = "localhost:4317"
-	defaultTimeout         = config.Duration(5 * time.Second)
-	defaultCompression     = "gzip"
+	defaultServiceAddress   = "localhost:4317"
+	defaultTimeout          = config.Duration(5 * time.Second)
+	defaultCompression      = "gzip"
 	defaultMetricNameFormat = "prometheus"
 )
 

--- a/plugins/outputs/opentelemetry/opentelemetry.go
+++ b/plugins/outputs/opentelemetry/opentelemetry.go
@@ -228,7 +228,7 @@ func (o *OpenTelemetry) transformMetricName(name string) string {
 	if format == "" {
 		format = defaultMetricNameFormat
 	}
-	
+
 	if format == "otel" {
 		// Preserve dots for OpenTelemetry semantic conventions
 		return name

--- a/plugins/outputs/opentelemetry/opentelemetry_test.go
+++ b/plugins/outputs/opentelemetry/opentelemetry_test.go
@@ -512,7 +512,7 @@ func TestOpenTelemetryMetricNameWithUnderscores(t *testing.T) {
 
 	metricsConverter, err := influx2otel.NewLineProtocolToOtelMetrics(common.NoopLogger{})
 	require.NoError(t, err)
-	
+
 	// Test prometheus format - underscores should remain, dots should be converted
 	plugin := &OpenTelemetry{
 		ServiceAddress:    m.Address(),
@@ -540,7 +540,7 @@ func TestOpenTelemetryMetricNameWithUnderscores(t *testing.T) {
 	require.Equal(t, 1, got.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().Len())
 	// Dots should be converted to underscores
 	require.Equal(t, "http_server_request_duration", got.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Name())
-	
+
 	// Test otel format - everything should be preserved
 	plugin2 := &OpenTelemetry{
 		ServiceAddress:    m.Address(),

--- a/plugins/outputs/opentelemetry/opentelemetry_test.go
+++ b/plugins/outputs/opentelemetry/opentelemetry_test.go
@@ -342,8 +342,230 @@ func (m *mockOtelService) Address() string {
 func (m *mockOtelService) Export(ctx context.Context, request pmetricotlp.ExportRequest) (pmetricotlp.ExportResponse, error) {
 	m.metrics = pmetric.NewMetrics()
 	request.Metrics().CopyTo(m.metrics)
+	// Only check metadata if it exists (for tests that provide headers)
 	ctxMetadata, ok := metadata.FromIncomingContext(ctx)
-	require.Equal(m.t, []string{"header1"}, ctxMetadata.Get("test"))
-	require.True(m.t, ok)
+	if ok {
+		if testHeader := ctxMetadata.Get("test"); len(testHeader) > 0 {
+			require.Equal(m.t, []string{"header1"}, testHeader)
+		}
+	}
 	return pmetricotlp.NewExportResponse(), nil
+}
+
+func TestOpenTelemetryMetricNameFormatPrometheus(t *testing.T) {
+	expect := pmetric.NewMetrics()
+	{
+		rm := expect.ResourceMetrics().AppendEmpty()
+		ilm := rm.ScopeMetrics().AppendEmpty()
+		m := ilm.Metrics().AppendEmpty()
+		m.SetName("http_server_duration") // dots converted to underscores
+		m.SetEmptyGauge()
+		dp := m.Gauge().DataPoints().AppendEmpty()
+		dp.SetTimestamp(pcommon.Timestamp(1622848686000000000))
+		dp.SetDoubleValue(87.332)
+	}
+	m := newMockOtelService(t)
+	t.Cleanup(m.Cleanup)
+
+	metricsConverter, err := influx2otel.NewLineProtocolToOtelMetrics(common.NoopLogger{})
+	require.NoError(t, err)
+	plugin := &OpenTelemetry{
+		ServiceAddress:    m.Address(),
+		Timeout:          config.Duration(time.Second),
+		MetricNameFormat: "prometheus",
+		metricsConverter: metricsConverter,
+		otlpMetricClient: &gRPCClient{
+			grpcClientConn:       m.GrpcClient(),
+			metricsServiceClient: pmetricotlp.NewGRPCClient(m.GrpcClient()),
+		},
+		Log: testutil.Logger{},
+	}
+
+	input := testutil.MustMetric(
+		"http.server.duration", // dot-separated name
+		map[string]string{},
+		map[string]interface{}{
+			"gauge": 87.332,
+		},
+		time.Unix(0, 1622848686000000000),
+	)
+
+	require.NoError(t, plugin.Write([]telegraf.Metric{input}))
+
+	got := m.GotMetrics()
+	require.Equal(t, 1, got.ResourceMetrics().Len())
+	require.Equal(t, 1, got.ResourceMetrics().At(0).ScopeMetrics().Len())
+	require.Equal(t, 1, got.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().Len())
+	require.Equal(t, "http_server_duration", got.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Name())
+}
+
+func TestOpenTelemetryMetricNameFormatOtel(t *testing.T) {
+	expect := pmetric.NewMetrics()
+	{
+		rm := expect.ResourceMetrics().AppendEmpty()
+		ilm := rm.ScopeMetrics().AppendEmpty()
+		m := ilm.Metrics().AppendEmpty()
+		m.SetName("http.server.duration") // dots preserved
+		m.SetEmptyGauge()
+		dp := m.Gauge().DataPoints().AppendEmpty()
+		dp.SetTimestamp(pcommon.Timestamp(1622848686000000000))
+		dp.SetDoubleValue(87.332)
+	}
+	m := newMockOtelService(t)
+	t.Cleanup(m.Cleanup)
+
+	metricsConverter, err := influx2otel.NewLineProtocolToOtelMetrics(common.NoopLogger{})
+	require.NoError(t, err)
+	plugin := &OpenTelemetry{
+		ServiceAddress:    m.Address(),
+		Timeout:          config.Duration(time.Second),
+		MetricNameFormat: "otel",
+		metricsConverter: metricsConverter,
+		otlpMetricClient: &gRPCClient{
+			grpcClientConn:       m.GrpcClient(),
+			metricsServiceClient: pmetricotlp.NewGRPCClient(m.GrpcClient()),
+		},
+		Log: testutil.Logger{},
+	}
+
+	input := testutil.MustMetric(
+		"http.server.duration", // dot-separated name
+		map[string]string{},
+		map[string]interface{}{
+			"gauge": 87.332,
+		},
+		time.Unix(0, 1622848686000000000),
+	)
+
+	require.NoError(t, plugin.Write([]telegraf.Metric{input}))
+
+	got := m.GotMetrics()
+	require.Equal(t, 1, got.ResourceMetrics().Len())
+	require.Equal(t, 1, got.ResourceMetrics().At(0).ScopeMetrics().Len())
+	require.Equal(t, 1, got.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().Len())
+	require.Equal(t, "http.server.duration", got.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Name())
+}
+
+func TestOpenTelemetryMetricNameFormatDefault(t *testing.T) {
+	expect := pmetric.NewMetrics()
+	{
+		rm := expect.ResourceMetrics().AppendEmpty()
+		ilm := rm.ScopeMetrics().AppendEmpty()
+		m := ilm.Metrics().AppendEmpty()
+		m.SetName("http_server_duration") // default is prometheus format
+		m.SetEmptyGauge()
+		dp := m.Gauge().DataPoints().AppendEmpty()
+		dp.SetTimestamp(pcommon.Timestamp(1622848686000000000))
+		dp.SetDoubleValue(87.332)
+	}
+	m := newMockOtelService(t)
+	t.Cleanup(m.Cleanup)
+
+	metricsConverter, err := influx2otel.NewLineProtocolToOtelMetrics(common.NoopLogger{})
+	require.NoError(t, err)
+	plugin := &OpenTelemetry{
+		ServiceAddress:    m.Address(),
+		Timeout:          config.Duration(time.Second),
+		MetricNameFormat: "", // empty should default to prometheus
+		metricsConverter: metricsConverter,
+		otlpMetricClient: &gRPCClient{
+			grpcClientConn:       m.GrpcClient(),
+			metricsServiceClient: pmetricotlp.NewGRPCClient(m.GrpcClient()),
+		},
+		Log: testutil.Logger{},
+	}
+	require.NoError(t, plugin.Connect()) // Connect sets default
+
+	input := testutil.MustMetric(
+		"http.server.duration", // dot-separated name
+		map[string]string{},
+		map[string]interface{}{
+			"gauge": 87.332,
+		},
+		time.Unix(0, 1622848686000000000),
+	)
+
+	require.NoError(t, plugin.Write([]telegraf.Metric{input}))
+
+	got := m.GotMetrics()
+	require.Equal(t, 1, got.ResourceMetrics().Len())
+	require.Equal(t, 1, got.ResourceMetrics().At(0).ScopeMetrics().Len())
+	require.Equal(t, 1, got.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().Len())
+	require.Equal(t, "http_server_duration", got.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Name())
+}
+
+func TestOpenTelemetryInvalidMetricNameFormat(t *testing.T) {
+	plugin := &OpenTelemetry{
+		ServiceAddress:    "localhost:4317",
+		MetricNameFormat: "invalid",
+		Log:              testutil.Logger{},
+	}
+	err := plugin.Connect()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid metric_name_format")
+}
+
+func TestOpenTelemetryMetricNameWithUnderscores(t *testing.T) {
+	// Test that existing underscores are preserved in both formats
+	m := newMockOtelService(t)
+	t.Cleanup(m.Cleanup)
+
+	metricsConverter, err := influx2otel.NewLineProtocolToOtelMetrics(common.NoopLogger{})
+	require.NoError(t, err)
+	
+	// Test prometheus format - underscores should remain, dots should be converted
+	plugin := &OpenTelemetry{
+		ServiceAddress:    m.Address(),
+		Timeout:          config.Duration(time.Second),
+		MetricNameFormat: "prometheus",
+		metricsConverter: metricsConverter,
+		otlpMetricClient: &gRPCClient{
+			grpcClientConn:       m.GrpcClient(),
+			metricsServiceClient: pmetricotlp.NewGRPCClient(m.GrpcClient()),
+		},
+		Log: testutil.Logger{},
+	}
+
+	input := testutil.MustMetric(
+		"http.server.request.duration", // dots and underscores
+		map[string]string{},
+		map[string]interface{}{
+			"gauge": 87.332,
+		},
+		time.Unix(0, 1622848686000000000),
+	)
+
+	require.NoError(t, plugin.Write([]telegraf.Metric{input}))
+	got := m.GotMetrics()
+	require.Equal(t, 1, got.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().Len())
+	// Dots should be converted to underscores
+	require.Equal(t, "http_server_request_duration", got.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Name())
+	
+	// Test otel format - everything should be preserved
+	plugin2 := &OpenTelemetry{
+		ServiceAddress:    m.Address(),
+		Timeout:          config.Duration(time.Second),
+		MetricNameFormat: "otel",
+		metricsConverter: metricsConverter,
+		otlpMetricClient: &gRPCClient{
+			grpcClientConn:       m.GrpcClient(),
+			metricsServiceClient: pmetricotlp.NewGRPCClient(m.GrpcClient()),
+		},
+		Log: testutil.Logger{},
+	}
+
+	input2 := testutil.MustMetric(
+		"http.server.request.duration",
+		map[string]string{},
+		map[string]interface{}{
+			"gauge": 87.332,
+		},
+		time.Unix(0, 1622848686000000000),
+	)
+
+	require.NoError(t, plugin2.Write([]telegraf.Metric{input2}))
+	got2 := m.GotMetrics()
+	require.Equal(t, 1, got2.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().Len())
+	// Dots should be preserved
+	require.Equal(t, "http.server.request.duration", got2.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Name())
 }

--- a/plugins/outputs/opentelemetry/opentelemetry_test.go
+++ b/plugins/outputs/opentelemetry/opentelemetry_test.go
@@ -370,7 +370,7 @@ func TestOpenTelemetryMetricNameFormatPrometheus(t *testing.T) {
 	metricsConverter, err := influx2otel.NewLineProtocolToOtelMetrics(common.NoopLogger{})
 	require.NoError(t, err)
 	plugin := &OpenTelemetry{
-		ServiceAddress:    m.Address(),
+		ServiceAddress:   m.Address(),
 		Timeout:          config.Duration(time.Second),
 		MetricNameFormat: "prometheus",
 		metricsConverter: metricsConverter,
@@ -417,7 +417,7 @@ func TestOpenTelemetryMetricNameFormatOtel(t *testing.T) {
 	metricsConverter, err := influx2otel.NewLineProtocolToOtelMetrics(common.NoopLogger{})
 	require.NoError(t, err)
 	plugin := &OpenTelemetry{
-		ServiceAddress:    m.Address(),
+		ServiceAddress:   m.Address(),
 		Timeout:          config.Duration(time.Second),
 		MetricNameFormat: "otel",
 		metricsConverter: metricsConverter,
@@ -464,7 +464,7 @@ func TestOpenTelemetryMetricNameFormatDefault(t *testing.T) {
 	metricsConverter, err := influx2otel.NewLineProtocolToOtelMetrics(common.NoopLogger{})
 	require.NoError(t, err)
 	plugin := &OpenTelemetry{
-		ServiceAddress:    m.Address(),
+		ServiceAddress:   m.Address(),
 		Timeout:          config.Duration(time.Second),
 		MetricNameFormat: "", // empty should default to prometheus
 		metricsConverter: metricsConverter,
@@ -496,7 +496,7 @@ func TestOpenTelemetryMetricNameFormatDefault(t *testing.T) {
 
 func TestOpenTelemetryInvalidMetricNameFormat(t *testing.T) {
 	plugin := &OpenTelemetry{
-		ServiceAddress:    "localhost:4317",
+		ServiceAddress:   "localhost:4317",
 		MetricNameFormat: "invalid",
 		Log:              testutil.Logger{},
 	}
@@ -515,7 +515,7 @@ func TestOpenTelemetryMetricNameWithUnderscores(t *testing.T) {
 
 	// Test prometheus format - underscores should remain, dots should be converted
 	plugin := &OpenTelemetry{
-		ServiceAddress:    m.Address(),
+		ServiceAddress:   m.Address(),
 		Timeout:          config.Duration(time.Second),
 		MetricNameFormat: "prometheus",
 		metricsConverter: metricsConverter,
@@ -543,7 +543,7 @@ func TestOpenTelemetryMetricNameWithUnderscores(t *testing.T) {
 
 	// Test otel format - everything should be preserved
 	plugin2 := &OpenTelemetry{
-		ServiceAddress:    m.Address(),
+		ServiceAddress:   m.Address(),
 		Timeout:          config.Duration(time.Second),
 		MetricNameFormat: "otel",
 		metricsConverter: metricsConverter,

--- a/plugins/outputs/opentelemetry/sample.conf
+++ b/plugins/outputs/opentelemetry/sample.conf
@@ -8,6 +8,11 @@
   ## protobuf, json
   # encoding_type = "protobuf"
 
+  ## Override the default (prometheus) metric name format
+  ## prometheus: converts dots to underscores (default, Prometheus-compatible)
+  ## otel: preserves dot-separated names (OpenTelemetry semantic conventions)
+  # metric_name_format = "prometheus"
+
   ## Override the default (5s) request timeout
   # timeout = "5s"
 


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

This is a reopened PR #18252 which was closed due to inactivity. I've personally reviewed the changes in this one and can answer any questions or make changes which may be requested during the review process. 

_Summary from original PR:_

This PR adds support for preserving dot-separated OpenTelemetry metric names in the OpenTelemetry output plugin, addressing issue https://github.com/influxdata/telegraf/issues/18251.

Added a new metric_name_format configuration option that allows users to choose between:

    prometheus (default): Converts dots to underscores - maintains backward compatibility
    otel: Preserves dot-separated names - enables OpenTelemetry semantic conventions

This PR adds support for preserving dot-separated OpenTelemetry metric names in the OpenTelemetry output plugin

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #18251 
