### PR TITLE
chore(testutil): Allow specifying a log-level

### DIFF
--- a/testutil/log.go
+++ b/testutil/log.go
@@ -9,11 +9,16 @@ import (
 var _ telegraf.Logger = &Logger{}
 
 type Logger struct {
-	Name  string // Name is the plugin name, will be printed in the `[]`.
-	Quiet bool
+	Name     string // Name is the plugin name, will be printed in the `[]`.
+	LogLevel *telegraf.LogLevel
+	Quiet    bool
 }
 
-func (Logger) Level() telegraf.LogLevel {
+func (l Logger) Level() telegraf.LogLevel {
+	// Return the log level if any
+	if l.LogLevel != nil {
+		return *l.LogLevel
+	}
 	// We always want to output at debug level during testing to find issues easier
 	return telegraf.Debug
 }


### PR DESCRIPTION
## Summary

This PR allows to set a custom log-level for `testutil.Logger`.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

related to #18790 