### PR TITLE
fix(agent): Log Windows service startup errors to configured logger

### DIFF
--- a/cmd/telegraf/telegraf_windows.go
+++ b/cmd/telegraf/telegraf_windows.go
@@ -7,6 +7,7 @@ package main
 import (
 	"errors"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -148,6 +149,7 @@ func (t *Telegraf) Execute(_ []string, r <-chan svc.ChangeRequest, changes chan<
 		select {
 		case err := <-loopErr:
 			if err != nil {
+				log.Printf("E! %s", err)
 				//nolint:errcheck // We have no way to route the error to the user so ignore it
 				svclog.Error(eventID, err.Error())
 				return true, 3


### PR DESCRIPTION
## Summary

This PR updates the Windows service error path to write startup errors to the configured Telegraf logfile, addressing issue #18782.

When Telegraf runs as a Windows service and `reloadLoop()` returns an error, the error was only written to the Windows Event Log. As a result, startup failures after logger initialization, such as input plugin startup errors, were not visible in the configured `logfile`.

This PR also keeps the existing Windows Event Log behavior, while making the Windows service behavior consistent with command-line execution, where the final `Error running agent` message is written to the logfile.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the InfluxData Policy on AI-Generated Code Contributions

## Related issues

resolves #18782