### PR TITLE
feat(outputs.socket_writer): Implement startup error behavior handling

### DIFF
--- a/plugins/outputs/socket_writer/README.md
+++ b/plugins/outputs/socket_writer/README.md
@@ -17,6 +17,23 @@ plugin ordering. See [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 [CONFIGURATION.md]: ../../../docs/CONFIGURATION.md#plugins
 
+## Startup error behavior options <!-- @/docs/includes/startup_error_behavior.md -->
+
+In addition to the plugin-specific and global configuration settings the plugin
+supports options for specifying the behavior when experiencing startup errors
+using the `startup_error_behavior` setting. Available values are:
+
+- `error`:  Telegraf with stop and exit in case of startup errors. This is the
+            default behavior.
+- `ignore`: Telegraf will ignore startup errors for this plugin and disables it
+            but continues processing for all other plugins.
+- `retry`:  Telegraf will try to startup the plugin in every gather or write
+            cycle in case of startup errors. The plugin is disabled until
+            the startup succeeds.
+- `probe`:  Telegraf will probe the plugin's function (if possible) and disables
+            the plugin in case probing fails. If the plugin does not support
+            probing, Telegraf will behave as if `ignore` was set instead.
+
 ## Configuration
 
 ```toml @sample.conf

--- a/plugins/outputs/socket_writer/socket_writer.go
+++ b/plugins/outputs/socket_writer/socket_writer.go
@@ -155,7 +155,8 @@ func (sw *SocketWriter) Write(metrics []telegraf.Metric) error {
 
 		if _, err := sw.Conn.Write(bs); err != nil {
 			// TODO log & keep going with remaining strings
-			if netErr, ok := errors.AsType[net.Error](err); ok {
+			var netErr net.Error
+			if errors.As(err, &netErr) {
 				// permanent error. close the connection
 				sw.Close()
 				sw.Conn = nil

--- a/plugins/outputs/socket_writer/socket_writer.go
+++ b/plugins/outputs/socket_writer/socket_writer.go
@@ -58,7 +58,7 @@ func (sw *SocketWriter) Connect() error {
 	}
 
 	var c net.Conn
-
+	var sockErr error
 	if spl[0] == "vsock" {
 		addrTuple := strings.SplitN(spl[1], ":", 2)
 
@@ -83,26 +83,19 @@ func (sw *SocketWriter) Connect() error {
 		if (port >= uint64(math.Pow(2, 32))-1) && (port <= 0) {
 			return fmt.Errorf("port number %d is out of range", port)
 		}
-		c, err = vsock.Dial(uint32(cid), uint32(port), nil)
-		if err != nil {
-			return err
-		}
+		c, sockErr = vsock.Dial(uint32(cid), uint32(port), nil)
 	} else {
 		if tlsCfg == nil {
-			c, err = net.Dial(spl[0], spl[1])
+			c, sockErr = net.Dial(spl[0], spl[1])
 		} else {
-			c, err = tls.Dial(spl[0], spl[1], tlsCfg)
+			c, sockErr = tls.Dial(spl[0], spl[1], tlsCfg)
 		}
-		if err != nil {
-			if opErr, ok := errors.AsType[*net.OpError](err); ok {
-				return &internal.StartupError{
-					Err:     opErr,
-					Retry:   true,
-					Partial: false,
-				}
-			}
+	}
 
-			return err
+	if sockErr != nil {
+		return &internal.StartupError{
+			Err:   sockErr,
+			Retry: true,
 		}
 	}
 

--- a/plugins/outputs/socket_writer/socket_writer.go
+++ b/plugins/outputs/socket_writer/socket_writer.go
@@ -94,6 +94,14 @@ func (sw *SocketWriter) Connect() error {
 			c, err = tls.Dial(spl[0], spl[1], tlsCfg)
 		}
 		if err != nil {
+			if opErr, ok := errors.AsType[*net.OpError](err); ok {
+				return &internal.StartupError{
+					Err:     opErr,
+					Retry:   true,
+					Partial: false,
+				}
+			}
+
 			return err
 		}
 	}
@@ -154,8 +162,7 @@ func (sw *SocketWriter) Write(metrics []telegraf.Metric) error {
 
 		if _, err := sw.Conn.Write(bs); err != nil {
 			// TODO log & keep going with remaining strings
-			var netErr net.Error
-			if errors.As(err, &netErr) {
+			if netErr, ok := errors.AsType[net.Error](err); ok {
 				// permanent error. close the connection
 				sw.Close()
 				sw.Conn = nil

--- a/plugins/outputs/socket_writer/socket_writer_test.go
+++ b/plugins/outputs/socket_writer/socket_writer_test.go
@@ -241,8 +241,7 @@ func TestStartupErrorBehaviorDefault(t *testing.T) {
 	require.NoError(t, model.Init())
 
 	// Starting the plugin will fail with an error because the server does not listen
-	err = model.Connect()
-	require.Error(t, err, "connection should be refused")
+	require.Error(t, model.Connect(), "connection should be refused")
 	var serr *internal.StartupError
 	require.ErrorAs(t, err, &serr)
 }
@@ -271,8 +270,7 @@ func TestStartupErrorBehaviorError(t *testing.T) {
 	require.NoError(t, model.Init())
 
 	// Starting the plugin will fail with an error because the server does not listen
-	err = model.Connect()
-	require.Error(t, err, "connection should be refused")
+	require.Error(t, model.Connect(), "connection should be refused")
 	var serr *internal.StartupError
 	require.ErrorAs(t, err, &serr)
 }
@@ -303,8 +301,8 @@ func TestStartupErrorBehaviorIgnore(t *testing.T) {
 	// Starting the plugin will fail because the server does not accept connections.
 	// The model code should convert it to a fatal error for the agent to remove
 	// the plugin.
-	err = model.Connect()
-	require.Error(t, err, "connection should be refused")
+
+	require.Error(t, model.Connect(), "connection should be refused")
 	var fatalErr *internal.FatalError
 	require.ErrorAs(t, err, &fatalErr)
 }

--- a/plugins/outputs/socket_writer/socket_writer_test.go
+++ b/plugins/outputs/socket_writer/socket_writer_test.go
@@ -6,10 +6,13 @@ import (
 	"runtime"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/internal"
+	"github.com/influxdata/telegraf/models"
 	"github.com/influxdata/telegraf/plugins/serializers/influx"
 	"github.com/influxdata/telegraf/testutil"
 )
@@ -212,4 +215,172 @@ func TestSocketWriter_udp_gzip(t *testing.T) {
 	require.NoError(t, sw.Connect())
 
 	testSocketWriterPacket(t, sw, listener)
+}
+
+func TestStartupErrorBehaviorDefault(t *testing.T) {
+	// Setup a dummy listener but do not accept connections
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	address := listener.Addr().String()
+	listener.Close()
+
+	// Setup the plugin and the model to be able to use the startup retry strategy
+	plugin := &SocketWriter{
+		ContentEncoding: "",
+		Address:         "tcp://" + address,
+	}
+
+	model, err := models.NewRunningOutput(
+		plugin,
+		&models.OutputConfig{
+			Name: "socket_writer",
+		},
+		10, 100,
+	)
+	require.NoError(t, err)
+	require.NoError(t, model.Init())
+
+	// Starting the plugin will fail with an error because the server does not listen
+	err = model.Connect()
+	require.Error(t, err, "connection should be refused")
+	var serr *internal.StartupError
+	require.ErrorAs(t, err, &serr)
+}
+
+func TestStartupErrorBehaviorError(t *testing.T) {
+	// Setup a dummy listener but do not accept connections
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	address := listener.Addr().String()
+	listener.Close()
+
+	// Setup the plugin and the model to be able to use the startup retry strategy
+	plugin := &SocketWriter{
+		Address: "tcp://" + address,
+	}
+
+	model, err := models.NewRunningOutput(
+		plugin,
+		&models.OutputConfig{
+			Name:                 "socket_writer",
+			StartupErrorBehavior: "error",
+		},
+		10, 100,
+	)
+	require.NoError(t, err)
+	require.NoError(t, model.Init())
+
+	// Starting the plugin will fail with an error because the server does not listen
+	err = model.Connect()
+	require.Error(t, err, "connection should be refused")
+	var serr *internal.StartupError
+	require.ErrorAs(t, err, &serr)
+}
+
+func TestStartupErrorBehaviorIgnore(t *testing.T) {
+	// Setup a dummy listener but do not accept connections
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	address := listener.Addr().String()
+	listener.Close()
+
+	// Setup the plugin and the model to be able to use the startup retry strategy
+	plugin := &SocketWriter{
+		Address: "tcp://" + address,
+	}
+
+	model, err := models.NewRunningOutput(
+		plugin,
+		&models.OutputConfig{
+			Name:                 "socket_writer",
+			StartupErrorBehavior: "ignore",
+		},
+		10, 100,
+	)
+	require.NoError(t, err)
+	require.NoError(t, model.Init())
+
+	// Starting the plugin will fail because the server does not accept connections.
+	// The model code should convert it to a fatal error for the agent to remove
+	// the plugin.
+	err = model.Connect()
+	require.Error(t, err, "connection should be refused")
+	var fatalErr *internal.FatalError
+	require.ErrorAs(t, err, &fatalErr)
+}
+
+func TestStartupErrorBehaviorRetry(t *testing.T) {
+	// Setup a dummy listener but do not accept connections
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	address := listener.Addr().String()
+	listener.Close()
+
+	// Setup the plugin and the model to be able to use the startup retry strategy
+	plugin := &SocketWriter{
+		Address:    "tcp://" + address,
+		serializer: &influx.Serializer{},
+	}
+
+	model, err := models.NewRunningOutput(
+		plugin,
+		&models.OutputConfig{
+			Name:                 "socket_writer",
+			StartupErrorBehavior: "retry",
+		},
+		10, 100,
+	)
+	require.NoError(t, err)
+	require.NoError(t, model.Init())
+
+	// Starting the plugin will return no error because the plugin will
+	// retry to connect in every write cycle.
+	require.NoError(t, model.Connect())
+	defer model.Close()
+
+	// Writing metrics in this state should fail because we are not fully
+	// started up
+	metrics := testutil.MockMetrics()
+	for _, m := range metrics {
+		model.AddMetric(m)
+	}
+	require.ErrorIs(t, model.WriteBatch(), internal.ErrNotConnected)
+
+	// Startup an actually working listener we can connect and write to
+	listener, err = net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer listener.Close()
+
+	var wg sync.WaitGroup
+	buf := make([]byte, 256)
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		conn, err := listener.Accept()
+		if err != nil {
+			t.Logf("accepting connection failed: %v", err)
+			t.Fail()
+			return
+		}
+
+		if err := conn.SetReadDeadline(time.Now().Add(3 * time.Second)); err != nil {
+			t.Logf("setting read deadline failed: %v", err)
+			t.Fail()
+			return
+		}
+
+		if _, err := conn.Read(buf); err != nil {
+			t.Logf("reading failed: %v", err)
+			t.Fail()
+		}
+	}()
+
+	// Update the plugin's address and write again. This time the write should
+	// succeed.
+	plugin.Address = "tcp://" + listener.Addr().String()
+	require.NoError(t, model.WriteBatch())
+	wg.Wait()
+	require.NotEmpty(t, string(buf))
 }

--- a/plugins/outputs/socket_writer/socket_writer_test.go
+++ b/plugins/outputs/socket_writer/socket_writer_test.go
@@ -241,9 +241,8 @@ func TestStartupErrorBehaviorDefault(t *testing.T) {
 	require.NoError(t, model.Init())
 
 	// Starting the plugin will fail with an error because the server does not listen
-	require.Error(t, model.Connect(), "connection should be refused")
 	var serr *internal.StartupError
-	require.ErrorAs(t, err, &serr)
+	require.ErrorAs(t, model.Connect(), &serr)
 }
 
 func TestStartupErrorBehaviorError(t *testing.T) {
@@ -270,9 +269,8 @@ func TestStartupErrorBehaviorError(t *testing.T) {
 	require.NoError(t, model.Init())
 
 	// Starting the plugin will fail with an error because the server does not listen
-	require.Error(t, model.Connect(), "connection should be refused")
 	var serr *internal.StartupError
-	require.ErrorAs(t, err, &serr)
+	require.ErrorAs(t, model.Connect(), &serr)
 }
 
 func TestStartupErrorBehaviorIgnore(t *testing.T) {
@@ -301,10 +299,8 @@ func TestStartupErrorBehaviorIgnore(t *testing.T) {
 	// Starting the plugin will fail because the server does not accept connections.
 	// The model code should convert it to a fatal error for the agent to remove
 	// the plugin.
-
-	require.Error(t, model.Connect(), "connection should be refused")
 	var fatalErr *internal.FatalError
-	require.ErrorAs(t, err, &fatalErr)
+	require.ErrorAs(t, model.Connect(), &fatalErr)
 }
 
 func TestStartupErrorBehaviorRetry(t *testing.T) {
@@ -352,28 +348,22 @@ func TestStartupErrorBehaviorRetry(t *testing.T) {
 	var wg sync.WaitGroup
 	buf := make([]byte, 256)
 
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-
+	wg.Go(func() {
 		conn, err := listener.Accept()
 		if err != nil {
-			t.Logf("accepting connection failed: %v", err)
-			t.Fail()
+			t.Errorf("accepting connection failed: %v", err)
 			return
 		}
 
 		if err := conn.SetReadDeadline(time.Now().Add(3 * time.Second)); err != nil {
-			t.Logf("setting read deadline failed: %v", err)
-			t.Fail()
+			t.Errorf("setting read deadline failed: %v", err)
 			return
 		}
 
 		if _, err := conn.Read(buf); err != nil {
-			t.Logf("reading failed: %v", err)
-			t.Fail()
+			t.Errorf("reading failed: %v", err)
 		}
-	}()
+	})
 
 	// Update the plugin's address and write again. This time the write should
 	// succeed.


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

The socket writer now supports the `startup_error_behaviour` feature.

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #19032 
