### PR TITLE
feat(inputs.directory_monitor): Allow to preserve timestamps when moving file

### DIFF
--- a/plugins/inputs/directory_monitor/README.md
+++ b/plugins/inputs/directory_monitor/README.md
@@ -75,6 +75,10 @@ plugin ordering. See [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## https://docs.influxdata.com/influxdb/cloud/reference/glossary/#series-cardinality
   # file_tag = ""
   #
+  ## Preserve the original access and modification timestamps when moving
+  ## processed files to the finished or error directory.
+  # preserve_timestamps = false
+  #
   ## Specify if the file can be read completely at once or if it needs to be read line by line (default).
   ## Possible values: "line-by-line", "at-once"
   # parse_method = "line-by-line"

--- a/plugins/inputs/directory_monitor/directory_monitor.go
+++ b/plugins/inputs/directory_monitor/directory_monitor.go
@@ -41,11 +41,12 @@ const (
 )
 
 type DirectoryMonitor struct {
-	Directory         string `toml:"directory"`
-	FinishedDirectory string `toml:"finished_directory"`
-	Recursive         bool   `toml:"recursive"`
-	ErrorDirectory    string `toml:"error_directory"`
-	FileTag           string `toml:"file_tag"`
+	Directory          string `toml:"directory"`
+	FinishedDirectory  string `toml:"finished_directory"`
+	Recursive          bool   `toml:"recursive"`
+	ErrorDirectory     string `toml:"error_directory"`
+	FileTag            string `toml:"file_tag"`
+	PreserveTimestamps bool   `toml:"preserve_timestamps"`
 
 	FilesToMonitor             []string        `toml:"files_to_monitor"`
 	FilesToIgnore              []string        `toml:"files_to_ignore"`
@@ -436,8 +437,28 @@ func (monitor *DirectoryMonitor) moveFile(srcPath, dstBaseDir string) {
 		monitor.Log.Errorf("Could not close input file: %s", err)
 	}
 
+	// Capture the source timestamps before removing the original so they can
+	// be restored on the moved file.
+	var srcTimes times.Timespec
+	if monitor.PreserveTimestamps {
+		if srcTimes, err = times.Stat(srcPath); err != nil {
+			monitor.Log.Errorf("Could not read timestamps of %q: %v", srcPath, err)
+		}
+	}
+
 	if err := os.Remove(srcPath); err != nil {
 		monitor.Log.Errorf("Failed removing original file: %s", err)
+	}
+
+	if monitor.PreserveTimestamps && srcTimes != nil {
+		// Close the destination file before adjusting its timestamps so the
+		// change is not undone by a later flush and applies cleanly on Windows.
+		if err := outputFile.Close(); err != nil {
+			monitor.Log.Errorf("Could not close output file: %s", err)
+		}
+		if err := os.Chtimes(dstPath, srcTimes.AccessTime(), srcTimes.ModTime()); err != nil {
+			monitor.Log.Errorf("Could not preserve timestamps on %q: %v", dstPath, err)
+		}
 	}
 }
 

--- a/plugins/inputs/directory_monitor/directory_monitor.go
+++ b/plugins/inputs/directory_monitor/directory_monitor.go
@@ -437,29 +437,29 @@ func (monitor *DirectoryMonitor) moveFile(srcPath, dstBaseDir string) {
 		monitor.Log.Errorf("Could not close input file: %s", err)
 	}
 
-	// Capture the source timestamps before removing the original so they can
-	// be restored on the moved file.
-	var srcTimes times.Timespec
-	if monitor.PreserveTimestamps {
-		if srcTimes, err = times.Stat(srcPath); err != nil {
-			monitor.Log.Errorf("Could not read timestamps of %q: %v", srcPath, err)
-		}
+	// Close the destination file
+	if err := outputFile.Close(); err != nil {
+		monitor.Log.Errorf("Could not close output file: %s", err)
 	}
 
+	// Restore the timestamps on the moved file to be able to keep track of the original file
+	if monitor.PreserveTimestamps {
+		srcTimes, err := times.Stat(srcPath)
+		if err != nil {
+			monitor.Log.Errorf("Could not read timestamps of %q: %v", srcPath, err)
+		}
+		
+		if srcTimes != nil {
+			if err := os.Chtimes(dstPath, srcTimes.AccessTime(), srcTimes.ModTime()); err != nil {
+				monitor.Log.Errorf("Could not preserve timestamps on %q: %v", dstPath, err)
+			}
+		}
+	}
+	
 	if err := os.Remove(srcPath); err != nil {
 		monitor.Log.Errorf("Failed removing original file: %s", err)
 	}
 
-	if monitor.PreserveTimestamps && srcTimes != nil {
-		// Close the destination file before adjusting its timestamps so the
-		// change is not undone by a later flush and applies cleanly on Windows.
-		if err := outputFile.Close(); err != nil {
-			monitor.Log.Errorf("Could not close output file: %s", err)
-		}
-		if err := os.Chtimes(dstPath, srcTimes.AccessTime(), srcTimes.ModTime()); err != nil {
-			monitor.Log.Errorf("Could not preserve timestamps on %q: %v", dstPath, err)
-		}
-	}
 }
 
 func (monitor *DirectoryMonitor) isMonitoredFile(fileName string) bool {

--- a/plugins/inputs/directory_monitor/directory_monitor.go
+++ b/plugins/inputs/directory_monitor/directory_monitor.go
@@ -448,18 +448,17 @@ func (monitor *DirectoryMonitor) moveFile(srcPath, dstBaseDir string) {
 		if err != nil {
 			monitor.Log.Errorf("Could not read timestamps of %q: %v", srcPath, err)
 		}
-		
+
 		if srcTimes != nil {
 			if err := os.Chtimes(dstPath, srcTimes.AccessTime(), srcTimes.ModTime()); err != nil {
 				monitor.Log.Errorf("Could not preserve timestamps on %q: %v", dstPath, err)
 			}
 		}
 	}
-	
+
 	if err := os.Remove(srcPath); err != nil {
 		monitor.Log.Errorf("Failed removing original file: %s", err)
 	}
-
 }
 
 func (monitor *DirectoryMonitor) isMonitoredFile(fileName string) bool {

--- a/plugins/inputs/directory_monitor/directory_monitor_test.go
+++ b/plugins/inputs/directory_monitor/directory_monitor_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -679,4 +680,55 @@ func TestParseSubdirectoriesFilesIgnore(t *testing.T) {
 	// File should have gone back to the test directory, as we configured.
 	_, err = os.Stat(filepath.Join(finishedDirectory, testJSONFile))
 	require.NoError(t, err)
+}
+
+func TestPreserveTimestamps(t *testing.T) {
+	testJSONFile := "test.json"
+	originalTime := time.Date(2020, 1, 2, 3, 4, 5, 0, time.UTC)
+
+	runMonitor := func(t *testing.T, preserve bool) os.FileInfo {
+		t.Helper()
+		acc := testutil.Accumulator{}
+		finishedDirectory := t.TempDir()
+		processDirectory := t.TempDir()
+
+		r := DirectoryMonitor{
+			Directory:          processDirectory,
+			FinishedDirectory:  finishedDirectory,
+			PreserveTimestamps: preserve,
+			MaxBufferedMetrics: defaultMaxBufferedMetrics,
+			FileQueueSize:      defaultFileQueueSize,
+			ParseMethod:        defaultParseMethod,
+		}
+		require.NoError(t, r.Init())
+		r.SetParserFunc(func() (telegraf.Parser, error) {
+			p := &json.Parser{NameKey: "Name"}
+			err := p.Init()
+			return p, err
+		})
+
+		srcPath := filepath.Join(processDirectory, testJSONFile)
+		require.NoError(t, os.WriteFile(srcPath, []byte(`{"Name": "event1", "Speed": 100.1}`), 0640))
+		require.NoError(t, os.Chtimes(srcPath, originalTime, originalTime))
+
+		r.Log = testutil.Logger{}
+		require.NoError(t, r.Start(&acc))
+		require.NoError(t, r.Gather(&acc))
+		acc.Wait(1)
+		r.Stop()
+
+		info, err := os.Stat(filepath.Join(finishedDirectory, testJSONFile))
+		require.NoError(t, err)
+		return info
+	}
+
+	t.Run("enabled keeps the original modification time", func(t *testing.T) {
+		info := runMonitor(t, true)
+		require.True(t, info.ModTime().Equal(originalTime), "expected %s, got %s", originalTime, info.ModTime())
+	})
+
+	t.Run("disabled uses the move time", func(t *testing.T) {
+		info := runMonitor(t, false)
+		require.False(t, info.ModTime().Equal(originalTime), "expected the move time, got the original timestamp")
+	})
 }

--- a/plugins/inputs/directory_monitor/sample.conf
+++ b/plugins/inputs/directory_monitor/sample.conf
@@ -39,6 +39,10 @@
   ## https://docs.influxdata.com/influxdb/cloud/reference/glossary/#series-cardinality
   # file_tag = ""
   #
+  ## Preserve the original access and modification timestamps when moving
+  ## processed files to the finished or error directory.
+  # preserve_timestamps = false
+  #
   ## Specify if the file can be read completely at once or if it needs to be read line by line (default).
   ## Possible values: "line-by-line", "at-once"
   # parse_method = "line-by-line"


### PR DESCRIPTION
## Summary

When a processed file is moved to the finished or error directory, the plugin copies it to a new file, so the moved file gets the current time as its modification time and the original file history is lost. This is a problem for the auditing and tracking use cases described in #16885.

This adds an optional `preserve_timestamps` setting. When enabled, the source file's access and modification times are captured before the original is removed, then reapplied to the moved file with `os.Chtimes`. It defaults to `false`, so existing behavior is unchanged. Added a test covering both the enabled and disabled paths.

## Checklist

- [ ] No AI generated code was used in this PR
- [x] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

partially resolves #16885