### PR TITLE
fix(common.adx): Make Close safe to call multiple times

### DIFF
--- a/plugins/common/adx/adx.go
+++ b/plugins/common/adx/adx.go
@@ -102,14 +102,15 @@ func (adx *Client) Close() error {
 			errs.AddError(err)
 		}
 	}
-	if err := adx.client.Close(); err != nil {
-		errs.AddError(err)
+	if adx.client != nil {
+		if err := adx.client.Close(); err != nil {
+			errs.AddError(err)
+		}
 	}
 
 	adx.client = nil
 	adx.ingestors = nil
 
-	// Combine errors into a single object and return the combined error
 	return errs.GetError()
 }
 

--- a/plugins/common/adx/adx_test.go
+++ b/plugins/common/adx/adx_test.go
@@ -189,6 +189,7 @@ func TestAlreadyClosed(t *testing.T) {
 	plugin, err := cfg.NewClient("test", testutil.Logger{})
 	require.NoError(t, err)
 	require.NoError(t, plugin.Close())
+	require.NoError(t, plugin.Close())
 }
 
 // Internal


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
`Client.Close()` sets `adx.client = nil` after closing, so a second call would dereference a nil client and panic. This guards the inner `Close()` call so the method is idempotent.                             
                                                                                                                                                                                                                   
  `TestAlreadyClosed` is also extended to actually invoke `Close()` twice, which it didn't before despite its name.

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
