### PR TITLE
feat(outputs.opensearch): Implement startup-error-behavior options

### DIFF
--- a/plugins/outputs/opensearch/README.md
+++ b/plugins/outputs/opensearch/README.md
@@ -21,6 +21,21 @@ plugin ordering. See [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 [CONFIGURATION.md]: ../../../docs/CONFIGURATION.md#plugins
 
+## Startup error behavior options <!-- @/docs/includes/startup_error_behavior.md -->
+
+In addition to the plugin-specific and global configuration settings the plugin
+supports options for specifying the behavior when experiencing startup errors
+using the `startup_error_behavior` setting. Available values are:
+
+- `error`:  Telegraf with stop and exit in case of startup errors. This is the
+            default behavior.
+- `ignore`: Telegraf will ignore startup errors for this plugin and disables it
+            but continues processing for all other plugins.
+- `retry`:  Telegraf will try to startup the plugin in every gather or write
+            cycle in case of startup errors. The plugin is disabled until
+            the startup succeeds.
+
+
 ## Configuration
 
 ```toml @sample.conf

--- a/plugins/outputs/opensearch/README.md
+++ b/plugins/outputs/opensearch/README.md
@@ -34,7 +34,9 @@ using the `startup_error_behavior` setting. Available values are:
 - `retry`:  Telegraf will try to startup the plugin in every gather or write
             cycle in case of startup errors. The plugin is disabled until
             the startup succeeds.
-
+- `probe`:  Telegraf will probe the plugin's function (if possible) and disables
+            the plugin in case probing fails. If the plugin does not support
+            probing, Telegraf will behave as if `ignore` was set instead.
 
 ## Configuration
 

--- a/plugins/outputs/opensearch/README.md
+++ b/plugins/outputs/opensearch/README.md
@@ -146,9 +146,9 @@ using the `startup_error_behavior` setting. Available values are:
 
 ### Required parameters
 
-* `urls`: A list containing the full HTTP URL of one or more nodes from your
+- `urls`: A list containing the full HTTP URL of one or more nodes from your
   OpenSearch instance.
-* `index_name`: The target index for metrics. You can use the date format
+- `index_name`: The target index for metrics. You can use the date format
 
 For example: "telegraf-{{.Time.Format \"2006-01-02\"}}" would set it to
 "telegraf-2023-07-27". You can also specify metric name (`{{ .Name }}`), tag

--- a/plugins/outputs/opensearch/opensearch.go
+++ b/plugins/outputs/opensearch/opensearch.go
@@ -145,7 +145,7 @@ func (o *Opensearch) Connect() error {
 	_, err = o.osClient.Ping()
 	if err != nil {
 		return &internal.StartupError{
-			Err:   err,
+			Err:   fmt.Errorf("unable to ping server: %w", err),
 			Retry: true,
 		}
 	}

--- a/plugins/outputs/opensearch/opensearch.go
+++ b/plugins/outputs/opensearch/opensearch.go
@@ -135,18 +135,21 @@ func (o *Opensearch) Connect() error {
 		o.Log.Errorf("error creating OpenSearch client: %v", err)
 	}
 
-	if o.ManageTemplate {
-		err := o.manageTemplate(ctx)
-		if err != nil {
-			return err
-		}
-	}
-
 	_, err = o.osClient.Ping()
 	if err != nil {
 		return &internal.StartupError{
-			Err:   fmt.Errorf("unable to ping server: %w", err),
+			Err:   fmt.Errorf("unable to ping OpenSearch server: %w", err),
 			Retry: true,
+		}
+	}
+
+	if o.ManageTemplate {
+		err := o.manageTemplate(ctx)
+		if err != nil {
+			return &internal.StartupError{
+				Err:   err,
+				Retry: true,
+			}
 		}
 	}
 

--- a/plugins/outputs/opensearch/opensearch.go
+++ b/plugins/outputs/opensearch/opensearch.go
@@ -143,7 +143,7 @@ func (o *Opensearch) Connect() error {
 
 	_, err = o.osClient.Ping()
 	if err != nil {
-		return fmt.Errorf("unable to ping OpenSearch server: %w", err)
+		o.Log.Errorf("unable to ping OpenSearch server: %v", err)
 	}
 
 	return nil

--- a/plugins/outputs/opensearch/opensearch.go
+++ b/plugins/outputs/opensearch/opensearch.go
@@ -113,6 +113,16 @@ func (o *Opensearch) Init() error {
 		return errors.New("template_name configuration not defined")
 	}
 
+	if o.ManageTemplate {
+		prefix := o.IndexName
+		if idx := strings.Index(prefix, "{{"); idx >= 0 {
+			prefix = prefix[:idx]
+		}
+		if prefix == "" {
+			return errors.New("template cannot be created for dynamic index names without an index prefix")
+		}
+	}
+
 	return nil
 }
 

--- a/plugins/outputs/opensearch/opensearch.go
+++ b/plugins/outputs/opensearch/opensearch.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
+	"github.com/influxdata/telegraf/internal"
 	"github.com/influxdata/telegraf/internal/choice"
 	"github.com/influxdata/telegraf/plugins/common/tls"
 	"github.com/influxdata/telegraf/plugins/outputs"
@@ -143,7 +144,10 @@ func (o *Opensearch) Connect() error {
 
 	_, err = o.osClient.Ping()
 	if err != nil {
-		o.Log.Errorf("unable to ping OpenSearch server: %v", err)
+		return &internal.StartupError{
+			Err:   err,
+			Retry: true,
+		}
 	}
 
 	return nil

--- a/plugins/outputs/opensearch/opensearch.go
+++ b/plugins/outputs/opensearch/opensearch.go
@@ -135,7 +135,7 @@ func (o *Opensearch) Connect() error {
 		o.Log.Errorf("error creating OpenSearch client: %v", err)
 	}
 
-	_, err = o.osClient.Ping()
+	_, err = o.osClient.Ping(o.osClient.Ping.WithContext(ctx))
 	if err != nil {
 		return &internal.StartupError{
 			Err:   fmt.Errorf("unable to ping OpenSearch server: %w", err),

--- a/plugins/outputs/opensearch/opensearch_test.go
+++ b/plugins/outputs/opensearch/opensearch_test.go
@@ -312,6 +312,7 @@ func TestDisconnectedServerOnConnect(t *testing.T) {
 
 func TestConnectionIssueAtStartup(t *testing.T) {
 	ts := httptest.NewUnstartedServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {}))
+	defer ts.Close()
 
 	urls := []string{"http://" + ts.Listener.Addr().String()}
 
@@ -319,7 +320,7 @@ func TestConnectionIssueAtStartup(t *testing.T) {
 		URLs:            urls,
 		ManageTemplate:  true,
 		TemplateName:    "telegraf",
-		IndexName:       `{{.Tag "tag1"}}-{{.Time.Format "2006-01-02"}}`,
+		IndexName:       `test-{{.Tag "tag1"}}-{{.Time.Format "2006-01-02"}}`,
 		Timeout:         config.Duration(time.Second * 5),
 		AuthBearerToken: config.NewSecret([]byte("0123456789abcdef")),
 		Log:             testutil.Logger{},
@@ -339,6 +340,7 @@ func TestConnectionIssueAtStartup(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.NoError(t, model.Init())
+	t.Cleanup(func() { model.Close() })
 
 	// The connect call should not fail even though the server is closed due to the "retry" strategy
 	require.NoError(t, model.Connect())
@@ -353,9 +355,6 @@ func TestConnectionIssueAtStartup(t *testing.T) {
 	// Start the server and check that writes succeed
 	ts.Start()
 	require.NoError(t, model.WriteBatch())
-
-	defer ts.Close()
-	model.Close()
 }
 
 func TestDisconnectedServerOnWrite(t *testing.T) {

--- a/plugins/outputs/opensearch/opensearch_test.go
+++ b/plugins/outputs/opensearch/opensearch_test.go
@@ -305,7 +305,7 @@ func TestDisconnectedServerOnConnect(t *testing.T) {
 
 	// Close the server right before we try to connect.
 	ts.Close()
-	require.Error(t, e.Connect())
+	require.NoError(t, e.Connect())
 }
 
 func TestDisconnectedServerOnWrite(t *testing.T) {

--- a/plugins/outputs/opensearch/opensearch_test.go
+++ b/plugins/outputs/opensearch/opensearch_test.go
@@ -311,17 +311,14 @@ func TestDisconnectedServerOnConnect(t *testing.T) {
 }
 
 func TestConnectionIssueAtStartup(t *testing.T) {
-	// Test case for https://github.com/influxdata/telegraf/issues/18783
-	if testing.Short() {
-		t.Skip("Skipping integration test in short mode")
-	}
-
-	ts := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {}))
+	ts := httptest.NewUnstartedServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {}))
 
 	urls := []string{"http://" + ts.Listener.Addr().String()}
 
 	plugin := &Opensearch{
 		URLs:            urls,
+		ManageTemplate:  true,
+		TemplateName:    "telegraf",
 		IndexName:       `{{.Tag "tag1"}}-{{.Time.Format "2006-01-02"}}`,
 		Timeout:         config.Duration(time.Second * 5),
 		AuthBearerToken: config.NewSecret([]byte("0123456789abcdef")),
@@ -330,9 +327,6 @@ func TestConnectionIssueAtStartup(t *testing.T) {
 	var err error
 	plugin.indexTmpl, err = template.New("index").Parse(plugin.IndexName)
 	require.NoError(t, err)
-
-	// Close the server before we try to connect
-	ts.Close()
 
 	// Create a model to be able to use the startup retry strategy
 	model, err := models.NewRunningOutput(
@@ -360,8 +354,8 @@ func TestConnectionIssueAtStartup(t *testing.T) {
 	ts.Start()
 	require.NoError(t, model.WriteBatch())
 
-	ts.Close()
-	model.Close()
+	defer ts.Close()
+	defer model.Close()
 }
 
 func TestDisconnectedServerOnWrite(t *testing.T) {

--- a/plugins/outputs/opensearch/opensearch_test.go
+++ b/plugins/outputs/opensearch/opensearch_test.go
@@ -355,7 +355,7 @@ func TestConnectionIssueAtStartup(t *testing.T) {
 	require.NoError(t, model.WriteBatch())
 
 	defer ts.Close()
-	defer model.Close()
+	model.Close()
 }
 
 func TestDisconnectedServerOnWrite(t *testing.T) {

--- a/plugins/outputs/opensearch/opensearch_test.go
+++ b/plugins/outputs/opensearch/opensearch_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/testcontainers/testcontainers-go/wait"
 
 	"github.com/influxdata/telegraf/config"
+	"github.com/influxdata/telegraf/internal"
+	"github.com/influxdata/telegraf/models"
 	"github.com/influxdata/telegraf/testutil"
 )
 
@@ -305,7 +307,63 @@ func TestDisconnectedServerOnConnect(t *testing.T) {
 
 	// Close the server right before we try to connect.
 	ts.Close()
-	require.NoError(t, e.Connect())
+	require.Error(t, e.Connect())
+}
+
+func TestConnectionIssueAtStartup(t *testing.T) {
+	// Test case for https://github.com/influxdata/telegraf/issues/18783
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {}))
+
+	urls := []string{"http://" + ts.Listener.Addr().String()}
+
+	plugin := &Opensearch{
+		URLs:            urls,
+		IndexName:       `{{.Tag "tag1"}}-{{.Time.Format "2006-01-02"}}`,
+		Timeout:         config.Duration(time.Second * 5),
+		EnableGzip:      false,
+		ManageTemplate:  false,
+		Log:             testutil.Logger{},
+		AuthBearerToken: config.NewSecret([]byte("0123456789abcdef")),
+	}
+	var err error
+	plugin.indexTmpl, err = template.New("index").Parse(plugin.IndexName)
+	require.NoError(t, err)
+
+	// Close the server before we try to connect
+	ts.Close()
+
+	// Create a model to be able to use the startup retry strategy
+	model, err := models.NewRunningOutput(
+		plugin,
+		&models.OutputConfig{
+			Name:                 "opensearch",
+			StartupErrorBehavior: "retry",
+		},
+		1000, 1000,
+	)
+	require.NoError(t, err)
+	require.NoError(t, model.Init())
+
+	// The connect call should not fail even though the server is closed due to the "retry" strategy
+	require.NoError(t, model.Connect())
+
+	// Writing metrics in this state should fail since server is closed
+	metrics := testutil.MockMetrics()
+	for _, m := range metrics {
+		model.AddMetric(m)
+	}
+	require.ErrorIs(t, model.WriteBatch(), internal.ErrNotConnected)
+
+	// Start the server and check that writes succeed
+	ts.Start()
+	require.NoError(t, model.WriteBatch())
+
+	ts.Close()
+	model.Close()
 }
 
 func TestDisconnectedServerOnWrite(t *testing.T) {

--- a/plugins/outputs/opensearch/opensearch_test.go
+++ b/plugins/outputs/opensearch/opensearch_test.go
@@ -324,10 +324,8 @@ func TestConnectionIssueAtStartup(t *testing.T) {
 		URLs:            urls,
 		IndexName:       `{{.Tag "tag1"}}-{{.Time.Format "2006-01-02"}}`,
 		Timeout:         config.Duration(time.Second * 5),
-		EnableGzip:      false,
-		ManageTemplate:  false,
-		Log:             testutil.Logger{},
 		AuthBearerToken: config.NewSecret([]byte("0123456789abcdef")),
+		Log:             testutil.Logger{},
 	}
 	var err error
 	plugin.indexTmpl, err = template.New("index").Parse(plugin.IndexName)


### PR DESCRIPTION

## Summary

Telegraf will fail on start if there's no network path to the output opensearch service. In scenarios where the local device occasionally has no internet, this shouldn't hard fail telegraf's start sequence. Telegraf can start collecting and buffering metrics to send to opensearch when possible.

The current implementation works fine if the connection to opensearch is available on boot, then the buffering of metrics works as expected

## Checklist

- [x] No AI generated code was used in this PR
- [x] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

resolves #18783
