### PR TITLE
feat(parsers.opentsdb): Implement ParserTimeFuncPlugin interface

### DIFF
--- a/plugins/parsers/opentsdb/parser.go
+++ b/plugins/parsers/opentsdb/parser.go
@@ -18,6 +18,24 @@ import (
 type Parser struct {
 	DefaultTags map[string]string `toml:"-"`
 	Log         telegraf.Logger   `toml:"-"`
+
+	timeFunc func() time.Time
+}
+
+func (p *Parser) SetDefaultTags(tags map[string]string) {
+	p.DefaultTags = tags
+}
+
+func (p *Parser) SetTimeFunc(f func() time.Time) {
+	p.timeFunc = f
+}
+
+func (p *Parser) Init() error {
+	if p.timeFunc == nil {
+		p.timeFunc = time.Now
+	}
+
+	return nil
 }
 
 func (p *Parser) Parse(buf []byte) ([]telegraf.Metric, error) {
@@ -107,10 +125,6 @@ func (p *Parser) ParseLine(line string) (telegraf.Metric, error) {
 	}
 
 	return metric.New(measurement, tags, fieldValues, timestamp), nil
-}
-
-func (p *Parser) SetDefaultTags(tags map[string]string) {
-	p.DefaultTags = tags
 }
 
 func init() {

--- a/plugins/parsers/opentsdb/parser_test.go
+++ b/plugins/parsers/opentsdb/parser_test.go
@@ -94,6 +94,7 @@ func TestParseLine(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p := &Parser{Log: testutil.Logger{}}
+			require.NoError(t, p.Init())
 
 			actual, err := p.ParseLine(tt.input)
 			require.NoError(t, err)
@@ -230,6 +231,7 @@ func TestParse(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p := &Parser{Log: testutil.Logger{}}
+			require.NoError(t, p.Init())
 
 			actual, err := p.Parse(tt.input)
 			require.NoError(t, err)
@@ -315,6 +317,7 @@ put benchmark_b 1653643420 5 tags_host=myhost tags_platform=python tags_sdkver=3
 
 func TestBenchmarkData(t *testing.T) {
 	plugin := &Parser{}
+	require.NoError(t, plugin.Init())
 
 	expected := []telegraf.Metric{
 		metric.New(
@@ -350,6 +353,7 @@ func TestBenchmarkData(t *testing.T) {
 
 func BenchmarkParsing(b *testing.B) {
 	plugin := &Parser{}
+	require.NoError(b, plugin.Init())
 
 	for n := 0; n < b.N; n++ {
 		//nolint:errcheck // Benchmarking so skip the error check to avoid the unnecessary operations


### PR DESCRIPTION
## Summary

This PR implements the `ParserTimeFuncPlugin` interface for the plugin.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
