### PR TITLE
feat(agent): Accept TELEGRAF_CONTROLLER_TOKEN environment variable

### DIFF
--- a/cmd/telegraf/telegraf.go
+++ b/cmd/telegraf/telegraf.go
@@ -359,7 +359,9 @@ func (*Telegraf) watchRemoteConfigs(ctx context.Context, signals chan os.Signal,
 					continue
 				}
 
-				if v, exists := os.LookupEnv("INFLUX_TOKEN"); exists {
+				if v, exists := os.LookupEnv("TELEGRAF_CONTROLLER_TOKEN"); exists {
+					req.Header.Add("Authorization", "Bearer "+v)
+				} else if v, exists := os.LookupEnv("INFLUX_TOKEN"); exists {
 					req.Header.Add("Authorization", "Token "+v)
 				}
 				req.Header.Set("User-Agent", internal.ProductToken())

--- a/config/config.go
+++ b/config/config.go
@@ -903,7 +903,9 @@ func fetchConfig(u *url.URL, urlRetryAttempts int) ([]byte, error) {
 		return nil, err
 	}
 
-	if v, exists := os.LookupEnv("INFLUX_TOKEN"); exists {
+	if v, exists := os.LookupEnv("TELEGRAF_CONTROLLER_TOKEN"); exists {
+		req.Header.Add("Authorization", "Bearer "+v)
+	} else if v, exists := os.LookupEnv("INFLUX_TOKEN"); exists {
 		req.Header.Add("Authorization", "Token "+v)
 	}
 	req.Header.Add("Accept", "application/toml")


### PR DESCRIPTION
## Summary

This PR accepts the `TELEGRAF_CONTROLLER_TOKEN` environment variable used to set a bearer authentication header.

> [!IMPORTANT]
> `TELEGRAF_CONTROLLER_TOKEN` will take precedence over `INFLUX_TOKEN` if both are specified!

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

resolves #18423 
