### PR TITLE
feat(inputs.kafka_consumer): Add consumer_fetch_min and consumer_fetch_max_wait options

### DIFF
--- a/plugins/inputs/kafka_consumer/README.md
+++ b/plugins/inputs/kafka_consumer/README.md
@@ -240,12 +240,11 @@ to use them.
 
   ## The minimum number of message bytes to fetch in a request; the broker
   ## waits until at least this many bytes are available or 'consumer_fetch_max_wait'
-  ## elapses before responding. Similar to the JVM's `fetch.min.bytes`.
+  ## elapses before responding.
   # consumer_fetch_min = "1B"
 
   ## The maximum amount of time the broker waits for 'consumer_fetch_min' bytes
-  ## to become available before responding with fewer bytes anyway. Similar to
-  ## the JVM's `fetch.max.wait.ms`.
+  ## to become available before responding with fewer bytes anyway.
   # consumer_fetch_max_wait = "500ms"
 
   ## Data format to consume.

--- a/plugins/inputs/kafka_consumer/README.md
+++ b/plugins/inputs/kafka_consumer/README.md
@@ -238,6 +238,16 @@ to use them.
   ## `fetch.message.max.bytes`.
   # consumer_fetch_default = "1MB"
 
+  ## The minimum number of message bytes to fetch in a request; the broker
+  ## waits until at least this many bytes are available or 'consumer_fetch_max_wait'
+  ## elapses before responding. Similar to the JVM's `fetch.min.bytes`.
+  # consumer_fetch_min = "1B"
+
+  ## The maximum amount of time the broker waits for 'consumer_fetch_min' bytes
+  ## to become available before responding with fewer bytes anyway. Similar to
+  ## the JVM's `fetch.max.wait.ms`.
+  # consumer_fetch_max_wait = "500ms"
+
   ## Data format to consume.
   ## Each data format has its own unique set of configuration options, read
   ## more about them here:

--- a/plugins/inputs/kafka_consumer/kafka_consumer.go
+++ b/plugins/inputs/kafka_consumer/kafka_consumer.go
@@ -49,6 +49,8 @@ type KafkaConsumer struct {
 	MsgHeaderAsMetricName                string          `toml:"msg_header_as_metric_name"`
 	TimestampSource                      string          `toml:"timestamp_source"`
 	ConsumerFetchDefault                 config.Size     `toml:"consumer_fetch_default"`
+	ConsumerFetchMin                     config.Size     `toml:"consumer_fetch_min"`
+	ConsumerFetchMaxWait                 config.Duration `toml:"consumer_fetch_max_wait"`
 	ConnectionStrategy                   string          `toml:"connection_strategy" deprecated:"1.33.0;1.40.0;use 'startup_error_behavior' instead"`
 	ResolveCanonicalBootstrapServersOnly bool            `toml:"resolve_canonical_bootstrap_servers_only"`
 	Log                                  telegraf.Logger `toml:"-"`
@@ -188,6 +190,14 @@ func (k *KafkaConsumer) Init() error {
 
 	if k.ConsumerFetchDefault != 0 {
 		cfg.Consumer.Fetch.Default = int32(k.ConsumerFetchDefault)
+	}
+
+	if k.ConsumerFetchMin != 0 {
+		cfg.Consumer.Fetch.Min = int32(k.ConsumerFetchMin)
+	}
+
+	if k.ConsumerFetchMaxWait != 0 {
+		cfg.Consumer.MaxWaitTime = time.Duration(k.ConsumerFetchMaxWait)
 	}
 
 	switch strings.ToLower(k.ConnectionStrategy) {

--- a/plugins/inputs/kafka_consumer/kafka_consumer_test.go
+++ b/plugins/inputs/kafka_consumer/kafka_consumer_test.go
@@ -204,6 +204,26 @@ func TestInit(t *testing.T) {
 				require.Equal(t, 1000*time.Millisecond, plugin.config.Consumer.MaxProcessingTime)
 			},
 		},
+		{
+			name: "custom consumer_fetch_min",
+			plugin: &KafkaConsumer{
+				ConsumerFetchMin: config.Size(1024),
+				Log:              testutil.Logger{},
+			},
+			check: func(t *testing.T, plugin *KafkaConsumer) {
+				require.Equal(t, int32(1024), plugin.config.Consumer.Fetch.Min)
+			},
+		},
+		{
+			name: "custom consumer_fetch_max_wait",
+			plugin: &KafkaConsumer{
+				ConsumerFetchMaxWait: config.Duration(250 * time.Millisecond),
+				Log:                  testutil.Logger{},
+			},
+			check: func(t *testing.T, plugin *KafkaConsumer) {
+				require.Equal(t, 250*time.Millisecond, plugin.config.Consumer.MaxWaitTime)
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/plugins/inputs/kafka_consumer/sample.conf
+++ b/plugins/inputs/kafka_consumer/sample.conf
@@ -169,12 +169,11 @@
 
   ## The minimum number of message bytes to fetch in a request; the broker
   ## waits until at least this many bytes are available or 'consumer_fetch_max_wait'
-  ## elapses before responding. Similar to the JVM's `fetch.min.bytes`.
+  ## elapses before responding.
   # consumer_fetch_min = "1B"
 
   ## The maximum amount of time the broker waits for 'consumer_fetch_min' bytes
-  ## to become available before responding with fewer bytes anyway. Similar to
-  ## the JVM's `fetch.max.wait.ms`.
+  ## to become available before responding with fewer bytes anyway.
   # consumer_fetch_max_wait = "500ms"
 
   ## Data format to consume.

--- a/plugins/inputs/kafka_consumer/sample.conf
+++ b/plugins/inputs/kafka_consumer/sample.conf
@@ -167,6 +167,16 @@
   ## `fetch.message.max.bytes`.
   # consumer_fetch_default = "1MB"
 
+  ## The minimum number of message bytes to fetch in a request; the broker
+  ## waits until at least this many bytes are available or 'consumer_fetch_max_wait'
+  ## elapses before responding. Similar to the JVM's `fetch.min.bytes`.
+  # consumer_fetch_min = "1B"
+
+  ## The maximum amount of time the broker waits for 'consumer_fetch_min' bytes
+  ## to become available before responding with fewer bytes anyway. Similar to
+  ## the JVM's `fetch.max.wait.ms`.
+  # consumer_fetch_max_wait = "500ms"
+
   ## Data format to consume.
   ## Each data format has its own unique set of configuration options, read
   ## more about them here:


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Adds two new configuration options to the `kafka_consumer` input plugin that map directly to existing Sarama consumer settings:                                                                                                                                          
  
  - `consumer_fetch_min` (`config.Size`) sets `Consumer.Fetch.Min`, the minimum number of message bytes the broker waits to accumulate before responding. Equivalent to the JVM client's `fetch.min.bytes`.
  - `consumer_fetch_max_wait` (`config.Duration`) sets `Consumer.MaxWaitTime`, the maximum time the broker waits for `consumer_fetch_min` bytes to become available before responding with fewer bytes. Equivalent to the JVM client's `fetch.max.wait.ms`.



## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

