### PR TITLE
docs: fix code-block lint errors across plugin READMEs

### DIFF
--- a/plugins/inputs/bind/README.md
+++ b/plugins/inputs/bind/README.md
@@ -71,7 +71,7 @@ depending on your BIND version and configured statistics channel.
 Add the following to your named.conf if running Telegraf on the same host
 as the BIND daemon:
 
-```json
+```text
 statistics-channels {
     inet 127.0.0.1 port 8053;
 };

--- a/plugins/inputs/ctrlx_datalayer/README.md
+++ b/plugins/inputs/ctrlx_datalayer/README.md
@@ -309,7 +309,7 @@ Configuration:
 
 Source:
 
-```json
+```text
 "framework/metrics/system/memavailable-mb" : 365.93359375
 "framework/metrics/system/memused-mb" : 567.67578125
 ```
@@ -336,7 +336,7 @@ Configuration:
 
 Source:
 
-```json
+```text
 "alldata/dynamic/array-of-bool8" : [true, false, true]
 "alldata/dynamic/array-of-uint8" : [0, 255]
 ```
@@ -363,7 +363,7 @@ Configuration:
 
 Source:
 
-```json
+```text
 "motion/axs/Axis_1/state/values/actual" : {"actualPos":65.249329860957,"actualVel":5,"actualAcc":0,"actualTorque":0,"distLeft":0,"actualPosUnit":"mm","actualVelUnit":"mm/min","actualAccUnit":"m/s^2","actualTorqueUnit":"Nm","distLeftUnit":"mm"}
 "motion/axs/Axis_2/state/values/actual" : {"actualPos":120,"actualVel":0,"actualAcc":0,"actualTorque":0,"distLeft":0,"actualPosUnit":"deg","actualVelUnit":"rpm","actualAccUnit":"rad/s^2","actualTorqueUnit":"Nm","distLeftUnit":"deg"}
 ```

--- a/plugins/inputs/docker/README.md
+++ b/plugins/inputs/docker/README.md
@@ -158,7 +158,7 @@ for containers that have no explicit hostname set, as defined by docker.
 Kubernetes may add many labels to your containers, if they are not needed you
 may prefer to exclude them:
 
-```json
+```toml
   docker_label_exclude = ["annotation.kubernetes*"]
 ```
 
@@ -167,7 +167,7 @@ may prefer to exclude them:
 Docker-compose will add labels to your containers. You can limit restrict labels
 to selected ones, e.g.
 
