### PR TITLE
chore(inputs.azure_monitor): Remove dependency on github.com/logzio/azure-monitor-metrics-receiver

### DIFF
--- a/docs/LICENSE_OF_DEPENDENCIES.md
+++ b/docs/LICENSE_OF_DEPENDENCIES.md
@@ -298,7 +298,6 @@ following works:
 - github.com/likexian/whois [Apache License 2.0](https://github.com/likexian/whois/blob/master/LICENSE)
 - github.com/likexian/whois-parser [Apache License 2.0](https://github.com/likexian/whois-parser/blob/master/LICENSE)
 - github.com/linkedin/goavro [Apache License 2.0](https://github.com/linkedin/goavro/blob/master/LICENSE)
-- github.com/logzio/azure-monitor-metrics-receiver [MIT License](https://github.com/logzio/azure-monitor-metrics-receiver/blob/master/LICENSE)
 - github.com/magiconair/properties [BSD 2-Clause "Simplified" License](https://github.com/magiconair/properties/blob/main/LICENSE.md)
 - github.com/mailru/easyjson [MIT License](https://github.com/mailru/easyjson/blob/master/LICENSE)
 - github.com/mattn/go-colorable [MIT License](https://github.com/mattn/go-colorable/blob/master/LICENSE)

--- a/go.mod
+++ b/go.mod
@@ -146,7 +146,6 @@ require (
 	github.com/likexian/whois v1.15.7
 	github.com/likexian/whois-parser v1.24.21
 	github.com/linkedin/goavro/v2 v2.15.0
-	github.com/logzio/azure-monitor-metrics-receiver v1.1.0
 	github.com/lxc/incus/v6 v6.23.0
 	github.com/mdlayher/apcupsd v0.0.0-20220319200143-473c7b5f3c6a
 	github.com/mdlayher/vsock v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -1820,8 +1820,6 @@ github.com/likexian/whois-parser v1.24.21 h1:MxsrGRxDOiZIVp7q7N/yAIbKuN4QAkGjCpO
 github.com/likexian/whois-parser v1.24.21/go.mod h1:o3DUruO65Pb8WXCJCTlSVkTbwuYVrBCeoMTw2q0mxY4=
 github.com/linkedin/goavro/v2 v2.15.0 h1:pDj1UrjUOO62iXhgBiE7jQkpNIc5/tA5eZsgolMjgVI=
 github.com/linkedin/goavro/v2 v2.15.0/go.mod h1:KXx+erlq+RPlGSPmLF7xGo6SAbh8sCQ53x064+ioxhk=
-github.com/logzio/azure-monitor-metrics-receiver v1.1.0 h1:L2LU/jWTOFibZeSKUeEDBdPY6iFL1gkSE3A/9mnk/Ms=
-github.com/logzio/azure-monitor-metrics-receiver v1.1.0/go.mod h1:6J/ZJtFGAuv3XvLWOWTefbi1BBHvnawNjUTGcx2qUG4=
 github.com/loov/hrtime v1.0.1/go.mod h1:yDY3Pwv2izeY4sq7YcPX/dtLwzg5NU1AxWuWxKwd0p0=
 github.com/loov/hrtime v1.0.3/go.mod h1:yDY3Pwv2izeY4sq7YcPX/dtLwzg5NU1AxWuWxKwd0p0=
 github.com/loov/hrtime/hrplot v1.0.2/go.mod h1:9t65xYn4d42ntjv40Wt5lbU72/VC5S0zGDgjC8kD5BU=

--- a/plugins/inputs/azure_monitor/azure_monitor.go
+++ b/plugins/inputs/azure_monitor/azure_monitor.go
@@ -125,21 +125,21 @@ func (am *AzureMonitor) Init() error {
 }
 
 func (am *AzureMonitor) Gather(acc telegraf.Accumulator) error {
-	var waitGroup sync.WaitGroup
+	var wg sync.WaitGroup
 
+	ctx := context.Background()
 	for _, target := range am.receiver.resources {
 		am.Log.Debug("Collecting metrics for resource target ", target.ResourceID)
-		ctx := context.Background()
 
-		waitGroup.Add(1)
+		wg.Add(1)
 		go func(target *resourceTarget) {
-			defer waitGroup.Done()
+			defer wg.Done()
 
 			am.receiver.collectMetrics(ctx, acc, target, am.Log)
 		}(target)
 	}
+	wg.Wait()
 
-	waitGroup.Wait()
 	return nil
 }
 

--- a/plugins/inputs/azure_monitor/azure_monitor.go
+++ b/plugins/inputs/azure_monitor/azure_monitor.go
@@ -2,6 +2,7 @@
 package azure_monitor
 
 import (
+	"context"
 	_ "embed"
 	"errors"
 	"fmt"
@@ -9,13 +10,16 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
-	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
-	receiver "github.com/logzio/azure-monitor-metrics-receiver"
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/plugins/inputs"
 )
+
+//go:embed sample.conf
+var sampleConfig string
+
+const maxMetricsBatch = 20
 
 type AzureMonitor struct {
 	SubscriptionID       string                 `toml:"subscription_id"`
@@ -28,9 +32,8 @@ type AzureMonitor struct {
 	SubscriptionTargets  []*resource            `toml:"subscription_target"`
 	Log                  telegraf.Logger        `toml:"-"`
 
-	receiver     *receiver.AzureMonitorMetricsReceiver
-	azureManager azureClientsCreator
-	azureClients *receiver.AzureClients
+	receiver *metricReceiver
+	factory  clientFactory
 }
 
 type resourceTarget struct {
@@ -50,33 +53,39 @@ type resource struct {
 	Aggregations []string `toml:"aggregations"`
 }
 
-type azureClientsManager struct{}
-
-type azureClientsCreator interface {
-	createAzureClients(subscriptionID string, clientID string, clientSecret string, tenantID string,
-		clientOptions azcore.ClientOptions) (*receiver.AzureClients, error)
-}
-
-//go:embed sample.conf
-var sampleConfig string
-
 func (*AzureMonitor) SampleConfig() string {
 	return sampleConfig
 }
 
 func (am *AzureMonitor) Init() error {
+	// Validate settings
 	if am.SubscriptionID == "" {
 		return errors.New("subscription_id is required")
 	}
 
+	if len(am.ResourceTargets) == 0 && len(am.ResourceGroupTargets) == 0 && len(am.SubscriptionTargets) == 0 {
+		return errors.New("no target to collect metrics from")
+	}
+
+	// Validate the targets
+	if err := am.validateTargets(); err != nil {
+		return err
+	}
+
+	// Canonicalize resource target IDs
+	for _, target := range am.ResourceTargets {
+		target.ResourceID = "/subscriptions/" + am.SubscriptionID + "/" + target.ResourceID
+	}
+
+	// Setup client options
 	var clientOptions azcore.ClientOptions
 	switch am.CloudOption {
 	case "AzureChina":
-		clientOptions = azcore.ClientOptions{Cloud: cloud.AzureChina}
+		clientOptions.Cloud = cloud.AzureChina
 	case "AzureGovernment":
-		clientOptions = azcore.ClientOptions{Cloud: cloud.AzureGovernment}
+		clientOptions.Cloud = cloud.AzureGovernment
 	case "", "AzurePublic":
-		clientOptions = azcore.ClientOptions{Cloud: cloud.AzurePublic}
+		clientOptions.Cloud = cloud.AzurePublic
 	default:
 		return fmt.Errorf("unknown cloud option: %s", am.CloudOption)
 	}
@@ -97,40 +106,20 @@ func (am *AzureMonitor) Init() error {
 		secret.Destroy()
 	}
 
-	var err error
-	am.azureClients, err = am.azureManager.createAzureClients(am.SubscriptionID, am.ClientID, clientSecret, am.TenantID, clientOptions)
+	// Create a new client
+	client, err := am.factory.createClient(am.SubscriptionID, am.ClientID, clientSecret, am.TenantID, clientOptions)
 	if err != nil {
-		return err
+		return fmt.Errorf("creating client failed: %w", err)
 	}
 
-	if err = am.setReceiver(); err != nil {
-		return fmt.Errorf("error setting Azure Monitor receiver: %w", err)
+	// Setup the receiver
+	ctx := context.Background()
+	receiver, err := newReceiver(ctx, client, am.SubscriptionID, am.ResourceTargets, am.ResourceGroupTargets, am.SubscriptionTargets)
+	if err != nil {
+		return fmt.Errorf("creating receiver failed: %w", err)
 	}
-
-	if err = am.receiver.CreateResourceTargetsFromResourceGroupTargets(); err != nil {
-		return fmt.Errorf("error creating resource targets from resource group targets: %w", err)
-	}
-
-	if err = am.receiver.CreateResourceTargetsFromSubscriptionTargets(); err != nil {
-		return fmt.Errorf("error creating resource targets from subscription targets: %w", err)
-	}
-
-	if err = am.receiver.CheckResourceTargetsMetricsValidation(); err != nil {
-		return fmt.Errorf("error checking resource targets metrics validation: %w", err)
-	}
-
-	if err = am.receiver.SetResourceTargetsMetrics(); err != nil {
-		return fmt.Errorf("error setting resource targets metrics: %w", err)
-	}
-
-	if err = am.receiver.SplitResourceTargetsMetricsByMinTimeGrain(); err != nil {
-		return fmt.Errorf("error splitting resource targets metrics by min time grain: %w", err)
-	}
-
-	am.receiver.SplitResourceTargetsWithMoreThanMaxMetrics()
-	am.receiver.SetResourceTargetsAggregations()
-
-	am.Log.Debug("Total resource targets: ", len(am.receiver.Targets.ResourceTargets))
+	am.receiver = receiver
+	am.Log.Debug("Total resource targets: ", len(am.receiver.resources))
 
 	return nil
 }
@@ -138,25 +127,15 @@ func (am *AzureMonitor) Init() error {
 func (am *AzureMonitor) Gather(acc telegraf.Accumulator) error {
 	var waitGroup sync.WaitGroup
 
-	for _, target := range am.receiver.Targets.ResourceTargets {
+	for _, target := range am.receiver.resources {
 		am.Log.Debug("Collecting metrics for resource target ", target.ResourceID)
-		waitGroup.Add(1)
+		ctx := context.Background()
 
-		go func(target *receiver.ResourceTarget) {
+		waitGroup.Add(1)
+		go func(target *resourceTarget) {
 			defer waitGroup.Done()
 
-			collectedMetrics, notCollectedMetrics, err := am.receiver.CollectResourceTargetMetrics(target)
-			if err != nil {
-				acc.AddError(err)
-			}
-
-			for _, collectedMetric := range collectedMetrics {
-				acc.AddFields(collectedMetric.Name, collectedMetric.Fields, collectedMetric.Tags)
-			}
-
-			for _, notCollectedMetric := range notCollectedMetrics {
-				am.Log.Info("Did not get any metric value from Azure Monitor API for the metric ID ", notCollectedMetric)
-			}
+			am.receiver.collectMetrics(ctx, acc, target, am.Log)
 		}(target)
 	}
 
@@ -164,54 +143,45 @@ func (am *AzureMonitor) Gather(acc telegraf.Accumulator) error {
 	return nil
 }
 
-func (am *AzureMonitor) setReceiver() error {
-	resourceTargets := make([]*receiver.ResourceTarget, 0, len(am.ResourceTargets))
-	resourceGroupTargets := make([]*receiver.ResourceGroupTarget, 0, len(am.ResourceGroupTargets))
-	subscriptionTargets := make([]*receiver.Resource, 0, len(am.SubscriptionTargets))
-
-	for _, target := range am.ResourceTargets {
-		resourceTargets = append(resourceTargets, receiver.NewResourceTarget(target.ResourceID, target.Metrics, target.Aggregations))
+func (am *AzureMonitor) validateTargets() error {
+	// Validate resource targets
+	for index, target := range am.ResourceTargets {
+		if target.ResourceID == "" {
+			return fmt.Errorf("missing resource ID in resource target #%d", index+1)
+		}
 	}
 
-	for _, target := range am.ResourceGroupTargets {
-		resources := make([]*receiver.Resource, 0, len(target.Resources))
-		for _, resource := range target.Resources {
-			resources = append(resources, receiver.NewResource(resource.ResourceType, resource.Metrics, resource.Aggregations))
+	// Validate resource group targets
+	for index, target := range am.ResourceGroupTargets {
+		if target.ResourceGroup == "" {
+			return fmt.Errorf("missing resource group in resource group target #%d", index+1)
 		}
 
-		resourceGroupTargets = append(resourceGroupTargets, receiver.NewResourceGroupTarget(target.ResourceGroup, resources))
+		if len(target.Resources) == 0 {
+			return fmt.Errorf("no resources in resource group target #%d", index+1)
+		}
+
+		for resourceIndex, resource := range target.Resources {
+			if resource.ResourceType == "" {
+				return fmt.Errorf("no resource type for resource group target #%d resource #%d", index+1, resourceIndex+1)
+			}
+		}
 	}
 
-	for _, target := range am.SubscriptionTargets {
-		subscriptionTargets = append(subscriptionTargets, receiver.NewResource(target.ResourceType, target.Metrics, target.Aggregations))
+	// Validate subscription targets
+	for index, target := range am.SubscriptionTargets {
+		if target.ResourceType == "" {
+			return fmt.Errorf("missing resource type in subscription target #%d", index+1)
+		}
 	}
 
-	targets := receiver.NewTargets(resourceTargets, resourceGroupTargets, subscriptionTargets)
-	var err error
-	am.receiver, err = receiver.NewAzureMonitorMetricsReceiver(am.SubscriptionID, targets, am.azureClients)
-	return err
-}
-
-func (*azureClientsManager) createAzureClients(
-	subscriptionID, clientID, clientSecret, tenantID string,
-	clientOptions azcore.ClientOptions,
-) (*receiver.AzureClients, error) {
-	if clientSecret != "" {
-		return receiver.CreateAzureClients(subscriptionID, clientID, clientSecret, tenantID, receiver.WithAzureClientOptions(&clientOptions))
-	}
-
-	token, err := azidentity.NewDefaultAzureCredential(&azidentity.DefaultAzureCredentialOptions{TenantID: tenantID,
-		ClientOptions: clientOptions})
-	if err != nil {
-		return nil, fmt.Errorf("error creating Azure token: %w", err)
-	}
-	return receiver.CreateAzureClientsWithCreds(subscriptionID, token, receiver.WithAzureClientOptions(&clientOptions))
+	return nil
 }
 
 func init() {
 	inputs.Add("azure_monitor", func() telegraf.Input {
 		return &AzureMonitor{
-			azureManager: &azureClientsManager{},
+			factory: &azureFactory{},
 		}
 	})
 }

--- a/plugins/inputs/azure_monitor/azure_monitor_test.go
+++ b/plugins/inputs/azure_monitor/azure_monitor_test.go
@@ -12,188 +12,10 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/monitor/armmonitor"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 	"github.com/influxdata/toml"
-	receiver "github.com/logzio/azure-monitor-metrics-receiver"
 	"github.com/stretchr/testify/require"
 
 	"github.com/influxdata/telegraf/testutil"
 )
-
-type mockAzureClientsManager struct{}
-
-type mockAzureResourcesClient struct{}
-
-type mockAzureMetricDefinitionsClient struct{}
-
-type mockAzureMetricsClient struct{}
-
-func (*mockAzureClientsManager) createAzureClients(_, _, _, _ string, _ azcore.ClientOptions) (*receiver.AzureClients, error) {
-	return &receiver.AzureClients{
-		Ctx:                     context.Background(),
-		ResourcesClient:         &mockAzureResourcesClient{},
-		MetricDefinitionsClient: &mockAzureMetricDefinitionsClient{},
-		MetricsClient:           &mockAzureMetricsClient{},
-	}, nil
-}
-
-func (*mockAzureResourcesClient) List(_ context.Context, _ *armresources.ClientListOptions) ([]*armresources.ClientListResponse, error) {
-	file, err := os.ReadFile("testdata/json/azure_resources_response.json")
-	if err != nil {
-		return nil, fmt.Errorf("error reading file: %w", err)
-	}
-
-	var genericResourcesExpanded []*armresources.GenericResourceExpanded
-	if err := json.Unmarshal(file, &genericResourcesExpanded); err != nil {
-		return nil, err
-	}
-
-	response := &armresources.ClientListResponse{
-		ResourceListResult: armresources.ResourceListResult{
-			Value: genericResourcesExpanded,
-		},
-	}
-
-	return []*armresources.ClientListResponse{response}, nil
-}
-
-func (*mockAzureResourcesClient) ListByResourceGroup(
-	_ context.Context,
-	resourceGroup string,
-	_ *armresources.ClientListByResourceGroupOptions) ([]*armresources.ClientListByResourceGroupResponse, error) {
-	var responses []*armresources.ClientListByResourceGroupResponse
-
-	file, err := os.ReadFile("testdata/json/azure_resources_response.json")
-	if err != nil {
-		return nil, fmt.Errorf("error reading file: %w", err)
-	}
-
-	var genericResourcesExpanded []*armresources.GenericResourceExpanded
-	if err := json.Unmarshal(file, &genericResourcesExpanded); err != nil {
-		return nil, err
-	}
-
-	if resourceGroup == "resourceGroup1" {
-		response := &armresources.ClientListByResourceGroupResponse{
-			ResourceListResult: armresources.ResourceListResult{
-				Value: []*armresources.GenericResourceExpanded{
-					genericResourcesExpanded[0],
-					genericResourcesExpanded[1],
-				},
-			},
-		}
-
-		responses = append(responses, response)
-		return responses, nil
-	}
-
-	if resourceGroup == "resourceGroup2" {
-		response := &armresources.ClientListByResourceGroupResponse{
-			ResourceListResult: armresources.ResourceListResult{
-				Value: []*armresources.GenericResourceExpanded{
-					genericResourcesExpanded[2],
-				},
-			},
-		}
-
-		responses = append(responses, response)
-		return responses, nil
-	}
-
-	return nil, errors.New("resource group was not found")
-}
-
-func (*mockAzureMetricDefinitionsClient) List(
-	_ context.Context,
-	resourceID string,
-	_ *armmonitor.MetricDefinitionsClientListOptions) (armmonitor.MetricDefinitionsClientListResponse, error) {
-	file, err := os.ReadFile("testdata/json/azure_metric_definitions_responses.json")
-	if err != nil {
-		return armmonitor.MetricDefinitionsClientListResponse{}, fmt.Errorf("error reading file: %w", err)
-	}
-
-	var metricDefinitions [][]*armmonitor.MetricDefinition
-	if err := json.Unmarshal(file, &metricDefinitions); err != nil {
-		return armmonitor.MetricDefinitionsClientListResponse{}, err
-	}
-
-	switch resourceID {
-	case "/subscriptions/subscriptionID/resourceGroups/resourceGroup1/providers/Microsoft.Test/type1/resource1":
-		return armmonitor.MetricDefinitionsClientListResponse{
-			MetricDefinitionCollection: armmonitor.MetricDefinitionCollection{
-				Value: metricDefinitions[0],
-			},
-		}, nil
-	case "/subscriptions/subscriptionID/resourceGroups/resourceGroup1/providers/Microsoft.Test/type2/resource2",
-		"/subscriptions/subscriptionID/resourceGroups/resourceGroup2/providers/Microsoft.Test/type2/resource4",
-		"/subscriptions/subscriptionID/resourceGroups/resourceGroup2/providers/Microsoft.Test/type2/resource5",
-		"/subscriptions/subscriptionID/resourceGroups/resourceGroup2/providers/Microsoft.Test/type2/resource6":
-		return armmonitor.MetricDefinitionsClientListResponse{
-			MetricDefinitionCollection: armmonitor.MetricDefinitionCollection{
-				Value: metricDefinitions[1],
-			},
-		}, nil
-	case "/subscriptions/subscriptionID/resourceGroups/resourceGroup2/providers/Microsoft.Test/type1/resource3":
-		return armmonitor.MetricDefinitionsClientListResponse{
-			MetricDefinitionCollection: armmonitor.MetricDefinitionCollection{
-				Value: metricDefinitions[2],
-			},
-		}, nil
-	}
-
-	return armmonitor.MetricDefinitionsClientListResponse{}, errors.New("resource ID was not found")
-}
-
-func (*mockAzureMetricsClient) List(
-	_ context.Context,
-	resourceID string,
-	_ *armmonitor.MetricsClientListOptions) (armmonitor.MetricsClientListResponse, error) {
-	file, err := os.ReadFile("testdata/json/azure_metrics_responses.json")
-	if err != nil {
-		return armmonitor.MetricsClientListResponse{}, fmt.Errorf("error reading file: %w", err)
-	}
-
-	var metricResponses []armmonitor.Response
-	if err := json.Unmarshal(file, &metricResponses); err != nil {
-		return armmonitor.MetricsClientListResponse{}, err
-	}
-
-	if resourceID == "/subscriptions/subscriptionID/resourceGroups/resourceGroup1/providers/Microsoft.Test/type1/resource1" {
-		return armmonitor.MetricsClientListResponse{
-			Response: metricResponses[0],
-		}, nil
-	}
-
-	if resourceID == "/subscriptions/subscriptionID/resourceGroups/resourceGroup1/providers/Microsoft.Test/type2/resource2" {
-		return armmonitor.MetricsClientListResponse{
-			Response: metricResponses[1],
-		}, nil
-	}
-
-	if resourceID == "/subscriptions/subscriptionID/resourceGroups/resourceGroup2/providers/Microsoft.Test/type1/resource3" {
-		return armmonitor.MetricsClientListResponse{
-			Response: metricResponses[2],
-		}, nil
-	}
-
-	if resourceID == "/subscriptions/subscriptionID/resourceGroups/resourceGroup2/providers/Microsoft.Test/type2/resource4" {
-		return armmonitor.MetricsClientListResponse{
-			Response: metricResponses[3],
-		}, nil
-	}
-
-	if resourceID == "/subscriptions/subscriptionID/resourceGroups/resourceGroup2/providers/Microsoft.Test/type2/resource5" {
-		return armmonitor.MetricsClientListResponse{
-			Response: metricResponses[4],
-		}, nil
-	}
-
-	if resourceID == "/subscriptions/subscriptionID/resourceGroups/resourceGroup2/providers/Microsoft.Test/type2/resource6" {
-		return armmonitor.MetricsClientListResponse{
-			Response: metricResponses[5],
-		}, nil
-	}
-
-	return armmonitor.MetricsClientListResponse{}, errors.New("resource ID was not found")
-}
 
 func TestInit_ResourceTargetsOnly(t *testing.T) {
 	file, err := os.ReadFile("testdata/toml/init_resource_targets_only.toml")
@@ -205,7 +27,7 @@ func TestInit_ResourceTargetsOnly(t *testing.T) {
 	require.NoError(t, toml.Unmarshal(file, &am))
 
 	am.Log = testutil.Logger{}
-	am.azureManager = &mockAzureClientsManager{}
+	am.factory = &mockClientFactory{}
 
 	for index := 1; index <= 27; index++ {
 		if index <= 10 {
@@ -218,7 +40,7 @@ func TestInit_ResourceTargetsOnly(t *testing.T) {
 	}
 
 	var expectedResourceMetrics []string
-	for index := 1; index <= receiver.MaxMetricsPerRequest; index++ {
+	for index := 1; index <= maxMetricsBatch; index++ {
 		if index <= 10 {
 			expectedResourceMetrics = append(expectedResourceMetrics, "metric1")
 		} else {
@@ -227,16 +49,16 @@ func TestInit_ResourceTargetsOnly(t *testing.T) {
 	}
 
 	require.NoError(t, am.Init())
-	require.Len(t, am.receiver.Targets.ResourceTargets, 8)
+	require.Len(t, am.receiver.resources, 8)
 
-	for _, target := range am.receiver.Targets.ResourceTargets {
+	for _, target := range am.receiver.resources {
 		require.Contains(t, []string{
 			"/subscriptions/subscriptionID/resourceGroups/resourceGroup1/providers/Microsoft.Test/type1/resource1",
 			"/subscriptions/subscriptionID/resourceGroups/resourceGroup1/providers/Microsoft.Test/type2/resource2",
 			"/subscriptions/subscriptionID/resourceGroups/resourceGroup2/providers/Microsoft.Test/type1/resource3"}, target.ResourceID)
 
 		if target.ResourceID == "/subscriptions/subscriptionID/resourceGroups/resourceGroup1/providers/Microsoft.Test/type1/resource1" {
-			require.Contains(t, []int{1, 2, 3, 4, receiver.MaxMetricsPerRequest}, len(target.Metrics))
+			require.Contains(t, []int{1, 2, 3, 4, maxMetricsBatch}, len(target.Metrics))
 
 			if len(target.Metrics) == 1 {
 				require.Equal(t, []string{"metric3"}, target.Metrics)
@@ -266,7 +88,7 @@ func TestInit_ResourceTargetsOnly(t *testing.T) {
 					string(armmonitor.AggregationTypeEnumTotal),
 				}, target.Aggregations)
 			}
-			if len(target.Metrics) == receiver.MaxMetricsPerRequest {
+			if len(target.Metrics) == maxMetricsBatch {
 				require.Equal(t, expectedResourceMetrics, target.Metrics)
 				require.Equal(t, []string{
 					string(armmonitor.AggregationTypeEnumAverage),
@@ -304,7 +126,7 @@ func TestInit_ResourceGroupTargetsOnly(t *testing.T) {
 	require.NoError(t, toml.Unmarshal(file, &am))
 
 	am.Log = testutil.Logger{}
-	am.azureManager = &mockAzureClientsManager{}
+	am.factory = &mockClientFactory{}
 
 	for index := 1; index <= 27; index++ {
 		if index <= 10 {
@@ -317,7 +139,7 @@ func TestInit_ResourceGroupTargetsOnly(t *testing.T) {
 	}
 
 	var expectedResourceMetrics []string
-	for index := 1; index <= receiver.MaxMetricsPerRequest; index++ {
+	for index := 1; index <= maxMetricsBatch; index++ {
 		if index <= 10 {
 			expectedResourceMetrics = append(expectedResourceMetrics, "metric1")
 		} else {
@@ -326,16 +148,16 @@ func TestInit_ResourceGroupTargetsOnly(t *testing.T) {
 	}
 
 	require.NoError(t, am.Init())
-	require.Len(t, am.receiver.Targets.ResourceTargets, 9)
+	require.Len(t, am.receiver.resources, 9)
 
-	for _, target := range am.receiver.Targets.ResourceTargets {
+	for _, target := range am.receiver.resources {
 		require.Contains(t, []string{
 			"/subscriptions/subscriptionID/resourceGroups/resourceGroup1/providers/Microsoft.Test/type1/resource1",
 			"/subscriptions/subscriptionID/resourceGroups/resourceGroup1/providers/Microsoft.Test/type2/resource2",
 			"/subscriptions/subscriptionID/resourceGroups/resourceGroup2/providers/Microsoft.Test/type1/resource3"}, target.ResourceID)
 
 		if target.ResourceID == "/subscriptions/subscriptionID/resourceGroups/resourceGroup1/providers/Microsoft.Test/type1/resource1" {
-			require.Contains(t, []int{1, 2, 3, 4, receiver.MaxMetricsPerRequest}, len(target.Metrics))
+			require.Contains(t, []int{1, 2, 3, 4, maxMetricsBatch}, len(target.Metrics))
 
 			if len(target.Metrics) == 1 {
 				require.Equal(t, []string{"metric3"}, target.Metrics)
@@ -365,7 +187,7 @@ func TestInit_ResourceGroupTargetsOnly(t *testing.T) {
 					string(armmonitor.AggregationTypeEnumTotal),
 				}, target.Aggregations)
 			}
-			if len(target.Metrics) == receiver.MaxMetricsPerRequest {
+			if len(target.Metrics) == maxMetricsBatch {
 				require.Equal(t, expectedResourceMetrics, target.Metrics)
 				require.Equal(t, []string{
 					string(armmonitor.AggregationTypeEnumAverage),
@@ -425,7 +247,7 @@ func TestInit_SubscriptionTargetsOnly(t *testing.T) {
 	require.NoError(t, toml.Unmarshal(file, &am))
 
 	am.Log = testutil.Logger{}
-	am.azureManager = &mockAzureClientsManager{}
+	am.factory = &mockClientFactory{}
 
 	for index := 1; index <= 27; index++ {
 		if index <= 10 {
@@ -438,7 +260,7 @@ func TestInit_SubscriptionTargetsOnly(t *testing.T) {
 	}
 
 	var expectedResourceMetrics []string
-	for index := 1; index <= receiver.MaxMetricsPerRequest; index++ {
+	for index := 1; index <= maxMetricsBatch; index++ {
 		if index <= 10 {
 			expectedResourceMetrics = append(expectedResourceMetrics, "metric1")
 		} else {
@@ -447,16 +269,16 @@ func TestInit_SubscriptionTargetsOnly(t *testing.T) {
 	}
 
 	require.NoError(t, am.Init())
-	require.Len(t, am.receiver.Targets.ResourceTargets, 11)
+	require.Len(t, am.receiver.resources, 11)
 
-	for _, target := range am.receiver.Targets.ResourceTargets {
+	for _, target := range am.receiver.resources {
 		require.Contains(t, []string{
 			"/subscriptions/subscriptionID/resourceGroups/resourceGroup1/providers/Microsoft.Test/type1/resource1",
 			"/subscriptions/subscriptionID/resourceGroups/resourceGroup1/providers/Microsoft.Test/type2/resource2",
 			"/subscriptions/subscriptionID/resourceGroups/resourceGroup2/providers/Microsoft.Test/type1/resource3"}, target.ResourceID)
 
 		if target.ResourceID == "/subscriptions/subscriptionID/resourceGroups/resourceGroup1/providers/Microsoft.Test/type1/resource1" {
-			require.Contains(t, []int{1, 2, 3, 4, receiver.MaxMetricsPerRequest}, len(target.Metrics))
+			require.Contains(t, []int{1, 2, 3, 4, maxMetricsBatch}, len(target.Metrics))
 
 			if len(target.Metrics) == 1 {
 				require.Equal(t, []string{"metric3"}, target.Metrics)
@@ -489,7 +311,7 @@ func TestInit_SubscriptionTargetsOnly(t *testing.T) {
 					string(armmonitor.AggregationTypeEnumTotal),
 				}, target.Aggregations)
 			}
-			if len(target.Metrics) == receiver.MaxMetricsPerRequest {
+			if len(target.Metrics) == maxMetricsBatch {
 				require.Equal(t, expectedResourceMetrics, target.Metrics)
 				require.Equal(t, []string{
 					string(armmonitor.AggregationTypeEnumAverage),
@@ -533,7 +355,7 @@ func TestInit_SubscriptionTargetsOnly(t *testing.T) {
 			}
 		}
 		if target.ResourceID == "/subscriptions/subscriptionID/resourceGroups/resourceGroup2/providers/Microsoft.Test/type1/resource3" {
-			require.Contains(t, []int{3, 7, receiver.MaxMetricsPerRequest}, len(target.Metrics))
+			require.Contains(t, []int{3, 7, maxMetricsBatch}, len(target.Metrics))
 
 			if len(target.Metrics) == 3 {
 				require.Equal(t, []string{"metric1", "metric2", "metric3"}, target.Metrics)
@@ -549,7 +371,7 @@ func TestInit_SubscriptionTargetsOnly(t *testing.T) {
 					string(armmonitor.AggregationTypeEnumTotal),
 				}, target.Aggregations)
 			}
-			if len(target.Metrics) == receiver.MaxMetricsPerRequest {
+			if len(target.Metrics) == maxMetricsBatch {
 				require.Equal(t, expectedResourceMetrics, target.Metrics)
 				require.Equal(t, []string{
 					string(armmonitor.AggregationTypeEnumAverage),
@@ -573,7 +395,7 @@ func TestInit_AllTargetTypes(t *testing.T) {
 	require.NoError(t, toml.Unmarshal(file, &am))
 
 	am.Log = testutil.Logger{}
-	am.azureManager = &mockAzureClientsManager{}
+	am.factory = &mockClientFactory{}
 
 	for index := 1; index <= 27; index++ {
 		if index <= 10 {
@@ -592,7 +414,7 @@ func TestInit_AllTargetTypes(t *testing.T) {
 	}
 
 	require.NoError(t, am.Init())
-	require.Len(t, am.receiver.Targets.ResourceTargets, 28)
+	require.Len(t, am.receiver.resources, 28)
 }
 
 func TestInit_NoSubscriptionID(t *testing.T) {
@@ -605,7 +427,7 @@ func TestInit_NoSubscriptionID(t *testing.T) {
 	require.NoError(t, toml.Unmarshal(file, &am))
 
 	am.Log = testutil.Logger{}
-	am.azureManager = &mockAzureClientsManager{}
+	am.factory = &mockClientFactory{}
 
 	require.Error(t, am.Init())
 }
@@ -620,7 +442,7 @@ func TestInit_NoClientID(t *testing.T) {
 	require.NoError(t, toml.Unmarshal(file, &am))
 
 	am.Log = testutil.Logger{}
-	am.azureManager = &mockAzureClientsManager{}
+	am.factory = &mockClientFactory{}
 
 	require.Error(t, am.Init())
 }
@@ -635,7 +457,7 @@ func TestInit_NoTenantID(t *testing.T) {
 	require.NoError(t, toml.Unmarshal(file, &am))
 
 	am.Log = testutil.Logger{}
-	am.azureManager = &mockAzureClientsManager{}
+	am.factory = &mockClientFactory{}
 
 	require.Error(t, am.Init())
 }
@@ -650,7 +472,7 @@ func TestInit_NoTargets(t *testing.T) {
 	require.NoError(t, toml.Unmarshal(file, &am))
 
 	am.Log = testutil.Logger{}
-	am.azureManager = &mockAzureClientsManager{}
+	am.factory = &mockClientFactory{}
 
 	require.Error(t, am.Init())
 }
@@ -665,7 +487,7 @@ func TestInit_ResourceTargetWithoutResourceID(t *testing.T) {
 	require.NoError(t, toml.Unmarshal(file, &am))
 
 	am.Log = testutil.Logger{}
-	am.azureManager = &mockAzureClientsManager{}
+	am.factory = &mockClientFactory{}
 
 	require.Error(t, am.Init())
 }
@@ -680,7 +502,7 @@ func TestInit_ResourceTargetWithInvalidResourceID(t *testing.T) {
 	require.NoError(t, toml.Unmarshal(file, &am))
 
 	am.Log = testutil.Logger{}
-	am.azureManager = &mockAzureClientsManager{}
+	am.factory = &mockClientFactory{}
 
 	require.Error(t, am.Init())
 }
@@ -695,7 +517,7 @@ func TestInit_ResourceTargetWithInvalidMetric(t *testing.T) {
 	require.NoError(t, toml.Unmarshal(file, &am))
 
 	am.Log = testutil.Logger{}
-	am.azureManager = &mockAzureClientsManager{}
+	am.factory = &mockClientFactory{}
 
 	require.Error(t, am.Init())
 }
@@ -710,7 +532,7 @@ func TestInit_ResourceTargetWithInvalidAggregation(t *testing.T) {
 	require.NoError(t, toml.Unmarshal(file, &am))
 
 	am.Log = testutil.Logger{}
-	am.azureManager = &mockAzureClientsManager{}
+	am.factory = &mockClientFactory{}
 
 	require.Error(t, am.Init())
 }
@@ -725,7 +547,7 @@ func TestInit_ResourceGroupTargetWithoutResourceGroup(t *testing.T) {
 	require.NoError(t, toml.Unmarshal(file, &am))
 
 	am.Log = testutil.Logger{}
-	am.azureManager = &mockAzureClientsManager{}
+	am.factory = &mockClientFactory{}
 
 	require.Error(t, am.Init())
 }
@@ -740,7 +562,7 @@ func TestInit_ResourceGroupTargetWithResourceWithoutResourceType(t *testing.T) {
 	require.NoError(t, toml.Unmarshal(file, &am))
 
 	am.Log = testutil.Logger{}
-	am.azureManager = &mockAzureClientsManager{}
+	am.factory = &mockClientFactory{}
 
 	require.Error(t, am.Init())
 }
@@ -755,7 +577,7 @@ func TestInit_ResourceGroupTargetWithInvalidResourceGroup(t *testing.T) {
 	require.NoError(t, toml.Unmarshal(file, &am))
 
 	am.Log = testutil.Logger{}
-	am.azureManager = &mockAzureClientsManager{}
+	am.factory = &mockClientFactory{}
 
 	require.Error(t, am.Init())
 }
@@ -770,7 +592,7 @@ func TestInit_ResourceGroupTargetWithInvalidResourceType(t *testing.T) {
 	require.NoError(t, toml.Unmarshal(file, &am))
 
 	am.Log = testutil.Logger{}
-	am.azureManager = &mockAzureClientsManager{}
+	am.factory = &mockClientFactory{}
 
 	require.Error(t, am.Init())
 }
@@ -785,7 +607,7 @@ func TestInit_ResourceGroupTargetWithInvalidMetric(t *testing.T) {
 	require.NoError(t, toml.Unmarshal(file, &am))
 
 	am.Log = testutil.Logger{}
-	am.azureManager = &mockAzureClientsManager{}
+	am.factory = &mockClientFactory{}
 
 	require.Error(t, am.Init())
 }
@@ -800,7 +622,7 @@ func TestInit_ResourceGroupTargetWithInvalidAggregation(t *testing.T) {
 	require.NoError(t, toml.Unmarshal(file, &am))
 
 	am.Log = testutil.Logger{}
-	am.azureManager = &mockAzureClientsManager{}
+	am.factory = &mockClientFactory{}
 
 	require.Error(t, am.Init())
 }
@@ -815,7 +637,7 @@ func TestInit_ResourceGroupTargetWithoutResources(t *testing.T) {
 	require.NoError(t, toml.Unmarshal(file, &am))
 
 	am.Log = testutil.Logger{}
-	am.azureManager = &mockAzureClientsManager{}
+	am.factory = &mockClientFactory{}
 
 	require.Error(t, am.Init())
 }
@@ -830,7 +652,7 @@ func TestInit_ResourceGroupTargetNoResourceFound(t *testing.T) {
 	require.NoError(t, toml.Unmarshal(file, &am))
 
 	am.Log = testutil.Logger{}
-	am.azureManager = &mockAzureClientsManager{}
+	am.factory = &mockClientFactory{}
 
 	require.Error(t, am.Init())
 }
@@ -845,7 +667,7 @@ func TestInit_SubscriptionTargetWithoutResourceType(t *testing.T) {
 	require.NoError(t, toml.Unmarshal(file, &am))
 
 	am.Log = testutil.Logger{}
-	am.azureManager = &mockAzureClientsManager{}
+	am.factory = &mockClientFactory{}
 
 	require.Error(t, am.Init())
 }
@@ -860,7 +682,7 @@ func TestInit_SubscriptionTargetWithInvalidResourceType(t *testing.T) {
 	require.NoError(t, toml.Unmarshal(file, &am))
 
 	am.Log = testutil.Logger{}
-	am.azureManager = &mockAzureClientsManager{}
+	am.factory = &mockClientFactory{}
 
 	require.Error(t, am.Init())
 }
@@ -875,7 +697,7 @@ func TestInit_SubscriptionTargetWithInvalidMetric(t *testing.T) {
 	require.NoError(t, toml.Unmarshal(file, &am))
 
 	am.Log = testutil.Logger{}
-	am.azureManager = &mockAzureClientsManager{}
+	am.factory = &mockClientFactory{}
 
 	require.Error(t, am.Init())
 }
@@ -890,7 +712,7 @@ func TestInit_SubscriptionTargetWithInvalidAggregation(t *testing.T) {
 	require.NoError(t, toml.Unmarshal(file, &am))
 
 	am.Log = testutil.Logger{}
-	am.azureManager = &mockAzureClientsManager{}
+	am.factory = &mockClientFactory{}
 
 	require.Error(t, am.Init())
 }
@@ -905,7 +727,7 @@ func TestInit_SubscriptionTargetNoResourceFound(t *testing.T) {
 	require.NoError(t, toml.Unmarshal(file, &am))
 
 	am.Log = testutil.Logger{}
-	am.azureManager = &mockAzureClientsManager{}
+	am.factory = &mockClientFactory{}
 
 	require.Error(t, am.Init())
 }
@@ -920,7 +742,7 @@ func TestInit_BadCredentials(t *testing.T) {
 	require.NoError(t, toml.Unmarshal(file, &am))
 
 	am.Log = testutil.Logger{}
-	am.azureManager = &azureClientsManager{}
+	am.factory = &azureFactory{}
 	require.Error(t, am.Init())
 }
 
@@ -934,53 +756,53 @@ func TestGather_Success(t *testing.T) {
 	require.NoError(t, toml.Unmarshal(file, &am))
 
 	am.Log = testutil.Logger{}
-	am.azureManager = &mockAzureClientsManager{}
+	am.factory = &mockClientFactory{}
 
 	require.NoError(t, am.Init())
 
 	expectedResource1Metric1Name := "azure_monitor_microsoft_test_type1_metric1"
 	expectedResource1Metric1MetricFields := make(map[string]interface{})
-	expectedResource1Metric1MetricFields[receiver.MetricFieldTimeStamp] = "2022-02-22T22:59:00Z"
-	expectedResource1Metric1MetricFields[receiver.MetricFieldTotal] = 5.0
-	expectedResource1Metric1MetricFields[receiver.MetricFieldMaximum] = 5.0
+	expectedResource1Metric1MetricFields["timeStamp"] = "2022-02-22T22:59:00Z"
+	expectedResource1Metric1MetricFields["total"] = 5.0
+	expectedResource1Metric1MetricFields["maximum"] = 5.0
 	expectedResource1Metric2Name := "azure_monitor_microsoft_test_type1_metric2"
 	expectedResource1Metric2MetricFields := make(map[string]interface{})
-	expectedResource1Metric2MetricFields[receiver.MetricFieldTimeStamp] = "2022-02-22T22:59:00Z"
-	expectedResource1Metric2MetricFields[receiver.MetricFieldTotal] = 2.5
-	expectedResource1Metric2MetricFields[receiver.MetricFieldMaximum] = 2.5
+	expectedResource1Metric2MetricFields["timeStamp"] = "2022-02-22T22:59:00Z"
+	expectedResource1Metric2MetricFields["total"] = 2.5
+	expectedResource1Metric2MetricFields["maximum"] = 2.5
 	expectedResource1MetricsTags := make(map[string]string)
-	expectedResource1MetricsTags[receiver.MetricTagSubscriptionID] = "subscriptionID"
-	expectedResource1MetricsTags[receiver.MetricTagResourceGroup] = "resourceGroup1"
-	expectedResource1MetricsTags[receiver.MetricTagNamespace] = "Microsoft.Test/type1"
-	expectedResource1MetricsTags[receiver.MetricTagResourceName] = "resource1"
-	expectedResource1MetricsTags[receiver.MetricTagResourceRegion] = "eastus"
-	expectedResource1MetricsTags[receiver.MetricTagUnit] = string(armmonitor.MetricUnitCount)
+	expectedResource1MetricsTags["subscription_id"] = "subscriptionID"
+	expectedResource1MetricsTags["resource_group"] = "resourceGroup1"
+	expectedResource1MetricsTags["namespace"] = "Microsoft.Test/type1"
+	expectedResource1MetricsTags["resource_name"] = "resource1"
+	expectedResource1MetricsTags["resource_region"] = "eastus"
+	expectedResource1MetricsTags["unit"] = string(armmonitor.MetricUnitCount)
 
 	expectedResource2Metric1Name := "azure_monitor_microsoft_test_type2_metric1"
 	expectedResource2Metric1MetricFields := make(map[string]interface{})
-	expectedResource2Metric1MetricFields[receiver.MetricFieldTimeStamp] = "2022-02-22T22:59:00Z"
-	expectedResource2Metric1MetricFields[receiver.MetricFieldTotal] = 5.0
-	expectedResource2Metric1MetricFields[receiver.MetricFieldMinimum] = 2.5
+	expectedResource2Metric1MetricFields["timeStamp"] = "2022-02-22T22:59:00Z"
+	expectedResource2Metric1MetricFields["total"] = 5.0
+	expectedResource2Metric1MetricFields["minimum"] = 2.5
 	expectedResource2MetricsTags := make(map[string]string)
-	expectedResource2MetricsTags[receiver.MetricTagSubscriptionID] = "subscriptionID"
-	expectedResource2MetricsTags[receiver.MetricTagResourceGroup] = "resourceGroup1"
-	expectedResource2MetricsTags[receiver.MetricTagNamespace] = "Microsoft.Test/type2"
-	expectedResource2MetricsTags[receiver.MetricTagResourceName] = "resource2"
-	expectedResource2MetricsTags[receiver.MetricTagResourceRegion] = "eastus"
-	expectedResource2MetricsTags[receiver.MetricTagUnit] = string(armmonitor.MetricUnitCount)
+	expectedResource2MetricsTags["subscription_id"] = "subscriptionID"
+	expectedResource2MetricsTags["resource_group"] = "resourceGroup1"
+	expectedResource2MetricsTags["namespace"] = "Microsoft.Test/type2"
+	expectedResource2MetricsTags["resource_name"] = "resource2"
+	expectedResource2MetricsTags["resource_region"] = "eastus"
+	expectedResource2MetricsTags["unit"] = string(armmonitor.MetricUnitCount)
 
 	expectedResource3Metric1Name := "azure_monitor_microsoft_test_type1_metric1"
 	expectedResource3Metric1MetricFields := make(map[string]interface{})
-	expectedResource3Metric1MetricFields[receiver.MetricFieldTimeStamp] = "2022-02-22T22:58:00Z"
-	expectedResource3Metric1MetricFields[receiver.MetricFieldTotal] = 2.5
-	expectedResource3Metric1MetricFields[receiver.MetricFieldMinimum] = 2.5
+	expectedResource3Metric1MetricFields["timeStamp"] = "2022-02-22T22:58:00Z"
+	expectedResource3Metric1MetricFields["total"] = 2.5
+	expectedResource3Metric1MetricFields["minimum"] = 2.5
 	expectedResource3MetricsTags := make(map[string]string)
-	expectedResource3MetricsTags[receiver.MetricTagSubscriptionID] = "subscriptionID"
-	expectedResource3MetricsTags[receiver.MetricTagResourceGroup] = "resourceGroup2"
-	expectedResource3MetricsTags[receiver.MetricTagNamespace] = "Microsoft.Test/type1"
-	expectedResource3MetricsTags[receiver.MetricTagResourceName] = "resource3"
-	expectedResource3MetricsTags[receiver.MetricTagResourceRegion] = "eastus"
-	expectedResource3MetricsTags[receiver.MetricTagUnit] = string(armmonitor.MetricUnitBytes)
+	expectedResource3MetricsTags["subscription_id"] = "subscriptionID"
+	expectedResource3MetricsTags["resource_group"] = "resourceGroup2"
+	expectedResource3MetricsTags["namespace"] = "Microsoft.Test/type1"
+	expectedResource3MetricsTags["resource_name"] = "resource3"
+	expectedResource3MetricsTags["resource_region"] = "eastus"
+	expectedResource3MetricsTags["unit"] = string(armmonitor.MetricUnitBytes)
 
 	acc := testutil.Accumulator{}
 
@@ -1003,7 +825,7 @@ func TestGather_China_Success(t *testing.T) {
 	require.NoError(t, toml.Unmarshal(file, &am))
 
 	am.Log = testutil.Logger{}
-	am.azureManager = &mockAzureClientsManager{}
+	am.factory = &mockClientFactory{}
 
 	require.NoError(t, am.Init())
 }
@@ -1018,7 +840,7 @@ func TestGather_Government_Success(t *testing.T) {
 	require.NoError(t, toml.Unmarshal(file, &am))
 
 	am.Log = testutil.Logger{}
-	am.azureManager = &mockAzureClientsManager{}
+	am.factory = &mockClientFactory{}
 
 	require.NoError(t, am.Init())
 }
@@ -1033,7 +855,175 @@ func TestGather_Public_Success(t *testing.T) {
 	require.NoError(t, toml.Unmarshal(file, &am))
 
 	am.Log = testutil.Logger{}
-	am.azureManager = &mockAzureClientsManager{}
+	am.factory = &mockClientFactory{}
 
 	require.NoError(t, am.Init())
+}
+
+type mockClientFactory struct{}
+
+func (*mockClientFactory) createClient(_, _, _, _ string, _ azcore.ClientOptions) (client, error) {
+	return &mockClient{}, nil
+}
+
+type mockClient struct{}
+
+func (*mockClient) ResourcesList(context.Context, *armresources.ClientListOptions) ([]*armresources.ClientListResponse, error) {
+	file, err := os.ReadFile("testdata/json/azure_resources_response.json")
+	if err != nil {
+		return nil, fmt.Errorf("error reading file: %w", err)
+	}
+
+	var genericResourcesExpanded []*armresources.GenericResourceExpanded
+	if err := json.Unmarshal(file, &genericResourcesExpanded); err != nil {
+		return nil, err
+	}
+
+	response := &armresources.ClientListResponse{
+		ResourceListResult: armresources.ResourceListResult{
+			Value: genericResourcesExpanded,
+		},
+	}
+
+	return []*armresources.ClientListResponse{response}, nil
+}
+
+func (*mockClient) ResourcesListByResourceGroup(
+	_ context.Context,
+	resourceGroup string,
+	_ *armresources.ClientListByResourceGroupOptions) ([]*armresources.ClientListByResourceGroupResponse, error) {
+	var responses []*armresources.ClientListByResourceGroupResponse
+
+	file, err := os.ReadFile("testdata/json/azure_resources_response.json")
+	if err != nil {
+		return nil, fmt.Errorf("error reading file: %w", err)
+	}
+
+	var genericResourcesExpanded []*armresources.GenericResourceExpanded
+	if err := json.Unmarshal(file, &genericResourcesExpanded); err != nil {
+		return nil, err
+	}
+
+	if resourceGroup == "resourceGroup1" {
+		response := &armresources.ClientListByResourceGroupResponse{
+			ResourceListResult: armresources.ResourceListResult{
+				Value: []*armresources.GenericResourceExpanded{
+					genericResourcesExpanded[0],
+					genericResourcesExpanded[1],
+				},
+			},
+		}
+
+		responses = append(responses, response)
+		return responses, nil
+	}
+
+	if resourceGroup == "resourceGroup2" {
+		response := &armresources.ClientListByResourceGroupResponse{
+			ResourceListResult: armresources.ResourceListResult{
+				Value: []*armresources.GenericResourceExpanded{
+					genericResourcesExpanded[2],
+				},
+			},
+		}
+
+		responses = append(responses, response)
+		return responses, nil
+	}
+
+	return nil, errors.New("resource group was not found")
+}
+
+func (*mockClient) MetricDefinitionsList(
+	_ context.Context,
+	resourceID string,
+	_ *armmonitor.MetricDefinitionsClientListOptions) (armmonitor.MetricDefinitionsClientListResponse, error) {
+	file, err := os.ReadFile("testdata/json/azure_metric_definitions_responses.json")
+	if err != nil {
+		return armmonitor.MetricDefinitionsClientListResponse{}, fmt.Errorf("error reading file: %w", err)
+	}
+
+	var metricDefinitions [][]*armmonitor.MetricDefinition
+	if err := json.Unmarshal(file, &metricDefinitions); err != nil {
+		return armmonitor.MetricDefinitionsClientListResponse{}, err
+	}
+
+	switch resourceID {
+	case "/subscriptions/subscriptionID/resourceGroups/resourceGroup1/providers/Microsoft.Test/type1/resource1":
+		return armmonitor.MetricDefinitionsClientListResponse{
+			MetricDefinitionCollection: armmonitor.MetricDefinitionCollection{
+				Value: metricDefinitions[0],
+			},
+		}, nil
+	case "/subscriptions/subscriptionID/resourceGroups/resourceGroup1/providers/Microsoft.Test/type2/resource2",
+		"/subscriptions/subscriptionID/resourceGroups/resourceGroup2/providers/Microsoft.Test/type2/resource4",
+		"/subscriptions/subscriptionID/resourceGroups/resourceGroup2/providers/Microsoft.Test/type2/resource5",
+		"/subscriptions/subscriptionID/resourceGroups/resourceGroup2/providers/Microsoft.Test/type2/resource6":
+		return armmonitor.MetricDefinitionsClientListResponse{
+			MetricDefinitionCollection: armmonitor.MetricDefinitionCollection{
+				Value: metricDefinitions[1],
+			},
+		}, nil
+	case "/subscriptions/subscriptionID/resourceGroups/resourceGroup2/providers/Microsoft.Test/type1/resource3":
+		return armmonitor.MetricDefinitionsClientListResponse{
+			MetricDefinitionCollection: armmonitor.MetricDefinitionCollection{
+				Value: metricDefinitions[2],
+			},
+		}, nil
+	}
+
+	return armmonitor.MetricDefinitionsClientListResponse{}, errors.New("resource ID was not found")
+}
+
+func (*mockClient) MetricsList(
+	_ context.Context,
+	resourceID string,
+	_ *armmonitor.MetricsClientListOptions) (armmonitor.MetricsClientListResponse, error) {
+	file, err := os.ReadFile("testdata/json/azure_metrics_responses.json")
+	if err != nil {
+		return armmonitor.MetricsClientListResponse{}, fmt.Errorf("error reading file: %w", err)
+	}
+
+	var metricResponses []armmonitor.Response
+	if err := json.Unmarshal(file, &metricResponses); err != nil {
+		return armmonitor.MetricsClientListResponse{}, err
+	}
+
+	if resourceID == "/subscriptions/subscriptionID/resourceGroups/resourceGroup1/providers/Microsoft.Test/type1/resource1" {
+		return armmonitor.MetricsClientListResponse{
+			Response: metricResponses[0],
+		}, nil
+	}
+
+	if resourceID == "/subscriptions/subscriptionID/resourceGroups/resourceGroup1/providers/Microsoft.Test/type2/resource2" {
+		return armmonitor.MetricsClientListResponse{
+			Response: metricResponses[1],
+		}, nil
+	}
+
+	if resourceID == "/subscriptions/subscriptionID/resourceGroups/resourceGroup2/providers/Microsoft.Test/type1/resource3" {
+		return armmonitor.MetricsClientListResponse{
+			Response: metricResponses[2],
+		}, nil
+	}
+
+	if resourceID == "/subscriptions/subscriptionID/resourceGroups/resourceGroup2/providers/Microsoft.Test/type2/resource4" {
+		return armmonitor.MetricsClientListResponse{
+			Response: metricResponses[3],
+		}, nil
+	}
+
+	if resourceID == "/subscriptions/subscriptionID/resourceGroups/resourceGroup2/providers/Microsoft.Test/type2/resource5" {
+		return armmonitor.MetricsClientListResponse{
+			Response: metricResponses[4],
+		}, nil
+	}
+
+	if resourceID == "/subscriptions/subscriptionID/resourceGroups/resourceGroup2/providers/Microsoft.Test/type2/resource6" {
+		return armmonitor.MetricsClientListResponse{
+			Response: metricResponses[5],
+		}, nil
+	}
+
+	return armmonitor.MetricsClientListResponse{}, errors.New("resource ID was not found")
 }

--- a/plugins/inputs/azure_monitor/factory.go
+++ b/plugins/inputs/azure_monitor/factory.go
@@ -77,7 +77,7 @@ func (*azureFactory) createClient(subscriptionID, clientID, clientSecret, tenant
 
 	resClient, err := armresources.NewClient(subscriptionID, credentials, options)
 	if err != nil {
-		return nil, fmt.Errorf("error creating Azure definitions client: %w", err)
+		return nil, fmt.Errorf("error creating Azure resources client: %w", err)
 	}
 
 	return &azureClient{

--- a/plugins/inputs/azure_monitor/factory.go
+++ b/plugins/inputs/azure_monitor/factory.go
@@ -1,0 +1,161 @@
+package azure_monitor
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/monitor/armmonitor"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
+)
+
+type client interface {
+	ResourcesList(
+		context.Context,
+		*armresources.ClientListOptions,
+	) ([]*armresources.ClientListResponse, error)
+	ResourcesListByResourceGroup(
+		context.Context,
+		string,
+		*armresources.ClientListByResourceGroupOptions,
+	) ([]*armresources.ClientListByResourceGroupResponse, error)
+	MetricDefinitionsList(
+		context.Context,
+		string,
+		*armmonitor.MetricDefinitionsClientListOptions,
+	) (armmonitor.MetricDefinitionsClientListResponse, error)
+	MetricsList(
+		context.Context,
+		string,
+		*armmonitor.MetricsClientListOptions,
+	) (armmonitor.MetricsClientListResponse, error)
+}
+
+type clientFactory interface {
+	createClient(subscriptionID, clientID, clientSecret, tenantID string, clientOptions azcore.ClientOptions) (client, error)
+}
+
+type azureFactory struct{}
+
+func (*azureFactory) createClient(subscriptionID, clientID, clientSecret, tenantID string, clientOptions azcore.ClientOptions) (client, error) {
+	var credentials azcore.TokenCredential
+
+	if clientSecret != "" {
+		secret, err := azidentity.NewClientSecretCredential(
+			tenantID,
+			clientID,
+			clientSecret,
+			&azidentity.ClientSecretCredentialOptions{ClientOptions: clientOptions},
+		)
+		if err != nil {
+			return nil, fmt.Errorf("error creating Azure client credential: %w", err)
+		}
+		credentials = secret
+	} else {
+		token, err := azidentity.NewDefaultAzureCredential(
+			&azidentity.DefaultAzureCredentialOptions{
+				TenantID:      tenantID,
+				ClientOptions: clientOptions,
+			})
+		if err != nil {
+			return nil, fmt.Errorf("error creating Azure token: %w", err)
+		}
+		credentials = token
+	}
+
+	options := &arm.ClientOptions{ClientOptions: clientOptions}
+	metricClient, err := armmonitor.NewMetricsClient(subscriptionID, credentials, options)
+	if err != nil {
+		return nil, fmt.Errorf("error creating Azure metric client: %w", err)
+	}
+	defClient, err := armmonitor.NewMetricDefinitionsClient(subscriptionID, credentials, options)
+	if err != nil {
+		return nil, fmt.Errorf("error creating Azure definitions client: %w", err)
+	}
+
+	resClient, err := armresources.NewClient(subscriptionID, credentials, options)
+	if err != nil {
+		return nil, fmt.Errorf("error creating Azure definitions client: %w", err)
+	}
+
+	return &azureClient{
+		resourceClient:   resClient,
+		definitionClient: defClient,
+		metricsClient:    metricClient,
+	}, nil
+}
+
+type azureClient struct {
+	resourceClient   *armresources.Client
+	definitionClient *armmonitor.MetricDefinitionsClient
+	metricsClient    *armmonitor.MetricsClient
+}
+
+// ResourcesList lists the resources
+func (c *azureClient) ResourcesList(
+	ctx context.Context,
+	options *armresources.ClientListOptions,
+) ([]*armresources.ClientListResponse, error) {
+	responses := make([]*armresources.ClientListResponse, 0)
+	pager := c.resourceClient.NewListPager(options)
+
+	for pager.More() {
+		response, err := pager.NextPage(ctx)
+		if err != nil {
+			return nil, err
+		}
+		responses = append(responses, &response)
+	}
+
+	return responses, nil
+}
+
+// ResourcesListByResourceGroup lists the resources by group
+func (c *azureClient) ResourcesListByResourceGroup(
+	ctx context.Context,
+	resourceGroup string,
+	options *armresources.ClientListByResourceGroupOptions,
+) ([]*armresources.ClientListByResourceGroupResponse, error) {
+	responses := make([]*armresources.ClientListByResourceGroupResponse, 0)
+	pager := c.resourceClient.NewListByResourceGroupPager(resourceGroup, options)
+
+	for pager.More() {
+		response, err := pager.NextPage(ctx)
+		if err != nil {
+			return nil, err
+		}
+		responses = append(responses, &response)
+	}
+
+	return responses, nil
+}
+
+// MetricDefinitionsList lists the metric definitions for a given resource
+func (c *azureClient) MetricDefinitionsList(
+	ctx context.Context,
+	resourceID string,
+	options *armmonitor.MetricDefinitionsClientListOptions,
+) (armmonitor.MetricDefinitionsClientListResponse, error) {
+	var response armmonitor.MetricDefinitionsClientListResponse
+
+	pager := c.definitionClient.NewListPager(resourceID, options)
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			return armmonitor.MetricDefinitionsClientListResponse{}, err
+		}
+		response.MetricDefinitionCollection.Value = append(response.MetricDefinitionCollection.Value, page.Value...)
+	}
+	return response, nil
+}
+
+// MetricsList collects the metric for a given resource
+func (c *azureClient) MetricsList(
+	ctx context.Context,
+	resource string,
+	option *armmonitor.MetricsClientListOptions,
+) (armmonitor.MetricsClientListResponse, error) {
+	return c.metricsClient.List(ctx, resource, option)
+}

--- a/plugins/inputs/azure_monitor/receiver.go
+++ b/plugins/inputs/azure_monitor/receiver.go
@@ -16,8 +16,7 @@ import (
 var nameReplacer = strings.NewReplacer(".", "_", "/", "_", " ", "_", "(", "_", ")", "_")
 
 type metricReceiver struct {
-	AzureClients client
-
+	client         client
 	subscriptionID string
 	resources      []*resourceTarget
 }
@@ -31,7 +30,7 @@ func newReceiver(
 	subscriptions []*resource,
 ) (*metricReceiver, error) {
 	r := &metricReceiver{
-		AzureClients:   client,
+		client:         client,
 		subscriptionID: subscriptionID,
 	}
 
@@ -59,7 +58,7 @@ func newReceiver(
 	result := make([]*resourceTarget, 0, len(r.resources))
 	for _, target := range r.resources {
 		// Get all valid metric definitions for the given resource
-		response, err := r.AzureClients.MetricDefinitionsList(ctx, target.ResourceID, nil)
+		response, err := r.client.MetricDefinitionsList(ctx, target.ResourceID, nil)
 		if err != nil {
 			return nil, fmt.Errorf("listing metric definitions for resource target %q failed: %w", target.ResourceID, err)
 		}
@@ -105,7 +104,7 @@ func newReceiver(
 				})
 
 				if !exists {
-					return nil, fmt.Errorf("invalid metric %q for resource target", metric)
+					return nil, fmt.Errorf("invalid metric %q for resource target %q", metric, target.ResourceID)
 				}
 			}
 		} else {
@@ -153,7 +152,7 @@ func (r *metricReceiver) collectMetrics(ctx context.Context, acc telegraf.Accumu
 	names := strings.Join(target.Metrics, ",")
 	aggregations := strings.Join(target.Aggregations, ",")
 
-	response, err := r.AzureClients.MetricsList(ctx, target.ResourceID, &armmonitor.MetricsClientListOptions{
+	response, err := r.client.MetricsList(ctx, target.ResourceID, &armmonitor.MetricsClientListOptions{
 		Metricnames: &names,
 		Aggregation: &aggregations,
 	})
@@ -179,7 +178,13 @@ func (r *metricReceiver) collectMetrics(ctx context.Context, acc telegraf.Accumu
 			continue
 		}
 		if metric.ErrorCode != nil && *metric.ErrorCode != "Success" {
-			acc.AddError(fmt.Errorf("metric error for resource target %q: %s: %s", target.ResourceID, *metric.ErrorCode, *metric.ErrorMessage))
+			var err error
+			if metric.ErrorMessage != nil {
+				err = fmt.Errorf("metric error for resource target %q: %s: %s", target.ResourceID, *metric.ErrorCode, *metric.ErrorMessage)
+			} else {
+				err = fmt.Errorf("metric error for resource target %q: %s", target.ResourceID, *metric.ErrorCode)
+			}
+			acc.AddError(err)
 			continue
 		}
 		if metric.ID == nil {
@@ -290,21 +295,17 @@ func createClientResourcesFilter(resources []*resource) string {
 }
 
 func (r *metricReceiver) createResourceTargetFromResourceGroupTarget(ctx context.Context, target *resourceGroupTarget) error {
-	resourceTargetsCreatedNum := 0
 	filter := createClientResourcesFilter(target.Resources)
 	option := &armresources.ClientListByResourceGroupOptions{Filter: &filter}
-	responses, err := r.AzureClients.ResourcesListByResourceGroup(ctx, target.ResourceGroup, option)
+	responses, err := r.client.ResourcesListByResourceGroup(ctx, target.ResourceGroup, option)
 	if err != nil {
 		return fmt.Errorf("listing by resource group failed: %w", err)
 	}
 
 	for _, response := range responses {
-		currentResourceTargetsCreatedNum, err := r.createResourceTargetFromTargetResources(response.Value, target.Resources)
-		if err != nil {
+		if err := r.createResourceTargetFromTargetResources(response.Value, target.Resources); err != nil {
 			return fmt.Errorf("error creating resource target from resource group target resources: %w", err)
 		}
-
-		resourceTargetsCreatedNum += currentResourceTargetsCreatedNum
 	}
 
 	return nil
@@ -315,56 +316,47 @@ func (r *metricReceiver) createResourceTargetsFromSubscriptionTargets(ctx contex
 		return nil
 	}
 
-	resourceTargetsCreatedNum := 0
 	filter := createClientResourcesFilter(targets)
-	responses, err := r.AzureClients.ResourcesList(ctx, &armresources.ClientListOptions{Filter: &filter})
+	responses, err := r.client.ResourcesList(ctx, &armresources.ClientListOptions{Filter: &filter})
 	if err != nil {
 		return fmt.Errorf("listing resources failed: %w", err)
 	}
 
 	for _, response := range responses {
-		currentResourceTargetsCreatedNum, err := r.createResourceTargetFromTargetResources(response.Value, targets)
-		if err != nil {
+		if err := r.createResourceTargetFromTargetResources(response.Value, targets); err != nil {
 			return fmt.Errorf("error creating resource target from subscription targets: %w", err)
 		}
-
-		resourceTargetsCreatedNum += currentResourceTargetsCreatedNum
 	}
 
 	return nil
 }
 
-func (r *metricReceiver) createResourceTargetFromTargetResources(resources []*armresources.GenericResourceExpanded, targetResources []*resource) (int, error) {
-	resourceTargetsCreatedNum := 0
-
+func (r *metricReceiver) createResourceTargetFromTargetResources(resources []*armresources.GenericResourceExpanded, targetResources []*resource) error {
 	for _, targetResource := range targetResources {
-		isResourceTargetCreated := false
+		var isResourceTargetCreated bool
 
 		for _, resource := range resources {
 			if resource == nil {
-				return resourceTargetsCreatedNum, errors.New("invalid resource")
+				return errors.New("invalid resource")
 			}
 			if resource.ID == nil {
-				return resourceTargetsCreatedNum, errors.New("invalid resource ID")
+				return errors.New("invalid resource ID")
 			}
-			resourceID := *resource.ID
-
 			if resource.Type == nil {
-				return resourceTargetsCreatedNum, errors.New("invalid resource type")
+				return errors.New("invalid resource type")
 			}
 			if *resource.Type != targetResource.ResourceType {
 				continue
 			}
 
-			r.resources = append(r.resources, &resourceTarget{resourceID, targetResource.Metrics, targetResource.Aggregations})
+			r.resources = append(r.resources, &resourceTarget{*resource.ID, targetResource.Metrics, targetResource.Aggregations})
 			isResourceTargetCreated = true
-			resourceTargetsCreatedNum++
 		}
 
 		if !isResourceTargetCreated {
-			return resourceTargetsCreatedNum, fmt.Errorf("could not find resources with resource type %q", targetResource.ResourceType)
+			return fmt.Errorf("could not find resources with resource type %q", targetResource.ResourceType)
 		}
 	}
 
-	return resourceTargetsCreatedNum, nil
+	return nil
 }

--- a/plugins/inputs/azure_monitor/receiver.go
+++ b/plugins/inputs/azure_monitor/receiver.go
@@ -225,7 +225,7 @@ func (r *metricReceiver) collectMetrics(ctx context.Context, acc telegraf.Accumu
 			continue
 		}
 		if len(parts[1]) < 3 {
-			err := fmt.Errorf("not enough parts (%d/3) for section 1 for metric %q of resource target %q", len(parts[0]), *metric.ID, target.ResourceID)
+			err := fmt.Errorf("not enough parts (%d/3) for section 1 for metric %q of resource target %q", len(parts[1]), *metric.ID, target.ResourceID)
 			acc.AddError(err)
 			continue
 		}

--- a/plugins/inputs/azure_monitor/receiver.go
+++ b/plugins/inputs/azure_monitor/receiver.go
@@ -206,8 +206,7 @@ func (r *metricReceiver) collectMetrics(ctx context.Context, acc telegraf.Accumu
 			log.Debugf("no timeseries data for metric %q of resource target %q", *metric.ID, target.ResourceID)
 			continue
 		}
-		// This is from https://github.com/logzio/azure-monitor-metrics-receiver/blob/master/collector.go but why do we
-		// only get the first index?
+		// We only want to collect latest metric which should be in the first timeseries segment
 		timeseries := metric.Timeseries[0].Data
 
 		// Construct the metric name

--- a/plugins/inputs/azure_monitor/receiver.go
+++ b/plugins/inputs/azure_monitor/receiver.go
@@ -220,7 +220,7 @@ func (r *metricReceiver) collectMetrics(ctx context.Context, acc telegraf.Accumu
 		for _, s := range idSplit {
 			parts = append(parts, strings.Split(s, "/"))
 		}
-		if len(parts) <= 1 {
+		if len(parts) < 2 {
 			acc.AddError(fmt.Errorf("not enough top parts for metric %q of resource target %q", *metric.ID, target.ResourceID))
 			continue
 		}
@@ -238,7 +238,7 @@ func (r *metricReceiver) collectMetrics(ctx context.Context, acc telegraf.Accumu
 		tags := map[string]string{
 			"subscription_id": parts[0][2],
 			"resource_group":  parts[0][4],
-			"resource_name":   parts[1][2],
+			"resource_name":   strings.Join(parts[1][2:], "/"),
 			"namespace":       *response.Namespace,
 			"resource_region": *response.Resourceregion,
 			"unit":            string(*metric.Unit),

--- a/plugins/inputs/azure_monitor/receiver.go
+++ b/plugins/inputs/azure_monitor/receiver.go
@@ -1,0 +1,370 @@
+package azure_monitor
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/monitor/armmonitor"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
+
+	"github.com/influxdata/telegraf"
+)
+
+var nameReplacer = strings.NewReplacer(".", "_", "/", "_", " ", "_", "(", "_", ")", "_")
+
+type metricReceiver struct {
+	AzureClients client
+
+	subscriptionID string
+	resources      []*resourceTarget
+}
+
+func newReceiver(
+	ctx context.Context,
+	client client,
+	subscriptionID string,
+	resources []*resourceTarget,
+	groups []*resourceGroupTarget,
+	subscriptions []*resource,
+) (*metricReceiver, error) {
+	r := &metricReceiver{
+		AzureClients:   client,
+		subscriptionID: subscriptionID,
+	}
+
+	// Create all resource targets from the different configurations
+	r.resources = slices.Clone(resources)
+
+	for _, target := range groups {
+		if err := r.createResourceTargetFromResourceGroupTarget(ctx, target); err != nil {
+			return nil, fmt.Errorf("creating resource targets from resource group target %q failed: %w", target.ResourceGroup, err)
+		}
+	}
+
+	if err := r.createResourceTargetsFromSubscriptionTargets(ctx, subscriptions); err != nil {
+		return nil, fmt.Errorf("error creating resource targets from subscription targets: %w", err)
+	}
+
+	// Get valid aggregation types
+	pagt := armmonitor.PossibleAggregationTypeEnumValues()
+	validAggregationTypes := make([]string, 0, len(pagt))
+	for _, v := range pagt {
+		validAggregationTypes = append(validAggregationTypes, string(v))
+	}
+
+	// Validate the metrics of the final result
+	result := make([]*resourceTarget, 0, len(r.resources))
+	for _, target := range r.resources {
+		// Get all valid metric definitions for the given resource
+		response, err := r.AzureClients.MetricDefinitionsList(ctx, target.ResourceID, nil)
+		if err != nil {
+			return nil, fmt.Errorf("listing metric definitions for resource target %q failed: %w", target.ResourceID, err)
+		}
+		if len(response.Value) == 0 {
+			return nil, errors.New("no value for metric definitions response")
+		}
+
+		// Validate the received metric definitions
+		for _, definition := range response.Value {
+			if definition == nil {
+				return nil, fmt.Errorf("bad metric definition %v for resource target %q", definition, target.ResourceID)
+			}
+
+			if definition.Name == nil || definition.Name.Value == nil {
+				return nil, fmt.Errorf("bad name-value in metric definition %v for resource target %q", definition, target.ResourceID)
+			}
+
+			if len(definition.MetricAvailabilities) == 0 || definition.MetricAvailabilities[0] == nil {
+				return nil, fmt.Errorf("bad availability in metric definition %v for resource target %q", definition, target.ResourceID)
+			}
+
+			if definition.MetricAvailabilities[0].TimeGrain == nil {
+				return nil, fmt.Errorf("bad time grain in metric definition %v for resource target %q", definition, target.ResourceID)
+			}
+		}
+
+		// Validate the target aggregations or set defaults
+		if len(target.Aggregations) == 0 {
+			target.Aggregations = validAggregationTypes
+		} else {
+			for _, a := range target.Aggregations {
+				if !slices.Contains(validAggregationTypes, a) {
+					return nil, fmt.Errorf("invalid aggregation %q in resource target %q", a, target.ResourceID)
+				}
+			}
+		}
+
+		if len(target.Metrics) > 0 {
+			// Validate metrics assigned to the resource target if any
+			for _, metric := range target.Metrics {
+				exists := slices.ContainsFunc(response.Value, func(definition *armmonitor.MetricDefinition) bool {
+					return metric == *definition.Name.Value
+				})
+
+				if !exists {
+					return nil, fmt.Errorf("invalid metric %q for resource target", metric)
+				}
+			}
+		} else {
+			// Create metrics for all definitions
+			for _, definition := range response.Value {
+				target.Metrics = append(target.Metrics, *definition.Name.Value)
+			}
+		}
+
+		timeGrains := make(map[string][]string)
+		for _, metric := range target.Metrics {
+			for _, definition := range response.Value {
+				if metric != *definition.Name.Value {
+					continue
+				}
+
+				timeGrain := *definition.MetricAvailabilities[0].TimeGrain
+				if _, found := timeGrains[timeGrain]; !found {
+					timeGrains[timeGrain] = make([]string, 0, 1)
+				}
+				timeGrains[timeGrain] = append(timeGrains[timeGrain], metric)
+			}
+		}
+
+		// Group the resource targets by minimum time gain and split large batches
+		for _, metrics := range timeGrains {
+			// Split the metrics into batches which do not exceed the maximum size
+			for start := 0; start < len(metrics); start += maxMetricsBatch {
+				end := min(start+maxMetricsBatch, len(metrics))
+
+				result = append(result, &resourceTarget{
+					ResourceID:   target.ResourceID,
+					Metrics:      metrics[start:end],
+					Aggregations: target.Aggregations,
+				})
+			}
+		}
+	}
+	r.resources = result
+
+	return r, nil
+}
+
+func (r *metricReceiver) collectMetrics(ctx context.Context, acc telegraf.Accumulator, target *resourceTarget, log telegraf.Logger) {
+	names := strings.Join(target.Metrics, ",")
+	aggregations := strings.Join(target.Aggregations, ",")
+
+	response, err := r.AzureClients.MetricsList(ctx, target.ResourceID, &armmonitor.MetricsClientListOptions{
+		Metricnames: &names,
+		Aggregation: &aggregations,
+	})
+	if err != nil {
+		acc.AddError(fmt.Errorf("listing metrics for resource target %q failed: %w", target.ResourceID, err))
+		return
+	}
+
+	// Check the reponse
+	if response.Namespace == nil {
+		acc.AddError(fmt.Errorf("bad namespace in response for resource target %q", target.ResourceID))
+		return
+	}
+	if response.Resourceregion == nil {
+		acc.AddError(fmt.Errorf("bad resource region in response for resource target %q", target.ResourceID))
+		return
+	}
+
+	for _, metric := range response.Value {
+		// Check the returned metric
+		if metric == nil {
+			acc.AddError(fmt.Errorf("bad metric for resource target %q", target.ResourceID))
+			continue
+		}
+		if metric.ErrorCode != nil && *metric.ErrorCode != "Success" {
+			acc.AddError(fmt.Errorf("metric error for resource target %q: %s: %s", target.ResourceID, *metric.ErrorCode, *metric.ErrorMessage))
+			continue
+		}
+		if metric.ID == nil {
+			acc.AddError(fmt.Errorf("missing metric ID for resource target %q", target.ResourceID))
+			continue
+		}
+
+		if metric.Name == nil || metric.Name.LocalizedValue == nil {
+			acc.AddError(fmt.Errorf("bad metric name for metric %q of resource target %q", *metric.ID, target.ResourceID))
+			continue
+		}
+
+		if metric.Unit == nil {
+			acc.AddError(fmt.Errorf("missing unit for metric %q of resource target %q", *metric.ID, target.ResourceID))
+			continue
+		}
+
+		if len(metric.Timeseries) == 0 || metric.Timeseries[0] == nil || len(metric.Timeseries[0].Data) == 0 {
+			log.Debugf("no timeseries data for metric %q of resource target %q", *metric.ID, target.ResourceID)
+			continue
+		}
+		// This is from https://github.com/logzio/azure-monitor-metrics-receiver/blob/master/collector.go but why do we
+		// only get the first index?
+		timeseries := metric.Timeseries[0].Data
+
+		// Construct the metric name
+		name := "azure_monitor_" + *response.Namespace + "_" + *metric.Name.LocalizedValue
+		name = nameReplacer.Replace(strings.ToLower(name))
+
+		// Construct the metric tags
+		idSplit := strings.Split(*metric.ID, "/providers/")
+		parts := make([][]string, 0, len(idSplit))
+		for _, s := range idSplit {
+			parts = append(parts, strings.Split(s, "/"))
+		}
+		if len(parts) <= 1 {
+			acc.AddError(fmt.Errorf("not enough top parts for metric %q of resource target %q", *metric.ID, target.ResourceID))
+			continue
+		}
+		if len(parts[0]) < 5 {
+			err := fmt.Errorf("not enough parts (%d/5) for section 0 for metric %q of resource target %q", len(parts[0]), *metric.ID, target.ResourceID)
+			acc.AddError(err)
+			continue
+		}
+		if len(parts[1]) < 3 {
+			err := fmt.Errorf("not enough parts (%d/3) for section 1 for metric %q of resource target %q", len(parts[0]), *metric.ID, target.ResourceID)
+			acc.AddError(err)
+			continue
+		}
+
+		tags := map[string]string{
+			"subscription_id": parts[0][2],
+			"resource_group":  parts[0][4],
+			"resource_name":   parts[1][2],
+			"namespace":       *response.Namespace,
+			"resource_region": *response.Resourceregion,
+			"unit":            string(*metric.Unit),
+		}
+
+		// Construct the metric fields. Iterate the timeseries in reverse order
+		// and only accept the latest valid field set
+		for i := len(timeseries) - 1; i >= 0; i-- {
+			data := timeseries[i]
+			if data == nil {
+				acc.AddError(fmt.Errorf("bad timeseries data for metric %q of resource target %q", *metric.ID, target.ResourceID))
+				continue
+			}
+
+			if data.TimeStamp == nil {
+				acc.AddError(fmt.Errorf("bad timestamp for data in metric %q of resource target %q", *metric.ID, target.ResourceID))
+				continue
+			}
+
+			fields := make(map[string]interface{}, 6)
+			fields["timeStamp"] = data.TimeStamp.Format("2006-01-02T15:04:05Z07:00")
+			if data.Total != nil {
+				fields["total"] = *data.Total
+			}
+			if data.Average != nil {
+				fields["average"] = *data.Average
+			}
+			if data.Count != nil {
+				fields["count"] = *data.Count
+			}
+			if data.Minimum != nil {
+				fields["minimum"] = *data.Minimum
+			}
+			if data.Maximum != nil {
+				fields["maximum"] = *data.Maximum
+			}
+
+			// Add metric if we do have at least the timestamp and another field
+			// Exit on success to only keep the latest metric
+			if len(fields) > 1 {
+				acc.AddFields(name, fields, tags)
+				break
+			}
+		}
+	}
+}
+
+func createClientResourcesFilter(resources []*resource) string {
+	filter := make([]string, 0, len(resources))
+	for _, r := range resources {
+		filter = append(filter, "resourceType eq "+"'"+r.ResourceType+"'")
+	}
+	return strings.Join(filter, " or ")
+}
+
+func (r *metricReceiver) createResourceTargetFromResourceGroupTarget(ctx context.Context, target *resourceGroupTarget) error {
+	resourceTargetsCreatedNum := 0
+	filter := createClientResourcesFilter(target.Resources)
+	option := &armresources.ClientListByResourceGroupOptions{Filter: &filter}
+	responses, err := r.AzureClients.ResourcesListByResourceGroup(ctx, target.ResourceGroup, option)
+	if err != nil {
+		return fmt.Errorf("listing by resource group failed: %w", err)
+	}
+
+	for _, response := range responses {
+		currentResourceTargetsCreatedNum, err := r.createResourceTargetFromTargetResources(response.Value, target.Resources)
+		if err != nil {
+			return fmt.Errorf("error creating resource target from resource group target resources: %w", err)
+		}
+
+		resourceTargetsCreatedNum += currentResourceTargetsCreatedNum
+	}
+
+	return nil
+}
+
+func (r *metricReceiver) createResourceTargetsFromSubscriptionTargets(ctx context.Context, targets []*resource) error {
+	if len(targets) == 0 {
+		return nil
+	}
+
+	resourceTargetsCreatedNum := 0
+	filter := createClientResourcesFilter(targets)
+	responses, err := r.AzureClients.ResourcesList(ctx, &armresources.ClientListOptions{Filter: &filter})
+	if err != nil {
+		return fmt.Errorf("listing resources failed: %w", err)
+	}
+
+	for _, response := range responses {
+		currentResourceTargetsCreatedNum, err := r.createResourceTargetFromTargetResources(response.Value, targets)
+		if err != nil {
+			return fmt.Errorf("error creating resource target from subscription targets: %w", err)
+		}
+
+		resourceTargetsCreatedNum += currentResourceTargetsCreatedNum
+	}
+
+	return nil
+}
+
+func (r *metricReceiver) createResourceTargetFromTargetResources(resources []*armresources.GenericResourceExpanded, targetResources []*resource) (int, error) {
+	resourceTargetsCreatedNum := 0
+
+	for _, targetResource := range targetResources {
+		isResourceTargetCreated := false
+
+		for _, resource := range resources {
+			if resource == nil {
+				return resourceTargetsCreatedNum, errors.New("invalid resource")
+			}
+			if resource.ID == nil {
+				return resourceTargetsCreatedNum, errors.New("invalid resource ID")
+			}
+			resourceID := *resource.ID
+
+			if resource.Type == nil {
+				return resourceTargetsCreatedNum, errors.New("invalid resource type")
+			}
+			if *resource.Type != targetResource.ResourceType {
+				continue
+			}
+
+			r.resources = append(r.resources, &resourceTarget{resourceID, targetResource.Metrics, targetResource.Aggregations})
+			isResourceTargetCreated = true
+			resourceTargetsCreatedNum++
+		}
+
+		if !isResourceTargetCreated {
+			return resourceTargetsCreatedNum, fmt.Errorf("could not find resources with resource type %q", targetResource.ResourceType)
+		}
+	}
+
+	return resourceTargetsCreatedNum, nil
+}


### PR DESCRIPTION
## Summary

This PR gets rid of the `github.com/logzio/azure-monitor-metrics-receiver` dependency which abstracts some of the Azure SDK functions. However, as the dependency is not well maintained it blocks upgrading the Azure SDK (see e.g. #19030).

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

required for #19030 