### PR TITLE
feat(outputs.kafka): Add support for custom record headers

### DIFF
--- a/plugins/outputs/kafka/README.md
+++ b/plugins/outputs/kafka/README.md
@@ -134,9 +134,6 @@ to use them.
   ##   * now: Uses the time of write
   # producer_timestamp = metric
 
-  ## Add metric name as specified kafka header if not empty
-  # metric_name_header = ""
-
   ## Optional TLS Config
   # enable_tls = false
   # tls_ca = "/etc/telegraf/ca.pem"
@@ -248,6 +245,12 @@ to use them.
   #   method = "tags"
   #   keys = ["foo", "bar"]
   #   separator = "_"
+
+  ## Kafka headers to add to the message where header values accept templates
+  # [outputs.kafka.headers]
+  #   metric_name = "{{ .Name }}"
+  #   my_tag = "foo-{{ .Tag "mytag" }}"
+  #   my_value = "bar-{{ .Field "my" }}-{{ .Field "value" }}"
 ```
 
 ### `max_retry`

--- a/plugins/outputs/kafka/README.md
+++ b/plugins/outputs/kafka/README.md
@@ -248,9 +248,9 @@ to use them.
 
   ## Kafka headers to add to the message where header values accept templates
   # [outputs.kafka.headers]
-  #   metric_name = "{{ .Name }}"
-  #   my_tag = "foo-{{ .Tag "mytag" }}"
-  #   my_value = "bar-{{ .Field "my" }}-{{ .Field "value" }}"
+  #   metric_name = '{{ .Name }}'
+  #   my_tag = 'foo-{{ .Tag "mytag" }}'
+  #   my_value = 'bar-{{ .Field "my" }}-{{ .Field "value" }}'
 ```
 
 ### `max_retry`

