### PR TITLE
chore(inputs.docker_log): Migrate to maintained github.com/moby/moby library

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1961,6 +1961,8 @@ github.com/moby/moby/client v0.4.0 h1:S+2XegzHQrrvTCvF6s5HFzcrywWQmuVnhOXe2kiWjI
 github.com/moby/moby/client v0.4.0/go.mod h1:QWPbvWchQbxBNdaLSpoKpCdf5E+WxFAgNHogCWDoa7g=
 github.com/moby/patternmatcher v0.6.1 h1:qlhtafmr6kgMIJjKJMDmMWq7WLkKIo23hsrpR3x084U=
 github.com/moby/patternmatcher v0.6.1/go.mod h1:hDPoyOpDY7OrrMDLaYoY3hf52gNCR/YOUYxkhApJIxc=
+github.com/moby/patternmatcher v0.6.0 h1:GmP9lR19aU5GqSSFko+5pRqHi+Ohk1O69aFiKkVGiPk=
+github.com/moby/patternmatcher v0.6.0/go.mod h1:hDPoyOpDY7OrrMDLaYoY3hf52gNCR/YOUYxkhApJIxc=
 github.com/moby/sys/atomicwriter v0.1.0 h1:kw5D/EqkBwsBFi0ss9v1VG3wIkVhzGvLklJ+w3A14Sw=
 github.com/moby/sys/atomicwriter v0.1.0/go.mod h1:Ul8oqv2ZMNHOceF643P6FKPXeCmYtlQMvpizfsSoaWs=
 github.com/moby/sys/mountinfo v0.7.2 h1:1shs6aH5s4o5H2zQLn796ADW1wMrIwHsyJ2v9KouLrg=

--- a/go.sum
+++ b/go.sum
@@ -1961,8 +1961,6 @@ github.com/moby/moby/client v0.4.0 h1:S+2XegzHQrrvTCvF6s5HFzcrywWQmuVnhOXe2kiWjI
 github.com/moby/moby/client v0.4.0/go.mod h1:QWPbvWchQbxBNdaLSpoKpCdf5E+WxFAgNHogCWDoa7g=
 github.com/moby/patternmatcher v0.6.1 h1:qlhtafmr6kgMIJjKJMDmMWq7WLkKIo23hsrpR3x084U=
 github.com/moby/patternmatcher v0.6.1/go.mod h1:hDPoyOpDY7OrrMDLaYoY3hf52gNCR/YOUYxkhApJIxc=
-github.com/moby/patternmatcher v0.6.0 h1:GmP9lR19aU5GqSSFko+5pRqHi+Ohk1O69aFiKkVGiPk=
-github.com/moby/patternmatcher v0.6.0/go.mod h1:hDPoyOpDY7OrrMDLaYoY3hf52gNCR/YOUYxkhApJIxc=
 github.com/moby/sys/atomicwriter v0.1.0 h1:kw5D/EqkBwsBFi0ss9v1VG3wIkVhzGvLklJ+w3A14Sw=
 github.com/moby/sys/atomicwriter v0.1.0/go.mod h1:Ul8oqv2ZMNHOceF643P6FKPXeCmYtlQMvpizfsSoaWs=
 github.com/moby/sys/mountinfo v0.7.2 h1:1shs6aH5s4o5H2zQLn796ADW1wMrIwHsyJ2v9KouLrg=

