### PR TITLE
feat(inputs.opcua_listener): Add workaround to split large subscriptions

### DIFF
--- a/plugins/common/opcua/client.go
+++ b/plugins/common/opcua/client.go
@@ -20,6 +20,10 @@ import (
 
 type OpcUAWorkarounds struct {
 	AdditionalValidStatusCodes []string `toml:"additional_valid_status_codes"`
+	// MonitoredItemsBatchSize splits CreateMonitoredItems into batches of this
+	// size to stay below a server's negotiated maximum message size. It only
+	// applies to subscriptions (opcua_listener); the polling opcua input ignores it.
+	MonitoredItemsBatchSize int `toml:"monitored_items_batch_size"`
 }
 
 type ConnectionState opcua.ConnState

--- a/plugins/inputs/opcua_listener/README.md
+++ b/plugins/inputs/opcua_listener/README.md
@@ -72,13 +72,6 @@ to use them.
   ## Therefore, always refer to the hardware/software documentation of your server to ensure the specified interval is supported.
   # subscription_interval = "100ms"
   #
-  ## Maximum number of monitored items registered per request when setting up
-  ## the subscription. With a large number of nodes the registration request can
-  ## exceed the server's maximum message size and cause the subscription to fail
-  ## (e.g. "BadTcpMessageTooLarge"). Splitting the registration into smaller
-  ## batches avoids this. 0 (the default) registers all items in a single request.
-  # monitored_items_batch_size = 0
-  #
   ## Security policy, one of "None", "Basic128Rsa15", "Basic256",
   ## "Basic256Sha256", or "auto"
   # security_policy = "auto"
@@ -372,6 +365,12 @@ to use them.
   #  # additional_valid_status_codes = ["0xC0"]
   #  ## Use unregistered reads instead of registered reads
   #  # use_unregistered_reads = false
+  #  ## Maximum number of monitored items registered per request when setting up the
+  #  ## subscription. With a large number of nodes the registration request can exceed
+  #  ## the server's maximum message size and cause the subscription to fail (e.g.
+  #  ## "BadTcpMessageTooLarge"). Splitting the registration into smaller batches avoids
+  #  ## this. 0 (the default) registers all items in a single request.
+  #  # monitored_items_batch_size = 0
 ```
 
 ### Node Configuration

--- a/plugins/inputs/opcua_listener/README.md
+++ b/plugins/inputs/opcua_listener/README.md
@@ -72,6 +72,13 @@ to use them.
   ## Therefore, always refer to the hardware/software documentation of your server to ensure the specified interval is supported.
   # subscription_interval = "100ms"
   #
+  ## Maximum number of monitored items registered per request when setting up
+  ## the subscription. With a large number of nodes the registration request can
+  ## exceed the server's maximum message size and cause the subscription to fail
+  ## (e.g. "BadTcpMessageTooLarge"). Splitting the registration into smaller
+  ## batches avoids this. 0 (the default) registers all items in a single request.
+  # monitored_items_batch_size = 0
+  #
   ## Security policy, one of "None", "Basic128Rsa15", "Basic256",
   ## "Basic256Sha256", or "auto"
   # security_policy = "auto"

--- a/plugins/inputs/opcua_listener/opcua_listener.go
+++ b/plugins/inputs/opcua_listener/opcua_listener.go
@@ -36,6 +36,9 @@ func (o *OpcUaListener) Init() (err error) {
 	default:
 		return fmt.Errorf("unknown setting %q for 'connect_fail_behavior'", o.ConnectFailBehavior)
 	}
+	if o.MonitoredItemsBatchSize < 0 {
+		return fmt.Errorf("'monitored_items_batch_size' must not be negative, got %d", o.MonitoredItemsBatchSize)
+	}
 	o.client, err = o.subscribeClientConfig.createSubscribeClient(o.Log)
 	return err
 }

--- a/plugins/inputs/opcua_listener/opcua_listener.go
+++ b/plugins/inputs/opcua_listener/opcua_listener.go
@@ -36,8 +36,8 @@ func (o *OpcUaListener) Init() (err error) {
 	default:
 		return fmt.Errorf("unknown setting %q for 'connect_fail_behavior'", o.ConnectFailBehavior)
 	}
-	if o.MonitoredItemsBatchSize < 0 {
-		return fmt.Errorf("'monitored_items_batch_size' must not be negative, got %d", o.MonitoredItemsBatchSize)
+	if o.Workarounds.MonitoredItemsBatchSize < 0 {
+		return fmt.Errorf("'monitored_items_batch_size' must not be negative, got %d", o.Workarounds.MonitoredItemsBatchSize)
 	}
 	o.client, err = o.subscribeClientConfig.createSubscribeClient(o.Log)
 	return err

--- a/plugins/inputs/opcua_listener/opcua_listener_test.go
+++ b/plugins/inputs/opcua_listener/opcua_listener_test.go
@@ -73,13 +73,13 @@ func TestInitPluginWithNegativeBatchSize(t *testing.T) {
 					SecurityMode:   "None",
 					ConnectTimeout: config.Duration(5 * time.Second),
 					RequestTimeout: config.Duration(10 * time.Second),
+					Workarounds:    opcua.OpcUAWorkarounds{MonitoredItemsBatchSize: -1},
 				},
 				MetricName: "opcua",
 				Timestamp:  input.TimestampSourceTelegraf,
 				RootNodes:  make([]input.NodeSettings, 0),
 			},
-			SubscriptionInterval:    config.Duration(100 * time.Millisecond),
-			MonitoredItemsBatchSize: -1,
+			SubscriptionInterval: config.Duration(100 * time.Millisecond),
 		},
 		Log: testutil.Logger{},
 	}
@@ -492,7 +492,6 @@ func TestMonitoredItemsBatchSizeIntegration(t *testing.T) {
 	}
 
 	subscribeConfig := subscribeClientConfig{
-		MonitoredItemsBatchSize: 2,
 		InputClientConfig: input.InputClientConfig{
 			OpcUAClientConfig: opcua.OpcUAClientConfig{
 				Endpoint:       fmt.Sprintf("opc.tcp://%s:%s", container.Address, container.Ports[servicePort]),
@@ -501,6 +500,7 @@ func TestMonitoredItemsBatchSizeIntegration(t *testing.T) {
 				AuthMethod:     "Anonymous",
 				ConnectTimeout: config.Duration(10 * time.Second),
 				RequestTimeout: config.Duration(1 * time.Second),
+				Workarounds:    opcua.OpcUAWorkarounds{MonitoredItemsBatchSize: 2},
 			},
 			MetricName: "testing",
 			RootNodes:  nodes,
@@ -550,7 +550,6 @@ connect_timeout = "10s"
 request_timeout = "5s"
 subscription_interval = "200ms"
 connect_fail_behavior = "error"
-monitored_items_batch_size = 500
 security_policy = "auto"
 security_mode = "auto"
 certificate = "/etc/telegraf/cert.pem"
@@ -589,6 +588,7 @@ default_tags = {tag1="val1", tag2="val2"}
 
 [inputs.opcua_listener.workarounds]
 additional_valid_status_codes = ["0xC0"]
+monitored_items_batch_size = 500
 `
 
 	c := config.NewConfig()
@@ -606,7 +606,6 @@ additional_valid_status_codes = ["0xC0"]
 	require.Equal(t, config.Duration(5*time.Second), o.subscribeClientConfig.RequestTimeout)
 	require.Equal(t, config.Duration(200*time.Millisecond), o.subscribeClientConfig.SubscriptionInterval)
 	require.Equal(t, "error", o.subscribeClientConfig.ConnectFailBehavior)
-	require.Equal(t, 500, o.subscribeClientConfig.MonitoredItemsBatchSize)
 	require.Equal(t, "auto", o.subscribeClientConfig.SecurityPolicy)
 	require.Equal(t, "auto", o.subscribeClientConfig.SecurityMode)
 	require.Equal(t, "/etc/telegraf/cert.pem", o.subscribeClientConfig.Certificate)
@@ -652,7 +651,7 @@ additional_valid_status_codes = ["0xC0"]
 			}},
 		},
 	}, o.subscribeClientConfig.Groups)
