### PR TITLE
fix(inputs.docker): Lock stats cache before reading

### DIFF
--- a/plugins/inputs/docker/docker.go
+++ b/plugins/inputs/docker/docker.go
@@ -356,12 +356,12 @@ func (d *Docker) fixPodmanCPUStats(containerID string, current *container.StatsR
 
 // cleanupStaleCache removes expired entries from the stats cache
 func (d *Docker) cleanupStaleCache() {
+	d.statsCacheMutex.Lock()
+	defer d.statsCacheMutex.Unlock()
+
 	if len(d.statsCache) == 0 {
 		return // Early exit if cache is empty
 	}
-
-	d.statsCacheMutex.Lock()
-	defer d.statsCacheMutex.Unlock()
 
 	cutoff := time.Now().Add(-time.Duration(d.PodmanCacheTTL))
 	expiredCount := 0


### PR DESCRIPTION
## Summary

This PR fixes a potential race condition when accessing the stats-cache length without holding the lock.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
