### PR TITLE
chore(inputs.system): Restore previous 'legacy' metrics

### DIFF
--- a/plugins/inputs/system/README.md
+++ b/plugins/inputs/system/README.md
@@ -21,14 +21,14 @@ plugin ordering. See [CONFIGURATION.md][CONFIGURATION.md] for more details.
 # Read metrics about system load & uptime
 [[inputs.system]]
   ## Information to collect; available options are:
-  ##   cpus             - CPU counts of the system
-  ##   dmi              - BIOS, baseboard, chassis and product information from DMI/SMBIOS
-  ##   legacy_uptime    - legacy layout of system uptime; see README for details
-  ##   load             - 1, 5 and 15-minute load averages
-  ##   os               - operating system release and uname information
-  ##   uptime           - system uptime
-  ##   users            - logged-in user counts
-  # include = ["cpus", "legacy_uptime", "load", "users"]
+  ##   legacy - legacy layout of system metrics; see README for details
+  ##   cpus   - CPU counts of the system
+  ##   dmi    - BIOS, baseboard, chassis and product information from DMI/SMBIOS
+  ##   load   - 1, 5 and 15-minute load averages
+  ##   os     - operating system release and uname information
+  ##   uptime - system uptime
+  ##   users  - logged-in user counts
+  # include = ["legacy"]
 
   ## How long to cache the result of the "os" group between gathers.
   ## Set higher to reduce the number of os-release/uname reads, lower to
