### PR TITLE
test(inputs.snmp_trap): Add test for SNMPv3 long passwords

### DIFF
--- a/plugins/inputs/snmp_trap/snmp_trap_test.go
+++ b/plugins/inputs/snmp_trap/snmp_trap_test.go
@@ -1161,6 +1161,71 @@ func TestReceiveTrapV3(t *testing.T) {
 				),
 			},
 		},
+		// Test v3 with long passwords (>12 characters) to verify password length handling
+		// This test ensures that Telegraf correctly processes SNMPv3 passwords longer than 12 characters
+		// Related to: https://github.com/influxdata/telegraf/issues/18273
+		{
+			name:      "authPriv SHA-AES with long passwords",
+			secName:   "peter",
+			secLevel:  "authPriv",
+			authProto: "SHA",
+			authPass:  "this_is_a_very_long_authentication_password_with_more_than_12_characters",
+			privProto: "AES",
+			privPass:  "this_is_a_very_long_privacy_password_with_more_than_12_characters_too",
+			trap: gosnmp.SnmpTrap{
+				Variables: []gosnmp.SnmpPDU{
+					{
+						Name:  ".1.3.6.1.2.1.1.3.0",
+						Type:  gosnmp.TimeTicks,
+						Value: now,
+					},
+					{
+						Name:  ".1.3.6.1.6.3.1.1.4.1.0", // SNMPv2-MIB::snmpTrapOID.0
+						Type:  gosnmp.ObjectIdentifier,
+						Value: ".1.3.6.1.6.3.1.1.5.1", // coldStart
+					},
+				},
+			},
+			entries: []entry{
+				{
+					oid: ".1.3.6.1.6.3.1.1.4.1.0",
+					e: snmp.MibEntry{
+						MibName: "SNMPv2-MIB",
+						OidText: "snmpTrapOID.0",
+					},
+				},
+				{
+					oid: ".1.3.6.1.6.3.1.1.5.1",
+					e: snmp.MibEntry{
+						MibName: "SNMPv2-MIB",
+						OidText: "coldStart",
+					},
+				},
+				{
+					oid: ".1.3.6.1.2.1.1.3.0",
+					e: snmp.MibEntry{
+						MibName: "UNUSED_MIB_NAME",
+						OidText: "sysUpTimeInstance",
+					},
+				},
+			},
+			expected: []telegraf.Metric{
+				metric.New(
+					"snmp_trap", // name
+					map[string]string{ // tags
+						"oid":     ".1.3.6.1.6.3.1.1.5.1",
+						"name":    "coldStart",
+						"mib":     "SNMPv2-MIB",
+						"version": "3",
+						"source":  "127.0.0.1",
+					},
+					map[string]interface{}{ // fields
+						"sysUpTimeInstance": now,
+					},
+					time.Unix(0, 0),
+				),
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

Adds a regression test to verify that Telegraf correctly handles SNMPv3 passwords longer than 12 characters for the SNMP trap input plugin.

This addresses a user misconception where it was believed that Telegraf had a 12-character password limit for SNMPv3 authentication and privacy passwords. The test demonstrates that Telegraf actually supports long passwords correctly, following SNMP RFC standards.

## Changes

- Add test case to verify SNMPv3 password length handling >12 characters
- Test uses 72-character auth password and 69-character priv password  
- Validates that Telegraf correctly processes long passwords
- Addresses issue where users believed 12-character limit existed
- Includes proper test documentation and GitHub issue reference

## Testing

- [x] New test case passes consistently
- [x] All existing tests continue to pass
- [x] Code follows Go formatting standards (gofmt)
- [x] Test covers complete SNMPv3 authPriv workflow with long passwords

## Checklist

- [ ] No AI generated code was used in this PR
- [x] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

resolves #18273