### PR TITLE
feat(inputs.x509_cert): Add field for public-key length

### DIFF
--- a/plugins/inputs/x509_cert/README.md
+++ b/plugins/inputs/x509_cert/README.md
@@ -115,6 +115,7 @@ details.
     - age (int, seconds)
     - startdate (int, seconds)
     - enddate (int, seconds)
+    - public_key_algorithm (uint, bit) - for RSA, ECDSA and ed25519 keys
     - ocsp_status_code (int)
     - ocsp_next_update (int, seconds)
     - ocsp_produced_at (int, seconds)

--- a/plugins/inputs/x509_cert/README.md
+++ b/plugins/inputs/x509_cert/README.md
@@ -115,7 +115,7 @@ details.
     - age (int, seconds)
     - startdate (int, seconds)
     - enddate (int, seconds)
-    - public_key_algorithm (uint, bit) - for RSA, ECDSA and ed25519 keys
+    - public_key_length (uint, bit) - for RSA, ECDSA and ed25519 keys
     - ocsp_status_code (int)
     - ocsp_next_update (int, seconds)
     - ocsp_produced_at (int, seconds)

--- a/plugins/inputs/x509_cert/x509_cert.go
+++ b/plugins/inputs/x509_cert/x509_cert.go
@@ -5,6 +5,9 @@ package x509_cert
 
 import (
 	"bytes"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/rsa"
 	"crypto/tls"
 	"crypto/x509"
 	_ "embed"
@@ -492,6 +495,16 @@ func getFields(cert *x509.Certificate, now time.Time) map[string]interface{} {
 		"expiry":    expiry,
 		"startdate": startdate,
 		"enddate":   enddate,
+	}
+
+	// Determine the bit-length of the public key for algorithms that support it
+	switch v := cert.PublicKey.(type) {
+	case *rsa.PublicKey:
+		fields["public_key_length"] = 8 * uint64(v.Size())
+	case *ecdsa.PublicKey:
+		fields["public_key_length"] = uint64(v.Params().BitSize)
+	case ed25519.PublicKey:
+		fields["public_key_length"] = uint64(ed25519.PublicKeySize)
 	}
 
 	return fields

--- a/plugins/inputs/x509_cert/x509_cert.go
+++ b/plugins/inputs/x509_cert/x509_cert.go
@@ -504,7 +504,7 @@ func getFields(cert *x509.Certificate, now time.Time) map[string]interface{} {
 	case *ecdsa.PublicKey:
 		fields["public_key_length"] = uint64(v.Params().BitSize)
 	case ed25519.PublicKey:
-		fields["public_key_length"] = uint64(ed25519.PublicKeySize)
+		fields["public_key_length"] = 8 * uint64(ed25519.PublicKeySize)
 	}
 
 	return fields

--- a/plugins/inputs/x509_cert/x509_cert_test.go
+++ b/plugins/inputs/x509_cert/x509_cert_test.go
@@ -1,6 +1,9 @@
 package x509_cert
 
 import (
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/tls"
@@ -633,6 +636,7 @@ func TestClassification(t *testing.T) {
 				"startdate":         start.Unix(),
 				"enddate":           end.Unix(),
 				"verification_code": int64(0),
+				"public_key_length": uint64(2048),
 			},
 			time.Unix(0, 0),
 		),
@@ -659,6 +663,7 @@ func TestClassification(t *testing.T) {
 				"startdate":         start.Unix(),
 				"enddate":           end.Unix(),
 				"verification_code": int64(0),
+				"public_key_length": uint64(2048),
 			},
 			time.Unix(0, 0),
 		),
@@ -685,6 +690,7 @@ func TestClassification(t *testing.T) {
 				"startdate":         start.Unix(),
 				"enddate":           end.Unix(),
 				"verification_code": int64(0),
+				"public_key_length": uint64(4096),
 			},
 			time.Unix(0, 0),
 		),
@@ -698,4 +704,277 @@ func TestClassification(t *testing.T) {
 	}
 	actual := acc.GetTelegrafMetrics()
 	testutil.RequireMetricsEqual(t, expected, actual, opts...)