@@ -42,16 +42,20 @@ plugin ordering. See [CONFIGURATION.md][CONFIGURATION.md] for more details.
   # dmi_cache_ttl = "8h"
 ```
 
-> [!NOTE]
-> The `uptime` and `legacy_uptime` options are mutually exclusive.
+### `legacy` include vs. fine-grained options
 
-<!-- markdownlint-disable-next-line MD028 -->
+While `legacy` is the default `include` for compatibility reasons, it is _not_
+recommended as it creates three, sparse metrics, one containing the CPU, load
+and user information, one for the uptime and one for the formatted uptime.
+However, if you are using Prometheus as an output, it might be your preferred
+choice as the metrics are typed correctly.
 
-> [!IMPORTANT]
-> Switching from `legacy_uptime` to `uptime` changes the Prometheus metric
-> type of `system_uptime` from **counter** to **gauge**. If your dashboards
-> or alerts use `rate()` or `increase()` on `system_uptime`, update them
-> before migrating.
+If you are using the fine-grained options such as `cpus` you will get a _single_,
+untyped metric containing all selected information.
+
+Both `legacy` and the fine-grained options can be used at the same time
+resulting in four metrics in total (one for the fine-grained set and three for
+the `legacy` setting).
 
 ### Permissions
 
@@ -82,80 +86,99 @@ there. Results are cached between gathers, see `dmi_cache_ttl` above.
 ## Metrics
 
 The `include` option controls which measurements and fields are gathered.
-The `cpus`, `load`, `users` and `uptime` / `legacy_uptime` groups populate the
-`system` measurement, while the `os` group emits a separate `system_os`
-measurement.
+The fine-grained options like `cpus`, `load` or `users` populate the `system`
+metric, while the `legacy` setting emits three `system` metrics.
 
-### `system`
+### fine-grained options
 
-| Field             | Include option             | Type    | Description                                 |
-|-------------------|----------------------------|---------|---------------------------------------------|
-| `load1`           | `load`                     | float   | 1-minute load average                       |
-| `load5`           | `load`                     | float   | 5-minute load average                       |
-| `load15`          | `load`                     | float   | 15-minute load average                      |
-| `n_users`         | `users`                    | integer | Number of logged-in user sessions           |
-| `n_unique_users`  | `users`                    | integer | Number of unique logged-in usernames        |
-| `n_cpus`          | `cpus`                     | integer | Number of logical CPUs                      |
-| `n_physical_cpus` | `cpus`                     | integer | Number of physical CPUs                     |
-| `uptime`          | `uptime`                   | integer | System uptime in seconds (gauge field)      |
-| `uptime`          | `legacy_uptime`            | integer | System uptime in seconds (separate counter) |
-| `uptime_format`   | `legacy_uptime`            | string  | Human-readable uptime (deprecated)          |
+When `os` is included, the values reflect operating system release information
+together with `uname`-style kernel data. Fields are reported as strings. The
+`os` and `arch` fields are always populated; the `platform`, `platform_family`,
+`platform_version` and `kernel_version` fields may be empty on unsupported
+platforms.
 
-### `system_os`
+When `dmi` is included fields may be empty if the field is not exposed by the
+system, or `unknown` when it is restricted by the kernel (typical for serial
+numbers, asset tags and the product UUID on Linux without root).
 
-Emitted only when `os` is included. The values reflect operating system
-release information together with `uname`-style kernel data. Fields are
-reported as strings. The `os` and `arch` fields are always populated; the
-`platform`, `platform_family`, `platform_version` and `kernel_version` fields
-may be empty on platforms where gopsutil cannot determine them.
+#### `system`
 
-| Field              | Type   | Description                                                          |
-|--------------------|--------|----------------------------------------------------------------------|
-| `os`               | string | Operating system family as reported by Go's runtime (e.g. `linux`)   |
-| `arch`             | string | Architecture as returned by `uname -m` (e.g. `x86_64`)               |
-| `platform`         | string | OS distribution / platform identifier (e.g. `ubuntu`, `centos`)      |
-| `platform_family`  | string | Platform family (e.g. `debian`, `rhel`)                              |
-| `platform_version` | string | Platform / distribution version (e.g. `26.04`)                       |
-| `kernel_version`   | string | Kernel release as returned by `uname -r` (e.g. `7.0.0-7-generic`)    |
+| Field               | Include option | Type    | Description                                    |
+|---------------------|----------------|---------|------------------------------------------------|
+| `n_cpus`            | `cpus`         | integer | Number of logical CPUs                         |
+| `n_physical_cpus`   | `cpus`         | integer | Number of physical CPUs                        |
+| `bios_vendor`       | `dmi`          | string  | BIOS vendor (e.g. `Dell Inc.`)                 |
+| `bios_version`      | `dmi`          | string  | BIOS version (e.g. `2.18.0`)                   |
+| `bios_date`         | `dmi`          | string  | BIOS release date (e.g. `04/12/2024`)          |
+| `board_vendor`      | `dmi`          | string  | Baseboard / motherboard vendor                 |
+| `board_product`     | `dmi`          | string  | Baseboard product name (e.g. `0X3D66`)         |
+| `board_version`     | `dmi`          | string  | Baseboard version                              |
+| `board_serial`      | `dmi`          | string  | Baseboard serial number (restricted)           |
+| `board_asset_tag`   | `dmi`          | string  | Baseboard asset tag (restricted)               |
+| `chassis_vendor`    | `dmi`          | string  | Chassis vendor                                 |
+| `chassis_type_code` | `dmi`          | string  | Chassis type code as defined by SMBIOS DSP0134 |
+| `chassis_type`      | `dmi`          | string  | Human-readable chassis type description        |
+| `chassis_version`   | `dmi`          | string  | Chassis version                                |
+| `chassis_serial`    | `dmi`          | string  | Chassis serial number (restricted)             |
+| `chassis_asset_tag` | `dmi`          | string  | Chassis asset tag (restricted)                 |
+| `product_vendor`    | `dmi`          | string  | System product vendor (e.g. `Dell Inc.`)       |
+| `product_name`      | `dmi`          | string  | System product name (e.g. `PowerEdge R750`)    |
+| `product_family`    | `dmi`          | string  | System product family                          |
+| `product_version`   | `dmi`          | string  | System product version                         |
+| `product_serial`    | `dmi`          | string  | System product serial number (restricted)      |
+| `product_sku`       | `dmi`          | string  | System product SKU                             |
+| `product_uuid`      | `dmi`          | string  | System product UUID (restricted)               |
+| `load1`             | `load`         | float   | 1-minute load average                          |
+| `load5`             | `load`         | float   | 5-minute load average                          |
+| `load15`            | `load`         | float   | 15-minute load average                         |
+| `os`                | `os`           | string  | OS family                                      |
+| `arch`              | `os`           | string  | Architecture                                   |
+| `platform`          | `os`           | string  | OS distribution / platform identifier          |
+| `platform_family`   | `os`           | string  | Platform family (e.g. `debian`, `rhel`)        |
+| `platform_version`  | `os`           | string  | Platform / distribution version                |
+| `kernel_version`    | `os`           | string  | Kernel release as returned by `uname -r`       |
+| `uptime`            | `uptime`       | integer | System uptime in seconds                       |
+| `n_users`           | `users`        | integer | Number of logged-in user sessions              |
+| `n_unique_users`    | `users`        | integer | Number of unique logged-in usernames           |
 
-### `system_dmi`
+The resulting metric is untyped.
 
-Emitted only when `dmi` is included. All fields are reported as strings
-with the values returned by the underlying source: an empty string when
-the field is not exposed by the system, or `unknown` when it is restricted
-by the kernel (typical for serial numbers, asset tags and the product
-UUID on Linux without root).
+### legacy setting
 
-| Field                      | Type   | Description                                                          |
-|----------------------------|--------|----------------------------------------------------------------------|
-| `bios_vendor`              | string | BIOS vendor (e.g. `Dell Inc.`)                                       |
-| `bios_version`             | string | BIOS version (e.g. `2.18.0`)                                         |
-| `bios_date`                | string | BIOS release date (e.g. `04/12/2024`)                                |
-| `board_vendor`             | string | Baseboard / motherboard vendor                                       |
-| `board_product`            | string | Baseboard product name (e.g. `0X3D66`)                               |
-| `board_version`            | string | Baseboard version                                                    |
-| `board_serial`             | string | Baseboard serial number (kernel-restricted on Linux)                 |
-| `board_asset_tag`          | string | Baseboard asset tag (kernel-restricted on Linux)                     |
-| `chassis_vendor`           | string | Chassis vendor                                                       |
-| `chassis_type`             | string | Chassis type code as defined by SMBIOS DSP0134 (e.g. `3`, `10`)      |
-| `chassis_type_description` | string | Human-readable chassis type description (e.g. `Desktop`, `Notebook`) |
-| `chassis_version`          | string | Chassis version                                                      |
-| `chassis_serial`           | string | Chassis serial number (kernel-restricted on Linux)                   |
-| `chassis_asset_tag`        | string | Chassis asset tag (kernel-restricted on Linux)                       |
-| `product_vendor`           | string | System product vendor (e.g. `Dell Inc.`)                             |
-| `product_name`             | string | System product name (e.g. `PowerEdge R750`)                          |
-| `product_family`           | string | System product family                                                |
-| `product_version`          | string | System product version                                               |
-| `product_serial`           | string | System product serial number (kernel-restricted on Linux)            |
-| `product_sku`              | string | System product SKU                                                   |
-| `product_uuid`             | string | System product UUID (kernel-restricted on Linux)                     |
+The following three metrics are emitted if `include` contains the `legacy`
+setting.
+
+#### `system` (gauge)
+
+| Field             | Type    | Description                                    |
+|-------------------|---------|------------------------------------------------|
+| `load1`           | float   | 1-minute load average                          |
+| `load5`           | float   | 5-minute load average                          |
+| `load15`          | float   | 15-minute load average                         |
+| `n_users`         | integer | Number of logged-in user sessions              |
+| `n_unique_users`  | integer | Number of unique logged-in usernames           |
+| `n_cpus`          | integer | Number of logical CPUs                         |
+| `n_physical_cpus` | integer | Number of physical CPUs                        |
+| `uptime`          | integer | System uptime in seconds                       |
+
+#### `system` (counter)
+
+| Field             | Type    | Description                                    |
+|-------------------|---------|------------------------------------------------|
+| `uptime`          | integer | System uptime in seconds                       |
+
+#### `system` (untyped)
+
+| Field             | Type    | Description                                    |
+|-------------------|---------|------------------------------------------------|
+| `uptime_format`   | string  | Human-readable uptime                          |
 
 ## Example Output
 
 ### Default configuration
 
-With the default `include = ["cpus", "legacy_uptime", "load", "users"]`,
-the output is backward-compatible with previous versions:
+With the default `include = ["legacy"]` the output is backward-compatible with
+previous versions:
 
 ```text
 system,host=worker-01 load1=3.72,load5=2.4,load15=2.1,n_users=3i,n_unique_users=2i,n_cpus=4i,n_physical_cpus=2i 1748000000000000000
