### PR TITLE
feat(inputs.temp): Add setting to force thermal-zones gathering on linux

### DIFF
--- a/plugins/inputs/temp/README.md
+++ b/plugins/inputs/temp/README.md
@@ -27,6 +27,9 @@ plugin ordering. See [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
   ## Add device tag to distinguish devices with the same name (Linux only)
   # add_device_tag = false
+
+  ## Always gather values from the thermal-zones even if some hwmon exists (Linux only)
+  # always_gather_zones = false
 ```
 
 ## Troubleshooting

--- a/plugins/inputs/temp/sample.conf
+++ b/plugins/inputs/temp/sample.conf
@@ -8,3 +8,6 @@
 
   ## Add device tag to distinguish devices with the same name (Linux only)
   # add_device_tag = false
+
+  ## Always gather values from the thermal-zones even if some hwmon exists (Linux only)
+  # always_gather_zones = false

--- a/plugins/inputs/temp/temp.go
+++ b/plugins/inputs/temp/temp.go
@@ -14,6 +14,7 @@ var sampleConfig string
 type Temperature struct {
 	MetricFormat string          `toml:"metric_format"`
 	DeviceTag    bool            `toml:"add_device_tag"`
+	ThermalZones bool            `toml:"always_gather_zones"`
 	Log          telegraf.Logger `toml:"-"`
 }
 

--- a/plugins/inputs/temp/temp_linux.go
+++ b/plugins/inputs/temp/temp_linux.go
@@ -46,12 +46,14 @@ func (t *Temperature) Gather(acc telegraf.Accumulator) error {
 		return fmt.Errorf("getting temperatures failed: %w", err)
 	}
 
-	if len(temperatures) == 0 {
+	if len(temperatures) == 0 || t.ThermalZones {
 		// There is no hwmon interface, fallback to thermal-zone parsing
-		temperatures, err = t.gatherThermalZone(path)
+		// Or append the thermal-zone parsing if set in the configuration
+		temperaturesZones, err := t.gatherThermalZone(path)
 		if err != nil {
 			return fmt.Errorf("getting temperatures (via fallback) failed: %w", err)
 		}
+		temperatures = append(temperatures, temperaturesZones...)
 	}
 
 	switch t.MetricFormat {

--- a/plugins/inputs/temp/temp_notlinux.go
+++ b/plugins/inputs/temp/temp_notlinux.go
@@ -22,6 +22,10 @@ func (t *Temperature) Init() error {
 		t.Log.Warn("Ignoring 'add_device_tag' on non-Linux platforms!")
 	}
 
+	if t.ThermalZones {
+		t.Log.Warn("Ignoring 'always_gather_zones' on non-Linux platforms!")
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
- ~~When the hardware device is sleeping, the temp input plugin completely hangs waiting for the os.ReadFile call to return.\
The EAGAIN returned by the kernel is handled internally by os.ReadFile and the function waits for the file to become available.\
-> Use the non-blocking syscall function to read the files and silently ignoring unavailable thermal-zones.~~ moved to its own PR, see #18913

- Adding a parameter to force the gathering of the thermal-zones temperatures. Some systems combine both hwmon and thermal-zones. Current implemenentation ignores thermal-zones when some hwmon exist.

#### Some comments/potential issues
1. No tests were previously implemented for the thermal-zones gathering. Are they needed ?
1. Should I convert the new boolean parameter to a string (like prefered in the docs), at the expense of more code changes?
1. ~~technically these are two distinct features, should I open 2 PRs?~~ the fix moved to its own PR, see #18913

Looking forward to your feedback and your thoughts on the potential issues.
Thanks for your great work on this tool!

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

partially resolves #18899
related to #18913 
