### PR TITLE
docs(telegraf): Fix typo

### DIFF
--- a/cmd/telegraf/telegraf.go
+++ b/cmd/telegraf/telegraf.go
@@ -188,7 +188,7 @@ func (t *Telegraf) reloadLoop() error {
 				if sig == syscall.SIGHUP {
 					log.Println("I! Reloading Telegraf config")
 					// May need to update the list of known config files
-					// if a delete or create occured. That way on the reload
+					// if a delete or create occurred. That way on the reload
 					// we ensure we watch the correct files.
 					if err := t.getConfigFiles(); err != nil {
 						log.Println("E! Error loading config files: ", err)


### PR DESCRIPTION
## Summary

`cmd/telegraf/telegraf.go` had a comment misspelling `occured`. Line 191: `// if a delete or create occured.` → `// if a delete or create occurred.`

Comment-only change. No behavior, API, or logic change.

## Checklist

- [ ] No AI generated code was used in this PR
- [x] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
