### PR TITLE
chore(inputs.huebridge): Plumb gather timeout into go-hue calls

### DIFF
--- a/plugins/inputs/huebridge/huebridge.go
+++ b/plugins/inputs/huebridge/huebridge.go
@@ -90,7 +90,9 @@ func (h *HueBridge) Gather(acc telegraf.Accumulator) error {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			acc.AddError(bridge.process(context.Background(), acc))
+			ctx, cancel := context.WithTimeout(context.Background(), time.Duration(h.Timeout))
+			defer cancel()
+			acc.AddError(bridge.process(ctx, acc))
 		}()
 	}
 	wg.Wait()


### PR DESCRIPTION


## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Follow-up cleanups after the go-hue v1.2.0 upgrade:

- Derive a context.WithTimeout from the configured Timeout in Gather so cancellation and the deadline flow into go-hue's HTTP calls instead of handing the library a bare context.Background().

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
