### PR TITLE
chore(inputs.huebridge): Tidy up after go-hue v1.2.0 upgrade

### DIFF
--- a/plugins/inputs/huebridge/bridge.go
+++ b/plugins/inputs/huebridge/bridge.go
@@ -71,7 +71,7 @@ func (b *bridge) processLights(ctx context.Context, acc telegraf.Accumulator) er
 			"room":      b.resolveResourceRoom(light.Id, light.Metadata.Name),
 			"device":    light.Metadata.Name,
 		}
-		fields := make(map[string]interface{}, 1)
+		fields := make(map[string]interface{}, 5)
 		if light.On.On {
 			fields["on"] = 1
 		} else {
@@ -347,10 +347,6 @@ func (b *bridge) fetchDeviceNames(ctx context.Context) error {
 		return fmt.Errorf("failed to fetch bridge devices from %s: %s", b, getDevicesResponse.HTTPResponse.Status)
 	}
 	responseData := getDevicesResponse.JSON200.Data
-	if responseData == nil {
-		b.deviceNames = make(map[string]string)
-		return nil
-	}
 	b.deviceNames = make(map[string]string, len(responseData))
 	for _, device := range responseData {
 		b.deviceNames[device.Id] = device.Metadata.Name
@@ -367,10 +363,6 @@ func (b *bridge) fetchRoomAssignments(ctx context.Context) error {
 		return fmt.Errorf("failed to fetch bridge rooms from %s: %s", b, getRoomsResponse.HTTPResponse.Status)
 	}
 	responseData := getRoomsResponse.JSON200.Data
-	if responseData == nil {
-		b.roomAssignments = maps.Clone(b.configRoomAssignments)
-		return nil
-	}
 	b.roomAssignments = make(map[string]string, len(responseData))
 	for _, roomGet := range responseData {
 		for _, children := range roomGet.Children {


### PR DESCRIPTION


## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
- Raise the fields-map capacity hint in processLights from 1 to 5 to match the maximum number of keys written (on, brightness, color_temp, color_x, color_y) and avoid a re-hash on full lights.
- Remove the responseData == nil branches in fetchDeviceNames and fetchRoomAssignments. Upstream switched these from pointer-to-slice to value slices, so len(nil) is 0 and range on a nil slice iterates zero times, making the guarded branch equivalent to the unguarded one.

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->


- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
