### PR TITLE
test(inputs.x509_cert): Stabilize TestGatherUDPCertIntegration with pion/dtls v3

### DIFF
--- a/plugins/inputs/x509_cert/x509_cert_test.go
+++ b/plugins/inputs/x509_cert/x509_cert_test.go
@@ -312,10 +312,15 @@ func TestGatherUDPCertIntegration(t *testing.T) {
 	require.NoError(t, err)
 	defer listener.Close()
 
+	// Hold the server-side connection open until the client is done gathering.
+	// Closing earlier sends a CloseNotify that can race with the client's
+	// in-flight handshake under pion/dtls v3 and surface as a handshake error.
+	done := make(chan struct{})
+	defer close(done)
 	go func() {
 		conn, err := listener.Accept()
 		if err != nil {
-			t.Error(err)
+			t.Errorf("accept failed: %v", err)
 			return
 		}
 		defer conn.Close()
@@ -326,8 +331,10 @@ func TestGatherUDPCertIntegration(t *testing.T) {
 			return
 		}
 		if err := dtlsConn.Handshake(); err != nil {
-			t.Error(err)
+			t.Errorf("server handshake failed: %v", err)
+			return
 		}
+		<-done
 	}()
 
 	m := &X509Cert{


### PR DESCRIPTION


## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
`TestGatherUDPCertIntegration` is intermittently failing on master with:

```
cannot get SSL cert "udp://127.0.0.1:XXXXX": handshake error: alert: Alert Warning: CloseNotify
```

The failure has been observed on multiple unrelated PRs (e.g. dependabot dependency bumps that don't touch DTLS), confirming it is a master-branch flake rather than a regression in those PRs.

**Fix**                                                                   
                                                                                                                                                                                                                   
Hold the server-side connection open until the client has finished gathering, using a `clientDone` channel signaled by the test after `Gather()` returns. A second `serverDone` channel ensures the test waits for the server goroutine to fully unwind before asserting. This mirrors real-world DTLS behavior (servers stay connected while clients do work) and removes the race regardless of pion/dtls v3's handshake-completion timing.  


## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
