### PR TITLE
chore(ci): Limit permissions to read-only on suitable workflows

### DIFF
--- a/.github/workflows/pr-target-branch.yml
+++ b/.github/workflows/pr-target-branch.yml
@@ -7,6 +7,9 @@ on:
       - synchronize
       - edited
 
+permissions:
+  contents: read
+
 jobs:
   check-target-master:
     name: master

--- a/.github/workflows/readme-linter.yml
+++ b/.github/workflows/readme-linter.yml
@@ -5,6 +5,10 @@ on:
   pull_request:
     branches: # Names of target branches, not source branches
       - master
+
+permissions:
+  contents: read
+
 jobs:
   run-readme-linter:
     runs-on: ubuntu-latest

--- a/.github/workflows/semantic.yml
+++ b/.github/workflows/semantic.yml
@@ -7,6 +7,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   semantic:
     uses: influxdata/validate-semantic-github-messages/.github/workflows/semantic.yml@main


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` on 3 workflows in `.github/workflows/` that don't call a GitHub API beyond the initial checkout.

## Why

CVE-2025-30066 (March 2025 `tj-actions/changed-files` supply-chain compromise) exfiltrated `GITHUB_TOKEN` from workflow logs. Pinning per workflow caps runtime authority irrespective of the repo or org default, gives drift protection if the default ever widens, and is credited per-file by the OpenSSF Scorecard `Token-Permissions` check.

YAML validated locally with `yaml.safe_load` on each touched file.