@@ -172,28 +195,8 @@ in a single metric with the new field names:
 system,host=worker-01 load1=3.72,load5=2.4,load15=2.1,n_users=3i,n_unique_users=2i,n_cpus=4i,n_physical_cpus=2i,uptime=1249632i 1748000000000000000
 ```
 
-### OS information
-
-With `include = ["os"]`, a separate `system_os` measurement is emitted:
+When including all options the emitted metric will be
 
 ```text
-system_os,host=worker-01 os="linux",arch="x86_64",platform="ubuntu",platform_family="debian",platform_version="26.04",kernel_version="7.0.0-7-generic" 1748000000000000000
-```
-
-### DMI information
-
-With `include = ["dmi"]`, a separate `system_dmi` measurement is emitted.
-When telegraf has access to all DMI fields (e.g. running as root or with
-`CAP_SYS_ADMIN` on Linux), the metric carries the full information:
-
-```text
-system_dmi,host=worker-01 bios_vendor="Dell Inc.",bios_version="2.18.0",bios_date="04/12/2024",board_vendor="Dell Inc.",board_product="0X3D66",board_version="A00",board_serial="CN747503AB0123",board_asset_tag="",chassis_vendor="Dell Inc.",chassis_type="23",chassis_type_description="Rack mount chassis",chassis_version="",chassis_serial="7XK4P03",chassis_asset_tag="",product_vendor="Dell Inc.",product_name="PowerEdge R750",product_family="PowerEdge",product_version="",product_serial="7XK4P03",product_sku="SKU=NotProvided;ModelName=PowerEdge R750",product_uuid="4c4c4544-0058-4b10-8034-b3c04f503033" 1748000000000000000
-```
-
-When telegraf runs without privileges to read kernel-restricted DMI fields,
-those fields are reported as `unknown` instead. This is the typical case
-when telegraf runs as a regular user on Linux:
-
-```text
-system_dmi,host=worker-01 bios_vendor="Dell Inc.",bios_version="2.18.0",bios_date="04/12/2024",board_vendor="Dell Inc.",board_product="0X3D66",board_version="A00",board_serial="unknown",board_asset_tag="",chassis_vendor="Dell Inc.",chassis_type="23",chassis_type_description="Rack mount chassis",chassis_version="",chassis_serial="unknown",chassis_asset_tag="",product_vendor="Dell Inc.",product_name="PowerEdge R750",product_family="PowerEdge",product_version="",product_serial="unknown",product_sku="SKU=NotProvided;ModelName=PowerEdge R750",product_uuid="unknown" 1748000000000000000
+system,host=worker-01 load1=3.72,load5=2.4,load15=2.1,n_users=3i,n_unique_users=2i,n_cpus=4i,n_physical_cpus=2i,uptime=1249632i os="linux",arch="x86_64",platform="ubuntu",platform_family="debian",platform_version="26.04",kernel_version="7.0.0-7-generic" bios_vendor="Dell Inc.",bios_version="2.18.0",bios_date="04/12/2024",board_vendor="Dell Inc.",board_product="0X3D66",board_version="A00",board_serial="CN747503AB0123",board_asset_tag="",chassis_vendor="Dell Inc.",chassis_type="23",chassis_type_description="Rack mount chassis",chassis_version="",chassis_serial="7XK4P03",chassis_asset_tag="",product_vendor="Dell Inc.",product_name="PowerEdge R750",product_family="PowerEdge",product_version="",product_serial="7XK4P03",product_sku="SKU=NotProvided;ModelName=PowerEdge R750",product_uuid="4c4c4544-0058-4b10-8034-b3c04f503033" 1748000000000000000
 ```

--- a/plugins/inputs/system/sample.conf
+++ b/plugins/inputs/system/sample.conf
@@ -1,14 +1,14 @@
 # Read metrics about system load & uptime
 [[inputs.system]]
   ## Information to collect; available options are:
-  ##   cpus             - CPU counts of the system
-  ##   dmi              - BIOS, baseboard, chassis and product information from DMI/SMBIOS
-  ##   legacy_uptime    - legacy layout of system uptime; see README for details
-  ##   load             - 1, 5 and 15-minute load averages
-  ##   os               - operating system release and uname information
-  ##   uptime           - system uptime
-  ##   users            - logged-in user counts
-  # include = ["cpus", "legacy_uptime", "load", "users"]
+  ##   legacy - legacy layout of system metrics; see README for details
+  ##   cpus   - CPU counts of the system
+  ##   dmi    - BIOS, baseboard, chassis and product information from DMI/SMBIOS
+  ##   load   - 1, 5 and 15-minute load averages
+  ##   os     - operating system release and uname information
+  ##   uptime - system uptime
+  ##   users  - logged-in user counts
+  # include = ["legacy"]
 
   ## How long to cache the result of the "os" group between gathers.
   ## Set higher to reduce the number of os-release/uname reads, lower to

--- a/plugins/inputs/system/system.go
+++ b/plugins/inputs/system/system.go
@@ -177,8 +177,11 @@ func (s *System) Gather(acc telegraf.Accumulator) error {
 
 func (s *System) gatherLegacy(acc telegraf.Accumulator, now time.Time) error {
 	loadavg, err := load.Avg()
-	if err != nil && !strings.Contains(err.Error(), "not implemented") {
-		return err
+	if err != nil {
+		if !strings.Contains(err.Error(), "not implemented") {
+			return err
+		}
+		loadavg = &load.AvgStat{}
 	}
 
 	numLogicalCPUs, err := cpu.Counts(true)

--- a/plugins/inputs/system/system.go
+++ b/plugins/inputs/system/system.go
@@ -5,8 +5,8 @@ import (
 	"bufio"
 	"bytes"
 	_ "embed"
-	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"runtime"
 	"strings"
@@ -35,7 +35,6 @@ type System struct {
 	osCachedAt  time.Time
 	dmiFields   map[string]interface{}
 	dmiCachedAt time.Time
-	dmiEnabled  bool
 }
 
 func (*System) SampleConfig() string {
@@ -46,23 +45,22 @@ func (s *System) Init() error {
 	// Suppress deprecation warnings for default-only configs.
 	userSupplied := len(s.Include) > 0
 	if !userSupplied {
-		s.Include = []string{"cpus", "load", "users", "legacy_uptime"}
+		s.Include = []string{"legacy"}
 	}
 
 	enabled := make(map[string]bool, len(s.Include))
-	deduped := make([]string, 0, len(s.Include))
 	for _, incl := range s.Include {
 		if enabled[incl] {
 			continue
 		}
 		switch incl {
 		case "load", "users", "cpus", "uptime", "os", "dmi":
-		case "legacy_uptime":
+		case "legacy":
 			if userSupplied {
 				config.PrintOptionValueDeprecationNotice(
 					"inputs.system",
 					"include",
-					"legacy_uptime",
+					"legacy",
 					telegraf.DeprecationInfo{
 						Since:     "1.39.0",
 						RemovalIn: "1.45.0",
@@ -74,20 +72,16 @@ func (s *System) Init() error {
 			return fmt.Errorf("invalid 'include' option %q", incl)
 		}
 		enabled[incl] = true
-		deduped = append(deduped, incl)
-	}
-	s.Include = deduped
-
-	if enabled["uptime"] && enabled["legacy_uptime"] {
-		return errors.New(`"uptime" and "legacy_uptime" are mutually exclusive`)
 	}
 
-	if enabled["dmi"] {
-		if dmiSupported {
-			s.dmiEnabled = true
-		} else {
-			s.Log.Warn("'dmi' is not supported on this platform, ignoring")
-		}
+	if enabled["dmi"] && !dmiSupported {
+		s.Log.Warn("'dmi' is not supported on this platform, ignoring")
+		delete(enabled, "dmi")
+	}
+
+	s.Include = make([]string, 0, len(enabled))
+	for k := range enabled {
+		s.Include = append(s.Include, k)
 	}
 
 	return nil
@@ -104,18 +98,16 @@ func (s *System) Gather(acc telegraf.Accumulator) error {
 				osCache, err := gatherOS()
 				if err != nil {
 					acc.AddError(err)
-				} else {
-					s.osCache = osCache
-					s.osCachedAt = now
+					continue
 				}
+
+				s.osCache = osCache
+				s.osCachedAt = now
 			}
 			if len(s.osCache) > 0 {
-				acc.AddFields("system_os", s.osCache, nil, now)
+				maps.Copy(fields, s.osCache)
 			}
 		case "dmi":
-			if !s.dmiEnabled {
-				continue
-			}
 			if time.Since(s.dmiCachedAt) > time.Duration(s.DMICacheTTL) {
 				dmiFields, err := gatherDMI()
 				if err != nil {
@@ -126,7 +118,7 @@ func (s *System) Gather(acc telegraf.Accumulator) error {
 				}
 			}
 			if len(s.dmiFields) > 0 {
-				acc.AddFields("system_dmi", s.dmiFields, nil, now)
+				maps.Copy(fields, s.dmiFields)
 			}
 		case "load":
 			loadavg, err := load.Avg()
@@ -145,11 +137,11 @@ func (s *System) Gather(acc telegraf.Accumulator) error {
 				fields["n_users"] = len(users)
 				fields["n_unique_users"] = findUniqueUsers(users)
 			} else if os.IsNotExist(err) {
-				s.Log.Tracef("Reading users: %s", err.Error())
+				s.Log.Tracef("Reading users: %v", err)
 			} else if os.IsPermission(err) {
-				s.Log.Debug(err.Error())
+				s.Log.Tracef("Reading users: %v", err)
 			} else {
-				s.Log.Warnf("Reading users: %s", err.Error())
+				s.Log.Warnf("Reading users: %v", err)
 			}
 		case "cpus":
 			numLogicalCPUs, err := cpu.Counts(true)
@@ -171,24 +163,59 @@ func (s *System) Gather(acc telegraf.Accumulator) error {
 				continue
 			}
 			fields["uptime"] = uptime
-		case "legacy_uptime":
-			uptime, err := host.Uptime()
-			if err != nil {
-				acc.AddError(fmt.Errorf("reading uptime: %w", err))
-				continue
-			}
-			acc.AddCounter("system", map[string]interface{}{
-				"uptime": uptime,
-			}, nil, now)
-			acc.AddFields("system", map[string]interface{}{
-				"uptime_format": formatUptime(uptime),
-			}, nil, now)
+		case "legacy":
+			acc.AddError(s.gatherLegacy(acc, now))
 		}
 	}
 
 	if len(fields) > 0 {
-		acc.AddGauge("system", fields, nil, now)
+		acc.AddFields("system", fields, nil, now)
 	}
+
+	return nil
+}
+
+func (s *System) gatherLegacy(acc telegraf.Accumulator, now time.Time) error {
+	loadavg, err := load.Avg()
+	if err != nil && !strings.Contains(err.Error(), "not implemented") {
+		return err
+	}
+
+	numLogicalCPUs, err := cpu.Counts(true)
+	if err != nil {
+		return err
+	}
+
+	numPhysicalCPUs, err := cpu.Counts(false)
+	if err != nil {
+		return err
+	}
+
+	fields := map[string]interface{}{
+		"load1":           loadavg.Load1,
+		"load5":           loadavg.Load5,
+		"load15":          loadavg.Load15,
+		"n_cpus":          numLogicalCPUs,
+		"n_physical_cpus": numPhysicalCPUs,
+	}
+
+	users, err := host.Users()
+	if err == nil {
+		fields["n_users"] = len(users)
+		fields["n_unique_users"] = findUniqueUsers(users)
+	} else {
+		s.Log.Debugf("Reading users: %v", err)
+	}
+
+	acc.AddGauge("system", fields, nil, now)
+
+	uptime, err := host.Uptime()
+	if err != nil {
+		return err
+	}
+
+	acc.AddCounter("system", map[string]interface{}{"uptime": uptime}, nil, now)
+	acc.AddFields("system", map[string]interface{}{"uptime_format": formatUptime(uptime)}, nil, now)
 
 	return nil
 }
@@ -259,8 +286,8 @@ func gatherDMI() (map[string]interface{}, error) {
 	}
 	if ch != nil {
 		fields["chassis_vendor"] = ch.Vendor
-		fields["chassis_type"] = ch.Type
-		fields["chassis_type_description"] = ch.TypeDescription
+		fields["chassis_type_code"] = ch.Type
+		fields["chassis_type"] = ch.TypeDescription
 		fields["chassis_version"] = ch.Version
 		fields["chassis_serial"] = ch.SerialNumber
 		fields["chassis_asset_tag"] = ch.AssetTag

--- a/plugins/inputs/system/system_test.go
+++ b/plugins/inputs/system/system_test.go
@@ -153,19 +153,6 @@ func TestGather(t *testing.T) {
 			},
 		},
 		{
-			name:    "uptime as gauge field",
-			include: []string{"uptime"},
-			expected: []telegraf.Metric{
-				metric.New(
-					"system",
-					map[string]string{},
-					map[string]interface{}{"uptime": uint64(0)},
-					time.Unix(0, 0),
-					telegraf.Untyped,
-				),
-			},
-		},
-		{
 			name:         "all new options",
 			include:      []string{"load", "users", "cpus", "uptime"},
 			requireUsers: true,

--- a/plugins/inputs/system/system_test.go
+++ b/plugins/inputs/system/system_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/shirou/gopsutil/v4/host"
 	"github.com/stretchr/testify/require"
 
@@ -188,8 +189,9 @@ func TestGather(t *testing.T) {
 			},
 		},
 		{
-			name:    "legacy only",
-			include: []string{"legacy"},
+			name:         "legacy only",
+			include:      []string{"legacy"},
+			requireUsers: true,
 			expected: []telegraf.Metric{
 				metric.New(
 					"system",
@@ -239,68 +241,27 @@ func TestGather(t *testing.T) {
 				),
 			},
 		},
-		{
-			name:    "duplicates are de-duplicated",
-			include: []string{"legacy", "legacy", "cpus", "cpus"},
-			expected: []telegraf.Metric{
-				metric.New(
-					"system",
-					map[string]string{},
-					map[string]interface{}{
-						"load1":           float64(0),
-						"load5":           float64(0),
-						"load15":          float64(0),
-						"n_users":         0,
-						"n_unique_users":  0,
-						"n_cpus":          0,
-						"n_physical_cpus": 0,
-					},
-					time.Unix(0, 0),
-					telegraf.Gauge,
-				),
-				metric.New(
-					"system",
-					map[string]string{},
-					map[string]interface{}{"uptime": uint64(0)},
-					time.Unix(0, 0),
-					telegraf.Counter,
-				),
-				metric.New(
-					"system",
-					map[string]string{},
-					map[string]interface{}{"uptime_format": string("")},
-					time.Unix(0, 0),
-					telegraf.Untyped,
-				),
-				metric.New(
-					"system",
-					map[string]string{},
-					map[string]interface{}{
-						"n_cpus":          0,
-						"n_physical_cpus": 0,
-					},
-					time.Unix(0, 0),
-					telegraf.Untyped,
-				),
-			},
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.requireUsers && !usersAvailable {
 				t.Skip("host.Users() not mockable on this platform")
 			}
-			s := &System{
+
+			plugin := &System{
 				Include: tt.include,
 				Log:     &testutil.Logger{},
 			}
-			require.NoError(t, s.Init())
+			require.NoError(t, plugin.Init())
 
 			var acc testutil.Accumulator
-			require.NoError(t, s.Gather(&acc))
+			require.NoError(t, plugin.Gather(&acc))
 
-			actual := acc.GetTelegrafMetrics()
-			testutil.RequireMetricsStructureEqual(t, tt.expected, actual, testutil.IgnoreTime(), testutil.SortMetrics())
+			options := []cmp.Option{
+				testutil.IgnoreTime(),
+				testutil.SortMetrics(),
+			}
+			testutil.RequireMetricsStructureEqual(t, tt.expected, acc.GetTelegrafMetrics(), options...)
 		})
 	}
 }

--- a/plugins/inputs/system/system_test.go
+++ b/plugins/inputs/system/system_test.go
@@ -18,8 +18,8 @@ import (
 func TestUniqueUsers(t *testing.T) {
 	tests := []struct {
 		name     string
-		expected int
 		data     []host.UserStat
+		expected int
 	}{
 		{
 			name:     "single entry",
@@ -72,49 +72,19 @@ func TestUniqueUsers(t *testing.T) {
 }
 
 func TestInitAllValidOptions(t *testing.T) {
-	// The uptime/legacy_uptime settings are mutually exclusive, so cover all
-	// valid values across two configurations.
-	tests := []struct {
-		name    string
-		include []string
-	}{
-		{"new", []string{"load", "users", "cpus", "uptime", "os", "dmi"}},
-		{"legacy", []string{"load", "users", "cpus", "legacy_uptime", "os", "dmi"}},
+	plugin := &System{
+		Include: []string{"load", "users", "cpus", "legacy", "os", "dmi"},
+		Log:     &testutil.Logger{},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			s := &System{Include: tt.include, Log: &testutil.Logger{}}
-			require.NoError(t, s.Init())
-		})
-	}
+	require.NoError(t, plugin.Init())
 }
 
 func TestInitErrors(t *testing.T) {
-	tests := []struct {
-		name    string
-		include []string
-		errMsg  string
-	}{
-		{
-			name:    "invalid option",
-			include: []string{"invalid"},
-			errMsg:  `invalid 'include' option "invalid"`,
-		},
-		{
-			name:    "uptime mutually exclusive",
-			include: []string{"uptime", "legacy_uptime"},
-			errMsg:  "mutually exclusive",
-		},
+	plugin := &System{
+		Include: []string{"invalid"},
+		Log:     &testutil.Logger{},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			s := &System{
-				Include: tt.include,
-				Log:     &testutil.Logger{},
-			}
-			require.ErrorContains(t, s.Init(), tt.errMsg)
-		})
-	}
+	require.ErrorContains(t, plugin.Init(), `invalid 'include' option "invalid"`)
 }
 
 func TestGather(t *testing.T) {
@@ -177,7 +147,7 @@ func TestGather(t *testing.T) {
 						"n_physical_cpus": 0,
 					},
 					time.Unix(0, 0),
-					telegraf.Gauge,
+					telegraf.Untyped,
 				),
 			},
 		},
@@ -190,7 +160,7 @@ func TestGather(t *testing.T) {
 					map[string]string{},
 					map[string]interface{}{"uptime": uint64(0)},
 					time.Unix(0, 0),
-					telegraf.Gauge,
+					telegraf.Untyped,
 				),
 			},
 		},
@@ -213,14 +183,29 @@ func TestGather(t *testing.T) {
 						"uptime":          uint64(0),
 					},
 					time.Unix(0, 0),
-					telegraf.Gauge,
+					telegraf.Untyped,
 				),
 			},
 		},
 		{
-			name:    "legacy_uptime only",
-			include: []string{"legacy_uptime"},
+			name:    "legacy only",
+			include: []string{"legacy"},
 			expected: []telegraf.Metric{
+				metric.New(
+					"system",
+					map[string]string{},
+					map[string]interface{}{
+						"load1":           float64(0),
+						"load5":           float64(0),
+						"load15":          float64(0),
+						"n_users":         0,
+						"n_unique_users":  0,
+						"n_cpus":          0,
+						"n_physical_cpus": 0,
+					},
+					time.Unix(0, 0),
+					telegraf.Gauge,
+				),
 				metric.New(
 					"system",
 					map[string]string{},
@@ -250,18 +235,23 @@ func TestGather(t *testing.T) {
 						"n_unique_users": 0,
 					},
 					time.Unix(0, 0),
-					telegraf.Gauge,
+					telegraf.Untyped,
 				),
 			},
 		},
 		{
 			name:    "duplicates are de-duplicated",
-			include: []string{"legacy_uptime", "legacy_uptime", "cpus", "cpus"},
+			include: []string{"legacy", "legacy", "cpus", "cpus"},
 			expected: []telegraf.Metric{
 				metric.New(
 					"system",
 					map[string]string{},
 					map[string]interface{}{
+						"load1":           float64(0),
+						"load5":           float64(0),
+						"load15":          float64(0),
+						"n_users":         0,
+						"n_unique_users":  0,
 						"n_cpus":          0,
 						"n_physical_cpus": 0,
 					},
@@ -279,6 +269,16 @@ func TestGather(t *testing.T) {
 					"system",
 					map[string]string{},
 					map[string]interface{}{"uptime_format": string("")},
+					time.Unix(0, 0),
+					telegraf.Untyped,
+				),
+				metric.New(
+					"system",
+					map[string]string{},
+					map[string]interface{}{
+						"n_cpus":          0,
+						"n_physical_cpus": 0,
+					},
 					time.Unix(0, 0),
 					telegraf.Untyped,
 				),
@@ -327,7 +327,7 @@ func TestGatherOSValues(t *testing.T) {
 	// arch and kernel_version come from uname(2) and depend on the host.
 	expected := []telegraf.Metric{
 		metric.New(
-			"system_os",
+			"system",
 			map[string]string{},
 			map[string]interface{}{
 				"os":               "linux",
@@ -370,32 +370,33 @@ func TestGatherDMIValues(t *testing.T) {
 	require.NoError(t, s.Init())
 
 	expected := metric.New(
-		"system_dmi",
+		"system",
 		nil,
 		map[string]interface{}{
-			"bios_vendor":              "Telegraf BIOS, Inc.",
-			"bios_version":             "1.2.3",
-			"bios_date":                "01/01/2026",
-			"board_vendor":             "Telegraf Boards Co.",
-			"board_product":            "TG-BOARD-X1",
-			"board_version":            "A1",
-			"board_serial":             "BS-1234",
-			"board_asset_tag":          "ASSET-A",
-			"chassis_vendor":           "Telegraf Chassis Ltd.",
-			"chassis_type":             "3",
-			"chassis_type_description": "Desktop",
-			"chassis_version":          "v0",
-			"chassis_serial":           "CS-5678",
-			"chassis_asset_tag":        "ASSET-C",
-			"product_vendor":           "Telegraf Systems",
-			"product_name":             "TG-Server-9000",
-			"product_family":           "TG-Server",
-			"product_version":          "v9",
-			"product_serial":           "PS-9999",
-			"product_sku":              "SKU-XYZ",
-			"product_uuid":             "00000000-0000-0000-0000-000000000001",
+			"bios_vendor":       "Telegraf BIOS, Inc.",
+			"bios_version":      "1.2.3",
+			"bios_date":         "01/01/2026",
+			"board_vendor":      "Telegraf Boards Co.",
+			"board_product":     "TG-BOARD-X1",
+			"board_version":     "A1",
+			"board_serial":      "BS-1234",
+			"board_asset_tag":   "ASSET-A",
+			"chassis_vendor":    "Telegraf Chassis Ltd.",
+			"chassis_type_code": "3",
+			"chassis_type":      "Desktop",
+			"chassis_version":   "v0",
+			"chassis_serial":    "CS-5678",
+			"chassis_asset_tag": "ASSET-C",
+			"product_vendor":    "Telegraf Systems",
+			"product_name":      "TG-Server-9000",
+			"product_family":    "TG-Server",
+			"product_version":   "v9",
+			"product_serial":    "PS-9999",
+			"product_sku":       "SKU-XYZ",
+			"product_uuid":      "00000000-0000-0000-0000-000000000001",
 		},
 		time.Unix(0, 0),
+		telegraf.Untyped,
 	)
 
 	var acc testutil.Accumulator
@@ -408,6 +409,5 @@ func TestGatherDMIValues(t *testing.T) {
 	require.NoError(t, s.Gather(&acc))
 	require.Equal(t, firstCachedAt, s.dmiCachedAt)
 
-	expected2 := []telegraf.Metric{expected, expected}
-	testutil.RequireMetricsEqual(t, expected2, acc.GetTelegrafMetrics(), testutil.IgnoreTime())
+	testutil.RequireMetricsEqual(t, []telegraf.Metric{expected, expected}, acc.GetTelegrafMetrics(), testutil.IgnoreTime())
 }


### PR DESCRIPTION
## Summary

This PR fully restores the previous metrics including their metric-type. As a consequence, the `legacy_uptime` option was renamed to `legacy` and producing _exactly_ the previous metric set. The new option is non-exclusive and can be used in combination with the new, fine-grained options.

The fine-grained options (`cpu`, `load`, etc) now produce only a **single** `system` metric which isn't typed because it potentially mixes counters, gauges etc. Also the newly introduced `system_os` and `system_dmi` metrics are merged into the single `system` metric to reduce the number of emitted metrics. Use the [split processor](https://github.com/influxdata/telegraf/tree/release-1.38/plugins/processors/split) if you need separate metrics.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

resolves #18952 
