### PR TITLE
fix(inputs.system): Restore n_cpu field name

### DIFF
--- a/plugins/inputs/system/README.md
+++ b/plugins/inputs/system/README.md
@@ -21,15 +21,14 @@ plugin ordering. See [CONFIGURATION.md][CONFIGURATION.md] for more details.
 # Read metrics about system load & uptime
 [[inputs.system]]
   ## Information to collect; available options are:
-  ##   load             - 1, 5 and 15-minute load averages
-  ##   users            - logged-in user counts
   ##   cpus             - CPU counts of the system
-  ##   legacy_cpus      - legacy layout of CPU counts; see README for details
+  ##   dmi              - BIOS, baseboard, chassis and product information from DMI/SMBIOS
+  ##   load             - 1, 5 and 15-minute load averages
+  ##   os               - operating system release and uname information
   ##   uptime           - system uptime
   ##   legacy_uptime    - legacy layout of system uptime; see README for details
-  ##   os               - operating system release and uname information
-  ##   dmi              - BIOS, baseboard, chassis and product information from DMI/SMBIOS
-  # include = ["load", "users", "legacy_cpus", "legacy_uptime"]
+  ##   users            - logged-in user counts
+  # include = ["cpus", "legacy_uptime", "load", "users"]
 
   ## How long to cache the result of the "os" group between gathers.
   ## Set higher to reduce the number of os-release/uname reads, lower to
@@ -44,8 +43,7 @@ plugin ordering. See [CONFIGURATION.md][CONFIGURATION.md] for more details.
 ```
 
 > [!NOTE]
-> The `cpus` and `legacy_cpus` options are mutually exclusive,
-> as are `uptime` and `legacy_uptime`.
+> The `uptime` and `legacy_uptime` options are mutually exclusive.
 
 <!-- markdownlint-disable-next-line MD028 -->
 
@@ -84,9 +82,9 @@ there. Results are cached between gathers, see `dmi_cache_ttl` above.
 ## Metrics
 
 The `include` option controls which measurements and fields are gathered.
-The `load`, `users`, `cpus` / `legacy_cpus` and `uptime` / `legacy_uptime`
-groups populate the `system` measurement, while the `os` group emits a
-separate `system_os` measurement.
+The `cpus`, `load`, `users` and `uptime` / `legacy_uptime` groups populate the
+`system` measurement, while the `os` group emits a separate `system_os`
+measurement.
 
 ### `system`
 
@@ -97,9 +95,8 @@ separate `system_os` measurement.
 | `load15`          | `load`                     | float   | 15-minute load average                      |
 | `n_users`         | `users`                    | integer | Number of logged-in user sessions           |
 | `n_unique_users`  | `users`                    | integer | Number of unique logged-in usernames        |
-| `n_virtual_cpus`  | `cpus`                     | integer | Number of logical CPUs                      |
-| `n_cpus`          | `legacy_cpus`              | integer | Number of logical CPUs (legacy name)        |
-| `n_physical_cpus` | `cpus` / `legacy_cpus`     | integer | Number of physical CPUs                     |
+| `n_cpus`          | `cpus`                     | integer | Number of logical CPUs                      |
+| `n_physical_cpus` | `cpus`                     | integer | Number of physical CPUs                     |
 | `uptime`          | `uptime`                   | integer | System uptime in seconds (gauge field)      |
 | `uptime`          | `legacy_uptime`            | integer | System uptime in seconds (separate counter) |
 | `uptime_format`   | `legacy_uptime`            | string  | Human-readable uptime (deprecated)          |
@@ -157,7 +154,7 @@ UUID on Linux without root).
 
 ### Default configuration
 
-With the default `include = ["load", "users", "legacy_cpus", "legacy_uptime"]`,
+With the default `include = ["cpus", "legacy_uptime", "load", "users"]`,
 the output is backward-compatible with previous versions:
 
 ```text
