### PR TITLE
feat(outputs.opentelemetry): Add proxy support

### DIFF
--- a/plugins/outputs/opentelemetry/README.md
+++ b/plugins/outputs/opentelemetry/README.md
@@ -50,6 +50,14 @@ plugin ordering. See [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## Supports: "gzip", "none"
   # compression = "gzip"
 
+  ## Optional proxy settings for HTTP endpoints (service_address starts with http:// or https://)
+  # use_system_proxy = false
+  # http_proxy_url = ""
+
+  ## Optional proxy settings for gRPC endpoints (service_address is host:port)
+  # use_proxy = false
+  # proxy_url = ""
+
   ## NOTE: Due to the way TOML is parsed, tables must be at the END of the
   ## plugin definition, otherwise additional config options are read as part of
   ## the table

--- a/plugins/outputs/opentelemetry/client_grpc.go
+++ b/plugins/outputs/opentelemetry/client_grpc.go
@@ -3,6 +3,7 @@ package opentelemetry
 import (
 	"context"
 	ntls "crypto/tls"
+	"fmt"
 	"net"
 
 	"go.opentelemetry.io/collector/pdata/pmetric/pmetricotlp"
@@ -32,7 +33,7 @@ func (g *gRPCClient) Connect(cfg *clientConfig) error {
 
 	dialer, err := cfg.TCPProxy.Proxy()
 	if err != nil {
-		return err
+		return fmt.Errorf("creating proxy failed: %w", err)
 	}
 
 	grpcDialOption := grpc.WithContextDialer(func(ctx context.Context, addr string) (net.Conn, error) {

--- a/plugins/outputs/opentelemetry/client_grpc.go
+++ b/plugins/outputs/opentelemetry/client_grpc.go
@@ -3,6 +3,7 @@ package opentelemetry
 import (
 	"context"
 	ntls "crypto/tls"
+	"net"
 
 	"go.opentelemetry.io/collector/pdata/pmetric/pmetricotlp"
 	"google.golang.org/grpc"
@@ -29,7 +30,16 @@ func (g *gRPCClient) Connect(cfg *clientConfig) error {
 		grpcTLSDialOption = grpc.WithTransportCredentials(insecure.NewCredentials())
 	}
 
-	grpcClientConn, err := grpc.NewClient(cfg.ServiceAddress, grpcTLSDialOption, grpc.WithUserAgent(userAgent))
+	dialer, err := cfg.TCPProxy.Proxy()
+	if err != nil {
+		return err
+	}
+
+	grpcDialOption := grpc.WithContextDialer(func(ctx context.Context, addr string) (net.Conn, error) {
+		return dialer.DialContext(ctx, "tcp", addr)
+	})
+
+	grpcClientConn, err := grpc.NewClient(cfg.ServiceAddress, grpcTLSDialOption, grpcDialOption, grpc.WithUserAgent(userAgent))
 	if err != nil {
 		return err
 	}

--- a/plugins/outputs/opentelemetry/client_http.go
+++ b/plugins/outputs/opentelemetry/client_http.go
@@ -28,6 +28,11 @@ func (h *httpClient) Connect(cfg *clientConfig) error {
 	h.compress = cfg.Compression
 	h.headers = cfg.Headers
 
+	proxyFunc, err := cfg.HTTPProxy.Proxy()
+	if err != nil {
+		return fmt.Errorf("creating proxy failed: %w", err)
+	}
+
 	tlsConfig, err := cfg.TLSConfig.TLSConfig()
 	if err != nil {
 		return err
@@ -41,7 +46,7 @@ func (h *httpClient) Connect(cfg *clientConfig) error {
 	if tlsConfig != nil {
 		h.httpClient.Transport = &http.Transport{
 			TLSClientConfig: tlsConfig,
-			Proxy:           http.ProxyFromEnvironment,
+			Proxy:           proxyFunc,
 		}
 	}
 

--- a/plugins/outputs/opentelemetry/client_http.go
+++ b/plugins/outputs/opentelemetry/client_http.go
@@ -41,6 +41,7 @@ func (h *httpClient) Connect(cfg *clientConfig) error {
 	if tlsConfig != nil {
 		h.httpClient.Transport = &http.Transport{
 			TLSClientConfig: tlsConfig,
+			Proxy:           http.ProxyFromEnvironment,
 		}
 	}
 

--- a/plugins/outputs/opentelemetry/client_http.go
+++ b/plugins/outputs/opentelemetry/client_http.go
@@ -43,12 +43,10 @@ func (h *httpClient) Connect(cfg *clientConfig) error {
 		tlsConfig = &tls.Config{}
 	}
 
-	if tlsConfig != nil {
-		h.httpClient.Transport = &http.Transport{
-			TLSClientConfig: tlsConfig,
-			Proxy:           proxyFunc,
-		}
-	}
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.TLSClientConfig = tlsConfig
+	transport.Proxy = proxyFunc
+	h.httpClient.Transport = transport
 
 	return nil
 }

--- a/plugins/outputs/opentelemetry/opentelemetry.go
+++ b/plugins/outputs/opentelemetry/opentelemetry.go
@@ -18,6 +18,7 @@ import (
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/internal"
+	"github.com/influxdata/telegraf/plugins/common/proxy"
 	"github.com/influxdata/telegraf/plugins/common/tls"
 	"github.com/influxdata/telegraf/plugins/outputs"
 )
@@ -37,6 +38,8 @@ type OpenTelemetry struct {
 	Headers     map[string]string `toml:"headers"`
 	Attributes  map[string]string `toml:"attributes"`
 	Coralogix   *CoralogixConfig  `toml:"coralogix"`
+	proxy.HTTPProxy
+	proxy.TCPProxy
 
 	Log telegraf.Logger `toml:"-"`
 
@@ -49,6 +52,8 @@ type clientConfig struct {
 	TLSConfig       *tls.ClientConfig
 	Compression     string
 	CoralogixConfig *CoralogixConfig
+	HTTPProxy       *proxy.HTTPProxy
+	TCPProxy        *proxy.TCPProxy
 	Encoding        string            // only for HTTP client
 	Headers         map[string]string // only for HTTP client, gRPC client uses metadata
 }
@@ -118,6 +123,8 @@ func (o *OpenTelemetry) Connect() error {
 		TLSConfig:       &o.ClientConfig,
 		Compression:     o.Compression,
 		CoralogixConfig: o.Coralogix,
+		HTTPProxy:       &o.HTTPProxy,
+		TCPProxy:        &o.TCPProxy,
 		Encoding:        o.EncodingType,
 		Headers:         o.Headers,
 	}
@@ -220,6 +227,8 @@ func init() {
 			ServiceAddress: defaultServiceAddress,
 			Timeout:        defaultTimeout,
 			Compression:    defaultCompression,
+			HTTPProxy:      proxy.HTTPProxy{UseSystemProxy: false},
+			TCPProxy:       proxy.TCPProxy{UseProxy: false},
 		}
 	})
 }

--- a/plugins/outputs/opentelemetry/opentelemetry.go
+++ b/plugins/outputs/opentelemetry/opentelemetry.go
@@ -52,8 +52,8 @@ type clientConfig struct {
 	TLSConfig       *tls.ClientConfig
 	Compression     string
 	CoralogixConfig *CoralogixConfig
-	HTTPProxy       *proxy.HTTPProxy
-	TCPProxy        *proxy.TCPProxy
+	HTTPProxy       *proxy.HTTPProxy  // only for HTTP client
+	TCPProxy        *proxy.TCPProxy   // only for gRPC client
 	Encoding        string            // only for HTTP client
 	Headers         map[string]string // only for HTTP client, gRPC client uses metadata
 }

--- a/plugins/outputs/opentelemetry/opentelemetry.go
+++ b/plugins/outputs/opentelemetry/opentelemetry.go
@@ -227,8 +227,6 @@ func init() {
 			ServiceAddress: defaultServiceAddress,
 			Timeout:        defaultTimeout,
 			Compression:    defaultCompression,
-			HTTPProxy:      proxy.HTTPProxy{UseSystemProxy: false},
-			TCPProxy:       proxy.TCPProxy{UseProxy: false},
 		}
 	})
 }

--- a/plugins/outputs/opentelemetry/sample.conf
+++ b/plugins/outputs/opentelemetry/sample.conf
@@ -28,6 +28,14 @@
   ## Supports: "gzip", "none"
   # compression = "gzip"
 
+  ## Optional proxy settings for HTTP endpoints (service_address starts with http:// or https://)
+  # use_system_proxy = false
+  # http_proxy_url = ""
+
+  ## Optional proxy settings for gRPC endpoints (service_address is host:port)
+  # use_proxy = false
+  # proxy_url = ""
+
   ## NOTE: Due to the way TOML is parsed, tables must be at the END of the
   ## plugin definition, otherwise additional config options are read as part of
   ## the table


### PR DESCRIPTION
## Summary
We use telegraf in some of our datacenters that require proxying for egress. We found that switching from gRPC to HTTP, when using the opentelemetry output plugin, started failing requests with `context deadline exceeded`. After some testing; we found this to be due to the fact that using tls config with the output does not respect the use of `HTTP(S)_PROXY` environment variables. 

This change ensures that the combination of otel, http, and (m)tls, respects the use of these environment variables.

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #18822
