### PR TITLE
feat(secretstores.vault): Add token authentication

### DIFF
--- a/plugins/secretstores/vault/README.md
+++ b/plugins/secretstores/vault/README.md
@@ -65,7 +65,7 @@ store usage.
   ## secret-store, e.g. @{other_store:vault_token}). Use "approle" to have
   ## Telegraf authenticate via the AppRole method and manage token renewal.
 
-  ## Vault token
+  ## Vault token used to authenticate with the server
   # token = ""
 
   # [secretstores.vault.approle]

--- a/plugins/secretstores/vault/README.md
+++ b/plugins/secretstores/vault/README.md
@@ -2,7 +2,17 @@
 
 The `vault` plugin allows to utilize secrets stored in a
 [HashiCorp Vault][vault] server via the Vault API. It supports authentication
-via AppRole.
+via a pre-obtained Vault token or via the AppRole method.
+
+When authenticating with a `token`, the token may be provided directly or
+chained from another secret-store (e.g. `@{other_store:vault_token}`). This
+lets you obtain a token through any mechanism another secret-store can
+produce (OAuth2, file, environment, etc.) and hand it to this plugin. Token
+renewal is the responsibility of the supplying source.
+
+When authenticating with `approle`, the plugin logs in with the configured
+Role ID and Secret ID and starts a lifetime watcher to keep the token
+renewed.
 
 ⭐ Telegraf v1.37.0
 🏷️ secrets
@@ -49,15 +59,24 @@ store usage.
   ## By default will use the kv-v2 engine.
   # engine = "kv-v2"
 
-  [secretstores.vault.approle]
-    ## The Role ID for AppRole Authentication, a UUID string
-    role_id = ""
+  ## Authentication
+  ## Exactly one of "token" or "approle" must be configured. Use "token" to
+  ## pass an already-obtained Vault token (directly or via another
+  ## secret-store, e.g. @{other_store:vault_token}). Use "approle" to have
+  ## Telegraf authenticate via the AppRole method and manage token renewal.
 
-    ## Whether the Secret ID is configured to be response wrapped or not
-    # response_wrapped = false
+  ## Vault token
+  # token = ""
 
-    ## The Secret ID for AppRole Authentication
-    secret = ""
+  # [secretstores.vault.approle]
+  #   ## The Role ID for AppRole Authentication, a UUID string
+  #   role_id = ""
+  #
+  #   ## Whether the Secret ID is configured to be response wrapped or not
+  #   # response_wrapped = false
+  #
+  #   ## The Secret ID for AppRole Authentication
+  #   secret = ""
 ```
 
 [vault]: https://www.hashicorp.com/en/products/vault

--- a/plugins/secretstores/vault/README.md
+++ b/plugins/secretstores/vault/README.md
@@ -4,16 +4,6 @@ The `vault` plugin allows to utilize secrets stored in a
 [HashiCorp Vault][vault] server via the Vault API. It supports authentication
 via a pre-obtained Vault token or via the AppRole method.
 
-When authenticating with a `token`, the token may be provided directly or
-chained from another secret-store (e.g. `@{other_store:vault_token}`). This
-lets you obtain a token through any mechanism another secret-store can
-produce (OAuth2, file, environment, etc.) and hand it to this plugin. Token
-renewal is the responsibility of the supplying source.
-
-When authenticating with `approle`, the plugin logs in with the configured
-Role ID and Secret ID and starts a lifetime watcher to keep the token
-renewed.
-
 ⭐ Telegraf v1.37.0
 🏷️ secrets
 💻 all
@@ -29,6 +19,18 @@ secrets, see their respective documentation (e.g.
 store usage.
 
 ## Configuration
+
+### Authentication
+
+When authenticating with a `token`, the token may be provided directly or
+chained from another secret-store (e.g. `@{other_store:vault_token}`). This
+lets you obtain a token through any mechanism another secret-store can
+produce (OAuth2, file, environment, etc.) and hand it to this plugin. Token
+renewal is the responsibility of the supplying source.
+
+When authenticating with `approle`, the plugin logs in with the configured
+Role ID and Secret ID and starts a lifetime watcher to keep the token
+renewed.
 
 ```toml @sample.conf
 # Secret-store to access Vault Secrets

--- a/plugins/secretstores/vault/sample.conf
+++ b/plugins/secretstores/vault/sample.conf
@@ -32,7 +32,7 @@
   ## secret-store, e.g. @{other_store:vault_token}). Use "approle" to have
   ## Telegraf authenticate via the AppRole method and manage token renewal.
 
-  ## Vault token
+  ## Vault token used to authenticate with the server
   # token = ""
 
   # [secretstores.vault.approle]

--- a/plugins/secretstores/vault/sample.conf
+++ b/plugins/secretstores/vault/sample.conf
@@ -26,12 +26,21 @@
   ## By default will use the kv-v2 engine.
   # engine = "kv-v2"
 
-  [secretstores.vault.approle]
-    ## The Role ID for AppRole Authentication, a UUID string
-    role_id = ""
+  ## Authentication
+  ## Exactly one of "token" or "approle" must be configured. Use "token" to
+  ## pass an already-obtained Vault token (directly or via another
+  ## secret-store, e.g. @{other_store:vault_token}). Use "approle" to have
+  ## Telegraf authenticate via the AppRole method and manage token renewal.
 
