### PR TITLE
feat(parsers): Add time-setting interface

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -1,5 +1,7 @@
 package telegraf
 
+import "time"
+
 // Parser is an interface defining functions that a parser plugin must satisfy.
 type Parser interface {
 	// Parse takes a byte buffer separated by newlines
@@ -37,4 +39,10 @@ type ParserPlugin interface {
 type ParserFuncPlugin interface {
 	// SetParserFunc returns a new parser.
 	SetParserFunc(fn ParserFunc)
+}
+
+// ParserTimeFuncPlugin allows to override the time used if parsed metrics do
+// not contain an explicit timestamp. By default the current time is used.
+type ParserTimeFuncPlugin interface {
+	SetTimeFunc(func() time.Time)
 }


### PR DESCRIPTION
## Summary

This PR adds an interface for parsers to modify the time emitted if the data does not contain a timestamp. The current behavior (an new default) is to emit `time.Now`, i.e. the current time for metrics that do not have an _explicit_ timestamp.
By overriding the time function it is possible to emit a _zero_ timestamp marking those metrics as "not having a timestamp" to fix #16331 requiring this distinction.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

related to #16331 