--- a/plugins/inputs/docker_log/client.go
+++ b/plugins/inputs/docker_log/client.go
@@ -6,25 +6,25 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/docker/docker/api/types/container"
-	docker "github.com/docker/docker/client"
+	"github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/client"
 )
 
 type dockerClient interface {
 	// ContainerList lists the containers in the Docker environment.
-	ContainerList(ctx context.Context, options container.ListOptions) ([]container.Summary, error)
+	ContainerList(ctx context.Context, options client.ContainerListOptions) ([]container.Summary, error)
 	// ContainerLogs retrieves the logs of a specific container.
-	ContainerLogs(ctx context.Context, containerID string, options container.LogsOptions) (io.ReadCloser, error)
+	ContainerLogs(ctx context.Context, containerID string, options client.ContainerLogsOptions) (io.ReadCloser, error)
 	// ContainerInspect inspects a specific container and retrieves its details.
 	ContainerInspect(ctx context.Context, containerID string) (container.InspectResponse, error)
 }
 
 func newEnvClient() (dockerClient, error) {
-	client, err := docker.NewClientWithOpts(docker.FromEnv)
+	c, err := client.New(client.FromEnv)
 	if err != nil {
 		return nil, err
 	}
-	return &socketClient{client}, nil
+	return &socketClient{c}, nil
 }
 
 func newClient(host string, tlsConfig *tls.Config) (dockerClient, error) {
@@ -32,33 +32,41 @@ func newClient(host string, tlsConfig *tls.Config) (dockerClient, error) {
 		TLSClientConfig: tlsConfig,
 	}
 	httpClient := &http.Client{Transport: transport}
-	client, err := docker.NewClientWithOpts(
-		docker.WithHTTPHeaders(map[string]string{"User-Agent": "engine-api-cli-1.0"}),
-		docker.WithHTTPClient(httpClient),
-		docker.WithAPIVersionNegotiation(),
-		docker.WithHost(host))
-
+	c, err := client.New(
+		client.WithHTTPHeaders(map[string]string{"User-Agent": "engine-api-cli-1.0"}),
+		client.WithHTTPClient(httpClient),
+		client.WithHost(host),
+	)
 	if err != nil {
 		return nil, err
 	}
-	return &socketClient{client}, nil
+
+	return &socketClient{client: c}, nil
 }
 
 type socketClient struct {
-	client *docker.Client
+	client *client.Client
 }
 
 // ContainerList lists the containers in the Docker environment.
