### PR TITLE
chore: typo `occured` -> `occurred` in telegraf reload comment

### DIFF
--- a/cmd/telegraf/telegraf.go
+++ b/cmd/telegraf/telegraf.go
@@ -188,7 +188,7 @@ func (t *Telegraf) reloadLoop() error {
 				if sig == syscall.SIGHUP {
 					log.Println("I! Reloading Telegraf config")
 					// May need to update the list of known config files
-					// if a delete or create occured. That way on the reload
+					// if a delete or create occurred. That way on the reload
 					// we ensure we watch the correct files.
 					if err := t.getConfigFiles(); err != nil {
 						log.Println("E! Error loading config files: ", err)


### PR DESCRIPTION
One-character typo fix inside `cmd/telegraf/telegraf.go:191`. No functional change.

Signed-off-by: SAY-5 <SAY-5@users.noreply.github.com>