--- a/plugins/outputs/kafka/kafka.go
+++ b/plugins/outputs/kafka/kafka.go
@@ -2,10 +2,13 @@
 package kafka
 
 import (
+	"bytes"
 	_ "embed"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
+	"text/template"
 	"time"
 
 	"github.com/IBM/sarama"
@@ -24,16 +27,17 @@ var sampleConfig string
 var zeroTime = time.Unix(0, 0)
 
 type Kafka struct {
-	Brokers           []string        `toml:"brokers"`
-	Topic             string          `toml:"topic"`
-	TopicTag          string          `toml:"topic_tag"`
-	ExcludeTopicTag   bool            `toml:"exclude_topic_tag"`
-	TopicSuffix       TopicSuffix     `toml:"topic_suffix"`
-	RoutingTag        string          `toml:"routing_tag"`
-	RoutingKey        string          `toml:"routing_key"`
-	ProducerTimestamp string          `toml:"producer_timestamp"`
-	MetricNameHeader  string          `toml:"metric_name_header"`
-	Log               telegraf.Logger `toml:"-"`
+	Brokers           []string          `toml:"brokers"`
+	Topic             string            `toml:"topic"`
+	TopicTag          string            `toml:"topic_tag"`
+	ExcludeTopicTag   bool              `toml:"exclude_topic_tag"`
+	TopicSuffix       TopicSuffix       `toml:"topic_suffix"`
+	RoutingTag        string            `toml:"routing_tag"`
+	RoutingKey        string            `toml:"routing_key"`
+	ProducerTimestamp string            `toml:"producer_timestamp"`
+	MetricNameHeader  string            `toml:"metric_name_header" deprecated:"1.39.0;1.45.0;please use 'headers' instead"`
+	Headers           map[string]string `toml:"headers"`
+	Log               telegraf.Logger   `toml:"-"`
 	proxy.Socks5ProxyConfig
 	kafka.WriteConfig
 
@@ -45,6 +49,7 @@ type Kafka struct {
 	saramaConfig *sarama.Config
 	producerFunc func(addrs []string, config *sarama.Config) (sarama.SyncProducer, error)
 	producer     sarama.SyncProducer
+	headerTmpl   map[string]*template.Template
 
 	serializer telegraf.Serializer
 }
@@ -74,16 +79,22 @@ func (k *Kafka) Init() error {
 		return fmt.Errorf("unknown topic suffix method provided: %s", k.TopicSuffix.Method)
 	}
 
-	config := sarama.NewConfig()
-	if err := k.SetConfig(config, k.Log); err != nil {
-		return err
-	}
-
 	// Legacy support ssl config
 	if k.Certificate != "" {
 		k.TLSCert = k.Certificate
 		k.TLSCA = k.CA
 		k.TLSKey = k.Key
+	}
+
+	// Legacy support for metric_name_header
+	if k.MetricNameHeader != "" {
+		k.Headers[k.MetricNameHeader] = "{{ .Name }}"
+	}
+
+	// Create new configuration
+	config := sarama.NewConfig()
+	if err := k.SetConfig(config, k.Log); err != nil {
+		return err
 	}
 
 	if k.Socks5ProxyEnabled {
@@ -103,6 +114,16 @@ func (k *Kafka) Init() error {
 	case "metric", "now":
 	default:
 		return fmt.Errorf("unknown producer_timestamp option: %s", k.ProducerTimestamp)
+	}
+
+	// Setup header templates
+	k.headerTmpl = make(map[string]*template.Template, len(k.Headers))
+	for name, expr := range k.Headers {
+		tmpl, err := template.New(name).Parse(expr)
+		if err != nil {
+			return fmt.Errorf("creating template for header %q failed: %w", name, err)
+		}
+		k.headerTmpl[name] = tmpl
 	}
 
 	return nil
@@ -136,17 +157,23 @@ func (k *Kafka) Write(metrics []telegraf.Metric) error {
 		}
 
 		m := &sarama.ProducerMessage{
-			Topic: topic,
-			Value: sarama.ByteEncoder(buf),
+			Topic:   topic,
+			Value:   sarama.ByteEncoder(buf),
+			Headers: make([]sarama.RecordHeader, 0, len(k.headerTmpl)),
 		}
 
-		if k.MetricNameHeader != "" {
-			m.Headers = []sarama.RecordHeader{
-				{
-					Key:   []byte(k.MetricNameHeader),
-					Value: []byte(metric.Name()),
-				},
+		// Set the message headers
+		var headerValue bytes.Buffer
+		for name, tmpl := range k.headerTmpl {
+			headerValue.Reset()
+			if err := tmpl.Execute(&headerValue, metric); err != nil {
+				k.Log.Errorf("adding header %q failed: %v", name, err)
+				continue
 			}
+			m.Headers = append(m.Headers, sarama.RecordHeader{
+				Key:   []byte(name),
+				Value: slices.Clone(headerValue.Bytes()),
+			})
 		}
 
 		// Negative timestamps are not allowed by the Kafka protocol.
@@ -154,14 +181,15 @@ func (k *Kafka) Write(metrics []telegraf.Metric) error {
 			m.Timestamp = metric.Time()
 		}
 
+		// Add the routing key if configured
 		key, err := k.routingKey(metric)
 		if err != nil {
 			return fmt.Errorf("could not generate routing key: %w", err)
 		}
-
 		if key != "" {
 			m.Key = sarama.StringEncoder(key)
 		}
+
 		msgs = append(msgs, m)
 	}
 

--- a/plugins/outputs/kafka/kafka.go
+++ b/plugins/outputs/kafka/kafka.go
@@ -88,6 +88,9 @@ func (k *Kafka) Init() error {
 
 	// Legacy support for metric_name_header
 	if k.MetricNameHeader != "" {
+		if k.Headers == nil {
+			k.Headers = make(map[string]string, 1)
+		}
 		k.Headers[k.MetricNameHeader] = "{{ .Name }}"
 	}
 

--- a/plugins/outputs/kafka/kafka_test.go
+++ b/plugins/outputs/kafka/kafka_test.go
@@ -268,6 +268,105 @@ func TestTopicTag(t *testing.T) {
 	}
 }
 
+func TestHeaders(t *testing.T) {
+	tests := []struct {
+		name     string
+		headers  map[string]string
+		expected []sarama.RecordHeader
+	}{
+		{
+			name: "none",
+		},
+		{
+			name:    "static string",
+			headers: map[string]string{"agent": "telegraf"},
+			expected: []sarama.RecordHeader{
+				{
+					Key:   []byte("agent"),
+					Value: []byte("telegraf"),
+				},
+			},
+		},
+		{
+			name:    "metric name header",
+			headers: map[string]string{"metric": "{{ .Name }}"},
+			expected: []sarama.RecordHeader{
+				{
+					Key:   []byte("metric"),
+					Value: []byte("cpu"),
+				},
+			},
+		},
+		{
+			name: "complex",
+			headers: map[string]string{
+				"source": `{{ .Tag "source" }}:{{ .Tag "topic"}}`,
+				"device": `{{ .Name }}-{{ .Field "id" }}`,
+			},
+			expected: []sarama.RecordHeader{
+				{
+					Key:   []byte("source"),
+					Value: []byte("server:xyzzy"),
+				},
+				{
+					Key:   []byte("device"),
+					Value: []byte("cpu-3254345daab4"),
+				},
+			},
+		},
+	}
+
+	// Define an input metric for writing
+	input := []telegraf.Metric{
+		metric.New(
+			"cpu",
+			map[string]string{
+				"topic":  "xyzzy",
+				"source": "server",
+			},
+			map[string]interface{}{
+				"id":    "3254345daab4",
+				"value": 42.0,
+				"hours": 255,
+			},
+			time.Unix(0, 0),
+		),
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup the serializer
+			s := &influx.Serializer{}
+			require.NoError(t, s.Init())
+
+			// Setup the plugin under test
+			plugin := &Kafka{
+				Brokers:      []string{"127.0.0.1"},
+				Topic:        "telegraf",
+				Headers:      tt.headers,
+				Log:          testutil.Logger{},
+				producerFunc: newMockProducer,
+			}
+			plugin.SetSerializer(s)
+			require.NoError(t, plugin.Init())
+
+			// Connect and write a metric
+			require.NoError(t, plugin.Connect())
+			require.NoError(t, plugin.Write(input))
+
+			// Check the content that would be sent by the producer
+			producer, ok := plugin.producer.(*mockProducer)
+			require.True(t, ok, "invalid producer type")
+
+			producer.Lock()
+			message := producer.sent[0]
+			producer.Unlock()
+
+			require.ElementsMatch(t, tt.expected, message.Headers)
+		})
+	}
+}
+
 type mockProducer struct {
 	sent []*sarama.ProducerMessage
 	sarama.SyncProducer

--- a/plugins/outputs/kafka/sample.conf
+++ b/plugins/outputs/kafka/sample.conf
@@ -87,9 +87,6 @@
   ##   * now: Uses the time of write
   # producer_timestamp = metric
 
-  ## Add metric name as specified kafka header if not empty
-  # metric_name_header = ""
-
   ## Optional TLS Config
   # enable_tls = false
   # tls_ca = "/etc/telegraf/ca.pem"
@@ -201,3 +198,9 @@
   #   method = "tags"
   #   keys = ["foo", "bar"]
   #   separator = "_"
+
+  ## Kafka headers to add to the message where header values accept templates
+  # [outputs.kafka.headers]
+  #   metric_name = "{{ .Name }}"
+  #   my_tag = "foo-{{ .Tag "mytag" }}"
+  #   my_value = "bar-{{ .Field "my" }}-{{ .Field "value" }}"

--- a/plugins/outputs/kafka/sample.conf
+++ b/plugins/outputs/kafka/sample.conf
@@ -201,6 +201,6 @@
 
   ## Kafka headers to add to the message where header values accept templates
   # [outputs.kafka.headers]
-  #   metric_name = "{{ .Name }}"
-  #   my_tag = "foo-{{ .Tag "mytag" }}"
-  #   my_value = "bar-{{ .Field "my" }}-{{ .Field "value" }}"
+  #   metric_name = '{{ .Name }}'
+  #   my_tag = 'foo-{{ .Tag "mytag" }}'
+  #   my_value = 'bar-{{ .Field "my" }}-{{ .Field "value" }}'


### PR DESCRIPTION
## Summary

This PR allows to set custom record headers for outgoing Kafka messages based on metric information. Each header value can be a Go template to construct values from metric name, tags or fields. By doing so, it replaces the `metric_name_header` setting which is now just yet-another-header with `{{ .Name }}` content.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

resolves #16163 
