### PR TITLE
fix(outputs.influxdb_v2): Capture unix socket path before URL mutation

### DIFF
--- a/plugins/outputs/influxdb_v2/http.go
+++ b/plugins/outputs/influxdb_v2/http.go
@@ -105,13 +105,10 @@ func (c *httpClient) Init() error {
 			}
 		}
 	case "unix":
+		socketPath := c.url.Path
 		transport = &http.Transport{
 			Dial: func(_, _ string) (net.Conn, error) {
-				return net.DialTimeout(
-					c.url.Scheme,
-					c.url.Path,
-					c.timeout,
-				)
+				return net.DialTimeout("unix", socketPath, c.timeout)
 			},
 		}
 	default:

--- a/plugins/outputs/influxdb_v2/http_test.go
+++ b/plugins/outputs/influxdb_v2/http_test.go
@@ -2,12 +2,10 @@ package influxdb_v2
 
 import (
 	"fmt"
-	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"path"
-	"runtime"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -55,37 +53,6 @@ func TestHTTPClientInit(t *testing.T) {
 	}
 }
 
-func TestHTTPClientUnixSocketDial(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("unix socket path cannot be represented as a URL on Windows")
-	}
-
-	socketPath := testutil.TempSocket(t)
-
-	ln, err := net.Listen("unix", socketPath)
-	if err != nil {
-		t.Skipf("unix sockets not supported on this platform: %v", err)
-	}
-
-	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusNoContent)
-	}))
-	srv.Listener = ln
-	srv.Start()
-	defer srv.Close()
-
-	plugin := &InfluxDB{
-		URLs:   []string{"unix://" + socketPath},
-		Bucket: "test",
-		Log:    &testutil.Logger{},
-	}
-	require.NoError(t, plugin.Init())
-	require.NoError(t, plugin.Connect())
-	defer plugin.Close()
-
-	m := metric.New("cpu", nil, map[string]interface{}{"value": 1.0}, time.Now())
-	require.NoError(t, plugin.Write([]telegraf.Metric{m}))
-}
 
 func TestHTTPClientInitFail(t *testing.T) {
 	tests := []struct {

--- a/plugins/outputs/influxdb_v2/http_test.go
+++ b/plugins/outputs/influxdb_v2/http_test.go
@@ -2,10 +2,12 @@ package influxdb_v2
 
 import (
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"path"
+	"runtime"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -51,6 +53,38 @@ func TestHTTPClientInit(t *testing.T) {
 			require.NoError(t, tt.client.Init())
 		})
 	}
+}
+
+func TestHTTPClientUnixSocketDial(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix socket path cannot be represented as a URL on Windows")
+	}
+
+	socketPath := testutil.TempSocket(t)
+
+	ln, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Skipf("unix sockets not supported on this platform: %v", err)
+	}
+
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	srv.Listener = ln
+	srv.Start()
+	defer srv.Close()
+
+	plugin := &InfluxDB{
+		URLs:   []string{"unix://" + socketPath},
+		Bucket: "test",
+		Log:    &testutil.Logger{},
+	}
+	require.NoError(t, plugin.Init())
+	require.NoError(t, plugin.Connect())
+	defer plugin.Close()
+
+	m := metric.New("cpu", nil, map[string]interface{}{"value": 1.0}, time.Now())
+	require.NoError(t, plugin.Write([]telegraf.Metric{m}))
 }
 
 func TestHTTPClientInitFail(t *testing.T) {

--- a/plugins/outputs/influxdb_v2/http_test.go
+++ b/plugins/outputs/influxdb_v2/http_test.go
@@ -53,7 +53,6 @@ func TestHTTPClientInit(t *testing.T) {
 	}
 }
 
-
 func TestHTTPClientInitFail(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/plugins/outputs/influxdb_v2/influxdb_v2_test.go
+++ b/plugins/outputs/influxdb_v2/influxdb_v2_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"reflect"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -143,6 +144,36 @@ func TestInfluxDBLocalAddress(t *testing.T) {
 	output := influxdb.InfluxDB{LocalAddr: "localhost"}
 	require.NoError(t, output.Connect())
 	require.NoError(t, output.Close())
+}
+
+func TestUnixSocketWrite(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix socket path cannot be represented as a URL on Windows")
+	}
+
+	socketPath := testutil.TempSocket(t)
+
+	ln, err := net.Listen("unix", socketPath)
+	require.NoError(t, err)
+
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	srv.Listener = ln
+	srv.Start()
+	defer srv.Close()
+
+	plugin := &influxdb.InfluxDB{
+		URLs:   []string{"unix://" + socketPath},
+		Bucket: "test",
+		Log:    &testutil.Logger{},
+	}
+	require.NoError(t, plugin.Init())
+	require.NoError(t, plugin.Connect())
+	defer plugin.Close()
+
+	m := metric.New("cpu", nil, map[string]any{"value": 1.0}, time.Now())
+	require.NoError(t, plugin.Write([]telegraf.Metric{m}))
 }
 
 func TestWrite(t *testing.T) {


### PR DESCRIPTION
## Summary
net.DialTimeout is called with "http" as the network parameter instead of "unix", producing dial http: unknown network http

> First contribution to this repo, and also my first time writing Go — happy to adjust anything that doesn't match the project's conventions or style.

## Checklist
- [ ] No AI generated code was used in this PR
- [x] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
resolves #18983
