### PR TITLE
fix(agent): Reset secret-counter on reload

### DIFF
--- a/cmd/telegraf/telegraf.go
+++ b/cmd/telegraf/telegraf.go
@@ -390,6 +390,9 @@ func (*Telegraf) watchRemoteConfigs(ctx context.Context, signals chan os.Signal,
 }
 
 func (t *Telegraf) loadConfiguration() (*config.Config, error) {
+	// Make sure secrets are cleared
+	config.ResetSecrets()
+
 	// If no other options are specified, load the config file and run.
 	c := config.NewConfig()
 	c.Agent.Quiet = t.quiet

--- a/config/secret.go
+++ b/config/secret.go
@@ -16,7 +16,7 @@ import (
 // by the config to their respective secret-stores.
 // Secrets containing constant strings will not be found in this
 // list.
-var unlinkedSecrets = make([]*Secret, 0)
+var unlinkedSecrets []*Secret
 
 // secretStorePattern is a regex to validate secret-store IDs
 var secretStorePattern = regexp.MustCompile(`^\w+$`)
@@ -38,6 +38,11 @@ type secretImpl interface {
 	Container(secret []byte) secretContainer
 	EmptyBuffer() SecretBuffer
 	Wipe(secret []byte)
+}
+
+func ResetSecrets() {
+	unlinkedSecrets = make([]*Secret, 0)
+	secretCount.Store(0)
 }
 
 func EnableSecretProtection() {


### PR DESCRIPTION
## Summary

This PR resets the unlinked secret-list and the secret count when reloading configuration. While the memory requirement itself did not grow, the user-visible requirement message will show an increase in memory requirements for secrets. This PR fixes the issue.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

resolves #17099 
