### PR TITLE
feat(outputs.mqtt): Add websocket URI support

### DIFF
--- a/plugins/common/mqtt/mqtt_v3.go
+++ b/plugins/common/mqtt/mqtt_v3.go
@@ -71,8 +71,15 @@ func NewMQTTv311Client(cfg *MqttConfig) (*mqttv311Client, error) {
 		return nil, err
 	}
 	for _, server := range servers {
-		if tlsCfg != nil {
-			server.Scheme = "tls"
+		switch server.Scheme {
+		case "ws":
+			// Keep ws:// as-is
+		case "wss":
+			// Keep wss:// as-is
+		default:
+			if tlsCfg != nil {
+				server.Scheme = "tls"
+			}
 		}
 		broker := server.String()
 		opts.AddBroker(broker)

--- a/plugins/common/mqtt/mqtt_v5.go
+++ b/plugins/common/mqtt/mqtt_v5.go
@@ -67,8 +67,13 @@ func NewMQTTv5Client(cfg *MqttConfig) (*mqttv5Client, error) {
 
 	brokers := make([]*url.URL, 0, len(servers))
 	for _, server := range servers {
-		if tlsCfg != nil {
-			server.Scheme = "tls"
+		switch server.Scheme {
+		case "ws", "wss":
+			// Keep websocket schemes as-is
+		default:
+			if tlsCfg != nil {
+				server.Scheme = "tls"
+			}
 		}
 		brokers = append(brokers, server)
 	}

--- a/plugins/outputs/mqtt/sample.conf
+++ b/plugins/outputs/mqtt/sample.conf
@@ -4,9 +4,9 @@
   ## The list of brokers should only include the hostname or IP address and the
   ## port to the broker. This should follow the format `[{scheme}://]{host}:{port}`. For
   ## example, `localhost:1883` or `mqtt://localhost:1883`.
-  ## Scheme can be any of the following: tcp://, mqtt://, tls://, mqtts://
+  ## Scheme can be any of the following: tcp://, mqtt://, tls://, mqtts://, ws://, wss://
   ## non-TLS and TLS servers can not be mix-and-matched.
-  servers = ["localhost:1883", ] # or ["mqtts://tls.example.com:1883"]
+  servers = ["localhost:1883", ] # or ["mqtts://tls.example.com:1883"] or ["wss://broker.example.com:443"]
 
   ## Protocol can be `3.1.1` or `5`. Default is `3.1.1`
   # protocol = "3.1.1"


### PR DESCRIPTION
## Summary
Adds WebSocket (`ws://`) and WebSocket Secure (`wss://`) transport support to the MQTT output plugin.

## Motivation
Many MQTT brokers (e.g., cloud-hosted or behind ingress controllers) only expose WebSocket endpoints. The MQTT input plugin (`mqtt_consumer`) already supports `ws://` — this brings parity to the output.

## Changes
- `plugins/common/mqtt/mqtt_v3.go` — preserve `ws`/`wss` schemes instead of overriding to `tls`
- `plugins/common/mqtt/mqtt_v5.go` — same fix for the v5 client
- `plugins/outputs/mqtt/sample.conf` — document `ws://` and `wss://` in the scheme list

## Notes
The underlying `paho.mqtt.golang` library already supports WebSocket transport — this change simply passes the scheme through correctly.

## Example config
```toml
[[outputs.mqtt]]
  servers = ["wss://broker.example.com:443"]
  topic = 'metrics/{{ .Tag "host" }}'
  username = "user"
  password = "${MQTT_TOKEN}"
  insecure_skip_verify = true
  keep_alive = 30
  data_format = "json"
```