### PR TITLE
test(inputs.openntpd): Use testutil functions

### DIFF
--- a/plugins/inputs/openntpd/openntpd_test.go
+++ b/plugins/inputs/openntpd/openntpd_test.go
@@ -20,244 +20,335 @@ func openntpdCTL(output string) func(string, config.Duration, bool) (*bytes.Buff
 }
 
 func TestParseSimpleOutput(t *testing.T) {
-	acc := &testutil.Accumulator{}
-	v := &Openntpd{
+	plugin := &Openntpd{
 		run: openntpdCTL(simpleOutput),
 	}
-	err := v.Gather(acc)
 
-	require.NoError(t, err)
-	require.True(t, acc.HasMeasurement("openntpd"))
-	require.Equal(t, uint64(1), acc.NMetrics())
+	var acc testutil.Accumulator
+	require.NoError(t, plugin.Gather(&acc))
 
-	require.Equal(t, 7, acc.NFields())
-
-	firstpeerfields := map[string]interface{}{
-		"wt":     int64(1),
-		"tl":     int64(10),
-		"next":   int64(56),
-		"poll":   int64(63),
-		"offset": float64(9.271),
-		"delay":  float64(44.662),
-		"jitter": float64(2.678),
+	expected := []telegraf.Metric{
+		metric.New(
+			"openntpd",
+			map[string]string{
+				"remote":  "212.129.9.36",
+				"stratum": "3",
+			},
+			map[string]interface{}{
+				"wt":     int64(1),
+				"tl":     int64(10),
+				"next":   int64(56),
+				"poll":   int64(63),
+				"offset": float64(9.271),
+				"delay":  float64(44.662),
+				"jitter": float64(2.678),
+			},
+			time.Unix(0, 0),
+		),
 	}
 
-	firstpeertags := map[string]string{
-		"remote":  "212.129.9.36",
-		"stratum": "3",
-	}
-
-	acc.AssertContainsTaggedFields(t, "openntpd", firstpeerfields, firstpeertags)
+	testutil.RequireMetricsEqual(t, expected, acc.GetTelegrafMetrics(), testutil.IgnoreTime())
 }
 
 func TestParseSimpleOutputwithStatePrefix(t *testing.T) {
-	acc := &testutil.Accumulator{}
-	v := &Openntpd{
+	plugin := &Openntpd{
 		run: openntpdCTL(simpleOutputwithStatePrefix),
 	}
-	err := v.Gather(acc)
 
-	require.NoError(t, err)
-	require.True(t, acc.HasMeasurement("openntpd"))
-	require.Equal(t, uint64(1), acc.NMetrics())
+	var acc testutil.Accumulator
+	require.NoError(t, plugin.Gather(&acc))
 
-	require.Equal(t, 7, acc.NFields())
-
-	firstpeerfields := map[string]interface{}{
-		"wt":     int64(1),
-		"tl":     int64(10),
-		"next":   int64(45),
-		"poll":   int64(980),
-		"offset": float64(-9.901),
-		"delay":  float64(67.573),
-		"jitter": float64(29.350),
+	expected := []telegraf.Metric{
+		metric.New(
+			"openntpd",
+			map[string]string{
+				"remote":       "92.243.6.5",
+				"stratum":      "2",
+				"state_prefix": "*",
+			},
+			map[string]interface{}{
+				"wt":     int64(1),
+				"tl":     int64(10),
+				"next":   int64(45),
+				"poll":   int64(980),
+				"offset": float64(-9.901),
+				"delay":  float64(67.573),
+				"jitter": float64(29.350),
+			},
+			time.Unix(0, 0),
+		),
 	}
 
-	firstpeertags := map[string]string{
-		"remote":       "92.243.6.5",
-		"stratum":      "2",
-		"state_prefix": "*",
-	}
-
-	acc.AssertContainsTaggedFields(t, "openntpd", firstpeerfields, firstpeertags)
+	testutil.RequireMetricsEqual(t, expected, acc.GetTelegrafMetrics(), testutil.IgnoreTime())
 }
 
 func TestParseSimpleOutputInvalidPeer(t *testing.T) {
-	acc := &testutil.Accumulator{}
-	v := &Openntpd{
+	plugin := &Openntpd{
 		run: openntpdCTL(simpleOutputInvalidPeer),
 	}
-	err := v.Gather(acc)
 
-	require.NoError(t, err)
-	require.True(t, acc.HasMeasurement("openntpd"))
-	require.Equal(t, uint64(1), acc.NMetrics())
+	var acc testutil.Accumulator
+	require.NoError(t, plugin.Gather(&acc))
 
-	require.Equal(t, 4, acc.NFields())
-
-	firstpeerfields := map[string]interface{}{
-		"wt":   int64(1),
-		"tl":   int64(2),
-		"next": int64(203),
-		"poll": int64(300),
+	expected := []telegraf.Metric{
+		metric.New(
+			"openntpd",
+			map[string]string{
+				"remote":  "178.33.111.49",
+				"stratum": "-",
+			},
+			map[string]interface{}{
+				"wt":   int64(1),
+				"tl":   int64(2),
+				"next": int64(203),
+				"poll": int64(300),
+			},
+			time.Unix(0, 0),
+		),
 	}
 
-	firstpeertags := map[string]string{
-		"remote":  "178.33.111.49",
-		"stratum": "-",
-	}
-
-	acc.AssertContainsTaggedFields(t, "openntpd", firstpeerfields, firstpeertags)
+	testutil.RequireMetricsEqual(t, expected, acc.GetTelegrafMetrics(), testutil.IgnoreTime())
 }
 
 func TestParseSimpleOutputServersDNSError(t *testing.T) {
-	acc := &testutil.Accumulator{}
-	v := &Openntpd{
+	plugin := &Openntpd{
 		run: openntpdCTL(simpleOutputServersDNSError),
 	}
-	err := v.Gather(acc)
 
-	require.NoError(t, err)
-	require.True(t, acc.HasMeasurement("openntpd"))
-	require.Equal(t, uint64(1), acc.NMetrics())
+	var acc testutil.Accumulator
+	require.NoError(t, plugin.Gather(&acc))
 
-	require.Equal(t, 4, acc.NFields())
-
-	firstpeerfields := map[string]interface{}{
-		"next": int64(2),
-		"poll": int64(15),
-		"wt":   int64(1),
-		"tl":   int64(2),
+	expected := []telegraf.Metric{
+		metric.New(
+			"openntpd",
+			map[string]string{
+				"remote":  "pool.nl.ntp.org",
+				"stratum": "-",
+			},
+			map[string]interface{}{
+				"wt":   int64(1),
+				"tl":   int64(2),
+				"next": int64(2),
+				"poll": int64(15),
+			},
+			time.Unix(0, 0),
+		),
 	}
 
-	firstpeertags := map[string]string{
-		"remote":  "pool.nl.ntp.org",
-		"stratum": "-",
-	}
-
-	acc.AssertContainsTaggedFields(t, "openntpd", firstpeerfields, firstpeertags)
-
-	secondpeerfields := map[string]interface{}{
-		"next": int64(2),
-		"poll": int64(15),
-		"wt":   int64(1),
-		"tl":   int64(2),
-	}
-
-	secondpeertags := map[string]string{
-		"remote":  "pool.nl.ntp.org",
-		"stratum": "-",
-	}
-
-	acc.AssertContainsTaggedFields(t, "openntpd", secondpeerfields, secondpeertags)
+	testutil.RequireMetricsEqual(t, expected, acc.GetTelegrafMetrics(), testutil.IgnoreTime())
 }
 
 func TestParseSimpleOutputServerDNSError(t *testing.T) {
-	acc := &testutil.Accumulator{}
-	v := &Openntpd{
+	plugin := &Openntpd{
 		run: openntpdCTL(simpleOutputServerDNSError),
 	}
-	err := v.Gather(acc)
 
-	require.NoError(t, err)
-	require.True(t, acc.HasMeasurement("openntpd"))
-	require.Equal(t, uint64(1), acc.NMetrics())
+	var acc testutil.Accumulator
+	require.NoError(t, plugin.Gather(&acc))
 
-	require.Equal(t, 4, acc.NFields())
-
-	firstpeerfields := map[string]interface{}{
-		"next": int64(12),
-		"poll": int64(15),
-		"wt":   int64(1),
-		"tl":   int64(2),
+	expected := []telegraf.Metric{
+		metric.New(
+			"openntpd",
+			map[string]string{
+				"remote":  "pool.fr.ntp.org",
+				"stratum": "-",
+			},
+			map[string]interface{}{
+				"wt":   int64(1),
+				"tl":   int64(2),
+				"next": int64(12),
+				"poll": int64(15),
+			},
+			time.Unix(0, 0),
+		),
 	}
 
-	firstpeertags := map[string]string{
-		"remote":  "pool.fr.ntp.org",
-		"stratum": "-",
-	}
-
-	acc.AssertContainsTaggedFields(t, "openntpd", firstpeerfields, firstpeertags)
+	testutil.RequireMetricsEqual(t, expected, acc.GetTelegrafMetrics(), testutil.IgnoreTime())
 }
 
 func TestParseFullOutput(t *testing.T) {
-	acc := &testutil.Accumulator{}
-	v := &Openntpd{
+	plugin := &Openntpd{
 		run: openntpdCTL(fullOutput),
 	}
-	err := v.Gather(acc)
 
-	require.NoError(t, err)
-	require.True(t, acc.HasMeasurement("openntpd"))
-	require.Equal(t, uint64(20), acc.NMetrics())
+	var acc testutil.Accumulator
+	require.NoError(t, plugin.Gather(&acc))
 
-	require.Equal(t, 113, acc.NFields())
-
-	firstpeerfields := map[string]interface{}{
-		"wt":     int64(1),
-		"tl":     int64(10),
-		"next":   int64(56),
-		"poll":   int64(63),
-		"offset": float64(9.271),
-		"delay":  float64(44.662),
-		"jitter": float64(2.678),
+	expected := []telegraf.Metric{
+		metric.New(
+			"openntpd",
+			map[string]string{"remote": "212.129.9.36", "stratum": "3"},
+			map[string]interface{}{
+				"wt": int64(1), "tl": int64(10), "next": int64(56), "poll": int64(63),
+				"offset": float64(9.271), "delay": float64(44.662), "jitter": float64(2.678),
+			},
+			time.Unix(0, 0),
+		),
+		metric.New(
+			"openntpd",
+			map[string]string{"remote": "163.172.25.19", "stratum": "2"},
+			map[string]interface{}{
+				"wt": int64(1), "tl": int64(10), "next": int64(21), "poll": int64(64),
+				"offset": float64(-0.103), "delay": float64(53.199), "jitter": float64(9.046),
+			},
+			time.Unix(0, 0),
+		),
+		metric.New(
+			"openntpd",
+			map[string]string{"remote": "92.243.6.5", "stratum": "2", "state_prefix": "*"},
+			map[string]interface{}{
+				"wt": int64(1), "tl": int64(10), "next": int64(45), "poll": int64(980),
+				"offset": float64(-9.901), "delay": float64(67.573), "jitter": float64(29.350),
+			},
+			time.Unix(0, 0),
+		),
+		metric.New(
+			"openntpd",
+			map[string]string{"remote": "178.33.111.49", "stratum": "-"},
+			map[string]interface{}{
+				"wt": int64(1), "tl": int64(2), "next": int64(203), "poll": int64(300),
+			},
+			time.Unix(0, 0),
+		),
+		metric.New(
+			"openntpd",
+			map[string]string{"remote": "62.210.122.129", "stratum": "3"},
+			map[string]interface{}{
+				"wt": int64(1), "tl": int64(10), "next": int64(4), "poll": int64(60),
+				"offset": float64(5.372), "delay": float64(53.690), "jitter": float64(14.700),
+			},
+			time.Unix(0, 0),
+		),
+		metric.New(
+			"openntpd",
+			map[string]string{"remote": "163.172.225.159", "stratum": "3"},
+			map[string]interface{}{
+				"wt": int64(1), "tl": int64(10), "next": int64(38), "poll": int64(61),
+				"offset": float64(12.276), "delay": float64(40.631), "jitter": float64(1.282),
+			},
+			time.Unix(0, 0),
+		),
+		metric.New(
+			"openntpd",
+			map[string]string{"remote": "5.196.192.58", "stratum": "-"},
+			map[string]interface{}{
+				"wt": int64(1), "tl": int64(2), "next": int64(0), "poll": int64(300),
+			},
+			time.Unix(0, 0),
+		),
+		metric.New(
+			"openntpd",
+			map[string]string{"remote": "129.250.35.250", "stratum": "2"},
+			map[string]interface{}{
+				"wt": int64(1), "tl": int64(10), "next": int64(28), "poll": int64(63),
+				"offset": float64(11.236), "delay": float64(43.874), "jitter": float64(1.381),
+			},
+			time.Unix(0, 0),
+		),
+		metric.New(
+			"openntpd",
+			map[string]string{"remote": "2001:41d0:a:5a7::1", "stratum": "-"},
+			map[string]interface{}{
+				"wt": int64(1), "tl": int64(2), "next": int64(5), "poll": int64(15),
+			},
+			time.Unix(0, 0),
+		),
+		metric.New(
+			"openntpd",
+			map[string]string{"remote": "2001:41d0:8:188d::16", "stratum": "-"},
+			map[string]interface{}{
+				"wt": int64(1), "tl": int64(2), "next": int64(3), "poll": int64(15),
+			},
+			time.Unix(0, 0),
+		),
+		metric.New(
+			"openntpd",
+			map[string]string{"remote": "2001:4b98:dc0:41:216:3eff:fe69:46e3", "stratum": "-"},
+			map[string]interface{}{
+				"wt": int64(1), "tl": int64(2), "next": int64(14), "poll": int64(15),
+			},
+			time.Unix(0, 0),
+		),
+		metric.New(
+			"openntpd",
+			map[string]string{"remote": "2a01:e0d:1:3:58bf:fa61:0:1", "stratum": "-"},
+			map[string]interface{}{
+				"wt": int64(1), "tl": int64(2), "next": int64(9), "poll": int64(15),
+			},
+			time.Unix(0, 0),
+		),
+		metric.New(
+			"openntpd",
+			map[string]string{"remote": "163.172.179.38", "stratum": "2"},
+			map[string]interface{}{
+				"wt": int64(1), "tl": int64(10), "next": int64(51), "poll": int64(65),
+				"offset": float64(-19.229), "delay": float64(85.404), "jitter": float64(48.734),
+			},
+			time.Unix(0, 0),
+		),
+		metric.New(
+			"openntpd",
+			map[string]string{"remote": "5.135.3.88", "stratum": "-"},
+			map[string]interface{}{
+				"wt": int64(1), "tl": int64(2), "next": int64(173), "poll": int64(300),
+			},
+			time.Unix(0, 0),
+		),
+		metric.New(
+			"openntpd",
+			map[string]string{"remote": "195.154.41.195", "stratum": "2"},
+			map[string]interface{}{
+				"wt": int64(1), "tl": int64(10), "next": int64(84), "poll": int64(1004),
+				"offset": float64(-3.956), "delay": float64(54.549), "jitter": float64(13.658),
+			},
+			time.Unix(0, 0),
+		),
+		metric.New(
+			"openntpd",
+			map[string]string{"remote": "62.210.81.130", "stratum": "2"},
+			map[string]interface{}{
+				"wt": int64(1), "tl": int64(10), "next": int64(158), "poll": int64(1043),
+				"offset": float64(-42.593), "delay": float64(124.353), "jitter": float64(94.230),
+			},
+			time.Unix(0, 0),
+		),
+		metric.New(
+			"openntpd",
+			map[string]string{"remote": "149.202.97.123", "stratum": "-"},
+			map[string]interface{}{
+				"wt": int64(1), "tl": int64(2), "next": int64(205), "poll": int64(300),
+			},
+			time.Unix(0, 0),
+		),
+		metric.New(
+			"openntpd",
+			map[string]string{"remote": "51.15.175.224", "stratum": "2"},
+			map[string]interface{}{
+				"wt": int64(1), "tl": int64(10), "next": int64(9), "poll": int64(64),
+				"offset": float64(8.861), "delay": float64(46.640), "jitter": float64(0.668),
+			},
+			time.Unix(0, 0),
+		),
+		metric.New(
+			"openntpd",
+			map[string]string{"remote": "37.187.5.167", "stratum": "-"},
+			map[string]interface{}{
+				"wt": int64(1), "tl": int64(2), "next": int64(105), "poll": int64(300),
+			},
+			time.Unix(0, 0),
+		),
+		metric.New(
+			"openntpd",
+			map[string]string{"remote": "194.57.169.1", "stratum": "2"},
+			map[string]interface{}{
+				"wt": int64(1), "tl": int64(10), "next": int64(32), "poll": int64(63),
+				"offset": float64(6.589), "delay": float64(52.051), "jitter": float64(2.057),
+			},
+			time.Unix(0, 0),
+		),
 	}
 
-	firstpeertags := map[string]string{
-		"remote":  "212.129.9.36",
-		"stratum": "3",
-	}
-
-	acc.AssertContainsTaggedFields(t, "openntpd", firstpeerfields, firstpeertags)
-
-	secondpeerfields := map[string]interface{}{
-		"wt":     int64(1),
-		"tl":     int64(10),
-		"next":   int64(21),
-		"poll":   int64(64),
-		"offset": float64(-0.103),
-		"delay":  float64(53.199),
-		"jitter": float64(9.046),
-	}
-
-	secondpeertags := map[string]string{
-		"remote":  "163.172.25.19",
-		"stratum": "2",
-	}
-
-	acc.AssertContainsTaggedFields(t, "openntpd", secondpeerfields, secondpeertags)
-
-	thirdpeerfields := map[string]interface{}{
-		"wt":     int64(1),
-		"tl":     int64(10),
-		"next":   int64(45),
-		"poll":   int64(980),
-		"offset": float64(-9.901),
-		"delay":  float64(67.573),
-		"jitter": float64(29.350),
-	}
-
-	thirdpeertags := map[string]string{
-		"remote":       "92.243.6.5",
-		"stratum":      "2",
-		"state_prefix": "*",
-	}
-
-	acc.AssertContainsTaggedFields(t, "openntpd", thirdpeerfields, thirdpeertags)
-
-	fourthpeerfields := map[string]interface{}{
-		"wt":   int64(1),
-		"tl":   int64(2),
-		"next": int64(203),
-		"poll": int64(300),
-	}
-
-	fourthpeertags := map[string]string{
-		"remote":  "178.33.111.49",
-		"stratum": "-",
-	}
-
-	acc.AssertContainsTaggedFields(t, "openntpd", fourthpeerfields, fourthpeertags)
+	testutil.RequireMetricsEqual(t, expected, acc.GetTelegrafMetrics(), testutil.IgnoreTime())
 }
 
 func TestParseFullOutputAll(t *testing.T) {


### PR DESCRIPTION


## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Migrate existing tests to use testutil.RequireMetricsEqual with metric.New() and value accumulators, replacing manual field/tag assertions with AssertContainsTaggedFields.

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
