### PR TITLE
fix(inputs.docker_log): Read only new entries if from_beginning is false

### DIFF
--- a/plugins/inputs/docker_log/docker_log.go
+++ b/plugins/inputs/docker_log/docker_log.go
@@ -48,6 +48,7 @@ type DockerLogs struct {
 
 	// State of the plugin mapping container-ID to the timestamp of the
 	// last record processed
+	startupTime   string
 	lastRecord    map[string]time.Time
 	lastRecordMtx sync.Mutex
 }
@@ -120,7 +121,9 @@ func (d *DockerLogs) Init() error {
 }
 
 // Start is a noop which is required for a *DockerLogs to implement the telegraf.ServiceInput interface
-func (*DockerLogs) Start(telegraf.Accumulator) error {
+func (d *DockerLogs) Start(telegraf.Accumulator) error {
+	d.startupTime = time.Now().Format(time.RFC3339Nano)
+
 	return nil
 }
 
@@ -257,22 +260,22 @@ func (d *DockerLogs) tailContainerLogs(
 		return err
 	}
 
-	since := time.Time{}.Format(time.RFC3339Nano)
-	if !d.FromBeginning {
-		d.lastRecordMtx.Lock()
-		if ts, ok := d.lastRecord[cntnr.ID]; ok {
-			since = ts.Format(time.RFC3339Nano)
-		}
-		d.lastRecordMtx.Unlock()
-	}
-
 	logOptions := client.ContainerLogsOptions{
 		ShowStdout: true,
 		ShowStderr: true,
 		Timestamps: true,
 		Details:    false,
 		Follow:     false,
-		Since:      since,
+	}
+
+	if !d.FromBeginning {
+		since := d.startupTime
+		d.lastRecordMtx.Lock()
+		if ts, ok := d.lastRecord[cntnr.ID]; ok {
+			since = ts.Format(time.RFC3339Nano)
+		}
+		d.lastRecordMtx.Unlock()
+		logOptions.Since = since
 	}
 
 	logReader, err := d.client.ContainerLogs(ctx, cntnr.ID, logOptions)


### PR DESCRIPTION
## Summary

Currently, the plugin will emit _all_ logs if `from_beginning` is `false`, however, the documentation clearly states that 

>  [...] otherwise reading begins at the end of the log

This PR fixes the issue by start reading from the startup time if no state was persisted.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

resolves #18989 
