### PR TITLE
chore(inputs.gnmi): Cleanup code

### DIFF
--- a/plugins/inputs/gnmi/gnmi.go
+++ b/plugins/inputs/gnmi/gnmi.go
@@ -12,7 +12,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/google/gnxi/utils/xpath"
 	"github.com/openconfig/gnmi/proto/gnmi"
 	"github.com/openconfig/gnmi/proto/gnmi_ext"
 	"google.golang.org/grpc/keepalive"
@@ -76,24 +75,6 @@ type GNMI struct {
 	wg              sync.WaitGroup
 }
 
-type subscription struct {
-	Name              string          `toml:"name"`
-	Origin            string          `toml:"origin"`
-	Path              string          `toml:"path"`
-	SubscriptionMode  string          `toml:"subscription_mode"`
-	SampleInterval    config.Duration `toml:"sample_interval"`
-	SuppressRedundant bool            `toml:"suppress_redundant"`
-	HeartbeatInterval config.Duration `toml:"heartbeat_interval"`
-
-	fullPath *gnmi.Path
-}
-
-type tagSubscription struct {
-	subscription
-	Match    string   `toml:"match"`
-	Elements []string `toml:"elements"`
-}
-
 func (*GNMI) SampleConfig() string {
 	return sampleConfig
 }
@@ -125,11 +106,6 @@ func (c *GNMI) Init() error {
 		return fmt.Errorf("invalid 'path_guessing_strategy' %q", c.GuessPathStrategy)
 	}
 