+}
+
+func TestPublicKeyLength(t *testing.T) {
+	start := time.Now()
+	end := time.Now().AddDate(0, 0, 1)
+
+	tests := []struct {
+		algorithm string
+		length    int
+		expected  []telegraf.Metric
+	}{
+		{
+			algorithm: "rsa",
+			length:    2048,
+			expected: []telegraf.Metric{
+				metric.New(
+					"x509_cert",
+					map[string]string{
+						"common_name":          "Root CA",
+						"country":              "US",
+						"issuer_common_name":   "Root CA",
+						"issuer_serial_number": "",
+						"ocsp_stapled":         "no",
+						"organization":         "Testing Inc.",
+						"public_key_algorithm": "RSA",
+						"san":                  "",
+						"serial_number":        "5394e",
+						"signature_algorithm":  "SHA256-RSA",
+						"source":               "<dummy>",
+						"type":                 "root",
+						"verification":         "invalid",
+					},
+					map[string]interface{}{
+						"age":                int64(0),
+						"expiry":             int64(86399),
+						"startdate":          start.Unix(),
+						"enddate":            end.Unix(),
+						"verification_code":  int64(1),
+						"verification_error": "x509: certificate signed by unknown authority",
+						"public_key_length":  uint64(2048),
+					},
+					time.Unix(0, 0),
+				),
+			},
+		},
+		{
+			algorithm: "rsa",
+			length:    4096,
+			expected: []telegraf.Metric{
+				metric.New(
+					"x509_cert",
+					map[string]string{
+						"common_name":          "Root CA",
+						"country":              "US",
+						"issuer_common_name":   "Root CA",
+						"issuer_serial_number": "",
+						"ocsp_stapled":         "no",
+						"organization":         "Testing Inc.",
+						"public_key_algorithm": "RSA",
+						"san":                  "",
+						"serial_number":        "5394e",
+						"signature_algorithm":  "SHA256-RSA",
+						"source":               "<dummy>",
+						"type":                 "root",
+						"verification":         "invalid",
+					},
+					map[string]interface{}{
+						"age":                int64(0),
+						"expiry":             int64(86399),
+						"startdate":          start.Unix(),
+						"enddate":            end.Unix(),
+						"verification_code":  int64(1),
+						"verification_error": "x509: certificate signed by unknown authority",
+						"public_key_length":  uint64(4096),
+					},
+					time.Unix(0, 0),
+				),
+			},
+		},
+		{
+			algorithm: "ecdsa",
+			length:    256,
+			expected: []telegraf.Metric{
+				metric.New(
+					"x509_cert",
+					map[string]string{
+						"common_name":          "Root CA",
+						"country":              "US",
+						"issuer_common_name":   "Root CA",
+						"issuer_serial_number": "",
+						"ocsp_stapled":         "no",
+						"organization":         "Testing Inc.",
+						"public_key_algorithm": "ECDSA",
+						"san":                  "",
+						"serial_number":        "5394e",
+						"signature_algorithm":  "ECDSA-SHA256",
+						"source":               "<dummy>",
+						"type":                 "root",
+						"verification":         "invalid",
+					},
+					map[string]interface{}{
+						"age":                int64(0),
+						"expiry":             int64(86399),
+						"startdate":          start.Unix(),
+						"enddate":            end.Unix(),
+						"verification_code":  int64(1),
+						"verification_error": "x509: certificate signed by unknown authority",
+						"public_key_length":  uint64(256),
+					},
+					time.Unix(0, 0),
+				),
+			},
+		},
+		{
+			algorithm: "ecdsa",
+			length:    384,
+			expected: []telegraf.Metric{
+				metric.New(
+					"x509_cert",
+					map[string]string{
+						"common_name":          "Root CA",
+						"country":              "US",
+						"issuer_common_name":   "Root CA",
+						"issuer_serial_number": "",
+						"ocsp_stapled":         "no",
+						"organization":         "Testing Inc.",
+						"public_key_algorithm": "ECDSA",
+						"san":                  "",
+						"serial_number":        "5394e",
+						"signature_algorithm":  "ECDSA-SHA384",
+						"source":               "<dummy>",
+						"type":                 "root",
+						"verification":         "invalid",
+					},
+					map[string]interface{}{
+						"age":                int64(0),
+						"expiry":             int64(86399),
+						"startdate":          start.Unix(),
+						"enddate":            end.Unix(),
+						"verification_code":  int64(1),
+						"verification_error": "x509: certificate signed by unknown authority",
+						"public_key_length":  uint64(384),
+					},
+					time.Unix(0, 0),
+				),
+			},
+		},
+		{
+			algorithm: "ed25519",
+			expected: []telegraf.Metric{
+				metric.New(
+					"x509_cert",
+					map[string]string{
+						"common_name":          "Root CA",
+						"country":              "US",
+						"issuer_common_name":   "Root CA",
+						"issuer_serial_number": "",
+						"ocsp_stapled":         "no",
+						"organization":         "Testing Inc.",
+						"public_key_algorithm": "Ed25519",
+						"san":                  "",
+						"serial_number":        "5394e",
+						"signature_algorithm":  "Ed25519",
+						"source":               "<dummy>",
+						"type":                 "root",
+						"verification":         "invalid",
+					},
+					map[string]interface{}{
+						"age":                int64(0),
+						"expiry":             int64(86399),
+						"startdate":          start.Unix(),
+						"enddate":            end.Unix(),
+						"verification_code":  int64(1),
+						"verification_error": "x509: certificate signed by unknown authority",
+						"public_key_length":  uint64(32),
+					},
+					time.Unix(0, 0),
+				),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		name := tt.algorithm
+		if tt.length > 0 {
+			name = fmt.Sprintf("%s %d", tt.algorithm, tt.length)
+		}
+		t.Run(name, func(t *testing.T) {
+			// Generate the (unsigned) certificate
+			root := t.TempDir()
+
+			var priv, pub interface{}
+			switch tt.algorithm {
+			case "rsa":
+				key, err := rsa.GenerateKey(rand.Reader, tt.length)
+				require.NoError(t, err)
+				priv = key
+				pub = &key.PublicKey
+			case "ecdsa":
+				var curve elliptic.Curve
+				switch tt.length {
+				case 224:
+					curve = elliptic.P224()
+				case 256:
+					curve = elliptic.P256()
+				case 384:
+					curve = elliptic.P384()
+				case 521:
+					curve = elliptic.P521()
+				default:
+					require.FailNowf(t, "generating private key", "invalid size %d", tt.length)
+				}
+
+				key, err := ecdsa.GenerateKey(curve, rand.Reader)
+				require.NoError(t, err)
+				priv = key
+				pub = &key.PublicKey
+			case "ed25519":
+				seed := make([]byte, ed25519.SeedSize)
+				_, err := rand.Reader.Read(seed)
+				require.NoError(t, err)
+				key := ed25519.NewKeyFromSeed(seed)
+				priv = key
+				pub = key.Public()
+			default:
+				require.FailNowf(t, "generating private key", "unknown algorithm %q", tt.algorithm)
+			}
+
+			certCfg := &x509.Certificate{
+				SerialNumber: big.NewInt(342350),
+				Subject: pkix.Name{
+					Organization: []string{"Testing Inc."},
+					Country:      []string{"US"},
+					CommonName:   "Root CA",
+				},
+				NotBefore:             start,
+				NotAfter:              end,
+				IsCA:                  true,
+				KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment | x509.KeyUsageCertSign,
+				ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+				BasicConstraintsValid: true,
+			}
+			cert, err := x509.CreateCertificate(rand.Reader, certCfg, certCfg, pub, priv)
+			require.NoError(t, err)
+			encoded := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert})
+
+			// Write cert
+			require.NoError(t, os.WriteFile(filepath.Join(root, "cert.pem"), encoded, 0600))
+
+			// Create the actual test
+			certURI := "file://" + filepath.Join(root, "cert.pem")
+			plugin := &X509Cert{
+				Sources: []string{certURI},
+				Log:     testutil.Logger{},
+			}
+			require.NoError(t, plugin.Init())
+
+			var acc testutil.Accumulator
+			require.NoError(t, plugin.Gather(&acc))
+			require.Empty(t, acc.Errors)
+
+			opts := []cmp.Option{
+				testutil.SortMetrics(),
+				testutil.IgnoreTime(),
+				// We need to ignore those fields as they are timing sensitive.
+				testutil.IgnoreFields("age", "expiry"),
+				// We need to ignore the source as it is random in this test
+				testutil.IgnoreTags("source"),
+			}
+			actual := acc.GetTelegrafMetrics()
+			testutil.RequireMetricsEqual(t, tt.expected, actual, opts...)
+		})
+	}
 }

