### PR TITLE
test(common.opcua): Cover ua.ByteArray array decoding

### DIFF
--- a/plugins/common/opcua/input/input_client.go
+++ b/plugins/common/opcua/input/input_client.go
@@ -695,7 +695,7 @@ func (o *OpcUAInputClient) MetricForNode(nodeIdx int) telegraf.Metric {
 			case []uint8:
 				fields = unpack(nmm.Tag.FieldName, typedValue)
 			case ua.ByteArray:
-				fields = unpack(nmm.Tag.FieldName, []byte(typedValue))
+				fields = unpack(nmm.Tag.FieldName, typedValue)
 			case []uint16:
 				fields = unpack(nmm.Tag.FieldName, typedValue)
 			case []uint32:

--- a/plugins/common/opcua/input/input_client_test.go
+++ b/plugins/common/opcua/input/input_client_test.go
@@ -784,6 +784,28 @@ func TestMetricForNode(t *testing.T) {
 				time.Date(2022, 03, 17, 8, 55, 00, 00, &time.Location{})),
 		},
 		{
+			testname: "byte array metric build correctly",
+			nmm: []NodeMetricMapping{
+				{
+					Tag: NodeSettings{
+						FieldName: "fn",
+					},
+					idStr:      "ns=3;s=hi",
+					metricName: "testingmetric",
+					MetricTags: map[string]string{"t1": "v1"},
+				},
+			},
+			v:        ua.ByteArray{0x01, 0x02},
+			isArray:  true,
+			dataType: ua.TypeIDByte,
+			time:     time.Date(2022, 03, 17, 8, 55, 00, 00, &time.Location{}),
+			status:   ua.StatusOK,
+			expected: metric.New("testingmetric",
+				map[string]string{"t1": "v1", "id": "ns=3;s=hi"},
+				map[string]interface{}{"Quality": "The operation succeeded. StatusGood (0x0)", "fn[0]": byte(1), "fn[1]": byte(2)},
+				time.Date(2022, 03, 17, 8, 55, 00, 00, &time.Location{})),
+		},
+		{
 			testname: "datetime array metric build correctly",
 			nmm: []NodeMetricMapping{
 				{


### PR DESCRIPTION
## Summary

The `ua.ByteArray` branch in `MetricForNode` (added in #18825) had no test coverage. Add a table-driven case asserting a `ua.ByteArray` value is unpacked into per-index byte fields (`fn[0]`, `fn[1]`).

Also drop the unnecessary `[]byte(...)` conversion in the `ua.ByteArray` case. `unpack` is generic over `~[]E`, so `ua.ByteArray` satisfies it directly, matching every other case in the switch.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

related to #18825