### PR TITLE
fix(common.opcua): Support byte arrays in decoding

### DIFF
--- a/plugins/common/opcua/input/input_client.go
+++ b/plugins/common/opcua/input/input_client.go
@@ -601,6 +601,8 @@ func (o *OpcUAInputClient) MetricForNode(nodeIdx int) telegraf.Metric {
 			switch typedValue := o.LastReceivedData[nodeIdx].Value.(type) {
 			case []uint8:
 				fields = unpack(nmm.Tag.FieldName, typedValue)
+			case ua.ByteArray:
+				fields = unpack(nmm.Tag.FieldName, []byte(typedValue))
 			case []uint16:
 				fields = unpack(nmm.Tag.FieldName, typedValue)
 			case []uint32:


### PR DESCRIPTION
## Summary

When decoding OPC UA variant arrays, the plugin crashes when encountering `ua.ByteArray` values because the decoder does not handle this specific type. This fix adds proper handling for `ua.ByteArray` in the variant array decoding logic, preventing the crash.

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [ ] No AI generated code was used in this PR
- [x] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #18824