-	// Use the new TLS option for enabling
-	// Honor deprecated option
-	enable := c.ClientConfig.Enable != nil && *c.ClientConfig.Enable
-	c.ClientConfig.Enable = &enable
-
 	// Split the subscriptions into "normal" and "tag" subscription
 	// and prepare them.
 	for i := len(c.Subscriptions) - 1; i >= 0; i-- {
@@ -143,12 +119,12 @@ func (c *GNMI) Init() error {
 			return fmt.Errorf("empty 'path' found for subscription %d", i+1)
 		}
 
-		if err := subscription.buildFullPath(c); err != nil {
+		if err := subscription.buildFullPath(c.Origin, c.Prefix, c.Target); err != nil {
 			return err
 		}
 	}
 	for idx := range c.TagSubscriptions {
-		if err := c.TagSubscriptions[idx].buildFullPath(c); err != nil {
+		if err := c.TagSubscriptions[idx].buildFullPath(c.Origin, c.Prefix, c.Target); err != nil {
 			return err
 		}
 		switch c.TagSubscriptions[idx].Match {
@@ -172,13 +148,21 @@ func (c *GNMI) Init() error {
 	// Invert explicit alias list and prefill subscription names
 	c.internalAliases = make(map[*pathInfo]string, len(c.Subscriptions)+len(c.Aliases)+len(c.TagSubscriptions))
 	for _, s := range c.Subscriptions {
-		if err := s.buildAlias(c.internalAliases, c.EnforceFirstNamespaceAsOrigin); err != nil {
+		info, name, err := s.buildAlias(c.EnforceFirstNamespaceAsOrigin)
+		if err != nil {
 			return err
+		}
+		if info != nil && name != "" {
+			c.internalAliases[info] = name
 		}
 	}
 	for _, s := range c.TagSubscriptions {
-		if err := s.buildAlias(c.internalAliases, c.EnforceFirstNamespaceAsOrigin); err != nil {
+		info, name, err := s.buildAlias(c.EnforceFirstNamespaceAsOrigin)
+		if err != nil {
 			return err
+		}
+		if info != nil && name != "" {
+			c.internalAliases[info] = name
 		}
 	}
 	for alias, encodingPath := range c.Aliases {
@@ -308,31 +292,13 @@ func (c *GNMI) Start(acc telegraf.Accumulator) error {
 	return nil
 }
 
-func (*GNMI) Gather(telegraf.Accumulator) error {
-	return nil
-}
-
 func (c *GNMI) Stop() {
 	c.cancel()
 	c.wg.Wait()
 }
 
-func (s *subscription) buildSubscription() (*gnmi.Subscription, error) {
-	gnmiPath, err := parsePath(s.Origin, s.Path, "")
-	if err != nil {
-		return nil, err
-	}
-	mode, ok := gnmi.SubscriptionMode_value[strings.ToUpper(s.SubscriptionMode)]
-	if !ok {
-		return nil, fmt.Errorf("invalid subscription mode %s", s.SubscriptionMode)
-	}
-	return &gnmi.Subscription{
-		Path:              gnmiPath,
-		Mode:              gnmi.SubscriptionMode(mode),
-		HeartbeatInterval: uint64(time.Duration(s.HeartbeatInterval).Nanoseconds()),
-		SampleInterval:    uint64(time.Duration(s.SampleInterval).Nanoseconds()),
-		SuppressRedundant: s.SuppressRedundant,
-	}, nil
+func (*GNMI) Gather(telegraf.Accumulator) error {
+	return nil
 }
 
 // Create a new gNMI SubscribeRequest
@@ -395,59 +361,6 @@ func (c *GNMI) newSubscribeRequest() (*gnmi.SubscribeRequest, error) {
 		},
 		Extension: extensions,
 	}, nil
-}
-
-// ParsePath from XPath-like string to gNMI path structure
-func parsePath(origin, pathToParse, target string) (*gnmi.Path, error) {
-	gnmiPath, err := xpath.ToGNMIPath(pathToParse)
-	if err != nil {
-		return nil, err
-	}
-	gnmiPath.Origin = origin
-	gnmiPath.Target = target
-	return gnmiPath, err
-}
-
-func (s *subscription) buildFullPath(c *GNMI) error {
-	var err error
-	if s.fullPath, err = xpath.ToGNMIPath(s.Path); err != nil {
-		return err
-	}
-	s.fullPath.Origin = s.Origin
-	s.fullPath.Target = c.Target
-	if c.Prefix != "" {
-		prefix, err := xpath.ToGNMIPath(c.Prefix)
-		if err != nil {
-			return err
-		}
-		s.fullPath.Elem = append(prefix.Elem, s.fullPath.Elem...)
-		if s.Origin == "" && c.Origin != "" {
-			s.fullPath.Origin = c.Origin
-		}
-	}
-	return nil
-}
-
-func (s *subscription) buildAlias(aliases map[*pathInfo]string, enforceFirstNamespaceAsOrigin bool) error {
-	// Build the subscription path without keys
-	path, err := parsePath(s.Origin, s.Path, "")
-	if err != nil {
-		return err
-	}
-	info := newInfoFromPathWithoutKeys(path)
-	if enforceFirstNamespaceAsOrigin {
-		info.enforceFirstNamespaceAsOrigin()
-	}
-
-	// If the user didn't provide a measurement name, use last path element
-	name := s.Name
-	if name == "" && len(info.segments) > 0 {
-		name = info.segments[len(info.segments)-1].id
-	}
-	if name != "" {
-		aliases[info] = name
-	}
-	return nil
 }
 
 func init() {

--- a/plugins/inputs/gnmi/gnmi.go
+++ b/plugins/inputs/gnmi/gnmi.go
@@ -174,6 +174,11 @@ func (c *GNMI) Init() error {
 	}
 	c.Log.Debugf("Internal alias mapping: %+v", c.internalAliases)
 
+	// Use the new TLS option for enabling
+	// Honor deprecated option
+	enable := c.ClientConfig.Enable != nil && *c.ClientConfig.Enable
+	c.ClientConfig.Enable = &enable
+
 	// Warn about configures insecure cipher suites
 	insecure := common_tls.InsecureCiphers(c.ClientConfig.TLSCipherSuites)
 	if len(insecure) > 0 {

--- a/plugins/inputs/gnmi/path.go
+++ b/plugins/inputs/gnmi/path.go
@@ -3,6 +3,7 @@ package gnmi
 import (
 	"strings"
 
+	"github.com/google/gnxi/utils/xpath"
 	"github.com/openconfig/gnmi/proto/gnmi"
 )
 
@@ -22,6 +23,17 @@ type pathInfo struct {
 	target    string
 	segments  []segment
 	keyValues []keySegment
+}
+
+// ParsePath from XPath-like string to gNMI path structure
+func parsePath(origin, pathToParse, target string) (*gnmi.Path, error) {
+	gnmiPath, err := xpath.ToGNMIPath(pathToParse)
+	if err != nil {
+		return nil, err
+	}
+	gnmiPath.Origin = origin
+	gnmiPath.Target = target
+	return gnmiPath, err
 }
 
 func newInfoFromString(path string) *pathInfo {

--- a/plugins/inputs/gnmi/subscription.go
+++ b/plugins/inputs/gnmi/subscription.go
@@ -55,11 +55,11 @@ func (s *subscription) buildFullPath(origin, prefix, target string) error {
 	s.fullPath.Origin = s.Origin
 	s.fullPath.Target = target
 	if prefix != "" {
-		prefix, err := xpath.ToGNMIPath(prefix)
+		prefixPath, err := xpath.ToGNMIPath(prefix)
 		if err != nil {
 			return err
 		}
-		s.fullPath.Elem = append(prefix.Elem, s.fullPath.Elem...)
+		s.fullPath.Elem = append(prefixPath.Elem, s.fullPath.Elem...)
 		if s.Origin == "" && origin != "" {
 			s.fullPath.Origin = origin
 		}

--- a/plugins/inputs/gnmi/subscription.go
+++ b/plugins/inputs/gnmi/subscription.go
@@ -1,0 +1,87 @@
+package gnmi
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/gnxi/utils/xpath"
+	"github.com/openconfig/gnmi/proto/gnmi"
+
+	"github.com/influxdata/telegraf/config"
+)
+
+type subscription struct {
+	Name              string          `toml:"name"`
+	Origin            string          `toml:"origin"`
+	Path              string          `toml:"path"`
+	SubscriptionMode  string          `toml:"subscription_mode"`
+	SampleInterval    config.Duration `toml:"sample_interval"`
+	SuppressRedundant bool            `toml:"suppress_redundant"`
+	HeartbeatInterval config.Duration `toml:"heartbeat_interval"`
+
+	fullPath *gnmi.Path
+}
+
+type tagSubscription struct {
+	subscription
+	Match    string   `toml:"match"`
+	Elements []string `toml:"elements"`
+}
+
+func (s *subscription) buildSubscription() (*gnmi.Subscription, error) {
+	gnmiPath, err := parsePath(s.Origin, s.Path, "")
+	if err != nil {
+		return nil, err
+	}
+	mode, ok := gnmi.SubscriptionMode_value[strings.ToUpper(s.SubscriptionMode)]
+	if !ok {
+		return nil, fmt.Errorf("invalid subscription mode %s", s.SubscriptionMode)
+	}
+	return &gnmi.Subscription{
+		Path:              gnmiPath,
+		Mode:              gnmi.SubscriptionMode(mode),
+		HeartbeatInterval: uint64(time.Duration(s.HeartbeatInterval).Nanoseconds()),
+		SampleInterval:    uint64(time.Duration(s.SampleInterval).Nanoseconds()),
+		SuppressRedundant: s.SuppressRedundant,
+	}, nil
+}
+
+func (s *subscription) buildFullPath(origin, prefix, target string) error {
+	var err error
+	if s.fullPath, err = xpath.ToGNMIPath(s.Path); err != nil {
+		return err
+	}
+	s.fullPath.Origin = s.Origin
+	s.fullPath.Target = target
+	if prefix != "" {
+		prefix, err := xpath.ToGNMIPath(prefix)
+		if err != nil {
+			return err
+		}
+		s.fullPath.Elem = append(prefix.Elem, s.fullPath.Elem...)
+		if s.Origin == "" && origin != "" {
+			s.fullPath.Origin = origin
+		}
+	}
+	return nil
+}
+
+func (s *subscription) buildAlias(enforceFirstNamespaceAsOrigin bool) (*pathInfo, string, error) {
+	// Build the subscription path without keys
+	path, err := parsePath(s.Origin, s.Path, "")
+	if err != nil {
+		return nil, "", err
+	}
+	info := newInfoFromPathWithoutKeys(path)
+	if enforceFirstNamespaceAsOrigin {
+		info.enforceFirstNamespaceAsOrigin()
+	}
+
+	// If the user didn't provide a measurement name, use last path element
+	name := s.Name
+	if name == "" && len(info.segments) > 0 {
+		name = info.segments[len(info.segments)-1].id
+	}
+	return info, name, nil
+}


### PR DESCRIPTION
## Summary

This PR cleans the GNMI plugin code my moving subscription related things into an own file as well as moving a path function to the path group.
Additionally, the PR removes passing the GNMI object to the subscription building function to get a cleaner structure. Last but not least, the PR removes a redundant setting of the TLS-enable flag which does exactly the same as the code in common...

All changes are in preparation of factoring common GNMI code out into `plugins/common/gnmi` in order to prepare the GNMI-listener plugin in PR #18790.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

related to #18790 