### PR TITLE
fix(inputs.opcua_listener): Defer node ID parsing until after server connection

### DIFF
--- a/plugins/inputs/opcua_listener/opcua_listener_test.go
+++ b/plugins/inputs/opcua_listener/opcua_listener_test.go
@@ -811,8 +811,14 @@ func TestSubscribeClientConfigValidMonitoringParams(t *testing.T) {
 		},
 	})
 
-	subClient, err := subscribeConfig.createSubscribeClient(testutil.Logger{})
+	_, err := subscribeConfig.createSubscribeClient(testutil.Logger{})
 	require.NoError(t, err)
+
+	// Verify assignConfigValuesToRequest correctly translates monitoring params
+	nodeID, err := ua.ParseNodeID("ns=3;i=1")
+	require.NoError(t, err)
+	req := gopcua.NewMonitoredItemCreateRequestWithDefaults(nodeID, ua.AttributeIDValue, 0)
+	require.NoError(t, assignConfigValuesToRequest(req, &subscribeConfig.RootNodes[0].MonitoringParams))
 	require.Equal(t, &ua.MonitoringParameters{
 		SamplingInterval: 50,
 		QueueSize:        queueSize,
@@ -824,48 +830,26 @@ func TestSubscribeClientConfigValidMonitoringParams(t *testing.T) {
 				DeadbandValue: deadbandValue,
 			},
 		),
-	}, subClient.monitoredItemsReqs[0].RequestedParameters)
+	}, req.RequestedParameters)
 }
 
 func TestSubscribeClientConfigValidMonitoringParamsNoDeadband(t *testing.T) {
-	subscribeConfig := subscribeClientConfig{
-		InputClientConfig: input.InputClientConfig{
-			OpcUAClientConfig: opcua.OpcUAClientConfig{
-				Endpoint:       "opc.tcp://localhost:4840",
-				SecurityPolicy: "None",
-				SecurityMode:   "None",
-				AuthMethod:     "Anonymous",
-				ConnectTimeout: config.Duration(10 * time.Second),
-				RequestTimeout: config.Duration(1 * time.Second),
-				Workarounds:    opcua.OpcUAWorkarounds{},
-			},
-			MetricName: "testing",
-			RootNodes:  make([]input.NodeSettings, 0),
-			Groups:     make([]input.NodeGroupSettings, 0),
-		},
-		SubscriptionInterval: 0,
-	}
-
 	var queueSize uint32 = 10
 	discardOldest := true
-	subscribeConfig.RootNodes = append(subscribeConfig.RootNodes, input.NodeSettings{
-		FieldName:      "foo",
-		Namespace:      "3",
-		Identifier:     "1",
-		IdentifierType: "i",
-		MonitoringParams: input.MonitoringParameters{
-			SamplingInterval: 50000000,
-			QueueSize:        &queueSize,
-			DiscardOldest:    &discardOldest,
-			DataChangeFilter: &input.DataChangeFilter{
-				Trigger:      "Status",
-				DeadbandType: "None",
-			},
+	monParams := input.MonitoringParameters{
+		SamplingInterval: 50000000,
+		QueueSize:        &queueSize,
+		DiscardOldest:    &discardOldest,
+		DataChangeFilter: &input.DataChangeFilter{
+			Trigger:      "Status",
+			DeadbandType: "None",
 		},
-	})
+	}
 
-	subClient, err := subscribeConfig.createSubscribeClient(testutil.Logger{})
+	nodeID, err := ua.ParseNodeID("ns=3;i=1")
 	require.NoError(t, err)
+	req := gopcua.NewMonitoredItemCreateRequestWithDefaults(nodeID, ua.AttributeIDValue, 0)
+	require.NoError(t, assignConfigValuesToRequest(req, &monParams))
 	require.Equal(t, &ua.MonitoringParameters{
 		SamplingInterval: 50,
 		QueueSize:        queueSize,
@@ -877,7 +861,7 @@ func TestSubscribeClientConfigValidMonitoringParamsNoDeadband(t *testing.T) {
 				DeadbandValue: 0,
 			},
 		),
-	}, subClient.monitoredItemsReqs[0].RequestedParameters)
+	}, req.RequestedParameters)
 }
 
 func TestSubscribeClientConfigValidMonitoringAndEventParams(t *testing.T) {
@@ -944,8 +928,14 @@ func TestSubscribeClientConfigValidMonitoringAndEventParams(t *testing.T) {
 		Fields:      []string{"PressureValue"},
 	})
 
-	subClient, err := subscribeConfig.createSubscribeClient(testutil.Logger{})
+	_, err := subscribeConfig.createSubscribeClient(testutil.Logger{})
 	require.NoError(t, err)
