### PR TITLE
feat(inputs.azure_monitor): Support secrets for client_secret

### DIFF
--- a/plugins/inputs/azure_monitor/README.md
+++ b/plugins/inputs/azure_monitor/README.md
@@ -58,6 +58,14 @@ plugin ordering. See [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 [CONFIGURATION.md]: ../../../docs/CONFIGURATION.md#plugins
 
+## Secret-store support
+
+This plugin supports secrets from secret-stores for the `client_secret` option.
+See the [secret-store documentation][SECRETSTORE] for more details on how
+to use them.
+
+[SECRETSTORE]: ../../../docs/CONFIGURATION.md#secret-store-secrets
+
 ## Configuration
 
 ```toml @sample.conf
@@ -74,6 +82,7 @@ plugin ordering. See [CONFIGURATION.md][CONFIGURATION.md] for more details.
   # - Managed Identity
   # - Azure CLI auth
   # - Developer Azure CLI auth
+  # Supports referencing values from secret stores using @{<store>:<key>} syntax
   client_secret = "<<CLIENT_SECRET>>"
   # can be found under Azure Active Directory->Properties
   tenant_id = "<<TENANT_ID>>"

--- a/plugins/inputs/azure_monitor/azure_monitor.go
+++ b/plugins/inputs/azure_monitor/azure_monitor.go
@@ -12,13 +12,14 @@ import (
 	receiver "github.com/logzio/azure-monitor-metrics-receiver"
 
 	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/plugins/inputs"
 )
 
 type AzureMonitor struct {
 	SubscriptionID       string                 `toml:"subscription_id"`
 	ClientID             string                 `toml:"client_id"`
-	ClientSecret         string                 `toml:"client_secret"`
+	ClientSecret         config.Secret          `toml:"client_secret"`
 	TenantID             string                 `toml:"tenant_id"`
 	CloudOption          string                 `toml:"cloud_option,omitempty"`
 	ResourceTargets      []*resourceTarget      `toml:"resource_target"`
@@ -75,8 +76,18 @@ func (am *AzureMonitor) Init() error {
 		return fmt.Errorf("unknown cloud option: %s", am.CloudOption)
 	}
 
+	var clientSecret string
+	if !am.ClientSecret.Empty() {
+		secret, err := am.ClientSecret.Get()
+		if err != nil {
+			return err
+		}
+		clientSecret = secret.String()
+		defer secret.Destroy()
+	}
+
 	var err error
-	am.azureClients, err = am.azureManager.createAzureClients(am.SubscriptionID, am.ClientID, am.ClientSecret, am.TenantID, clientOptions)
+	am.azureClients, err = am.azureManager.createAzureClients(am.SubscriptionID, am.ClientID, clientSecret, am.TenantID, clientOptions)
 	if err != nil {
 		return err
 	}

--- a/plugins/inputs/azure_monitor/azure_monitor.go
+++ b/plugins/inputs/azure_monitor/azure_monitor.go
@@ -94,7 +94,7 @@ func (am *AzureMonitor) Init() error {
 			return fmt.Errorf("getting client secret failed: %w", err)
 		}
 		clientSecret = secret.String()
-		defer secret.Destroy()
+		secret.Destroy()
 	}
 
 	var err error

--- a/plugins/inputs/azure_monitor/azure_monitor.go
+++ b/plugins/inputs/azure_monitor/azure_monitor.go
@@ -91,7 +91,7 @@ func (am *AzureMonitor) Init() error {
 	if !am.ClientSecret.Empty() {
 		secret, err := am.ClientSecret.Get()
 		if err != nil {
-			return err
+			return fmt.Errorf("getting client secret failed: %w", err)
 		}
 		clientSecret = secret.String()
 		defer secret.Destroy()

--- a/plugins/inputs/azure_monitor/azure_monitor.go
+++ b/plugins/inputs/azure_monitor/azure_monitor.go
@@ -68,12 +68,6 @@ func (am *AzureMonitor) Init() error {
 	if am.SubscriptionID == "" {
 		return errors.New("subscription_id is required")
 	}
-	if am.ClientID == "" {
-		return errors.New("client_id is required")
-	}
-	if am.TenantID == "" {
-		return errors.New("tenant_id is required")
-	}
 
 	var clientOptions azcore.ClientOptions
 	switch am.CloudOption {
@@ -89,6 +83,12 @@ func (am *AzureMonitor) Init() error {
 
 	var clientSecret string
 	if !am.ClientSecret.Empty() {
+		if am.ClientID == "" {
+			return errors.New("client_id is required when client_secret is set")
+		}
+		if am.TenantID == "" {
+			return errors.New("tenant_id is required when client_secret is set")
+		}
 		secret, err := am.ClientSecret.Get()
 		if err != nil {
 			return fmt.Errorf("getting client secret failed: %w", err)

--- a/plugins/inputs/azure_monitor/azure_monitor.go
+++ b/plugins/inputs/azure_monitor/azure_monitor.go
@@ -3,6 +3,7 @@ package azure_monitor
 
 import (
 	_ "embed"
+	"errors"
 	"fmt"
 	"sync"
 
@@ -64,6 +65,16 @@ func (*AzureMonitor) SampleConfig() string {
 }
 
 func (am *AzureMonitor) Init() error {
+	if am.SubscriptionID == "" {
+		return errors.New("subscription_id is required")
+	}
+	if am.ClientID == "" {
+		return errors.New("client_id is required")
+	}
+	if am.TenantID == "" {
+		return errors.New("tenant_id is required")
+	}
+
 	var clientOptions azcore.ClientOptions
 	switch am.CloudOption {
 	case "AzureChina":

--- a/plugins/inputs/azure_monitor/azure_monitor_test.go
+++ b/plugins/inputs/azure_monitor/azure_monitor_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/monitor/armmonitor"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 	"github.com/influxdata/toml"
@@ -136,6 +135,16 @@ func (*mockAzureMetricDefinitionsClient) List(
 		return armmonitor.MetricDefinitionsClientListResponse{
 			MetricDefinitionCollection: armmonitor.MetricDefinitionCollection{
 				Value: metricDefinitions[2],
+			},
+		}, nil
+	}
+
+	if resourceID == "/subscriptions/subscriptionID/resourceGroups/resourceGroup2/providers/Microsoft.Test/type2/resource4" ||
+		resourceID == "/subscriptions/subscriptionID/resourceGroups/resourceGroup2/providers/Microsoft.Test/type2/resource5" ||
+		resourceID == "/subscriptions/subscriptionID/resourceGroups/resourceGroup2/providers/Microsoft.Test/type2/resource6" {
+		return armmonitor.MetricDefinitionsClientListResponse{
+			MetricDefinitionCollection: armmonitor.MetricDefinitionCollection{
+				Value: metricDefinitions[1],
 			},
 		}, nil
 	}
@@ -936,33 +945,8 @@ func TestGather_Success(t *testing.T) {
 
 	am.Log = testutil.Logger{}
 	am.azureManager = &mockAzureClientsManager{}
-	resourceTargets := make([]*receiver.ResourceTarget, 0, len(am.ResourceTargets))
-	for _, target := range am.ResourceTargets {
-		resourceTargets = append(resourceTargets, receiver.NewResourceTarget(target.ResourceID, target.Metrics, target.Aggregations))
-	}
 
-	var clientSecret string
-	if !am.ClientSecret.Empty() {
-		clientSecretValue, err := am.ClientSecret.Get()
-		require.NoError(t, err)
-		clientSecret = clientSecretValue.String()
-		defer clientSecretValue.Destroy()
-	}
-
-	var clientOptions = azcore.ClientOptions{Cloud: cloud.AzurePublic}
-
-	var azureClients *receiver.AzureClients
-	azureClients, err = am.azureManager.createAzureClients(am.SubscriptionID, am.ClientID, clientSecret, am.TenantID, clientOptions)
-	require.NoError(t, err)
-	require.NotNil(t, azureClients)
-
-	am.receiver, err = receiver.NewAzureMonitorMetricsReceiver(
-		am.SubscriptionID,
-		receiver.NewTargets(resourceTargets, nil, nil),
-		azureClients,
-	)
-	require.NoError(t, err)
-	require.NotNil(t, am.receiver)
+	require.NoError(t, am.Init())
 
 	expectedResource1Metric1Name := "azure_monitor_microsoft_test_type1_metric1"
 	expectedResource1Metric1MetricFields := make(map[string]interface{})
@@ -1031,33 +1015,7 @@ func TestGather_China_Success(t *testing.T) {
 	am.Log = testutil.Logger{}
 	am.azureManager = &mockAzureClientsManager{}
 
-	resourceTargets := make([]*receiver.ResourceTarget, 0, len(am.ResourceTargets))
-	for _, target := range am.ResourceTargets {
-		resourceTargets = append(resourceTargets, receiver.NewResourceTarget(target.ResourceID, target.Metrics, target.Aggregations))
-	}
-
-	var clientSecret string
-	if !am.ClientSecret.Empty() {
-		clientSecretValue, err := am.ClientSecret.Get()
-		require.NoError(t, err)
-		clientSecret = clientSecretValue.String()
-		defer clientSecretValue.Destroy()
-	}
-
-	var clientOptions = azcore.ClientOptions{Cloud: cloud.AzureChina}
-
-	var azureClients *receiver.AzureClients
-	azureClients, err = am.azureManager.createAzureClients(am.SubscriptionID, am.ClientID, clientSecret, am.TenantID, clientOptions)
-	require.NoError(t, err)
-	require.NotNil(t, azureClients)
-
-	am.receiver, err = receiver.NewAzureMonitorMetricsReceiver(
-		am.SubscriptionID,
-		receiver.NewTargets(resourceTargets, nil, nil),
-		azureClients,
-	)
-	require.NoError(t, err)
-	require.NotNil(t, am.receiver)
+	require.NoError(t, am.Init())
 }
 
 func TestGather_Government_Success(t *testing.T) {
@@ -1072,33 +1030,7 @@ func TestGather_Government_Success(t *testing.T) {
 	am.Log = testutil.Logger{}
 	am.azureManager = &mockAzureClientsManager{}
 
-	resourceTargets := make([]*receiver.ResourceTarget, 0, len(am.ResourceTargets))
-	for _, target := range am.ResourceTargets {
-		resourceTargets = append(resourceTargets, receiver.NewResourceTarget(target.ResourceID, target.Metrics, target.Aggregations))
-	}
-
-	var clientSecret string
-	if !am.ClientSecret.Empty() {
-		clientSecretValue, err := am.ClientSecret.Get()
-		require.NoError(t, err)
-		clientSecret = clientSecretValue.String()
-		defer clientSecretValue.Destroy()
-	}
-
-	var clientOptions = azcore.ClientOptions{Cloud: cloud.AzureGovernment}
-
-	var azureClients *receiver.AzureClients
-	azureClients, err = am.azureManager.createAzureClients(am.SubscriptionID, am.ClientID, clientSecret, am.TenantID, clientOptions)
-	require.NoError(t, err)
-	require.NotNil(t, azureClients)
-
-	am.receiver, err = receiver.NewAzureMonitorMetricsReceiver(
-		am.SubscriptionID,
-		receiver.NewTargets(resourceTargets, nil, nil),
-		azureClients,
-	)
-	require.NoError(t, err)
-	require.NotNil(t, am.receiver)
+	require.NoError(t, am.Init())
 }
 
 func TestGather_Public_Success(t *testing.T) {
@@ -1113,31 +1045,5 @@ func TestGather_Public_Success(t *testing.T) {
 	am.Log = testutil.Logger{}
 	am.azureManager = &mockAzureClientsManager{}
 
-	resourceTargets := make([]*receiver.ResourceTarget, 0, len(am.ResourceTargets))
-	for _, target := range am.ResourceTargets {
-		resourceTargets = append(resourceTargets, receiver.NewResourceTarget(target.ResourceID, target.Metrics, target.Aggregations))
-	}
-
-	var clientSecret string
-	if !am.ClientSecret.Empty() {
-		clientSecretValue, err := am.ClientSecret.Get()
-		require.NoError(t, err)
-		clientSecret = clientSecretValue.String()
-		defer clientSecretValue.Destroy()
-	}
-
-	var clientOptions = azcore.ClientOptions{Cloud: cloud.AzurePublic}
-
-	var azureClients *receiver.AzureClients
-	azureClients, err = am.azureManager.createAzureClients(am.SubscriptionID, am.ClientID, clientSecret, am.TenantID, clientOptions)
-	require.NoError(t, err)
-	require.NotNil(t, azureClients)
-
-	am.receiver, err = receiver.NewAzureMonitorMetricsReceiver(
-		am.SubscriptionID,
-		receiver.NewTargets(resourceTargets, nil, nil),
-		azureClients,
-	)
-	require.NoError(t, err)
-	require.NotNil(t, am.receiver)
+	require.NoError(t, am.Init())
 }

--- a/plugins/inputs/azure_monitor/azure_monitor_test.go
+++ b/plugins/inputs/azure_monitor/azure_monitor_test.go
@@ -115,36 +115,26 @@ func (*mockAzureMetricDefinitionsClient) List(
 		return armmonitor.MetricDefinitionsClientListResponse{}, err
 	}
 
-	if resourceID == "/subscriptions/subscriptionID/resourceGroups/resourceGroup1/providers/Microsoft.Test/type1/resource1" {
+	switch resourceID {
+	case "/subscriptions/subscriptionID/resourceGroups/resourceGroup1/providers/Microsoft.Test/type1/resource1":
 		return armmonitor.MetricDefinitionsClientListResponse{
 			MetricDefinitionCollection: armmonitor.MetricDefinitionCollection{
 				Value: metricDefinitions[0],
 			},
 		}, nil
-	}
-
-	if resourceID == "/subscriptions/subscriptionID/resourceGroups/resourceGroup1/providers/Microsoft.Test/type2/resource2" {
+	case "/subscriptions/subscriptionID/resourceGroups/resourceGroup1/providers/Microsoft.Test/type2/resource2",
+		"/subscriptions/subscriptionID/resourceGroups/resourceGroup2/providers/Microsoft.Test/type2/resource4",
+		"/subscriptions/subscriptionID/resourceGroups/resourceGroup2/providers/Microsoft.Test/type2/resource5",
+		"/subscriptions/subscriptionID/resourceGroups/resourceGroup2/providers/Microsoft.Test/type2/resource6":
 		return armmonitor.MetricDefinitionsClientListResponse{
 			MetricDefinitionCollection: armmonitor.MetricDefinitionCollection{
 				Value: metricDefinitions[1],
 			},
 		}, nil
-	}
-
-	if resourceID == "/subscriptions/subscriptionID/resourceGroups/resourceGroup2/providers/Microsoft.Test/type1/resource3" {
+	case "/subscriptions/subscriptionID/resourceGroups/resourceGroup2/providers/Microsoft.Test/type1/resource3":
 		return armmonitor.MetricDefinitionsClientListResponse{
 			MetricDefinitionCollection: armmonitor.MetricDefinitionCollection{
 				Value: metricDefinitions[2],
-			},
-		}, nil
-	}
-
-	if resourceID == "/subscriptions/subscriptionID/resourceGroups/resourceGroup2/providers/Microsoft.Test/type2/resource4" ||
-		resourceID == "/subscriptions/subscriptionID/resourceGroups/resourceGroup2/providers/Microsoft.Test/type2/resource5" ||
-		resourceID == "/subscriptions/subscriptionID/resourceGroups/resourceGroup2/providers/Microsoft.Test/type2/resource6" {
-		return armmonitor.MetricDefinitionsClientListResponse{
-			MetricDefinitionCollection: armmonitor.MetricDefinitionCollection{
-				Value: metricDefinitions[1],
 			},
 		}, nil
 	}

--- a/plugins/inputs/azure_monitor/azure_monitor_test.go
+++ b/plugins/inputs/azure_monitor/azure_monitor_test.go
@@ -611,6 +611,36 @@ func TestInit_NoSubscriptionID(t *testing.T) {
 	require.Error(t, am.Init())
 }
 
+func TestInit_NoClientID(t *testing.T) {
+	file, err := os.ReadFile("testdata/toml/init_no_client_id.toml")
+	require.NoError(t, err)
+	require.NotNil(t, file)
+	require.NotEmpty(t, file)
+
+	var am *AzureMonitor
+	require.NoError(t, toml.Unmarshal(file, &am))
+
+	am.Log = testutil.Logger{}
+	am.azureManager = &mockAzureClientsManager{}
+
+	require.Error(t, am.Init())
+}
+
+func TestInit_NoTenantID(t *testing.T) {
+	file, err := os.ReadFile("testdata/toml/init_no_tenant_id.toml")
+	require.NoError(t, err)
+	require.NotNil(t, file)
+	require.NotEmpty(t, file)
+
+	var am *AzureMonitor
+	require.NoError(t, toml.Unmarshal(file, &am))
+
+	am.Log = testutil.Logger{}
+	am.azureManager = &mockAzureClientsManager{}
+
+	require.Error(t, am.Init())
+}
+
 func TestInit_NoTargets(t *testing.T) {
 	file, err := os.ReadFile("testdata/toml/init_no_targets.toml")
 	require.NoError(t, err)
@@ -911,10 +941,18 @@ func TestGather_Success(t *testing.T) {
 		resourceTargets = append(resourceTargets, receiver.NewResourceTarget(target.ResourceID, target.Metrics, target.Aggregations))
 	}
 
+	var clientSecret string
+	if !am.ClientSecret.Empty() {
+		clientSecretValue, err := am.ClientSecret.Get()
+		require.NoError(t, err)
+		clientSecret = clientSecretValue.String()
+		defer clientSecretValue.Destroy()
+	}
+
 	var clientOptions = azcore.ClientOptions{Cloud: cloud.AzurePublic}
 
 	var azureClients *receiver.AzureClients
-	azureClients, err = am.azureManager.createAzureClients(am.SubscriptionID, am.ClientID, am.ClientSecret, am.TenantID, clientOptions)
+	azureClients, err = am.azureManager.createAzureClients(am.SubscriptionID, am.ClientID, clientSecret, am.TenantID, clientOptions)
 	require.NoError(t, err)
 	require.NotNil(t, azureClients)
 
@@ -998,10 +1036,18 @@ func TestGather_China_Success(t *testing.T) {
 		resourceTargets = append(resourceTargets, receiver.NewResourceTarget(target.ResourceID, target.Metrics, target.Aggregations))
 	}
 
+	var clientSecret string
+	if !am.ClientSecret.Empty() {
+		clientSecretValue, err := am.ClientSecret.Get()
+		require.NoError(t, err)
+		clientSecret = clientSecretValue.String()
+		defer clientSecretValue.Destroy()
+	}
+
 	var clientOptions = azcore.ClientOptions{Cloud: cloud.AzureChina}
 
 	var azureClients *receiver.AzureClients
-	azureClients, err = am.azureManager.createAzureClients(am.SubscriptionID, am.ClientID, am.ClientSecret, am.TenantID, clientOptions)
+	azureClients, err = am.azureManager.createAzureClients(am.SubscriptionID, am.ClientID, clientSecret, am.TenantID, clientOptions)
 	require.NoError(t, err)
 	require.NotNil(t, azureClients)
 
@@ -1031,10 +1077,18 @@ func TestGather_Government_Success(t *testing.T) {
 		resourceTargets = append(resourceTargets, receiver.NewResourceTarget(target.ResourceID, target.Metrics, target.Aggregations))
 	}
 
+	var clientSecret string
+	if !am.ClientSecret.Empty() {
+		clientSecretValue, err := am.ClientSecret.Get()
+		require.NoError(t, err)
+		clientSecret = clientSecretValue.String()
+		defer clientSecretValue.Destroy()
+	}
+
 	var clientOptions = azcore.ClientOptions{Cloud: cloud.AzureGovernment}
 
 	var azureClients *receiver.AzureClients
-	azureClients, err = am.azureManager.createAzureClients(am.SubscriptionID, am.ClientID, am.ClientSecret, am.TenantID, clientOptions)
+	azureClients, err = am.azureManager.createAzureClients(am.SubscriptionID, am.ClientID, clientSecret, am.TenantID, clientOptions)
 	require.NoError(t, err)
 	require.NotNil(t, azureClients)
 
@@ -1064,10 +1118,18 @@ func TestGather_Public_Success(t *testing.T) {
 		resourceTargets = append(resourceTargets, receiver.NewResourceTarget(target.ResourceID, target.Metrics, target.Aggregations))
 	}
 
+	var clientSecret string
+	if !am.ClientSecret.Empty() {
+		clientSecretValue, err := am.ClientSecret.Get()
+		require.NoError(t, err)
+		clientSecret = clientSecretValue.String()
+		defer clientSecretValue.Destroy()
+	}
+
 	var clientOptions = azcore.ClientOptions{Cloud: cloud.AzurePublic}
 
 	var azureClients *receiver.AzureClients
-	azureClients, err = am.azureManager.createAzureClients(am.SubscriptionID, am.ClientID, am.ClientSecret, am.TenantID, clientOptions)
+	azureClients, err = am.azureManager.createAzureClients(am.SubscriptionID, am.ClientID, clientSecret, am.TenantID, clientOptions)
 	require.NoError(t, err)
 	require.NotNil(t, azureClients)
 

--- a/plugins/inputs/azure_monitor/sample.conf
+++ b/plugins/inputs/azure_monitor/sample.conf
@@ -11,6 +11,7 @@
   # - Managed Identity
   # - Azure CLI auth
   # - Developer Azure CLI auth
+  # Supports referencing values from secret stores using @{<store>:<key>} syntax
   client_secret = "<<CLIENT_SECRET>>"
   # can be found under Azure Active Directory->Properties
   tenant_id = "<<TENANT_ID>>"


### PR DESCRIPTION
## Summary
<!-- Mandatory
Need use secrets for client_secret in azure_monitor input plugin
-->

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [ ] No AI generated code was used in this PR
- [X] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves [#18743](https://github.com/influxdata/telegraf/issues/18743)
