### PR TITLE
fix(inputs.docker_log): Guard concurrent access to the state map

### DIFF
--- a/plugins/inputs/docker_log/docker_log.go
+++ b/plugins/inputs/docker_log/docker_log.go
@@ -296,11 +296,11 @@ func (d *DockerLogs) tailContainerLogs(
 		return err
 	}
 
+	d.lastRecordMtx.Lock()
 	if ts, ok := d.lastRecord[cntnr.ID]; !ok || ts.Before(last) {
-		d.lastRecordMtx.Lock()
 		d.lastRecord[cntnr.ID] = last
-		d.lastRecordMtx.Unlock()
 	}
+	d.lastRecordMtx.Unlock()
 
 	return nil
 }

--- a/plugins/inputs/docker_log/docker_log_test.go
+++ b/plugins/inputs/docker_log/docker_log_test.go
@@ -151,7 +151,7 @@ func TestGatherConcurrentState(t *testing.T) {
 		Inspect: make(map[string]container.InspectResponse, count),
 		Logs:    make(map[string]mock.Logs, count),
 	}
-	for i := 0; i < count; i++ {
+	for i := range count {
 		id := fmt.Sprintf("container%03d", i)
 		server.List = append(server.List, container.Summary{
 			ID:    id,

--- a/plugins/inputs/docker_log/docker_log_test.go
+++ b/plugins/inputs/docker_log/docker_log_test.go
@@ -1,6 +1,7 @@
 package docker_log
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -139,4 +140,44 @@ func TestGather(t *testing.T) {
 			testutil.RequireMetricsEqual(t, tt.expected, acc.GetTelegrafMetrics())
 		})
 	}
+}
+
+func TestGatherConcurrentState(t *testing.T) {
+	// Spawn many containers so their tailing goroutines update the shared
+	// last-record state concurrently. Run with -race to detect unsynchronized
+	// access to the state map.
+	const count = 64
+	server := &mock.Server{
+		Inspect: make(map[string]container.InspectResponse, count),
+		Logs:    make(map[string]mock.Logs, count),
+	}
+	for i := 0; i < count; i++ {
+		id := fmt.Sprintf("container%03d", i)
+		server.List = append(server.List, container.Summary{
+			ID:    id,
+			Names: []string{"/" + id},
+			Image: "influxdata/telegraf:1.11.0",
+			State: "running",
+		})
+		server.Inspect[id] = container.InspectResponse{Config: &container.Config{Tty: true}}
+		server.Logs[id] = mock.Logs{Content: "2020-04-28T18:43:16.432691200Z hello\n"}
+	}
+	addr := server.Start(t)
+	defer server.Close()
+
+	plugin := &DockerLogs{
+		Endpoint: addr,
+		Timeout:  config.Duration(time.Second * 5),
+	}
+	require.NoError(t, plugin.Init())
+
+	var acc testutil.Accumulator
+	require.NoError(t, plugin.Start(&acc))
+	defer plugin.Stop()
+
+	require.NoError(t, plugin.Gather(&acc))
+	require.Eventually(t, func() bool {
+		return acc.NMetrics() >= uint64(count)
+	}, 5*time.Second, 50*time.Millisecond)
+	require.Empty(t, acc.Errors)
 }


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Each container is tailed in its own goroutine. After reading a batch, the goroutine read the `lastRecord` state map outside `lastRecordMtx` before persisting the offset, while sibling goroutines write to the same map under the lock. Concurrent map read/write is undefined behavior in Go and can crash the agent with `fatal error: concurrent map read and map write`. This path runs on every gather interval once the plugin tails logs without follow container.
  
The fix takes `lastRecordMtx` around the read as well as the write.

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

related to #18059
