### PR TITLE
fix(inputs.docker_log): Don't use follow when tailing docker logs

### DIFF
--- a/plugins/inputs/docker_log/docker_log.go
+++ b/plugins/inputs/docker_log/docker_log.go
@@ -271,7 +271,7 @@ func (d *DockerLogs) tailContainerLogs(
 		ShowStderr: true,
 		Timestamps: true,
 		Details:    false,
-		Follow:     true,
+		Follow:     false,
 		Since:      since,
 	}
 


### PR DESCRIPTION
## Summary
When follow is set to true the stream tailer never ends and therefore never executes the state persisting code. When the tailer gets stopped by telegraf on shutdown it throws an error of context cancelled and also doesn't persist the state.

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #18059