--- a/plugins/inputs/x509_cert/x509_cert_test.go
+++ b/plugins/inputs/x509_cert/x509_cert_test.go
@@ -968,7 +968,9 @@ func TestPublicKeyLength(t *testing.T) {
 			opts := []cmp.Option{
 				testutil.SortMetrics(),
 				testutil.IgnoreTime(),
-				// We need to ignore those fields as they are timing sensitive.
+				// We need to ignore age and expiry fields as they are timing
+				// sensitive. The verification error varies accross OSes so we
+				// also need to ignore it.
 				testutil.IgnoreFields("age", "expiry", "verification_error"),
 				// We need to ignore the source as it is random in this test
 				testutil.IgnoreTags("source"),

--- a/plugins/inputs/x509_cert/x509_cert_test.go
+++ b/plugins/inputs/x509_cert/x509_cert_test.go
@@ -878,7 +878,7 @@ func TestPublicKeyLength(t *testing.T) {
 						"enddate":            end.Unix(),
 						"verification_code":  int64(1),
 						"verification_error": "x509: certificate signed by unknown authority",
-						"public_key_length":  uint64(32),
+						"public_key_length":  uint64(256),
 					},
 					time.Unix(0, 0),
 				),

--- a/plugins/inputs/x509_cert/x509_cert_test.go
+++ b/plugins/inputs/x509_cert/x509_cert_test.go
@@ -969,7 +969,7 @@ func TestPublicKeyLength(t *testing.T) {
 				testutil.SortMetrics(),
 				testutil.IgnoreTime(),
 				// We need to ignore those fields as they are timing sensitive.
-				testutil.IgnoreFields("age", "expiry"),
+				testutil.IgnoreFields("age", "expiry", "verification_error"),
 				// We need to ignore the source as it is random in this test
 				testutil.IgnoreTags("source"),
 			}


### PR DESCRIPTION
## Summary

This PR adds a field for the public key length for RSA, ECDSA and ed25519 keys.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

resolves #16479 
