### PR TITLE
fix(inputs.system): Demote missing utmp debug log to trace

### DIFF
--- a/plugins/inputs/system/system.go
+++ b/plugins/inputs/system/system.go
@@ -132,7 +132,7 @@ func (s *System) Gather(acc telegraf.Accumulator) error {
 				fields["n_users"] = len(users)
 				fields["n_unique_users"] = findUniqueUsers(users)
 			} else if os.IsNotExist(err) {
-				s.Log.Debugf("Reading users: %s", err.Error())
+				s.Log.Tracef("Reading users: %s", err.Error())
 			} else if os.IsPermission(err) {
 				s.Log.Debug(err.Error())
 			} else {


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
On systems without /var/run/utmp (newer Ubuntu, distroless containers, etc.), the users collection in inputs.system logs Reading users: ... no such file or directory every gather interval. The plugin already silently drops n_users / n_unique_users in this case, so the message is just diagnostic noise for anyone running with debug logging enabled.

This demotes that one log line (the os.IsNotExist branch) from debug to trace. The os.IsPermission case stays at debug (actionable) and unexpected errors stay at warn.

  The include option added in #18533 will let users skip users entirely starting in v1.39.0, but the default config still gathers it, so the noise survives that change without this fix.

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
