### PR TITLE
fix(aggregators): Prevent duplicate push on early timer fire

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -766,6 +766,18 @@ func (*Agent) push(ctx context.Context, aggregator *models.RunningAggregator, ac
 
 		select {
 		case <-time.After(until):
+			// Go's timers may fire slightly before the deadline, especially
+			// on platforms with coarse timer granularity. Sleep any remaining
+			// time so Push always runs at or after the window end, never
+			// before.
+			if remaining := time.Until(aggregator.EndPeriod()); remaining > 0 {
+				select {
+				case <-time.After(remaining):
+				case <-ctx.Done():
+					aggregator.Push(acc)
+					return
+				}
+			}
 			aggregator.Push(acc)
 		case <-ctx.Done():
 			aggregator.Push(acc)

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -766,6 +766,16 @@ func (*Agent) push(ctx context.Context, aggregator *models.RunningAggregator, ac
 
 		select {
 		case <-time.After(until):
+			// With round_interval the window end is a wall-clock time while
+			// the timer sleeps on the monotonic clock, so the timer can fire
+			// before the wall clock reaches the window end. Re-arm for the
+			// remainder rather than pushing early, which would reset the
+			// window onto the same slot and push it twice. A remainder of a
+			// full period or more is a clock adjustment, which Push handles
+			// by resetting the window, so let that through.
+			if remaining := time.Until(aggregator.EndPeriod()); remaining > 0 && remaining < aggregator.Period() {
+				continue
+			}
 			aggregator.Push(acc)
 		case <-ctx.Done():
 			aggregator.Push(acc)

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -766,18 +766,6 @@ func (*Agent) push(ctx context.Context, aggregator *models.RunningAggregator, ac
 
 		select {
 		case <-time.After(until):
-			// Go's timers may fire slightly before the deadline, especially
-			// on platforms with coarse timer granularity. Sleep any remaining
-			// time so Push always runs at or after the window end, never
-			// before.
-			if remaining := time.Until(aggregator.EndPeriod()); remaining > 0 {
-				select {
-				case <-time.After(remaining):
-				case <-ctx.Done():
-					aggregator.Push(acc)
-					return
-				}
-			}
 			aggregator.Push(acc)
 		case <-ctx.Done():
 			aggregator.Push(acc)

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -270,3 +270,72 @@ func collect(ctx context.Context, a *Agent, wait time.Duration) ([]telegraf.Metr
 	}
 	return received, nil
 }
+
+// pushRecorder reports the wall-clock time of the first Push.
+type pushRecorder struct {
+	pushed chan time.Time
+}
+
+func (*pushRecorder) SampleConfig() string { return "" }
+func (*pushRecorder) Add(telegraf.Metric)  {}
+func (*pushRecorder) Reset()               {}
+func (r *pushRecorder) Push(telegraf.Accumulator) {
+	select {
+	case r.pushed <- time.Now():
+	default:
+	}
+}
+
+// pushAfterWindowShift runs the aggregator push loop against a window that
+// ends 500ms out, then moves the window end forward by shift while the loop
+// is asleep on its timer. From the loop's point of view that is the same as
+// the wall clock stepping back by shift while it waited. It returns the time
+// of the first Push and the shifted window end.
+func pushAfterWindowShift(t *testing.T, shift time.Duration) (pushed, windowEnd time.Time) {
+	rec := &pushRecorder{pushed: make(chan time.Time, 1)}
+	ra := models.NewRunningAggregator(rec, &models.AggregatorConfig{
+		Name:   "test",
+		Filter: models.Filter{NamePass: []string{"*"}},
+		Period: time.Second,
+	})
+	require.NoError(t, ra.Config.Filter.Compile())
+
+	// Strip the monotonic reading, as AlignTime does under round_interval.
+	end := time.Now().Add(500 * time.Millisecond).Truncate(-1)
+	ra.UpdateWindow(end.Add(-ra.Period()), end)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var acc testutil.Accumulator
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		(&Agent{}).push(ctx, ra, &acc)
+	}()
+
+	// Give the loop time to arm its timer before moving the deadline under
+	// it; the shift has to land while the timer is pending.
+	time.Sleep(50 * time.Millisecond)
+	windowEnd = end.Add(shift)
+	ra.Lock()
+	ra.UpdateWindow(windowEnd.Add(-ra.Period()), windowEnd)
+	ra.Unlock()
+
+	select {
+	case pushed = <-rec.pushed:
+	case <-time.After(5 * time.Second):
+		t.Fatal("no push within 5s")
+	}
+	cancel()
+	<-done
+	return pushed, windowEnd
+}
+
+func TestAggregatorPushWaitsForWindowEndOnEarlyTimer(t *testing.T) {
+	pushed, windowEnd := pushAfterWindowShift(t, 500*time.Millisecond)
+	require.False(t, pushed.Before(windowEnd), "pushed at %v, before the window end %v", pushed, windowEnd)
+}
+
+func TestAggregatorPushDoesNotWaitOutClockAdjustment(t *testing.T) {
+	pushed, windowEnd := pushAfterWindowShift(t, 2*time.Second)
+	require.True(t, pushed.Before(windowEnd), "pushed at %v, waited for the window end %v", pushed, windowEnd)
+}

--- a/models/running_aggregator.go
+++ b/models/running_aggregator.go
@@ -182,12 +182,16 @@ func (r *RunningAggregator) Push(acc telegraf.Accumulator) {
 	since := r.periodEnd
 	until := r.periodEnd.Add(r.Config.Period)
 
-	// Check if the next aggregation window will contain "now". This might
-	// not be the case if the machine's clock was adjusted or the machine
-	// hibernated as in those cases the clock might be advanced before or
-	// after the initial aggregation window.
+	// Reset the window only when the current wall-clock time is outside
+	// the next aggregation window by at least one full period, which
+	// indicates the clock was adjusted or the machine hibernated. Smaller
+	// skew (e.g., a Go timer firing a few ms early) is not a clock jump;
+	// resetting in that case would recompute the same slot and cause Push
+	// to run twice for one period.
 	nowWall := time.Now().Truncate(-1)
-	if nowWall.Before(since.Truncate(-1)) || nowWall.After(until.Truncate(-1)) {
+	earliest := since.Add(-r.Config.Period).Truncate(-1)
+	latest := until.Add(r.Config.Period).Truncate(-1)
+	if nowWall.Before(earliest) || nowWall.After(latest) {
 		since = nowWall.Truncate(r.Config.Period)
 		until = since.Add(r.Config.Period)
 	}

--- a/models/running_aggregator.go
+++ b/models/running_aggregator.go
@@ -183,7 +183,7 @@ func (r *RunningAggregator) Push(acc telegraf.Accumulator) {
 	until := r.periodEnd.Add(r.Config.Period)
 
 	// Reset the window only when the current wall-clock time is outside
-	// the next aggregation window by at least one full period, which
+	// the next aggregation window by more than one full period, which
 	// indicates the clock was adjusted or the machine hibernated. Smaller
 	// skew (e.g., a Go timer firing a few ms early) is not a clock jump;
 	// resetting in that case would recompute the same slot and cause Push

--- a/models/running_aggregator.go
+++ b/models/running_aggregator.go
@@ -116,6 +116,8 @@ func (r *RunningAggregator) Period() time.Duration {
 }
 
 func (r *RunningAggregator) EndPeriod() time.Time {
+	r.Lock()
+	defer r.Unlock()
 	return r.periodEnd
 }
 
@@ -182,16 +184,12 @@ func (r *RunningAggregator) Push(acc telegraf.Accumulator) {
 	since := r.periodEnd
 	until := r.periodEnd.Add(r.Config.Period)
 
-	// Reset the window only when the current wall-clock time is outside
-	// the next aggregation window by more than one full period, which
-	// indicates the clock was adjusted or the machine hibernated. Smaller
-	// skew (e.g., a Go timer firing a few ms early) is not a clock jump;
-	// resetting in that case would recompute the same slot and cause Push
-	// to run twice for one period.
+	// Check if the next aggregation window will contain "now". This might
+	// not be the case if the machine's clock was adjusted or the machine
+	// hibernated as in those cases the clock might be advanced before or
+	// after the initial aggregation window.
 	nowWall := time.Now().Truncate(-1)
-	earliest := since.Add(-r.Config.Period).Truncate(-1)
-	latest := until.Add(r.Config.Period).Truncate(-1)
-	if nowWall.Before(earliest) || nowWall.After(latest) {
+	if nowWall.Before(since.Truncate(-1)) || nowWall.After(until.Truncate(-1)) {
 		since = nowWall.Truncate(r.Config.Period)
 		until = since.Add(r.Config.Period)
 	}

--- a/models/running_aggregator_test.go
+++ b/models/running_aggregator_test.go
@@ -240,6 +240,51 @@ func TestRunningAggregatorAddDoesNotModifyMetric(t *testing.T) {
 	testutil.RequireMetricEqual(t, expected, m)
 }
 
+func TestRunningAggregatorPushAdvancesWindowWhenFiringEarly(t *testing.T) {
+	ra := NewRunningAggregator(&mockAggregator{}, &AggregatorConfig{
+		Name:   "TestRunningAggregator",
+		Filter: Filter{NamePass: []string{"*"}},
+		Period: time.Second,
+	})
+	require.NoError(t, ra.Config.Filter.Compile())
+	acc := testutil.Accumulator{}
+
+	// Simulate a timer firing slightly before periodEnd: set periodEnd
+	// 500ms in the future so time.Now() inside Push falls within the
+	// current window. Before the drift safeguard was loosened, this
+	// tripped the reset and left periodEnd unchanged, causing a second
+	// Push for the same period.
+	windowEnd := time.Now().Add(500 * time.Millisecond)
+	ra.UpdateWindow(windowEnd.Add(-ra.Config.Period), windowEnd)
+
+	ra.Push(&acc)
+
+	require.True(t, ra.EndPeriod().Equal(windowEnd.Add(ra.Config.Period)),
+		"expected periodEnd to advance by one period: want %v, got %v",
+		windowEnd.Add(ra.Config.Period), ra.EndPeriod())
+}
+
+func TestRunningAggregatorPushResetsWindowOnLargeForwardJump(t *testing.T) {
+	// Regression guard for PR #16375: the drift safeguard must still
+	// reset the window when the wall clock is more than one period
+	// beyond the expected window, such as after hibernation.
+	ra := NewRunningAggregator(&mockAggregator{}, &AggregatorConfig{
+		Name:   "TestRunningAggregator",
+		Filter: Filter{NamePass: []string{"*"}},
+		Period: time.Second,
+	})
+	require.NoError(t, ra.Config.Filter.Compile())
+	acc := testutil.Accumulator{}
+
+	staleEnd := time.Now().Add(-2 * time.Minute)
+	ra.UpdateWindow(staleEnd.Add(-ra.Config.Period), staleEnd)
+
+	ra.Push(&acc)
+
+	require.Less(t, time.Since(ra.EndPeriod()).Abs(), 2*ra.Config.Period,
+		"expected safeguard to reset window near current time, got %v", ra.EndPeriod())
+}
+
 type mockAggregator struct {
 	sum int64
 }

--- a/models/running_aggregator_test.go
+++ b/models/running_aggregator_test.go
@@ -244,17 +244,18 @@ func TestRunningAggregatorPushAdvancesWindowWhenFiringEarly(t *testing.T) {
 	ra := NewRunningAggregator(&mockAggregator{}, &AggregatorConfig{
 		Name:   "TestRunningAggregator",
 		Filter: Filter{NamePass: []string{"*"}},
-		Period: time.Second,
+		Period: 10 * time.Second,
 	})
 	require.NoError(t, ra.Config.Filter.Compile())
 	acc := testutil.Accumulator{}
 
-	// Simulate a timer firing slightly before periodEnd: set periodEnd
-	// 500ms in the future so time.Now() inside Push falls within the
-	// current window. Before the drift safeguard was loosened, this
-	// tripped the reset and left periodEnd unchanged, causing a second
-	// Push for the same period.
-	windowEnd := time.Now().Add(500 * time.Millisecond)
+	// Simulate a timer firing before periodEnd: set periodEnd in the
+	// future so time.Now() inside Push falls within the current window.
+	// Before the drift safeguard was loosened, this tripped the reset and
+	// left periodEnd unchanged, causing a second Push for the same period.
+	// The lead has to stay below one period or the safeguard resets the
+	// window for the wrong reason, so keep it well inside that bound.
+	windowEnd := time.Now().Add(5 * time.Second)
 	ra.UpdateWindow(windowEnd.Add(-ra.Config.Period), windowEnd)
 
 	ra.Push(&acc)
@@ -271,7 +272,7 @@ func TestRunningAggregatorPushResetsWindowOnLargeForwardJump(t *testing.T) {
 	ra := NewRunningAggregator(&mockAggregator{}, &AggregatorConfig{
 		Name:   "TestRunningAggregator",
 		Filter: Filter{NamePass: []string{"*"}},
-		Period: time.Second,
+		Period: 10 * time.Second,
 	})
 	require.NoError(t, ra.Config.Filter.Compile())
 	acc := testutil.Accumulator{}
@@ -281,8 +282,8 @@ func TestRunningAggregatorPushResetsWindowOnLargeForwardJump(t *testing.T) {
 
 	ra.Push(&acc)
 
-	require.Less(t, time.Since(ra.EndPeriod()).Abs(), 2*ra.Config.Period,
-		"expected safeguard to reset window near current time, got %v", ra.EndPeriod())
+	// After a reset the new window end lands in (now, now+period].
+	require.WithinDuration(t, time.Now(), ra.EndPeriod(), ra.Config.Period)
 }
 
 type mockAggregator struct {

--- a/models/running_aggregator_test.go
+++ b/models/running_aggregator_test.go
@@ -240,35 +240,10 @@ func TestRunningAggregatorAddDoesNotModifyMetric(t *testing.T) {
 	testutil.RequireMetricEqual(t, expected, m)
 }
 
-func TestRunningAggregatorPushAdvancesWindowWhenFiringEarly(t *testing.T) {
-	ra := NewRunningAggregator(&mockAggregator{}, &AggregatorConfig{
-		Name:   "TestRunningAggregator",
-		Filter: Filter{NamePass: []string{"*"}},
-		Period: 10 * time.Second,
-	})
-	require.NoError(t, ra.Config.Filter.Compile())
-	acc := testutil.Accumulator{}
-
-	// Simulate a timer firing before periodEnd: set periodEnd in the
-	// future so time.Now() inside Push falls within the current window.
-	// Before the drift safeguard was loosened, this tripped the reset and
-	// left periodEnd unchanged, causing a second Push for the same period.
-	// The lead has to stay below one period or the safeguard resets the
-	// window for the wrong reason, so keep it well inside that bound.
-	windowEnd := time.Now().Add(5 * time.Second)
-	ra.UpdateWindow(windowEnd.Add(-ra.Config.Period), windowEnd)
-
-	ra.Push(&acc)
-
-	require.True(t, ra.EndPeriod().Equal(windowEnd.Add(ra.Config.Period)),
-		"expected periodEnd to advance by one period: want %v, got %v",
-		windowEnd.Add(ra.Config.Period), ra.EndPeriod())
-}
-
 func TestRunningAggregatorPushResetsWindowOnLargeForwardJump(t *testing.T) {
-	// Regression guard for PR #16375: the drift safeguard must still
-	// reset the window when the wall clock is more than one period
-	// beyond the expected window, such as after hibernation.
+	// Regression guard for PR #16375: the drift safeguard must reset the
+	// window when the wall clock is beyond the expected window, such as
+	// after hibernation.
 	ra := NewRunningAggregator(&mockAggregator{}, &AggregatorConfig{
 		Name:   "TestRunningAggregator",
 		Filter: Filter{NamePass: []string{"*"}},


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

Aggregator plugins with a configured `period` emit two flushed batches at every period boundary instead of one. Reported on Docker Desktop for Windows and WSL2, but it can happen on any host whose wall clock lags the monotonic clock slightly, such as under NTP slewing or VM clock drift.

#### Root cause

With `round_interval` enabled (the default) the aggregation window end comes out of `AlignTime` with its monotonic reading stripped, so the agent's `time.Until(EndPeriod())` measures the wall clock while the timer sleeps on the monotonic clock. When the wall clock lags by even a millisecond the timer wakes up a hair before the wall-clock window end and calls `Push` early.

`RunningAggregator.Push()` contains a safeguard from #16375 that resets the window when the wall clock is outside the next window, so a clock adjustment or hibernation does not leave the aggregator on a stale window. Called a hair early, that check trips, and its reset recomputes the same slot. `periodEnd` does not advance, the agent loop sees `EndPeriod()` already reached, and it fires a second `Push` for the same period immediately.

Trace from the reported log:
- `08:12:59.998` - timer fires 2 ms early, safeguard rewinds window to `[08:12:00, 08:13:00]`, Push runs.
- `08:13:00.054` - agent loop fires again (EndPeriod unchanged), Push runs a second time.

#### Fix

The push loop re-arms for the remainder when the timer wakes up before the wall-clock window end, so `Push` is not called early. The re-arm is bounded to under one period: a remainder of a full period or more is a clock adjustment, and `Push` runs so the safeguard resets the window as before. An unbounded wait stalls the loop by the size of any backward clock step, and loosening the safeguard's tolerance instead drops the metrics arriving until the wall clock catches up, so neither of those is used. `EndPeriod()` now takes the aggregator lock so the new agent test can move the window under the sleeping loop without racing.

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #18066