-func (c *socketClient) ContainerList(ctx context.Context, options container.ListOptions) ([]container.Summary, error) {
-	return c.client.ContainerList(ctx, options)
+func (c *socketClient) ContainerList(ctx context.Context, options client.ContainerListOptions) ([]container.Summary, error) {
+	result, err := c.client.ContainerList(ctx, options)
+	if err != nil {
+		return nil, err
+	}
+	return result.Items, nil
 }
 
 // ContainerLogs retrieves the logs of a specific container.
-func (c *socketClient) ContainerLogs(ctx context.Context, containerID string, options container.LogsOptions) (io.ReadCloser, error) {
+func (c *socketClient) ContainerLogs(ctx context.Context, containerID string, options client.ContainerLogsOptions) (io.ReadCloser, error) {
 	return c.client.ContainerLogs(ctx, containerID, options)
 }
 
 // ContainerInspect inspects a specific container and retrieves its details.
 func (c *socketClient) ContainerInspect(ctx context.Context, containerID string) (container.InspectResponse, error) {
-	return c.client.ContainerInspect(ctx, containerID)
+	result, err := c.client.ContainerInspect(ctx, containerID, client.ContainerInspectOptions{})
+	if err != nil {
+		return container.InspectResponse{}, err
+	}
+	return result.Container, nil
 }

--- a/plugins/inputs/docker_log/docker_log.go
+++ b/plugins/inputs/docker_log/docker_log.go
@@ -15,8 +15,9 @@ import (
 	"time"
 	"unicode"
 
-	"github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/pkg/stdcopy"
+	"github.com/moby/moby/api/pkg/stdcopy"
+	"github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/client"
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
@@ -28,15 +29,6 @@ import (
 
 //go:embed sample.conf
 var sampleConfig string
-
-var (
-	// ensure *DockerLogs implements telegraf.ServiceInput
-	_ telegraf.ServiceInput = (*DockerLogs)(nil)
-)
-
-const (
-	defaultEndpoint = "unix:///var/run/docker.sock"
-)
 
 type DockerLogs struct {
 	Endpoint              string          `toml:"endpoint"`
@@ -74,35 +66,33 @@ func (*DockerLogs) SampleConfig() string {
 }
 
 func (d *DockerLogs) Init() error {
-	var err error
 	if d.Endpoint == "ENV" {
-		d.client, err = d.newEnvClient()
+		c, err := d.newEnvClient()
 		if err != nil {
-			return err
+			return fmt.Errorf("creating client from environment failed: %w", err)
 		}
+		d.client = c
 	} else {
 		tlsConfig, err := d.ClientConfig.TLSConfig()
 		if err != nil {
-			return err
+			return fmt.Errorf("creating TLS configuration failed: %w", err)
 		}
-		d.client, err = d.newClient(d.Endpoint, tlsConfig)
+		c, err := d.newClient(d.Endpoint, tlsConfig)
 		if err != nil {
-			return err
+			return fmt.Errorf("creating client failed: %w", err)
 		}
+		d.client = c
 	}
 
 	// Create filters
-	err = d.createLabelFilters()
-	if err != nil {
-		return err
+	if err := d.createLabelFilters(); err != nil {
+		return fmt.Errorf("creating label filter failed: %w", err)
 	}
-	err = d.createContainerFilters()
-	if err != nil {
-		return err
+	if err := d.createContainerFilters(); err != nil {
+		return fmt.Errorf("creating container filter failed: %w", err)
 	}
-	err = d.createContainerStateFilters()
-	if err != nil {
-		return err
+	if err := d.createContainerStateFilters(); err != nil {
+		return fmt.Errorf("creating container state filter failed: %w", err)
 	}
 
 	d.lastRecord = make(map[string]time.Time)
@@ -146,7 +136,7 @@ func (d *DockerLogs) Gather(acc telegraf.Accumulator) error {
 
 	ctx, cancel := context.WithTimeout(ctx, time.Duration(d.Timeout))
 	defer cancel()
-	containers, err := d.client.ContainerList(ctx, container.ListOptions{})
+	containers, err := d.client.ContainerList(ctx, client.ContainerListOptions{})
 	if err != nil {
 		return err
 	}
@@ -166,7 +156,7 @@ func (d *DockerLogs) Gather(acc telegraf.Accumulator) error {
 			continue
 		}
 
-		if !d.stateFilter.Match(cntnr.State) {
+		if !d.stateFilter.Match(string(cntnr.State)) {
 			continue
 		}
 
@@ -268,7 +258,7 @@ func (d *DockerLogs) tailContainerLogs(
 		d.lastRecordMtx.Unlock()
 	}
 
-	logOptions := container.LogsOptions{
+	logOptions := client.ContainerLogsOptions{
 		ShowStdout: true,
 		ShowStderr: true,
 		Timestamps: true,
@@ -389,12 +379,7 @@ func tailStream(
 	}
 }
 
-func tailMultiplexed(
-	acc telegraf.Accumulator,
-	tags map[string]string,
-	containerID string,
-	src io.ReadCloser,
-) (time.Time, error) {
+func tailMultiplexed(acc telegraf.Accumulator, tags map[string]string, containerID string, src io.ReadCloser) (time.Time, error) {
 	outReader, outWriter := io.Pipe()
 	errReader, errWriter := io.Pipe()
 
@@ -479,7 +464,7 @@ func init() {
 	inputs.Add("docker_log", func() telegraf.Input {
 		return &DockerLogs{
 			Timeout:       config.Duration(time.Second * 5),
-			Endpoint:      defaultEndpoint,
+			Endpoint:      "unix:///var/run/docker.sock",
 			newEnvClient:  newEnvClient,
 			newClient:     newClient,
 			containerList: make(map[string]context.CancelFunc),

--- a/plugins/inputs/docker_log/docker_log_test.go
+++ b/plugins/inputs/docker_log/docker_log_test.go
@@ -4,12 +4,13 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
+	"encoding/binary"
 	"io"
 	"testing"
 	"time"
 
-	"github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/pkg/stdcopy"
+	"github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/client"
 	"github.com/stretchr/testify/require"
 
 	"github.com/influxdata/telegraf"
@@ -17,40 +18,6 @@ import (
 	"github.com/influxdata/telegraf/metric"
 	"github.com/influxdata/telegraf/testutil"
 )
-
-type mockClient struct {
-	ContainerListF    func() ([]container.Summary, error)
-	ContainerInspectF func() (container.InspectResponse, error)
-	ContainerLogsF    func() (io.ReadCloser, error)
-}
-
-func (c *mockClient) ContainerList(context.Context, container.ListOptions) ([]container.Summary, error) {
-	return c.ContainerListF()
-}
-
-func (c *mockClient) ContainerInspect(context.Context, string) (container.InspectResponse, error) {
-	return c.ContainerInspectF()
-}
-
-func (c *mockClient) ContainerLogs(context.Context, string, container.LogsOptions) (io.ReadCloser, error) {
-	return c.ContainerLogsF()
-}
-
-type response struct {
-	io.Reader
-}
-
-func (*response) Close() error {
-	return nil
-}
-
-func mustParse(layout, value string) time.Time {
-	tm, err := time.Parse(layout, value)
-	if err != nil {
-		panic(err)
-	}
-	return tm
-}
 
 func Test(t *testing.T) {
 	tests := []struct {
@@ -129,10 +96,19 @@ func Test(t *testing.T) {
 					}, nil
 				},
 				ContainerLogsF: func() (io.ReadCloser, error) {
+					content := []byte("2020-04-28T18:42:16.432691200Z hello from stdout")
+
+					// Emulate a multiplexed writer
 					var buf bytes.Buffer
-					w := stdcopy.NewStdWriter(&buf, stdcopy.Stdout)
-					_, err := w.Write([]byte("2020-04-28T18:42:16.432691200Z hello from stdout"))
-					return &response{Reader: &buf}, err
+					header := [8]byte{0: 1}
+					binary.BigEndian.PutUint32(header[4:], uint32(len(content)))
+					if _, err := buf.Write(header[:]); err != nil {
+						return nil, err
+					}
+					if _, err := buf.Write(content); err != nil {
+						return nil, err
+					}
+					return &response{Reader: &buf}, nil
 				},
 			},
 			expected: []telegraf.Metric{
@@ -178,4 +154,38 @@ func Test(t *testing.T) {
 			testutil.RequireMetricsEqual(t, tt.expected, acc.GetTelegrafMetrics())
 		})
 	}
+}
+
+type mockClient struct {
+	ContainerListF    func() ([]container.Summary, error)
+	ContainerInspectF func() (container.InspectResponse, error)
+	ContainerLogsF    func() (io.ReadCloser, error)
+}
+
+func (c *mockClient) ContainerList(context.Context, client.ContainerListOptions) ([]container.Summary, error) {
+	return c.ContainerListF()
+}
+
+func (c *mockClient) ContainerLogs(context.Context, string, client.ContainerLogsOptions) (io.ReadCloser, error) {
+	return c.ContainerLogsF()
+}
+
+func (c *mockClient) ContainerInspect(context.Context, string) (container.InspectResponse, error) {
+	return c.ContainerInspectF()
+}
+
+type response struct {
+	io.Reader
+}
+
+func (*response) Close() error {
+	return nil
+}
+
+func mustParse(layout, value string) time.Time {
+	tm, err := time.Parse(layout, value)
+	if err != nil {
+		panic(err)
+	}
+	return tm
 }


### PR DESCRIPTION
## Summary

Switch to the `github.com/moby/moby` library which is now the official one because the `github.com/docker/docker` dependency is no longer maintained.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
