### PR TITLE
fix(inputs.docker_log): Restore following the log-stream and keep the state

### DIFF
--- a/plugins/common/docker/mock/logs.go
+++ b/plugins/common/docker/mock/logs.go
@@ -1,0 +1,59 @@
+package mock
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"fmt"
+	"net/http"
+	"testing"
+)
+
+type Logs struct {
+	Content     string
+	Multiplexed bool
+}
+
+func WriteLog(ctx context.Context, t *testing.T, w http.ResponseWriter, msgs <-chan *Logs) {
+	t.Helper()
+
+	// We need to flush all content to really transmit it over the wrie and
+	// avoid keeping things in the buffer
+	f := w.(interface{ Flush() })
+
+	// Write the header first so the client knows stuff succeeds
+	w.WriteHeader(http.StatusOK)
+	f.Flush()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case msg, ok := <-msgs:
+			if !ok {
+				return
+			}
+			logLine := []byte(msg.Content)
+			if _, err := w.Write(logLine); err != nil {
+				t.Logf("writing log line failed: %v", err)
+			}
+			f.Flush()
+			continue
+		}
+	}
+}
+
+func (l *Logs) multiplex() ([]byte, error) {
+	// Emulate a multiplexed writer
+	var buf bytes.Buffer
+	header := [8]byte{0: 1}
+	binary.BigEndian.PutUint32(header[4:], uint32(len(l.Content)))
+	if _, err := buf.Write(header[:]); err != nil {
+		return nil, fmt.Errorf("writing log multiplex header failed: %w", err)
+	}
+	if _, err := buf.WriteString(l.Content); err != nil {
+		return nil, fmt.Errorf("writing log multiplex content failed: %w", err)
+	}
+
+	return buf.Bytes(), nil
+}