+
+	// Verify assignConfigValuesToRequest correctly translates monitoring params
+	nodeID, err := ua.ParseNodeID("ns=3;i=1")
+	require.NoError(t, err)
+	req := gopcua.NewMonitoredItemCreateRequestWithDefaults(nodeID, ua.AttributeIDValue, 0)
+	require.NoError(t, assignConfigValuesToRequest(req, &subscribeConfig.RootNodes[0].MonitoringParams))
 	require.Equal(t, &ua.MonitoringParameters{
 		SamplingInterval: 50,
 		QueueSize:        queueSize,
@@ -957,7 +947,7 @@ func TestSubscribeClientConfigValidMonitoringAndEventParams(t *testing.T) {
 				DeadbandValue: deadbandValue,
 			},
 		),
-	}, subClient.monitoredItemsReqs[0].RequestedParameters)
+	}, req.RequestedParameters)
 }
 
 func TestSubscribeClientConfigValidEventStreamingParams(t *testing.T) {

--- a/plugins/inputs/opcua_listener/subscribe_client.go
+++ b/plugins/inputs/opcua_listener/subscribe_client.go
@@ -99,7 +99,7 @@ func (sc *subscribeClientConfig) createSubscribeClient(log telegraf.Logger) (*su
 	for _, node := range client.NodeMetricMapping {
 		if node.Tag.MonitoringParams.DataChangeFilter != nil {
 			if err := checkDataChangeFilterParameters(node.Tag.MonitoringParams.DataChangeFilter); err != nil {
-				return nil, fmt.Errorf("%s, node '%s'", err, node.Tag.NodeID())
+				return nil, fmt.Errorf("node '%s': %w", node.Tag.NodeID(), err)
 			}
 		}
 	}
@@ -144,6 +144,7 @@ func (o *subscribeClient) connect() error {
 		return fmt.Errorf("initializing event node IDs failed: %w", err)
 	}
 
+	o.Log.Debugf("Creating monitored items")
 	o.monitoredItemsReqs = make([]*ua.MonitoredItemCreateRequest, 0, len(o.NodeIDs))
 	for i, nodeID := range o.NodeIDs {
 		req := opcua.NewMonitoredItemCreateRequestWithDefaults(nodeID, ua.AttributeIDValue, uint32(i))
@@ -153,6 +154,7 @@ func (o *subscribeClient) connect() error {
 		o.monitoredItemsReqs = append(o.monitoredItemsReqs, req)
 	}
 
+	o.Log.Debugf("Creating event streaming items")
 	o.eventItemsReqs = make([]*ua.MonitoredItemCreateRequest, 0, len(o.EventNodeMetricMapping))
 	for i, node := range o.EventNodeMetricMapping {
 		req := opcua.NewMonitoredItemCreateRequestWithDefaults(node.NodeID, ua.AttributeIDEventNotifier, uint32(i))

--- a/plugins/inputs/opcua_listener/subscribe_client.go
+++ b/plugins/inputs/opcua_listener/subscribe_client.go
@@ -95,13 +95,13 @@ func (sc *subscribeClientConfig) createSubscribeClient(log telegraf.Logger) (*su
 		return nil, err
 	}
 
-	// Initialize node IDs (namespace URI resolution will happen during connect if needed)
-	if err := client.InitNodeIDs(); err != nil {
-		return nil, err
-	}
-
-	if err := client.InitEventNodeIDs(); err != nil {
-		return nil, err
+	// Validate monitoring parameters at config time (no server connection needed)
+	for _, node := range client.NodeMetricMapping {
+		if node.Tag.MonitoringParams.DataChangeFilter != nil {
+			if err := checkDataChangeFilterParameters(node.Tag.MonitoringParams.DataChangeFilter); err != nil {
+				return nil, fmt.Errorf("%s, node '%s'", err, node.Tag.NodeID())
+			}
+		}
 	}
 
 	processingCtx, processingCancel := context.WithCancel(context.Background())
@@ -109,8 +109,8 @@ func (sc *subscribeClientConfig) createSubscribeClient(log telegraf.Logger) (*su
 	subClient := &subscribeClient{
 		OpcUAInputClient:   client,
 		Config:             *sc,
-		monitoredItemsReqs: make([]*ua.MonitoredItemCreateRequest, len(client.NodeIDs)),
-		eventItemsReqs:     make([]*ua.MonitoredItemCreateRequest, len(client.EventNodeMetricMapping)),
+		monitoredItemsReqs: make([]*ua.MonitoredItemCreateRequest, 0, len(client.NodeMetricMapping)),
+		eventItemsReqs:     make([]*ua.MonitoredItemCreateRequest, 0, len(client.EventNodeMetricMapping)),
 		// 100 was chosen to make sure that the channels will not block when multiple changes come in at the same time.
 		// The channel size should be increased if reports come in on Telegraf blocking when many changes come in at
 		// the same time. It could be made dependent on the number of nodes subscribed to and the subscription interval.
@@ -120,33 +120,6 @@ func (sc *subscribeClientConfig) createSubscribeClient(log telegraf.Logger) (*su
 		cancel:            processingCancel,
 	}
 
-	log.Debugf("Creating monitored items")
-	for i, nodeID := range client.NodeIDs {
-		// The node id index (i) is used as the handle for the monitored item
-		req := opcua.NewMonitoredItemCreateRequestWithDefaults(nodeID, ua.AttributeIDValue, uint32(i))
-		if err := assignConfigValuesToRequest(req, &client.NodeMetricMapping[i].Tag.MonitoringParams); err != nil {
-			return nil, fmt.Errorf("assigning monitoring params failed: %w", err)
-		}
-		subClient.monitoredItemsReqs[i] = req
-	}
-
-	log.Debugf("Creating event streaming items")
-	for i, node := range client.EventNodeMetricMapping {
-		req := opcua.NewMonitoredItemCreateRequestWithDefaults(node.NodeID, ua.AttributeIDEventNotifier, uint32(i))
-		if node.SamplingInterval != nil {
-			req.RequestedParameters.SamplingInterval = float64(time.Duration(*node.SamplingInterval) / time.Millisecond)
-		}
-		if node.QueueSize != nil {
-			req.RequestedParameters.QueueSize = *node.QueueSize
-		}
-
-		filterExtObj, err := node.CreateEventFilter()
-		if err != nil {
-			return nil, fmt.Errorf("failed to create event filter: %w", err)
-		}
-		req.RequestedParameters.Filter = filterExtObj
-		subClient.eventItemsReqs[i] = req
-	}
 	return subClient, nil
 }
 
@@ -161,6 +134,41 @@ func (o *subscribeClient) connect() error {
 	if err := o.OpcUAClient.UpdateNamespaceArray(o.ctx); err != nil {
 		o.Log.Warnf("Failed to fetch namespace array: %v", err)
 		// Continue anyway - this is only needed if using namespace URIs
+	}
+
+	// Initialize node IDs after connection so namespace URIs can be resolved
+	if err := o.OpcUAInputClient.InitNodeIDs(); err != nil {
+		return fmt.Errorf("initializing node IDs failed: %w", err)
+	}
+	if err := o.OpcUAInputClient.InitEventNodeIDs(); err != nil {
+		return fmt.Errorf("initializing event node IDs failed: %w", err)
+	}
+
+	o.monitoredItemsReqs = make([]*ua.MonitoredItemCreateRequest, 0, len(o.NodeIDs))
+	for i, nodeID := range o.NodeIDs {
+		req := opcua.NewMonitoredItemCreateRequestWithDefaults(nodeID, ua.AttributeIDValue, uint32(i))
+		if err := assignConfigValuesToRequest(req, &o.NodeMetricMapping[i].Tag.MonitoringParams); err != nil {
+			return fmt.Errorf("assigning monitoring params failed: %w", err)
+		}
+		o.monitoredItemsReqs = append(o.monitoredItemsReqs, req)
+	}
+
+	o.eventItemsReqs = make([]*ua.MonitoredItemCreateRequest, 0, len(o.EventNodeMetricMapping))
+	for i, node := range o.EventNodeMetricMapping {
+		req := opcua.NewMonitoredItemCreateRequestWithDefaults(node.NodeID, ua.AttributeIDEventNotifier, uint32(i))
+		if node.SamplingInterval != nil {
+			req.RequestedParameters.SamplingInterval = float64(time.Duration(*node.SamplingInterval) / time.Millisecond)
+		}
+		if node.QueueSize != nil {
+			req.RequestedParameters.QueueSize = *node.QueueSize
+		}
+
+		filterExtObj, err := node.CreateEventFilter()
+		if err != nil {
+			return fmt.Errorf("creating event filter failed: %w", err)
+		}
+		req.RequestedParameters.Filter = filterExtObj
+		o.eventItemsReqs = append(o.eventItemsReqs, req)
 	}
 
 	o.Log.Debugf("Creating OPC UA subscription")


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Node IDs using namespace URLs (nsu=) require the server's NamespaceArray, which is only available after connecting. Move InitNodeIDs() from createSubscribeClient() into connect(), matching the read client pattern.

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #18681
