### PR TITLE
feat(parsers.grok): Implement ParserTimeFuncPlugin interface

### DIFF
--- a/plugins/parsers/grok/parser.go
+++ b/plugins/parsers/grok/parser.go
@@ -196,6 +196,10 @@ func (p *Parser) Compile() error {
 	return p.compileCustomPatterns()
 }
 
+func (p *Parser) SetTimeFunc(fn func() time.Time) {
+	p.timeFunc = fn
+}
+
 // ParseLine is the primary function to process individual lines, returning the metrics
 func (p *Parser) ParseLine(line string) (telegraf.Metric, error) {
 	var err error
@@ -226,7 +230,7 @@ func (p *Parser) ParseLine(line string) (telegraf.Metric, error) {
 		tags[k] = v
 	}
 
-	timestamp := time.Now()
+	timestamp := p.timeFunc()
 	for k, v := range values {
 		if k == "" || v == "" {
 			continue

--- a/plugins/parsers/grok/parser_test.go
+++ b/plugins/parsers/grok/parser_test.go
@@ -1027,7 +1027,6 @@ func TestMultilinePatterns(t *testing.T) {
 }
 
 func TestSyslogTimestamp(t *testing.T) {
-	currentYear := time.Now().Year()
 	tests := []struct {
 		name     string
 		line     string
@@ -1036,17 +1035,17 @@ func TestSyslogTimestamp(t *testing.T) {
 		{
 			name:     "two digit day of month",
 			line:     "Sep 25 09:01:55 value=42",
-			expected: time.Date(currentYear, time.September, 25, 9, 1, 55, 0, time.UTC),
+			expected: time.Date(2017, time.September, 25, 9, 1, 55, 0, time.UTC),
 		},
 		{
 			name:     "one digit day of month single space",
 			line:     "Sep 2 09:01:55 value=42",
-			expected: time.Date(currentYear, time.September, 2, 9, 1, 55, 0, time.UTC),
+			expected: time.Date(2017, time.September, 2, 9, 1, 55, 0, time.UTC),
 		},
 		{
 			name:     "one digit day of month double space",
 			line:     "Sep  2 09:01:55 value=42",
-			expected: time.Date(currentYear, time.September, 2, 9, 1, 55, 0, time.UTC),
+			expected: time.Date(2017, time.September, 2, 9, 1, 55, 0, time.UTC),
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

This PR implements the `ParserTimeFuncPlugin` interface for the plugin.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