-    ## Whether the Secret ID is configured to be response wrapped or not
-    # response_wrapped = false
+  ## Vault token
+  # token = ""
 
-    ## The Secret ID for AppRole Authentication
-    secret = ""
+  # [secretstores.vault.approle]
+  #   ## The Role ID for AppRole Authentication, a UUID string
+  #   role_id = ""
+  #
+  #   ## Whether the Secret ID is configured to be response wrapped or not
+  #   # response_wrapped = false
+  #
+  #   ## The Secret ID for AppRole Authentication
+  #   secret = ""

--- a/plugins/secretstores/vault/vault.go
+++ b/plugins/secretstores/vault/vault.go
@@ -21,12 +21,13 @@ import (
 var sampleConfig string
 
 type Vault struct {
-	ID         string   `toml:"id"`
-	Address    string   `toml:"address"`
-	MountPath  string   `toml:"mount_path"`
-	SecretPath string   `toml:"secret_path"`
-	Engine     string   `toml:"engine"`
-	AppRole    *appRole `toml:"approle"`
+	ID         string        `toml:"id"`
+	Address    string        `toml:"address"`
+	MountPath  string        `toml:"mount_path"`
+	SecretPath string        `toml:"secret_path"`
+	Engine     string        `toml:"engine"`
+	Token      config.Secret `toml:"token"`
+	AppRole    *appRole      `toml:"approle"`
 
 	client *vault.Client
 }
@@ -50,8 +51,13 @@ func (v *Vault) Init() error {
 		return fmt.Errorf("unsupported engine: %s", v.Engine)
 	}
 
-	if v.AppRole == nil {
-		return errors.New("approle configuration missing")
+	tokenSet := !v.Token.Empty()
+	approleSet := v.AppRole != nil
+	switch {
+	case !tokenSet && !approleSet:
+		return errors.New("authentication method missing: set either \"token\" or \"approle\"")
+	case tokenSet && approleSet:
+		return errors.New("only one authentication method may be set: \"token\" or \"approle\"")
 	}
 	if v.ID == "" {
 		return errors.New("id missing")
@@ -132,6 +138,16 @@ func (v *Vault) GetResolver(key string) (telegraf.ResolveFunc, error) {
 }
 
 func (v *Vault) authenticate() error {
+	if !v.Token.Empty() {
+		token, err := v.Token.Get()
+		if err != nil {
+			return fmt.Errorf("getting token failed: %w", err)
+		}
+		defer token.Destroy()
+		v.client.SetToken(token.String())
+		return nil
+	}
+
 	secret, err := v.AppRole.Secret.Get()
 	if err != nil {
 		return fmt.Errorf("getting secret failed: %w", err)

--- a/plugins/secretstores/vault/vault.go
+++ b/plugins/secretstores/vault/vault.go
@@ -55,9 +55,9 @@ func (v *Vault) Init() error {
 	approleSet := v.AppRole != nil
 	switch {
 	case !tokenSet && !approleSet:
-		return errors.New("authentication method missing: set either \"token\" or \"approle\"")
+		return errors.New("authentication method missing: set either `token` or `approle`")
 	case tokenSet && approleSet:
-		return errors.New("only one authentication method may be set: \"token\" or \"approle\"")
+		return errors.New("only one authentication method may be set: `token` or `approle`")
 	}
 	if v.ID == "" {
 		return errors.New("id missing")

--- a/plugins/secretstores/vault/vault_test.go
+++ b/plugins/secretstores/vault/vault_test.go
@@ -242,3 +242,77 @@ func TestIntegrationAppRoleSecretWrapped(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []byte(secretValue), secret)
 }
+
+func TestInitAuthValidation(t *testing.T) {
+	tests := []struct {
+		name        string
+		plugin      *Vault
+		errContains string
+	}{
+		{
+			name: "no auth method",
+			plugin: &Vault{
+				ID:         "vault",
+				Address:    "http://localhost:8200",
+				MountPath:  "secret",
+				SecretPath: "my/path",
+			},
+			errContains: `set either "token" or "approle"`,
+		},
+		{
+			name: "both token and approle",
+			plugin: &Vault{
+				ID:         "vault",
+				Address:    "http://localhost:8200",
+				MountPath:  "secret",
+				SecretPath: "my/path",
+				Token:      config.NewSecret([]byte("some-token")),
+				AppRole: &appRole{
+					RoleID: "role",
+					Secret: config.NewSecret([]byte("secret")),
+				},
+			},
+			errContains: "only one authentication method",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.ErrorContains(t, tt.plugin.Init(), tt.errContains)
+		})
+	}
+}
+
+func TestIntegrationTokenAuth(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	mountPath := "my-mount-path"
+	secretPath := "my-secret-path"
+	secretName := "secret-some-name"
+	secretValue := "secret-some-value"
+
+	container, closer := createContainer(t, []string{
+		fmt.Sprintf("secrets enable -path=%s kv-v2", mountPath),
+		fmt.Sprintf("kv put -mount=%s %s %s=%s", mountPath, secretPath, secretName, secretValue),
+	})
+	defer closer()
+
+	addr, err := container.HttpHostAddress(context.Background())
+	require.NoError(t, err)
+
+	plugin := &Vault{
+		ID:         "test_integration_token",
+		Address:    addr,
+		MountPath:  mountPath,
+		SecretPath: secretPath,
+		Token:      config.NewSecret([]byte("SomeToken")),
+	}
+
+	require.NoError(t, plugin.Init())
+
+	secret, err := plugin.Get(secretName)
+	require.NoError(t, err)
+	require.Equal(t, []byte(secretValue), secret)
+}

--- a/plugins/secretstores/vault/vault_test.go
+++ b/plugins/secretstores/vault/vault_test.go
@@ -251,14 +251,14 @@ func TestInitAuthValidation(t *testing.T) {
 		SecretPath: "my/path",
 	}
 	tests := []struct {
-		name        string
-		token       config.Secret
-		approle     *appRole
-		errContains string
+		name     string
+		token    config.Secret
+		approle  *appRole
+		expected string
 	}{
 		{
-			name:        "no auth method",
-			errContains: "set either `token` or `approle`",
+			name:     "no auth method",
+			expected: "set either `token` or `approle`",
 		},
 		{
 			name:  "both token and approle",
@@ -267,7 +267,7 @@ func TestInitAuthValidation(t *testing.T) {
 				RoleID: "role",
 				Secret: config.NewSecret([]byte("secret")),
 			},
-			errContains: "only one authentication method",
+			expected: "only one authentication method",
 		},
 	}
 
@@ -276,7 +276,7 @@ func TestInitAuthValidation(t *testing.T) {
 			v := base
 			v.Token = tt.token
 			v.AppRole = tt.approle
-			require.ErrorContains(t, v.Init(), tt.errContains)
+			require.ErrorContains(t, v.Init(), tt.expected)
 		})
 	}
 }
@@ -312,5 +312,5 @@ func TestIntegrationTokenAuth(t *testing.T) {
 
 	secret, err := plugin.Get(secretName)
 	require.NoError(t, err)
-	require.Equal(t, []byte(secretValue), secret)
+	require.Equal(t, secretValue, string(secret))
 }

--- a/plugins/secretstores/vault/vault_test.go
+++ b/plugins/secretstores/vault/vault_test.go
@@ -244,33 +244,28 @@ func TestIntegrationAppRoleSecretWrapped(t *testing.T) {
 }
 
 func TestInitAuthValidation(t *testing.T) {
+	base := Vault{
+		ID:         "vault",
+		Address:    "http://localhost:8200",
+		MountPath:  "secret",
+		SecretPath: "my/path",
+	}
 	tests := []struct {
 		name        string
-		plugin      *Vault
+		token       config.Secret
+		approle     *appRole
 		errContains string
 	}{
 		{
-			name: "no auth method",
-			plugin: &Vault{
-				ID:         "vault",
-				Address:    "http://localhost:8200",
-				MountPath:  "secret",
-				SecretPath: "my/path",
-			},
-			errContains: `set either "token" or "approle"`,
+			name:        "no auth method",
+			errContains: "set either `token` or `approle`",
 		},
 		{
-			name: "both token and approle",
-			plugin: &Vault{
-				ID:         "vault",
-				Address:    "http://localhost:8200",
-				MountPath:  "secret",
-				SecretPath: "my/path",
-				Token:      config.NewSecret([]byte("some-token")),
-				AppRole: &appRole{
-					RoleID: "role",
-					Secret: config.NewSecret([]byte("secret")),
-				},
+			name:  "both token and approle",
+			token: config.NewSecret([]byte("some-token")),
+			approle: &appRole{
+				RoleID: "role",
+				Secret: config.NewSecret([]byte("secret")),
 			},
 			errContains: "only one authentication method",
 		},
@@ -278,7 +273,10 @@ func TestInitAuthValidation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			require.ErrorContains(t, tt.plugin.Init(), tt.errContains)
+			v := base
+			v.Token = tt.token
+			v.AppRole = tt.approle
+			require.ErrorContains(t, v.Init(), tt.errContains)
 		})
 	}
 }


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Adds token-based authentication to the `vault` secret-store plugin, alongside
the existing AppRole method. Until now, the plugin could only authenticate via
AppRole, which forced users with an already-obtained Vault token to jump
through hoops or maintain an AppRole just for Telegraf.

A new `token` option accepts a `config.Secret`, so the token can be supplied
directly or chained from another secret-store (e.g.
`@{other_store:vault_token}`). This lets users obtain a token through any
mechanism another secret-store can produce (OAuth2, file, environment, etc.)
and hand it to this plugin. Token renewal in that path is the responsibility
of the supplying source, so the plugin skips the AppRole lifetime watcher
when authenticating with a token.

Exactly one of `token` or `approle` must be configured; `Init()` returns an
error if neither or both are set. The README and sample config were updated
to document both methods and the chaining pattern.

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->
related to #18222