-	require.Equal(t, opcua.OpcUAWorkarounds{AdditionalValidStatusCodes: []string{"0xC0"}}, o.subscribeClientConfig.Workarounds)
+	require.Equal(t, opcua.OpcUAWorkarounds{AdditionalValidStatusCodes: []string{"0xC0"}, MonitoredItemsBatchSize: 500}, o.subscribeClientConfig.Workarounds)
 	require.Equal(t, []string{"DataType"}, o.subscribeClientConfig.OptionalFields)
 }
 

--- a/plugins/inputs/opcua_listener/opcua_listener_test.go
+++ b/plugins/inputs/opcua_listener/opcua_listener_test.go
@@ -63,6 +63,29 @@ func TestInitPluginWithBadConnectFailBehaviorValue(t *testing.T) {
 	require.ErrorContains(t, err, "unknown setting \"notanoption\" for 'connect_fail_behavior'")
 }
 
+func TestInitPluginWithNegativeBatchSize(t *testing.T) {
+	plugin := OpcUaListener{
+		subscribeClientConfig: subscribeClientConfig{
+			InputClientConfig: input.InputClientConfig{
+				OpcUAClientConfig: opcua.OpcUAClientConfig{
+					Endpoint:       "opc.tcp://notarealserver:4840",
+					SecurityPolicy: "None",
+					SecurityMode:   "None",
+					ConnectTimeout: config.Duration(5 * time.Second),
+					RequestTimeout: config.Duration(10 * time.Second),
+				},
+				MetricName: "opcua",
+				Timestamp:  input.TimestampSourceTelegraf,
+				RootNodes:  make([]input.NodeSettings, 0),
+			},
+			SubscriptionInterval:    config.Duration(100 * time.Millisecond),
+			MonitoredItemsBatchSize: -1,
+		},
+		Log: testutil.Logger{},
+	}
+	require.ErrorContains(t, plugin.Init(), "'monitored_items_batch_size' must not be negative")
+}
+
 func TestStartPlugin(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
@@ -440,6 +463,84 @@ func TestSkipFailedMonitoredItemsIntegration(t *testing.T) {
 	}
 }
 
+func TestMonitoredItemsBatchSizeIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	container := testutil.Container{
+		Image:        "open62541/open62541",
+		ExposedPorts: []string{servicePort},
+		WaitingFor: wait.ForAll(
+			wait.ForListeningPort(servicePort),
+			wait.ForLog("TCP network layer listening on opc.tcp://"),
+		),
+	}
+	require.NoError(t, container.Start(), "failed to start container")
+	defer container.Terminate()
+
+	// Register more monitored items than the batch size so the registration is
+	// split across multiple CreateMonitoredItems requests. All items must still
+	// be monitored and their results mapped back to the correct field. Each item
+	// points at the continuously updating server CurrentTime node (i=2258) so
+	// every monitored item reliably emits an initial notification.
+	nodes := []input.NodeSettings{
+		{FieldName: "time1", Namespace: "0", IdentifierType: "i", Identifier: "2258"},
+		{FieldName: "time2", Namespace: "0", IdentifierType: "i", Identifier: "2258"},
+		{FieldName: "time3", Namespace: "0", IdentifierType: "i", Identifier: "2258"},
+		{FieldName: "time4", Namespace: "0", IdentifierType: "i", Identifier: "2258"},
+	}
+
+	subscribeConfig := subscribeClientConfig{
+		MonitoredItemsBatchSize: 2,
+		InputClientConfig: input.InputClientConfig{
+			OpcUAClientConfig: opcua.OpcUAClientConfig{
+				Endpoint:       fmt.Sprintf("opc.tcp://%s:%s", container.Address, container.Ports[servicePort]),
+				SecurityPolicy: "None",
+				SecurityMode:   "None",
+				AuthMethod:     "Anonymous",
+				ConnectTimeout: config.Duration(10 * time.Second),
+				RequestTimeout: config.Duration(1 * time.Second),
+			},
+			MetricName: "testing",
+			RootNodes:  nodes,
+		},
+	}
+
+	o, err := subscribeConfig.createSubscribeClient(testutil.Logger{})
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		return o.SetupOptions() == nil
+	}, 5*time.Second, 10*time.Millisecond)
+
+	require.NoError(t, o.connect())
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+	res, err := o.startMonitoring(ctx)
+	require.NoError(t, err)
+
+	expected := make(map[string]bool, len(nodes))
+	for _, node := range nodes {
+		expected[node.FieldName] = true
+	}
+
+	received := make(map[string]bool, len(nodes))
+	for len(received) < len(expected) {
+		select {
+		case m := <-res:
+			for field := range m.Fields() {
+				if expected[field] {
+					received[field] = true
+				}
+			}
+		case <-ctx.Done():
+			t.Fatalf("Timed out waiting for metrics, only received %v", received)
+		}
+	}
+}
+
 func TestSubscribeClientConfig(t *testing.T) {
 	toml := `
 [[inputs.opcua_listener]]
@@ -449,6 +550,7 @@ connect_timeout = "10s"
 request_timeout = "5s"
 subscription_interval = "200ms"
 connect_fail_behavior = "error"
+monitored_items_batch_size = 500
 security_policy = "auto"
 security_mode = "auto"
 certificate = "/etc/telegraf/cert.pem"
@@ -504,6 +606,7 @@ additional_valid_status_codes = ["0xC0"]
 	require.Equal(t, config.Duration(5*time.Second), o.subscribeClientConfig.RequestTimeout)
 	require.Equal(t, config.Duration(200*time.Millisecond), o.subscribeClientConfig.SubscriptionInterval)
 	require.Equal(t, "error", o.subscribeClientConfig.ConnectFailBehavior)
+	require.Equal(t, 500, o.subscribeClientConfig.MonitoredItemsBatchSize)
 	require.Equal(t, "auto", o.subscribeClientConfig.SecurityPolicy)
 	require.Equal(t, "auto", o.subscribeClientConfig.SecurityMode)
 	require.Equal(t, "/etc/telegraf/cert.pem", o.subscribeClientConfig.Certificate)

--- a/plugins/inputs/opcua_listener/sample.conf
+++ b/plugins/inputs/opcua_listener/sample.conf
@@ -30,6 +30,13 @@
   ## Therefore, always refer to the hardware/software documentation of your server to ensure the specified interval is supported.
   # subscription_interval = "100ms"
   #
+  ## Maximum number of monitored items registered per request when setting up
+  ## the subscription. With a large number of nodes the registration request can
+  ## exceed the server's maximum message size and cause the subscription to fail
+  ## (e.g. "BadTcpMessageTooLarge"). Splitting the registration into smaller
+  ## batches avoids this. 0 (the default) registers all items in a single request.
+  # monitored_items_batch_size = 0
+  #
   ## Security policy, one of "None", "Basic128Rsa15", "Basic256",
   ## "Basic256Sha256", or "auto"
   # security_policy = "auto"

--- a/plugins/inputs/opcua_listener/sample.conf
+++ b/plugins/inputs/opcua_listener/sample.conf
@@ -30,13 +30,6 @@
   ## Therefore, always refer to the hardware/software documentation of your server to ensure the specified interval is supported.
   # subscription_interval = "100ms"
   #
-  ## Maximum number of monitored items registered per request when setting up
-  ## the subscription. With a large number of nodes the registration request can
-  ## exceed the server's maximum message size and cause the subscription to fail
-  ## (e.g. "BadTcpMessageTooLarge"). Splitting the registration into smaller
-  ## batches avoids this. 0 (the default) registers all items in a single request.
-  # monitored_items_batch_size = 0
-  #
   ## Security policy, one of "None", "Basic128Rsa15", "Basic256",
   ## "Basic256Sha256", or "auto"
   # security_policy = "auto"
@@ -330,3 +323,9 @@
   #  # additional_valid_status_codes = ["0xC0"]
   #  ## Use unregistered reads instead of registered reads
   #  # use_unregistered_reads = false
+  #  ## Maximum number of monitored items registered per request when setting up the
+  #  ## subscription. With a large number of nodes the registration request can exceed
+  #  ## the server's maximum message size and cause the subscription to fail (e.g.
+  #  ## "BadTcpMessageTooLarge"). Splitting the registration into smaller batches avoids
+  #  ## this. 0 (the default) registers all items in a single request.
+  #  # monitored_items_batch_size = 0

--- a/plugins/inputs/opcua_listener/subscribe_client.go
+++ b/plugins/inputs/opcua_listener/subscribe_client.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"slices"
 	"time"
 
 	"github.com/gopcua/opcua"
@@ -223,16 +224,19 @@ func (o *subscribeClient) stop(ctx context.Context) <-chan struct{} {
 // results are concatenated in the original order so the caller's index-to-node
 // mapping stays valid.
 func (o *subscribeClient) monitor(ctx context.Context, reqs []*ua.MonitoredItemCreateRequest) ([]*ua.MonitoredItemCreateResult, error) {
-	batchSize := o.Config.MonitoredItemsBatchSize
-	if batchSize <= 0 || batchSize >= len(reqs) {
-		batchSize = len(reqs)
+	// Build the batches first: a single batch holds everything when batching is
+	// disabled, otherwise split into chunks of the configured size.
+	var batches [][]*ua.MonitoredItemCreateRequest
+	if o.Config.MonitoredItemsBatchSize <= 0 {
+		batches = [][]*ua.MonitoredItemCreateRequest{reqs}
+	} else {
+		for chunk := range slices.Chunk(reqs, o.Config.MonitoredItemsBatchSize) {
+			batches = append(batches, chunk)
+		}
 	}
 
 	results := make([]*ua.MonitoredItemCreateResult, 0, len(reqs))
-	for start := 0; start < len(reqs); start += batchSize {
-		end := min(start+batchSize, len(reqs))
-		batch := reqs[start:end]
-
+	for _, batch := range batches {
 		resp, err := o.sub.Monitor(ctx, ua.TimestampsToReturnBoth, batch...)
 		if err != nil {
 			return nil, err

--- a/plugins/inputs/opcua_listener/subscribe_client.go
+++ b/plugins/inputs/opcua_listener/subscribe_client.go
@@ -19,9 +19,8 @@ import (
 
 type subscribeClientConfig struct {
 	input.InputClientConfig
-	SubscriptionInterval    config.Duration `toml:"subscription_interval"`
-	ConnectFailBehavior     string          `toml:"connect_fail_behavior"`
-	MonitoredItemsBatchSize int             `toml:"monitored_items_batch_size"`
+	SubscriptionInterval config.Duration `toml:"subscription_interval"`
+	ConnectFailBehavior  string          `toml:"connect_fail_behavior"`
 }
 
 type subscribeClient struct {
@@ -226,11 +225,12 @@ func (o *subscribeClient) stop(ctx context.Context) <-chan struct{} {
 func (o *subscribeClient) monitor(ctx context.Context, reqs []*ua.MonitoredItemCreateRequest) ([]*ua.MonitoredItemCreateResult, error) {
 	// Build the batches first: a single batch holds everything when batching is
 	// disabled, otherwise split into chunks of the configured size.
+	batchSize := o.Config.Workarounds.MonitoredItemsBatchSize
 	var batches [][]*ua.MonitoredItemCreateRequest
-	if o.Config.MonitoredItemsBatchSize <= 0 {
+	if batchSize <= 0 {
 		batches = [][]*ua.MonitoredItemCreateRequest{reqs}
 	} else {
-		for chunk := range slices.Chunk(reqs, o.Config.MonitoredItemsBatchSize) {
+		for chunk := range slices.Chunk(reqs, batchSize) {
 			batches = append(batches, chunk)
 		}
 	}

--- a/plugins/inputs/opcua_listener/subscribe_client.go
+++ b/plugins/inputs/opcua_listener/subscribe_client.go
@@ -18,8 +18,9 @@ import (
 
 type subscribeClientConfig struct {
 	input.InputClientConfig
-	SubscriptionInterval config.Duration `toml:"subscription_interval"`
-	ConnectFailBehavior  string          `toml:"connect_fail_behavior"`
+	SubscriptionInterval    config.Duration `toml:"subscription_interval"`
+	ConnectFailBehavior     string          `toml:"connect_fail_behavior"`
+	MonitoredItemsBatchSize int             `toml:"monitored_items_batch_size"`
 }
 
 type subscribeClient struct {
@@ -214,6 +215,37 @@ func (o *subscribeClient) stop(ctx context.Context) <-chan struct{} {
 	return closing
 }
 
+// monitor registers the given monitored-item requests on the subscription.
+// Servers reject a CreateMonitoredItems request whose encoded size exceeds
+// their negotiated maximum message size, which surfaces as a connection drop
+// (BadTcpMessageTooLarge) for large node counts. When monitored_items_batch_size
+// is set, the requests are split into batches of that size and the per-request
+// results are concatenated in the original order so the caller's index-to-node
+// mapping stays valid.
+func (o *subscribeClient) monitor(ctx context.Context, reqs []*ua.MonitoredItemCreateRequest) ([]*ua.MonitoredItemCreateResult, error) {
+	batchSize := o.Config.MonitoredItemsBatchSize
+	if batchSize <= 0 || batchSize >= len(reqs) {
+		batchSize = len(reqs)
+	}
+
+	results := make([]*ua.MonitoredItemCreateResult, 0, len(reqs))
+	for start := 0; start < len(reqs); start += batchSize {
+		end := min(start+batchSize, len(reqs))
+		batch := reqs[start:end]
+
+		resp, err := o.sub.Monitor(ctx, ua.TimestampsToReturnBoth, batch...)
+		if err != nil {
+			return nil, err
+		}
+		if len(resp.Results) != len(batch) {
+			return nil, fmt.Errorf("server returned %d results for %d requested items", len(resp.Results), len(batch))
+		}
+		results = append(results, resp.Results...)
+	}
+
+	return results, nil
+}
+
 func (o *subscribeClient) startMonitoring(ctx context.Context) (<-chan telegraf.Metric, error) {
 	err := o.connect()
 	if err != nil {
@@ -230,13 +262,13 @@ func (o *subscribeClient) startMonitoring(ctx context.Context) (<-chan telegraf.
 
 	var skippedItems int
 	if len(o.monitoredItemsReqs) != 0 {
-		resp, err := o.sub.Monitor(ctx, ua.TimestampsToReturnBoth, o.monitoredItemsReqs...)
+		results, err := o.monitor(ctx, o.monitoredItemsReqs)
 		if err != nil {
 			return nil, fmt.Errorf("failed to start monitoring items: %w", err)
 		}
 		o.Log.Debug("Monitoring items")
 
-		for idx, res := range resp.Results {
+		for idx, res := range results {
 			if o.StatusCodeOK(res.StatusCode) {
 				continue
 			}
@@ -251,13 +283,13 @@ func (o *subscribeClient) startMonitoring(ctx context.Context) (<-chan telegraf.
 	}
 
 	if len(o.eventItemsReqs) != 0 {
-		resp, err := o.sub.Monitor(ctx, ua.TimestampsToReturnBoth, o.eventItemsReqs...)
+		results, err := o.monitor(ctx, o.eventItemsReqs)
 		if err != nil {
 			return nil, fmt.Errorf("failed to start monitoring event stream: %w", err)
 		}
 		o.Log.Debug("Monitoring events")
 
-		for idx, res := range resp.Results {
+		for idx, res := range results {
 			if o.StatusCodeOK(res.StatusCode) {
 				continue
 			}


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
  The OPC UA listener registers every monitored item in a single `CreateMonitoredItems` request. With many nodes the encoded request exceeds the server's negotiated maximum message size, so the server drops the connection
  (`BadTcpMessageTooLarge`), surfacing as:

E! [telegraf] Error running agent: starting input inputs.opcua_listener: failed to start monitoring items: EOF
  
  This happens at roughly ~1150 nodes on plaintext, lower (~900) with `SignAndEncrypt` since signing/encryption padding inflates the request.
  
  This adds an optional `monitored_items_batch_size`. When set, monitored items are registered in batches of that size across multiple `CreateMonitoredItems` requests, with the per-request results concatenated in their original order so the existing index-to-node mapping and per-node status reporting stay valid. Both the data-item and event-item paths use the same batching.
  
  The limit is the server's negotiated message size, not a fixed node count, so there is no universal default. It defaults to `0`, which preserves the current single-request behavior exactly. Users hitting the failure can set a server-appropriate value (e.g. `500`).
  
  Note: batches are registered sequentially. If a later batch fails, items from earlier batches remain registered on the server until the connection is torn down. This matches the pre-existing teardown behavior for a failed startup and self-resolves when the failed `Start` exits the connection.

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #14568
