### PR TITLE
feat(outputs.sql): Add oracle driver

### DIFF
--- a/plugins/outputs/sql/sql.go
+++ b/plugins/outputs/sql/sql.go
@@ -98,16 +98,15 @@ func (p *SQL) Init() error {
 	switch p.Driver {
 	case "sqlite":
 		p.tableListColumnsTemplate = "SELECT name AS column_name FROM pragma_table_info({TABLE})"
+	case "clickhouse":
+		p.tableListColumnsTemplate = "SELECT column_name FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME={TABLE}"
+		p.convertClickHouseDsn()
 	case "oracle":
 		p.tableListColumnsTemplate = "SELECT column_name FROM all_tab_columns WHERE table_name = {TABLE}"
-	case "mssql", "mysql", "pgx", "snowflake", "clickhouse":
+	case "mssql", "mysql", "pgx", "snowflake":
 		p.tableListColumnsTemplate = "SELECT column_name FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME={TABLE}"
 	default:
 		return fmt.Errorf("unknown driver %q", p.Driver) // checks for valid driver
-	}
-
-	if p.Driver == "clickhouse" {
-		p.convertClickHouseDsn()
 	}
 
 	return nil
@@ -342,7 +341,6 @@ func (p *SQL) tableExists(tableName string) bool {
 
 func (p *SQL) updateTableCache(tablename string) error {
 	stmt := strings.ReplaceAll(p.tableListColumnsTemplate, "{TABLE}", quoteStr(tablename))
-	fmt.Println(stmt)
 
 	columns, err := p.db.Query(stmt)
 	if err != nil {

--- a/plugins/outputs/sql/sql.go
+++ b/plugins/outputs/sql/sql.go
@@ -106,7 +106,7 @@ func (p *SQL) Init() error {
 	case "mssql", "mysql", "pgx", "snowflake":
 		p.tableListColumnsTemplate = "SELECT column_name FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME={TABLE}"
 	default:
-		return fmt.Errorf("unknown driver %q", p.Driver) // checks for valid driver
+		return fmt.Errorf("unknown driver %q", p.Driver)
 	}
 
 	return nil

--- a/plugins/outputs/sql/sql.go
+++ b/plugins/outputs/sql/sql.go
@@ -101,7 +101,7 @@ func (p *SQL) Init() error {
 	case "oracle":
 		p.tableListColumnsTemplate = "SELECT column_name FROM all_tab_columns WHERE table_name = {TABLE}"
 	case "mssql", "mysql", "pgx", "snowflake", "clickhouse":
-		p.TableExistsTemplate = "SELECT column_name FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME={TABLE}"
+		p.tableListColumnsTemplate = "SELECT column_name FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME={TABLE}"
 	default:
 		return fmt.Errorf("unknown driver %q", p.Driver) // checks for valid driver
 	}
@@ -342,6 +342,7 @@ func (p *SQL) tableExists(tableName string) bool {
 
 func (p *SQL) updateTableCache(tablename string) error {
 	stmt := strings.ReplaceAll(p.tableListColumnsTemplate, "{TABLE}", quoteStr(tablename))
+	fmt.Println(stmt)
 
 	columns, err := p.db.Query(stmt)
 	if err != nil {

--- a/plugins/outputs/sql/sql.go
+++ b/plugins/outputs/sql/sql.go
@@ -100,6 +100,8 @@ func (p *SQL) Init() error {
 		p.tableListColumnsTemplate = "SELECT name AS column_name FROM pragma_table_info({TABLE})"
 	case "clickhouse":
 		p.tableListColumnsTemplate = "SELECT column_name FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME={TABLE}"
+
+		// Convert v1-style Clickhouse DSN to v2-style
 		p.convertClickHouseDsn()
 	case "oracle":
 		p.tableListColumnsTemplate = "SELECT column_name FROM all_tab_columns WHERE table_name = {TABLE}"

--- a/plugins/outputs/sql/sql.go
+++ b/plugins/outputs/sql/sql.go
@@ -18,6 +18,7 @@ import (
 	_ "github.com/jackc/pgx/v5/stdlib"                      // pgx (postgres)
 	_ "github.com/microsoft/go-mssqldb"                     // mssql (sql server)
 	_ "github.com/microsoft/go-mssqldb/integratedauth/krb5" // integrated auth for mssql
+	_ "github.com/sijms/go-ora/v2"                          // oracle
 	_ "github.com/snowflakedb/gosnowflake"                  // snowflake
 
 	"github.com/influxdata/telegraf"
@@ -79,7 +80,11 @@ func (*SQL) SampleConfig() string {
 func (p *SQL) Init() error {
 	// Set defaults
 	if p.TableExistsTemplate == "" {
-		p.TableExistsTemplate = "SELECT 1 FROM {TABLE} LIMIT 1"
+		if p.Driver == "oracle" {
+			p.TableExistsTemplate = "SELECT 1 FROM {TABLE} FETCH FIRST 1 ROWS ONLY"
+		} else {
+			p.TableExistsTemplate = "SELECT 1 FROM {TABLE} LIMIT 1"
+		}
 	}
 
 	if p.TableTemplate == "" {
@@ -90,20 +95,19 @@ func (p *SQL) Init() error {
 		}
 	}
 
-	p.tableListColumnsTemplate = "SELECT column_name FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME={TABLE}"
-	if p.Driver == "sqlite" {
+	switch p.Driver {
+	case "sqlite":
 		p.tableListColumnsTemplate = "SELECT name AS column_name FROM pragma_table_info({TABLE})"
+	case "oracle":
+		p.tableListColumnsTemplate = "SELECT column_name FROM all_tab_columns WHERE table_name = {TABLE}"
+	case "mssql", "mysql", "pgx", "snowflake", "clickhouse":
+		p.TableExistsTemplate = "SELECT column_name FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME={TABLE}"
+	default:
+		return fmt.Errorf("unknown driver %q", p.Driver) // checks for valid driver
 	}
 
-	// Check for a valid driver
-	switch p.Driver {
-	case "clickhouse":
-		// Convert v1-style Clickhouse DSN to v2-style
+	if p.Driver == "clickhouse" {
 		p.convertClickHouseDsn()
-	case "mssql", "mysql", "pgx", "snowflake", "sqlite":
-		// Do nothing, those are valid
-	default:
-		return fmt.Errorf("unknown driver %q", p.Driver)
 	}
 
 	return nil
@@ -245,14 +249,21 @@ func (p *SQL) generateInsert(tablename string, columns []string) string {
 	for _, column := range columns {
 		quotedColumns = append(quotedColumns, quoteIdent(column))
 	}
-	if p.Driver == "pgx" {
+
+	switch p.Driver {
+	case "pgx":
 		// Postgres uses $1 $2 $3 as placeholders
-		for i := 0; i < len(columns); i++ {
+		for i := range columns {
 			placeholders = append(placeholders, fmt.Sprintf("$%d", i+1))
 		}
-	} else {
+	case "oracle":
+		// Oracle uses :1 :2 :3 as placeholder
+		for i := range columns {
+			placeholders = append(placeholders, fmt.Sprintf(":%d", i+1))
+		}
+	default:
 		// Everything else uses ? ? ? as placeholders
-		for i := 0; i < len(columns); i++ {
+		for range columns {
 			placeholders = append(placeholders, "?")
 		}
 	}

--- a/plugins/outputs/sql/sql_test.go
+++ b/plugins/outputs/sql/sql_test.go
@@ -149,8 +149,6 @@ func TestOracleIntegration(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
-	const username = "system"
-
 	password := testutil.GetRandomString(30) // oracle max pw size is 30 bytes
 
 	servicePort := "1521"
@@ -168,8 +166,8 @@ func TestOracleIntegration(t *testing.T) {
 	require.NoError(t, container.Start(), "failed to start container")
 	defer container.Terminate()
 
-	address := config.NewSecret([]byte(fmt.Sprintf("oracle://%s:%s@%s:%s/FREEPDB1",
-		username, password, container.Address, container.Ports[servicePort],
+	address := config.NewSecret([]byte(fmt.Sprintf("oracle://system:%s@%s:%s/FREEPDB1",
+		password, container.Address, container.Ports[servicePort],
 	)))
 	p := &SQL{
 		Driver:            "oracle",
@@ -246,8 +244,6 @@ func TestOracleUpdateSchemeIntegration(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
-	const username = "system"
-
 	password := testutil.GetRandomString(30) // oracle max pw size is 30 bytes
 
 	servicePort := "1521"
@@ -265,8 +261,8 @@ func TestOracleUpdateSchemeIntegration(t *testing.T) {
 	require.NoError(t, container.Start(), "failed to start container")
 	defer container.Terminate()
 
-	address := config.NewSecret([]byte(fmt.Sprintf("oracle://%s:%s@%s:%s/FREEPDB1",
-		username, password, container.Address, container.Ports[servicePort],
+	address := config.NewSecret([]byte(fmt.Sprintf("oracle://system:%s@%s:%s/FREEPDB1",
+		password, container.Address, container.Ports[servicePort],
 	)))
 	p := &SQL{
 		Driver:              "oracle",
@@ -333,8 +329,6 @@ func TestOracleIntegrationSendBatch(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
-	const username = "system"
-
 	password := testutil.GetRandomString(30) // oracle max pw size is 30 bytes
 
 	servicePort := "1521"
@@ -352,8 +346,8 @@ func TestOracleIntegrationSendBatch(t *testing.T) {
 	require.NoError(t, container.Start(), "failed to start container")
 	defer container.Terminate()
 
-	address := config.NewSecret([]byte(fmt.Sprintf("oracle://%s:%s@%s:%s/FREEPDB1",
-		username, password, container.Address, container.Ports[servicePort],
+	address := config.NewSecret([]byte(fmt.Sprintf("oracle://system:%s@%s:%s/FREEPDB1",
+		password, container.Address, container.Ports[servicePort],
 	)))
 	p := &SQL{
 		Driver:            "oracle",

--- a/plugins/outputs/sql/sql_test.go
+++ b/plugins/outputs/sql/sql_test.go
@@ -210,13 +210,16 @@ func TestOracleIntegration(t *testing.T) {
 			}
 			_, err = p.db.Exec(stmt)
 			require.NoError(t, err, "error building expected results table!")
-
 		}
+
 		expectedTable := "expected_" + resTable
 
 		var schemeCount int32
-		resColumns := fmt.Sprintf(`SELECT column_name, data_type, data_precision, data_scale, data_length FROM USER_TAB_COLUMNS WHERE table_name = '%s'`, resTable)
-		expectedColumns := fmt.Sprintf(`SELECT column_name, data_type, data_precision, data_scale, data_length FROM USER_TAB_COLUMNS WHERE table_name = '%s'`, expectedTable)
+		resColumns := fmt.Sprintf(`SELECT column_name, data_type, data_precision, data_scale, data_length 
+			FROM USER_TAB_COLUMNS WHERE table_name = '%s'`, resTable)
+		expectedColumns := fmt.Sprintf(`SELECT column_name, data_type, data_precision, data_scale, data_length 
+			FROM USER_TAB_COLUMNS WHERE table_name = '%s'`, expectedTable)
+		//nolint:gosec // linter doesnt like due to security; no risk of injection so is fine
 		emptyTable := fmt.Sprintf(`SELECT COUNT(*) FROM ((%s MINUS %s) UNION (%s MINUS %s)) countdiff`,
 			resColumns, expectedColumns, expectedColumns, resColumns,
 		)
@@ -226,8 +229,9 @@ func TestOracleIntegration(t *testing.T) {
 		require.Zero(t, schemeCount, "There are mismatching rows! Tables do not share the same schema")
 
 		var rowCount int32
-		resQuery := fmt.Sprintf(`SELECT * FROM "%s"`, resTable)
-		expectedQuery := fmt.Sprintf(`SELECT * FROM "%s"`, expectedTable)
+		resQuery := fmt.Sprintf(`SELECT * FROM %q`, resTable)
+		expectedQuery := fmt.Sprintf(`SELECT * FROM %q`, expectedTable)
+		//nolint:gosec // linter doesnt like due to security; no risk of injection so is fine
 		emptyInsertion := fmt.Sprintf("SELECT COUNT(*) FROM ((%s MINUS %s) UNION (%s MINUS %s)) countdiff",
 			resQuery, expectedQuery, expectedQuery, resQuery,
 		)
@@ -236,7 +240,6 @@ func TestOracleIntegration(t *testing.T) {
 		require.NoError(t, err, "Error in row difference query!")
 		require.Zero(t, rowCount, "There are mismatching rows! Rows do not share the same data!")
 	}
-
 }
 
 func TestOracleUpdateSchemeIntegration(t *testing.T) {
@@ -301,8 +304,10 @@ func TestOracleUpdateSchemeIntegration(t *testing.T) {
 	}
 
 	var schemeCount int32
-	resColumns := `SELECT column_name, data_type, data_precision, data_scale, data_length FROM USER_TAB_COLUMNS WHERE table_name = 'metric_one'`
-	expectedColumns := `SELECT column_name, data_type, data_precision, data_scale, data_length FROM USER_TAB_COLUMNS WHERE table_name = 'expected_metric_one'`
+	resColumns := `SELECT column_name, data_type, data_precision, data_scale, data_length 
+		FROM USER_TAB_COLUMNS WHERE table_name = 'metric_one'`
+	expectedColumns := `SELECT column_name, data_type, data_precision, data_scale, data_length 
+		FROM USER_TAB_COLUMNS WHERE table_name = 'expected_metric_one'`
 	emptyTable := fmt.Sprintf(`SELECT COUNT(*) FROM ((%s MINUS %s) UNION (%s MINUS %s)) countdiff`,
 		resColumns, expectedColumns, expectedColumns, resColumns,
 	)
@@ -390,13 +395,15 @@ func TestOracleIntegrationSendBatch(t *testing.T) {
 			}
 			_, err = p.db.Exec(stmt)
 			require.NoError(t, err, "error building expected results table!")
-
 		}
 		expectedTable := "expected_" + resTable
 
 		var schemeCount int32
-		resColumns := fmt.Sprintf(`SELECT column_name, data_type, data_precision, data_scale, data_length FROM USER_TAB_COLUMNS WHERE table_name = '%s'`, resTable)
-		expectedColumns := fmt.Sprintf(`SELECT column_name, data_type, data_precision, data_scale, data_length FROM USER_TAB_COLUMNS WHERE table_name = '%s'`, expectedTable)
+		resColumns := fmt.Sprintf(`SELECT column_name, data_type, data_precision, data_scale, data_length 
+			FROM USER_TAB_COLUMNS WHERE table_name = '%s'`, resTable)
+		expectedColumns := fmt.Sprintf(`SELECT column_name, data_type, data_precision, data_scale, data_length 
+			FROM USER_TAB_COLUMNS WHERE table_name = '%s'`, expectedTable)
+		//nolint:gosec // linter doesnt like due to security; no risk of injection so is fine
 		emptyTable := fmt.Sprintf(`SELECT COUNT(*) FROM ((%s MINUS %s) UNION (%s MINUS %s)) countdiff`,
 			resColumns, expectedColumns, expectedColumns, resColumns,
 		)
@@ -406,8 +413,9 @@ func TestOracleIntegrationSendBatch(t *testing.T) {
 		require.Zero(t, schemeCount, "There are mismatching rows! Tables do not share the same schema")
 
 		var rowCount int32
-		resQuery := fmt.Sprintf(`SELECT * FROM "%s"`, resTable)
-		expectedQuery := fmt.Sprintf(`SELECT * FROM "%s"`, expectedTable)
+		resQuery := fmt.Sprintf(`SELECT * FROM %q`, resTable)
+		expectedQuery := fmt.Sprintf(`SELECT * FROM %q`, expectedTable)
+		//nolint:gosec // linter doesnt like due to security; no risk of injection so is fine
 		emptyInsertion := fmt.Sprintf("SELECT COUNT(*) FROM ((%s MINUS %s) UNION (%s MINUS %s)) countdiff",
 			resQuery, expectedQuery, expectedQuery, resQuery,
 		)

--- a/plugins/outputs/sql/sql_test.go
+++ b/plugins/outputs/sql/sql_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"testing"
 	"time"
 
@@ -143,6 +144,279 @@ var (
 		),
 	}
 )
+
+func TestOracleIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	const username = "system"
+
+	password := testutil.GetRandomString(30) // oracle max pw size is 30 bytes
+
+	servicePort := "1521"
+	container := testutil.Container{
+		Image: "gvenzl/oracle-free:latest",
+		Env: map[string]string{
+			"ORACLE_PASSWORD": password,
+		},
+		ExposedPorts: []string{servicePort},
+		WaitingFor: wait.ForAll(
+			wait.ForListeningPort(servicePort),
+			wait.ForLog("DATABASE IS READY TO USE"),
+		),
+	}
+	require.NoError(t, container.Start(), "failed to start container")
+	defer container.Terminate()
+
+	address := config.NewSecret([]byte(fmt.Sprintf("oracle://%s:%s@%s:%s/FREEPDB1",
+		username, password, container.Address, container.Ports[servicePort],
+	)))
+	p := &SQL{
+		Driver:            "oracle",
+		DataSourceName:    address,
+		Convert:           defaultConvert,
+		TimestampColumn:   "timestamp",
+		ConnectionMaxIdle: 2,
+		Log:               testutil.Logger{},
+	}
+
+	p.Convert.Integer = "NUMBER(38)"
+	p.Convert.Real = "NUMBER"
+	p.Convert.Text = "VARCHAR2(4000)"
+	p.Convert.Timestamp = "TIMESTAMP"
+	p.Convert.Defaultvalue = "VARCHAR2(4000)"
+	p.Convert.Bool = "BOOLEAN"
+	p.Convert.Unsigned = ""
+
+	require.NoError(t, p.Init())
+	require.NoError(t, p.Connect())
+	require.NoError(t, p.Write(testMetrics))
+
+	tableMap := map[string]string{
+		"metric_one":   "./testdata/oracle/expected_metric_one.sql",
+		"metric_two":   "./testdata/oracle/expected_metric_two.sql",
+		"metric three": "./testdata/oracle/expected_metric_three.sql",
+	}
+
+	for resTable, expectedTableQuery := range tableMap {
+		query, err := os.ReadFile(expectedTableQuery)
+		require.NoError(t, err, "failed to read expected sql table generation file!")
+		sqlStmts := strings.SplitSeq(string(query), ";")
+
+		for stmt := range sqlStmts {
+			// Handles white space after final statement in sql file
+			if strings.TrimSpace(stmt) == "" {
+				continue
+			}
+			_, err = p.db.Exec(stmt)
+			require.NoError(t, err, "error building expected results table!")
+
+		}
+		expectedTable := "expected_" + resTable
+
+		var schemeCount int32
+		resColumns := fmt.Sprintf(`SELECT column_name, data_type, data_precision, data_scale, data_length FROM USER_TAB_COLUMNS WHERE table_name = '%s'`, resTable)
+		expectedColumns := fmt.Sprintf(`SELECT column_name, data_type, data_precision, data_scale, data_length FROM USER_TAB_COLUMNS WHERE table_name = '%s'`, expectedTable)
+		emptyTable := fmt.Sprintf(`SELECT COUNT(*) FROM ((%s MINUS %s) UNION (%s MINUS %s)) countdiff`,
+			resColumns, expectedColumns, expectedColumns, resColumns,
+		)
+		err = p.db.QueryRow(emptyTable).Scan(&schemeCount)
+
+		require.NoError(t, err, "Error in table difference query!")
+		require.Zero(t, schemeCount, "There are mismatching rows! Tables do not share the same schema")
+
+		var rowCount int32
+		resQuery := fmt.Sprintf(`SELECT * FROM "%s"`, resTable)
+		expectedQuery := fmt.Sprintf(`SELECT * FROM "%s"`, expectedTable)
+		emptyInsertion := fmt.Sprintf("SELECT COUNT(*) FROM ((%s MINUS %s) UNION (%s MINUS %s)) countdiff",
+			resQuery, expectedQuery, expectedQuery, resQuery,
+		)
+		err = p.db.QueryRow(emptyInsertion).Scan(&rowCount)
+
+		require.NoError(t, err, "Error in row difference query!")
+		require.Zero(t, rowCount, "There are mismatching rows! Rows do not share the same data!")
+	}
+
+}
+
+func TestOracleUpdateSchemeIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	const username = "system"
+
+	password := testutil.GetRandomString(30) // oracle max pw size is 30 bytes
+
+	servicePort := "1521"
+	container := testutil.Container{
+		Image: "gvenzl/oracle-free:latest",
+		Env: map[string]string{
+			"ORACLE_PASSWORD": password,
+		},
+		ExposedPorts: []string{servicePort},
+		WaitingFor: wait.ForAll(
+			wait.ForListeningPort(servicePort),
+			wait.ForLog("DATABASE IS READY TO USE"),
+		),
+	}
+	require.NoError(t, container.Start(), "failed to start container")
+	defer container.Terminate()
+
+	address := config.NewSecret([]byte(fmt.Sprintf("oracle://%s:%s@%s:%s/FREEPDB1",
+		username, password, container.Address, container.Ports[servicePort],
+	)))
+	p := &SQL{
+		Driver:              "oracle",
+		DataSourceName:      address,
+		Convert:             defaultConvert,
+		TimestampColumn:     "timestamp",
+		ConnectionMaxIdle:   2,
+		TableUpdateTemplate: "ALTER TABLE {TABLE} ADD {COLUMN}",
+		Log:                 testutil.Logger{},
+	}
+
+	p.Convert.Integer = "NUMBER(38)"
+	p.Convert.Real = "NUMBER"
+	p.Convert.Text = "VARCHAR2(4000)"
+	p.Convert.Timestamp = "TIMESTAMP"
+	p.Convert.Defaultvalue = "VARCHAR2(4000)"
+	p.Convert.Bool = "BOOLEAN"
+	p.Convert.Unsigned = ""
+
+	require.NoError(t, p.Init())
+	require.NoError(t, p.Connect())
+	require.NoError(t, p.Write(testMetrics))
+	require.NoError(t, p.Write(postCreateMetrics))
+
+	query, err := os.ReadFile("./testdata/oracle/updatetable/expected_metric_one.sql")
+	require.NoError(t, err, "failed to read expected sql table generation file!")
+	sqlStmts := strings.SplitSeq(string(query), ";")
+
+	for stmt := range sqlStmts {
+		if strings.TrimSpace(stmt) == "" {
+			continue
+		}
+		_, err = p.db.Exec(stmt)
+		require.NoError(t, err, "error building expected results table!")
+	}
+
+	var schemeCount int32
+	resColumns := `SELECT column_name, data_type, data_precision, data_scale, data_length FROM USER_TAB_COLUMNS WHERE table_name = 'metric_one'`
+	expectedColumns := `SELECT column_name, data_type, data_precision, data_scale, data_length FROM USER_TAB_COLUMNS WHERE table_name = 'expected_metric_one'`
+	emptyTable := fmt.Sprintf(`SELECT COUNT(*) FROM ((%s MINUS %s) UNION (%s MINUS %s)) countdiff`,
+		resColumns, expectedColumns, expectedColumns, resColumns,
+	)
+
+	err = p.db.QueryRow(emptyTable).Scan(&schemeCount)
+
+	require.NoError(t, err, "Error in table difference query!")
+	require.Zero(t, schemeCount, "There are mismatching rows! Tables do not share the same schema")
+
+	var rowCount int32
+	resQuery := `SELECT * FROM "metric_one"`
+	expectedQuery := `select * from "expected_metric_one"`
+	emptyInsertion := fmt.Sprintf(`SELECT COUNT(*) FROM ((%s MINUS %s) UNION (%s MINUS %s)) countdiff`,
+		resQuery, expectedQuery, expectedQuery, resQuery,
+	)
+	err = p.db.QueryRow(emptyInsertion).Scan(&rowCount)
+
+	require.NoError(t, err, "Error in row difference query!")
+	require.Zero(t, rowCount, "There are mismatching rows! Rows do not share the same data!")
+}
+
+func TestOracleIntegrationSendBatch(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	const username = "system"
+
+	password := testutil.GetRandomString(30) // oracle max pw size is 30 bytes
+
+	servicePort := "1521"
+	container := testutil.Container{
+		Image: "gvenzl/oracle-free:latest",
+		Env: map[string]string{
+			"ORACLE_PASSWORD": password,
+		},
+		ExposedPorts: []string{servicePort},
+		WaitingFor: wait.ForAll(
+			wait.ForListeningPort(servicePort),
+			wait.ForLog("DATABASE IS READY TO USE"),
+		),
+	}
+	require.NoError(t, container.Start(), "failed to start container")
+	defer container.Terminate()
+
+	address := config.NewSecret([]byte(fmt.Sprintf("oracle://%s:%s@%s:%s/FREEPDB1",
+		username, password, container.Address, container.Ports[servicePort],
+	)))
+	p := &SQL{
+		Driver:            "oracle",
+		DataSourceName:    address,
+		Convert:           defaultConvert,
+		TimestampColumn:   "timestamp",
+		ConnectionMaxIdle: 2,
+		BatchTx:           true,
+		Log:               testutil.Logger{},
+	}
+
+	p.Convert.Integer = "NUMBER(38)"
+	p.Convert.Real = "NUMBER"
+	p.Convert.Text = "VARCHAR2(4000)"
+	p.Convert.Timestamp = "TIMESTAMP"
+	p.Convert.Defaultvalue = "VARCHAR2(4000)"
+	p.Convert.Bool = "BOOLEAN"
+	p.Convert.Unsigned = ""
+
+	require.NoError(t, p.Init())
+	require.NoError(t, p.Connect())
+	require.NoError(t, p.Write(testMetrics))
+
+	tableMap := map[string]string{
+		"metric_one":   "./testdata/oracle/expected_metric_one.sql",
+		"metric_two":   "./testdata/oracle/expected_metric_two.sql",
+		"metric three": "./testdata/oracle/expected_metric_three.sql",
+	}
+
+	for resTable, expectedTableQuery := range tableMap {
+		query, err := os.ReadFile(expectedTableQuery)
+		require.NoError(t, err, "failed to read expected sql table generation file!")
+		sqlStmts := strings.SplitSeq(string(query), ";")
+
+		for stmt := range sqlStmts {
+			// Handles white space after final statement in sql file
+			if strings.TrimSpace(stmt) == "" {
+				continue
+			}
+			_, err = p.db.Exec(stmt)
+			require.NoError(t, err, "error building expected results table!")
+
+		}
+		expectedTable := "expected_" + resTable
+
+		var schemeCount int32
+		resColumns := fmt.Sprintf(`SELECT column_name, data_type, data_precision, data_scale, data_length FROM USER_TAB_COLUMNS WHERE table_name = '%s'`, resTable)
+		expectedColumns := fmt.Sprintf(`SELECT column_name, data_type, data_precision, data_scale, data_length FROM USER_TAB_COLUMNS WHERE table_name = '%s'`, expectedTable)
+		emptyTable := fmt.Sprintf(`SELECT COUNT(*) FROM ((%s MINUS %s) UNION (%s MINUS %s)) countdiff`,
+			resColumns, expectedColumns, expectedColumns, resColumns,
+		)
+		err = p.db.QueryRow(emptyTable).Scan(&schemeCount)
+
+		require.NoError(t, err, "Error in table difference query!")
+		require.Zero(t, schemeCount, "There are mismatching rows! Tables do not share the same schema")
+
+		var rowCount int32
+		resQuery := fmt.Sprintf(`SELECT * FROM "%s"`, resTable)
+		expectedQuery := fmt.Sprintf(`SELECT * FROM "%s"`, expectedTable)
+		emptyInsertion := fmt.Sprintf("SELECT COUNT(*) FROM ((%s MINUS %s) UNION (%s MINUS %s)) countdiff",
+			resQuery, expectedQuery, expectedQuery, resQuery,
+		)
+		err = p.db.QueryRow(emptyInsertion).Scan(&rowCount)
+
+		require.NoError(t, err, "Error in row difference query!")
+		require.Zero(t, rowCount, "There are mismatching rows! Rows do not share the same data!")
+	}
+}
 
 func TestMysqlIntegration(t *testing.T) {
 	if testing.Short() {

--- a/plugins/outputs/sql/testdata/oracle/expected_metric_one.sql
+++ b/plugins/outputs/sql/testdata/oracle/expected_metric_one.sql
@@ -1,0 +1,12 @@
+CREATE TABLE "expected_metric_one" (
+    "timestamp" TIMESTAMP,
+    "tag_one" VARCHAR2(4000),
+    "tag_two" VARCHAR2(4000),
+    "int64_one" NUMBER(38),
+    "int64_two" NUMBER(38),
+    "bool_one" BOOLEAN,
+    "bool_two" BOOLEAN,
+    "uint64_one" NUMBER(38),
+    "float64_one" NUMBER
+);
+INSERT INTO "expected_metric_one" VALUES (TO_TIMESTAMP('2021-05-17 22:04:45', 'YYYY-MM-DD HH24:MI:SS'),'tag1','tag2',1234,2345,1,0,1000000000,3.1415);

--- a/plugins/outputs/sql/testdata/oracle/expected_metric_three.sql
+++ b/plugins/outputs/sql/testdata/oracle/expected_metric_three.sql
@@ -1,0 +1,6 @@
+CREATE TABLE "expected_metric three" (
+    "timestamp" TIMESTAMP,
+    "tag four" VARCHAR2(4000),
+    "string two" VARCHAR2(4000)
+);
+INSERT INTO "expected_metric three" VALUES (TO_TIMESTAMP('2021-05-17 22:04:45', 'YYYY-MM-DD HH24:MI:SS'), 'tag4', 'string2');

--- a/plugins/outputs/sql/testdata/oracle/expected_metric_two.sql
+++ b/plugins/outputs/sql/testdata/oracle/expected_metric_two.sql
@@ -1,0 +1,6 @@
+CREATE TABLE "expected_metric_two" (
+    "timestamp" TIMESTAMP,
+    "tag_three" VARCHAR2(4000),
+    "string_one" VARCHAR2(4000)
+);
+INSERT INTO "expected_metric_two" VALUES (TO_TIMESTAMP('2021-05-17 22:04:45', 'YYYY-MM-DD HH24:MI:SS'), 'tag3', 'string1');

--- a/plugins/outputs/sql/testdata/oracle/updatetable/expected_metric_one.sql
+++ b/plugins/outputs/sql/testdata/oracle/updatetable/expected_metric_one.sql
@@ -1,0 +1,15 @@
+CREATE TABLE "expected_metric_one" (
+    "timestamp" TIMESTAMP,
+    "tag_one" VARCHAR2(4000),
+    "tag_two" VARCHAR2(4000),
+    "int64_one" NUMBER(38),
+    "int64_two" NUMBER(38),
+    "bool_one" BOOLEAN,
+    "bool_two" BOOLEAN,
+    "uint64_one" NUMBER(38),
+    "float64_one" NUMBER,
+    "tag_add_after_create" VARCHAR2(4000),
+    "bool_add_after_create" BOOLEAN
+);
+INSERT INTO "expected_metric_one" VALUES (TO_TIMESTAMP('2021-05-17 22:04:45', 'YYYY-MM-DD HH24:MI:SS'),'tag1','tag2',1234,2345,1,0,1000000000,3.1415,null,null);
+INSERT INTO "expected_metric_one" VALUES (TO_TIMESTAMP('2021-05-17 22:04:45', 'YYYY-MM-DD HH24:MI:SS'),null,null,null,null,null,null,null,null,'tag2',1);


### PR DESCRIPTION
## Summary

Adds Oracle support for `outputs/sql` plugin. Involved small additions to the code in `outputs/sql/sql.go` which encouraged slight stylistic changes (namely converting some if blocks to switches). Also added 3 integration tests for the Oracle support.

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #18959 
