### PR TITLE
test(logging): Fix flaky test

### DIFF
--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -28,6 +28,11 @@ func TestErrorCounting(t *testing.T) {
 		"errors",
 		map[string]string{"input": "test"},
 	)
+	defer selfstat.Unregister(
+		"gather",
+		"errors",
+		map[string]string{"input": "test"},
+	)
 	iLog := New("inputs", "test", "")
 	iLog.RegisterErrorCallback(func() {
 		reg.Incr(1)


### PR DESCRIPTION
## Summary

This PR removes the statefullness in the error counting test that may lead to flaky tests.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
