### PR TITLE
chore: Update go to v1.26.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
     working_directory: '/go/src/github.com/influxdata/telegraf'
     resource_class: large
     docker:
-      - image: 'quay.io/influxdb/telegraf-ci:1.26.2'
+      - image: 'quay.io/influxdb/telegraf-ci:1.26.3'
     environment:
       GOFLAGS: -p=4
   mac:

--- a/.github/workflows/readme-linter.yml
+++ b/.github/workflows/readme-linter.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.26.2'
+          go-version: '1.26.3'
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0

--- a/Makefile
+++ b/Makefile
@@ -270,8 +270,8 @@ plugins/parsers/influx/machine.go: plugins/parsers/influx/machine.go.rl
 
 .PHONY: ci
 ci:
-	docker build -t quay.io/influxdb/telegraf-ci:1.26.2 - < scripts/ci.docker
-	docker push quay.io/influxdb/telegraf-ci:1.26.2
+	docker build -t quay.io/influxdb/telegraf-ci:1.26.3 - < scripts/ci.docker
+	docker push quay.io/influxdb/telegraf-ci:1.26.3
 
 .PHONY: install
 install: $(buildbin)

--- a/scripts/ci.docker
+++ b/scripts/ci.docker
@@ -1,4 +1,4 @@
-FROM golang:1.26.2
+FROM golang:1.26.3
 
 RUN chmod -R 755 "$GOPATH"
 

--- a/scripts/installgo_linux.sh
+++ b/scripts/installgo_linux.sh
@@ -2,10 +2,10 @@
 
 set -eux
 
-GO_VERSION="1.26.2"
+GO_VERSION="1.26.3"
 GO_ARCH="linux-amd64"
 # from https://go.dev/dl
-GO_VERSION_SHA="990e6b4bbba816dc3ee129eaeaf4b42f17c2800b88a2166c265ac1a200262282"
+GO_VERSION_SHA="2b2cfc7148493da5e73981bffbf3353af381d5f93e789c82c79aff64962eb556"
 
 # Download Go and verify Go tarball
 setup_go () {

--- a/scripts/installgo_mac.sh
+++ b/scripts/installgo_mac.sh
@@ -3,9 +3,9 @@
 set -eux
 
 ARCH=$(uname -m)
-GO_VERSION="1.26.2"
-GO_VERSION_SHA_arm64="32af1522bf3e3ff3975864780a429cc0b41d190ec7bf90faa661d6d64566e7af" # from https://go.dev/dl
-GO_VERSION_SHA_amd64="bc3f1500d9968c36d705442d90ba91addf9271665033748b82532682e90a7966" # from https://go.dev/dl
+GO_VERSION="1.26.3"
+GO_VERSION_SHA_arm64="875cf54a15311eee2c99b9dd67c68c4a49351d489ab622bf2cfd28c8f2078d3c" # from https://go.dev/dl
+GO_VERSION_SHA_amd64="278d580b32e299fe4a9c990fcf2d02acfe538c7e551a6ee18f9c7164573d2c63" # from https://go.dev/dl
 
 if [ "$ARCH" = 'arm64' ]; then
     GO_ARCH="darwin-arm64"

--- a/scripts/installgo_windows.sh
+++ b/scripts/installgo_windows.sh
@@ -2,7 +2,7 @@
 
 set -eux
 
-GO_VERSION="1.26.2"
+GO_VERSION="1.26.3"
 
 setup_go () {
     choco upgrade golang -d --allow-downgrade --version=${GO_VERSION}


### PR DESCRIPTION
## Summary

This PR bumps the go version.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

resolves #18916
