### PR TITLE
feat(parsers.openmetrics): Implement ParserTimeFuncPlugin interface

### DIFF
--- a/plugins/inputs/prometheus/prometheus.go
+++ b/plugins/inputs/prometheus/prometheus.go
@@ -584,12 +584,16 @@ func (p *Prometheus) gatherURL(u urlAndAddress, acc telegraf.Accumulator) (map[s
 	// Parse the metrics
 	var metricParser telegraf.Parser
 	if openmetrics.AcceptsContent(resp.Header) {
-		metricParser = &openmetrics.Parser{
+		mp := &openmetrics.Parser{
 			Header:          resp.Header,
 			MetricVersion:   p.MetricVersion,
 			IgnoreTimestamp: p.IgnoreTimestamp,
 			Log:             p.Log,
 		}
+		if err := mp.Init(); err != nil {
+			return nil, nil, err
+		}
+		metricParser = mp
 	} else {
 		metricParser = &parsers_prometheus.Parser{
 			Header:          resp.Header,

--- a/plugins/parsers/openmetrics/metric_v1.go
+++ b/plugins/parsers/openmetrics/metric_v1.go
@@ -11,7 +11,7 @@ import (
 )
 
 func (p *Parser) extractMetricsV1(ometrics *MetricFamily) []telegraf.Metric {
-	now := time.Now()
+	now := p.timeFunc()
 
 	// Convert each prometheus metrics to the corresponding telegraf metrics.
 	// You will get one telegraf metric with one field per prometheus metric

--- a/plugins/parsers/openmetrics/metric_v2.go
+++ b/plugins/parsers/openmetrics/metric_v2.go
@@ -11,7 +11,7 @@ import (
 )
 
 func (p *Parser) extractMetricsV2(ometrics *MetricFamily) []telegraf.Metric {
-	now := time.Now()
+	now := p.timeFunc()
 
 	// Convert each openmetric metric to a corresponding telegraf metric
 	// with one field each. The process will filter NaNs in values and skip

--- a/plugins/parsers/openmetrics/parser.go
+++ b/plugins/parsers/openmetrics/parser.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"mime"
 	"net/http"
+	"time"
 
 	"github.com/prometheus/common/expfmt"
 	"google.golang.org/protobuf/proto"
@@ -14,34 +15,29 @@ import (
 	"github.com/influxdata/telegraf/plugins/parsers"
 )
 
-func AcceptsContent(header http.Header) bool {
-	contentType := header.Get("Content-Type")
-	if contentType == "" {
-		return false
-	}
-	mediaType, params, err := mime.ParseMediaType(contentType)
-	if err != nil {
-		return false
-	}
-	switch mediaType {
-	case expfmt.OpenMetricsType:
-		return true
-	case "application/openmetrics-protobuf":
-		return params["version"] == "1.0.0"
-	}
-	return false
-}
-
 type Parser struct {
 	IgnoreTimestamp bool              `toml:"openmetrics_ignore_timestamp"`
 	MetricVersion   int               `toml:"openmetrics_metric_version"`
 	Header          http.Header       `toml:"-"` // set by the input plugin
 	DefaultTags     map[string]string `toml:"-"`
 	Log             telegraf.Logger   `toml:"-"`
+
+	timeFunc func() time.Time
 }
 
 func (p *Parser) SetDefaultTags(tags map[string]string) {
 	p.DefaultTags = tags
+}
+
+func (p *Parser) SetTimeFunc(f func() time.Time) {
+	p.timeFunc = f
+}
+
+func (p *Parser) Init() error {
+	if p.timeFunc == nil {
+		p.timeFunc = time.Now
+	}
+	return nil
 }
 
 func (p *Parser) Parse(data []byte) ([]telegraf.Metric, error) {
@@ -116,6 +112,24 @@ func (p *Parser) ParseLine(line string) (telegraf.Metric, error) {
 	}
 
 	return metrics[0], nil
+}
+
+func AcceptsContent(header http.Header) bool {
+	contentType := header.Get("Content-Type")
+	if contentType == "" {
+		return false
+	}
+	mediaType, params, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		return false
+	}
+	switch mediaType {
+	case expfmt.OpenMetricsType:
+		return true
+	case "application/openmetrics-protobuf":
+		return params["version"] == "1.0.0"
+	}
+	return false
 }
 
 func getTagsFromLabels(m *Metric, defaultTags map[string]string) map[string]string {

--- a/plugins/parsers/openmetrics/parser_test.go
+++ b/plugins/parsers/openmetrics/parser_test.go
@@ -153,6 +153,7 @@ func TestCases(t *testing.T) {
 
 func BenchmarkParsingMetricVersion1(b *testing.B) {
 	plugin := &Parser{MetricVersion: 1}
+	require.NoError(b, plugin.Init())
 
 	benchmarkData, err := os.ReadFile(filepath.FromSlash("testcases/benchmark/input.txt"))
 	require.NoError(b, err)
@@ -166,6 +167,7 @@ func BenchmarkParsingMetricVersion1(b *testing.B) {
 
 func BenchmarkParsingMetricVersion2(b *testing.B) {
 	plugin := &Parser{MetricVersion: 2}
+	require.NoError(b, plugin.Init())
 
 	benchmarkData, err := os.ReadFile(filepath.FromSlash("testcases/benchmark/input.txt"))
 	require.NoError(b, err)


### PR DESCRIPTION
## Summary

This PR implements the `ParserTimeFuncPlugin` interface for the plugin.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
