### PR TITLE
docs(inputs.kubernetes): Document required RBAC permissions

### DIFF
--- a/plugins/inputs/kubernetes/README.md
+++ b/plugins/inputs/kubernetes/README.md
@@ -92,6 +92,40 @@ following Helm charts:
 - [Chronograf][helm_chronograf]
 - [Kapacitor][helm_kapacitor]
 
+### RBAC Permissions
+
+When `url` is left empty (cluster mode), the plugin uses the Kubernetes API to
+discover all nodes in the cluster, then connects to each node's Kubelet
+on port 10250. This requires a `ClusterRole` with read access to `nodes`:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: telegraf-kubernetes
+rules:
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["list", "get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: telegraf-kubernetes
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: telegraf-kubernetes
+subjects:
+  - kind: ServiceAccount
+    name: telegraf
+    namespace: monitoring
+```
+
+When `url` is explicitly set (e.g., `url = "http://127.0.0.1:10255"`), the plugin
+only talks to the local Kubelet API and does **not** use the Kubernetes API server,
+so no Kubernetes RBAC permissions are required.
+
 [k8s_telegraf_blog]: https://www.influxdata.com/blog/monitoring-kubernetes-architecture/
 [helm_telegraf]: https://github.com/helm/charts/tree/master/stable/telegraf
 [helm_influxdb]: https://github.com/helm/charts/tree/master/stable/influxdb

--- a/plugins/inputs/kubernetes/README.md
+++ b/plugins/inputs/kubernetes/README.md
@@ -96,31 +96,14 @@ following Helm charts:
 
 When `url` is left empty (cluster mode), the plugin uses the Kubernetes API to
 discover all nodes in the cluster, then connects to each node's Kubelet
-on port 10250. This requires a `ClusterRole` with read access to `nodes`:
+on port 10250. This requires a `ClusterRole` with the following permissions:
 
-```yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: telegraf-kubernetes
-rules:
-  - apiGroups: [""]
-    resources: ["nodes"]
-    verbs: ["list", "get"]
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: telegraf-kubernetes
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: telegraf-kubernetes
-subjects:
-  - kind: ServiceAccount
-    name: telegraf
-    namespace: monitoring
-```
+- **apiGroups**: `""` (core)
+- **resources**: `"nodes"`
+- **verbs**: `"list"`, `"get"`
+
+Refer to the [Kubernetes RBAC documentation][rbac] for creating the appropriate
+ClusterRole and ClusterRoleBinding.
 
 When `url` is explicitly set (e.g., `url = "http://127.0.0.1:10255"`), the plugin
 only talks to the local Kubelet API and does **not** use the Kubernetes API server,
@@ -131,6 +114,7 @@ so no Kubernetes RBAC permissions are required.
 [helm_influxdb]: https://github.com/helm/charts/tree/master/stable/influxdb
 [helm_chronograf]: https://github.com/helm/charts/tree/master/stable/chronograf
 [helm_kapacitor]: https://github.com/helm/charts/tree/master/stable/kapacitor
+[rbac]: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
 
 ## Metrics
 


### PR DESCRIPTION
## Summary

The kubernetes input plugin uses the Kubernetes API server to discover all
cluster nodes when `url` is not set (cluster mode). This requires a `ClusterRole`
with read access to `nodes`, which was previously undocumented.

Added a working `ClusterRole` and `ClusterRoleBinding` YAML example documenting
the minimal required permissions (`nodes: list, get`). Also clarified that no
Kubernetes RBAC is needed when `url` is explicitly set (single-node mode).

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #16407
