### PR TITLE
fix(inputs.ping): Use deterministic packet IDs to prevent collisions

### DIFF
--- a/plugins/inputs/ping/ping.go
+++ b/plugins/inputs/ping/ping.go
@@ -187,7 +187,7 @@ func freeNativePingID(id uint16) {
 	usedIDsCond.L.Unlock()
 
 	// Signal all waiting pingers to check for the free ID
-	usedIDsCond.Broadcast()
+	usedIDsCond.Signal()
 }
 
 func (p *Ping) nativePing(destination string, id int) (*pingStats, error) {

--- a/plugins/inputs/ping/ping.go
+++ b/plugins/inputs/ping/ping.go
@@ -156,22 +156,6 @@ func reserveNativePingID() (uint16, error) {
 		return id, nil
 	}
 
-	// Check for free spots in the list
-	if len(usedIDs) < math.MaxUint16 {
-		// There is still space in the list, find the free spot
-		for i, id := range usedIDs {
-			if uint16(i) == id {
-				continue
-			}
-			// We found an spot with a missing ID. Insert the biggest
-			// available in the spot to optimize searches and keep the list
-			// sorted.
-			id--
-			usedIDs = slices.Insert(usedIDs, i, id)
-			return id, nil
-		}
-	}
-
 	// All IDs are used, waiting for an ID to become available
 	for len(usedIDs) > math.MaxUint16 {
 		usedIDsCond.Wait()

--- a/plugins/inputs/ping/ping.go
+++ b/plugins/inputs/ping/ping.go
@@ -156,7 +156,7 @@ func reserveNativePingID() (uint16, error) {
 		return id, nil
 	}
 
-	// All IDs are used, waiting for an ID to become available
+	// Waiting for an ID to become available if all are in use
 	for len(usedIDs) > math.MaxUint16 {
 		usedIDsCond.Wait()
 	}
@@ -166,9 +166,11 @@ func reserveNativePingID() (uint16, error) {
 		if uint16(i) == used {
 			continue
 		}
-		// We found an spot with a missing ID. Insert the biggest
-		// available in the spot to optimize searches and keep the list
-		// sorted.
+		// We found an spot with a missing ID. Insert the largest available ID
+		// in the spot to optimize for future searches and keep the list sorted.
+		// I.e. if the list is [10, 65535] we will insert '9' and get
+		// [9, 10, 65535], making the next search also taking only one iteration
+		// instead of two.
 		id := used - 1
 		usedIDs = slices.Insert(usedIDs, i, id)
 		return id, nil

--- a/plugins/inputs/ping/ping.go
+++ b/plugins/inputs/ping/ping.go
@@ -12,7 +12,6 @@ import (
 	"slices"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	ping "github.com/prometheus-community/pro-bing"
@@ -29,9 +28,8 @@ var sampleConfig string
 // This variable needs to be global as the generated IDs have to be unique
 // within the PROCESS not just the thread.
 var (
-	availableIDs   []int
-	availableIDsMu sync.Mutex
-	once           sync.Once
+	usedIDs     []uint16
+	usedIDsCond = sync.NewCond(&sync.Mutex{})
 )
 
 type Ping struct {
@@ -57,19 +55,13 @@ type Ping struct {
 	sourceAddress  string
 	pingHost       hostPingerFunc // host ping function
 	nativePingFunc nativePingFunc
-
-	// Tracking the ID range for this plugin instance to avoid collisions when
-	// assigning received packets to sent ones.
-	availableIDs      []int
-	availableIDsIndex atomic.Uint32
-	sync.Mutex
 }
 
 // hostPingerFunc is a function that runs the "ping" function using a list of
 // passed arguments. This can be easily switched with a mocked ping function
 // for unit test purposes (see ping_test.go)
 type hostPingerFunc func(binary string, timeout float64, args ...string) (string, error)
-type nativePingFunc func(destination string) (*pingStats, error)
+type nativePingFunc func(destination string, id int) (*pingStats, error)
 
 type pingStats struct {
 	ping.Statistics
@@ -111,14 +103,6 @@ func (p *Ping) Init() error {
 		p.nativePingFunc = p.nativePing
 	}
 
-	// Check for the number of available IDs
-	if p.Method == "native" {
-		// Let's limit the number of endpoint to 65536 to be conservative
-		if len(p.Urls) > math.MaxUint16 {
-			return fmt.Errorf("too many URLs (%d), max 65536 are permitted across ALL plugin instances", len(p.Urls))
-		}
-	}
-
 	// The interval cannot be below 0.2 seconds, matching ping implementation: https://linux.die.net/man/8/ping
 	if time.Duration(p.PingInterval) < 200*time.Millisecond {
 		p.calcInterval = 200 * time.Millisecond
@@ -136,49 +120,7 @@ func (p *Ping) Init() error {
 	return nil
 }
 
-func (p *Ping) Start(telegraf.Accumulator) error {
-	// For native pings we need to generate unique IDs accross all plugin
-	// instances so use the latest offset and reserve an ID range for this plugin
-	if p.Method == "native" {
-		nURLs := len(p.Urls)
-
-		// Check if there are global enough IDs left and reserve them
-		availableIDsMu.Lock()
-		if len(availableIDs) < nURLs {
-			availableIDsMu.Unlock()
-			return errors.New("too many URLs across all plugin instances, max 65536 are permitted")
-		}
-
-		// Reserve the IDs
-		p.Lock()
-		p.availableIDs = availableIDs[:nURLs]
-		p.Unlock()
-
-		// Remove the reserved IDs from the available list
-		availableIDs = availableIDs[nURLs:]
-		availableIDsMu.Unlock()
-	}
-
-	return nil
-}
-
-func (p *Ping) Stop() {
-	// We must free the reserved IDs on shutdown
-	availableIDsMu.Lock()
-	defer availableIDsMu.Unlock()
-
-	p.Lock()
-	defer p.Unlock()
-
-	availableIDs = append(availableIDs, p.availableIDs...)
-	p.availableIDsIndex.Store(0)
-	p.availableIDs = make([]int, 0)
-}
-
 func (p *Ping) Gather(acc telegraf.Accumulator) error {
-	// Reset the IDs on the new cycle
-	p.availableIDsIndex.Store(0)
-
 	for _, host := range p.Urls {
 		p.wg.Add(1)
 		go func(host string) {
@@ -197,7 +139,74 @@ func (p *Ping) Gather(acc telegraf.Accumulator) error {
 	return nil
 }
 
-func (p *Ping) nativePing(destination string) (*pingStats, error) {
+func reserveNativePingID() (uint16, error) {
+	usedIDsCond.L.Lock()
+	defer usedIDsCond.L.Unlock()
+
+	// Check if we are the first
+	if len(usedIDs) == 0 {
+		usedIDs = append(usedIDs, 0)
+		return 0, nil
+	}
+
+	// Check if there is a free ID at the end
+	if id := usedIDs[len(usedIDs)-1]; id < math.MaxUint16 {
+		id++
+		usedIDs = append(usedIDs, id)
+		return id, nil
+	}
+
+	// Check for free spots in the list
+	if len(usedIDs) < math.MaxUint16 {
+		// There is still space in the list, find the free spot
+		for i, id := range usedIDs {
+			if uint16(i) == id {
+				continue
+			}
+			// We found an spot with a missing ID. Insert the biggest
+			// available in the spot to optimize searches and keep the list
+			// sorted.
+			id--
+			usedIDs = slices.Insert(usedIDs, i, id)
+			return id, nil
+		}
+	}
+
+	// All IDs are used, waiting for an ID to become available
+	for len(usedIDs) > math.MaxUint16 {
+		usedIDsCond.Wait()
+	}
+
+	// Search for a free spot
+	for i, used := range usedIDs {
+		if uint16(i) == used {
+			continue
+		}
+		// We found an spot with a missing ID. Insert the biggest
+		// available in the spot to optimize searches and keep the list
+		// sorted.
+		id := used - 1
+		usedIDs = slices.Insert(usedIDs, i, id)
+		return id, nil
+	}
+
+	return 0, errors.New("no unused ID available")
+}
+
+func freeNativePingID(id uint16) {
+	// Removing the ID from the presorted list keeping the list sorted
+	usedIDsCond.L.Lock()
+	idx, found := slices.BinarySearch(usedIDs, id)
+	if found {
+		usedIDs = slices.Delete(usedIDs, idx, idx+1)
+	}
+	usedIDsCond.L.Unlock()
+
+	// Signal all waiting pingers to check for the free ID
+	usedIDsCond.Broadcast()
+}
+
+func (p *Ping) nativePing(destination string, id int) (*pingStats, error) {
 	ps := &pingStats{}
 
 	pinger, err := ping.NewPinger(destination)
@@ -207,9 +216,8 @@ func (p *Ping) nativePing(destination string) (*pingStats, error) {
 
 	// Make sure we get a unique ID as otherwise the library may confuse
 	// responses between multiple pingers and present wrong results
-	p.Lock()
-	pinger.SetID(p.availableIDs[p.availableIDsIndex.Add(1)-1])
-	p.Unlock()
+	pinger.SetID(id)
+
 	pinger.SetPrivileged(true)
 
 	if p.IPv4 && p.IPv6 {
@@ -280,7 +288,13 @@ func (p *Ping) nativePing(destination string) (*pingStats, error) {
 func (p *Ping) pingToURLNative(acc telegraf.Accumulator, destination string) {
 	tags := map[string]string{"url": destination}
 
-	stats, err := p.nativePingFunc(destination)
+	id, err := reserveNativePingID()
+	if err != nil {
+		p.Log.Errorf("ping failed: %v", err)
+	}
+	defer freeNativePingID(id)
+
+	stats, err := p.nativePingFunc(destination, int(id))
 	if err != nil {
 		p.Log.Errorf("ping failed: %s", err.Error())
 		fields := make(map[string]interface{}, 1)
@@ -374,16 +388,6 @@ func hostPinger(binary string, timeout float64, args ...string) (string, error) 
 }
 
 func init() {
-	// Fill the available IDs once
-	once.Do(func() {
-		availableIDsMu.Lock()
-		defer availableIDsMu.Unlock()
-		availableIDs = make([]int, math.MaxUint16)
-		for i := range math.MaxUint16 {
-			availableIDs[i] = i
-		}
-	})
-
 	inputs.Add("ping", func() telegraf.Input {
 		return &Ping{
 			PingInterval: config.Duration(1 * time.Second),

--- a/plugins/inputs/ping/ping.go
+++ b/plugins/inputs/ping/ping.go
@@ -139,44 +139,45 @@ func (p *Ping) Gather(acc telegraf.Accumulator) error {
 	return nil
 }
 
-func reserveNativePingID() (uint16, error) {
+func reserveNativePingID() uint16 {
 	usedIDsCond.L.Lock()
 	defer usedIDsCond.L.Unlock()
 
-	// Check if we are the first
-	if len(usedIDs) == 0 {
-		usedIDs = append(usedIDs, 0)
-		return 0, nil
-	}
-
-	// Check if there is a free ID at the end
-	if id := usedIDs[len(usedIDs)-1]; id < math.MaxUint16 {
-		id++
-		usedIDs = append(usedIDs, id)
-		return id, nil
-	}
-
-	// Waiting for an ID to become available if all are in use
-	for len(usedIDs) > math.MaxUint16 {
-		usedIDsCond.Wait()
-	}
-
-	// Search for a free spot
-	for i, used := range usedIDs {
-		if uint16(i) == used {
-			continue
+	// Wait for an ID to become avaulable
+	for {
+		// Check if we are the first
+		if len(usedIDs) == 0 {
+			usedIDs = append(usedIDs, 0)
+			return 0
 		}
-		// We found an spot with a missing ID. Insert the largest available ID
-		// in the spot to optimize for future searches and keep the list sorted.
-		// I.e. if the list is [10, 65535] we will insert '9' and get
-		// [9, 10, 65535], making the next search also taking only one iteration
-		// instead of two.
-		id := used - 1
-		usedIDs = slices.Insert(usedIDs, i, id)
-		return id, nil
-	}
 
-	return 0, errors.New("no unused ID available")
+		// Check if there is a free ID at the end
+		if id := usedIDs[len(usedIDs)-1]; id < math.MaxUint16 {
+			id++
+			usedIDs = append(usedIDs, id)
+			return id
+		}
+
+		// Waiting for an ID to become available if all are in use
+		for len(usedIDs) > math.MaxUint16 {
+			usedIDsCond.Wait()
+		}
+
+		// Search for a free spot
+		for i, used := range usedIDs {
+			if uint16(i) == used {
+				continue
+			}
+			// We found a spot with a missing ID. Insert the largest available ID
+			// in the spot to optimize for future searches and keep the list sorted.
+			// I.e. if the list is [10, 65535] we will insert '9' and get
+			// [9, 10, 65535], making the next search also taking only one iteration
+			// instead of two.
+			id := used - 1
+			usedIDs = slices.Insert(usedIDs, i, id)
+			return id
+		}
+	}
 }
 
 func freeNativePingID(id uint16) {
@@ -274,15 +275,12 @@ func (p *Ping) nativePing(destination string, id int) (*pingStats, error) {
 func (p *Ping) pingToURLNative(acc telegraf.Accumulator, destination string) {
 	tags := map[string]string{"url": destination}
 
-	id, err := reserveNativePingID()
-	if err != nil {
-		p.Log.Errorf("ping failed: %v", err)
-	}
+	id := reserveNativePingID()
 	defer freeNativePingID(id)
 
 	stats, err := p.nativePingFunc(destination, int(id))
 	if err != nil {
-		p.Log.Errorf("ping failed: %s", err.Error())
+		p.Log.Errorf("ping failed: %v", err)
 		fields := make(map[string]interface{}, 1)
 		if strings.Contains(err.Error(), "unknown") {
 			fields["result_code"] = 1

--- a/plugins/inputs/ping/ping.go
+++ b/plugins/inputs/ping/ping.go
@@ -12,6 +12,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	ping "github.com/prometheus-community/pro-bing"
@@ -24,6 +25,14 @@ import (
 
 //go:embed sample.conf
 var sampleConfig string
+
+// This variable needs to be global as the generated IDs have to be unique
+// within the PROCESS not just the thread.
+var (
+	availableIDs   []int
+	availableIDsMu sync.Mutex
+	once           sync.Once
+)
 
 type Ping struct {
 	Urls         []string        `toml:"urls"`          // URLs to ping
@@ -48,6 +57,12 @@ type Ping struct {
 	sourceAddress  string
 	pingHost       hostPingerFunc // host ping function
 	nativePingFunc nativePingFunc
+
+	// Tracking the ID range for this plugin instance to avoid collisions when
+	// assigning received packets to sent ones.
+	availableIDs      []int
+	availableIDsIndex atomic.Uint32
+	sync.Mutex
 }
 
 // hostPingerFunc is a function that runs the "ping" function using a list of
@@ -96,6 +111,14 @@ func (p *Ping) Init() error {
 		p.nativePingFunc = p.nativePing
 	}
 
+	// Check for the number of available IDs
+	if p.Method == "native" {
+		// Let's limit the number of endpoint to 65536 to be conservative
+		if len(p.Urls) > math.MaxUint16 {
+			return fmt.Errorf("too many URLs (%d), max 65536 are permitted across ALL plugin instances", len(p.Urls))
+		}
+	}
+
 	// The interval cannot be below 0.2 seconds, matching ping implementation: https://linux.die.net/man/8/ping
 	if time.Duration(p.PingInterval) < 200*time.Millisecond {
 		p.calcInterval = 200 * time.Millisecond
@@ -113,7 +136,49 @@ func (p *Ping) Init() error {
 	return nil
 }
 
+func (p *Ping) Start(telegraf.Accumulator) error {
+	// For native pings we need to generate unique IDs accross all plugin
+	// instances so use the latest offset and reserve an ID range for this plugin
+	if p.Method == "native" {
+		nURLs := len(p.Urls)
+
+		// Check if there are global enough IDs left and reserve them
+		availableIDsMu.Lock()
+		if len(availableIDs) < nURLs {
+			availableIDsMu.Unlock()
+			return errors.New("too many URLs across all plugin instances, max 65536 are permitted")
+		}
+
+		// Reserve the IDs
+		p.Lock()
+		p.availableIDs = availableIDs[:nURLs]
+		p.Unlock()
+
+		// Remove the reserved IDs from the available list
+		availableIDs = availableIDs[nURLs:]
+		availableIDsMu.Unlock()
+	}
+
+	return nil
+}
+
+func (p *Ping) Stop() {
+	// We must free the reserved IDs on shutdown
+	availableIDsMu.Lock()
+	defer availableIDsMu.Unlock()
+
+	p.Lock()
+	defer p.Unlock()
+
+	availableIDs = append(availableIDs, p.availableIDs...)
+	p.availableIDsIndex.Store(0)
+	p.availableIDs = make([]int, 0)
+}
+
 func (p *Ping) Gather(acc telegraf.Accumulator) error {
+	// Reset the IDs on the new cycle
+	p.availableIDsIndex.Store(0)
+
 	for _, host := range p.Urls {
 		p.wg.Add(1)
 		go func(host string) {
@@ -140,6 +205,11 @@ func (p *Ping) nativePing(destination string) (*pingStats, error) {
 		return nil, fmt.Errorf("failed to create new pinger: %w", err)
 	}
 
+	// Make sure we get a unique ID as otherwise the library may confuse
+	// responses between multiple pingers and present wrong results
+	p.Lock()
+	pinger.SetID(p.availableIDs[p.availableIDsIndex.Add(1)-1])
+	p.Unlock()
 	pinger.SetPrivileged(true)
 
 	if p.IPv4 && p.IPv6 {
@@ -304,6 +374,16 @@ func hostPinger(binary string, timeout float64, args ...string) (string, error) 
 }
 
 func init() {
+	// Fill the available IDs once
+	once.Do(func() {
+		availableIDsMu.Lock()
+		defer availableIDsMu.Unlock()
+		availableIDs = make([]int, math.MaxUint16)
+		for i := range math.MaxUint16 {
+			availableIDs[i] = i
+		}
+	})
+
 	inputs.Add("ping", func() telegraf.Input {
 		return &Ping{
 			PingInterval: config.Duration(1 * time.Second),

--- a/plugins/inputs/ping/ping_notwindows_test.go
+++ b/plugins/inputs/ping/ping_notwindows_test.go
@@ -1,0 +1,562 @@
+//go:build !windows
+
+package ping
+
+import (
+	"errors"
+	"sort"
+	"testing"
+	"time"
+
+	ping "github.com/prometheus-community/pro-bing"
+	"github.com/stretchr/testify/require"
+
+	"github.com/influxdata/telegraf/config"
+	"github.com/influxdata/telegraf/plugins/inputs"
+	"github.com/influxdata/telegraf/testutil"
+)
+
+// BSD/Darwin ping output
+var bsdPingOutput = `
+PING www.google.com (216.58.217.36): 56 data bytes
+64 bytes from 216.58.217.36: icmp_seq=0 ttl=55 time=15.087 ms
+64 bytes from 216.58.217.36: icmp_seq=1 ttl=55 time=21.564 ms
+64 bytes from 216.58.217.36: icmp_seq=2 ttl=55 time=27.263 ms
+64 bytes from 216.58.217.36: icmp_seq=3 ttl=55 time=18.828 ms
+64 bytes from 216.58.217.36: icmp_seq=4 ttl=55 time=18.378 ms
+
+--- www.google.com ping statistics ---
+5 packets transmitted, 5 packets received, 0.0% packet loss
+round-trip min/avg/max/stddev = 15.087/20.224/27.263/4.076 ms
+`
+
+// FreeBSD ping6 output
+var freebsdPing6Output = `
+PING6(64=40+8+16 bytes) 2001:db8::1 --> 2a00:1450:4001:824::2004
+24 bytes from 2a00:1450:4001:824::2004, icmp_seq=0 hlim=117 time=93.870 ms
+24 bytes from 2a00:1450:4001:824::2004, icmp_seq=1 hlim=117 time=40.278 ms
+24 bytes from 2a00:1450:4001:824::2004, icmp_seq=2 hlim=120 time=59.077 ms
+24 bytes from 2a00:1450:4001:824::2004, icmp_seq=3 hlim=117 time=37.102 ms
+24 bytes from 2a00:1450:4001:824::2004, icmp_seq=4 hlim=117 time=35.727 ms
+
+--- www.google.com ping6 statistics ---
+5 packets transmitted, 5 packets received, 0.0% packet loss
+round-trip min/avg/max/std-dev = 35.727/53.211/93.870/22.000 ms
+`
+
+// Linux ping output
+var linuxPingOutput = `
+PING www.google.com (216.58.218.164) 56(84) bytes of data.
+64 bytes from host.net (216.58.218.164): icmp_seq=1 ttl=63 time=35.2 ms
+64 bytes from host.net (216.58.218.164): icmp_seq=2 ttl=63 time=42.3 ms
+64 bytes from host.net (216.58.218.164): icmp_seq=3 ttl=63 time=45.1 ms
+64 bytes from host.net (216.58.218.164): icmp_seq=4 ttl=63 time=43.5 ms
+64 bytes from host.net (216.58.218.164): icmp_seq=5 ttl=63 time=51.8 ms
+
+--- www.google.com ping statistics ---
+5 packets transmitted, 5 received, 0% packet loss, time 4010ms
+rtt min/avg/max/mdev = 35.225/43.628/51.806/5.325 ms
+`
+
+// BusyBox v1.24.1 (2017-02-28 03:28:13 CET) multi-call binary
+var busyBoxPingOutput = `
+PING 8.8.8.8 (8.8.8.8): 56 data bytes
+64 bytes from 8.8.8.8: seq=0 ttl=56 time=22.559 ms
+64 bytes from 8.8.8.8: seq=1 ttl=56 time=15.810 ms
+64 bytes from 8.8.8.8: seq=2 ttl=56 time=16.262 ms
+64 bytes from 8.8.8.8: seq=3 ttl=56 time=15.815 ms
+
+--- 8.8.8.8 ping statistics ---
+4 packets transmitted, 4 packets received, 0% packet loss
+round-trip min/avg/max = 15.810/17.611/22.559 ms
+`
+
+// Fatal ping output (invalid argument)
+var fatalPingOutput = `
+ping: -i interval too short: Operation not permitted
+`
+
+// Linux ping output with varying TTL
+var linuxPingOutputWithVaryingTTL = `
+PING www.google.com (216.58.218.164) 56(84) bytes of data.
+64 bytes from host.net (216.58.218.164): icmp_seq=1 ttl=63 time=35.2 ms
+64 bytes from host.net (216.58.218.164): icmp_seq=2 ttl=255 time=42.3 ms
+64 bytes from host.net (216.58.218.164): icmp_seq=3 ttl=64 time=45.1 ms
+64 bytes from host.net (216.58.218.164): icmp_seq=4 ttl=64 time=43.5 ms
+64 bytes from host.net (216.58.218.164): icmp_seq=5 ttl=255 time=51.8 ms
+
+--- www.google.com ping statistics ---
+5 packets transmitted, 5 received, 0% packet loss, time 4010ms
+rtt min/avg/max/mdev = 35.225/43.628/51.806/5.325 ms
+`
+
+var lossyPingOutput = `
+PING www.google.com (216.58.218.164) 56(84) bytes of data.
+64 bytes from host.net (216.58.218.164): icmp_seq=1 ttl=63 time=35.2 ms
+64 bytes from host.net (216.58.218.164): icmp_seq=3 ttl=63 time=45.1 ms
+64 bytes from host.net (216.58.218.164): icmp_seq=5 ttl=63 time=51.8 ms
+
+--- www.google.com ping statistics ---
+5 packets transmitted, 3 received, 40% packet loss, time 4010ms
+rtt min/avg/max/mdev = 35.225/44.033/51.806/5.325 ms
+`
+
+var errorPingOutput = `
+PING www.amazon.com (176.32.98.166): 56 data bytes
+Request timeout for icmp_seq 0
+
+--- www.amazon.com ping statistics ---
+2 packets transmitted, 0 packets received, 100.0% packet loss
+`
+
+// Test that ping command output is processed properly
+func TestProcessPingOutput(t *testing.T) {
+	stats, err := processPingOutput(bsdPingOutput)
+	require.NoError(t, err)
+	require.Equal(t, 55, stats.ttl, "ttl value is 55")
+	require.Equal(t, 5, stats.packetsTransmitted, "5 packets were transmitted")
+	require.Equal(t, 5, stats.packetsReceived, "5 packets were received")
+	require.InDelta(t, 15.087, stats.min, testutil.DefaultDelta)
+	require.InDelta(t, 20.224, stats.avg, testutil.DefaultDelta)
+	require.InDelta(t, 27.263, stats.max, testutil.DefaultDelta)
+	require.InDelta(t, 4.076, stats.stddev, testutil.DefaultDelta)
+
+	stats, err = processPingOutput(freebsdPing6Output)
+	require.NoError(t, err)
+	require.Equal(t, 117, stats.ttl, "ttl value is 117")
+	require.Equal(t, 5, stats.packetsTransmitted, "5 packets were transmitted")
+	require.Equal(t, 5, stats.packetsReceived, "5 packets were received")
+	require.InDelta(t, 35.727, stats.min, testutil.DefaultDelta)
+	require.InDelta(t, 53.211, stats.avg, testutil.DefaultDelta)
+	require.InDelta(t, 93.870, stats.max, testutil.DefaultDelta)
+	require.InDelta(t, 22.000, stats.stddev, testutil.DefaultDelta)
+
+	stats, err = processPingOutput(linuxPingOutput)
+	require.NoError(t, err)
+	require.Equal(t, 63, stats.ttl, "ttl value is 63")
+	require.Equal(t, 5, stats.packetsTransmitted, "5 packets were transmitted")
+	require.Equal(t, 5, stats.packetsReceived, "5 packets were received")
+	require.InDelta(t, 35.225, stats.min, testutil.DefaultDelta)
+	require.InDelta(t, 43.628, stats.avg, testutil.DefaultDelta)
+	require.InDelta(t, 51.806, stats.max, testutil.DefaultDelta)
+	require.InDelta(t, 5.325, stats.stddev, testutil.DefaultDelta)
+
+	stats, err = processPingOutput(busyBoxPingOutput)
+	require.NoError(t, err)
+	require.Equal(t, 56, stats.ttl, "ttl value is 56")
+	require.Equal(t, 4, stats.packetsTransmitted, "4 packets were transmitted")
+	require.Equal(t, 4, stats.packetsReceived, "4 packets were received")
+	require.InDelta(t, 15.810, stats.min, testutil.DefaultDelta)
+	require.InDelta(t, 17.611, stats.avg, testutil.DefaultDelta)
+	require.InDelta(t, 22.559, stats.max, testutil.DefaultDelta)
+	require.InDelta(t, -1.0, stats.stddev, testutil.DefaultDelta)
+}
+
+// Test that ping command output is processed properly
+func TestProcessPingOutputWithVaryingTTL(t *testing.T) {
+	stats, err := processPingOutput(linuxPingOutputWithVaryingTTL)
+	require.NoError(t, err)
+	require.Equal(t, 63, stats.ttl, "ttl value is 63")
+	require.Equal(t, 5, stats.packetsTransmitted, "5 packets were transmitted")
+	require.Equal(t, 5, stats.packetsReceived, "5 packets were transmitted")
+	require.InDelta(t, 35.225, stats.min, testutil.DefaultDelta)
+	require.InDelta(t, 43.628, stats.avg, testutil.DefaultDelta)
+	require.InDelta(t, 51.806, stats.max, testutil.DefaultDelta)
+	require.InDelta(t, 5.325, stats.stddev, testutil.DefaultDelta)
+}
+
+// Test that processPingOutput returns an error when 'ping' fails to run, such
+// as when an invalid argument is provided
+func TestErrorProcessPingOutput(t *testing.T) {
+	_, err := processPingOutput(fatalPingOutput)
+	require.Error(t, err, "Error was expected from processPingOutput")
+}
+
+// Test that default arg lists are created correctly
+func TestArgs(t *testing.T) {
+	p := Ping{
+		Count:        2,
+		Interface:    "eth0",
+		Timeout:      config.Duration(12 * time.Second),
+		Deadline:     config.Duration(24 * time.Second),
+		PingInterval: config.Duration(1200 * time.Millisecond),
+	}
+	require.NoError(t, p.Init())
+
+	var systemCases = []struct {
+		system string
+		output []string
+	}{
+		{"darwin", []string{"-c", "2", "-n", "-s", "16", "-i", "1.2", "-W", "12000", "-t", "24", "-I", "eth0", "www.google.com"}},
+		{"linux", []string{"-c", "2", "-n", "-s", "16", "-i", "1.2", "-W", "12", "-w", "24", "-I", "eth0", "www.google.com"}},
+		{"anything else", []string{"-c", "2", "-n", "-s", "16", "-i", "1.2", "-W", "12", "-w", "24", "-i", "eth0", "www.google.com"}},
+	}
+	for i := range systemCases {
+		actual := p.args("www.google.com", systemCases[i].system)
+		expected := systemCases[i].output
+		sort.Strings(actual)
+		sort.Strings(expected)
+		require.Equal(t, expected, actual)
+	}
+}
+
+// Test that default arg lists for ping6 are created correctly
+func TestArgs6(t *testing.T) {
+	p := Ping{
+		Count:        2,
+		Interface:    "eth0",
+		Timeout:      config.Duration(12 * time.Second),
+		Deadline:     config.Duration(24 * time.Second),
+		PingInterval: config.Duration(1200 * time.Millisecond),
+		Binary:       "ping6",
+	}
+	require.NoError(t, p.Init())
+
+	var systemCases = []struct {
+		system string
+		output []string
+	}{
+		{"freebsd", []string{"-c", "2", "-n", "-s", "16", "-i", "1.2", "-x", "12000", "-X", "24", "-S", "eth0", "www.google.com"}},
+		{"linux", []string{"-c", "2", "-n", "-s", "16", "-i", "1.2", "-W", "12", "-w", "24", "-I", "eth0", "www.google.com"}},
+		{"anything else", []string{"-c", "2", "-n", "-s", "16", "-i", "1.2", "-W", "12", "-w", "24", "-i", "eth0", "www.google.com"}},
+	}
+	for i := range systemCases {
+		actual := p.args("www.google.com", systemCases[i].system)
+		expected := systemCases[i].output
+		sort.Strings(actual)
+		sort.Strings(expected)
+		require.Equal(t, expected, actual)
+	}
+}
+
+func TestArguments(t *testing.T) {
+	p := Ping{
+		Count:        2,
+		Interface:    "eth0",
+		Timeout:      config.Duration(12 * time.Second),
+		Deadline:     config.Duration(24 * time.Second),
+		PingInterval: config.Duration(1200 * time.Millisecond),
+		Arguments:    []string{"-c", "3"},
+	}
+	require.NoError(t, p.Init())
+
+	expected := []string{"-c", "3", "www.google.com"}
+	for _, system := range []string{"darwin", "linux", "anything else"} {
+		actual := p.args("www.google.com", system)
+		require.Equal(t, expected, actual)
+	}
+}
+
+// Test that Gather function works on a normal ping
+func TestPingGather(t *testing.T) {
+	var acc testutil.Accumulator
+	p := Ping{
+		Urls:     []string{"localhost", "influxdata.com"},
+		pingHost: mockHostPinger,
+	}
+	require.NoError(t, p.Init())
+
+	require.NoError(t, acc.GatherError(p.Gather))
+	tags := map[string]string{"url": "localhost"}
+	fields := map[string]interface{}{
+		"packets_transmitted":   5,
+		"packets_received":      5,
+		"percent_packet_loss":   0.0,
+		"ttl":                   63,
+		"minimum_response_ms":   35.225,
+		"average_response_ms":   43.628,
+		"maximum_response_ms":   51.806,
+		"standard_deviation_ms": 5.325,
+		"result_code":           0,
+	}
+	acc.AssertContainsTaggedFields(t, "ping", fields, tags)
+
+	tags = map[string]string{"url": "influxdata.com"}
+	acc.AssertContainsTaggedFields(t, "ping", fields, tags)
+}
+
+func TestPingGatherIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode, retrieves systems ping utility")
+	}
+
+	p, ok := inputs.Inputs["ping"]().(*Ping)
+	require.True(t, ok)
+
+	p.Log = testutil.Logger{}
+	p.Urls = []string{"localhost", "influxdata.com"}
+	require.NoError(t, p.Init())
+
+	var acc testutil.Accumulator
+	require.NoError(t, acc.GatherError(p.Gather))
+
+	require.Equal(t, 0, acc.Metrics[0].Fields["result_code"])
+	require.Equal(t, 0, acc.Metrics[1].Fields["result_code"])
+}
+
+// Test that Gather works on a ping with lossy packets
+func TestLossyPingGather(t *testing.T) {
+	var acc testutil.Accumulator
+	p := Ping{
+		Urls:     []string{"www.google.com"},
+		pingHost: mockLossyHostPinger,
+	}
+	require.NoError(t, p.Init())
+
+	require.NoError(t, acc.GatherError(p.Gather))
+	tags := map[string]string{"url": "www.google.com"}
+	fields := map[string]interface{}{
+		"packets_transmitted":   5,
+		"packets_received":      3,
+		"percent_packet_loss":   40.0,
+		"ttl":                   63,
+		"minimum_response_ms":   35.225,
+		"average_response_ms":   44.033,
+		"maximum_response_ms":   51.806,
+		"standard_deviation_ms": 5.325,
+		"result_code":           0,
+	}
+	acc.AssertContainsTaggedFields(t, "ping", fields, tags)
+}
+
+// Test that Gather works on a ping with no transmitted packets, even though the
+// command returns an error
+func TestBadPingGather(t *testing.T) {
+	var acc testutil.Accumulator
+	p := Ping{
+		Urls:     []string{"www.amazon.com"},
+		pingHost: mockErrorHostPinger,
+	}
+	require.NoError(t, p.Init())
+
+	require.NoError(t, acc.GatherError(p.Gather))
+	tags := map[string]string{"url": "www.amazon.com"}
+	fields := map[string]interface{}{
+		"packets_transmitted": 2,
+		"packets_received":    0,
+		"percent_packet_loss": 100.0,
+		"result_code":         0,
+	}
+	acc.AssertContainsTaggedFields(t, "ping", fields, tags)
+}
+
+// Test that a fatal ping command does not gather any statistics.
+func TestFatalPingGather(t *testing.T) {
+	var acc testutil.Accumulator
+	p := Ping{
+		Urls:     []string{"www.amazon.com"},
+		pingHost: mockFatalHostPinger,
+	}
+	require.NoError(t, p.Init())
+
+	err := acc.GatherError(p.Gather)
+	require.Error(t, err)
+	require.EqualValues(t, "host \"www.amazon.com\": so very bad - ping: -i interval too short: Operation not permitted", err.Error())
+	require.False(t, acc.HasMeasurement("packets_transmitted"),
+		"Fatal ping should not have packet measurements")
+	require.False(t, acc.HasMeasurement("packets_received"),
+		"Fatal ping should not have packet measurements")
+	require.False(t, acc.HasMeasurement("percent_packet_loss"),
+		"Fatal ping should not have packet measurements")
+	require.False(t, acc.HasMeasurement("ttl"),
+		"Fatal ping should not have packet measurements")
+	require.False(t, acc.HasMeasurement("minimum_response_ms"),
+		"Fatal ping should not have packet measurements")
+	require.False(t, acc.HasMeasurement("average_response_ms"),
+		"Fatal ping should not have packet measurements")
+	require.False(t, acc.HasMeasurement("maximum_response_ms"),
+		"Fatal ping should not have packet measurements")
+}
+
+func TestErrorWithHostNamePingGather(t *testing.T) {
+	params := []struct {
+		out   string
+		error error
+	}{
+		{"", errors.New("host \"www.amazon.com\": so very bad")},
+		{"so bad", errors.New("host \"www.amazon.com\": so very bad")},
+	}
+
+	for _, param := range params {
+		var acc testutil.Accumulator
+		p := Ping{
+			Urls: []string{"www.amazon.com"},
+			pingHost: func(string, float64, ...string) (string, error) {
+				return param.out, errors.New("so very bad")
+			},
+		}
+		require.NoError(t, p.Init())
+
+		require.Error(t, acc.GatherError(p.Gather))
+		require.Len(t, acc.Errors, 1)
+		require.Contains(t, acc.Errors[0].Error(), param.error.Error())
+	}
+}
+
+func TestPingBinary(t *testing.T) {
+	var acc testutil.Accumulator
+	p := Ping{
+		Urls:   []string{"www.google.com"},
+		Binary: "ping6",
+		pingHost: func(binary string, _ float64, _ ...string) (string, error) {
+			require.Equal(t, "ping6", binary)
+			return "", nil
+		},
+	}
+	require.NoError(t, p.Init())
+
+	err := acc.GatherError(p.Gather)
+	require.Error(t, err)
+	require.EqualValues(t, "\"www.google.com\": fatal error processing ping output", err.Error())
+}
+
+// Test that Gather function works using native ping
+func TestPingGatherNative(t *testing.T) {
+	type test struct {
+		P *Ping
+	}
+
+	fakePingFunc := func(string) (*pingStats, error) {
+		s := &pingStats{
+			Statistics: ping.Statistics{
+				PacketsSent: 5,
+				PacketsRecv: 5,
+				Rtts: []time.Duration{
+					3 * time.Millisecond,
+					4 * time.Millisecond,
+					1 * time.Millisecond,
+					5 * time.Millisecond,
+					2 * time.Millisecond,
+				},
+			},
+			ttl: 1,
+		}
+
+		return s, nil
+	}
+
+	tests := []test{
+		{
+			P: &Ping{
+				Urls:           []string{"localhost", "127.0.0.2"},
+				Log:            testutil.Logger{},
+				Method:         "native",
+				Count:          5,
+				Percentiles:    []int{50, 95, 99},
+				nativePingFunc: fakePingFunc,
+			},
+		},
+		{
+			P: &Ping{
+				Urls:           []string{"localhost", "127.0.0.2"},
+				Log:            testutil.Logger{},
+				Method:         "native",
+				Count:          5,
+				PingInterval:   1,
+				Percentiles:    []int{50, 95, 99},
+				nativePingFunc: fakePingFunc,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		var acc testutil.Accumulator
+		require.NoError(t, tc.P.Init())
+		require.NoError(t, acc.GatherError(tc.P.Gather))
+		require.True(t, acc.HasPoint("ping", map[string]string{"url": "localhost"}, "packets_transmitted", 5))
+		require.True(t, acc.HasPoint("ping", map[string]string{"url": "localhost"}, "packets_received", 5))
+		require.True(t, acc.HasField("ping", "percentile50_ms"))
+		require.InDelta(t, float64(3), acc.Metrics[0].Fields["percentile50_ms"], testutil.DefaultDelta)
+		require.True(t, acc.HasField("ping", "percentile95_ms"))
+		require.InDelta(t, float64(4.799999), acc.Metrics[0].Fields["percentile95_ms"], testutil.DefaultDelta)
+		require.True(t, acc.HasField("ping", "percentile99_ms"))
+		require.InDelta(t, float64(4.96), acc.Metrics[0].Fields["percentile99_ms"], testutil.DefaultDelta)
+		require.True(t, acc.HasField("ping", "percent_packet_loss"))
+		require.True(t, acc.HasField("ping", "minimum_response_ms"))
+		require.True(t, acc.HasField("ping", "average_response_ms"))
+		require.True(t, acc.HasField("ping", "maximum_response_ms"))
+		require.True(t, acc.HasField("ping", "standard_deviation_ms"))
+	}
+}
+
+func TestInitWarnsForNativeTimeout(t *testing.T) {
+	logger := &testutil.CaptureLogger{Name: "ping"}
+	p := &Ping{
+		Log:      logger,
+		Method:   "native",
+		Count:    1,
+		Timeout:  config.Duration(2 * time.Second),
+		Deadline: config.Duration(10 * time.Second),
+	}
+	require.NoError(t, p.Init())
+
+	warnings := logger.Warnings()
+	require.Len(t, warnings, 1)
+	require.Contains(t, warnings[0], `"timeout" is ignored when method = "native"`)
+	require.Contains(t, warnings[0], `"deadline"`)
+}
+
+func TestNoPacketsSent(t *testing.T) {
+	p := &Ping{
+		Log:         testutil.Logger{},
+		Urls:        []string{"localhost", "127.0.0.2"},
+		Method:      "native",
+		Count:       5,
+		Percentiles: []int{50, 95, 99},
+		nativePingFunc: func(string) (*pingStats, error) {
+			s := &pingStats{
+				Statistics: ping.Statistics{
+					PacketsSent: 0,
+					PacketsRecv: 0,
+				},
+			}
+
+			return s, nil
+		},
+	}
+	require.NoError(t, p.Init())
+
+	var testAcc testutil.Accumulator
+	p.pingToURLNative(&testAcc, "localhost")
+	require.Zero(t, testAcc.Errors)
+	require.True(t, testAcc.HasField("ping", "result_code"))
+	require.Equal(t, 2, testAcc.Metrics[0].Fields["result_code"])
+}
+
+// Test failed DNS resolutions
+func TestDNSLookupError(t *testing.T) {
+	p := &Ping{
+		Count:  1,
+		Log:    testutil.Logger{},
+		Urls:   []string{"localhost"},
+		Method: "native",
+		IPv6:   false,
+		nativePingFunc: func(string) (*pingStats, error) {
+			return nil, errors.New("unknown")
+		},
+	}
+	require.NoError(t, p.Init())
+
+	var testAcc testutil.Accumulator
+	p.pingToURLNative(&testAcc, "localhost")
+	require.Zero(t, testAcc.Errors)
+	require.True(t, testAcc.HasField("ping", "result_code"))
+	require.Equal(t, 1, testAcc.Metrics[0].Fields["result_code"])
+}
+
+func mockHostPinger(string, float64, ...string) (string, error) {
+	return linuxPingOutput, nil
+}
+
+func mockLossyHostPinger(string, float64, ...string) (string, error) {
+	return lossyPingOutput, nil
+}
+
+func mockErrorHostPinger(string, float64, ...string) (string, error) {
+	// This error will not trigger correct error paths
+	return errorPingOutput, nil
+}
+
+func mockFatalHostPinger(string, float64, ...string) (string, error) {
+	return fatalPingOutput, errors.New("so very bad")
+}

--- a/plugins/inputs/ping/ping_notwindows_test.go
+++ b/plugins/inputs/ping/ping_notwindows_test.go
@@ -416,7 +416,7 @@ func TestPingGatherNative(t *testing.T) {
 		P *Ping
 	}
 
-	fakePingFunc := func(string) (*pingStats, error) {
+	fakePingFunc := func(string, int) (*pingStats, error) {
 		s := &pingStats{
 			Statistics: ping.Statistics{
 				PacketsSent: 5,
@@ -503,7 +503,7 @@ func TestNoPacketsSent(t *testing.T) {
 		Method:      "native",
 		Count:       5,
 		Percentiles: []int{50, 95, 99},
-		nativePingFunc: func(string) (*pingStats, error) {
+		nativePingFunc: func(string, int) (*pingStats, error) {
 			s := &pingStats{
 				Statistics: ping.Statistics{
 					PacketsSent: 0,
@@ -531,7 +531,7 @@ func TestDNSLookupError(t *testing.T) {
 		Urls:   []string{"localhost"},
 		Method: "native",
 		IPv6:   false,
-		nativePingFunc: func(string) (*pingStats, error) {
+		nativePingFunc: func(string, int) (*pingStats, error) {
 			return nil, errors.New("unknown")
 		},
 	}

--- a/plugins/inputs/ping/ping_test.go
+++ b/plugins/inputs/ping/ping_test.go
@@ -1,562 +1,107 @@
-//go:build !windows
-
 package ping
 
 import (
-	"errors"
-	"sort"
+	"math"
+	"slices"
 	"testing"
-	"time"
 
-	ping "github.com/prometheus-community/pro-bing"
 	"github.com/stretchr/testify/require"
 
-	"github.com/influxdata/telegraf/config"
-	"github.com/influxdata/telegraf/plugins/inputs"
 	"github.com/influxdata/telegraf/testutil"
 )
 
-// BSD/Darwin ping output
-var bsdPingOutput = `
-PING www.google.com (216.58.217.36): 56 data bytes
-64 bytes from 216.58.217.36: icmp_seq=0 ttl=55 time=15.087 ms
-64 bytes from 216.58.217.36: icmp_seq=1 ttl=55 time=21.564 ms
-64 bytes from 216.58.217.36: icmp_seq=2 ttl=55 time=27.263 ms
-64 bytes from 216.58.217.36: icmp_seq=3 ttl=55 time=18.828 ms
-64 bytes from 216.58.217.36: icmp_seq=4 ttl=55 time=18.378 ms
+func TestNativeIDsAssignment(t *testing.T) {
+	// Generate a target list
+	targets := slices.Repeat([]string{"localhost"}, 100)
 
---- www.google.com ping statistics ---
-5 packets transmitted, 5 packets received, 0.0% packet loss
-round-trip min/avg/max/stddev = 15.087/20.224/27.263/4.076 ms
-`
-
-// FreeBSD ping6 output
-var freebsdPing6Output = `
-PING6(64=40+8+16 bytes) 2001:db8::1 --> 2a00:1450:4001:824::2004
-24 bytes from 2a00:1450:4001:824::2004, icmp_seq=0 hlim=117 time=93.870 ms
-24 bytes from 2a00:1450:4001:824::2004, icmp_seq=1 hlim=117 time=40.278 ms
-24 bytes from 2a00:1450:4001:824::2004, icmp_seq=2 hlim=120 time=59.077 ms
-24 bytes from 2a00:1450:4001:824::2004, icmp_seq=3 hlim=117 time=37.102 ms
-24 bytes from 2a00:1450:4001:824::2004, icmp_seq=4 hlim=117 time=35.727 ms
-
---- www.google.com ping6 statistics ---
-5 packets transmitted, 5 packets received, 0.0% packet loss
-round-trip min/avg/max/std-dev = 35.727/53.211/93.870/22.000 ms
-`
-
-// Linux ping output
-var linuxPingOutput = `
-PING www.google.com (216.58.218.164) 56(84) bytes of data.
-64 bytes from host.net (216.58.218.164): icmp_seq=1 ttl=63 time=35.2 ms
-64 bytes from host.net (216.58.218.164): icmp_seq=2 ttl=63 time=42.3 ms
-64 bytes from host.net (216.58.218.164): icmp_seq=3 ttl=63 time=45.1 ms
-64 bytes from host.net (216.58.218.164): icmp_seq=4 ttl=63 time=43.5 ms
-64 bytes from host.net (216.58.218.164): icmp_seq=5 ttl=63 time=51.8 ms
-
---- www.google.com ping statistics ---
-5 packets transmitted, 5 received, 0% packet loss, time 4010ms
-rtt min/avg/max/mdev = 35.225/43.628/51.806/5.325 ms
-`
-
-// BusyBox v1.24.1 (2017-02-28 03:28:13 CET) multi-call binary
-var busyBoxPingOutput = `
-PING 8.8.8.8 (8.8.8.8): 56 data bytes
-64 bytes from 8.8.8.8: seq=0 ttl=56 time=22.559 ms
-64 bytes from 8.8.8.8: seq=1 ttl=56 time=15.810 ms
-64 bytes from 8.8.8.8: seq=2 ttl=56 time=16.262 ms
-64 bytes from 8.8.8.8: seq=3 ttl=56 time=15.815 ms
-
---- 8.8.8.8 ping statistics ---
-4 packets transmitted, 4 packets received, 0% packet loss
-round-trip min/avg/max = 15.810/17.611/22.559 ms
-`
-
-// Fatal ping output (invalid argument)
-var fatalPingOutput = `
-ping: -i interval too short: Operation not permitted
-`
-
-// Linux ping output with varying TTL
-var linuxPingOutputWithVaryingTTL = `
-PING www.google.com (216.58.218.164) 56(84) bytes of data.
-64 bytes from host.net (216.58.218.164): icmp_seq=1 ttl=63 time=35.2 ms
-64 bytes from host.net (216.58.218.164): icmp_seq=2 ttl=255 time=42.3 ms
-64 bytes from host.net (216.58.218.164): icmp_seq=3 ttl=64 time=45.1 ms
-64 bytes from host.net (216.58.218.164): icmp_seq=4 ttl=64 time=43.5 ms
-64 bytes from host.net (216.58.218.164): icmp_seq=5 ttl=255 time=51.8 ms
-
---- www.google.com ping statistics ---
-5 packets transmitted, 5 received, 0% packet loss, time 4010ms
-rtt min/avg/max/mdev = 35.225/43.628/51.806/5.325 ms
-`
-
-var lossyPingOutput = `
-PING www.google.com (216.58.218.164) 56(84) bytes of data.
-64 bytes from host.net (216.58.218.164): icmp_seq=1 ttl=63 time=35.2 ms
-64 bytes from host.net (216.58.218.164): icmp_seq=3 ttl=63 time=45.1 ms
-64 bytes from host.net (216.58.218.164): icmp_seq=5 ttl=63 time=51.8 ms
-
---- www.google.com ping statistics ---
-5 packets transmitted, 3 received, 40% packet loss, time 4010ms
-rtt min/avg/max/mdev = 35.225/44.033/51.806/5.325 ms
-`
-
-var errorPingOutput = `
-PING www.amazon.com (176.32.98.166): 56 data bytes
-Request timeout for icmp_seq 0
-
---- www.amazon.com ping statistics ---
-2 packets transmitted, 0 packets received, 100.0% packet loss
-`
-
-// Test that ping command output is processed properly
-func TestProcessPingOutput(t *testing.T) {
-	stats, err := processPingOutput(bsdPingOutput)
-	require.NoError(t, err)
-	require.Equal(t, 55, stats.ttl, "ttl value is 55")
-	require.Equal(t, 5, stats.packetsTransmitted, "5 packets were transmitted")
-	require.Equal(t, 5, stats.packetsReceived, "5 packets were received")
-	require.InDelta(t, 15.087, stats.min, testutil.DefaultDelta)
-	require.InDelta(t, 20.224, stats.avg, testutil.DefaultDelta)
-	require.InDelta(t, 27.263, stats.max, testutil.DefaultDelta)
-	require.InDelta(t, 4.076, stats.stddev, testutil.DefaultDelta)
-
-	stats, err = processPingOutput(freebsdPing6Output)
-	require.NoError(t, err)
-	require.Equal(t, 117, stats.ttl, "ttl value is 117")
-	require.Equal(t, 5, stats.packetsTransmitted, "5 packets were transmitted")
-	require.Equal(t, 5, stats.packetsReceived, "5 packets were received")
-	require.InDelta(t, 35.727, stats.min, testutil.DefaultDelta)
-	require.InDelta(t, 53.211, stats.avg, testutil.DefaultDelta)
-	require.InDelta(t, 93.870, stats.max, testutil.DefaultDelta)
-	require.InDelta(t, 22.000, stats.stddev, testutil.DefaultDelta)
-
-	stats, err = processPingOutput(linuxPingOutput)
-	require.NoError(t, err)
-	require.Equal(t, 63, stats.ttl, "ttl value is 63")
-	require.Equal(t, 5, stats.packetsTransmitted, "5 packets were transmitted")
-	require.Equal(t, 5, stats.packetsReceived, "5 packets were received")
-	require.InDelta(t, 35.225, stats.min, testutil.DefaultDelta)
-	require.InDelta(t, 43.628, stats.avg, testutil.DefaultDelta)
-	require.InDelta(t, 51.806, stats.max, testutil.DefaultDelta)
-	require.InDelta(t, 5.325, stats.stddev, testutil.DefaultDelta)
-
-	stats, err = processPingOutput(busyBoxPingOutput)
-	require.NoError(t, err)
-	require.Equal(t, 56, stats.ttl, "ttl value is 56")
-	require.Equal(t, 4, stats.packetsTransmitted, "4 packets were transmitted")
-	require.Equal(t, 4, stats.packetsReceived, "4 packets were received")
-	require.InDelta(t, 15.810, stats.min, testutil.DefaultDelta)
-	require.InDelta(t, 17.611, stats.avg, testutil.DefaultDelta)
-	require.InDelta(t, 22.559, stats.max, testutil.DefaultDelta)
-	require.InDelta(t, -1.0, stats.stddev, testutil.DefaultDelta)
-}
-
-// Test that ping command output is processed properly
-func TestProcessPingOutputWithVaryingTTL(t *testing.T) {
-	stats, err := processPingOutput(linuxPingOutputWithVaryingTTL)
-	require.NoError(t, err)
-	require.Equal(t, 63, stats.ttl, "ttl value is 63")
-	require.Equal(t, 5, stats.packetsTransmitted, "5 packets were transmitted")
-	require.Equal(t, 5, stats.packetsReceived, "5 packets were transmitted")
-	require.InDelta(t, 35.225, stats.min, testutil.DefaultDelta)
-	require.InDelta(t, 43.628, stats.avg, testutil.DefaultDelta)
-	require.InDelta(t, 51.806, stats.max, testutil.DefaultDelta)
-	require.InDelta(t, 5.325, stats.stddev, testutil.DefaultDelta)
-}
-
-// Test that processPingOutput returns an error when 'ping' fails to run, such
-// as when an invalid argument is provided
-func TestErrorProcessPingOutput(t *testing.T) {
-	_, err := processPingOutput(fatalPingOutput)
-	require.Error(t, err, "Error was expected from processPingOutput")
-}
-
-// Test that default arg lists are created correctly
-func TestArgs(t *testing.T) {
-	p := Ping{
-		Count:        2,
-		Interface:    "eth0",
-		Timeout:      config.Duration(12 * time.Second),
-		Deadline:     config.Duration(24 * time.Second),
-		PingInterval: config.Duration(1200 * time.Millisecond),
-	}
-	require.NoError(t, p.Init())
-
-	var systemCases = []struct {
-		system string
-		output []string
-	}{
-		{"darwin", []string{"-c", "2", "-n", "-s", "16", "-i", "1.2", "-W", "12000", "-t", "24", "-I", "eth0", "www.google.com"}},
-		{"linux", []string{"-c", "2", "-n", "-s", "16", "-i", "1.2", "-W", "12", "-w", "24", "-I", "eth0", "www.google.com"}},
-		{"anything else", []string{"-c", "2", "-n", "-s", "16", "-i", "1.2", "-W", "12", "-w", "24", "-i", "eth0", "www.google.com"}},
-	}
-	for i := range systemCases {
-		actual := p.args("www.google.com", systemCases[i].system)
-		expected := systemCases[i].output
-		sort.Strings(actual)
-		sort.Strings(expected)
-		require.Equal(t, expected, actual)
-	}
-}
-
-// Test that default arg lists for ping6 are created correctly
-func TestArgs6(t *testing.T) {
-	p := Ping{
-		Count:        2,
-		Interface:    "eth0",
-		Timeout:      config.Duration(12 * time.Second),
-		Deadline:     config.Duration(24 * time.Second),
-		PingInterval: config.Duration(1200 * time.Millisecond),
-		Binary:       "ping6",
-	}
-	require.NoError(t, p.Init())
-
-	var systemCases = []struct {
-		system string
-		output []string
-	}{
-		{"freebsd", []string{"-c", "2", "-n", "-s", "16", "-i", "1.2", "-x", "12000", "-X", "24", "-S", "eth0", "www.google.com"}},
-		{"linux", []string{"-c", "2", "-n", "-s", "16", "-i", "1.2", "-W", "12", "-w", "24", "-I", "eth0", "www.google.com"}},
-		{"anything else", []string{"-c", "2", "-n", "-s", "16", "-i", "1.2", "-W", "12", "-w", "24", "-i", "eth0", "www.google.com"}},
-	}
-	for i := range systemCases {
-		actual := p.args("www.google.com", systemCases[i].system)
-		expected := systemCases[i].output
-		sort.Strings(actual)
-		sort.Strings(expected)
-		require.Equal(t, expected, actual)
-	}
-}
-
-func TestArguments(t *testing.T) {
-	p := Ping{
-		Count:        2,
-		Interface:    "eth0",
-		Timeout:      config.Duration(12 * time.Second),
-		Deadline:     config.Duration(24 * time.Second),
-		PingInterval: config.Duration(1200 * time.Millisecond),
-		Arguments:    []string{"-c", "3"},
-	}
-	require.NoError(t, p.Init())
-
-	expected := []string{"-c", "3", "www.google.com"}
-	for _, system := range []string{"darwin", "linux", "anything else"} {
-		actual := p.args("www.google.com", system)
-		require.Equal(t, expected, actual)
-	}
-}
-
-// Test that Gather function works on a normal ping
-func TestPingGather(t *testing.T) {
-	var acc testutil.Accumulator
-	p := Ping{
-		Urls:     []string{"localhost", "influxdata.com"},
-		pingHost: mockHostPinger,
-	}
-	require.NoError(t, p.Init())
-
-	require.NoError(t, acc.GatherError(p.Gather))
-	tags := map[string]string{"url": "localhost"}
-	fields := map[string]interface{}{
-		"packets_transmitted":   5,
-		"packets_received":      5,
-		"percent_packet_loss":   0.0,
-		"ttl":                   63,
-		"minimum_response_ms":   35.225,
-		"average_response_ms":   43.628,
-		"maximum_response_ms":   51.806,
-		"standard_deviation_ms": 5.325,
-		"result_code":           0,
-	}
-	acc.AssertContainsTaggedFields(t, "ping", fields, tags)
-
-	tags = map[string]string{"url": "influxdata.com"}
-	acc.AssertContainsTaggedFields(t, "ping", fields, tags)
-}
-
-func TestPingGatherIntegration(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping integration test in short mode, retrieves systems ping utility")
-	}
-
-	p, ok := inputs.Inputs["ping"]().(*Ping)
-	require.True(t, ok)
-
-	p.Log = testutil.Logger{}
-	p.Urls = []string{"localhost", "influxdata.com"}
-	require.NoError(t, p.Init())
-
-	var acc testutil.Accumulator
-	require.NoError(t, acc.GatherError(p.Gather))
-
-	require.Equal(t, 0, acc.Metrics[0].Fields["result_code"])
-	require.Equal(t, 0, acc.Metrics[1].Fields["result_code"])
-}
-
-// Test that Gather works on a ping with lossy packets
-func TestLossyPingGather(t *testing.T) {
-	var acc testutil.Accumulator
-	p := Ping{
-		Urls:     []string{"www.google.com"},
-		pingHost: mockLossyHostPinger,
-	}
-	require.NoError(t, p.Init())
-
-	require.NoError(t, acc.GatherError(p.Gather))
-	tags := map[string]string{"url": "www.google.com"}
-	fields := map[string]interface{}{
-		"packets_transmitted":   5,
-		"packets_received":      3,
-		"percent_packet_loss":   40.0,
-		"ttl":                   63,
-		"minimum_response_ms":   35.225,
-		"average_response_ms":   44.033,
-		"maximum_response_ms":   51.806,
-		"standard_deviation_ms": 5.325,
-		"result_code":           0,
-	}
-	acc.AssertContainsTaggedFields(t, "ping", fields, tags)
-}
-
-// Test that Gather works on a ping with no transmitted packets, even though the
-// command returns an error
-func TestBadPingGather(t *testing.T) {
-	var acc testutil.Accumulator
-	p := Ping{
-		Urls:     []string{"www.amazon.com"},
-		pingHost: mockErrorHostPinger,
-	}
-	require.NoError(t, p.Init())
-
-	require.NoError(t, acc.GatherError(p.Gather))
-	tags := map[string]string{"url": "www.amazon.com"}
-	fields := map[string]interface{}{
-		"packets_transmitted": 2,
-		"packets_received":    0,
-		"percent_packet_loss": 100.0,
-		"result_code":         0,
-	}
-	acc.AssertContainsTaggedFields(t, "ping", fields, tags)
-}
-
-// Test that a fatal ping command does not gather any statistics.
-func TestFatalPingGather(t *testing.T) {
-	var acc testutil.Accumulator
-	p := Ping{
-		Urls:     []string{"www.amazon.com"},
-		pingHost: mockFatalHostPinger,
-	}
-	require.NoError(t, p.Init())
-
-	err := acc.GatherError(p.Gather)
-	require.Error(t, err)
-	require.EqualValues(t, "host \"www.amazon.com\": so very bad - ping: -i interval too short: Operation not permitted", err.Error())
-	require.False(t, acc.HasMeasurement("packets_transmitted"),
-		"Fatal ping should not have packet measurements")
-	require.False(t, acc.HasMeasurement("packets_received"),
-		"Fatal ping should not have packet measurements")
-	require.False(t, acc.HasMeasurement("percent_packet_loss"),
-		"Fatal ping should not have packet measurements")
-	require.False(t, acc.HasMeasurement("ttl"),
-		"Fatal ping should not have packet measurements")
-	require.False(t, acc.HasMeasurement("minimum_response_ms"),
-		"Fatal ping should not have packet measurements")
-	require.False(t, acc.HasMeasurement("average_response_ms"),
-		"Fatal ping should not have packet measurements")
-	require.False(t, acc.HasMeasurement("maximum_response_ms"),
-		"Fatal ping should not have packet measurements")
-}
-
-func TestErrorWithHostNamePingGather(t *testing.T) {
-	params := []struct {
-		out   string
-		error error
-	}{
-		{"", errors.New("host \"www.amazon.com\": so very bad")},
-		{"so bad", errors.New("host \"www.amazon.com\": so very bad")},
-	}
-
-	for _, param := range params {
-		var acc testutil.Accumulator
-		p := Ping{
-			Urls: []string{"www.amazon.com"},
-			pingHost: func(string, float64, ...string) (string, error) {
-				return param.out, errors.New("so very bad")
-			},
+	// Add a number of plugin instances that need to share the IDs
+	plugins := make([]*Ping, 0, 10)
+	for range 10 {
+		plugin := &Ping{
+			Method: "native",
+			Urls:   targets,
+			Log:    &testutil.Logger{},
 		}
-		require.NoError(t, p.Init())
-
-		require.Error(t, acc.GatherError(p.Gather))
-		require.Len(t, acc.Errors, 1)
-		require.Contains(t, acc.Errors[0].Error(), param.error.Error())
+		require.NoError(t, plugin.Init())
+		require.NoError(t, plugin.Start(nil))
+		plugins = append(plugins, plugin)
 	}
+
+	// Check for the IDs being missing
+	require.Len(t, availableIDs, math.MaxUint16-1000)
+
+	// Check the plugins for different ranges and stop them afterwards to
+	// free the IDs. This is crucial when stop/starting the plugin e.g. during
+	// reloading configurations
+	for i, plugin := range plugins {
+		require.Len(t, plugin.availableIDs, 100)
+		require.Equal(t, i*100, plugin.availableIDs[0])
+		plugin.Stop()
+		require.Empty(t, plugin.availableIDs)
+	}
+
+	// Check that all reserved IDs were returned
+	require.Len(t, availableIDs, math.MaxUint16)
 }
 
-func TestPingBinary(t *testing.T) {
-	var acc testutil.Accumulator
-	p := Ping{
-		Urls:   []string{"www.google.com"},
-		Binary: "ping6",
-		pingHost: func(binary string, _ float64, _ ...string) (string, error) {
-			require.Equal(t, "ping6", binary)
-			return "", nil
-		},
-	}
-	require.NoError(t, p.Init())
-
-	err := acc.GatherError(p.Gather)
-	require.Error(t, err)
-	require.EqualValues(t, "\"www.google.com\": fatal error processing ping output", err.Error())
-}
-
-// Test that Gather function works using native ping
-func TestPingGatherNative(t *testing.T) {
-	type test struct {
-		P *Ping
-	}
-
-	fakePingFunc := func(string) (*pingStats, error) {
-		s := &pingStats{
-			Statistics: ping.Statistics{
-				PacketsSent: 5,
-				PacketsRecv: 5,
-				Rtts: []time.Duration{
-					3 * time.Millisecond,
-					4 * time.Millisecond,
-					1 * time.Millisecond,
-					5 * time.Millisecond,
-					2 * time.Millisecond,
-				},
-			},
-			ttl: 1,
-		}
-
-		return s, nil
-	}
-
-	tests := []test{
-		{
-			P: &Ping{
-				Urls:           []string{"localhost", "127.0.0.2"},
-				Log:            testutil.Logger{},
-				Method:         "native",
-				Count:          5,
-				Percentiles:    []int{50, 95, 99},
-				nativePingFunc: fakePingFunc,
-			},
-		},
-		{
-			P: &Ping{
-				Urls:           []string{"localhost", "127.0.0.2"},
-				Log:            testutil.Logger{},
-				Method:         "native",
-				Count:          5,
-				PingInterval:   1,
-				Percentiles:    []int{50, 95, 99},
-				nativePingFunc: fakePingFunc,
-			},
-		},
-	}
-
-	for _, tc := range tests {
-		var acc testutil.Accumulator
-		require.NoError(t, tc.P.Init())
-		require.NoError(t, acc.GatherError(tc.P.Gather))
-		require.True(t, acc.HasPoint("ping", map[string]string{"url": "localhost"}, "packets_transmitted", 5))
-		require.True(t, acc.HasPoint("ping", map[string]string{"url": "localhost"}, "packets_received", 5))
-		require.True(t, acc.HasField("ping", "percentile50_ms"))
-		require.InDelta(t, float64(3), acc.Metrics[0].Fields["percentile50_ms"], testutil.DefaultDelta)
-		require.True(t, acc.HasField("ping", "percentile95_ms"))
-		require.InDelta(t, float64(4.799999), acc.Metrics[0].Fields["percentile95_ms"], testutil.DefaultDelta)
-		require.True(t, acc.HasField("ping", "percentile99_ms"))
-		require.InDelta(t, float64(4.96), acc.Metrics[0].Fields["percentile99_ms"], testutil.DefaultDelta)
-		require.True(t, acc.HasField("ping", "percent_packet_loss"))
-		require.True(t, acc.HasField("ping", "minimum_response_ms"))
-		require.True(t, acc.HasField("ping", "average_response_ms"))
-		require.True(t, acc.HasField("ping", "maximum_response_ms"))
-		require.True(t, acc.HasField("ping", "standard_deviation_ms"))
-	}
-}
-
-func TestInitWarnsForNativeTimeout(t *testing.T) {
-	logger := &testutil.CaptureLogger{Name: "ping"}
-	p := &Ping{
-		Log:      logger,
-		Method:   "native",
-		Count:    1,
-		Timeout:  config.Duration(2 * time.Second),
-		Deadline: config.Duration(10 * time.Second),
-	}
-	require.NoError(t, p.Init())
-
-	warnings := logger.Warnings()
-	require.Len(t, warnings, 1)
-	require.Contains(t, warnings[0], `"timeout" is ignored when method = "native"`)
-	require.Contains(t, warnings[0], `"deadline"`)
-}
-
-func TestNoPacketsSent(t *testing.T) {
-	p := &Ping{
-		Log:         testutil.Logger{},
-		Urls:        []string{"localhost", "127.0.0.2"},
-		Method:      "native",
-		Count:       5,
-		Percentiles: []int{50, 95, 99},
-		nativePingFunc: func(string) (*pingStats, error) {
-			s := &pingStats{
-				Statistics: ping.Statistics{
-					PacketsSent: 0,
-					PacketsRecv: 0,
-				},
-			}
-
-			return s, nil
-		},
-	}
-	require.NoError(t, p.Init())
-
-	var testAcc testutil.Accumulator
-	p.pingToURLNative(&testAcc, "localhost")
-	require.Zero(t, testAcc.Errors)
-	require.True(t, testAcc.HasField("ping", "result_code"))
-	require.Equal(t, 2, testAcc.Metrics[0].Fields["result_code"])
-}
-
-// Test failed DNS resolutions
-func TestDNSLookupError(t *testing.T) {
-	p := &Ping{
-		Count:  1,
-		Log:    testutil.Logger{},
-		Urls:   []string{"localhost"},
+func TestNativeIDsOverflow(t *testing.T) {
+	// Create plugin with too many URLS
+	plugin := &Ping{
 		Method: "native",
-		IPv6:   false,
-		nativePingFunc: func(string) (*pingStats, error) {
-			return nil, errors.New("unknown")
-		},
+		Urls:   slices.Repeat([]string{"localhost"}, 70000),
+
+		Log: &testutil.Logger{},
 	}
-	require.NoError(t, p.Init())
-
-	var testAcc testutil.Accumulator
-	p.pingToURLNative(&testAcc, "localhost")
-	require.Zero(t, testAcc.Errors)
-	require.True(t, testAcc.HasField("ping", "result_code"))
-	require.Equal(t, 1, testAcc.Metrics[0].Fields["result_code"])
+	require.ErrorContains(t, plugin.Init(), "too many URLs (70000)")
 }
 
-func mockHostPinger(string, float64, ...string) (string, error) {
-	return linuxPingOutput, nil
+func TestNativeIDsOverflowAcrossPlugins(t *testing.T) {
+	// Generate a target list
+	targets := slices.Repeat([]string{"localhost"}, 10000)
+
+	// Add plugin instances staying within the number of available IDs
+	plugins := make([]*Ping, 0, 10)
+	defer func() {
+		for _, plugin := range plugins {
+			plugin.Stop()
+		}
+	}()
+	for range 6 {
+		plugin := &Ping{
+			Method: "native",
+			Urls:   targets,
+			Log:    &testutil.Logger{},
+		}
+		require.NoError(t, plugin.Init())
+		require.NoError(t, plugin.Start(nil))
+		plugins = append(plugins, plugin)
+	}
+
+	// This instance should cause the overflow
+	plugin := &Ping{
+		Method: "native",
+		Urls:   targets,
+		Log:    &testutil.Logger{},
+	}
+	require.NoError(t, plugin.Init())
+	require.ErrorContains(t, plugin.Start(nil), "too many URLs across all plugin instances")
 }
 
-func mockLossyHostPinger(string, float64, ...string) (string, error) {
-	return lossyPingOutput, nil
-}
+func Benchmark(b *testing.B) {
+	// Generate a target list
+	targets := slices.Repeat([]string{"localhost"}, 100)
 
-func mockErrorHostPinger(string, float64, ...string) (string, error) {
-	// This error will not trigger correct error paths
-	return errorPingOutput, nil
-}
+	plugin := &Ping{
+		Method: "native",
+		Urls:   targets,
+		Log:    &testutil.Logger{},
+	}
+	require.NoError(b, plugin.Init())
+	require.NoError(b, plugin.Start(nil))
+	defer plugin.Stop()
 
-func mockFatalHostPinger(string, float64, ...string) (string, error) {
-	return fatalPingOutput, errors.New("so very bad")
+	acc := &testutil.Accumulator{Discard: true}
+	for b.Loop() {
+		require.NoError(b, plugin.Gather(acc))
+	}
 }

--- a/plugins/inputs/ping/ping_test.go
+++ b/plugins/inputs/ping/ping_test.go
@@ -1,90 +1,267 @@
 package ping
 
 import (
+	"context"
 	"math"
 	"slices"
+	"sync"
 	"testing"
+	"time"
 
+	ping "github.com/prometheus-community/pro-bing"
 	"github.com/stretchr/testify/require"
 
 	"github.com/influxdata/telegraf/testutil"
 )
 
-func TestNativeIDsAssignment(t *testing.T) {
+func TestNativeIDs(t *testing.T) {
 	// Generate a target list
 	targets := slices.Repeat([]string{"localhost"}, 100)
 
+	tests := []struct {
+		name        string
+		initializer func() []uint16
+		expected    func() []int
+	}{
+		{
+			name: "empty",
+			initializer: func() []uint16 {
+				return make([]uint16, 0)
+			},
+			expected: func() []int {
+				e := make([]int, 10*len(targets))
+				for i := range e {
+					e[i] = i
+				}
+				return e
+			},
+		},
+		{
+			name: "append",
+			initializer: func() []uint16 {
+				return []uint16{999}
+			},
+			expected: func() []int {
+				e := make([]int, 10*len(targets))
+				for i := range e {
+					e[i] = 1000 + i
+				}
+				return e
+			},
+		},
+		{
+			name: "insert",
+			initializer: func() []uint16 {
+				e := make([]uint16, 0, 10*len(targets)+1)
+				for i := range uint16(10 * len(targets)) {
+					e = append(e, 2*i+1)
+				}
+				// We need max at the end to force fill-in
+				e = append(e, math.MaxUint16)
+				return e
+			},
+			expected: func() []int {
+				e := make([]int, 10*len(targets))
+				for i := range e {
+					e[i] = 2 * i
+				}
+				return e
+			},
+		},
+		{
+			name: "insert highest",
+			initializer: func() []uint16 {
+				return []uint16{math.MaxUint16}
+			},
+			expected: func() []int {
+				e := make([]int, 10*len(targets))
+				for i := range e {
+					e[i] = math.MaxUint16 - len(e) + i
+				}
+				return e
+			},
+		},
+		{
+			name: "complete fill",
+			initializer: func() []uint16 {
+				e := make([]uint16, 0, math.MaxUint16-10*len(targets))
+				for i := range uint16(math.MaxUint16 - 10*len(targets)) {
+					e = append(e, i)
+				}
+				return e
+			},
+			expected: func() []int {
+				e := make([]int, 10*len(targets))
+				for i := range e {
+					e[i] = math.MaxUint16 - len(e) + i
+				}
+				return e
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup the initial state
+			initialIDs := tt.initializer()
+			usedIDsCond.L.Lock()
+			usedIDs = slices.Clone(initialIDs)
+			usedIDsCond.L.Unlock()
+
+			// Add a number of plugin instances that need to share the IDs
+			var wg sync.WaitGroup
+			var seenIDsMu sync.Mutex
+			seenIDs := make([]int, 0, 10*len(targets))
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+			for range 10 {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+
+					plugin := &Ping{
+						Method: "native",
+						Urls:   targets,
+						Log:    &testutil.Logger{},
+						nativePingFunc: func(_ string, id int) (*pingStats, error) {
+							seenIDsMu.Lock()
+							seenIDs = append(seenIDs, id)
+							seenIDsMu.Unlock()
+
+							<-ctx.Done()
+
+							return fakeResult()
+						},
+					}
+					if err := plugin.Init(); err != nil {
+						t.Errorf("initializing plugin failed: %v", err)
+					}
+
+					var acc testutil.Accumulator
+					if err := plugin.Gather(&acc); err != nil {
+						t.Errorf("running gather failed: %v", err)
+					}
+				}()
+			}
+
+			// Wait for all plugins to reach the pinging function to ensure we have seen
+			// all IDs and all IDs are unique as they are not free'ed in between.
+			require.Eventually(t, func() bool {
+				seenIDsMu.Lock()
+				defer seenIDsMu.Unlock()
+				return len(seenIDs) >= 10*len(targets)
+			}, 3*time.Second, 100*time.Millisecond)
+
+			// Allow all pings to complete and wait for the plugins to finish
+			cancel()
+			wg.Wait()
+
+			// Check the seen IDs
+			expected := tt.expected()
+
+			seenIDsMu.Lock()
+			defer seenIDsMu.Unlock()
+			require.Len(t, seenIDs, 10*len(targets))
+			slices.Sort(seenIDs)
+			require.Equal(t, expected, seenIDs)
+
+			// Check that all acquired IDs have been free'ed
+			usedIDsCond.L.Lock()
+			defer usedIDsCond.L.Unlock()
+			require.Equal(t, initialIDs, usedIDs)
+		})
+	}
+}
+
+func TestNativeIDsWaitOnFull(t *testing.T) {
+	// Generate a target list
+	targets := slices.Repeat([]string{"localhost"}, 10)
+
+	// Add some used IDs to force filling in
+	initialUsedIDs := make([]uint16, 0, math.MaxUint16)
+	for i := range uint16(math.MaxUint16) {
+		initialUsedIDs = append(initialUsedIDs, i)
+	}
+	initialUsedIDs = append(initialUsedIDs, math.MaxUint16)
+
+	usedIDsCond.L.Lock()
+	usedIDs = slices.Clone(initialUsedIDs)
+	usedIDsCond.L.Unlock()
+
 	// Add a number of plugin instances that need to share the IDs
-	plugins := make([]*Ping, 0, 10)
-	for range 10 {
+	var wg sync.WaitGroup
+	var seenIDsMu sync.Mutex
+	seenIDs := make([]int, 0, len(targets))
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
 		plugin := &Ping{
 			Method: "native",
 			Urls:   targets,
 			Log:    &testutil.Logger{},
+			nativePingFunc: func(_ string, id int) (*pingStats, error) {
+				seenIDsMu.Lock()
+				seenIDs = append(seenIDs, id)
+				seenIDsMu.Unlock()
+
+				<-ctx.Done()
+
+				return fakeResult()
+			},
 		}
-		require.NoError(t, plugin.Init())
-		require.NoError(t, plugin.Start(nil))
-		plugins = append(plugins, plugin)
-	}
+		if err := plugin.Init(); err != nil {
+			t.Errorf("initializing plugin failed: %v", err)
+		}
 
-	// Check for the IDs being missing
-	require.Len(t, availableIDs, math.MaxUint16-1000)
-
-	// Check the plugins for different ranges and stop them afterwards to
-	// free the IDs. This is crucial when stop/starting the plugin e.g. during
-	// reloading configurations
-	for i, plugin := range plugins {
-		require.Len(t, plugin.availableIDs, 100)
-		require.Equal(t, i*100, plugin.availableIDs[0])
-		plugin.Stop()
-		require.Empty(t, plugin.availableIDs)
-	}
-
-	// Check that all reserved IDs were returned
-	require.Len(t, availableIDs, math.MaxUint16)
-}
-
-func TestNativeIDsOverflow(t *testing.T) {
-	// Create plugin with too many URLS
-	plugin := &Ping{
-		Method: "native",
-		Urls:   slices.Repeat([]string{"localhost"}, 70000),
-
-		Log: &testutil.Logger{},
-	}
-	require.ErrorContains(t, plugin.Init(), "too many URLs (70000)")
-}
-
-func TestNativeIDsOverflowAcrossPlugins(t *testing.T) {
-	// Generate a target list
-	targets := slices.Repeat([]string{"localhost"}, 10000)
-
-	// Add plugin instances staying within the number of available IDs
-	plugins := make([]*Ping, 0, 10)
-	defer func() {
-		for _, plugin := range plugins {
-			plugin.Stop()
+		var acc testutil.Accumulator
+		if err := plugin.Gather(&acc); err != nil {
+			t.Errorf("running gather failed: %v", err)
 		}
 	}()
-	for range 6 {
-		plugin := &Ping{
-			Method: "native",
-			Urls:   targets,
-			Log:    &testutil.Logger{},
-		}
-		require.NoError(t, plugin.Init())
-		require.NoError(t, plugin.Start(nil))
-		plugins = append(plugins, plugin)
+
+	// All pingers should wait since the IDs are full
+	require.Never(t, func() bool {
+		seenIDsMu.Lock()
+		defer seenIDsMu.Unlock()
+		return len(seenIDs) > 0
+	}, time.Second, 100*time.Millisecond)
+
+	// Free the required amount of IDs
+	for i := range uint16(len(targets)) {
+		freeNativePingID(i)
 	}
 
-	// This instance should cause the overflow
-	plugin := &Ping{
-		Method: "native",
-		Urls:   targets,
-		Log:    &testutil.Logger{},
+	// Wait for all plugins to reach the pinging function to ensure we have seen
+	// all IDs and all IDs are unique as they are not free'ed in between.
+	require.Eventually(t, func() bool {
+		seenIDsMu.Lock()
+		defer seenIDsMu.Unlock()
+		return len(seenIDs) >= len(targets)
+	}, 3*time.Second, 100*time.Millisecond)
+
+	// Allow all pings to complete and wait for the plugins to finish
+	cancel()
+	wg.Wait()
+
+	// Check the seen IDs
+	expected := make([]int, len(targets))
+	for i := range expected {
+		expected[i] = i
 	}
-	require.NoError(t, plugin.Init())
-	require.ErrorContains(t, plugin.Start(nil), "too many URLs across all plugin instances")
+
+	seenIDsMu.Lock()
+	defer seenIDsMu.Unlock()
+	require.Len(t, seenIDs, len(targets))
+	slices.Sort(seenIDs)
+	require.Equal(t, expected, seenIDs)
+
+	// Check that all IDs have been free'ed
+	usedIDsCond.L.Lock()
+	defer usedIDsCond.L.Unlock()
+	require.Equal(t, initialUsedIDs[len(targets):], usedIDs)
 }
 
 func Benchmark(b *testing.B) {
@@ -97,11 +274,26 @@ func Benchmark(b *testing.B) {
 		Log:    &testutil.Logger{},
 	}
 	require.NoError(b, plugin.Init())
-	require.NoError(b, plugin.Start(nil))
-	defer plugin.Stop()
 
 	acc := &testutil.Accumulator{Discard: true}
 	for b.Loop() {
 		require.NoError(b, plugin.Gather(acc))
 	}
+}
+
+func fakeResult() (*pingStats, error) {
+	return &pingStats{
+		Statistics: ping.Statistics{
+			PacketsSent: 5,
+			PacketsRecv: 5,
+			Rtts: []time.Duration{
+				3 * time.Millisecond,
+				4 * time.Millisecond,
+				1 * time.Millisecond,
+				5 * time.Millisecond,
+				2 * time.Millisecond,
+			},
+		},
+		ttl: 1,
+	}, nil
 }

--- a/plugins/inputs/ping/ping_test.go
+++ b/plugins/inputs/ping/ping_test.go
@@ -107,6 +107,11 @@ func TestNativeIDs(t *testing.T) {
 			usedIDsCond.L.Lock()
 			usedIDs = slices.Clone(initialIDs)
 			usedIDsCond.L.Unlock()
+			t.Cleanup(func() {
+				usedIDsCond.L.Lock()
+				usedIDs = make([]uint16, 0)
+				usedIDsCond.L.Unlock()
+			})
 
 			// Add a number of plugin instances that need to share the IDs
 			var wg sync.WaitGroup
@@ -187,6 +192,11 @@ func TestNativeIDsWaitOnFull(t *testing.T) {
 	usedIDsCond.L.Lock()
 	usedIDs = slices.Clone(initialUsedIDs)
 	usedIDsCond.L.Unlock()
+	t.Cleanup(func() {
+		usedIDsCond.L.Lock()
+		usedIDs = make([]uint16, 0)
+		usedIDsCond.L.Unlock()
+	})
 
 	// Add a number of plugin instances that need to share the IDs
 	var wg sync.WaitGroup
@@ -262,23 +272,6 @@ func TestNativeIDsWaitOnFull(t *testing.T) {
 	usedIDsCond.L.Lock()
 	defer usedIDsCond.L.Unlock()
 	require.Equal(t, initialUsedIDs[len(targets):], usedIDs)
-}
-
-func Benchmark(b *testing.B) {
-	// Generate a target list
-	targets := slices.Repeat([]string{"localhost"}, 100)
-
-	plugin := &Ping{
-		Method: "native",
-		Urls:   targets,
-		Log:    &testutil.Logger{},
-	}
-	require.NoError(b, plugin.Init())
-
-	acc := &testutil.Accumulator{Discard: true}
-	for b.Loop() {
-		require.NoError(b, plugin.Gather(acc))
-	}
 }
 
 func fakeResult() (*pingStats, error) {


### PR DESCRIPTION
## Summary

This PR prevents collisions for native pining when interpreting received packet and doing false assignments to the corresponding sent packet. This false assignment produces wrong timings, mangles statistics and produces wrong results (see #8980 for details).

This PR introduces a deterministic packet-ID assignment to `Pinger`s accross **all** plugin **instances** to allow the underlying library to correctly assign a received packet to its correct sent-packet origin.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

resolves #8980
