### PR TITLE
fix(inputs.docker_log): Don't re-emit the last log line each interval

### DIFF
--- a/plugins/inputs/docker_log/docker_log.go
+++ b/plugins/inputs/docker_log/docker_log.go
@@ -257,14 +257,19 @@ func (d *DockerLogs) tailContainerLogs(
 		return err
 	}
 
+	var offset time.Time
 	since := time.Time{}.Format(time.RFC3339Nano)
-	if !d.FromBeginning {
-		d.lastRecordMtx.Lock()
-		if ts, ok := d.lastRecord[cntnr.ID]; ok {
+	d.lastRecordMtx.Lock()
+	if ts, ok := d.lastRecord[cntnr.ID]; ok {
+		// Continue past the last processed record. Docker's "since" filter is
+		// inclusive of the boundary timestamp, so the offset is used to drop
+		// records that were already emitted in a previous cycle.
+		offset = ts
+		if !d.FromBeginning {
 			since = ts.Format(time.RFC3339Nano)
 		}
-		d.lastRecordMtx.Unlock()
 	}
+	d.lastRecordMtx.Unlock()
 
 	logOptions := client.ContainerLogsOptions{
 		ShowStdout: true,
@@ -288,9 +293,9 @@ func (d *DockerLogs) tailContainerLogs(
 	// multiplexed.
 	var last time.Time
 	if hasTTY {
-		last, err = tailStream(acc, tags, cntnr.ID, logReader, "tty")
+		last, err = tailStream(acc, tags, cntnr.ID, logReader, "tty", offset)
 	} else {
-		last, err = tailMultiplexed(acc, tags, cntnr.ID, logReader)
+		last, err = tailMultiplexed(acc, tags, cntnr.ID, logReader, offset)
 	}
 	if err != nil {
 		return err

--- a/plugins/inputs/docker_log/docker_log.go
+++ b/plugins/inputs/docker_log/docker_log.go
@@ -261,9 +261,7 @@ func (d *DockerLogs) tailContainerLogs(
 	since := time.Time{}.Format(time.RFC3339Nano)
 	d.lastRecordMtx.Lock()
 	if ts, ok := d.lastRecord[cntnr.ID]; ok {
-		// Continue past the last processed record. Docker's "since" filter is
-		// inclusive of the boundary timestamp, so the offset is used to drop
-		// records that were already emitted in a previous cycle.
+		// Drop records already emitted in a previous cycle (see tailStream).
 		offset = ts
 		if !d.FromBeginning {
 			since = ts.Format(time.RFC3339Nano)

--- a/plugins/inputs/docker_log/docker_log_test.go
+++ b/plugins/inputs/docker_log/docker_log_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/moby/moby/api/types/container"
 	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go/wait"
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
@@ -180,4 +181,76 @@ func TestGatherConcurrentState(t *testing.T) {
 		return acc.NMetrics() >= uint64(count)
 	}, 5*time.Second, 50*time.Millisecond)
 	require.Empty(t, acc.Errors)
+}
+
+func TestTailLogsNoDuplicateIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	tests := []struct {
+		name          string
+		fromBeginning bool
+	}{
+		{name: "telegraf-docker-log-from-end", fromBeginning: false},
+		{name: "telegraf-docker-log-from-beginning", fromBeginning: true},
+	}
+
+	// Continuously emit a uniquely numbered line so every record has a distinct
+	// timestamp and we can detect any line that gets collected more than once.
+	const script = "i=1; while true; do echo \"log line $i\"; i=$((i+1)); sleep 0.3; done"
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cntnr := testutil.Container{
+				Name:       tt.name,
+				Image:      "alpine:3",
+				Entrypoint: []string{"/bin/sh", "-c", script},
+				WaitingFor: wait.ForLog("log line 1"),
+			}
+			require.NoError(t, cntnr.Start(), "failed to start container")
+			defer cntnr.Terminate()
+
+			// Restrict the plugin to our container so it ignores everything else
+			// running on the daemon (e.g. the testcontainers reaper).
+			plugin := &DockerLogs{
+				Endpoint:         "ENV",
+				FromBeginning:    tt.fromBeginning,
+				ContainerInclude: []string{tt.name},
+				Timeout:          config.Duration(5 * time.Second),
+			}
+			require.NoError(t, plugin.Init())
+
+			var acc testutil.Accumulator
+			require.NoError(t, plugin.Start(&acc))
+			defer plugin.Stop()
+
+			// First cycle reads the lines produced so far and persists the offset.
+			require.NoError(t, plugin.Gather(&acc))
+			require.Eventually(t, func() bool {
+				return acc.NMetrics() > 0
+			}, 10*time.Second, 200*time.Millisecond)
+			collected := acc.NMetrics()
+
+			// Keep gathering until lines produced after the first cycle are
+			// collected, proving the offset advances without over-skipping new
+			// records. The container guards a second goroutine while the first
+			// is still running, so repeated Gather calls cannot double-read.
+			require.Eventually(t, func() bool {
+				require.NoError(t, plugin.Gather(&acc))
+				return acc.NMetrics() > collected
+			}, 20*time.Second, 300*time.Millisecond)
+
+			// Docker's "since" filter is inclusive of the boundary timestamp, so
+			// the last line of one cycle must not be re-emitted by the next one.
+			counts := make(map[string]int)
+			for _, m := range acc.GetTelegrafMetrics() {
+				msg, ok := m.GetField("message")
+				require.True(t, ok)
+				counts[msg.(string)]++
+			}
+			for msg, n := range counts {
+				require.Equalf(t, 1, n, "log line %q was collected %d times", msg, n)
+			}
+		})
+	}
 }

--- a/plugins/inputs/docker_log/docker_log_test.go
+++ b/plugins/inputs/docker_log/docker_log_test.go
@@ -222,7 +222,6 @@ func TestTailLogsNoDuplicateIntegration(t *testing.T) {
 
 			var acc testutil.Accumulator
 			require.NoError(t, plugin.Start(&acc))
-			defer plugin.Stop()
 
 			// First cycle reads the lines produced so far and persists the offset.
 			require.NoError(t, plugin.Gather(&acc))
@@ -240,8 +239,11 @@ func TestTailLogsNoDuplicateIntegration(t *testing.T) {
 				return acc.NMetrics() > collected
 			}, 20*time.Second, 300*time.Millisecond)
 
-			// Docker's "since" filter is inclusive of the boundary timestamp, so
-			// the last line of one cycle must not be re-emitted by the next one.
+			// Drain any in-flight tailing goroutine so the final cycle's output
+			// is fully recorded before we inspect the accumulator.
+			plugin.Stop()
+
+			// Every line must be collected exactly once across cycles.
 			counts := make(map[string]int)
 			for _, m := range acc.GetTelegrafMetrics() {
 				msg, ok := m.GetField("message")

--- a/plugins/inputs/docker_log/util.go
+++ b/plugins/inputs/docker_log/util.go
@@ -63,6 +63,7 @@ func tailStream(
 	containerID string,
 	reader io.ReadCloser,
 	stream string,
+	offset time.Time,
 ) (time.Time, error) {
 	defer reader.Close()
 
@@ -82,16 +83,19 @@ func tailStream(
 			ts, message, err := parseLine(line)
 			if err != nil {
 				acc.AddError(err)
-			} else {
+			} else if ts.After(offset) {
+				// Docker's "since" filter is inclusive of the boundary
+				// timestamp, so skip records at or before the last processed
+				// one to avoid re-emitting them on every interval.
 				acc.AddFields("docker_log", map[string]interface{}{
 					"container_id": containerID,
 					"message":      message,
 				}, tags, ts)
-			}
 
-			// Store the last processed timestamp
-			if ts.After(lastTS) {
-				lastTS = ts
+				// Store the last processed timestamp
+				if ts.After(lastTS) {
+					lastTS = ts
+				}
 			}
 		}
 
@@ -104,7 +108,7 @@ func tailStream(
 	}
 }
 
-func tailMultiplexed(acc telegraf.Accumulator, tags map[string]string, containerID string, src io.ReadCloser) (time.Time, error) {
+func tailMultiplexed(acc telegraf.Accumulator, tags map[string]string, containerID string, src io.ReadCloser, offset time.Time) (time.Time, error) {
 	outReader, outWriter := io.Pipe()
 	errReader, errWriter := io.Pipe()
 
@@ -114,7 +118,7 @@ func tailMultiplexed(acc telegraf.Accumulator, tags map[string]string, container
 	go func() {
 		defer wg.Done()
 		var err error
-		tsStdout, err = tailStream(acc, tags, containerID, outReader, "stdout")
+		tsStdout, err = tailStream(acc, tags, containerID, outReader, "stdout", offset)
 		if err != nil {
 			acc.AddError(err)
 		}
@@ -124,7 +128,7 @@ func tailMultiplexed(acc telegraf.Accumulator, tags map[string]string, container
 	go func() {
 		defer wg.Done()
 		var err error
-		tsStderr, err = tailStream(acc, tags, containerID, errReader, "stderr")
+		tsStderr, err = tailStream(acc, tags, containerID, errReader, "stderr", offset)
 		if err != nil {
 			acc.AddError(err)
 		}


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Tailing without follow (#18988) re-requests logs since the last processed timestamp on every interval. Docker's `since` filter is inclusive of the boundary timestamp, so the last line of one cycle was collected again by the next one. With `from_beginning` enabled the read always started at the beginning, so every line was re-collected on every interval.

  This tracks the last processed timestamp as an offset and skips records at or before it when emitting. The offset is derived from persisted state regardless of `from_beginning`, so the option only governs the very first read. Per-line filtering is used (rather than bumping `since` by a nanosecond) so two lines sharing the exact same timestamp are never dropped.

  A `from_beginning = true` tail still re-downloads the full log each interval(the duplicates are now discarded rather than emitted); avoiding that re-download is a separate optimization and is left for a follow-up.

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

related to #18059
