### PR TITLE
fix(inputs.opcua): Disable auto-reconnect to fix session flood

### DIFF
--- a/plugins/common/opcua/client.go
+++ b/plugins/common/opcua/client.go
@@ -192,6 +192,9 @@ type OpcUAClient struct {
 
 	opts  []opcua.Option
 	codes []ua.StatusCode
+
+	// Internal flags
+	DisableAutoReconnect bool
 }
 
 // determineOrCreateCertificates handles certificate determination and generation logic

--- a/plugins/common/opcua/client_test.go
+++ b/plugins/common/opcua/client_test.go
@@ -227,6 +227,37 @@ func TestRemoteCertificateValidation(t *testing.T) {
 	}
 }
 
+func TestGenerateClientOptsDisableAutoReconnect(t *testing.T) {
+	endpoints := []*ua.EndpointDescription{
+		{
+			EndpointURL:       "opc.tcp://localhost:4840",
+			SecurityPolicyURI: ua.SecurityPolicyURINone,
+			SecurityMode:      ua.MessageSecurityModeNone,
+			SecurityLevel:     0,
+			UserIdentityTokens: []*ua.UserTokenPolicy{
+				{TokenType: ua.UserTokenTypeAnonymous},
+			},
+		},
+	}
+
+	cfg := &OpcUAClientConfig{
+		Endpoint:       "opc.tcp://localhost:4840",
+		SecurityPolicy: "None",
+		SecurityMode:   "None",
+		AuthMethod:     "Anonymous",
+	}
+
+	defaultClient := &OpcUAClient{Config: cfg, Log: &testutil.Logger{}}
+	defaultOpts, err := defaultClient.generateClientOpts(endpoints)
+	require.NoError(t, err)
+
+	disabledClient := &OpcUAClient{Config: cfg, Log: &testutil.Logger{}, DisableAutoReconnect: true}
+	disabledOpts, err := disabledClient.generateClientOpts(endpoints)
+	require.NoError(t, err)
+
+	require.Len(t, disabledOpts, len(defaultOpts)+1)
+}
+
 func TestGenerateClientOptsWithLocales(t *testing.T) {
 	endpoints := []*ua.EndpointDescription{
 		{

--- a/plugins/common/opcua/client_test.go
+++ b/plugins/common/opcua/client_test.go
@@ -227,7 +227,7 @@ func TestRemoteCertificateValidation(t *testing.T) {
 	}
 }
 
-func TestGenerateClientOptsDisableAutoReconnect(t *testing.T) {
+func TestGenerateClientOptsExtras(t *testing.T) {
 	endpoints := []*ua.EndpointDescription{
 		{
 			EndpointURL:       "opc.tcp://localhost:4840",
@@ -240,61 +240,42 @@ func TestGenerateClientOptsDisableAutoReconnect(t *testing.T) {
 		},
 	}
 
-	cfg := &OpcUAClientConfig{
-		Endpoint:       "opc.tcp://localhost:4840",
-		SecurityPolicy: "None",
-		SecurityMode:   "None",
-		AuthMethod:     "Anonymous",
-	}
-
-	defaultClient := &OpcUAClient{Config: cfg, Log: &testutil.Logger{}}
-	defaultOpts, err := defaultClient.generateClientOpts(endpoints)
-	require.NoError(t, err)
-
-	disabledClient := &OpcUAClient{Config: cfg, Log: &testutil.Logger{}, DisableAutoReconnect: true}
-	disabledOpts, err := disabledClient.generateClientOpts(endpoints)
-	require.NoError(t, err)
-
-	require.Len(t, disabledOpts, len(defaultOpts)+1)
-}
-
-func TestGenerateClientOptsWithLocales(t *testing.T) {
-	endpoints := []*ua.EndpointDescription{
-		{
-			EndpointURL:       "opc.tcp://localhost:4840",
-			SecurityPolicyURI: ua.SecurityPolicyURINone,
-			SecurityMode:      ua.MessageSecurityModeNone,
-			SecurityLevel:     0,
-			UserIdentityTokens: []*ua.UserTokenPolicy{
-				{TokenType: ua.UserTokenTypeAnonymous},
+	newBaseClient := func() *OpcUAClient {
+		return &OpcUAClient{
+			Config: &OpcUAClientConfig{
+				Endpoint:       "opc.tcp://localhost:4840",
+				SecurityPolicy: "None",
+				SecurityMode:   "None",
+				AuthMethod:     "Anonymous",
 			},
-		},
+			Log: &testutil.Logger{},
+		}
 	}
 
-	baseClient := &OpcUAClient{
-		Config: &OpcUAClientConfig{
-			Endpoint:       "opc.tcp://localhost:4840",
-			SecurityPolicy: "None",
-			SecurityMode:   "None",
-			AuthMethod:     "Anonymous",
-		},
-		Log: &testutil.Logger{},
-	}
-	baseOpts, err := baseClient.generateClientOpts(endpoints)
+	baseOpts, err := newBaseClient().generateClientOpts(endpoints)
 	require.NoError(t, err)
 
-	localesClient := &OpcUAClient{
-		Config: &OpcUAClientConfig{
-			Endpoint:       "opc.tcp://localhost:4840",
-			SecurityPolicy: "None",
-			SecurityMode:   "None",
-			AuthMethod:     "Anonymous",
-			Locales:        []string{"en", "de"},
+	tests := []struct {
+		name   string
+		modify func(*OpcUAClient)
+	}{
+		{
+			name:   "locales",
+			modify: func(c *OpcUAClient) { c.Config.Locales = []string{"en", "de"} },
 		},
-		Log: &testutil.Logger{},
+		{
+			name:   "disable auto-reconnect",
+			modify: func(c *OpcUAClient) { c.DisableAutoReconnect = true },
+		},
 	}
-	localesOpts, err := localesClient.generateClientOpts(endpoints)
-	require.NoError(t, err)
 
-	require.Len(t, localesOpts, len(baseOpts)+1)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := newBaseClient()
+			tt.modify(client)
+			opts, err := client.generateClientOpts(endpoints)
+			require.NoError(t, err)
+			require.Len(t, opts, len(baseOpts)+1)
+		})
+	}
 }

--- a/plugins/common/opcua/opcua_util.go
+++ b/plugins/common/opcua/opcua_util.go
@@ -220,6 +220,12 @@ func (o *OpcUAClient) generateClientOpts(endpoints []*ua.EndpointDescription) ([
 		opcua.RequestTimeout(time.Duration(o.Config.RequestTimeout)),
 	}
 
+	// Let the caller own reconnection. Without this, gopcua's monitor and the
+	// caller's reconnect cycle both create sessions, flooding the server.
+	if o.DisableAutoReconnect {
+		opts = append(opts, opcua.AutoReconnect(false))
+	}
+
 	if o.Config.SessionTimeout != 0 {
 		opts = append(opts, opcua.SessionTimeout(time.Duration(o.Config.SessionTimeout)))
 	}

--- a/plugins/inputs/opcua/read_client.go
+++ b/plugins/inputs/opcua/read_client.go
@@ -52,6 +52,11 @@ func (rc *readClientConfig) createReadClient(log telegraf.Logger) (*readClient, 
 		return nil, err
 	}
 
+	// The polling reader has no subscriptions to preserve across reconnects, so
+	// gopcua's auto-reconnect only races with our own connect cycle and floods
+	// the server with sessions during outages. Let Telegraf own reconnection.
+	inputClient.DisableAutoReconnect = true
+
 	tags := map[string]string{
 		"endpoint": inputClient.Config.OpcUAClientConfig.Endpoint,
 	}


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
  `inputs.opcua` floods the server with sessions on outage, hitting `BadTooManySessions`. Reported in #18787. User logs over 2 min after a server restart: 6,410 `CreateSessionRequest` / 6,788 `OpenSecureChannelRequest` / 1 `CloseSessionRequest`. Peak `CreateSession` rate is 75-114/sec; Telegraf's own connect log fires only 1-4/sec, so the bulk isn't coming from Telegraf's reconnect path.
                                                                                                                                                                                                                   
  #### Source of the problem                                                                                                                                                                                                   
 Dual-ownership of reconnect between gopcua and Telegraf:                                                                                                                                                         
                                             
  1. gopcua defaults to `AutoReconnect = true`. Each client runs a background monitor that, on channel break, loops `createSecureChannel` -> `restoreSession` -> `recreateSession` with no backoff between failures. When the server is overloaded by N parallel clients, intermediate steps fail, leaving orphan sessions.
  2. Telegraf also reconnects via `reconnect_error_threshold` / `forceReconnect` / explicit `Disconnect+Connect`, and creates a fresh `opcua.Client` (and another monitor goroutine) each time.                    
  3. With 10 inputs on the same endpoint, both mechanisms run in parallel and sessions accumulate faster than `session_timeout` clears them.                                                                       
                                                                                                                                                                                                                                                                          
Patched binary has been tested against Codesys reproducer over two server restarts ([comment](https://github.com/influxdata/telegraf/issues/18787#issuecomment-4337615949)).                                                                   
                                             
  | Metric                       | Before (1 restart, 2 min) | After (2 restarts, ~6 min) |                                                                                                                        
  |-----------------------------|---------------------------|----------------------------|
  | `CreateSessionRequest`      | 6,410                     | 51                         |                                                                                                                         
  | `OpenSecureChannelRequest`  | 6,788                     | 102                        |
  | `CloseSessionRequest`       | 1                         | 20                         |                                                                                                                         
  | `BadTooManySessions`        | yes                       | none                       |                                                                                                                         
                                                                                                                                                                                                                   


## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #18787
                                                                                                                                                               
