### PR TITLE
chore(ci): Adapt latest Ubuntu image

### DIFF
--- a/tools/package_incus_test/main.go
+++ b/tools/package_incus_test/main.go
@@ -24,7 +24,7 @@ var imagesDEB = []string{
 	// LTS
 	"ubuntu/noble",
 	// Latest
-	"ubuntu/plucky",
+	"ubuntu/resolute",
 }
 
 func main() {


### PR DESCRIPTION
## Summary

Adapt the latest Ubuntu image to `resolute` in incus tests to fix `ci/circleci: amd64-package-test-nightly` builds.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
