### PR TITLE
feat(outputs.mongodb): Allow specifying metadata fields

### DIFF
--- a/plugins/outputs/mongodb/README.md
+++ b/plugins/outputs/mongodb/README.md
@@ -66,6 +66,16 @@ to use them.
   ## Database to store measurements and time series collections
   # database = "telegraf"
 
+  ## If true, write multiple metrics for the same collection in a batched
+  ## fashion. Otherwise, write each metric individually.
+  # write_batch = false
+
+  ## List of tags to use as metadata (wildcards accepted)
+  ## If empty the "tags" element will be used as metadata field, otherwise
+  ## a "metadata" element will be created containing the matching, existing
+  ## tag key-values.
+  # metadata_keys = []
+
   ## Granularity can be seconds, minutes, or hours.
   ## Configuring this value will be based on your input collection frequency
   ## see https://docs.mongodb.com/manual/core/timeseries-collections/#create-a-time-series-collection
@@ -74,7 +84,4 @@ to use them.
   ## TTL to automatically expire documents from the measurement collections.
   # ttl = "360h"
 
-  ## If true, write multiple metrics for the same collection in a batched
-  ## fashion. Otherwise, write each metric individually.
-  # write_batch = false
 ```

--- a/plugins/outputs/mongodb/README.md
+++ b/plugins/outputs/mongodb/README.md
@@ -76,6 +76,12 @@ to use them.
   ## tag key-values.
   # metadata_keys = []
 
+  ## Behavior when using explicit metadata keys; ignored for empty metadata_keys
+  ##  keep  -- keep all tags as tags
+  ##  move  -- move tags matching metadata_keys and delete them in the tags field
+  ##  clear -- clear ALL tags and remove the tags field entirely from the document
+  # metadata_tag_strategy = "keep"
+
   ## Granularity can be seconds, minutes, or hours.
   ## Configuring this value will be based on your input collection frequency
   ## see https://docs.mongodb.com/manual/core/timeseries-collections/#create-a-time-series-collection

--- a/plugins/outputs/mongodb/mongodb.go
+++ b/plugins/outputs/mongodb/mongodb.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
+	"github.com/influxdata/telegraf/filter"
 	"github.com/influxdata/telegraf/plugins/common/tls"
 	"github.com/influxdata/telegraf/plugins/outputs"
 )
@@ -35,12 +36,14 @@ type MongoDB struct {
 	ServerSelectTimeout config.Duration `toml:"timeout"`
 	TTL                 config.Duration `toml:"ttl"`
 	WriteBatch          bool            `toml:"write_batch"`
+	MetadataKeys        []string        `toml:"metadata_keys"`
 	Log                 telegraf.Logger `toml:"-"`
 	tls.ClientConfig
 
-	client      *mongo.Client
-	options     *options.ClientOptions
-	collections map[string]bool
+	client         *mongo.Client
+	options        *options.ClientOptions
+	collections    map[string]bool
+	metadataFilter filter.Filter
 }
 
 func (*MongoDB) SampleConfig() string {
@@ -48,6 +51,7 @@ func (*MongoDB) SampleConfig() string {
 }
 
 func (s *MongoDB) Init() error {
+	// Set defaults
 	if s.MetricDatabase == "" {
 		s.MetricDatabase = "telegraf"
 	}
@@ -59,7 +63,7 @@ func (s *MongoDB) Init() error {
 		return errors.New("invalid time series collection granularity. please specify \"seconds\", \"minutes\", or \"hours\"")
 	}
 
-	// do some basic Dsn checks
+	// Do some basic Dsn checks
 	if !strings.HasPrefix(s.Dsn, "mongodb://") && !strings.HasPrefix(s.Dsn, "mongodb+srv://") {
 		return errors.New("invalid connection string. expected mongodb://host:port/?{options} or mongodb+srv://host:port/?{options}")
 	}
@@ -177,6 +181,16 @@ func (s *MongoDB) Init() error {
 	}
 
 	s.options.ApplyURI(s.Dsn)
+
+	// Setup metadata filter if given
+	if len(s.MetadataKeys) > 0 {
+		f, err := filter.Compile(s.MetadataKeys)
+		if err != nil {
+			return fmt.Errorf("creating meta-data filter failed: %w", err)
+		}
+		s.metadataFilter = f
+	}
+
 	return nil
 }
 
@@ -241,7 +255,7 @@ func (s *MongoDB) writeIndividual(ctx context.Context, metrics []telegraf.Metric
 				return fmt.Errorf("creating time series collection %q failed: %w", name, err)
 			}
 		}
-		doc := marshal(metric)
+		doc := s.marshal(metric)
 
 		collection := s.client.Database(s.MetricDatabase).Collection(name)
 		if _, err := collection.InsertOne(ctx, &doc); err != nil {
@@ -256,7 +270,7 @@ func (s *MongoDB) writeBatch(ctx context.Context, metrics []telegraf.Metric) err
 	batches := make(map[string][]interface{})
 	for _, m := range metrics {
 		name := m.Name()
-		batches[name] = append(batches[name], marshal(m))
+		batches[name] = append(batches[name], s.marshal(m))
 	}
 
 	// Write all metrics of a collection at a time
@@ -281,7 +295,11 @@ func (s *MongoDB) createCollection(ctx context.Context, name string) error {
 	// Setup a new timeseries collection for the given metric name
 	series := options.TimeSeries()
 	series.SetTimeField("timestamp")
-	series.SetMetaField("tags")
+	if s.metadataFilter != nil {
+		series.SetMetaField("metadata")
+	} else {
+		series.SetMetaField("tags")
+	}
 	series.SetGranularity(s.MetricGranularity)
 
 	collection := options.CreateCollection()
@@ -302,7 +320,7 @@ func (s *MongoDB) createCollection(ctx context.Context, name string) error {
 // Convert a metric into a MongoDB document with all fields being parent level
 // of document and the metadata field is named "tags". MongoDB stores timestamp
 // as UTC so conversion should be performed on the query or aggregation side.
-func marshal(metric telegraf.Metric) bson.D {
+func (s *MongoDB) marshal(metric telegraf.Metric) bson.D {
 	doc := make(bson.D, 0, len(metric.FieldList())+2)
 	for _, f := range metric.FieldList() {
 		doc = append(doc, primitive.E{Key: f.Key, Value: f.Value})
@@ -315,6 +333,17 @@ func marshal(metric telegraf.Metric) bson.D {
 		primitive.E{Key: "tags", Value: tags},
 		primitive.E{Key: "timestamp", Value: metric.Time()},
 	)
+
+	// Add metadata if specified any
+	if s.metadataFilter != nil {
+		metadata := make(bson.D, 0, len(s.MetadataKeys))
+		for _, t := range metric.TagList() {
+			if s.metadataFilter.Match(t.Key) {
+				metadata = append(metadata, primitive.E{Key: t.Key, Value: t.Value})
+			}
+		}
+		doc = append(doc, primitive.E{Key: "metadata", Value: metadata})
+	}
 	return doc
 }
 

--- a/plugins/outputs/mongodb/mongodb.go
+++ b/plugins/outputs/mongodb/mongodb.go
@@ -33,10 +33,10 @@ type MongoDB struct {
 	MetricGranularity   string          `toml:"granularity"`
 	Username            config.Secret   `toml:"username"`
 	Password            config.Secret   `toml:"password"`
-	ServerSelectTimeout config.Duration `toml:"timeout"`
-	TTL                 config.Duration `toml:"ttl"`
 	WriteBatch          bool            `toml:"write_batch"`
 	MetadataKeys        []string        `toml:"metadata_keys"`
+	ServerSelectTimeout config.Duration `toml:"timeout"`
+	TTL                 config.Duration `toml:"ttl"`
 	Log                 telegraf.Logger `toml:"-"`
 	tls.ClientConfig
 
@@ -322,17 +322,6 @@ func (s *MongoDB) createCollection(ctx context.Context, name string) error {
 // as UTC so conversion should be performed on the query or aggregation side.
 func (s *MongoDB) marshal(metric telegraf.Metric) bson.D {
 	doc := make(bson.D, 0, len(metric.FieldList())+2)
-	for _, f := range metric.FieldList() {
-		doc = append(doc, primitive.E{Key: f.Key, Value: f.Value})
-	}
-	tags := make(bson.D, 0, len(metric.TagList()))
-	for _, t := range metric.TagList() {
-		tags = append(tags, primitive.E{Key: t.Key, Value: t.Value})
-	}
-	doc = append(doc,
-		primitive.E{Key: "tags", Value: tags},
-		primitive.E{Key: "timestamp", Value: metric.Time()},
-	)
 
 	// Add metadata if specified any
 	if s.metadataFilter != nil {
@@ -344,6 +333,18 @@ func (s *MongoDB) marshal(metric telegraf.Metric) bson.D {
 		}
 		doc = append(doc, primitive.E{Key: "metadata", Value: metadata})
 	}
+	tags := make(bson.D, 0, len(metric.TagList()))
+	for _, t := range metric.TagList() {
+		tags = append(tags, primitive.E{Key: t.Key, Value: t.Value})
+	}
+	doc = append(doc,
+		primitive.E{Key: "tags", Value: tags},
+		primitive.E{Key: "timestamp", Value: metric.Time()},
+	)
+	for _, f := range metric.FieldList() {
+		doc = append(doc, primitive.E{Key: f.Key, Value: f.Value})
+	}
+
 	return doc
 }
 

--- a/plugins/outputs/mongodb/mongodb.go
+++ b/plugins/outputs/mongodb/mongodb.go
@@ -354,7 +354,7 @@ func (s *MongoDB) marshal(metric telegraf.Metric) bson.D {
 		doc = append(doc, primitive.E{Key: "metadata", Value: metadata})
 	}
 
-	if s.MetadataTagStrategy != "clear" {
+	if s.metadataFilter == nil || s.MetadataTagStrategy != "clear" {
 		doc = append(doc, primitive.E{Key: "tags", Value: tags})
 	}
 

--- a/plugins/outputs/mongodb/mongodb.go
+++ b/plugins/outputs/mongodb/mongodb.go
@@ -69,9 +69,7 @@ func (s *MongoDB) Init() error {
 		s.MetadataTagStrategy = "keep"
 	case "keep", "move", "clear":
 	default:
-		if len(s.MetadataKeys) > 0 {
-			return fmt.Errorf("invalid 'metadata_tag_strategy' %q", s.MetadataTagStrategy)
-		}
+		return fmt.Errorf("invalid 'metadata_tag_strategy' %q", s.MetadataTagStrategy)
 	}
 
 	// Do some basic Dsn checks

--- a/plugins/outputs/mongodb/mongodb.go
+++ b/plugins/outputs/mongodb/mongodb.go
@@ -197,7 +197,7 @@ func (s *MongoDB) Init() error {
 	if len(s.MetadataKeys) > 0 {
 		f, err := filter.Compile(s.MetadataKeys)
 		if err != nil {
-			return fmt.Errorf("creating meta-data filter failed: %w", err)
+			return fmt.Errorf("creating metadata filter failed: %w", err)
 		}
 		s.metadataFilter = f
 	}

--- a/plugins/outputs/mongodb/mongodb.go
+++ b/plugins/outputs/mongodb/mongodb.go
@@ -35,6 +35,7 @@ type MongoDB struct {
 	Password            config.Secret   `toml:"password"`
 	WriteBatch          bool            `toml:"write_batch"`
 	MetadataKeys        []string        `toml:"metadata_keys"`
+	MetadataTagStrategy string          `toml:"metadata_tag_strategy"`
 	ServerSelectTimeout config.Duration `toml:"timeout"`
 	TTL                 config.Duration `toml:"ttl"`
 	Log                 telegraf.Logger `toml:"-"`
@@ -61,6 +62,16 @@ func (s *MongoDB) Init() error {
 	case "seconds", "minutes", "hours":
 	default:
 		return errors.New("invalid time series collection granularity. please specify \"seconds\", \"minutes\", or \"hours\"")
+	}
+
+	switch s.MetadataTagStrategy {
+	case "":
+		s.MetadataTagStrategy = "keep"
+	case "keep", "move", "clear":
+	default:
+		if len(s.MetadataKeys) > 0 {
+			return fmt.Errorf("invalid 'metadata_tag_strategy' %q", s.MetadataTagStrategy)
+		}
 	}
 
 	// Do some basic Dsn checks
@@ -318,29 +329,35 @@ func (s *MongoDB) createCollection(ctx context.Context, name string) error {
 }
 
 // Convert a metric into a MongoDB document with all fields being parent level
-// of document and the metadata field is named "tags". MongoDB stores timestamp
-// as UTC so conversion should be performed on the query or aggregation side.
+// of document. Metadata and/or tags will be added as subdocument. MongoDB
+// stores timestamp as UTC so conversion should be performed on the query or
+// aggregation side.
 func (s *MongoDB) marshal(metric telegraf.Metric) bson.D {
 	doc := make(bson.D, 0, len(metric.FieldList())+2)
+	doc = append(doc, primitive.E{Key: "timestamp", Value: metric.Time()})
 
-	// Add metadata if specified any
-	if s.metadataFilter != nil {
-		metadata := make(bson.D, 0, len(s.MetadataKeys))
-		for _, t := range metric.TagList() {
-			if s.metadataFilter.Match(t.Key) {
-				metadata = append(metadata, primitive.E{Key: t.Key, Value: t.Value})
+	tags := make(bson.D, 0, len(metric.TagList()))
+	metadata := make(bson.D, 0, len(s.MetadataKeys))
+	for _, t := range metric.TagList() {
+		// Add metadata if specified any
+		if s.metadataFilter != nil && s.metadataFilter.Match(t.Key) {
+			metadata = append(metadata, primitive.E{Key: t.Key, Value: t.Value})
+			if s.MetadataTagStrategy == "keep" {
+				tags = append(tags, primitive.E{Key: t.Key, Value: t.Value})
 			}
+		} else if s.MetadataTagStrategy != "clear" {
+			tags = append(tags, primitive.E{Key: t.Key, Value: t.Value})
 		}
+	}
+
+	if s.metadataFilter != nil {
 		doc = append(doc, primitive.E{Key: "metadata", Value: metadata})
 	}
-	tags := make(bson.D, 0, len(metric.TagList()))
-	for _, t := range metric.TagList() {
-		tags = append(tags, primitive.E{Key: t.Key, Value: t.Value})
+
+	if s.MetadataTagStrategy != "clear" {
+		doc = append(doc, primitive.E{Key: "tags", Value: tags})
 	}
-	doc = append(doc,
-		primitive.E{Key: "tags", Value: tags},
-		primitive.E{Key: "timestamp", Value: metric.Time()},
-	)
+
 	for _, f := range metric.FieldList() {
 		doc = append(doc, primitive.E{Key: f.Key, Value: f.Value})
 	}

--- a/plugins/outputs/mongodb/mongodb_test.go
+++ b/plugins/outputs/mongodb/mongodb_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/testcontainers/testcontainers-go/wait"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 
 	"github.com/influxdata/telegraf"
@@ -418,15 +419,228 @@ func TestWriteIntegration(t *testing.T) {
 	}
 
 	tests := []struct {
-		name  string
-		batch bool
+		name     string
+		meta     []string
+		batch    bool
+		expected map[string][]bson.D
 	}{
 		{
 			name: "individual",
+			expected: map[string][]bson.D{
+				"test1": {
+					bson.D{
+						primitive.E{Key: "timestamp", Value: primitive.DateTime(0)},
+						primitive.E{Key: "tags", Value: bson.D{
+							primitive.E{Key: "source", Value: "foo"},
+							primitive.E{Key: "version", Value: "v1.2"},
+						}},
+						primitive.E{Key: "value", Value: int64(1)},
+					},
+					bson.D{
+						primitive.E{Key: "timestamp", Value: primitive.DateTime(10000)},
+						primitive.E{Key: "tags", Value: bson.D{
+							primitive.E{Key: "source", Value: "foo"},
+							primitive.E{Key: "version", Value: "v1.2"},
+						}},
+						primitive.E{Key: "value", Value: int64(2)},
+					},
+					bson.D{
+						primitive.E{Key: "timestamp", Value: primitive.DateTime(20000)},
+						primitive.E{Key: "tags", Value: bson.D{
+							primitive.E{Key: "source", Value: "foo"},
+							primitive.E{Key: "version", Value: "v1.2"},
+						}},
+						primitive.E{Key: "value", Value: int64(3)},
+					},
+				},
+				"test2": {
+					bson.D{
+						primitive.E{Key: "timestamp", Value: primitive.DateTime(0)},
+						primitive.E{Key: "tags", Value: bson.D{
+							primitive.E{Key: "source", Value: "bar"},
+							primitive.E{Key: "version", Value: "v1.2"},
+						}},
+						primitive.E{Key: "value", Value: int64(10)},
+					},
+					bson.D{
+						primitive.E{Key: "timestamp", Value: primitive.DateTime(10000)},
+						primitive.E{Key: "tags", Value: bson.D{
+							primitive.E{Key: "source", Value: "bar"},
+							primitive.E{Key: "version", Value: "v1.2"},
+						}},
+						primitive.E{Key: "value", Value: int64(20)},
+					},
+					bson.D{
+						primitive.E{Key: "timestamp", Value: primitive.DateTime(20000)},
+						primitive.E{Key: "tags", Value: bson.D{
+							primitive.E{Key: "source", Value: "bar"},
+							primitive.E{Key: "version", Value: "v1.2"},
+						}},
+						primitive.E{Key: "value", Value: int64(30)},
+					},
+					bson.D{
+						primitive.E{Key: "timestamp", Value: primitive.DateTime(30000)},
+						primitive.E{Key: "tags", Value: bson.D{
+							primitive.E{Key: "source", Value: "bar"},
+							primitive.E{Key: "version", Value: "v1.2"},
+						}},
+						primitive.E{Key: "value", Value: int64(40)},
+					},
+				},
+			},
 		},
 		{
 			name:  "batch",
 			batch: true,
+			expected: map[string][]bson.D{
+				"test1": {
+					bson.D{
+						primitive.E{Key: "timestamp", Value: primitive.DateTime(0)},
+						primitive.E{Key: "tags", Value: bson.D{
+							primitive.E{Key: "source", Value: "foo"},
+							primitive.E{Key: "version", Value: "v1.2"},
+						}},
+						primitive.E{Key: "value", Value: int64(1)},
+					},
+					bson.D{
+						primitive.E{Key: "timestamp", Value: primitive.DateTime(10000)},
+						primitive.E{Key: "tags", Value: bson.D{
+							primitive.E{Key: "source", Value: "foo"},
+							primitive.E{Key: "version", Value: "v1.2"},
+						}},
+						primitive.E{Key: "value", Value: int64(2)},
+					},
+					bson.D{
+						primitive.E{Key: "timestamp", Value: primitive.DateTime(20000)},
+						primitive.E{Key: "tags", Value: bson.D{
+							primitive.E{Key: "source", Value: "foo"},
+							primitive.E{Key: "version", Value: "v1.2"},
+						}},
+						primitive.E{Key: "value", Value: int64(3)},
+					},
+				},
+				"test2": {
+					bson.D{
+						primitive.E{Key: "timestamp", Value: primitive.DateTime(0)},
+						primitive.E{Key: "tags", Value: bson.D{
+							primitive.E{Key: "source", Value: "bar"},
+							primitive.E{Key: "version", Value: "v1.2"},
+						}},
+						primitive.E{Key: "value", Value: int64(10)},
+					},
+					bson.D{
+						primitive.E{Key: "timestamp", Value: primitive.DateTime(10000)},
+						primitive.E{Key: "tags", Value: bson.D{
+							primitive.E{Key: "source", Value: "bar"},
+							primitive.E{Key: "version", Value: "v1.2"},
+						}},
+						primitive.E{Key: "value", Value: int64(20)},
+					},
+					bson.D{
+						primitive.E{Key: "timestamp", Value: primitive.DateTime(20000)},
+						primitive.E{Key: "tags", Value: bson.D{
+							primitive.E{Key: "source", Value: "bar"},
+							primitive.E{Key: "version", Value: "v1.2"},
+						}},
+						primitive.E{Key: "value", Value: int64(30)},
+					},
+					bson.D{
+						primitive.E{Key: "timestamp", Value: primitive.DateTime(30000)},
+						primitive.E{Key: "tags", Value: bson.D{
+							primitive.E{Key: "source", Value: "bar"},
+							primitive.E{Key: "version", Value: "v1.2"},
+						}},
+						primitive.E{Key: "value", Value: int64(40)},
+					},
+				},
+			},
+		},
+		{
+			name: "metadata source",
+			meta: []string{"source"},
+			expected: map[string][]bson.D{
+				"test1": {
+					bson.D{
+						primitive.E{Key: "timestamp", Value: primitive.DateTime(0)},
+						primitive.E{Key: "metadata", Value: bson.D{
+							primitive.E{Key: "source", Value: "foo"},
+						}},
+						primitive.E{Key: "tags", Value: bson.D{
+							primitive.E{Key: "source", Value: "foo"},
+							primitive.E{Key: "version", Value: "v1.2"},
+						}},
+						primitive.E{Key: "value", Value: int64(1)},
+					},
+					bson.D{
+						primitive.E{Key: "timestamp", Value: primitive.DateTime(10000)},
+						primitive.E{Key: "metadata", Value: bson.D{
+							primitive.E{Key: "source", Value: "foo"},
+						}},
+						primitive.E{Key: "tags", Value: bson.D{
+							primitive.E{Key: "source", Value: "foo"},
+							primitive.E{Key: "version", Value: "v1.2"},
+						}},
+						primitive.E{Key: "value", Value: int64(2)},
+					},
+					bson.D{
+						primitive.E{Key: "timestamp", Value: primitive.DateTime(20000)},
+						primitive.E{Key: "metadata", Value: bson.D{
+							primitive.E{Key: "source", Value: "foo"},
+						}},
+						primitive.E{Key: "tags", Value: bson.D{
+							primitive.E{Key: "source", Value: "foo"},
+							primitive.E{Key: "version", Value: "v1.2"},
+						}},
+						primitive.E{Key: "value", Value: int64(3)},
+					},
+				},
+				"test2": {
+					bson.D{
+						primitive.E{Key: "timestamp", Value: primitive.DateTime(0)},
+						primitive.E{Key: "metadata", Value: bson.D{
+							primitive.E{Key: "source", Value: "bar"},
+						}},
+						primitive.E{Key: "tags", Value: bson.D{
+							primitive.E{Key: "source", Value: "bar"},
+							primitive.E{Key: "version", Value: "v1.2"},
+						}},
+						primitive.E{Key: "value", Value: int64(10)},
+					},
+					bson.D{
+						primitive.E{Key: "timestamp", Value: primitive.DateTime(10000)},
+						primitive.E{Key: "metadata", Value: bson.D{
+							primitive.E{Key: "source", Value: "bar"},
+						}},
+						primitive.E{Key: "tags", Value: bson.D{
+							primitive.E{Key: "source", Value: "bar"},
+							primitive.E{Key: "version", Value: "v1.2"},
+						}},
+						primitive.E{Key: "value", Value: int64(20)},
+					},
+					bson.D{
+						primitive.E{Key: "timestamp", Value: primitive.DateTime(20000)},
+						primitive.E{Key: "metadata", Value: bson.D{
+							primitive.E{Key: "source", Value: "bar"},
+						}},
+						primitive.E{Key: "tags", Value: bson.D{
+							primitive.E{Key: "source", Value: "bar"},
+							primitive.E{Key: "version", Value: "v1.2"},
+						}},
+						primitive.E{Key: "value", Value: int64(30)},
+					},
+					bson.D{
+						primitive.E{Key: "timestamp", Value: primitive.DateTime(30000)},
+						primitive.E{Key: "metadata", Value: bson.D{
+							primitive.E{Key: "source", Value: "bar"},
+						}},
+						primitive.E{Key: "tags", Value: bson.D{
+							primitive.E{Key: "source", Value: "bar"},
+							primitive.E{Key: "version", Value: "v1.2"},
+						}},
+						primitive.E{Key: "value", Value: int64(40)},
+					},
+				},
+			},
 		},
 	}
 
@@ -434,88 +648,46 @@ func TestWriteIntegration(t *testing.T) {
 	input := []telegraf.Metric{
 		metric.New(
 			"test1",
-			map[string]string{"source": "foo"},
+			map[string]string{"source": "foo", "version": "v1.2"},
 			map[string]interface{}{"value": 1},
 			time.Unix(0, 0),
 		),
 		metric.New(
 			"test1",
-			map[string]string{"source": "foo"},
+			map[string]string{"source": "foo", "version": "v1.2"},
 			map[string]interface{}{"value": 2},
 			time.Unix(10, 0),
 		),
 		metric.New(
 			"test1",
-			map[string]string{"source": "foo"},
+			map[string]string{"source": "foo", "version": "v1.2"},
 			map[string]interface{}{"value": 3},
 			time.Unix(20, 0),
 		),
 		metric.New(
 			"test2",
-			map[string]string{"source": "bar"},
+			map[string]string{"source": "bar", "version": "v1.2"},
 			map[string]interface{}{"value": 10},
 			time.Unix(0, 10),
 		),
 		metric.New(
 			"test2",
-			map[string]string{"source": "bar"},
+			map[string]string{"source": "bar", "version": "v1.2"},
 			map[string]interface{}{"value": 20},
 			time.Unix(10, 20),
 		),
 		metric.New(
 			"test2",
-			map[string]string{"source": "bar"},
+			map[string]string{"source": "bar", "version": "v1.2"},
 			map[string]interface{}{"value": 30},
 			time.Unix(20, 30),
 		),
 		metric.New(
 			"test2",
-			map[string]string{"source": "bar"},
+			map[string]string{"source": "bar", "version": "v1.2"},
 			map[string]interface{}{"value": 40},
 			time.Unix(30, 40),
 		),
-	}
-
-	expected := map[string][]bson.D{
-		"test1": {
-			bson.D{
-				primitive.E{Key: "timestamp", Value: primitive.DateTime(0)},
-				primitive.E{Key: "tags", Value: bson.D{primitive.E{Key: "source", Value: "foo"}}},
-				primitive.E{Key: "value", Value: int64(1)},
-			},
-			bson.D{
-				primitive.E{Key: "timestamp", Value: primitive.DateTime(10000)},
-				primitive.E{Key: "tags", Value: bson.D{primitive.E{Key: "source", Value: "foo"}}},
-				primitive.E{Key: "value", Value: int64(2)},
-			},
-			bson.D{
-				primitive.E{Key: "timestamp", Value: primitive.DateTime(20000)},
-				primitive.E{Key: "tags", Value: bson.D{primitive.E{Key: "source", Value: "foo"}}},
-				primitive.E{Key: "value", Value: int64(3)},
-			},
-		},
-		"test2": {
-			bson.D{
-				primitive.E{Key: "timestamp", Value: primitive.DateTime(0)},
-				primitive.E{Key: "tags", Value: bson.D{primitive.E{Key: "source", Value: "bar"}}},
-				primitive.E{Key: "value", Value: int64(10)},
-			},
-			bson.D{
-				primitive.E{Key: "timestamp", Value: primitive.DateTime(10000)},
-				primitive.E{Key: "tags", Value: bson.D{primitive.E{Key: "source", Value: "bar"}}},
-				primitive.E{Key: "value", Value: int64(20)},
-			},
-			bson.D{
-				primitive.E{Key: "timestamp", Value: primitive.DateTime(20000)},
-				primitive.E{Key: "tags", Value: bson.D{primitive.E{Key: "source", Value: "bar"}}},
-				primitive.E{Key: "value", Value: int64(30)},
-			},
-			bson.D{
-				primitive.E{Key: "timestamp", Value: primitive.DateTime(30000)},
-				primitive.E{Key: "tags", Value: bson.D{primitive.E{Key: "source", Value: "bar"}}},
-				primitive.E{Key: "value", Value: int64(40)},
-			},
-		},
 	}
 
 	for _, tt := range tests {
@@ -536,6 +708,7 @@ func TestWriteIntegration(t *testing.T) {
 				Dsn:            "mongodb://" + container.Address + ":" + container.Ports[servicePort],
 				MetricDatabase: "telegraf_test",
 				WriteBatch:     tt.batch,
+				MetadataKeys:   tt.meta,
 			}
 			require.NoError(t, plugin.Init())
 			require.NoError(t, plugin.Connect())
@@ -555,18 +728,41 @@ func TestWriteIntegration(t *testing.T) {
 			collections, err := database.ListCollectionNames(t.Context(), bson.D{})
 			require.NoError(t, err)
 
-			// Read the metrics from the database and compare
-			for expectedCollection, expectedDocuments := range expected {
-				require.Contains(t, collections, expectedCollection)
+			speclist, err := database.ListCollectionSpecifications(t.Context(), bson.D{})
+			require.NoError(t, err)
+			specifications := make(map[string]*mongo.CollectionSpecification, len(speclist))
+			for _, s := range speclist {
+				specifications[s.Name] = s
+			}
 
+			// Read the metrics from the database and compare
+			for expectedCollection, expectedDocuments := range tt.expected {
+				require.Contains(t, collections, expectedCollection)
 				c := database.Collection(expectedCollection)
+
+				// Check metadata field
+				require.Contains(t, specifications, expectedCollection)
+				ts := specifications[expectedCollection].Options.Lookup("timeseries")
+				metaField := ts.Document().Lookup("metaField")
+				if len(tt.meta) == 0 {
+					require.Equal(t, "tags", metaField.StringValue())
+				} else {
+					require.Equal(t, "metadata", metaField.StringValue())
+				}
+
+				// Verify the collection documents
 				projection := bson.D{primitive.E{Key: "_id", Value: 0}}
 				cur, err := c.Find(t.Context(), bson.D{}, options.Find().SetProjection(projection))
 				require.NoError(t, err)
 
 				var documents []bson.D
 				require.NoError(t, cur.All(t.Context(), &documents))
-				require.ElementsMatchf(t, expectedDocuments, documents, "mismatch in collection %q", expectedCollection)
+				require.Len(t, documents, len(expectedDocuments))
+
+				for i, actual := range documents {
+					expected := expectedDocuments[i]
+					require.ElementsMatchf(t, expected, actual, "mismatch in collection %q element %d", expectedCollection, i)
+				}
 			}
 		})
 	}

--- a/plugins/outputs/mongodb/mongodb_test.go
+++ b/plugins/outputs/mongodb/mongodb_test.go
@@ -896,7 +896,11 @@ func TestWriteIntegration(t *testing.T) {
 
 				// Verify the collection documents
 				projection := bson.D{primitive.E{Key: "_id", Value: 0}}
-				cur, err := c.Find(t.Context(), bson.D{}, options.Find().SetProjection(projection))
+				cur, err := c.Find(
+					t.Context(),
+					bson.D{},
+					options.Find().SetProjection(projection).SetSort(bson.D{{Key: "timestamp", Value: 1}}),
+				)
 				require.NoError(t, err)
 
 				var documents []bson.D

--- a/plugins/outputs/mongodb/mongodb_test.go
+++ b/plugins/outputs/mongodb/mongodb_test.go
@@ -56,7 +56,8 @@ func TestInitFail(t *testing.T) {
 		username    config.Secret
 		password    config.Secret
 		granularity string
-		expected    string
+
+		expected string
 	}{
 		{
 			name:        "invalid metric granularity",
@@ -419,10 +420,11 @@ func TestWriteIntegration(t *testing.T) {
 	}
 
 	tests := []struct {
-		name     string
-		meta     []string
-		batch    bool
-		expected map[string][]bson.D
+		name         string
+		batch        bool
+		meta         []string
+		metaStrategy string
+		expected     map[string][]bson.D
 	}{
 		{
 			name: "individual",
@@ -642,6 +644,147 @@ func TestWriteIntegration(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:         "metadata source move",
+			meta:         []string{"source"},
+			metaStrategy: "move",
+			expected: map[string][]bson.D{
+				"test1": {
+					bson.D{
+						primitive.E{Key: "timestamp", Value: primitive.DateTime(0)},
+						primitive.E{Key: "metadata", Value: bson.D{
+							primitive.E{Key: "source", Value: "foo"},
+						}},
+						primitive.E{Key: "tags", Value: bson.D{
+							primitive.E{Key: "version", Value: "v1.2"},
+						}},
+						primitive.E{Key: "value", Value: int64(1)},
+					},
+					bson.D{
+						primitive.E{Key: "timestamp", Value: primitive.DateTime(10000)},
+						primitive.E{Key: "metadata", Value: bson.D{
+							primitive.E{Key: "source", Value: "foo"},
+						}},
+						primitive.E{Key: "tags", Value: bson.D{
+							primitive.E{Key: "version", Value: "v1.2"},
+						}},
+						primitive.E{Key: "value", Value: int64(2)},
+					},
+					bson.D{
+						primitive.E{Key: "timestamp", Value: primitive.DateTime(20000)},
+						primitive.E{Key: "metadata", Value: bson.D{
+							primitive.E{Key: "source", Value: "foo"},
+						}},
+						primitive.E{Key: "tags", Value: bson.D{
+							primitive.E{Key: "version", Value: "v1.2"},
+						}},
+						primitive.E{Key: "value", Value: int64(3)},
+					},
+				},
+				"test2": {
+					bson.D{
+						primitive.E{Key: "timestamp", Value: primitive.DateTime(0)},
+						primitive.E{Key: "metadata", Value: bson.D{
+							primitive.E{Key: "source", Value: "bar"},
+						}},
+						primitive.E{Key: "tags", Value: bson.D{
+							primitive.E{Key: "version", Value: "v1.2"},
+						}},
+						primitive.E{Key: "value", Value: int64(10)},
+					},
+					bson.D{
+						primitive.E{Key: "timestamp", Value: primitive.DateTime(10000)},
+						primitive.E{Key: "metadata", Value: bson.D{
+							primitive.E{Key: "source", Value: "bar"},
+						}},
+						primitive.E{Key: "tags", Value: bson.D{
+							primitive.E{Key: "version", Value: "v1.2"},
+						}},
+						primitive.E{Key: "value", Value: int64(20)},
+					},
+					bson.D{
+						primitive.E{Key: "timestamp", Value: primitive.DateTime(20000)},
+						primitive.E{Key: "metadata", Value: bson.D{
+							primitive.E{Key: "source", Value: "bar"},
+						}},
+						primitive.E{Key: "tags", Value: bson.D{
+							primitive.E{Key: "version", Value: "v1.2"},
+						}},
+						primitive.E{Key: "value", Value: int64(30)},
+					},
+					bson.D{
+						primitive.E{Key: "timestamp", Value: primitive.DateTime(30000)},
+						primitive.E{Key: "metadata", Value: bson.D{
+							primitive.E{Key: "source", Value: "bar"},
+						}},
+						primitive.E{Key: "tags", Value: bson.D{
+							primitive.E{Key: "version", Value: "v1.2"},
+						}},
+						primitive.E{Key: "value", Value: int64(40)},
+					},
+				},
+			},
+		},
+		{
+			name:         "metadata source clear",
+			meta:         []string{"source"},
+			metaStrategy: "clear",
+			expected: map[string][]bson.D{
+				"test1": {
+					bson.D{
+						primitive.E{Key: "timestamp", Value: primitive.DateTime(0)},
+						primitive.E{Key: "metadata", Value: bson.D{
+							primitive.E{Key: "source", Value: "foo"},
+						}},
+						primitive.E{Key: "value", Value: int64(1)},
+					},
+					bson.D{
+						primitive.E{Key: "timestamp", Value: primitive.DateTime(10000)},
+						primitive.E{Key: "metadata", Value: bson.D{
+							primitive.E{Key: "source", Value: "foo"},
+						}},
+						primitive.E{Key: "value", Value: int64(2)},
+					},
+					bson.D{
+						primitive.E{Key: "timestamp", Value: primitive.DateTime(20000)},
+						primitive.E{Key: "metadata", Value: bson.D{
+							primitive.E{Key: "source", Value: "foo"},
+						}},
+						primitive.E{Key: "value", Value: int64(3)},
+					},
+				},
+				"test2": {
+					bson.D{
+						primitive.E{Key: "timestamp", Value: primitive.DateTime(0)},
+						primitive.E{Key: "metadata", Value: bson.D{
+							primitive.E{Key: "source", Value: "bar"},
+						}},
+						primitive.E{Key: "value", Value: int64(10)},
+					},
+					bson.D{
+						primitive.E{Key: "timestamp", Value: primitive.DateTime(10000)},
+						primitive.E{Key: "metadata", Value: bson.D{
+							primitive.E{Key: "source", Value: "bar"},
+						}},
+						primitive.E{Key: "value", Value: int64(20)},
+					},
+					bson.D{
+						primitive.E{Key: "timestamp", Value: primitive.DateTime(20000)},
+						primitive.E{Key: "metadata", Value: bson.D{
+							primitive.E{Key: "source", Value: "bar"},
+						}},
+						primitive.E{Key: "value", Value: int64(30)},
+					},
+					bson.D{
+						primitive.E{Key: "timestamp", Value: primitive.DateTime(30000)},
+						primitive.E{Key: "metadata", Value: bson.D{
+							primitive.E{Key: "source", Value: "bar"},
+						}},
+						primitive.E{Key: "value", Value: int64(40)},
+					},
+				},
+			},
+		},
 	}
 
 	// Setup the input metrics and expected results
@@ -705,10 +848,11 @@ func TestWriteIntegration(t *testing.T) {
 
 			// Setup and start the plugin
 			plugin := &MongoDB{
-				Dsn:            "mongodb://" + container.Address + ":" + container.Ports[servicePort],
-				MetricDatabase: "telegraf_test",
-				WriteBatch:     tt.batch,
-				MetadataKeys:   tt.meta,
+				Dsn:                 "mongodb://" + container.Address + ":" + container.Ports[servicePort],
+				MetricDatabase:      "telegraf_test",
+				WriteBatch:          tt.batch,
+				MetadataKeys:        tt.meta,
+				MetadataTagStrategy: tt.metaStrategy,
 			}
 			require.NoError(t, plugin.Init())
 			require.NoError(t, plugin.Connect())

--- a/plugins/outputs/mongodb/sample.conf
+++ b/plugins/outputs/mongodb/sample.conf
@@ -32,6 +32,16 @@
   ## Database to store measurements and time series collections
   # database = "telegraf"
 
+  ## If true, write multiple metrics for the same collection in a batched
+  ## fashion. Otherwise, write each metric individually.
+  # write_batch = false
+
+  ## List of tags to use as metadata (wildcards accepted)
+  ## If empty the "tags" element will be used as metadata field, otherwise
+  ## a "metadata" element will be created containing the matching, existing
+  ## tag key-values.
+  # metadata_keys = []
+
   ## Granularity can be seconds, minutes, or hours.
   ## Configuring this value will be based on your input collection frequency
   ## see https://docs.mongodb.com/manual/core/timeseries-collections/#create-a-time-series-collection
@@ -40,6 +50,3 @@
   ## TTL to automatically expire documents from the measurement collections.
   # ttl = "360h"
 
-  ## If true, write multiple metrics for the same collection in a batched
-  ## fashion. Otherwise, write each metric individually.
-  # write_batch = false

--- a/plugins/outputs/mongodb/sample.conf
+++ b/plugins/outputs/mongodb/sample.conf
@@ -42,6 +42,12 @@
   ## tag key-values.
   # metadata_keys = []
 
+  ## Behavior when using explicit metadata keys; ignored for empty metadata_keys
+  ##  keep  -- keep all tags as tags
+  ##  move  -- move tags matching metadata_keys and delete them in the tags field
+  ##  clear -- clear ALL tags and remove the tags field entirely from the document
+  # metadata_tag_strategy = "keep"
+
   ## Granularity can be seconds, minutes, or hours.
   ## Configuring this value will be based on your input collection frequency
   ## see https://docs.mongodb.com/manual/core/timeseries-collections/#create-a-time-series-collection


### PR DESCRIPTION
## Summary

This PR allows to specify tags to be used as metadata fields. By default, the `tags` element is used as metadata-field to preserve backward-compatibility with existing setup. However, if a list of metadata fields is given, a new `metadata` element is created containing the key-value pairs with the matching tags.

> [!NOTE]
> The new `metadata_keys` option accepts wildcards. All tags matching the given list will be added as metadata. If a metadata field does not match a tag it is simply ignored.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

resolves #18419 