-```json
+```toml
   docker_label_include = [
     "com.docker.compose.config-hash",
     "com.docker.compose.container-number",

--- a/plugins/inputs/jti_openconfig_telemetry/README.md
+++ b/plugins/inputs/jti_openconfig_telemetry/README.md
@@ -60,12 +60,13 @@ plugin ordering. See [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
   ## We allow specifying sensor group level reporting rate. To do this, specify the
   ## reporting rate in Duration at the beginning of sensor paths / collection
-  ## name. For entries without reporting rate, we use configured sample frequency
-  sensors = [
-   "1000ms customReporting /interfaces /lldp",
-   "2000ms collection /components",
-   "/interfaces",
-  ]
+  ## name. For entries without reporting rate, we use configured sample frequency.
+  ## Use this form INSTEAD of the simple `sensors` list above:
+  # sensors = [
+  #  "1000ms customReporting /interfaces /lldp",
+  #  "2000ms collection /components",
+  #  "/interfaces",
+  # ]
 
   ## Timestamp Source
   ## Set to 'collection' for time of collection, and 'data' for using the time

--- a/plugins/inputs/opcua_listener/README.md
+++ b/plugins/inputs/opcua_listener/README.md
@@ -538,9 +538,9 @@ This example group configuration shows how to use group settings:
      identifier = "5678"
 
     node_ids = [
-      {identifier="Sensor1"}, // default values will be used for namespace and identifier_type
-      {namespace="2", identifier="TemperatureSensor"}, // default values will be used for identifier_type
-      {namespace="5", identifier_type="i", identifier="2002"} // no default values will be used
+      {identifier="Sensor1"},                                  # default values will be used for namespace and identifier_type
+      {namespace="2", identifier="TemperatureSensor"},         # default values will be used for identifier_type
+      {namespace="5", identifier_type="i", identifier="2002"}  # no default values will be used
     ]
 ```
 

--- a/plugins/inputs/postgresql_extensible/README.md
+++ b/plugins/inputs/postgresql_extensible/README.md
@@ -131,8 +131,9 @@ using the postgresql extensions [pg_stat_statements][pg_stat_statements],
   withdbname=false
   tagvalue="db,username,state"
 [[inputs.postgresql_extensible.query]]
-  sqlquery="select setting as max_connections from pg_settings where \
-  name='max_connections'"
+  sqlquery="""\
+  select setting as max_connections from pg_settings where \
+  name='max_connections'"""
   version=801
   withdbname=false
   tagvalue=""
@@ -142,15 +143,17 @@ using the postgresql extensions [pg_stat_statements][pg_stat_statements],
   withdbname=false
   tagvalue=""
 [[inputs.postgresql_extensible.query]]
-  sqlquery="select setting as shared_buffers from pg_settings where \
-  name='shared_buffers'"
+  sqlquery="""\
+  select setting as shared_buffers from pg_settings where \
+  name='shared_buffers'"""
   version=801
   withdbname=false
   tagvalue=""
 [[inputs.postgresql_extensible.query]]
-  sqlquery="SELECT db, count( distinct blocking_pid ) AS num_blocking_sessions,\
+  sqlquery="""\
+  SELECT db, count( distinct blocking_pid ) AS num_blocking_sessions,\
   count( distinct blocked_pid) AS num_blocked_sessions FROM \
-  public.blocking_procs group by db"
+  public.blocking_procs group by db"""
   version=901
   withdbname=false
   tagvalue="db"

--- a/plugins/inputs/win_eventlog/README.md
+++ b/plugins/inputs/win_eventlog/README.md
@@ -137,7 +137,7 @@ There are three types of filtering: **Event Log** name, **XPath Query** and
 
 ```toml
   eventlog_name = "Application"
-  xpath_query = '''
+  xpath_query = ""
 ```
 
 For **XPath Query** filtering set the `xpath_query` value, and `eventlog_name`

--- a/plugins/outputs/azure_data_explorer/README.md
+++ b/plugins/outputs/azure_data_explorer/README.md
@@ -244,7 +244,7 @@ stored as dynamic data type, multiple ways to query this data-
    recommended performant way for querying over large volumes of data compared
    to querying directly over JSON attributes:
 
-  ```json
+  ```kusto
   // Function to transform data
   .create-or-alter function Transform_TargetTableName() {
         SourceTableName

--- a/plugins/outputs/clarify/README.md
+++ b/plugins/outputs/clarify/README.md
@@ -68,7 +68,7 @@ The following input would be stored in Clarify with the values shown below:
 temperature,host=demo.clarifylocal,sensor=TC0P value=49 1682670910000000000
 ```
 
-```json
+```text
 "signal" {
   "id": "temperature.value.TC0P"
   "name": "temperature.value"

--- a/plugins/outputs/dynatrace/README.md
+++ b/plugins/outputs/dynatrace/README.md
@@ -91,7 +91,7 @@ The endpoint for the Dynatrace Metrics API v2 is
   url = "https://{your-environment-id}.live.dynatrace.com/api/v2/metrics/ingest"
 
   ## API token is required if a URL is specified and should be restricted to the 'Ingest metrics' scope
-  api_token = "your API token here" // hard-coded for illustration only, should be read from environment
+  api_token = "your API token here"  # hard-coded for illustration only, should be read from environment
 ```
 
 You can learn more about how to use the [Dynatrace API][api].

--- a/plugins/outputs/elasticsearch/README.md
+++ b/plugins/outputs/elasticsearch/README.md
@@ -205,7 +205,7 @@ compatibility mode users need to set the `override_main_response_version` to
 
 On existing clusters run:
 
-```json
+```text
 PUT /_cluster/settings
 {
   "persistent" : {
@@ -216,7 +216,7 @@ PUT /_cluster/settings
 
 And on new clusters set the option to true under advanced options:
 
-```json
+```text
 POST https://es.us-east-1.amazonaws.com/2021-01-01/opensearch/upgradeDomain
 {
   "DomainName": "domain-name",

--- a/plugins/outputs/zabbix/README.md
+++ b/plugins/outputs/zabbix/README.md
@@ -174,7 +174,7 @@ measurement,host=hostname valueA=0,valueB=1
 
 It will generate this Zabbix metrics:
 
-```json
+```jsonl
 {"host": "hostname", "key": "telegraf.measurement.valueA", "value": "0"}
 {"host": "hostname", "key": "telegraf.measurement.valueB", "value": "1"}
 ```
@@ -188,7 +188,7 @@ measurement,host=hostname,tagA=keyA,tagB=keyB valueA=0,valueB=1
 
 Zabbix generated metrics:
 
-```json
+```jsonl
 {"host": "hostname", "key": "telegraf.measurement.valueA[keyA,keyB]", "value": "0"}
 {"host": "hostname", "key": "telegraf.measurement.valueB[keyA,keyB]", "value": "1"}
 ```

--- a/plugins/processors/converter/README.md
+++ b/plugins/processors/converter/README.md
@@ -131,7 +131,7 @@ Set the metric timestamp from a tag:
 [[processors.converter]]
   [processors.converter.tags]
     timestamp = ["time"]
-    timestamp_format = "unix
+    timestamp_format = "unix"
 ```
 
 ```diff

--- a/plugins/processors/lookup/README.md
+++ b/plugins/processors/lookup/README.md
@@ -63,7 +63,7 @@ added to a metric if the key matches.
 
 In the `json` format, the input `files` must have the following format
 
-```json
+```text
 {
   "keyA": {
     "tag-name1": "tag-value1",
@@ -133,7 +133,7 @@ With a lookup table of
   "xyzzy-red": {
     "location": "us-west",
     "rack": "C01-42"
-  },
+  }
 }
 ```
 


### PR DESCRIPTION
## Summary

InfluxData docs-v2 ([influxdata/docs-v2#7136](https://github.com/influxdata/docs-v2/pull/7136)) added a parse/compile lint check for fenced code blocks. JSON, YAML, and TOML blocks that fail to parse block CI on the docs site.

The plugin READMEs in this repo are mirrored verbatim into docs-v2 by the sync process, so several blocks that were never valid JSON or TOML now break the docs build downstream. The corresponding [influxdata/docs-v2 fixes](https://github.com/influxdata/docs-v2/pull/7166) and [JSON fixes](https://github.com/influxdata/docs-v2/pull/7170) explicitly defer these 14 files to upstream because any in-place fix would be overwritten on the next sync.

These changes preserve the original intent and content where possible. Where a block is genuinely illustrative (placeholders, ellipses, mixed HTTP-method-line plus body, or vendor query languages), the fence is relabeled to the closer-fit language so the lint check skips it.

## TOML fixes (6 files)

| File | Fix |
|---|---|
| `inputs/jti_openconfig_telemetry/README.md` | `sensors = [...]` was redefined twice; commented out the alternative-form example |
| `inputs/opcua_listener/README.md` | `// ... default values ...` C-style comments inside an inline-table list. Converted to trailing `#` comments |
| `inputs/postgresql_extensible/README.md` | `sqlquery = "...where \` line continuations in basic strings are invalid TOML. Switched to multi-line basic strings (`"""..."""`) which preserve the `\` line-end continuation form for readability and parse cleanly per the TOML 1.0 spec |
| `inputs/win_eventlog/README.md` | `xpath_query = '''` opened a literal multi-line string but never closed; surrounding text says "set xpath_query empty" — replaced with `""` |
| `outputs/dynatrace/README.md` | `api_token = "..." // hard-coded ...` — converted `//` to `#` |
| `processors/converter/README.md` | `timestamp_format = "unix` missing close quote |

## JSON fixes (8 files)

| File | Fix |
|---|---|
| `inputs/bind/README.md` | BIND config (`statistics-channels { ... };`) tagged `json`. Relabeled `text` |
| `inputs/ctrlx_datalayer/README.md` (3 blocks) | `"key" : value` lines (the OPC UA address-value rendering) are not JSON. Relabeled `text` |
| `inputs/docker/README.md` (2 blocks) | `docker_label_exclude = [...]` / `docker_label_include = [...]` are TOML config snippets. Relabeled `toml` |
| `outputs/azure_data_explorer/README.md` | KQL function definition tagged `json`. Relabeled `kusto` |
| `outputs/clarify/README.md` | `"signal" { ... }` / `"values" { ... }` are Clarify's representation, not JSON. Relabeled `text` |
| `outputs/elasticsearch/README.md` (2 blocks) | `PUT /_cluster/settings` and `POST https://...` HTTP request lines mixed with JSON body. Relabeled `text` |
| `outputs/zabbix/README.md` (2 blocks) | Line-delimited multiple JSON objects. Relabeled `jsonl` |
| `processors/lookup/README.md` | Illustrative template with `...` ellipsis relabeled `text`; data block had a trailing comma that was removed |

## Why this approach

- **No code or behavior changes** — all changes are in README markdown only.
- **Telegraf's TOML parser supports the multi-line basic string form** with `\` line-end continuation. Confirmed by `influxdata/toml/parse.peg`: `mlBasicBody <- ... / escape newline wsnl` and exercised by `config/testdata/special_types.toml`.
- **`postgresql_extensible` SQL queries are functionally identical** before and after — the multi-line form folds whitespace per TOML 1.0, so the resulting query string is unchanged.
- **Relabeling fences as `text` for non-syntax-language blocks** is the standard fix when a snippet was only ever illustrative (HTTP request examples, vendor query languages, partial fragments with placeholders).

## Verification

Linted locally with the same script as docs-v2 CI:

```
$ node scripts/ci/lint-codeblocks.mjs <14 plugin READMEs>
$ echo $?
0
```

## Test plan

- [ ] CI passes
- [ ] Reviewers confirm no semantic changes to the configuration examples (TOML `"""..."""` continuation parses to identical query strings; relabeled fences render with appropriate or no syntax highlighting)