### PR TITLE
chore(ci): Disable Windows HNS excluded port ranges in test job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -199,6 +199,12 @@ jobs:
       - check-changed-files-or-halt
       - run: git config --system core.longpaths true
       - run: choco feature enable -n allowGlobalConfirmation
+      - run:
+          name: Disable Windows HNS excluded port ranges
+          shell: powershell.exe
+          command: |
+            reg add "HKLM\SYSTEM\CurrentControlSet\Services\hns\State" /v EnableExcludedPortRange /d 0 /f
+            Restart-Service hns -Force
       - run: 'sh ./scripts/installgo_windows.sh'
       - run: choco install mingw
       - run: echo 'export PATH="$PATH:/c/ProgramData/mingw64/mingw64/bin"' >> $BASH_ENV


### PR DESCRIPTION


## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Windows reserves blocks of the dynamic port range for Hyper-V/winnat (HNS excluded port ranges). On the CircleCI Windows executor this intermittently breaks tests that bind ephemeral (`:0`) ports, since a bind can land on a reserved port and fail with a permission error. Because the reserved port is random, the failures are flaky and not specific to a single plugin.

The nsdp test surfaced this most reliably because go-nsdp's `NewConn` binds an explicit derived local port (`target_port - 1`, see conn.go:59/75) rather than an OS-assigned one, so it hits a reserved port deterministically rather than intermittently.

Rather than wrapping individual tests in port-bind retry loops, disable the HNS excluded port ranges on the Windows test executor before running the Go tests. This fixes the nsdp test and the general class of `:0` bind flakiness in one place.


## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
