### PR TITLE
chore(common.adx): Drop redundant ToLower in getMetricIngestor

### DIFF
--- a/plugins/common/adx/adx.go
+++ b/plugins/common/adx/adx.go
@@ -155,7 +155,7 @@ func (adx *Client) getMetricIngestor(ctx context.Context, tableName string) (azk
 	// Create a new ingestor client for the table
 	var ingestor azkustoingest.Ingestor
 	var err error
-	switch strings.ToLower(adx.cfg.IngestionType) {
+	switch adx.cfg.IngestionType {
 	case ManagedIngestion:
 		ingestor, err = azkustoingest.NewManaged(adx.conn, options...)
 	case QueuedIngestion:


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
`cfg.IngestionType` is already validated in `NewClient` to be exactly `"managed"`, `"queued"`, or empty (defaulted to `"queued"`). Case-folding it again on every ingestor lookup in `getMetricIngestor` is unnecessary, so the switch can match `adx.cfg.IngestionType` directly.

  No behavior change.

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
