### PR TITLE
feat(inputs.http_response): Add secret token support

### DIFF
--- a/plugins/inputs/http_response/README.md
+++ b/plugins/inputs/http_response/README.md
@@ -45,11 +45,6 @@ to use them.
   ## Whether to follow redirects from the server (defaults to false)
   # follow_redirects = false
 
-  ## Optional file with Bearer token.
-  ##   deprecated in 1.39; use the token option
-  ## file content is added as an Authorization header
-  # bearer_token = "/path/to/file"
-
   ## Bearer token for authentication, accepting secret-store references
   ## This option cannot be used in combination with 'bearer_token'.
   # token = "my-token"

--- a/plugins/inputs/http_response/README.md
+++ b/plugins/inputs/http_response/README.md
@@ -24,10 +24,6 @@ to use them.
 
 [SECRETSTORE]: ../../../docs/CONFIGURATION.md#secret-store-secrets
 
-To use OAuth2 client credentials, configure the
-`secretstores.oauth2` secret store and reference the
-token from `inputs.http_response`.
-
 ## Configuration
 
 ```toml @sample.conf
@@ -49,13 +45,13 @@ token from `inputs.http_response`.
   ## Whether to follow redirects from the server (defaults to false)
   # follow_redirects = false
 
-  ## Optional file with Bearer token
+  ## Optional file with Bearer token.
+  ##   deprecated in 1.39; use the token option
   ## file content is added as an Authorization header
   # bearer_token = "/path/to/file"
 
-  ## Optional Bearer token used in the Authorization header.
-  ## To fetch this value from a secret store, use a secret-store reference such as
-  ## "@{oauth:healthcheck}". This option is exclusive with bearer_token.
+  ## Bearer token for authentication, accepting secret-store references
+  ## This option cannot be used in combination with 'bearer_token'.
   # token = "my-token"
 
   ## Optional HTTP Basic Auth Credentials

--- a/plugins/inputs/http_response/README.md
+++ b/plugins/inputs/http_response/README.md
@@ -17,12 +17,16 @@ plugin ordering. See [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 ## Secret store support
 
-This plugin supports secrets from secret stores for the `username` and
-`password` option.
+This plugin supports secrets from secret stores for the `username`, `password`
+and `token` options.
 See the [secret store documentation][SECRETSTORE] for more details on how
 to use them.
 
 [SECRETSTORE]: ../../../docs/CONFIGURATION.md#secret-store-secrets
+
+To use OAuth2 client credentials, configure the
+`secretstores.oauth2` secret store and reference the
+token from `inputs.http_response`.
 
 ## Configuration
 
@@ -48,6 +52,11 @@ to use them.
   ## Optional file with Bearer token
   ## file content is added as an Authorization header
   # bearer_token = "/path/to/file"
+
+  ## Optional Bearer token used in the Authorization header.
+  ## To fetch this value from a secret store, use a secret-store reference such as
+  ## "@{oauth:healthcheck}". This option is exclusive with bearer_token.
+  # token = "my-token"
 
   ## Optional HTTP Basic Auth Credentials
   # username = "username"

--- a/plugins/inputs/http_response/http_response.go
+++ b/plugins/inputs/http_response/http_response.go
@@ -47,12 +47,13 @@ type HTTPResponse struct {
 	Headers         map[string]string   `toml:"headers"`
 	FollowRedirects bool                `toml:"follow_redirects"`
 	// Absolute path to file with Bearer token
-	BearerToken         string      `toml:"bearer_token"`
-	ResponseBodyField   string      `toml:"response_body_field"`
-	ResponseBodyMaxSize config.Size `toml:"response_body_max_size"`
-	ResponseStringMatch string      `toml:"response_string_match"`
-	ResponseStatusCode  int         `toml:"response_status_code"`
-	Interface           string      `toml:"interface"`
+	BearerToken         string        `toml:"bearer_token"`
+	Token               config.Secret `toml:"token"`
+	ResponseBodyField   string        `toml:"response_body_field"`
+	ResponseBodyMaxSize config.Size   `toml:"response_body_max_size"`
+	ResponseStringMatch string        `toml:"response_string_match"`
+	ResponseStatusCode  int           `toml:"response_status_code"`
+	Interface           string        `toml:"interface"`
 	// HTTP Basic Auth Credentials
 	Username config.Secret `toml:"username"`
 	Password config.Secret `toml:"password"`
@@ -80,6 +81,10 @@ func (*HTTPResponse) SampleConfig() string {
 }
 
 func (h *HTTPResponse) Init() error {
+	if h.BearerToken != "" && !h.Token.Empty() {
+		return errors.New("either use 'bearer_token' or 'token' not both")
+	}
+
 	// Compile the body regex if it exists
 	if h.ResponseStringMatch != "" {
 		var err error
@@ -326,7 +331,15 @@ func (h *HTTPResponse) httpGather(cl client) (map[string]interface{}, map[string
 		request.Header.Set("User-Agent", internal.ProductToken())
 	}
 
-	if h.BearerToken != "" {
+	if !h.Token.Empty() {
+		token, err := h.Token.Get()
+		if err != nil {
+			return nil, nil, fmt.Errorf("getting token secret failed: %w", err)
+		}
+		bearer := "Bearer " + strings.TrimSpace(token.String())
+		token.Destroy()
+		request.Header.Add("Authorization", bearer)
+	} else if h.BearerToken != "" {
 		token, err := os.ReadFile(h.BearerToken)
 		if err != nil {
 			return nil, nil, err

--- a/plugins/inputs/http_response/http_response.go
+++ b/plugins/inputs/http_response/http_response.go
@@ -47,7 +47,7 @@ type HTTPResponse struct {
 	Headers         map[string]string   `toml:"headers"`
 	FollowRedirects bool                `toml:"follow_redirects"`
 	// Absolute path to file with Bearer token
-	BearerToken         string        `toml:"bearer_token" deprecated:"1.39.0;use 'token' instead"`
+	BearerToken         string        `toml:"bearer_token" deprecated:"1.39.0;1.45.0;use 'token' instead"`
 	Token               config.Secret `toml:"token"`
 	ResponseBodyField   string        `toml:"response_body_field"`
 	ResponseBodyMaxSize config.Size   `toml:"response_body_max_size"`

--- a/plugins/inputs/http_response/http_response.go
+++ b/plugins/inputs/http_response/http_response.go
@@ -47,7 +47,7 @@ type HTTPResponse struct {
 	Headers         map[string]string   `toml:"headers"`
 	FollowRedirects bool                `toml:"follow_redirects"`
 	// Absolute path to file with Bearer token
-	BearerToken         string        `toml:"bearer_token"`
+	BearerToken         string        `toml:"bearer_token" deprecated:"1.39.0;use 'token' instead"`
 	Token               config.Secret `toml:"token"`
 	ResponseBodyField   string        `toml:"response_body_field"`
 	ResponseBodyMaxSize config.Size   `toml:"response_body_max_size"`

--- a/plugins/inputs/http_response/http_response_test.go
+++ b/plugins/inputs/http_response/http_response_test.go
@@ -1215,6 +1215,55 @@ func TestBasicAuth(t *testing.T) {
 	checkOutput(t, &acc, expectedFields, expectedTags, absentFields, nil)
 }
 
+func TestTokenAuth(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if aHeader := r.Header.Get("Authorization"); aHeader != "Bearer my-token" {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Errorf("Not equal, expected: %q, actual: %q", "Bearer my-token", aHeader)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	h := &HTTPResponse{
+		Log:             testutil.Logger{},
+		URLs:            []string{ts.URL + "/good"},
+		Method:          "GET",
+		ResponseTimeout: config.Duration(time.Second * 20),
+		Token:           config.NewSecret([]byte("my-token")),
+	}
+
+	var acc testutil.Accumulator
+	require.NoError(t, h.Init())
+	require.NoError(t, h.Gather(&acc))
+
+	expectedFields := map[string]interface{}{
+		"http_response_code": http.StatusOK,
+		"result_type":        "success",
+		"result_code":        0,
+		"response_time":      nil,
+		"content_length":     nil,
+	}
+	expectedTags := map[string]interface{}{
+		"server":      nil,
+		"method":      "GET",
+		"status_code": "200",
+		"result":      "success",
+	}
+	absentFields := []string{"response_string_match"}
+	checkOutput(t, &acc, expectedFields, expectedTags, absentFields, nil)
+}
+
+func TestTokenConflictsWithBearerTokenFile(t *testing.T) {
+	h := &HTTPResponse{
+		BearerToken: "/path/to/token",
+		Token:       config.NewSecret([]byte("my-token")),
+	}
+
+	require.ErrorContains(t, h.Init(), "either use 'bearer_token' or 'token' not both")
+}
+
 func TestStatusCodeMatchFail(t *testing.T) {
 	mux := setUpTestMux()
 	ts := httptest.NewServer(mux)

--- a/plugins/inputs/http_response/sample.conf
+++ b/plugins/inputs/http_response/sample.conf
@@ -16,13 +16,13 @@
   ## Whether to follow redirects from the server (defaults to false)
   # follow_redirects = false
 
-  ## Optional file with Bearer token
+  ## Optional file with Bearer token.
+  ##   deprecated in 1.39; use the token option
   ## file content is added as an Authorization header
   # bearer_token = "/path/to/file"
 
-  ## Optional Bearer token used in the Authorization header.
-  ## To fetch this value from a secret store, use a secret-store reference such as
-  ## "@{oauth:healthcheck}". This option is exclusive with bearer_token.
+  ## Bearer token for authentication, accepting secret-store references
+  ## This option cannot be used in combination with 'bearer_token'.
   # token = "my-token"
 
   ## Optional HTTP Basic Auth Credentials

--- a/plugins/inputs/http_response/sample.conf
+++ b/plugins/inputs/http_response/sample.conf
@@ -16,11 +16,6 @@
   ## Whether to follow redirects from the server (defaults to false)
   # follow_redirects = false
 
-  ## Optional file with Bearer token.
-  ##   deprecated in 1.39; use the token option
-  ## file content is added as an Authorization header
-  # bearer_token = "/path/to/file"
-
   ## Bearer token for authentication, accepting secret-store references
   ## This option cannot be used in combination with 'bearer_token'.
   # token = "my-token"

--- a/plugins/inputs/http_response/sample.conf
+++ b/plugins/inputs/http_response/sample.conf
@@ -20,6 +20,11 @@
   ## file content is added as an Authorization header
   # bearer_token = "/path/to/file"
 
+  ## Optional Bearer token used in the Authorization header.
+  ## To fetch this value from a secret store, use a secret-store reference such as
+  ## "@{oauth:healthcheck}". This option is exclusive with bearer_token.
+  # token = "my-token"
+
   ## Optional HTTP Basic Auth Credentials
   # username = "username"
   # password = "pa$$word"


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

Add secret-store backed Bearer token support to `inputs.http_response`.

This adds a new `token` option using `config.Secret`, allowing the plugin to read a Bearer token directly or from Telegraf secret stores such as `secretstores.oauth2`. The existing `bearer_token` file option remains supported, and `token` is mutually exclusive with `bearer_token` to avoid ambiguous Authorization headers.

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [ ] No AI generated code was used in this PR
- [x] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #16644
