### PR TITLE
chore(inputs.system): Wrap errors in legacy gather path

### DIFF
--- a/plugins/inputs/system/README.md
+++ b/plugins/inputs/system/README.md
@@ -51,7 +51,8 @@ However, if you are using Prometheus as an output, it might be your preferred
 choice as the metrics are typed correctly.
 
 If you are using the fine-grained options such as `cpus` you will get a _single_,
-untyped metric containing all selected information.
+untyped metric containing all selected information. To reproduce the fields of
+the `legacy` set, use `include = ["load", "users", "cpus", "uptime"]`.
 
 Both `legacy` and the fine-grained options can be used at the same time
 resulting in four metrics in total (one for the fine-grained set and three for

--- a/plugins/inputs/system/system.go
+++ b/plugins/inputs/system/system.go
@@ -64,7 +64,7 @@ func (s *System) Init() error {
 					telegraf.DeprecationInfo{
 						Since:     "1.39.0",
 						RemovalIn: "1.45.0",
-						Notice:    "use 'uptime' instead",
+						Notice:    "use 'load', 'users', 'cpus' and 'uptime' instead",
 					},
 				)
 			}
@@ -179,19 +179,19 @@ func (s *System) gatherLegacy(acc telegraf.Accumulator, now time.Time) error {
 	loadavg, err := load.Avg()
 	if err != nil {
 		if !strings.Contains(err.Error(), "not implemented") {
-			return err
+			return fmt.Errorf("reading load averages: %w", err)
 		}
 		loadavg = &load.AvgStat{}
 	}
 
 	numLogicalCPUs, err := cpu.Counts(true)
 	if err != nil {
-		return err
+		return fmt.Errorf("reading logical CPU count: %w", err)
 	}
 
 	numPhysicalCPUs, err := cpu.Counts(false)
 	if err != nil {
-		return err
+		return fmt.Errorf("reading physical CPU count: %w", err)
 	}
 
 	fields := map[string]interface{}{
@@ -214,7 +214,7 @@ func (s *System) gatherLegacy(acc telegraf.Accumulator, now time.Time) error {
 
 	uptime, err := host.Uptime()
 	if err != nil {
-		return err
+		return fmt.Errorf("reading uptime: %w", err)
 	}
 
 	acc.AddCounter("system", map[string]interface{}{"uptime": uptime}, nil, now)

--- a/plugins/inputs/system/system_test.go
+++ b/plugins/inputs/system/system_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/shirou/gopsutil/v4/host"
 	"github.com/stretchr/testify/require"
 
@@ -244,11 +243,7 @@ func TestGather(t *testing.T) {
 			var acc testutil.Accumulator
 			require.NoError(t, plugin.Gather(&acc))
 
-			options := []cmp.Option{
-				testutil.IgnoreTime(),
-				testutil.SortMetrics(),
-			}
-			testutil.RequireMetricsStructureEqual(t, tt.expected, acc.GetTelegrafMetrics(), options...)
+			testutil.RequireMetricsStructureEqual(t, tt.expected, acc.GetTelegrafMetrics(), testutil.IgnoreTime(), testutil.SortMetrics())
 		})
 	}
 }


### PR DESCRIPTION


## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Add context to the errors returned from the legacy gather path so they match the fine-grained cases, and point the 'legacy' deprecation notice and README at the full replacement set ('load', 'users', 'cpus', 'uptime') instead of only 'uptime'.

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
