### PR TITLE
test(common.tls): Use TLSMinVersionDefault constant in expectation

### DIFF
--- a/plugins/common/tls/client_test.go
+++ b/plugins/common/tls/client_test.go
@@ -375,7 +375,7 @@ func TestEnableFlagEnabled(t *testing.T) {
 	require.NotNil(t, cfg)
 
 	expected := &cryptotls.Config{
-		MinVersion: cryptotls.VersionTLS12,
+		MinVersion: tls.TLSMinVersionDefault,
 	}
 	require.Equal(t, expected, cfg)
 }


### PR DESCRIPTION
## Summary

In `TestEnableFlagEnabled`, the expected `MinVersion` was hard-coded as `cryptotls.VersionTLS12`. Replace it with `tls.TLSMinVersionDefault`, the constant the production code in `client.go` actually sets.

This matches the existing reference at `client_test.go:254` and keeps the test honest: if the default minimum TLS version is ever bumped (e.g. to TLS 1.3), the expectation tracks the production default instead of silently asserting a stale value.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

related to #18910