--- a/plugins/common/docker/mock/logs.go
+++ b/plugins/common/docker/mock/logs.go
@@ -33,7 +33,17 @@ func WriteLog(ctx context.Context, t *testing.T, w http.ResponseWriter, msgs <-c
 			if !ok {
 				return
 			}
-			logLine := []byte(msg.Content)
+			var logLine []byte
+			if msg.Multiplexed {
+				buf, err := msg.multiplex()
+				if err != nil {
+					t.Logf("multiplexing failed: %v", err)
+					continue
+				}
+				logLine = buf
+			} else {
+				logLine = []byte(msg.Content)
+			}
 			if _, err := w.Write(logLine); err != nil {
 				t.Logf("writing log line failed: %v", err)
 			}

--- a/plugins/common/docker/mock/logs.go
+++ b/plugins/common/docker/mock/logs.go
@@ -17,7 +17,7 @@ type Logs struct {
 func WriteLog(ctx context.Context, t *testing.T, w http.ResponseWriter, msgs <-chan *Logs) {
 	t.Helper()
 
-	// We need to flush all content to really transmit it over the wrie and
+	// We need to flush all content to really transmit it over the wire and
 	// avoid keeping things in the buffer
 	f := w.(interface{ Flush() })
 

--- a/plugins/common/docker/mock/server.go
+++ b/plugins/common/docker/mock/server.go
@@ -1,8 +1,7 @@
 package mock
 
 import (
-	"bytes"
-	"encoding/binary"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -19,19 +18,15 @@ import (
 	"github.com/moby/moby/client"
 )
 
-type Logs struct {
-	Content     string
-	Multiplexed bool
-}
-
 type Server struct {
-	Info     system.Info
-	List     []container.Summary
-	Disks    system.DiskUsage
-	RawDisks []byte // Raw response as the disks response format depends on the API version
-	Inspect  map[string]container.InspectResponse
-	Stats    map[string]container.StatsResponse
-	Logs     map[string]Logs
+	Info       system.Info
+	List       []container.Summary
+	Disks      system.DiskUsage
+	RawDisks   []byte // Raw response as the disks response format depends on the API version
+	Inspect    map[string]container.InspectResponse
+	Stats      map[string]container.StatsResponse
+	Logs       map[string]Logs
+	LogStreans map[string]chan *Logs
 
 	Services []swarm.Service
 	Tasks    []swarm.Task
@@ -42,6 +37,7 @@ type Server struct {
 	ListParams map[string]string
 
 	server *httptest.Server
+	cancel context.CancelFunc
 }
 
 func NewServerFromFiles(path string) (*Server, error) {
@@ -162,6 +158,9 @@ func (s *Server) Start(t *testing.T) string {
 		s.APIVersion = "1.54"
 	}
 
+	ctx, cancel := context.WithCancel(t.Context())
+	s.cancel = cancel
+
 	s.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if agent := r.Header.Get("User-Agent"); agent != "engine-api-cli-1.0" {
 			w.WriteHeader(http.StatusInternalServerError)
@@ -230,8 +229,15 @@ func (s *Server) Start(t *testing.T) string {
 			}
 		case strings.HasPrefix(r.URL.Path, "/v"+s.APIVersion+"/containers/") &&
 			len(parts) == 5 && strings.HasSuffix(r.URL.Path, "/logs"):
-			// Logs response
 			id := parts[3]
+			// Log stream response
+			stream, found := s.LogStreans[id]
+			if found {
+				WriteLog(ctx, t, w, stream)
+				return
+			}
+
+			// Logs response
 			data, found := s.Logs[id]
 			if !found {
 				w.WriteHeader(http.StatusNotFound)
@@ -239,21 +245,13 @@ func (s *Server) Start(t *testing.T) string {
 				return
 			}
 			if data.Multiplexed {
-				// Emulate a multiplexed writer
-				var buf bytes.Buffer
-				header := [8]byte{0: 1}
-				binary.BigEndian.PutUint32(header[4:], uint32(len(data.Content)))
-				if _, err := buf.Write(header[:]); err != nil {
+				r, err := data.multiplex()
+				if err != nil {
 					w.WriteHeader(http.StatusInternalServerError)
-					t.Errorf("writing log multiplex header failed: %v", err)
+					t.Errorf("multiplexing failed: %v", err)
 					return
 				}
-				if _, err := buf.WriteString(data.Content); err != nil {
-					w.WriteHeader(http.StatusInternalServerError)
-					t.Errorf("writing log multiplex content failed: %v", err)
-					return
-				}
-				response = buf.Bytes()
+				response = r
 			} else {
 				response = []byte(data.Content)
 			}
@@ -332,6 +330,9 @@ func (s *Server) Start(t *testing.T) string {
 }
 
 func (s *Server) Close() {
+	if s.cancel != nil {
+		s.cancel()
+	}
 	if s.server != nil {
 		s.server.Close()
 	}

--- a/plugins/common/docker/mock/server.go
+++ b/plugins/common/docker/mock/server.go
@@ -26,7 +26,7 @@ type Server struct {
 	Inspect    map[string]container.InspectResponse
 	Stats      map[string]container.StatsResponse
 	Logs       map[string]Logs
-	LogStreans map[string]chan *Logs
+	LogStreams map[string]chan *Logs
 
 	Services []swarm.Service
 	Tasks    []swarm.Task
@@ -231,7 +231,7 @@ func (s *Server) Start(t *testing.T) string {
 			len(parts) == 5 && strings.HasSuffix(r.URL.Path, "/logs"):
 			id := parts[3]
 			// Log stream response
-			stream, found := s.LogStreans[id]
+			stream, found := s.LogStreams[id]
 			if found {
 				WriteLog(ctx, t, w, stream)
 				return

--- a/plugins/inputs/docker_log/docker_log.go
+++ b/plugins/inputs/docker_log/docker_log.go
@@ -4,6 +4,7 @@ package docker_log
 import (
 	"context"
 	_ "embed"
+	"errors"
 	"fmt"
 	"net/http"
 	"sync"
@@ -209,7 +210,9 @@ func (d *DockerLogs) Gather(acc telegraf.Accumulator) error {
 			}()
 
 			if err := d.tailContainerLogs(ctx, acc, container, containerName); err != nil {
-				acc.AddError(err)
+				if !errors.Is(err, context.Canceled) {
+					acc.AddError(err)
+				}
 			}
 		}(cntnr)
 	}

--- a/plugins/inputs/docker_log/docker_log.go
+++ b/plugins/inputs/docker_log/docker_log.go
@@ -4,7 +4,6 @@ package docker_log
 import (
 	"context"
 	_ "embed"
-	"errors"
 	"fmt"
 	"net/http"
 	"sync"
@@ -210,9 +209,7 @@ func (d *DockerLogs) Gather(acc telegraf.Accumulator) error {
 			}()
 
 			if err := d.tailContainerLogs(ctx, acc, container, containerName); err != nil {
-				if !errors.Is(err, context.Canceled) {
-					acc.AddError(err)
-				}
+				acc.AddError(err)
 			}
 		}(cntnr)
 	}
@@ -265,7 +262,7 @@ func (d *DockerLogs) tailContainerLogs(
 		ShowStderr: true,
 		Timestamps: true,
 		Details:    false,
-		Follow:     false,
+		Follow:     true,
 	}
 
 	if !d.FromBeginning {

--- a/plugins/inputs/docker_log/docker_log_test.go
+++ b/plugins/inputs/docker_log/docker_log_test.go
@@ -239,3 +239,63 @@ func TestStatePersistence(t *testing.T) {
 	require.Contains(t, state, id)
 	require.Equal(t, ts.UTC(), state[id])
 }
+
+func TestStatePersistenceMux(t *testing.T) {
+	// Create a log stream mimicing the actual behavior of the server
+	logs := make(chan *mock.Logs, 10)
+
+	// Create server
+	id := "1234567890"
+	server := &mock.Server{
+		Inspect: map[string]container.InspectResponse{id: {Config: &container.Config{}}},
+		List: []container.Summary{{
+			ID:    id,
+			Names: []string{"/" + id},
+			Image: "influxdata/telegraf:1.11.0",
+			State: "running",
+		}},
+		LogStreans: map[string]chan *mock.Logs{id: logs},
+	}
+	addr := server.Start(t)
+	defer server.Close()
+
+	// Setup plugin
+	plugin := &DockerLogs{
+		Endpoint: addr,
+		Timeout:  config.Duration(time.Second * 5),
+	}
+	require.NoError(t, plugin.Init())
+	plugin.lastRecordMtx.Lock()
+	state := maps.Clone(plugin.lastRecord)
+	plugin.lastRecordMtx.Unlock()
+	require.Empty(t, state)
+
+	// Write a first log message
+	ts, err := time.Parse(time.RFC3339Nano, "2020-04-28T18:43:16.432691200Z")
+	require.NoError(t, err)
+	logs <- &mock.Logs{
+		Content:     ts.Format(time.RFC3339Nano) + " hello\n",
+		Multiplexed: true,
+	}
+
+	// Start the plugin and gather
+	var acc testutil.Accumulator
+	require.NoError(t, plugin.Start(&acc))
+	defer plugin.Stop()
+
+	require.NoError(t, plugin.Gather(&acc))
+	require.Eventually(t, func() bool {
+		return acc.NMetrics() > 0
+	}, 5*time.Second, 50*time.Millisecond)
+	require.Empty(t, acc.Errors)
+
+	// Gracefully stop the plugin and make sure the state was updated
+	plugin.Stop()
+
+	plugin.lastRecordMtx.Lock()
+	state = maps.Clone(plugin.lastRecord)
+	plugin.lastRecordMtx.Unlock()
+
+	require.Contains(t, state, id)
+	require.Equal(t, ts.UTC(), state[id])
+}

--- a/plugins/inputs/docker_log/docker_log_test.go
+++ b/plugins/inputs/docker_log/docker_log_test.go
@@ -197,7 +197,7 @@ func TestStatePersistence(t *testing.T) {
 			Image: "influxdata/telegraf:1.11.0",
 			State: "running",
 		}},
-		LogStreans: map[string]chan *mock.Logs{id: logs},
+		LogStreams: map[string]chan *mock.Logs{id: logs},
 	}
 	addr := server.Start(t)
 	defer server.Close()
@@ -254,7 +254,7 @@ func TestStatePersistenceMux(t *testing.T) {
 			Image: "influxdata/telegraf:1.11.0",
 			State: "running",
 		}},
-		LogStreans: map[string]chan *mock.Logs{id: logs},
+		LogStreams: map[string]chan *mock.Logs{id: logs},
 	}
 	addr := server.Start(t)
 	defer server.Close()

--- a/plugins/inputs/docker_log/docker_log_test.go
+++ b/plugins/inputs/docker_log/docker_log_test.go
@@ -2,6 +2,7 @@ package docker_log
 
 import (
 	"fmt"
+	"maps"
 	"testing"
 	"time"
 
@@ -180,4 +181,61 @@ func TestGatherConcurrentState(t *testing.T) {
 		return acc.NMetrics() >= uint64(count)
 	}, 5*time.Second, 50*time.Millisecond)
 	require.Empty(t, acc.Errors)
+}
+
+func TestStatePersistence(t *testing.T) {
+	// Create a log stream mimicing the actual behavior of the server
+	logs := make(chan *mock.Logs, 10)
+
+	// Create server
+	id := "1234567890"
+	server := &mock.Server{
+		Inspect: map[string]container.InspectResponse{id: {Config: &container.Config{Tty: true}}},
+		List: []container.Summary{{
+			ID:    id,
+			Names: []string{"/" + id},
+			Image: "influxdata/telegraf:1.11.0",
+			State: "running",
+		}},
+		LogStreans: map[string]chan *mock.Logs{id: logs},
+	}
+	addr := server.Start(t)
+	defer server.Close()
+
+	// Setup plugin
+	plugin := &DockerLogs{
+		Endpoint: addr,
+		Timeout:  config.Duration(time.Second * 5),
+	}
+	require.NoError(t, plugin.Init())
+	plugin.lastRecordMtx.Lock()
+	state := maps.Clone(plugin.lastRecord)
+	plugin.lastRecordMtx.Unlock()
+	require.Empty(t, state)
+
+	// Write a first log message
+	ts, err := time.Parse(time.RFC3339Nano, "2020-04-28T18:43:16.432691200Z")
+	require.NoError(t, err)
+	logs <- &mock.Logs{Content: ts.Format(time.RFC3339Nano) + " hello\n"}
+
+	// Start the plugin and gather
+	var acc testutil.Accumulator
+	require.NoError(t, plugin.Start(&acc))
+	defer plugin.Stop()
+
+	require.NoError(t, plugin.Gather(&acc))
+	require.Eventually(t, func() bool {
+		return acc.NMetrics() > 0
+	}, 5*time.Second, 50*time.Millisecond)
+	require.Empty(t, acc.Errors)
+
+	// Gracefully stop the plugin and make sure the state was updated
+	plugin.Stop()
+
+	plugin.lastRecordMtx.Lock()
+	state = maps.Clone(plugin.lastRecord)
+	plugin.lastRecordMtx.Unlock()
+
+	require.Contains(t, state, id)
+	require.Equal(t, ts.UTC(), state[id])
 }

--- a/plugins/inputs/docker_log/util.go
+++ b/plugins/inputs/docker_log/util.go
@@ -3,6 +3,8 @@ package docker_log
 import (
 	"bufio"
 	"bytes"
+	"context"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -35,7 +37,6 @@ func parseLine(line []byte) (time.Time, string, error) {
 	}
 
 	tsString := string(parts[0])
-
 	// Keep any leading space, but remove whitespace from end of line.
 	// This preserves space in, for example, stacktraces, while removing
 	// annoying end of line characters and is similar to how other logging
@@ -77,7 +78,6 @@ func tailStream(
 	var lastTS time.Time
 	for {
 		line, err := r.ReadBytes('\n')
-
 		if len(line) != 0 {
 			ts, message, err := parseLine(line)
 			if err != nil {
@@ -96,7 +96,7 @@ func tailStream(
 		}
 
 		if err != nil {
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) || errors.Is(err, context.Canceled) {
 				return lastTS, nil
 			}
 			return time.Time{}, err

--- a/plugins/inputs/docker_log/util.go
+++ b/plugins/inputs/docker_log/util.go
@@ -138,7 +138,7 @@ func tailMultiplexed(acc telegraf.Accumulator, tags map[string]string, container
 	_ = src.Close()
 	wg.Wait()
 
-	if err != nil {
+	if err != nil && !errors.Is(err, context.Canceled) {
 		return time.Time{}, err
 	}
 	if tsStdout.After(tsStderr) {


### PR DESCRIPTION
## Summary

Issue #18059  describes a bug where the state of the log-position is not persisted correctly when Telegraf is shut down. PR #18988 tracks the issue down to a wrong handling of context-canceling when "following" the logs.

In turn PR #18988 deactivates the follow mode but this causes a new issue because now we cannot make sure we are continuing at the correct position of the log stream. This is due to the fact that time based filtering (based on the `since` parameter as in PR #19002) is racy in cases where multiple log messages are emitted with the same timestamp and we collect only a part in one gather cycle (e.g. due to latency at the daemon side).

This PR reverts PR #18988 and re-enables the follow-mode while fixing the handling of context cancellation. To ensure the fix is correct, the PR provides a unit-test which requires extending the mock-server to allow streaming of log-lines.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

resolves #18059 
reverts #18988 
superseeds #19002 