### PR TITLE
chore(testutil): Remove unused MustMetric function

### DIFF
--- a/testutil/metric.go
+++ b/testutil/metric.go
@@ -364,17 +364,6 @@ func RequireMetricsStructureSubset(t testing.TB, expected, actual []telegraf.Met
 	}
 }
 
-// MustMetric creates a new metric.
-func MustMetric(
-	name string,
-	tags map[string]string,
-	fields map[string]interface{},
-	tm time.Time,
-	tp ...telegraf.ValueType,
-) telegraf.Metric {
-	return metric.New(name, tags, fields, tm, tp...)
-}
-
 func FromTestMetric(met *Metric) telegraf.Metric {
 	return metric.New(met.Measurement, met.Tags, met.Fields, met.Time, met.Type)
 }

--- a/testutil/metric_test.go
+++ b/testutil/metric_test.go
@@ -69,13 +69,13 @@ func TestRequireMetricsEqual(t *testing.T) {
 		{
 			name: "sort metrics option sorts by name",
 			got: []telegraf.Metric{
-				MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{},
 					map[string]interface{}{},
 					time.Unix(0, 0),
 				),
-				MustMetric(
+				metric.New(
 					"net",
 					map[string]string{},
 					map[string]interface{}{},
@@ -83,13 +83,13 @@ func TestRequireMetricsEqual(t *testing.T) {
 				),
 			},
 			want: []telegraf.Metric{
-				MustMetric(
+				metric.New(
 					"net",
 					map[string]string{},
 					map[string]interface{}{},
 					time.Unix(0, 0),
 				),
-				MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{},
 					map[string]interface{}{},
@@ -116,19 +116,19 @@ func TestRequireMetricsSubset(t *testing.T) {
 		{
 			name: "subset of metrics",
 			got: []telegraf.Metric{
-				MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{},
 					map[string]interface{}{"value": float64(3.14)},
 					time.Unix(0, 0),
 				),
-				MustMetric(
+				metric.New(
 					"net",
 					map[string]string{},
 					map[string]interface{}{"value": int64(42)},
 					time.Unix(0, 0),
 				),
-				MustMetric(
+				metric.New(
 					"superfluous",
 					map[string]string{},
 					map[string]interface{}{"value": true},
@@ -136,13 +136,13 @@ func TestRequireMetricsSubset(t *testing.T) {
 				),
 			},
 			want: []telegraf.Metric{
-				MustMetric(
+				metric.New(
 					"net",
 					map[string]string{},
 					map[string]interface{}{"value": int64(42)},
 					time.Unix(0, 0),
 				),
-				MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{},
 					map[string]interface{}{"value": float64(3.14)},
@@ -169,13 +169,13 @@ func TestRequireMetricsStructureEqual(t *testing.T) {
 		{
 			name: "compare structure",
 			got: []telegraf.Metric{
-				MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{},
 					map[string]interface{}{"value": float64(3.14)},
 					time.Unix(0, 0),
 				),
-				MustMetric(
+				metric.New(
 					"net",
 					map[string]string{},
 					map[string]interface{}{"value": int64(42)},
@@ -183,13 +183,13 @@ func TestRequireMetricsStructureEqual(t *testing.T) {
 				),
 			},
 			want: []telegraf.Metric{
-				MustMetric(
+				metric.New(
 					"net",
 					map[string]string{},
 					map[string]interface{}{"value": int64(0)},
 					time.Unix(0, 0),
 				),
-				MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{},
 					map[string]interface{}{"value": float64(0)},
@@ -216,19 +216,19 @@ func TestRequireMetricsStructureSubset(t *testing.T) {
 		{
 			name: "subset of metric structure",
 			got: []telegraf.Metric{
-				MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{},
 					map[string]interface{}{"value": float64(3.14)},
 					time.Unix(0, 0),
 				),
-				MustMetric(
+				metric.New(
 					"net",
 					map[string]string{},
 					map[string]interface{}{"value": int64(42)},
 					time.Unix(0, 0),
 				),
-				MustMetric(
+				metric.New(
 					"superfluous",
 					map[string]string{},
 					map[string]interface{}{"value": true},
@@ -236,13 +236,13 @@ func TestRequireMetricsStructureSubset(t *testing.T) {
 				),
 			},
 			want: []telegraf.Metric{
-				MustMetric(
+				metric.New(
 					"net",
 					map[string]string{},
 					map[string]interface{}{"value": int64(0)},
 					time.Unix(0, 0),
 				),
-				MustMetric(
+				metric.New(
 					"cpu",
 					map[string]string{},
 					map[string]interface{}{"value": float64(0)},


### PR DESCRIPTION


## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
MustMetric was a thin wrapper around metric.New with no remaining callers. Remove it and update internal tests to call metric.New directly.

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
