### PR TITLE
inputs/kapacitor: always tag nested metrics with the source URL

### DIFF
--- a/plugins/inputs/kapacitor/kapacitor.go
+++ b/plugins/inputs/kapacitor/kapacitor.go
@@ -209,6 +209,20 @@ func (k *Kapacitor) gatherURL(
 				delete(obj.Tags, key)
 			}
 
+			// Always tag with the source URL so metrics from multiple
+			// Kapacitor instances are distinguishable downstream. The
+			// top-level kapacitor / kapacitor_memstats metrics already
+			// carry it, but kapacitor_edges / kapacitor_ingress /
+			// kapacitor_load did not, which made it impossible to tell
+			// which instance a row came from when the plugin polled
+			// more than one URL (see influxdata/telegraf#18645).
+			if obj.Tags == nil {
+				obj.Tags = make(map[string]string, 1)
+			}
+			if _, present := obj.Tags["url"]; !present {
+				obj.Tags["url"] = url
+			}
+
 			// Convert time-related string field to int
 			if _, ok := obj.Values["avg_exec_time_ns"]; ok {
 				d, err := time.ParseDuration(obj.Values["avg_exec_time_ns"].(string))


### PR DESCRIPTION
Fixes #18645.

## Problem

When `[[inputs.kapacitor]]` polls more than one URL, every emitted metric needs to carry the source URL so downstream consumers can tell the two instances apart. The top-level `kapacitor` and `kapacitor_memstats` measurements already do, but the nested objects that turn into `kapacitor_edges`, `kapacitor_ingress`, `kapacitor_load`, etc. were only tagged with whatever came out of Kapacitor's `/debug/vars` payload. Kapacitor itself does not include the URL there (it has no way to), so those rows had no way to be attributed back to their source endpoint:

```
kapacitor_edges,child=stream,parent=write_points,task=task_master:main,type=stream emitted=0,collected=0
kapacitor_load errors=0
```

(no `url` tag, and when two endpoints are polled you cannot tell these apart from each other).

## Fix

In `plugins/inputs/kapacitor/kapacitor.go`, before the nested `acc.AddFields` call, set `obj.Tags["url"] = url` when the object doesn't already carry one. The existing code path that copies `obj.Tags` straight to the field set is preserved (so the `task=...`, `type=...`, `child=...`, `parent=...` tags Kapacitor returns are still emitted), and if Kapacitor ever does start including its own `url` tag we prefer that more specific value.

## Back-compat

No change for users who poll a single URL (`url` tag becomes visible on a few more measurements). Users who already worked around this with the `[inputs.kapacitor.tags] url = "..."` block keep working because the hand-configured tag is applied at a later stage by telegraf core, and the new code only sets `url` when the nested object hadn't already supplied one.

Signed off per DCO.
