### PR TITLE
feat(inputs.opcua_listener): Wire browse-based node discovery

### DIFF
--- a/plugins/inputs/opcua_listener/README.md
+++ b/plugins/inputs/opcua_listener/README.md
@@ -323,6 +323,42 @@ to use them.
   #     # identifier_type = ""
   #     # identifier = ""
 
+  ## Browse-based discovery
+  ## Walks the server's address space using the Browse service and matches
+  ## browse paths against glob patterns to discover Variable nodes
+  ## automatically. Backwards compatible: when no paths are configured the
+  ## existing nodes/group configuration is used unchanged.
+  # [inputs.opcua_listener.browse]
+  #   ## Starting node for the browse walk. Defaults to the standard Objects
+  #   ## folder when empty.
+  #   # root = "ns=0;i=85"
+  #
+  #   ## Maximum tree depth descended below the root. 0 means unlimited.
+  #   # depth = 0
+  #
+  #   ## Maximum number of discovered nodes. 0 means unlimited.
+  #   # max_nodes = 0
+  #
+  #   ## Number of nodes browsed per Browse request. 0 falls back to the
+  #   ## built-in default. Lower values reduce per-RPC payload at the cost
+  #   ## of more round trips; raise for fast servers and large trees.
+  #   # batch_size = 0
+  #
+  #   ## Pattern-based discovery rules. Each path defines one glob pattern
+  #   ## over browse-path segments. Pattern syntax:
+  #   ##   *       any single segment (or any chars within a segment)
+  #   ##   **      zero or more segments (recursive descent)
+  #   ##   ?       single character within a segment
+  #   ##   [abc]   character class within a segment
+  #   ##   {a,b}   alternation: any of the comma-separated alternatives
+  #   ##   \       escapes the next character
+  #   ## Multiple paths may be configured; a node matching multiple patterns
+  #   ## appears in each matching group.
+  #   # [[inputs.opcua_listener.browse.paths]]
+  #   #   pattern = "Server/**"
+  #   #   name = "server_vars"
+  #   #   default_tags = { source = "browse" }
+
   ## Enable workarounds required by some devices to work correctly
   # [inputs.opcua_listener.workarounds]
   #  ## Set additional valid status codes, StatusOK (0x0) is always considered valid
