### PR TITLE
test(config): Add regression test for empty secret string

### DIFF
--- a/config/secret_test.go
+++ b/config/secret_test.go
@@ -545,6 +545,19 @@ func (tsuite *SecretImplTestSuite) TestSecretEqualTo() {
 	require.False(t, equal)
 }
 
+func (tsuite *SecretImplTestSuite) TestSecretEmpty() {
+	t := tsuite.T()
+
+	var s Secret
+	buf, err := s.Get()
+	require.NoError(t, err)
+	defer buf.Destroy()
+
+	require.Empty(t, buf.Bytes())
+	require.Empty(t, buf.TemporaryString())
+	require.Empty(t, buf.String())
+}
+
 func (tsuite *SecretImplTestSuite) TestSecretStoreInvalidReference() {
 	t := tsuite.T()
 


### PR DESCRIPTION
## Summary

`Secret.Get()` returns an empty buffer when no value is set, and calling `TemporaryString()` on that buffer must not panic. This case had no test coverage, so a future refactor of the unsafe string conversion could silently reintroduce a panic.

The case is added to `SecretImplTestSuite` so it runs against both the protected and unprotected backends via `TestSecretImplTestSuiteProtected` / `TestSecretImplTestSuiteUnprotected`.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

related to #18908