### PR TITLE
fix(inputs.nftables): Handle plain string elements in set unmarshalling

### DIFF
--- a/plugins/inputs/nftables/testcases/valid/expected.out
+++ b/plugins/inputs/nftables/testcases/valid/expected.out
@@ -1,4 +1,5 @@
 nftables,chain=test-chain,rule=test1,table=test bytes=2i,pkts=1i 1763040447356073265
 nftables,chain=test-chain,rule=test2,table=test bytes=1412296i,pkts=24468i 1763040447356078375
 nftables,set=non_empty_set,table=test count=5i 1763040447356078375
+nftables,set=static_set,table=test count=2i 1763040447356078375
 nftables,set=empty_set,table=test count=0i 1763040447356078375

--- a/plugins/inputs/nftables/testcases/valid/table_test.json
+++ b/plugins/inputs/nftables/testcases/valid/table_test.json
@@ -188,6 +188,20 @@
     {
       "set": {
         "family": "inet",
+        "name": "static_set",
+        "table": "test",
+        "type": "ipv4_addr",
+        "handle": 18,
+        "flags": ["interval"],
+        "elem": [
+          "10.47.55.250",
+          "10.47.56.232"
+        ]
+      }
+    },
+    {
+      "set": {
+        "family": "inet",
         "name": "empty_set",
         "table": "test",
         "type": "ipv4_addr",

--- a/plugins/inputs/nftables/types.go
+++ b/plugins/inputs/nftables/types.go
@@ -110,3 +110,10 @@ type namedSet struct {
 }
 
 type elem struct{}
+
+// UnmarshalJSON accepts any JSON value type. Statically defined nftables sets
+// use plain strings for elements while dynamically added entries use objects.
+// Since the plugin only counts elements, the content is discarded.
+func (*elem) UnmarshalJSON([]byte) error {
+	return nil
+}


### PR DESCRIPTION



## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Statically defined nftables sets return plain strings in the elem array while dynamically added entries return objects. The empty elem struct could not unmarshal strings, causing a JSON unmarshalling error. Add a custom UnmarshalJSON that accepts any JSON value type since the plugin only counts elements.

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #18685
