### PR TITLE
fix(inputs.docker): List all containers so non-running states are gathered

### DIFF
--- a/plugins/inputs/docker/docker.go
+++ b/plugins/inputs/docker/docker.go
@@ -247,7 +247,7 @@ func (d *Docker) Gather(acc telegraf.Accumulator) error {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(d.Timeout))
 	defer cancel()
 
-	containers, err := d.client.ContainerList(ctx, container.ListOptions{})
+	containers, err := d.client.ContainerList(ctx, container.ListOptions{All: true})
 	if errors.Is(err, context.DeadlineExceeded) {
 		return errListTimeout
 	}

--- a/plugins/inputs/docker/docker_test.go
+++ b/plugins/inputs/docker/docker_test.go
@@ -1246,6 +1246,30 @@ func TestContainerStateFilter(t *testing.T) {
 	}
 }
 
+func TestContainerListRequestsAllContainers(t *testing.T) {
+	var gotOptions container.ListOptions
+	newClientFunc := func(string, *tls.Config) (dockerClient, error) {
+		client := baseClient
+		client.ContainerListF = func(options container.ListOptions) ([]container.Summary, error) {
+			gotOptions = options
+			return nil, nil
+		}
+		return &client, nil
+	}
+
+	d := Docker{
+		Log:       testutil.Logger{},
+		newClient: newClientFunc,
+	}
+
+	var acc testutil.Accumulator
+	require.NoError(t, d.Init())
+	require.NoError(t, d.Start(&acc))
+	require.NoError(t, d.Gather(&acc))
+
+	require.True(t, gotOptions.All, "ContainerList must request all containers so non-running states can be filtered client-side")
+}
+
 func TestNonRunningContainerEmitsStatusMetrics(t *testing.T) {
 	newClientFunc := func(string, *tls.Config) (dockerClient, error) {
 		client := baseClient


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
The Docker input was failing to emit metrics for non-running containers (`created`, `exited`, `dead`, etc.) even when those states were explicitly listed in `container_state_include`.

This regression was introduced by #18374 ("Remove pre-filtering of states"), which removed the daemon-side `filters.NewArgs()` status filters but did not set `All: true` to compensate. Before #18374, passing `status` filters caused the daemon to include non-running containers; after #18374, nothing did.

#18453 ("Emit status metrics for non-running containers") addressed a related but narrower symptom: it ensured that *if* a non-running container reached `gatherContainer`, the empty stats body (EOF on JSON decode) would no longer cause an early return before `gatherContainerInspect`. That fix is necessary but insufficient - non-running containers still never reach `gatherContainer` in the first place because they are excluded at the list step.

This was reported on the #18453 thread: https://github.com/influxdata/telegraf/pull/18453#issuecomment-4250402075 - a user on v1.38.2 (which already contains #18453) confirms that exited containers are still not exposed via `outputs.prometheus_client` despite explicit `container_state_include = ["created", "restarting", "running", "removing", "paused", "exited", "dead"]`.

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
