### PR TITLE
feat(outputs.opentelemetry): Add support for token authentication

### DIFF
--- a/plugins/outputs/opentelemetry/README.md
+++ b/plugins/outputs/opentelemetry/README.md
@@ -77,7 +77,12 @@ plugin ordering. See [CONFIGURATION.md][CONFIGURATION.md] for more details.
   # [outputs.opentelemetry.attributes]
   # "service.name" = "demo"
 
-  ## Additional gRPC request metadata
+  ## Optional Bearer token for authentication.
+  ## Supports secret-store references, e.g. @{<store-id>:<key>}, so tokens
+  ## fetched via the oauth2 secret store are refreshed automatically.
+  # token = ""
+
+  ## Additional gRPC request metadata / HTTP headers
   # [outputs.opentelemetry.headers]
   # key1 = "value1"
 ```

--- a/plugins/outputs/opentelemetry/client_http.go
+++ b/plugins/outputs/opentelemetry/client_http.go
@@ -20,7 +20,8 @@ type httpClient struct {
 	url          string
 	encodingType string
 	compress     string
-	headers      map[string]*config.Secret
+	token        *config.Secret
+	headers      map[string]string
 }
 
 func (h *httpClient) Connect(cfg *clientConfig) error {
@@ -28,6 +29,7 @@ func (h *httpClient) Connect(cfg *clientConfig) error {
 	h.url = cfg.ServiceAddress
 	h.encodingType = cfg.Encoding
 	h.compress = cfg.Compression
+	h.token = cfg.Token
 	h.headers = cfg.Headers
 
 	proxyFunc, err := cfg.HTTPProxy.Proxy()
@@ -87,15 +89,17 @@ func (h *httpClient) Export(ctx context.Context, request pmetricotlp.ExportReque
 		return pmetricotlp.ExportResponse{}, err
 	}
 	for key, value := range h.headers {
-		secret, err := value.Get()
-		if err != nil {
-			return pmetricotlp.ExportResponse{}, fmt.Errorf("getting header %q secret failed: %w", key, err)
-		}
-		headerVal := secret.String()
 		if strings.EqualFold(key, "host") {
-			httpRequest.Host = headerVal
+			httpRequest.Host = value
 		}
-		httpRequest.Header.Set(key, headerVal)
+		httpRequest.Header.Set(key, value)
+	}
+	if h.token != nil && !h.token.Empty() {
+		secret, err := h.token.Get()
+		if err != nil {
+			return pmetricotlp.ExportResponse{}, fmt.Errorf("getting token secret failed: %w", err)
+		}
+		httpRequest.Header.Set("Authorization", "Bearer "+secret.String())
 		secret.Destroy()
 	}
 

--- a/plugins/outputs/opentelemetry/client_http.go
+++ b/plugins/outputs/opentelemetry/client_http.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 
 	"go.opentelemetry.io/collector/pdata/pmetric/pmetricotlp"
 
@@ -90,7 +91,11 @@ func (h *httpClient) Export(ctx context.Context, request pmetricotlp.ExportReque
 		if err != nil {
 			return pmetricotlp.ExportResponse{}, fmt.Errorf("getting header %q secret failed: %w", key, err)
 		}
-		httpRequest.Header.Set(key, secret.String())
+		headerVal := secret.String()
+		if strings.EqualFold(key, "host") {
+			httpRequest.Host = headerVal
+		}
+		httpRequest.Header.Set(key, headerVal)
 		secret.Destroy()
 	}
 

--- a/plugins/outputs/opentelemetry/client_http.go
+++ b/plugins/outputs/opentelemetry/client_http.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
 
 	"go.opentelemetry.io/collector/pdata/pmetric/pmetricotlp"
 
@@ -89,9 +88,6 @@ func (h *httpClient) Export(ctx context.Context, request pmetricotlp.ExportReque
 		return pmetricotlp.ExportResponse{}, err
 	}
 	for key, value := range h.headers {
-		if strings.EqualFold(key, "host") {
-			httpRequest.Host = value
-		}
 		httpRequest.Header.Set(key, value)
 	}
 	if h.token != nil && !h.token.Empty() {

--- a/plugins/outputs/opentelemetry/client_http.go
+++ b/plugins/outputs/opentelemetry/client_http.go
@@ -10,6 +10,7 @@ import (
 
 	"go.opentelemetry.io/collector/pdata/pmetric/pmetricotlp"
 
+	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/internal"
 )
 
@@ -18,7 +19,7 @@ type httpClient struct {
 	url          string
 	encodingType string
 	compress     string
-	headers      map[string]string
+	headers      map[string]*config.Secret
 }
 
 func (h *httpClient) Connect(cfg *clientConfig) error {
@@ -85,7 +86,12 @@ func (h *httpClient) Export(ctx context.Context, request pmetricotlp.ExportReque
 		return pmetricotlp.ExportResponse{}, err
 	}
 	for key, value := range h.headers {
-		httpRequest.Header.Set(key, value)
+		secret, err := value.Get()
+		if err != nil {
+			return pmetricotlp.ExportResponse{}, fmt.Errorf("getting header %q secret failed: %w", key, err)
+		}
+		httpRequest.Header.Set(key, secret.String())
+		secret.Destroy()
 	}
 
 	httpRequest.Header.Set("Content-Type", encoding)

--- a/plugins/outputs/opentelemetry/opentelemetry.go
+++ b/plugins/outputs/opentelemetry/opentelemetry.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
+	"maps"
 	"sort"
 	"strings"
 	"time"
@@ -211,20 +212,17 @@ func (o *OpenTelemetry) sendBatch(metrics []telegraf.Metric) error {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(o.Timeout))
 	defer cancel()
 
-	grpcMD := make(map[string]string, len(o.Headers))
-	for k, v := range o.Headers {
-		grpcMD[k] = v
-	}
+	headers := maps.Clone(o.Headers)
 	if !o.Token.Empty() {
 		token, err := o.Token.Get()
 		if err != nil {
 			return fmt.Errorf("getting token secret failed: %w", err)
 		}
-		grpcMD["authorization"] = "Bearer " + token.String()
+		headers["authorization"] = "Bearer " + token.String()
 		token.Destroy()
 	}
-	if len(grpcMD) > 0 {
-		ctx = metadata.NewOutgoingContext(ctx, metadata.New(grpcMD))
+	if len(headers) > 0 {
+		ctx = metadata.NewOutgoingContext(ctx, metadata.New(headers))
 	}
 	_, err := o.otlpMetricClient.Export(ctx, md)
 	return err

--- a/plugins/outputs/opentelemetry/opentelemetry.go
+++ b/plugins/outputs/opentelemetry/opentelemetry.go
@@ -209,6 +209,7 @@ func (o *OpenTelemetry) sendBatch(metrics []telegraf.Metric) error {
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(o.Timeout))
+	defer cancel()
 
 	if len(o.Headers) > 0 {
 		md := make(map[string]string, len(o.Headers))
@@ -222,7 +223,6 @@ func (o *OpenTelemetry) sendBatch(metrics []telegraf.Metric) error {
 		}
 		ctx = metadata.NewOutgoingContext(ctx, metadata.New(md))
 	}
-	defer cancel()
 	_, err := o.otlpMetricClient.Export(ctx, md)
 	return err
 }

--- a/plugins/outputs/opentelemetry/opentelemetry.go
+++ b/plugins/outputs/opentelemetry/opentelemetry.go
@@ -33,11 +33,12 @@ type OpenTelemetry struct {
 	EncodingType   string `toml:"encoding_type"`
 
 	tls.ClientConfig
-	Timeout     config.Duration           `toml:"timeout"`
-	Compression string                    `toml:"compression"`
-	Headers     map[string]*config.Secret `toml:"headers"`
-	Attributes  map[string]string         `toml:"attributes"`
-	Coralogix   *CoralogixConfig          `toml:"coralogix"`
+	Timeout     config.Duration   `toml:"timeout"`
+	Compression string            `toml:"compression"`
+	Token       config.Secret     `toml:"token"`
+	Headers     map[string]string `toml:"headers"`
+	Attributes  map[string]string `toml:"attributes"`
+	Coralogix   *CoralogixConfig  `toml:"coralogix"`
 	proxy.HTTPProxy
 	proxy.TCPProxy
 
@@ -52,10 +53,11 @@ type clientConfig struct {
 	TLSConfig       *tls.ClientConfig
 	Compression     string
 	CoralogixConfig *CoralogixConfig
-	HTTPProxy       *proxy.HTTPProxy          // only for HTTP client
-	TCPProxy        *proxy.TCPProxy           // only for gRPC client
-	Encoding        string                    // only for HTTP client
-	Headers         map[string]*config.Secret // only for HTTP client, gRPC client uses metadata
+	HTTPProxy       *proxy.HTTPProxy  // only for HTTP client
+	TCPProxy        *proxy.TCPProxy   // only for gRPC client
+	Encoding        string            // only for HTTP client
+	Token           *config.Secret    // only for HTTP client, gRPC client uses metadata
+	Headers         map[string]string // only for HTTP client, gRPC client uses metadata
 }
 
 type otlpMetricClient interface {
@@ -95,14 +97,11 @@ func (o *OpenTelemetry) Connect() error {
 	}
 	if o.Coralogix != nil {
 		if o.Headers == nil {
-			o.Headers = make(map[string]*config.Secret)
+			o.Headers = make(map[string]string)
 		}
-		appName := config.NewSecret([]byte(o.Coralogix.AppName))
-		o.Headers["ApplicationName"] = &appName
-		subSystem := config.NewSecret([]byte(o.Coralogix.SubSystem))
-		o.Headers["ApiName"] = &subSystem
-		bearer := config.NewSecret([]byte("Bearer " + o.Coralogix.PrivateKey))
-		o.Headers["Authorization"] = &bearer
+		o.Headers["ApplicationName"] = o.Coralogix.AppName
+		o.Headers["ApiName"] = o.Coralogix.SubSystem
+		o.Headers["Authorization"] = "Bearer " + o.Coralogix.PrivateKey
 	}
 
 	metricsConverter, err := influx2otel.NewLineProtocolToOtelMetrics(logger)
@@ -129,6 +128,7 @@ func (o *OpenTelemetry) Connect() error {
 		HTTPProxy:       &o.HTTPProxy,
 		TCPProxy:        &o.TCPProxy,
 		Encoding:        o.EncodingType,
+		Token:           &o.Token,
 		Headers:         o.Headers,
 	}
 	err = o.otlpMetricClient.Connect(clientCfg)
@@ -211,17 +211,20 @@ func (o *OpenTelemetry) sendBatch(metrics []telegraf.Metric) error {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(o.Timeout))
 	defer cancel()
 
-	if len(o.Headers) > 0 {
-		md := make(map[string]string, len(o.Headers))
-		for k, v := range o.Headers {
-			secret, err := v.Get()
-			if err != nil {
-				return fmt.Errorf("getting header %q secret failed: %w", k, err)
-			}
-			md[k] = secret.String()
-			secret.Destroy()
+	grpcMD := make(map[string]string, len(o.Headers))
+	for k, v := range o.Headers {
+		grpcMD[k] = v
+	}
+	if !o.Token.Empty() {
+		token, err := o.Token.Get()
+		if err != nil {
+			return fmt.Errorf("getting token secret failed: %w", err)
 		}
-		ctx = metadata.NewOutgoingContext(ctx, metadata.New(md))
+		grpcMD["authorization"] = "Bearer " + token.String()
+		token.Destroy()
+	}
+	if len(grpcMD) > 0 {
+		ctx = metadata.NewOutgoingContext(ctx, metadata.New(grpcMD))
 	}
 	_, err := o.otlpMetricClient.Export(ctx, md)
 	return err

--- a/plugins/outputs/opentelemetry/opentelemetry.go
+++ b/plugins/outputs/opentelemetry/opentelemetry.go
@@ -218,6 +218,9 @@ func (o *OpenTelemetry) sendBatch(metrics []telegraf.Metric) error {
 		if err != nil {
 			return fmt.Errorf("getting token secret failed: %w", err)
 		}
+		if headers == nil {
+			headers = make(map[string]string, 1)
+		}
 		headers["authorization"] = "Bearer " + token.String()
 		token.Destroy()
 	}

--- a/plugins/outputs/opentelemetry/opentelemetry.go
+++ b/plugins/outputs/opentelemetry/opentelemetry.go
@@ -35,7 +35,7 @@ type OpenTelemetry struct {
 	tls.ClientConfig
 	Timeout     config.Duration   `toml:"timeout"`
 	Compression string            `toml:"compression"`
-	Headers     map[string]string `toml:"headers"`
+	Headers     map[string]*config.Secret `toml:"headers"`
 	Attributes  map[string]string `toml:"attributes"`
 	Coralogix   *CoralogixConfig  `toml:"coralogix"`
 	proxy.HTTPProxy
@@ -55,7 +55,7 @@ type clientConfig struct {
 	HTTPProxy       *proxy.HTTPProxy  // only for HTTP client
 	TCPProxy        *proxy.TCPProxy   // only for gRPC client
 	Encoding        string            // only for HTTP client
-	Headers         map[string]string // only for HTTP client, gRPC client uses metadata
+	Headers         map[string]*config.Secret // only for HTTP client, gRPC client uses metadata
 }
 
 type otlpMetricClient interface {
@@ -95,11 +95,14 @@ func (o *OpenTelemetry) Connect() error {
 	}
 	if o.Coralogix != nil {
 		if o.Headers == nil {
-			o.Headers = make(map[string]string)
+			o.Headers = make(map[string]*config.Secret)
 		}
-		o.Headers["ApplicationName"] = o.Coralogix.AppName
-		o.Headers["ApiName"] = o.Coralogix.SubSystem
-		o.Headers["Authorization"] = "Bearer " + o.Coralogix.PrivateKey
+		appName := config.NewSecret([]byte(o.Coralogix.AppName))
+		o.Headers["ApplicationName"] = &appName
+		subSystem := config.NewSecret([]byte(o.Coralogix.SubSystem))
+		o.Headers["ApiName"] = &subSystem
+		bearer := config.NewSecret([]byte("Bearer " + o.Coralogix.PrivateKey))
+		o.Headers["Authorization"] = &bearer
 	}
 
 	metricsConverter, err := influx2otel.NewLineProtocolToOtelMetrics(logger)
@@ -208,7 +211,16 @@ func (o *OpenTelemetry) sendBatch(metrics []telegraf.Metric) error {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(o.Timeout))
 
 	if len(o.Headers) > 0 {
-		ctx = metadata.NewOutgoingContext(ctx, metadata.New(o.Headers))
+		md := make(map[string]string, len(o.Headers))
+		for k, v := range o.Headers {
+			secret, err := v.Get()
+			if err != nil {
+				return fmt.Errorf("getting header %q secret failed: %w", k, err)
+			}
+			md[k] = secret.String()
+			secret.Destroy()
+		}
+		ctx = metadata.NewOutgoingContext(ctx, metadata.New(md))
 	}
 	defer cancel()
 	_, err := o.otlpMetricClient.Export(ctx, md)

--- a/plugins/outputs/opentelemetry/opentelemetry.go
+++ b/plugins/outputs/opentelemetry/opentelemetry.go
@@ -33,11 +33,11 @@ type OpenTelemetry struct {
 	EncodingType   string `toml:"encoding_type"`
 
 	tls.ClientConfig
-	Timeout     config.Duration   `toml:"timeout"`
-	Compression string            `toml:"compression"`
+	Timeout     config.Duration           `toml:"timeout"`
+	Compression string                    `toml:"compression"`
 	Headers     map[string]*config.Secret `toml:"headers"`
-	Attributes  map[string]string `toml:"attributes"`
-	Coralogix   *CoralogixConfig  `toml:"coralogix"`
+	Attributes  map[string]string         `toml:"attributes"`
+	Coralogix   *CoralogixConfig          `toml:"coralogix"`
 	proxy.HTTPProxy
 	proxy.TCPProxy
 
@@ -52,9 +52,9 @@ type clientConfig struct {
 	TLSConfig       *tls.ClientConfig
 	Compression     string
 	CoralogixConfig *CoralogixConfig
-	HTTPProxy       *proxy.HTTPProxy  // only for HTTP client
-	TCPProxy        *proxy.TCPProxy   // only for gRPC client
-	Encoding        string            // only for HTTP client
+	HTTPProxy       *proxy.HTTPProxy          // only for HTTP client
+	TCPProxy        *proxy.TCPProxy           // only for gRPC client
+	Encoding        string                    // only for HTTP client
 	Headers         map[string]*config.Secret // only for HTTP client, gRPC client uses metadata
 }
 

--- a/plugins/outputs/opentelemetry/opentelemetry_test.go
+++ b/plugins/outputs/opentelemetry/opentelemetry_test.go
@@ -47,10 +47,11 @@ func TestOpenTelemetry(t *testing.T) {
 
 	metricsConverter, err := influx2otel.NewLineProtocolToOtelMetrics(common.NoopLogger{})
 	require.NoError(t, err)
+	testHeaderSecret := config.NewSecret([]byte("header1"))
 	plugin := &OpenTelemetry{
 		ServiceAddress:   m.Address(),
 		Timeout:          config.Duration(time.Second),
-		Headers:          map[string]string{"test": "header1"},
+		Headers:          map[string]*config.Secret{"test": &testHeaderSecret},
 		Attributes:       map[string]string{"attr-key": "attr-val"},
 		metricsConverter: metricsConverter,
 		otlpMetricClient: &gRPCClient{

--- a/plugins/outputs/opentelemetry/opentelemetry_test.go
+++ b/plugins/outputs/opentelemetry/opentelemetry_test.go
@@ -47,11 +47,10 @@ func TestOpenTelemetry(t *testing.T) {
 
 	metricsConverter, err := influx2otel.NewLineProtocolToOtelMetrics(common.NoopLogger{})
 	require.NoError(t, err)
-	testHeaderSecret := config.NewSecret([]byte("header1"))
 	plugin := &OpenTelemetry{
 		ServiceAddress:   m.Address(),
 		Timeout:          config.Duration(time.Second),
-		Headers:          map[string]*config.Secret{"test": &testHeaderSecret},
+		Headers:          map[string]string{"test": "header1"},
 		Attributes:       map[string]string{"attr-key": "attr-val"},
 		metricsConverter: metricsConverter,
 		otlpMetricClient: &gRPCClient{

--- a/plugins/outputs/opentelemetry/sample.conf
+++ b/plugins/outputs/opentelemetry/sample.conf
@@ -55,6 +55,11 @@
   # [outputs.opentelemetry.attributes]
   # "service.name" = "demo"
 
-  ## Additional gRPC request metadata
+  ## Optional Bearer token for authentication.
+  ## Supports secret-store references, e.g. @{<store-id>:<key>}, so tokens
+  ## fetched via the oauth2 secret store are refreshed automatically.
+  # token = ""
+
+  ## Additional gRPC request metadata / HTTP headers
   # [outputs.opentelemetry.headers]
   # key1 = "value1"


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

As described in the issue, there is no option to use OAuth2 secretstore with opentelemetry output. The output uses plain strings. This implementation makes us able to configure the secretstore and use it with the mentioned output. It's done by introducing a new `token` option as suggested in the review

It's inspired by [this implementation](https://github.com/influxdata/telegraf/blob/master/plugins/outputs/http/http.go)

I tested it the same way I configured the minimal setup for the linked issue:



```toml
[[secretstores.oauth2]]
  id             = "oauth2store"
  service        = "custom"
  token_endpoint = "http://localhost:9099/oauth2/token"

  [[secretstores.oauth2.token]]
    key           = "sink_token"
    client_id     = "demo-client"
    client_secret = "demo-secret"

