### PR TITLE
fix(agent): Skip output buffer initialization in test mode

### DIFF
--- a/cmd/telegraf/telegraf.go
+++ b/cmd/telegraf/telegraf.go
@@ -402,6 +402,7 @@ func (t *Telegraf) loadConfiguration() (*config.Config, error) {
 	c.OutputFilters = t.outputFilters
 	c.InputFilters = t.inputFilters
 	c.SecretStoreFilters = t.secretstoreFilters
+	c.TestMode = !t.once && (t.test || t.testWait != 0)
 
 	if err := t.getConfigFiles(); err != nil {
 		return c, err

--- a/cmd/telegraf/telegraf_config_test.go
+++ b/cmd/telegraf/telegraf_config_test.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/influxdata/telegraf/internal"
+)
+
+func TestLoadConfigurationTestModeSkipsDiskOutputBuffer(t *testing.T) {
+	savedVersion := internal.Version
+	internal.Version = "0.0.0"
+	defer func() {
+		internal.Version = savedVersion
+	}()
+
+	agent := &Telegraf{
+		GlobalFlags: GlobalFlags{
+			config: []string{"testdata/test_mode_disk_buffer.conf"},
+		},
+	}
+	_, err := agent.loadConfiguration()
+	require.ErrorContains(t, err, "creating buffer failed")
+
+	agent.test = true
+	cfg, err := agent.loadConfiguration()
+	require.NoError(t, err)
+	require.Len(t, cfg.Outputs, 1)
+	require.Equal(t, "discard", cfg.Outputs[0].Config.BufferStrategy)
+}

--- a/cmd/telegraf/testdata/buffer-not-directory
+++ b/cmd/telegraf/testdata/buffer-not-directory
@@ -1,0 +1,1 @@
+not a directory

--- a/cmd/telegraf/testdata/test_mode_disk_buffer.conf
+++ b/cmd/telegraf/testdata/test_mode_disk_buffer.conf
@@ -1,0 +1,9 @@
+[agent]
+  buffer_strategy = "disk"
+  buffer_directory = "testdata/buffer-not-directory"
+
+[[inputs.cpu]]
+
+[[outputs.influxdb]]
+  urls = ["http://localhost:8086"]
+  database = "telegraf"

--- a/config/config.go
+++ b/config/config.go
@@ -88,6 +88,9 @@ type Config struct {
 	InputFilters       []string
 	OutputFilters      []string
 	SecretStoreFilters []string
+	// TestMode keeps output parsing in place while avoiding resources only
+	// needed when outputs are actually used.
+	TestMode bool
 
 	SecretStores      map[string]telegraf.SecretStore
 	secretStoreSource map[string][]string
@@ -1784,7 +1787,12 @@ func (c *Config) buildOutput(name, source string, tbl *ast.Table) (*models.Outpu
 		return nil, c.firstErr()
 	}
 
-	if oc.BufferStrategy == "disk_write_through" {
+	if err := models.CheckBufferSettings(oc.BufferStrategy); err != nil {
+		return nil, err
+	}
+	if c.TestMode {
+		oc.BufferStrategy = "discard"
+	} else if oc.BufferStrategy == "disk_write_through" {
 		log.Printf("W! Using disk-write-through buffer strategy for plugin outputs.%s, this is an experimental feature", name)
 	}
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -504,6 +504,22 @@ func TestConfig_InlineTables(t *testing.T) {
 	require.Equal(t, []string{"org_id"}, c.Outputs[0].Config.Filter.TagInclude)
 }
 
+func TestConfig_TestModeSkipsOutputBuffer(t *testing.T) {
+	c := config.NewConfig()
+	err := c.LoadConfig("testdata/test_mode_disk_buffer.toml")
+	require.ErrorContains(t, err, "creating buffer failed")
+
+	c = config.NewConfig()
+	c.TestMode = true
+	require.NoError(t, c.LoadConfig("testdata/test_mode_disk_buffer.toml"))
+	require.Len(t, c.Outputs, 1)
+	require.Equal(t, "discard", c.Outputs[0].Config.BufferStrategy)
+
+	output, ok := c.Outputs[0].Output.(*MockupOutputPluginSerializerNew)
+	require.True(t, ok)
+	require.NotNil(t, output.Serializer)
+}
+
 func TestConfig_SliceComment(t *testing.T) {
 	c := config.NewConfig()
 	require.NoError(t, c.LoadConfig("./testdata/slice_comment.toml"))

--- a/config/testdata/buffer-not-directory
+++ b/config/testdata/buffer-not-directory
@@ -1,0 +1,1 @@
+not a directory

--- a/config/testdata/test_mode_disk_buffer.toml
+++ b/config/testdata/test_mode_disk_buffer.toml
@@ -1,0 +1,6 @@
+[agent]
+  buffer_strategy = "disk"
+  buffer_directory = "testdata/buffer-not-directory"
+
+[[outputs.serializer_test_new]]
+  data_format = "json"

--- a/models/buffer.go
+++ b/models/buffer.go
@@ -114,8 +114,20 @@ func NewBuffer(name, id, alias string, capacity int, strategy, path string, disk
 		return NewMemoryBuffer(capacity, bs)
 	case "disk_write_through":
 		return NewDiskBuffer(id, path, bs, diskSync)
+	case "discard":
+		return newDiscardBuffer(bs), nil
 	}
 	return nil, fmt.Errorf("invalid buffer strategy %q", strategy)
+}
+
+// CheckBufferSettings verifies that the buffer settings are valid without
+// opening or allocating the buffer.
+func CheckBufferSettings(strategy string) error {
+	switch strategy {
+	case "", "memory", "disk_write_through":
+		return nil
+	}
+	return fmt.Errorf("invalid buffer strategy %q", strategy)
 }
 
 func NewBufferStats(tags map[string]string, capacity int) BufferStats {

--- a/models/buffer_discard.go
+++ b/models/buffer_discard.go
@@ -1,0 +1,37 @@
+package models
+
+import "github.com/influxdata/telegraf"
+
+type discardBuffer struct {
+	BufferStats
+}
+
+func newDiscardBuffer(stats BufferStats) *discardBuffer {
+	return &discardBuffer{BufferStats: stats}
+}
+
+func (*discardBuffer) Len() int {
+	return 0
+}
+
+func (b *discardBuffer) Add(metrics ...telegraf.Metric) int {
+	for _, m := range metrics {
+		b.metricDropped(m)
+	}
+	return len(metrics)
+}
+
+func (*discardBuffer) BeginTransaction(int) *Transaction {
+	return &Transaction{}
+}
+
+func (*discardBuffer) EndTransaction(*Transaction) {
+}
+
+func (b *discardBuffer) Stats() BufferStats {
+	return b.BufferStats
+}
+
+func (*discardBuffer) Close() error {
+	return nil
+}

--- a/models/buffer_mem_test.go
+++ b/models/buffer_mem_test.go
@@ -31,6 +31,34 @@ func TestMemoryBufferAcceptCallsMetricAccept(t *testing.T) {
 	require.Equal(t, 2, accept)
 }
 
+func TestCheckBufferSettings(t *testing.T) {
+	for _, strategy := range []string{"", "memory", "disk_write_through"} {
+		require.NoError(t, CheckBufferSettings(strategy))
+	}
+	require.ErrorContains(t, CheckBufferSettings("discard"), `invalid buffer strategy "discard"`)
+	require.ErrorContains(t, CheckBufferSettings("unknown"), `invalid buffer strategy "unknown"`)
+}
+
+func TestDiscardBufferDropsMetrics(t *testing.T) {
+	buf, err := NewBuffer("test", "123", "", 5, "discard", "", true)
+	require.NoError(t, err)
+	buf.Stats().MetricsDropped.Set(0)
+	defer buf.Close()
+
+	var rejected int
+	mm := &mockMetric{
+		Metric: metric.New("cpu", map[string]string{}, map[string]interface{}{"value": 42.0}, time.Unix(0, 0)),
+		RejectF: func() {
+			rejected++
+		},
+	}
+	require.Equal(t, 1, buf.Add(mm))
+	require.Equal(t, 0, buf.Len())
+	require.Equal(t, 1, rejected)
+	require.Equal(t, int64(1), buf.Stats().MetricsDropped.Get())
+	require.Empty(t, buf.BeginTransaction(1).Batch)
+}
+
 func BenchmarkMemoryBufferAddMetrics(b *testing.B) {
 	buf, err := NewBuffer("test", "123", "", 10000, "memory", "", true)
 	require.NoError(b, err)


### PR DESCRIPTION
## Summary

This PR updates `telegraf --test` and `--test-wait` to avoid initializing runtime output buffers during config loading, addressing issue #18917.

In test mode, outputs are not used. However, Telegraf still initialized output buffers while loading the configuration. When `buffer_strategy = "disk"` was configured, this attempted to create/open the disk-backed WAL under `buffer_directory`, causing `telegraf --test` to fail if the current user did not have write access to that directory.

This PR marks config loading as test mode for `--test` and `--test-wait`. Output configs still parse normally, including serializers, but runtime output buffer initialization is skipped for parsed-but-unused outputs in test mode.

This PR also adds an internal discard buffer for outputs parsed in test mode.

Tests added in this PR cover:

- Config parsing in test mode with an unusable disk buffer path
- CLI config loading in test mode
- Serializer parsing in test mode
- Ensuring disk-backed output buffers are not initialized during test-mode config loading

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the InfluxData Policy on AI-Generated Code Contributions

## Related issues

resolves #18917