### PR TITLE
test(processors.tag_limit): Remove mustMetric function

### DIFF
--- a/plugins/processors/tag_limit/tag_limit_test.go
+++ b/plugins/processors/tag_limit/tag_limit_test.go
@@ -12,14 +12,6 @@ import (
 	"github.com/influxdata/telegraf/testutil"
 )
 
-func mustMetric(name string, tags map[string]string, metricTime time.Time) telegraf.Metric {
-	if tags == nil {
-		tags = map[string]string{}
-	}
-	m := metric.New(name, tags, map[string]interface{}{}, metricTime)
-	return m
-}
-
 func TestUnderLimit(t *testing.T) {
 	currentTime := time.Now()
 
@@ -43,8 +35,8 @@ func TestUnderLimit(t *testing.T) {
 		Keep:  []string{"foo", "bar"},
 	}
 
-	m1 := mustMetric("foo", oneTags, currentTime)
-	m2 := mustMetric("bar", tenTags, currentTime)
+	m1 := metric.New("foo", oneTags, map[string]interface{}{}, currentTime)
+	m2 := metric.New("bar", tenTags, map[string]interface{}{}, currentTime)
 	limitApply := tagLimitConfig.Apply(m1, m2)
 	require.Equal(t, oneTags, limitApply[0].Tags(), "one tag")
 	require.Equal(t, tenTags, limitApply[1].Tags(), "ten tags")
@@ -75,8 +67,8 @@ func TestTrim(t *testing.T) {
 		Keep:  []string{"a", "b"},
 	}
 
-	m1 := mustMetric("foo", threeTags, currentTime)
-	m2 := mustMetric("bar", tenTags, currentTime)
+	m1 := metric.New("foo", threeTags, map[string]interface{}{}, currentTime)
+	m2 := metric.New("bar", tenTags, map[string]interface{}{}, currentTime)
 	limitApply := tagLimitConfig.Apply(m1, m2)
 	require.Equal(t, threeTags, limitApply[0].Tags(), "three tags")
 	trimmedTags := limitApply[1].Tags()


### PR DESCRIPTION
## Summary

This PR removes an indirection for creating testing metrics to reduce code.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
