### PR TITLE
ci: declare workflow-level `contents: read` on 3 lint/check workflows

### DIFF
--- a/.github/workflows/pr-target-branch.yml
+++ b/.github/workflows/pr-target-branch.yml
@@ -7,6 +7,9 @@ on:
       - synchronize
       - edited
 
+permissions:
+  contents: read
+
 jobs:
   check-target-master:
     name: master

--- a/.github/workflows/readme-linter.yml
+++ b/.github/workflows/readme-linter.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
     branches: # Names of target branches, not source branches
       - master
+permissions:
+  contents: read
+
 jobs:
   run-readme-linter:
     runs-on: ubuntu-latest

--- a/.github/workflows/semantic.yml
+++ b/.github/workflows/semantic.yml
@@ -7,6 +7,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   semantic:
     uses: influxdata/validate-semantic-github-messages/.github/workflows/semantic.yml@main


### PR DESCRIPTION
Three workflows (`pr-target-branch`, `readme-linter`, `semantic`) just validate PR metadata or markdown. No GitHub API writes happen from the workflows.

Same hardening shape as the post-CVE-2025-30066 response (`tj-actions/changed-files` compromise). YAML validated locally with `yaml.safe_load` on each touched file.