@@ -543,6 +579,65 @@ This example group configuration shows how to use group settings:
       {namespace="5", identifier_type="i", identifier="2002"} // no default values will be used
     ]
 ```
+
+## Browse-based Discovery
+
+Large deployments often expose thousands of nodes that share a regular
+naming scheme. Instead of enumerating each node, the
+`[inputs.opcua_listener.browse]` section walks the server's address space
+with the Browse service and matches discovered Variable nodes against glob
+patterns over their browse paths. Discovered nodes are folded into the
+existing pipeline, so the configuration stays backwards compatible with any
+explicit `nodes` or `group` entries.
+
+```toml
+[inputs.opcua_listener.browse]
+  # Starting node for the browse walk (default: Objects folder).
+  root = "ns=0;i=85"
+
+  # Optional safety limits.
+  depth = 10
+  max_nodes = 50000
+
+  # Optional per-RPC tuning.
+  batch_size = 50
+
+  [[inputs.opcua_listener.browse.paths]]
+    pattern = "Plant1/*/MV*"
+    name = "motor_valves"
+    default_tags = { plant = "plant1" }
+
+  [[inputs.opcua_listener.browse.paths]]
+    pattern = "**/Temperature"
+    name = "temperatures"
+```
+
+### Pattern Syntax
+
+Patterns are compiled by Telegraf's `filter` package with `/` as the segment
+separator:
+
+| Token   | Meaning                                              |
+|---------|------------------------------------------------------|
+| literal | exact string match for one segment                   |
+| `*`     | any single segment, or any characters in a segment   |
+| `**`    | zero or more segments (recursive descent)            |
+| `?`     | single character within a segment                    |
+| `[abc]` | character class within a segment                     |
+| `{a,b}` | alternation: any of the comma-separated alternatives |
+| `\`     | escapes the next character                           |
+
+A node matched by multiple patterns appears in each matching group;
+duplicate `(metric_name, field_name, tags)` combinations are rejected at
+mapping time.
+
+The `root` option accepts node-ID strings (`ns=N;...`). Path-string form
+and namespace-URI (`nsu=...`) form are not currently supported.
+
+> [!NOTE]
+> Browse runs on every connect, so address-space changes (nodes added or
+> removed, renumbered namespaces) are picked up on reconnect without
+> restarting Telegraf.
 
 ## Metrics
 

--- a/plugins/inputs/opcua_listener/opcua_listener_test.go
+++ b/plugins/inputs/opcua_listener/opcua_listener_test.go
@@ -618,6 +618,57 @@ deadband_value = 100.0
 	}, o.subscribeClientConfig.Groups)
 }
 
+func TestSubscribeClientBrowseDiscoveryIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	container := testutil.Container{
+		Image:        "open62541/open62541",
+		ExposedPorts: []string{servicePort},
+		WaitingFor: wait.ForAll(
+			wait.ForListeningPort(servicePort),
+			wait.ForLog("TCP network layer listening on opc.tcp://"),
+		),
+	}
+	require.NoError(t, container.Start(), "failed to start container")
+	defer container.Terminate()
+
+	subscribeConfig := subscribeClientConfig{
+		InputClientConfig: input.InputClientConfig{
+			OpcUAClientConfig: opcua.OpcUAClientConfig{
+				Endpoint:       fmt.Sprintf("opc.tcp://%s:%s", container.Address, container.Ports[servicePort]),
+				SecurityPolicy: "None",
+				SecurityMode:   "None",
+				AuthMethod:     "Anonymous",
+				ConnectTimeout: config.Duration(10 * time.Second),
+				RequestTimeout: config.Duration(1 * time.Second),
+			},
+			MetricName: "browse_listener",
+			Browse: input.BrowseConfig{
+				Depth: 5,
+				Paths: []input.BrowsePathSettings{
+					{Pattern: "Server/**", MetricName: "server_vars"},
+				},
+			},
+		},
+		SubscriptionInterval: config.Duration(100 * time.Millisecond),
+	}
+
+	client, err := subscribeConfig.createSubscribeClient(testutil.Logger{})
+	require.NoError(t, err)
+
+	require.NoError(t, client.connect())
+	require.NotEmpty(t, client.NodeMetricMapping, "browse should discover at least one variable under Server/**")
+
+	// Reconnect re-runs discovery against an unchanged server; mapping size
+	// must stay bounded rather than grow with each reconnect.
+	mappingSize := len(client.NodeMetricMapping)
+	require.NoError(t, client.Disconnect(t.Context()))
+	require.NoError(t, client.connect())
+	require.Len(t, client.NodeMetricMapping, mappingSize, "rediscovery must not grow the mapping")
+}
+
 func TestSubscribeClientConfigInvalidTrigger(t *testing.T) {
 	subscribeConfig := subscribeClientConfig{
 		InputClientConfig: input.InputClientConfig{

--- a/plugins/inputs/opcua_listener/opcua_listener_test.go
+++ b/plugins/inputs/opcua_listener/opcua_listener_test.go
@@ -618,30 +618,6 @@ deadband_value = 100.0
 	}, o.subscribeClientConfig.Groups)
 }
 
-func TestSubscribeClientRejectsBrowseConfig(t *testing.T) {
-	subscribeConfig := subscribeClientConfig{
-		InputClientConfig: input.InputClientConfig{
-			OpcUAClientConfig: opcua.OpcUAClientConfig{
-				Endpoint:       "opc.tcp://localhost:4840",
-				SecurityPolicy: "None",
-				SecurityMode:   "None",
-				AuthMethod:     "Anonymous",
-				ConnectTimeout: config.Duration(10 * time.Second),
-				RequestTimeout: config.Duration(1 * time.Second),
-			},
-			MetricName: "testing",
-			Browse: input.BrowseConfig{
-				Paths: []input.BrowsePathSettings{
-					{Pattern: "Server/**", MetricName: "server_vars"},
-				},
-			},
-		},
-	}
-
-	_, err := subscribeConfig.createSubscribeClient(testutil.Logger{})
-	require.ErrorContains(t, err, "browse-based discovery is not yet supported for inputs.opcua_listener")
-}
-
 func TestSubscribeClientConfigInvalidTrigger(t *testing.T) {
 	subscribeConfig := subscribeClientConfig{
 		InputClientConfig: input.InputClientConfig{

--- a/plugins/inputs/opcua_listener/sample.conf
+++ b/plugins/inputs/opcua_listener/sample.conf
@@ -281,6 +281,42 @@
   #     # identifier_type = ""
   #     # identifier = ""
 
+  ## Browse-based discovery
+  ## Walks the server's address space using the Browse service and matches
+  ## browse paths against glob patterns to discover Variable nodes
+  ## automatically. Backwards compatible: when no paths are configured the
+  ## existing nodes/group configuration is used unchanged.
+  # [inputs.opcua_listener.browse]
+  #   ## Starting node for the browse walk. Defaults to the standard Objects
+  #   ## folder when empty.
+  #   # root = "ns=0;i=85"
+  #
+  #   ## Maximum tree depth descended below the root. 0 means unlimited.
+  #   # depth = 0
+  #
+  #   ## Maximum number of discovered nodes. 0 means unlimited.
+  #   # max_nodes = 0
+  #
+  #   ## Number of nodes browsed per Browse request. 0 falls back to the
+  #   ## built-in default. Lower values reduce per-RPC payload at the cost
+  #   ## of more round trips; raise for fast servers and large trees.
+  #   # batch_size = 0
+  #
+  #   ## Pattern-based discovery rules. Each path defines one glob pattern
+  #   ## over browse-path segments. Pattern syntax:
+  #   ##   *       any single segment (or any chars within a segment)
+  #   ##   **      zero or more segments (recursive descent)
+  #   ##   ?       single character within a segment
+  #   ##   [abc]   character class within a segment
+  #   ##   {a,b}   alternation: any of the comma-separated alternatives
+  #   ##   \       escapes the next character
+  #   ## Multiple paths may be configured; a node matching multiple patterns
+  #   ## appears in each matching group.
+  #   # [[inputs.opcua_listener.browse.paths]]
+  #   #   pattern = "Server/**"
+  #   #   name = "server_vars"
+  #   #   default_tags = { source = "browse" }
+
   ## Enable workarounds required by some devices to work correctly
   # [inputs.opcua_listener.workarounds]
   #  ## Set additional valid status codes, StatusOK (0x0) is always considered valid

--- a/plugins/inputs/opcua_listener/subscribe_client.go
+++ b/plugins/inputs/opcua_listener/subscribe_client.go
@@ -90,13 +90,6 @@ func assignConfigValuesToRequest(req *ua.MonitoredItemCreateRequest, monParams *
 }
 
 func (sc *subscribeClientConfig) createSubscribeClient(log telegraf.Logger) (*subscribeClient, error) {
-	// Browse-based discovery is currently only wired into inputs.opcua. The
-	// shared InputClientConfig accepts the [browse] table for inputs.opcua_listener
-	// too, so reject it explicitly here to avoid silently producing zero metrics.
-	if len(sc.Browse.Paths) > 0 {
-		return nil, errors.New("browse-based discovery is not yet supported for inputs.opcua_listener; use inputs.opcua instead")
-	}
-
 	client, err := sc.InputClientConfig.CreateInputClient(log)
 	if err != nil {
 		return nil, err
@@ -141,6 +134,19 @@ func (o *subscribeClient) connect() error {
 	if err := o.OpcUAClient.UpdateNamespaceArray(o.ctx); err != nil {
 		o.Log.Warnf("Failed to fetch namespace array: %v", err)
 		// Continue anyway - this is only needed if using namespace URIs
+	}
+
+	// Browse-based discovery runs on every connect so server-side schema
+	// changes (added or removed nodes, renumbered namespaces) are picked up
+	// on reconnect. DiscoverNodes replaces the previously discovered groups
+	// and InitNodeMetricMapping rebuilds the mapping from scratch.
+	if len(o.Config.Browse.Paths) > 0 {
+		if err := o.OpcUAInputClient.DiscoverNodes(o.ctx); err != nil {
+			return fmt.Errorf("browse discovery failed: %w", err)
+		}
+		if err := o.OpcUAInputClient.InitNodeMetricMapping(); err != nil {
+			return fmt.Errorf("initializing node metric mapping failed: %w", err)
+		}
 	}
 
 	// Initialize node IDs after connection so namespace URIs can be resolved


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Brings the browse-based node-discovery feature from `inputs.opcua` to `inputs.opcua_listener`. Subscription-mode users now get the same pattern-based automatic node resolution as the read-mode plugin.

`DiscoverNodes` + `InitNodeMetricMapping` run on every connect when the listener's `[browse]` block is configured, so server-side address-space changes (added or removed nodes, renumbered namespaces) are picked up on
reconnect without restarting Telegraf, matching the behavior in `inputs.opcua`.

All shared discovery code lives in `plugins/common/opcua` (added in #18831); this PR only touches the listener plugin. No new public structs, no new configuration types.

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

Partially resolves #18529
