### PR TITLE
fix(inputs.kinesis_consumer): Acquire lock before saving shard consumers

### DIFF
--- a/plugins/inputs/kinesis_consumer/consumer.go
+++ b/plugins/inputs/kinesis_consumer/consumer.go
@@ -147,6 +147,9 @@ func (c *consumer) init() error {
 		return errors.New("message handler is undefined")
 	}
 
+	c.Lock()
+	defer c.Unlock()
+
 	c.shardsConsumed = make(map[string]bool)
 	c.shardConsumers = make(map[string]*shardConsumer)
 
@@ -327,7 +330,10 @@ func (c *consumer) startShardConsumer(ctx context.Context, id, seqnr string) {
 		sc.params.ShardIteratorType = types.ShardIteratorTypeAfterSequenceNumber
 		sc.params.StartingSequenceNumber = &seqnr
 	}
+
+	c.Lock()
 	c.shardConsumers[id] = sc
+	c.Unlock()
 
 	childs, err := sc.consume(ctx, id)
 	if err != nil {


### PR DESCRIPTION
## Summary

This PR acquires the lock before saving the newly created shard-consumer avoiding race conditions when reading/modifying the map.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

resolves #18872 
