### PR TITLE
fix(secretstores.googlecloud): Handle public GCP service account keys correctly

### DIFF
--- a/plugins/secretstores/googlecloud/README.md
+++ b/plugins/secretstores/googlecloud/README.md
@@ -27,6 +27,12 @@ store usage.
   ## Path to the service account credentials file
   credentials_file = "./testdata/gdch.json"
 
+  ## Scopes for the generated access token.
+  ## Only used for standard public-GCP service-account JSON keys ("type": "service_account").
+  ## Defaults to the minimal scope needed for Cloud Monitoring / Stackdriver.
+  ## GDCH/STS users should leave this unset (they rely on sts_audience instead).
+  # scopes = ["https://www.googleapis.com/auth/monitoring"]
+
   ## Audience sent to when retrieving an STS token.
   ## Currently only used for GDCH auth flow
   sts_audience = "https://{AUDIENCE_URL}"

--- a/plugins/secretstores/googlecloud/README.md
+++ b/plugins/secretstores/googlecloud/README.md
@@ -27,10 +27,11 @@ store usage.
   ## Path to the service account credentials file
   credentials_file = "./testdata/gdch.json"
 
-  ## Scopes for the generated access token
-  ## Required for public-GCP service-accounts; GDCH/STS users can
-  ## ignore this option as only the audience parameter is evaluated.
-  # credential_scopes = ["https://www.googleapis.com/auth/monitoring"]
+  ## OAuth2 scopes for the generated access token.
+  ## Defaults to cloud-platform for service-account credentials.
+  ## GDCH/STS users can ignore this option as only the audience
+  ## parameter is evaluated for those credential types.
+  # scopes = ["https://www.googleapis.com/auth/cloud-platform"]
 
   ## Audience sent to when retrieving an STS token.
   ## Currently only used for GDCH auth flow

--- a/plugins/secretstores/googlecloud/README.md
+++ b/plugins/secretstores/googlecloud/README.md
@@ -27,11 +27,10 @@ store usage.
   ## Path to the service account credentials file
   credentials_file = "./testdata/gdch.json"
 
-  ## Scopes for the generated access token.
-  ## Only used for standard public-GCP service-account JSON keys ("type": "service_account").
-  ## Defaults to the minimal scope needed for Cloud Monitoring / Stackdriver.
-  ## GDCH/STS users should leave this unset (they rely on sts_audience instead).
-  credential_scopes = ["https://www.googleapis.com/auth/monitoring"]
+  ## Scopes for the generated access token
+  ## Required for public-GCP service-accounts; GDCH/STS users can
+  ## ignore this option as only the audience parameter is evaluated.
+  # credential_scopes = ["https://www.googleapis.com/auth/monitoring"]
 
   ## Audience sent to when retrieving an STS token.
   ## Currently only used for GDCH auth flow

--- a/plugins/secretstores/googlecloud/README.md
+++ b/plugins/secretstores/googlecloud/README.md
@@ -31,7 +31,7 @@ store usage.
   ## Only used for standard public-GCP service-account JSON keys ("type": "service_account").
   ## Defaults to the minimal scope needed for Cloud Monitoring / Stackdriver.
   ## GDCH/STS users should leave this unset (they rely on sts_audience instead).
-  # scopes = ["https://www.googleapis.com/auth/monitoring"]
+  credential_scopes = ["https://www.googleapis.com/auth/monitoring"]
 
   ## Audience sent to when retrieving an STS token.
   ## Currently only used for GDCH auth flow

