### PR TITLE
fix(inputs.webhooks.github): Restore secret field in configuration

### DIFF
--- a/plugins/inputs/webhooks/github/github_webhooks.go
+++ b/plugins/inputs/webhooks/github/github_webhooks.go
@@ -16,7 +16,7 @@ import (
 
 type Webhook struct {
 	Path   string
-	secret string
+	Secret string
 	acc    telegraf.Accumulator
 	log    telegraf.Logger
 	auth.BasicAuth
@@ -46,7 +46,7 @@ func (gh *Webhook) eventHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if gh.secret != "" && !checkSignature(gh.secret, data, r.Header.Get("X-Hub-Signature")) {
+	if gh.Secret != "" && !checkSignature(gh.Secret, data, r.Header.Get("X-Hub-Signature")) {
 		gh.log.Error("Fail to check the github webhook signature")
 		w.WriteHeader(http.StatusBadRequest)
 		return

--- a/plugins/inputs/webhooks/github/github_webhooks_test.go
+++ b/plugins/inputs/webhooks/github/github_webhooks_test.go
@@ -26,7 +26,7 @@ func githubWebhookRequest(t *testing.T, event, jsonString string) {
 
 func githubWebhookRequestWithSignature(t *testing.T, event, jsonString, signature string, expectedStatus int) {
 	var acc testutil.Accumulator
-	gh := &Webhook{Path: "/github", secret: "signature", acc: &acc, log: testutil.Logger{}}
+	gh := &Webhook{Path: "/github", Secret: "signature", acc: &acc, log: testutil.Logger{}}
 	req, err := http.NewRequest("POST", "/github", strings.NewReader(jsonString))
 	require.NoError(t, err)
 	req.Header.Add("X-Github-Event", event)


### PR DESCRIPTION
## Summary

Hello dear maintainers.

Since version 1.34.0, the "secret" field of the Github Webhook input plugin is not accepted anymore.

This issue seems to have been introduced in https://github.com/influxdata/telegraf/pull/16411, by making the "secret" field private: https://github.com/influxdata/telegraf/pull/16411/changes#diff-f064c332e0052ebf06d6967c5d61c9aba19661bedffcc22307d8690d5678891fR19


## Checklist
- [x] No AI generated code was used in this PR

## Related issues

resolves #18922 
