### PR TITLE
test(secretstores.vault): Use string comparison for readable failure output

### DIFF
--- a/plugins/secretstores/vault/vault_test.go
+++ b/plugins/secretstores/vault/vault_test.go
@@ -165,7 +165,7 @@ func TestIntegrationKVv1(t *testing.T) {
 
 	secret, err := plugin.Get(secretName)
 	require.NoError(t, err)
-	require.Equal(t, []byte(secretValue), secret)
+	require.Equal(t, secretValue, string(secret))
 }
 
 func TestIntegrationKVv2(t *testing.T) {
@@ -202,7 +202,7 @@ func TestIntegrationKVv2(t *testing.T) {
 
 	secret, err := plugin.Get(secretName)
 	require.NoError(t, err)
-	require.Equal(t, []byte(secretValue), secret)
+	require.Equal(t, secretValue, string(secret))
 }
 
 func TestIntegrationAppRoleSecretWrapped(t *testing.T) {
@@ -240,5 +240,5 @@ func TestIntegrationAppRoleSecretWrapped(t *testing.T) {
 
 	secret, err := plugin.Get(secretName)
 	require.NoError(t, err)
-	require.Equal(t, []byte(secretValue), secret)
+	require.Equal(t, secretValue, string(secret))
 }


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Use string comparison for readable failure output
## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
