### PR TITLE
fix(inputs.opcua_listener): Wrap error correctly in subscribe client

### DIFF
--- a/plugins/inputs/opcua_listener/opcua_listener_test.go
+++ b/plugins/inputs/opcua_listener/opcua_listener_test.go
@@ -594,7 +594,7 @@ func TestSubscribeClientConfigInvalidTrigger(t *testing.T) {
 	})
 
 	_, err := subscribeConfig.createSubscribeClient(testutil.Logger{})
-	require.ErrorContains(t, err, "trigger 'not_valid' not supported, node 'ns=3;i=1'")
+	require.ErrorContains(t, err, "node 'ns=3;i=1': trigger 'not_valid' not supported")
 }
 
 func TestSubscribeClientConfigMissingTrigger(t *testing.T) {
@@ -628,7 +628,7 @@ func TestSubscribeClientConfigMissingTrigger(t *testing.T) {
 	})
 
 	_, err := subscribeConfig.createSubscribeClient(testutil.Logger{})
-	require.ErrorContains(t, err, "trigger '' not supported, node 'ns=3;i=1'")
+	require.ErrorContains(t, err, "node 'ns=3;i=1': trigger '' not supported")
 }
 
 func TestSubscribeClientConfigInvalidDeadbandType(t *testing.T) {
@@ -663,7 +663,7 @@ func TestSubscribeClientConfigInvalidDeadbandType(t *testing.T) {
 	})
 
 	_, err := subscribeConfig.createSubscribeClient(testutil.Logger{})
-	require.ErrorContains(t, err, "deadband_type 'not_valid' not supported, node 'ns=3;i=1'")
+	require.ErrorContains(t, err, "node 'ns=3;i=1': deadband_type 'not_valid' not supported")
 }
 
 func TestSubscribeClientConfigMissingDeadbandType(t *testing.T) {
@@ -697,7 +697,7 @@ func TestSubscribeClientConfigMissingDeadbandType(t *testing.T) {
 	})
 
 	_, err := subscribeConfig.createSubscribeClient(testutil.Logger{})
-	require.ErrorContains(t, err, "deadband_type '' not supported, node 'ns=3;i=1'")
+	require.ErrorContains(t, err, "node 'ns=3;i=1': deadband_type '' not supported")
 }
 
 func TestSubscribeClientConfigInvalidDeadbandValue(t *testing.T) {
@@ -734,7 +734,7 @@ func TestSubscribeClientConfigInvalidDeadbandValue(t *testing.T) {
 	})
 
 	_, err := subscribeConfig.createSubscribeClient(testutil.Logger{})
-	require.ErrorContains(t, err, "negative deadband_value not supported, node 'ns=3;i=1'")
+	require.ErrorContains(t, err, "node 'ns=3;i=1': negative deadband_value not supported")
 }
 
 func TestSubscribeClientConfigMissingDeadbandValue(t *testing.T) {
@@ -769,7 +769,7 @@ func TestSubscribeClientConfigMissingDeadbandValue(t *testing.T) {
 	})
 
 	_, err := subscribeConfig.createSubscribeClient(testutil.Logger{})
-	require.ErrorContains(t, err, "deadband_value was not set, node 'ns=3;i=1'")
+	require.ErrorContains(t, err, "node 'ns=3;i=1': deadband_value was not set")
 }
 
 func TestSubscribeClientConfigValidMonitoringParams(t *testing.T) {

--- a/plugins/inputs/opcua_listener/subscribe_client.go
+++ b/plugins/inputs/opcua_listener/subscribe_client.go
@@ -68,7 +68,7 @@ func assignConfigValuesToRequest(req *ua.MonitoredItemCreateRequest, monParams *
 
 	if monParams.DataChangeFilter != nil {
 		if err := checkDataChangeFilterParameters(monParams.DataChangeFilter); err != nil {
-			return fmt.Errorf(err.Error()+", node '%s'", req.ItemToMonitor.NodeID)
+			return fmt.Errorf("node '%s': %w", req.ItemToMonitor.NodeID, err)
 		}
 
 		var deadbandValue float64
@@ -125,7 +125,7 @@ func (sc *subscribeClientConfig) createSubscribeClient(log telegraf.Logger) (*su
 		// The node id index (i) is used as the handle for the monitored item
 		req := opcua.NewMonitoredItemCreateRequestWithDefaults(nodeID, ua.AttributeIDValue, uint32(i))
 		if err := assignConfigValuesToRequest(req, &client.NodeMetricMapping[i].Tag.MonitoringParams); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("assigning monitoring params failed: %w", err)
 		}
 		subClient.monitoredItemsReqs[i] = req
 	}


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
- Use %w instead of err.Error() string concat in assignConfigValuesToRequest to preserve error chain for errors.Is/errors.As (fixes errorlint warning)
- Prefix error from assignConfigValuesToRequest in createSubscribeClient for unique identification during debugging

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