[[inputs.cpu]]
  percpu = false

[[outputs.opentelemetry]]
  service_address = "http://localhost:9099/_otlp/v1/metrics"
  token = "@{oauth2store:sink_token}"
```

```
make build
./telegraf --config telegraf-issue.toml --debug
2026-05-26T13:23:58Z W! Strict environment variable handling is the new default starting with v1.38.0! If your configuration does not work with strict handling please explicitly add the --non-strict-env-handling flag to switch to the previous behavior!
2026-05-26T13:23:58Z I! Loading config: telegraf-issue.toml
2026-05-26T13:23:58Z I! Starting Telegraf 1.39.0-cbcf1eac brought to you by InfluxData the makers of InfluxDB
2026-05-26T13:23:58Z I! Available plugins: 244 inputs, 9 aggregators, 35 processors, 26 parsers, 68 outputs, 7 secret stores
2026-05-26T13:23:58Z I! Loaded inputs: cpu
2026-05-26T13:23:58Z I! Loaded aggregators:
2026-05-26T13:23:58Z I! Loaded processors:
2026-05-26T13:23:58Z I! Loaded secretstores: oauth2store
2026-05-26T13:23:58Z I! Loaded outputs: opentelemetry
2026-05-26T13:23:58Z I! Tags enabled: host=Mac.home
2026-05-26T13:23:58Z I! [agent] Config: Interval:10s, Quiet:false, Hostname:"Mac.home", Flush Interval:10s
2026-05-26T13:23:58Z W! [agent] The default value of 'skip_processors_after_aggregators' will change to 'true' with Telegraf v1.40.0! If you need the current default behavior, please explicitly set the option to 'false'!
2026-05-26T13:23:58Z D! [agent] Initializing plugins
2026-05-26T13:23:58Z D! [agent] Connecting outputs
2026-05-26T13:23:58Z D! [agent] Attempting connection to [outputs.opentelemetry]
2026-05-26T13:23:58Z D! [agent] Successfully connected to outputs.opentelemetry
2026-05-26T13:23:58Z D! [agent] Starting service inputs
2026-05-26T13:24:08Z D! [outputs.opentelemetry] Buffer fullness: 0 / 10000 metrics
2026-05-26T13:24:18Z D! [outputs.opentelemetry] Received 1 metrics and split into 1 groups by timestamp
2026-05-26T13:24:18Z D! [outputs.opentelemetry] Wrote batch of 1 metrics in 14.153375ms
2026-05-26T13:24:18Z D! [outputs.opentelemetry] Buffer fullness: 0 / 10000 metrics
^C2026-05-26T13:24:21Z D! [agent] Stopping service inputs
2026-05-26T13:24:21Z D! [agent] Input channel closed
2026-05-26T13:24:21Z I! [agent] Hang on, flushing any cached metrics before shutdown
2026-05-26T13:24:21Z D! [outputs.opentelemetry] Received 1 metrics and split into 1 groups by timestamp
2026-05-26T13:24:21Z D! [outputs.opentelemetry] Wrote batch of 1 metrics in 2.652375ms
2026-05-26T13:24:21Z D! [outputs.opentelemetry] Buffer fullness: 0 / 10000 metrics
2026-05-26T13:24:21Z I! [agent] Stopping running outputs
2026-05-26T13:24:21Z D! [agent] Stopped Successfully
```

```
# dummy-sink log
time=2026-05-26T13:14:39.519+02:00 level=INFO msg="issued token" client_id=demo-client
...
```

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [ ] No AI generated code was used in this PR
- [x] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves https://github.com/influxdata/telegraf/issues/18979
