### PR TITLE
fix(common.tls): Explicitly set default minimum TLS version

### DIFF
--- a/plugins/common/tls/client.go
+++ b/plugins/common/tls/client.go
@@ -43,7 +43,9 @@ func (c *ClientConfig) TLSConfig() (*tls.Config, error) {
 		// Check if TLS config is forcefully enabled and supposed to
 		// use the system defaults.
 		if c.Enable != nil && *c.Enable {
-			return &tls.Config{}, nil
+			return &tls.Config{
+				MinVersion: TLSMinVersionDefault,
+			}, nil
 		}
 
 		return nil, nil

--- a/plugins/common/tls/client_test.go
+++ b/plugins/common/tls/client_test.go
@@ -374,6 +374,8 @@ func TestEnableFlagEnabled(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, cfg)
 
-	expected := &cryptotls.Config{}
+	expected := &cryptotls.Config{
+		MinVersion: cryptotls.VersionTLS12,
+	}
 	require.Equal(t, expected, cfg)
 }


### PR DESCRIPTION
## Summary
The current implementation in `plugins/common/tls/client.go` defaults to the Go runtime's standard behavior when a TLS configuration is explicitly enabled but otherwise empty. This change aligns this specific path with the rest of the package by explicitly setting the `MinVersion` to `TLSMinVersionDefault`.

Consistent enforcement of the project's intended minimum TLS version is ensured by this update, even with a minimal enabled configuration. Existing tests have been updated to reflect this alignment.

This change is a split from PR #18908 as requested by the maintainer.

## Checklist
- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

based on #18908 
