### PR TITLE
feat(inputs.prometheus): Add per-URL statistics on gather cycles

### DIFF
--- a/plugins/inputs/prometheus/prometheus.go
+++ b/plugins/inputs/prometheus/prometheus.go
@@ -30,6 +30,7 @@ import (
 	"github.com/influxdata/telegraf/plugins/inputs"
 	"github.com/influxdata/telegraf/plugins/parsers/openmetrics"
 	parsers_prometheus "github.com/influxdata/telegraf/plugins/parsers/prometheus"
+	"github.com/influxdata/telegraf/selfstat"
 )
 
 //go:embed sample.conf
@@ -531,6 +532,11 @@ func (p *Prometheus) gatherURL(u urlAndAddress, acc telegraf.Accumulator) (map[s
 
 	var err error
 	var resp *http.Response
+	urlStr := u.url.String()
+	connectStat := selfstat.Register("prometheus", "connection_status", map[string]string{"url": urlStr})
+	gatherSuccess := selfstat.Register("prometheus", "gathers_total", map[string]string{"url": urlStr, "status": "success"})
+	gatherFailure := selfstat.Register("prometheus", "gathers_total", map[string]string{"url": urlStr, "status": "failure"})
+
 	var start time.Time
 	if u.url.Scheme != "unix" {
 		start = time.Now()
@@ -541,6 +547,8 @@ func (p *Prometheus) gatherURL(u urlAndAddress, acc telegraf.Accumulator) (map[s
 	}
 	end := time.Since(start).Seconds()
 	if err != nil {
+		connectStat.Set(0)
+		gatherFailure.Incr(1)
 		return requestFields, tags, fmt.Errorf("error making HTTP request to %q: %w", u.url, err)
 	}
 	requestFields["response_time"] = end
@@ -548,6 +556,8 @@ func (p *Prometheus) gatherURL(u urlAndAddress, acc telegraf.Accumulator) (map[s
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
+		connectStat.Set(0)
+		gatherFailure.Incr(1)
 		return requestFields, tags, fmt.Errorf("%q returned HTTP status %q", u.url, resp.Status)
 	}
 
@@ -562,19 +572,26 @@ func (p *Prometheus) gatherURL(u urlAndAddress, acc telegraf.Accumulator) (map[s
 
 		body, err = io.ReadAll(lr)
 		if err != nil {
+			connectStat.Set(0)
+			gatherFailure.Incr(1)
 			return requestFields, tags, fmt.Errorf("error reading body: %w", err)
 		}
 		if int64(len(body)) > limit {
+			connectStat.Set(0)
+			gatherFailure.Incr(1)
 			p.Log.Infof("skipping %s: content length exceeded maximum body size (%d)", u.url, limit)
 			return requestFields, tags, nil
 		}
 	} else {
 		body, err = io.ReadAll(resp.Body)
 		if err != nil {
+			connectStat.Set(0)
+			gatherFailure.Incr(1)
 			return requestFields, tags, fmt.Errorf("error reading body: %w", err)
 		}
 	}
 	requestFields["content_length"] = len(body)
+	connectStat.Set(1)
 
 	// Override the response format if the user requested it
 	if p.contentType != "" {
@@ -600,8 +617,10 @@ func (p *Prometheus) gatherURL(u urlAndAddress, acc telegraf.Accumulator) (map[s
 	}
 	metrics, err := metricParser.Parse(body)
 	if err != nil {
+		gatherFailure.Incr(1)
 		return requestFields, tags, fmt.Errorf("error reading metrics for %q: %w", u.url, err)
 	}
+	gatherSuccess.Incr(1)
 
 	for _, metric := range metrics {
 		tags := metric.Tags()

--- a/plugins/inputs/prometheus/prometheus.go
+++ b/plugins/inputs/prometheus/prometheus.go
@@ -120,10 +120,6 @@ type Prometheus struct {
 
 	// list of http services to scrape
 	httpServices map[string]urlAndAddress
-
-	connectStat             map[string]selfstat.Stat
-	gathersTotalSuccessStat map[string]selfstat.Stat
-	gathersTotalFailureStat map[string]selfstat.Stat
 }
 
 type urlAndAddress struct {
@@ -261,15 +257,6 @@ func (p *Prometheus) Init() error {
 	}
 
 	p.kubernetesPods = make(map[podID]urlAndAddress)
-
-	// Initialize Internal Metrics
-	// if p.Statistics == nil {
-	// 	p.Statistics = selfstat.NewCollector(nil)
-	// }
-	p.connectStat = make(map[string]selfstat.Stat)
-	p.gathersTotalSuccessStat = make(map[string]selfstat.Stat)
-	p.gathersTotalFailureStat = make(map[string]selfstat.Stat)
-
 	return nil
 }
 
@@ -306,16 +293,22 @@ func (p *Prometheus) Gather(acc telegraf.Accumulator) error {
 	}
 	for _, URL := range allURLs {
 		wg.Add(1)
-		go func(serviceURL urlAndAddress) {
+		// Create internal metrics for the URL
+		urlStr := URL.url.String()
+		connectStat := p.Statistics.Register("prometheus", "connection_status", map[string]string{"url": urlStr})
+		gathersTotalSuccessStat := p.Statistics.Register("prometheus", "gathers_total", map[string]string{"url": urlStr, "status": "success"})
+		gathersTotalFailureStat := p.Statistics.Register("prometheus", "gathers_total", map[string]string{"url": urlStr, "status": "failure"})
+
+		go func(serviceURL urlAndAddress, connectStat selfstat.Stat, successStat selfstat.Stat, failureStat selfstat.Stat) {
 			defer wg.Done()
-			requestFields, tags, err := p.gatherURL(serviceURL, acc)
+			requestFields, tags, err := p.gatherURL(serviceURL, acc, connectStat, successStat, failureStat)
 			acc.AddError(err)
 
 			// Add metrics
 			if p.EnableRequestMetrics {
 				acc.AddFields("prometheus_request", requestFields, tags)
 			}
-		}(URL)
+		}(URL, connectStat, gathersTotalSuccessStat, gathersTotalFailureStat)
 	}
 
 	wg.Wait()
@@ -455,7 +448,7 @@ func (p *Prometheus) getAllURLs() (map[string]urlAndAddress, error) {
 	return allURLs, nil
 }
 
-func (p *Prometheus) gatherURL(u urlAndAddress, acc telegraf.Accumulator) (map[string]interface{}, map[string]string, error) {
+func (p *Prometheus) gatherURL(u urlAndAddress, acc telegraf.Accumulator, connectStat selfstat.Stat, successStat selfstat.Stat, failureStat selfstat.Stat) (map[string]interface{}, map[string]string, error) {
 	var req *http.Request
 	var uClient *http.Client
 	requestFields := make(map[string]interface{})
@@ -545,12 +538,6 @@ func (p *Prometheus) gatherURL(u urlAndAddress, acc telegraf.Accumulator) (map[s
 
 	var err error
 	var resp *http.Response
-	urlStr := u.url.String()
-
-	// Create internal metrics for each URL
-	p.connectStat[urlStr] = p.Statistics.Register("prometheus", "connection_status", map[string]string{"url": urlStr})
-	p.gathersTotalSuccessStat[urlStr] = p.Statistics.Register("prometheus", "gathers_total", map[string]string{"url": urlStr, "status": "success"})
-	p.gathersTotalFailureStat[urlStr] = p.Statistics.Register("prometheus", "gathers_total", map[string]string{"url": urlStr, "status": "failure"})
 
 	var start time.Time
 	if u.url.Scheme != "unix" {
@@ -562,8 +549,8 @@ func (p *Prometheus) gatherURL(u urlAndAddress, acc telegraf.Accumulator) (map[s
 	}
 	end := time.Since(start).Seconds()
 	if err != nil {
-		p.connectStat[urlStr].Set(0)
-		p.gathersTotalFailureStat[urlStr].Incr(1)
+		connectStat.Set(0)
+		failureStat.Incr(1)
 		return requestFields, tags, fmt.Errorf("error making HTTP request to %q: %w", u.url, err)
 	}
 	requestFields["response_time"] = end
@@ -571,8 +558,8 @@ func (p *Prometheus) gatherURL(u urlAndAddress, acc telegraf.Accumulator) (map[s
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		p.connectStat[urlStr].Set(0)
-		p.gathersTotalFailureStat[urlStr].Incr(1)
+		connectStat.Set(0)
+		failureStat.Incr(1)
 		return requestFields, tags, fmt.Errorf("%q returned HTTP status %q", u.url, resp.Status)
 	}
 
@@ -587,26 +574,26 @@ func (p *Prometheus) gatherURL(u urlAndAddress, acc telegraf.Accumulator) (map[s
 
 		body, err = io.ReadAll(lr)
 		if err != nil {
-			p.connectStat[urlStr].Set(0)
-			p.gathersTotalFailureStat[urlStr].Incr(1)
+			connectStat.Set(0)
+			failureStat.Incr(1)
 			return requestFields, tags, fmt.Errorf("error reading body: %w", err)
 		}
 		if int64(len(body)) > limit {
-			p.connectStat[urlStr].Set(0)
-			p.gathersTotalFailureStat[urlStr].Incr(1)
+			connectStat.Set(0)
+			failureStat.Incr(1)
 			p.Log.Infof("skipping %s: content length exceeded maximum body size (%d)", u.url, limit)
 			return requestFields, tags, nil
 		}
 	} else {
 		body, err = io.ReadAll(resp.Body)
 		if err != nil {
-			p.connectStat[urlStr].Set(0)
-			p.gathersTotalFailureStat[urlStr].Incr(1)
+			connectStat.Set(0)
+			failureStat.Incr(1)
 			return requestFields, tags, fmt.Errorf("error reading body: %w", err)
 		}
 	}
 	requestFields["content_length"] = len(body)
-	p.connectStat[urlStr].Set(1)
+	connectStat.Set(1)
 
 	// Override the response format if the user requested it
 	if p.contentType != "" {
@@ -632,10 +619,10 @@ func (p *Prometheus) gatherURL(u urlAndAddress, acc telegraf.Accumulator) (map[s
 	}
 	metrics, err := metricParser.Parse(body)
 	if err != nil {
-		p.gathersTotalFailureStat[urlStr].Incr(1)
+		failureStat.Incr(1)
 		return requestFields, tags, fmt.Errorf("error reading metrics for %q: %w", u.url, err)
 	}
-	p.gathersTotalSuccessStat[urlStr].Incr(1)
+	successStat.Incr(1)
 
 	for _, metric := range metrics {
 		tags := metric.Tags()

--- a/plugins/inputs/prometheus/prometheus.go
+++ b/plugins/inputs/prometheus/prometheus.go
@@ -120,6 +120,10 @@ type Prometheus struct {
 
 	// list of http services to scrape
 	httpServices map[string]urlAndAddress
+
+	// Set of URLs that currently have internal statistics registered, used to
+	// unregister stats for targets that are no longer being scraped.
+	statURLs map[string]struct{}
 }
 
 type urlAndAddress struct {
@@ -257,6 +261,7 @@ func (p *Prometheus) Init() error {
 	}
 
 	p.kubernetesPods = make(map[podID]urlAndAddress)
+	p.statURLs = make(map[string]struct{})
 	return nil
 }
 
@@ -291,29 +296,60 @@ func (p *Prometheus) Gather(acc telegraf.Accumulator) error {
 	if err != nil {
 		return err
 	}
+
+	p.unregisterStaleStats(allURLs)
+
 	for _, URL := range allURLs {
 		wg.Add(1)
 		// Create internal metrics for the URL
 		urlStr := URL.url.String()
+		p.statURLs[urlStr] = struct{}{}
 		connectStat := p.Statistics.Register("prometheus", "connection_status", map[string]string{"url": urlStr})
 		gathersTotalSuccessStat := p.Statistics.Register("prometheus", "gathers_total", map[string]string{"url": urlStr, "status": "success"})
 		gathersTotalFailureStat := p.Statistics.Register("prometheus", "gathers_total", map[string]string{"url": urlStr, "status": "failure"})
 
-		go func(serviceURL urlAndAddress, connectStat selfstat.Stat, successStat selfstat.Stat, failureStat selfstat.Stat) {
+		go func(serviceURL urlAndAddress) {
 			defer wg.Done()
-			requestFields, tags, err := p.gatherURL(serviceURL, acc, connectStat, successStat, failureStat)
+			requestFields, tags, err := p.gatherURL(serviceURL, acc)
+			if err != nil {
+				gathersTotalFailureStat.Incr(1)
+				connectStat.Set(0)
+			} else {
+				gathersTotalSuccessStat.Incr(1)
+				connectStat.Set(1)
+			}
 			acc.AddError(err)
 
 			// Add metrics
 			if p.EnableRequestMetrics {
 				acc.AddFields("prometheus_request", requestFields, tags)
 			}
-		}(URL, connectStat, gathersTotalSuccessStat, gathersTotalFailureStat)
+		}(URL)
 	}
 
 	wg.Wait()
 
 	return nil
+}
+
+// Remove internal statistics for any URL that was scraped previously but is not
+// part of the current target set, preventing stale metrics and unbounded growth
+// when targets are discovered dynamically.
+func (p *Prometheus) unregisterStaleStats(allURLs map[string]urlAndAddress) {
+	current := make(map[string]struct{}, len(allURLs))
+	for _, u := range allURLs {
+		current[u.url.String()] = struct{}{}
+	}
+
+	for urlStr := range p.statURLs {
+		if _, ok := current[urlStr]; ok {
+			continue
+		}
+		p.Statistics.Unregister("prometheus", "connection_status", map[string]string{"url": urlStr})
+		p.Statistics.Unregister("prometheus", "gathers_total", map[string]string{"url": urlStr, "status": "success"})
+		p.Statistics.Unregister("prometheus", "gathers_total", map[string]string{"url": urlStr, "status": "failure"})
+		delete(p.statURLs, urlStr)
+	}
 }
 
 func (p *Prometheus) Stop() {
@@ -448,11 +484,7 @@ func (p *Prometheus) getAllURLs() (map[string]urlAndAddress, error) {
 	return allURLs, nil
 }
 
-func (p *Prometheus) gatherURL(
-	u urlAndAddress,
-	acc telegraf.Accumulator,
-	connectStat, successStat, failureStat selfstat.Stat,
-) (map[string]interface{}, map[string]string, error) {
+func (p *Prometheus) gatherURL(u urlAndAddress, acc telegraf.Accumulator) (map[string]interface{}, map[string]string, error) {
 	var req *http.Request
 	var uClient *http.Client
 	requestFields := make(map[string]interface{})
@@ -553,8 +585,6 @@ func (p *Prometheus) gatherURL(
 	}
 	end := time.Since(start).Seconds()
 	if err != nil {
-		connectStat.Set(0)
-		failureStat.Incr(1)
 		return requestFields, tags, fmt.Errorf("error making HTTP request to %q: %w", u.url, err)
 	}
 	requestFields["response_time"] = end
@@ -562,8 +592,6 @@ func (p *Prometheus) gatherURL(
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		connectStat.Set(0)
-		failureStat.Incr(1)
 		return requestFields, tags, fmt.Errorf("%q returned HTTP status %q", u.url, resp.Status)
 	}
 
@@ -578,26 +606,19 @@ func (p *Prometheus) gatherURL(
 
 		body, err = io.ReadAll(lr)
 		if err != nil {
-			connectStat.Set(0)
-			failureStat.Incr(1)
 			return requestFields, tags, fmt.Errorf("error reading body: %w", err)
 		}
 		if int64(len(body)) > limit {
-			connectStat.Set(0)
-			failureStat.Incr(1)
 			p.Log.Infof("skipping %s: content length exceeded maximum body size (%d)", u.url, limit)
 			return requestFields, tags, nil
 		}
 	} else {
 		body, err = io.ReadAll(resp.Body)
 		if err != nil {
-			connectStat.Set(0)
-			failureStat.Incr(1)
 			return requestFields, tags, fmt.Errorf("error reading body: %w", err)
 		}
 	}
 	requestFields["content_length"] = len(body)
-	connectStat.Set(1)
 
 	// Override the response format if the user requested it
 	if p.contentType != "" {
@@ -623,10 +644,8 @@ func (p *Prometheus) gatherURL(
 	}
 	metrics, err := metricParser.Parse(body)
 	if err != nil {
-		failureStat.Incr(1)
 		return requestFields, tags, fmt.Errorf("error reading metrics for %q: %w", u.url, err)
 	}
-	successStat.Incr(1)
 
 	for _, metric := range metrics {
 		tags := metric.Tags()

--- a/plugins/inputs/prometheus/prometheus.go
+++ b/plugins/inputs/prometheus/prometheus.go
@@ -81,6 +81,7 @@ type Prometheus struct {
 	PodLabelInclude             []string            `toml:"pod_label_include"`
 	PodLabelExclude             []string            `toml:"pod_label_exclude"`
 	CacheRefreshInterval        int                 `toml:"cache_refresh_interval"`
+	Statistics                  *selfstat.Collector `toml:"-"`
 
 	// Consul discovery
 	ConsulConfig consulConfig `toml:"consul"`
@@ -119,6 +120,10 @@ type Prometheus struct {
 
 	// list of http services to scrape
 	httpServices map[string]urlAndAddress
+
+	connectStat             map[string]selfstat.Stat
+	gathersTotalSuccessStat map[string]selfstat.Stat
+	gathersTotalFailureStat map[string]selfstat.Stat
 }
 
 type urlAndAddress struct {
@@ -256,6 +261,11 @@ func (p *Prometheus) Init() error {
 	}
 
 	p.kubernetesPods = make(map[podID]urlAndAddress)
+
+	// Initialize Internal Metrics
+	p.connectStat = make(map[string]selfstat.Stat)
+	p.gathersTotalSuccessStat = make(map[string]selfstat.Stat)
+	p.gathersTotalFailureStat = make(map[string]selfstat.Stat)
 
 	return nil
 }
@@ -533,9 +543,11 @@ func (p *Prometheus) gatherURL(u urlAndAddress, acc telegraf.Accumulator) (map[s
 	var err error
 	var resp *http.Response
 	urlStr := u.url.String()
-	connectStat := selfstat.Register("prometheus", "connection_status", map[string]string{"url": urlStr})
-	gatherSuccess := selfstat.Register("prometheus", "gathers_total", map[string]string{"url": urlStr, "status": "success"})
-	gatherFailure := selfstat.Register("prometheus", "gathers_total", map[string]string{"url": urlStr, "status": "failure"})
+
+	// Create internal metrics for each URL
+	p.connectStat[urlStr] = p.Statistics.Register("prometheus", "connection_status", map[string]string{"url": urlStr})
+	p.gathersTotalSuccessStat[urlStr] = p.Statistics.Register("prometheus", "gathers_total", map[string]string{"url": urlStr, "status": "success"})
+	p.gathersTotalFailureStat[urlStr] = p.Statistics.Register("prometheus", "gathers_total", map[string]string{"url": urlStr, "status": "failure"})
 
 	var start time.Time
 	if u.url.Scheme != "unix" {
@@ -547,8 +559,8 @@ func (p *Prometheus) gatherURL(u urlAndAddress, acc telegraf.Accumulator) (map[s
 	}
 	end := time.Since(start).Seconds()
 	if err != nil {
-		connectStat.Set(0)
-		gatherFailure.Incr(1)
+		p.connectStat[urlStr].Set(0)
+		p.gathersTotalFailureStat[urlStr].Incr(1)
 		return requestFields, tags, fmt.Errorf("error making HTTP request to %q: %w", u.url, err)
 	}
 	requestFields["response_time"] = end
@@ -556,8 +568,8 @@ func (p *Prometheus) gatherURL(u urlAndAddress, acc telegraf.Accumulator) (map[s
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		connectStat.Set(0)
-		gatherFailure.Incr(1)
+		p.connectStat[urlStr].Set(0)
+		p.gathersTotalFailureStat[urlStr].Incr(1)
 		return requestFields, tags, fmt.Errorf("%q returned HTTP status %q", u.url, resp.Status)
 	}
 
@@ -572,26 +584,26 @@ func (p *Prometheus) gatherURL(u urlAndAddress, acc telegraf.Accumulator) (map[s
 
 		body, err = io.ReadAll(lr)
 		if err != nil {
-			connectStat.Set(0)
-			gatherFailure.Incr(1)
+			p.connectStat[urlStr].Set(0)
+			p.gathersTotalFailureStat[urlStr].Incr(1)
 			return requestFields, tags, fmt.Errorf("error reading body: %w", err)
 		}
 		if int64(len(body)) > limit {
-			connectStat.Set(0)
-			gatherFailure.Incr(1)
+			p.connectStat[urlStr].Set(0)
+			p.gathersTotalFailureStat[urlStr].Incr(1)
 			p.Log.Infof("skipping %s: content length exceeded maximum body size (%d)", u.url, limit)
 			return requestFields, tags, nil
 		}
 	} else {
 		body, err = io.ReadAll(resp.Body)
 		if err != nil {
-			connectStat.Set(0)
-			gatherFailure.Incr(1)
+			p.connectStat[urlStr].Set(0)
+			p.gathersTotalFailureStat[urlStr].Incr(1)
 			return requestFields, tags, fmt.Errorf("error reading body: %w", err)
 		}
 	}
 	requestFields["content_length"] = len(body)
-	connectStat.Set(1)
+	p.connectStat[urlStr].Set(1)
 
 	// Override the response format if the user requested it
 	if p.contentType != "" {
@@ -617,10 +629,10 @@ func (p *Prometheus) gatherURL(u urlAndAddress, acc telegraf.Accumulator) (map[s
 	}
 	metrics, err := metricParser.Parse(body)
 	if err != nil {
-		gatherFailure.Incr(1)
+		p.gathersTotalFailureStat[urlStr].Incr(1)
 		return requestFields, tags, fmt.Errorf("error reading metrics for %q: %w", u.url, err)
 	}
-	gatherSuccess.Incr(1)
+	p.gathersTotalSuccessStat[urlStr].Incr(1)
 
 	for _, metric := range metrics {
 		tags := metric.Tags()

--- a/plugins/inputs/prometheus/prometheus.go
+++ b/plugins/inputs/prometheus/prometheus.go
@@ -263,6 +263,9 @@ func (p *Prometheus) Init() error {
 	p.kubernetesPods = make(map[podID]urlAndAddress)
 
 	// Initialize Internal Metrics
+	// if p.Statistics == nil {
+	// 	p.Statistics = selfstat.NewCollector(nil)
+	// }
 	p.connectStat = make(map[string]selfstat.Stat)
 	p.gathersTotalSuccessStat = make(map[string]selfstat.Stat)
 	p.gathersTotalFailureStat = make(map[string]selfstat.Stat)

--- a/plugins/inputs/prometheus/prometheus.go
+++ b/plugins/inputs/prometheus/prometheus.go
@@ -448,7 +448,11 @@ func (p *Prometheus) getAllURLs() (map[string]urlAndAddress, error) {
 	return allURLs, nil
 }
 
-func (p *Prometheus) gatherURL(u urlAndAddress, acc telegraf.Accumulator, connectStat selfstat.Stat, successStat selfstat.Stat, failureStat selfstat.Stat) (map[string]interface{}, map[string]string, error) {
+func (p *Prometheus) gatherURL(
+	u urlAndAddress,
+	acc telegraf.Accumulator,
+	connectStat, successStat, failureStat selfstat.Stat,
+) (map[string]interface{}, map[string]string, error) {
 	var req *http.Request
 	var uClient *http.Client
 	requestFields := make(map[string]interface{})

--- a/plugins/inputs/prometheus/prometheus_test.go
+++ b/plugins/inputs/prometheus/prometheus_test.go
@@ -507,7 +507,8 @@ go_gc_duration_seconds_count 42`
 			map[string]string{},
 			map[string]interface{}{
 				"go_gc_duration_seconds_sum":   float64(42.0),
-				"go_gc_duration_seconds_count": float64(42)},
+				"go_gc_duration_seconds_count": float64(42),
+			},
 			time.Unix(0, 0),
 			telegraf.Summary,
 		),
@@ -516,7 +517,8 @@ go_gc_duration_seconds_count 42`
 			map[string]string{},
 			map[string]interface{}{
 				"content_length": int64(1),
-				"response_time":  float64(0)},
+				"response_time":  float64(0),
+			},
 			time.Unix(0, 0),
 			telegraf.Untyped,
 		),
@@ -688,10 +690,12 @@ test_counter{label="test"} 1 1685443805885`
 		metric.New(
 			"prometheus_request",
 			map[string]string{
-				"address": tsAddress},
+				"address": tsAddress,
+			},
 			map[string]interface{}{
 				"content_length": int64(1),
-				"response_time":  float64(0)},
+				"response_time":  float64(0),
+			},
 			time.UnixMilli(0),
 			telegraf.Untyped,
 		),
@@ -733,10 +737,12 @@ func TestPrometheusInternalContentBadFormat(t *testing.T) {
 		metric.New(
 			"prometheus_request",
 			map[string]string{
-				"address": tsAddress},
+				"address": tsAddress,
+			},
 			map[string]interface{}{
 				"content_length": int64(94),
-				"response_time":  float64(0)},
+				"response_time":  float64(0),
+			},
 			time.UnixMilli(0),
 			telegraf.Untyped,
 		),
@@ -769,10 +775,12 @@ func TestPrometheusInternalNoWeb(t *testing.T) {
 		metric.New(
 			"prometheus_request",
 			map[string]string{
-				"address": tsAddress},
+				"address": tsAddress,
+			},
 			map[string]interface{}{
 				"content_length": int64(94),
-				"response_time":  float64(0)},
+				"response_time":  float64(0),
+			},
 			time.UnixMilli(0),
 			telegraf.Untyped,
 		),
@@ -985,12 +993,12 @@ func TestPrometheusGatherStatsSuccess(t *testing.T) {
 	var acc testutil.Accumulator
 	require.NoError(t, acc.GatherError(p.Gather))
 
-	url := ts.URL
-	require.EqualValues(t, 1, p.Statistics.Get("prometheus", "connection_status", map[string]string{"url": url}).Get())
+	testUrl := ts.URL
+	require.EqualValues(t, 1, p.Statistics.Get("prometheus", "connection_status", map[string]string{"url": testUrl}).Get())
 	require.EqualValues(t, 1, p.Statistics.Get("prometheus", "gathers_total",
-		map[string]string{"url": url, "status": "success"}).Get())
+		map[string]string{"url": testUrl, "status": "success"}).Get())
 	require.EqualValues(t, 0, p.Statistics.Get("prometheus", "gathers_total",
-		map[string]string{"url": url, "status": "failure"}).Get())
+		map[string]string{"url": testUrl, "status": "failure"}).Get())
 }
 
 func TestPrometheusGatherStatsFailure(t *testing.T) {
@@ -1011,12 +1019,12 @@ func TestPrometheusGatherStatsFailure(t *testing.T) {
 	// Gather surfaces the per-URL error, so expect one.
 	require.Error(t, acc.GatherError(p.Gather))
 
-	url := ts.URL
-	require.EqualValues(t, 0, p.Statistics.Get("prometheus", "connection_status", map[string]string{"url": url}).Get())
+	testUrl := ts.URL
+	require.EqualValues(t, 0, p.Statistics.Get("prometheus", "connection_status", map[string]string{"url": testUrl}).Get())
 	require.EqualValues(t, 1, p.Statistics.Get("prometheus", "gathers_total",
-		map[string]string{"url": url, "status": "failure"}).Get())
+		map[string]string{"url": testUrl, "status": "failure"}).Get())
 	require.EqualValues(t, 0, p.Statistics.Get("prometheus", "gathers_total",
-		map[string]string{"url": url, "status": "success"}).Get())
+		map[string]string{"url": testUrl, "status": "success"}).Get())
 }
 
 func TestPrometheusGatherStatsRecovery(t *testing.T) {
@@ -1040,13 +1048,13 @@ func TestPrometheusGatherStatsRecovery(t *testing.T) {
 	}
 	require.NoError(t, p.Init())
 
-	url := ts.URL
+	testUrl := ts.URL
 	connect := func() int64 {
-		return p.Statistics.Get("prometheus", "connection_status", map[string]string{"url": url}).Get()
+		return p.Statistics.Get("prometheus", "connection_status", map[string]string{"url": testUrl}).Get()
 	}
 	total := func(status string) int64 {
 		return p.Statistics.Get("prometheus", "gathers_total",
-			map[string]string{"url": url, "status": status}).Get()
+			map[string]string{"url": testUrl, "status": status}).Get()
 	}
 
 	// First gather fails.

--- a/plugins/inputs/prometheus/prometheus_test.go
+++ b/plugins/inputs/prometheus/prometheus_test.go
@@ -993,12 +993,12 @@ func TestPrometheusGatherStatsSuccess(t *testing.T) {
 	var acc testutil.Accumulator
 	require.NoError(t, acc.GatherError(p.Gather))
 
-	testUrl := ts.URL
-	require.EqualValues(t, 1, p.Statistics.Get("prometheus", "connection_status", map[string]string{"url": testUrl}).Get())
+	testURL := ts.URL
+	require.EqualValues(t, 1, p.Statistics.Get("prometheus", "connection_status", map[string]string{"url": testURL}).Get())
 	require.EqualValues(t, 1, p.Statistics.Get("prometheus", "gathers_total",
-		map[string]string{"url": testUrl, "status": "success"}).Get())
+		map[string]string{"url": testURL, "status": "success"}).Get())
 	require.EqualValues(t, 0, p.Statistics.Get("prometheus", "gathers_total",
-		map[string]string{"url": testUrl, "status": "failure"}).Get())
+		map[string]string{"url": testURL, "status": "failure"}).Get())
 }
 
 func TestPrometheusGatherStatsFailure(t *testing.T) {
@@ -1019,12 +1019,12 @@ func TestPrometheusGatherStatsFailure(t *testing.T) {
 	// Gather surfaces the per-URL error, so expect one.
 	require.Error(t, acc.GatherError(p.Gather))
 
-	testUrl := ts.URL
-	require.EqualValues(t, 0, p.Statistics.Get("prometheus", "connection_status", map[string]string{"url": testUrl}).Get())
+	testURL := ts.URL
+	require.EqualValues(t, 0, p.Statistics.Get("prometheus", "connection_status", map[string]string{"url": testURL}).Get())
 	require.EqualValues(t, 1, p.Statistics.Get("prometheus", "gathers_total",
-		map[string]string{"url": testUrl, "status": "failure"}).Get())
+		map[string]string{"url": testURL, "status": "failure"}).Get())
 	require.EqualValues(t, 0, p.Statistics.Get("prometheus", "gathers_total",
-		map[string]string{"url": testUrl, "status": "success"}).Get())
+		map[string]string{"url": testURL, "status": "success"}).Get())
 }
 
 func TestPrometheusGatherStatsRecovery(t *testing.T) {
@@ -1048,13 +1048,13 @@ func TestPrometheusGatherStatsRecovery(t *testing.T) {
 	}
 	require.NoError(t, p.Init())
 
-	testUrl := ts.URL
+	testURL := ts.URL
 	connect := func() int64 {
-		return p.Statistics.Get("prometheus", "connection_status", map[string]string{"url": testUrl}).Get()
+		return p.Statistics.Get("prometheus", "connection_status", map[string]string{"url": testURL}).Get()
 	}
 	total := func(status string) int64 {
 		return p.Statistics.Get("prometheus", "gathers_total",
-			map[string]string{"url": testUrl, "status": status}).Get()
+			map[string]string{"url": testURL, "status": status}).Get()
 	}
 
 	// First gather fails.

--- a/plugins/inputs/prometheus/prometheus_test.go
+++ b/plugins/inputs/prometheus/prometheus_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/metric"
+	"github.com/influxdata/telegraf/selfstat"
 	"github.com/influxdata/telegraf/testutil"
 )
 
@@ -62,9 +63,10 @@ func TestPrometheusGeneratesMetrics(t *testing.T) {
 	defer ts.Close()
 
 	p := &Prometheus{
-		Log:    testutil.Logger{},
-		URLs:   []string{ts.URL},
-		URLTag: "url",
+		Log:        testutil.Logger{},
+		URLs:       []string{ts.URL},
+		Statistics: selfstat.NewCollector(nil),
+		URLTag:     "url",
 	}
 	err := p.Init()
 	require.NoError(t, err)
@@ -139,6 +141,7 @@ func TestPrometheusCustomHeader(t *testing.T) {
 			URLs:        []string{ts.URL},
 			URLTag:      "url",
 			HTTPHeaders: test.headers,
+			Statistics:  selfstat.NewCollector(nil),
 		}
 		err := p.Init()
 		require.NoError(t, err)
@@ -162,6 +165,7 @@ func TestPrometheusGeneratesMetricsWithHostNameTag(t *testing.T) {
 	p := &Prometheus{
 		Log:                testutil.Logger{},
 		KubernetesServices: []string{ts.URL},
+		Statistics:         selfstat.NewCollector(nil),
 		URLTag:             "url",
 	}
 	err := p.Init()
@@ -200,6 +204,7 @@ test_counter{label="test"} 1 1685443805885`
 	p := &Prometheus{
 		Log:                testutil.Logger{},
 		KubernetesServices: []string{ts.URL},
+		Statistics:         selfstat.NewCollector(nil),
 	}
 	require.NoError(t, p.Init())
 
@@ -240,6 +245,7 @@ func TestPrometheusGeneratesMetricsAlthoughFirstDNSFailsIntegration(t *testing.T
 		Log:                testutil.Logger{},
 		URLs:               []string{ts.URL},
 		KubernetesServices: []string{"http://random.telegraf.local:88/metrics"},
+		Statistics:         selfstat.NewCollector(nil),
 	}
 	err := p.Init()
 	require.NoError(t, err)
@@ -273,6 +279,7 @@ func TestPrometheusGeneratesMetricsSlowEndpoint(t *testing.T) {
 		client: &http.Client{
 			Timeout: time.Second * 5,
 		},
+		Statistics: selfstat.NewCollector(nil),
 	}
 	err := p.Init()
 	require.NoError(t, err)
@@ -308,6 +315,7 @@ func TestPrometheusGeneratesMetricsSlowEndpointHitTheTimeout(t *testing.T) {
 		client: &http.Client{
 			Timeout: time.Second * 5,
 		},
+		Statistics: selfstat.NewCollector(nil),
 	}
 	err := p.Init()
 	require.NoError(t, err)
@@ -334,9 +342,10 @@ func TestPrometheusGeneratesMetricsSlowEndpointNewConfigParameter(t *testing.T) 
 	defer ts.Close()
 
 	p := &Prometheus{
-		Log:    testutil.Logger{},
-		URLs:   []string{ts.URL},
-		URLTag: "url",
+		Log:        testutil.Logger{},
+		URLs:       []string{ts.URL},
+		URLTag:     "url",
+		Statistics: selfstat.NewCollector(nil),
 	}
 	err := p.Init()
 	require.NoError(t, err)
@@ -367,9 +376,10 @@ func TestPrometheusGeneratesMetricsSlowEndpointHitTheTimeoutNewConfigParameter(t
 	defer ts.Close()
 
 	p := &Prometheus{
-		Log:    testutil.Logger{},
-		URLs:   []string{ts.URL},
-		URLTag: "url",
+		Log:        testutil.Logger{},
+		URLs:       []string{ts.URL},
+		URLTag:     "url",
+		Statistics: selfstat.NewCollector(nil),
 	}
 	err := p.Init()
 	require.NoError(t, err)
@@ -396,6 +406,7 @@ func TestPrometheusContentLengthLimit(t *testing.T) {
 		URLs:               []string{ts.URL},
 		URLTag:             "url",
 		ContentLengthLimit: 1,
+		Statistics:         selfstat.NewCollector(nil),
 	}
 	require.NoError(t, p.Init())
 
@@ -419,6 +430,7 @@ func TestPrometheusGeneratesSummaryMetricsV2(t *testing.T) {
 		URLs:          []string{ts.URL},
 		URLTag:        "url",
 		MetricVersion: 2,
+		Statistics:    selfstat.NewCollector(nil),
 	}
 	err := p.Init()
 	require.NoError(t, err)
@@ -457,6 +469,7 @@ go_gc_duration_seconds_count 42`
 		URLTag:               "",
 		MetricVersion:        2,
 		EnableRequestMetrics: true,
+		Statistics:           selfstat.NewCollector(nil),
 	}
 	err := p.Init()
 	require.NoError(t, err)
@@ -528,6 +541,7 @@ func TestPrometheusGeneratesGaugeMetricsV2(t *testing.T) {
 		URLs:          []string{ts.URL},
 		URLTag:        "url",
 		MetricVersion: 2,
+		Statistics:    selfstat.NewCollector(nil),
 	}
 	err := p.Init()
 	require.NoError(t, err)
@@ -557,6 +571,7 @@ func TestPrometheusGeneratesMetricsWithIgnoreTimestamp(t *testing.T) {
 		URLs:            []string{ts.URL},
 		URLTag:          "url",
 		IgnoreTimestamp: true,
+		Statistics:      selfstat.NewCollector(nil),
 	}
 	require.NoError(t, p.Init())
 
@@ -571,7 +586,7 @@ func TestPrometheusGeneratesMetricsWithIgnoreTimestamp(t *testing.T) {
 
 func TestUnsupportedFieldSelector(t *testing.T) {
 	fieldSelectorString := "spec.containerName=container"
-	prom := &Prometheus{Log: testutil.Logger{}, KubernetesFieldSelector: fieldSelectorString}
+	prom := &Prometheus{Log: testutil.Logger{}, KubernetesFieldSelector: fieldSelectorString, Statistics: selfstat.NewCollector(nil)}
 
 	fieldSelector, err := fields.ParseSelector(prom.KubernetesFieldSelector)
 	require.NoError(t, err)
@@ -589,6 +604,7 @@ func TestInitConfigErrors(t *testing.T) {
 		MonitorPods:       true,
 		PodScrapeScope:    "node",
 		PodScrapeInterval: 60,
+		Statistics:        selfstat.NewCollector(nil),
 	}
 
 	// Both invalid IP addresses
@@ -634,6 +650,7 @@ func TestInitConfigSelectors(t *testing.T) {
 		PodScrapeInterval:           60,
 		KubernetesLabelSelector:     "app=test",
 		KubernetesFieldSelector:     "spec.nodeName=node-0",
+		Statistics:                  selfstat.NewCollector(nil),
 	}
 	err := p.Init()
 	require.NoError(t, err)
@@ -659,6 +676,7 @@ test_counter{label="test"} 1 1685443805885`
 		Log:                  testutil.Logger{},
 		KubernetesServices:   []string{ts.URL},
 		EnableRequestMetrics: true,
+		Statistics:           selfstat.NewCollector(nil),
 	}
 	require.NoError(t, p.Init())
 
@@ -703,6 +721,7 @@ func TestPrometheusInternalContentBadFormat(t *testing.T) {
 		Log:                  testutil.Logger{},
 		KubernetesServices:   []string{ts.URL},
 		EnableRequestMetrics: true,
+		Statistics:           selfstat.NewCollector(nil),
 	}
 	require.NoError(t, p.Init())
 
@@ -738,6 +757,7 @@ func TestPrometheusInternalNoWeb(t *testing.T) {
 		Log:                  testutil.Logger{},
 		KubernetesServices:   []string{ts.URL},
 		EnableRequestMetrics: true,
+		Statistics:           selfstat.NewCollector(nil),
 	}
 	require.NoError(t, p.Init())
 
@@ -793,6 +813,7 @@ go_memstats_heap_alloc_bytes 1.581062048e+09
 		URLs:          []string{ts.URL},
 		URLTag:        "",
 		MetricVersion: 2,
+		Statistics:    selfstat.NewCollector(nil),
 	}
 	require.NoError(t, p.Init())
 
@@ -845,6 +866,7 @@ func TestOpenmetricsProtobuf(t *testing.T) {
 		URLs:          []string{ts.URL},
 		URLTag:        "",
 		MetricVersion: 2,
+		Statistics:    selfstat.NewCollector(nil),
 	}
 	require.NoError(t, p.Init())
 
@@ -908,6 +930,7 @@ go_memstats_heap_alloc_bytes 1.581062048e+09
 		URLTag:              "",
 		MetricVersion:       2,
 		ContentTypeOverride: "openmetrics-text",
+		Statistics:          selfstat.NewCollector(nil),
 	}
 	require.NoError(t, p.Init())
 

--- a/plugins/inputs/prometheus/prometheus_test.go
+++ b/plugins/inputs/prometheus/prometheus_test.go
@@ -963,3 +963,144 @@ go_memstats_heap_alloc_bytes 1.581062048e+09
 
 	testutil.RequireMetricsEqual(t, expected, acc.GetTelegrafMetrics(), testutil.IgnoreTime(), testutil.SortMetrics())
 }
+
+func TestPrometheusGatherStatsSuccess(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if _, err := fmt.Fprintln(w, sampleTextFormat); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Error(err)
+			return
+		}
+	}))
+	defer ts.Close()
+
+	p := &Prometheus{
+		Log:        testutil.Logger{},
+		URLs:       []string{ts.URL},
+		Statistics: selfstat.NewCollector(nil),
+		URLTag:     "url",
+	}
+	require.NoError(t, p.Init())
+
+	var acc testutil.Accumulator
+	require.NoError(t, acc.GatherError(p.Gather))
+
+	url := ts.URL
+	require.EqualValues(t, 1, p.Statistics.Get("prometheus", "connection_status", map[string]string{"url": url}).Get())
+	require.EqualValues(t, 1, p.Statistics.Get("prometheus", "gathers_total",
+		map[string]string{"url": url, "status": "success"}).Get())
+	require.EqualValues(t, 0, p.Statistics.Get("prometheus", "gathers_total",
+		map[string]string{"url": url, "status": "failure"}).Get())
+}
+
+func TestPrometheusGatherStatsFailure(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+
+	p := &Prometheus{
+		Log:        testutil.Logger{},
+		URLs:       []string{ts.URL},
+		Statistics: selfstat.NewCollector(nil),
+		URLTag:     "url",
+	}
+	require.NoError(t, p.Init())
+
+	var acc testutil.Accumulator
+	// Gather surfaces the per-URL error, so expect one.
+	require.Error(t, acc.GatherError(p.Gather))
+
+	url := ts.URL
+	require.EqualValues(t, 0, p.Statistics.Get("prometheus", "connection_status", map[string]string{"url": url}).Get())
+	require.EqualValues(t, 1, p.Statistics.Get("prometheus", "gathers_total",
+		map[string]string{"url": url, "status": "failure"}).Get())
+	require.EqualValues(t, 0, p.Statistics.Get("prometheus", "gathers_total",
+		map[string]string{"url": url, "status": "success"}).Get())
+}
+
+func TestPrometheusGatherStatsRecovery(t *testing.T) {
+	var healthy bool
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if !healthy {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		if _, err := fmt.Fprintln(w, sampleTextFormat); err != nil {
+			t.Error(err)
+		}
+	}))
+	defer ts.Close()
+
+	p := &Prometheus{
+		Log:        testutil.Logger{},
+		URLs:       []string{ts.URL},
+		Statistics: selfstat.NewCollector(nil),
+		URLTag:     "url",
+	}
+	require.NoError(t, p.Init())
+
+	url := ts.URL
+	connect := func() int64 {
+		return p.Statistics.Get("prometheus", "connection_status", map[string]string{"url": url}).Get()
+	}
+	total := func(status string) int64 {
+		return p.Statistics.Get("prometheus", "gathers_total",
+			map[string]string{"url": url, "status": status}).Get()
+	}
+
+	// First gather fails.
+	var failAcc testutil.Accumulator
+	require.Error(t, failAcc.GatherError(p.Gather))
+	require.EqualValues(t, 0, connect())
+	require.EqualValues(t, 1, total("failure"))
+
+	// Server recovers; gauge flips to 1, success counter increments, failure unchanged.
+	healthy = true
+	var okAcc testutil.Accumulator
+	require.NoError(t, okAcc.GatherError(p.Gather))
+	require.EqualValues(t, 1, connect())
+	require.EqualValues(t, 1, total("success"))
+	require.EqualValues(t, 1, total("failure"))
+}
+
+func TestPrometheusGatherStatsUnregistersStaleURL(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if _, err := fmt.Fprintln(w, sampleTextFormat); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Error(err)
+			return
+		}
+	})
+	ts1 := httptest.NewServer(handler)
+	defer ts1.Close()
+	ts2 := httptest.NewServer(handler)
+	defer ts2.Close()
+
+	p := &Prometheus{
+		Log:        testutil.Logger{},
+		URLs:       []string{ts1.URL, ts2.URL},
+		Statistics: selfstat.NewCollector(nil),
+		URLTag:     "url",
+	}
+	require.NoError(t, p.Init())
+
+	// First gather scrapes both targets, registering stats for each.
+	var acc1 testutil.Accumulator
+	require.NoError(t, acc1.GatherError(p.Gather))
+	require.NotNil(t, p.Statistics.Get("prometheus", "connection_status", map[string]string{"url": ts1.URL}))
+	require.NotNil(t, p.Statistics.Get("prometheus", "connection_status", map[string]string{"url": ts2.URL}))
+
+	// Drop the second target from discovery and gather again.
+	p.URLs = []string{ts1.URL}
+	var acc2 testutil.Accumulator
+	require.NoError(t, acc2.GatherError(p.Gather))
+
+	// The surviving target keeps its stats; the dropped one is unregistered.
+	require.NotNil(t, p.Statistics.Get("prometheus", "connection_status", map[string]string{"url": ts1.URL}))
+	require.Nil(t, p.Statistics.Get("prometheus", "connection_status", map[string]string{"url": ts2.URL}))
+	require.Nil(t, p.Statistics.Get("prometheus", "gathers_total",
+		map[string]string{"url": ts2.URL, "status": "success"}))
+	require.Nil(t, p.Statistics.Get("prometheus", "gathers_total",
+		map[string]string{"url": ts2.URL, "status": "failure"}))
+}


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Adds 2 new internal metrics to the Prometheus input plugin.

- `connection_status` sets the value to either 0 (connection failed) or 1 (connection succeeded).
- `gathers_total` which has a `status` tag of either `success` or `failure` that increments on each gather.


## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #18943 
