### PR TITLE
docs(parsers): Remove duplicate "and" in comments

### DIFF
--- a/plugins/parsers/openmetrics/metric_v2.go
+++ b/plugins/parsers/openmetrics/metric_v2.go
@@ -111,7 +111,7 @@ func (p *Parser) extractMetricsV2(ometrics *MetricFamily) []telegraf.Metric {
 			case MetricType_HISTOGRAM, MetricType_GAUGE_HISTOGRAM:
 				histogram := omp.GetHistogramValue()
 
-				// Add an overall metric containing the number of samples and and its sum
+				// Add an overall metric containing the number of samples and its sum
 				histFields := make(map[string]interface{})
 				histFields[metricName+"_count"] = float64(histogram.GetCount())
 				if s := histogram.GetSum(); s != nil {

--- a/plugins/parsers/prometheus/metric_v2.go
+++ b/plugins/parsers/prometheus/metric_v2.go
@@ -36,7 +36,7 @@ func (p *Parser) extractMetricsV2(prommetrics *dto.MetricFamily) []telegraf.Metr
 		case dto.MetricType_SUMMARY:
 			summary := pm.GetSummary()
 
-			// Add an overall metric containing the number of samples and and its sum
+			// Add an overall metric containing the number of samples and its sum
 			summaryFields := make(map[string]interface{})
 			summaryFields[metricName+"_count"] = float64(summary.GetSampleCount())
 			summaryFields[metricName+"_sum"] = summary.GetSampleSum()
@@ -55,7 +55,7 @@ func (p *Parser) extractMetricsV2(prommetrics *dto.MetricFamily) []telegraf.Metr
 		case dto.MetricType_HISTOGRAM:
 			histogram := pm.GetHistogram()
 
-			// Add an overall metric containing the number of samples and and its sum
+			// Add an overall metric containing the number of samples and its sum
 			histFields := make(map[string]interface{})
 			histFields[metricName+"_count"] = float64(histogram.GetSampleCount())
 			histFields[metricName+"_sum"] = histogram.GetSampleSum()


### PR DESCRIPTION
Three identical one-line typo fixes in metric_v2.go comments:
- `plugins/parsers/prometheus/metric_v2.go` (line ~39) — "// Add an overall metric containing the number of samples and and its sum" → "// Add an overall metric containing the number of samples and its sum"
- `plugins/parsers/prometheus/metric_v2.go` (line ~58) — same comment, same fix
- `plugins/parsers/openmetrics/metric_v2.go` (line ~114) — same comment, same fix

No code/behavior change.