### PR TITLE
fix(outputs.graylog): Reconnect transparently when TCP peer closes connection

### DIFF
--- a/plugins/outputs/graylog/graylog.go
+++ b/plugins/outputs/graylog/graylog.go
@@ -358,6 +358,7 @@ func (g *Graylog) Connect() error {
 	}
 
 	if g.Reconnection {
+		g.wg.Add(1)
 		go g.connectRetry(tlsCfg)
 		return nil
 	}
@@ -382,11 +383,11 @@ func (g *Graylog) Connect() error {
 }
 
 func (g *Graylog) connectRetry(tlsCfg *tls.Config) {
+	defer g.wg.Done()
+
 	var writers []io.Writer
 	var closers []io.WriteCloser
 	var attempt int64
-
-	g.wg.Add(1)
 
 	servers := make([]string, 0, len(g.Servers))
 	servers = append(servers, g.Servers...)
@@ -418,8 +419,6 @@ func (g *Graylog) connectRetry(tlsCfg *tls.Config) {
 	g.writer = io.MultiWriter(writers...)
 	g.closers = closers
 	g.Unlock()
-
-	g.wg.Done()
 }
 
 func (g *Graylog) connectEndpoints(servers []string, tlsCfg *tls.Config) ([]string, []gelf) {

--- a/plugins/outputs/graylog/graylog.go
+++ b/plugins/outputs/graylog/graylog.go
@@ -305,6 +305,7 @@ func (g *gelfTCP) send(b []byte) error {
 	// only ever write to it. Reconnect and retry the write once before
 	// reporting the error to avoid noisy logs on every graceful close.
 	if err := g.Connect(); err != nil {
+		g.conn = nil
 		return err
 	}
 	return g.writeFrame(b)

--- a/plugins/outputs/graylog/graylog.go
+++ b/plugins/outputs/graylog/graylog.go
@@ -292,25 +292,36 @@ func (g *gelfTCP) Connect() error {
 
 func (g *gelfTCP) send(b []byte) error {
 	if g.conn == nil {
-		err := g.Connect()
-		if err != nil {
+		if err := g.Connect(); err != nil {
 			return err
 		}
 	}
 
-	_, err := g.conn.Write(b)
-	if err != nil {
-		_ = g.conn.Close()
-		g.conn = nil
-	} else {
-		_, err = g.conn.Write([]byte{0}) // message delimiter
-		if err != nil {
-			_ = g.conn.Close()
-			g.conn = nil
-		}
+	if err := g.writeFrame(b); err == nil {
+		return nil
 	}
 
-	return err
+	// The peer may have closed the connection without us noticing because we
+	// only ever write to it. Reconnect and retry the write once before
+	// reporting the error to avoid noisy logs on every graceful close.
+	if err := g.Connect(); err != nil {
+		return err
+	}
+	return g.writeFrame(b)
+}
+
+func (g *gelfTCP) writeFrame(b []byte) error {
+	if _, err := g.conn.Write(b); err != nil {
+		_ = g.conn.Close()
+		g.conn = nil
+		return err
+	}
+	if _, err := g.conn.Write([]byte{0}); err != nil { // message delimiter
+		_ = g.conn.Close()
+		g.conn = nil
+		return err
+	}
+	return nil
 }
 
 type Graylog struct {

--- a/plugins/outputs/graylog/graylog_linux_test.go
+++ b/plugins/outputs/graylog/graylog_linux_test.go
@@ -1,4 +1,4 @@
-//go:build !windows && !darwin
+//go:build linux
 
 package graylog
 
@@ -119,15 +119,15 @@ func TestWriteTCP(t *testing.T) {
 			metrics := testutil.MockMetrics()
 
 			// TCP scenario:
-			// 4 messages are send
-			// -> connection gets forcefully broken after the 2nd message (server closes connection)
-			// -> the 3rd write fails with error
-			// -> during the 4th write connection is restored and write is successful
+			// 4 messages are sent
+			// -> connection gets closed by the server after the 2nd message
+			// -> the 3rd write transparently reconnects and succeeds
+			// -> the 4th write also succeeds on the new connection
 
 			require.NoError(t, plugin.Write(metrics))
 			require.NoError(t, plugin.Write(metrics))
 			require.NoError(t, <-errs)
-			require.ErrorContains(t, plugin.Write(metrics), "error writing message")
+			require.NoError(t, plugin.Write(metrics))
 			require.NoError(t, plugin.Write(metrics))
 		})
 	}
@@ -279,7 +279,9 @@ func TCPServer(t *testing.T, wg *sync.WaitGroup, tlsConfig *tls.Config, errs cha
 		}
 		defer conn.Close()
 
-		// in TCP scenario only 3 messages are received, the 3rd is lost due to simulated connection break after the 2nd
+		// In the TCP scenario the server receives 2 messages on the first
+		// connection, closes it, then receives the remaining 2 messages
+		// after the client transparently reconnects.
 
 		fmt.Println("server: receiving packet 1")
 		err = recv(conn)
@@ -310,6 +312,11 @@ func TCPServer(t *testing.T, wg *sync.WaitGroup, tlsConfig *tls.Config, errs cha
 		}
 		defer conn.Close()
 
+		fmt.Println("server: receiving packet 3")
+		err = recv(conn)
+		if err != nil {
+			fmt.Println(err)
+		}
 		fmt.Println("server: receiving packet 4")
 		err = recv(conn)
 		if err != nil {
@@ -356,7 +363,7 @@ func TestWriteTCPServerDown(t *testing.T) {
 		Log:               testutil.Logger{},
 	}
 	require.NoError(t, dummy.Close())
-	require.ErrorContains(t, plugin.Connect(), "connect: connection refused")
+	require.ErrorContains(t, plugin.Connect(), "connect: connection failed for")
 }
 
 func TestWriteTCPServerUnavailableOnWrite(t *testing.T) {
@@ -421,7 +428,12 @@ func TestWriteTCPServerDownRetry(t *testing.T) {
 	require.NoError(t, dummy.Close())
 	require.NoError(t, plugin.Connect())
 	require.Eventually(t, func() bool {
-		return strings.Contains(logger.LastError(), "after attempt #5...")
+		for _, m := range logger.Messages() {
+			if strings.Contains(m.String(), "after attempt #5...") {
+				return true
+			}
+		}
+		return false
 	}, 5*time.Second, 100*time.Millisecond)
 	require.NoError(t, plugin.Close())
 }


### PR DESCRIPTION



## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Retry the write once on failure after reconnecting so a graceful server close no longer surfaces a 'broken pipe' error on every flush. Also rename graylog_test_linux.go to graylog_linux_test.go so the TCP/UDP tests are actually discovered by 'go test' (Go requires the _test.go suffix), and fix two dormant test bugs this uncovers.

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #18737