--- a/plugins/secretstores/googlecloud/googlecloud.go
+++ b/plugins/secretstores/googlecloud/googlecloud.go
@@ -28,7 +28,7 @@ func (*GoogleCloud) SampleConfig() string {
 type GoogleCloud struct {
 	STSAudience     string          `toml:"sts_audience"`
 	CredentialsFile string          `toml:"credentials_file"`
-	Scopes          []string        `toml:"credential_scopes"` // used for standard public-GCP service_account keys
+	CredentialScopes          []string        `toml:"credential_scopes"`
 	Log             telegraf.Logger `toml:"-"`
 	common_http.HTTPClientConfig
 

--- a/plugins/secretstores/googlecloud/googlecloud.go
+++ b/plugins/secretstores/googlecloud/googlecloud.go
@@ -28,7 +28,6 @@ func (*GoogleCloud) SampleConfig() string {
 type GoogleCloud struct {
 	STSAudience     string          `toml:"sts_audience"`
 	CredentialsFile string          `toml:"credentials_file"`
-	CredentialScopes          []string        `toml:"credential_scopes"`
 	Log             telegraf.Logger `toml:"-"`
 	common_http.HTTPClientConfig
 
@@ -51,10 +50,11 @@ func (g *GoogleCloud) Init() error {
 		return fmt.Errorf("unable to parse credentials file type: %w", err)
 	}
 
-	// Default minimal scope only for standard public-GCP service-account JSON keys.
+	// Default to cloud-platform scope for standard public-GCP service-account JSON keys.
+	// This covers all GCP APIs; actual permissions are still gated by IAM roles.
 	// GDCH/STS users continue to rely exclusively on sts_audience (Scopes is ignored).
 	if len(g.Scopes) == 0 && credType == "service_account" {
-		g.Scopes = []string{"https://www.googleapis.com/auth/monitoring"}
+		g.Scopes = []string{"https://www.googleapis.com/auth/cloud-platform"}
 	}
 
 	saType := credentials.CredType(credType)

--- a/plugins/secretstores/googlecloud/googlecloud.go
+++ b/plugins/secretstores/googlecloud/googlecloud.go
@@ -28,6 +28,7 @@ func (*GoogleCloud) SampleConfig() string {
 type GoogleCloud struct {
 	STSAudience     string          `toml:"sts_audience"`
 	CredentialsFile string          `toml:"credentials_file"`
+	Scopes          []string        `toml:"scopes"` // used for standard public-GCP service_account keys
 	Log             telegraf.Logger `toml:"-"`
 	common_http.HTTPClientConfig
 
@@ -49,9 +50,17 @@ func (g *GoogleCloud) Init() error {
 	if err != nil {
 		return fmt.Errorf("unable to parse credentials file type: %w", err)
 	}
+
+	// Default minimal scope only for standard public-GCP service-account JSON keys.
+	// GDCH/STS users continue to rely exclusively on sts_audience (Scopes is ignored).
+	if len(g.Scopes) == 0 && credType == "service_account" {
+		g.Scopes = []string{"https://www.googleapis.com/auth/monitoring"}
+	}
+
 	saType := credentials.CredType(credType)
 
 	creds, err := credentials.NewCredentialsFromJSON(saType, serviceAccount, &credentials.DetectOptions{
+		Scopes:      g.Scopes, // new
 		STSAudience: g.STSAudience,
 		Client:      client,
 		Logger:      slog.NewLogger(g.Log),

--- a/plugins/secretstores/googlecloud/googlecloud.go
+++ b/plugins/secretstores/googlecloud/googlecloud.go
@@ -28,7 +28,7 @@ func (*GoogleCloud) SampleConfig() string {
 type GoogleCloud struct {
 	STSAudience     string          `toml:"sts_audience"`
 	CredentialsFile string          `toml:"credentials_file"`
-	Scopes          []string        `toml:"scopes"` // used for standard public-GCP service_account keys
+	Scopes          []string        `toml:"credential_scopes"` // used for standard public-GCP service_account keys
 	Log             telegraf.Logger `toml:"-"`
 	common_http.HTTPClientConfig
 

--- a/plugins/secretstores/googlecloud/googlecloud.go
+++ b/plugins/secretstores/googlecloud/googlecloud.go
@@ -60,7 +60,7 @@ func (g *GoogleCloud) Init() error {
 	saType := credentials.CredType(credType)
 
 	creds, err := credentials.NewCredentialsFromJSON(saType, serviceAccount, &credentials.DetectOptions{
-		Scopes:      g.Scopes, // new
+		Scopes:      g.Scopes,
 		STSAudience: g.STSAudience,
 		Client:      client,
 		Logger:      slog.NewLogger(g.Log),

--- a/plugins/secretstores/googlecloud/sample.conf
+++ b/plugins/secretstores/googlecloud/sample.conf
@@ -8,11 +8,10 @@
   ## Path to the service account credentials file
   credentials_file = "./testdata/gdch.json"
 
-  ## Scopes for the generated access token.
-  ## Only used for standard public-GCP service-account JSON keys ("type": "service_account").
-  ## Defaults to the minimal scope needed for Cloud Monitoring / Stackdriver.
-  ## GDCH/STS users should leave this unset (they rely on sts_audience instead).
-  credential_scopes = ["https://www.googleapis.com/auth/monitoring"]
+  ## Scopes for the generated access token
+  ## Required for public-GCP service-accounts; GDCH/STS users can
+  ## ignore this option as only the audience parameter is evaluated.
+  # credential_scopes = ["https://www.googleapis.com/auth/monitoring"]
 
   ## Audience sent to when retrieving an STS token.
   ## Currently only used for GDCH auth flow

--- a/plugins/secretstores/googlecloud/sample.conf
+++ b/plugins/secretstores/googlecloud/sample.conf
@@ -8,6 +8,12 @@
   ## Path to the service account credentials file
   credentials_file = "./testdata/gdch.json"
 
+  ## Scopes for the generated access token.
+  ## Only used for standard public-GCP service-account JSON keys ("type": "service_account").
+  ## Defaults to the minimal scope needed for Cloud Monitoring / Stackdriver.
+  ## GDCH/STS users should leave this unset (they rely on sts_audience instead).
+  # scopes = ["https://www.googleapis.com/auth/monitoring"]
+
   ## Audience sent to when retrieving an STS token.
   ## Currently only used for GDCH auth flow
   sts_audience = "https://{AUDIENCE_URL}"

--- a/plugins/secretstores/googlecloud/sample.conf
+++ b/plugins/secretstores/googlecloud/sample.conf
@@ -12,7 +12,7 @@
   ## Only used for standard public-GCP service-account JSON keys ("type": "service_account").
   ## Defaults to the minimal scope needed for Cloud Monitoring / Stackdriver.
   ## GDCH/STS users should leave this unset (they rely on sts_audience instead).
-  # scopes = ["https://www.googleapis.com/auth/monitoring"]
+  credential_scopes = ["https://www.googleapis.com/auth/monitoring"]
 
   ## Audience sent to when retrieving an STS token.
   ## Currently only used for GDCH auth flow

--- a/plugins/secretstores/googlecloud/sample.conf
+++ b/plugins/secretstores/googlecloud/sample.conf
@@ -8,10 +8,11 @@
   ## Path to the service account credentials file
   credentials_file = "./testdata/gdch.json"
 
-  ## Scopes for the generated access token
-  ## Required for public-GCP service-accounts; GDCH/STS users can
-  ## ignore this option as only the audience parameter is evaluated.
-  # credential_scopes = ["https://www.googleapis.com/auth/monitoring"]
+  ## OAuth2 scopes for the generated access token.
+  ## Defaults to cloud-platform for service-account credentials.
+  ## GDCH/STS users can ignore this option as only the audience
+  ## parameter is evaluated for those credential types.
+  # scopes = ["https://www.googleapis.com/auth/cloud-platform"]
 
   ## Audience sent to when retrieving an STS token.
   ## Currently only used for GDCH auth flow


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
When using a normal GCP service-account key (the JSON downloaded from the Cloud Console, type: "service_account") with the new secret store

+ token = "@{id:token}" pattern in outputs.stackdriver, the Google auth library previously received an unscoped token that was rejected by the Monitoring API.

This change adds a tiny guarded default in Init():

- If credType == "service_account" and no scopes are explicitly set, automatically use [""https://www.googleapis.com/auth/cloud-platform"].


No changes to stackdriver.go or any other plugin — keeps the PR as small and low-risk as possible

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [ ] No AI generated code was used in this PR
- [x] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #16326 