### PR TITLE
fix(circleci): Fix destination of nightly build artifact uploads

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -354,26 +354,31 @@ jobs:
           nightly: << parameters.nightly >>
   nightly:
     executor: telegraf-ci
+    environment:
+      AWS_REGION: auto
+      AWS_REQUEST_CHECKSUM_CALCULATION: when_required
     steps:
       - attach_workspace:
           at: '/build'
       - run:
           command: |
-            aws s3 sync /build/dist s3://dl.influxdata.com/telegraf/nightlies/ \
+            aws s3 sync /build/dist s3://dl-influxdata-com/telegraf/nightlies/ \
               --exclude "*" \
               --include "*.tar.gz" \
               --include "*.deb" \
               --include "*.rpm" \
-              --include "*.zip" \
-              --acl public-read
+              --include "*.zip"
   release:
     executor: telegraf-ci
+    environment:
+      AWS_REGION: auto
+      AWS_REQUEST_CHECKSUM_CALCULATION: when_required
     steps:
       - attach_workspace:
           at: '/build'
       - run:
           command: |
-            aws s3 sync /build/dist s3://dl.influxdata.com/telegraf/releases/ \
+            aws s3 sync /build/dist s3://dl-influxdata-com/telegraf/releases/ \
               --exclude "*" \
               --include "telegraf*.DIGESTS" \
               --include "telegraf*.digests" \
@@ -382,8 +387,7 @@ jobs:
               --include "telegraf*.dmg" \
               --include "telegraf*.rpm" \
               --include "telegraf*.tar.gz" \
-              --include "telegraf*.zip" \
-              --acl public-read
+              --include "telegraf*.zip"
   docker-nightly:
     machine:
       image: ubuntu-2204:current


### PR DESCRIPTION
This changes the destination of artifact uploads to correspond with the migration of the bucket.

## Summary

We have migrated the bucket where releases and nightlies land; though we've been transparently proxying data, the cache TTL has caused new content to not appear in a timely fashion. This change causes artifacts to land directly in the new bucket, bypassing the proxy.

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

resolves #19013