@@ -168,11 +165,11 @@ system,host=worker-01 uptime_format="14 days, 11:07" 1748000000000000000
 
 ### Recommended configuration
 
-With `include = ["load", "users", "cpus", "uptime"]`, all fields are emitted
+With `include = ["cpus", "load", "users", "uptime"]`, all fields are emitted
 in a single metric with the new field names:
 
 ```text
-system,host=worker-01 load1=3.72,load5=2.4,load15=2.1,n_users=3i,n_unique_users=2i,n_virtual_cpus=4i,n_physical_cpus=2i,uptime=1249632i 1748000000000000000
+system,host=worker-01 load1=3.72,load5=2.4,load15=2.1,n_users=3i,n_unique_users=2i,n_cpus=4i,n_physical_cpus=2i,uptime=1249632i 1748000000000000000
 ```
 
 ### OS information

--- a/plugins/inputs/system/README.md
+++ b/plugins/inputs/system/README.md
@@ -23,10 +23,10 @@ plugin ordering. See [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## Information to collect; available options are:
   ##   cpus             - CPU counts of the system
   ##   dmi              - BIOS, baseboard, chassis and product information from DMI/SMBIOS
+  ##   legacy_uptime    - legacy layout of system uptime; see README for details
   ##   load             - 1, 5 and 15-minute load averages
   ##   os               - operating system release and uname information
   ##   uptime           - system uptime
-  ##   legacy_uptime    - legacy layout of system uptime; see README for details
   ##   users            - logged-in user counts
   # include = ["cpus", "legacy_uptime", "load", "users"]
 

--- a/plugins/inputs/system/sample.conf
+++ b/plugins/inputs/system/sample.conf
@@ -1,15 +1,14 @@
 # Read metrics about system load & uptime
 [[inputs.system]]
   ## Information to collect; available options are:
-  ##   load             - 1, 5 and 15-minute load averages
-  ##   users            - logged-in user counts
   ##   cpus             - CPU counts of the system
-  ##   legacy_cpus      - legacy layout of CPU counts; see README for details
-  ##   uptime           - system uptime
-  ##   legacy_uptime    - legacy layout of system uptime; see README for details
-  ##   os               - operating system release and uname information
   ##   dmi              - BIOS, baseboard, chassis and product information from DMI/SMBIOS
-  # include = ["load", "users", "legacy_cpus", "legacy_uptime"]
+  ##   legacy_uptime    - legacy layout of system uptime; see README for details
+  ##   load             - 1, 5 and 15-minute load averages
+  ##   os               - operating system release and uname information
+  ##   uptime           - system uptime
+  ##   users            - logged-in user counts
+  # include = ["cpus", "legacy_uptime", "load", "users"]
 
   ## How long to cache the result of the "os" group between gathers.
   ## Set higher to reduce the number of os-release/uname reads, lower to

--- a/plugins/inputs/system/system.go
+++ b/plugins/inputs/system/system.go
@@ -46,7 +46,7 @@ func (s *System) Init() error {
 	// Suppress deprecation warnings for default-only configs.
 	userSupplied := len(s.Include) > 0
 	if !userSupplied {
-		s.Include = []string{"load", "users", "legacy_cpus", "legacy_uptime"}
+		s.Include = []string{"cpus", "load", "users", "legacy_uptime"}
 	}
 
 	enabled := make(map[string]bool, len(s.Include))
@@ -57,19 +57,6 @@ func (s *System) Init() error {
 		}
 		switch incl {
 		case "load", "users", "cpus", "uptime", "os", "dmi":
-		case "legacy_cpus":
-			if userSupplied {
-				config.PrintOptionValueDeprecationNotice(
-					"inputs.system",
-					"include",
-					"legacy_cpus",
-					telegraf.DeprecationInfo{
-						Since:     "1.39.0",
-						RemovalIn: "1.45.0",
-						Notice:    "use 'cpus' instead",
-					},
-				)
-			}
 		case "legacy_uptime":
 			if userSupplied {
 				config.PrintOptionValueDeprecationNotice(
@@ -91,9 +78,6 @@ func (s *System) Init() error {
 	}
 	s.Include = deduped
 
-	if enabled["cpus"] && enabled["legacy_cpus"] {
-		return errors.New(`"cpus" and "legacy_cpus" are mutually exclusive`)
-	}
 	if enabled["uptime"] && enabled["legacy_uptime"] {
 		return errors.New(`"uptime" and "legacy_uptime" are mutually exclusive`)
 	}
@@ -167,7 +151,7 @@ func (s *System) Gather(acc telegraf.Accumulator) error {
 			} else {
 				s.Log.Warnf("Reading users: %s", err.Error())
 			}
-		case "cpus", "legacy_cpus":
+		case "cpus":
 			numLogicalCPUs, err := cpu.Counts(true)
 			if err != nil {
 				acc.AddError(fmt.Errorf("reading logical CPU count: %w", err))
@@ -178,11 +162,7 @@ func (s *System) Gather(acc telegraf.Accumulator) error {
 				acc.AddError(fmt.Errorf("reading physical CPU count: %w", err))
 				continue
 			}
-			if incl == "cpus" {
-				fields["n_virtual_cpus"] = numLogicalCPUs
-			} else {
-				fields["n_cpus"] = numLogicalCPUs
-			}
+			fields["n_cpus"] = numLogicalCPUs
 			fields["n_physical_cpus"] = numPhysicalCPUs
 		case "uptime":
 			uptime, err := host.Uptime()

--- a/plugins/inputs/system/system_test.go
+++ b/plugins/inputs/system/system_test.go
@@ -72,14 +72,14 @@ func TestUniqueUsers(t *testing.T) {
 }
 
 func TestInitAllValidOptions(t *testing.T) {
-	// cpus/legacy_cpus and uptime/legacy_uptime are mutually exclusive,
-	// so cover all six valid values across two configurations.
+	// The uptime/legacy_uptime settings are mutually exclusive, so cover all
+	// valid values across two configurations.
 	tests := []struct {
 		name    string
 		include []string
 	}{
 		{"new", []string{"load", "users", "cpus", "uptime", "os", "dmi"}},
-		{"legacy", []string{"load", "users", "legacy_cpus", "legacy_uptime", "os", "dmi"}},
+		{"legacy", []string{"load", "users", "cpus", "legacy_uptime", "os", "dmi"}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -99,11 +99,6 @@ func TestInitErrors(t *testing.T) {
 			name:    "invalid option",
 			include: []string{"invalid"},
 			errMsg:  `invalid 'include' option "invalid"`,
-		},
-		{
-			name:    "cpus mutually exclusive",
-			include: []string{"cpus", "legacy_cpus"},
-			errMsg:  "mutually exclusive",
 		},
 		{
 			name:    "uptime mutually exclusive",
@@ -178,7 +173,7 @@ func TestGather(t *testing.T) {
 					"system",
 					map[string]string{},
 					map[string]interface{}{
-						"n_virtual_cpus":  0,
+						"n_cpus":          0,
 						"n_physical_cpus": 0,
 					},
 					time.Unix(0, 0),
@@ -213,7 +208,7 @@ func TestGather(t *testing.T) {
 						"load15":          float64(0),
 						"n_users":         0,
 						"n_unique_users":  0,
-						"n_virtual_cpus":  0,
+						"n_cpus":          0,
 						"n_physical_cpus": 0,
 						"uptime":          uint64(0),
 					},
@@ -267,7 +262,7 @@ func TestGather(t *testing.T) {
 					"system",
 					map[string]string{},
 					map[string]interface{}{
-						"n_virtual_cpus":  0,
+						"n_cpus":          0,
 						"n_physical_cpus": 0,
 					},
 					time.Unix(0, 0),


### PR DESCRIPTION
## Summary

This PR restores the original `n_cpus` field-name and makes the `legacy_cpus` option superfluous.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

resolves #18954 
