### PR TITLE
fix(secrets): Avoid panic with empty content

### DIFF
--- a/config/secret_unprotected.go
+++ b/config/secret_unprotected.go
@@ -43,7 +43,7 @@ func (lb *unlockedBuffer) Bytes() []byte {
 
 func (lb *unlockedBuffer) TemporaryString() string {
 	//nolint:gosec // G103: Valid use of unsafe call to cast underlying bytes to string
-	return unsafe.String(&lb.content[0], len(lb.content))
+	return unsafe.String(unsafe.SliceData(lb.content), len(lb.content))
 }
 
 func (lb *unlockedBuffer) String() string {


### PR DESCRIPTION
The implementation of `TemporaryString` in `config/secret_unprotected.go` was susceptible to a runtime panic when handling empty secret buffers. This occurred because the code attempted to reference the first element of an empty slice before passing it to `unsafe.String`. 

I have updated the logic to use `unsafe.SliceData`, which provides a safe pointer for slice data even when the length is zero. The change has been verified against the existing test suite and the reproduction case for the panic.

As requested by the maintainer, the TLS consistency changes have been moved to a separate PR.

## Checklist
- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

## Related issues
resolves #
