### PR TITLE
chore(outputs.influxdb_v2): Migrate unix socket dialing from Dial to DialContext

### DIFF
--- a/plugins/outputs/influxdb_v2/http.go
+++ b/plugins/outputs/influxdb_v2/http.go
@@ -107,8 +107,8 @@ func (c *httpClient) Init() error {
 	case "unix":
 		socketPath := c.url.Path
 		transport = &http.Transport{
-			Dial: func(_, _ string) (net.Conn, error) {
-				return net.DialTimeout("unix", socketPath, c.timeout)
+			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+				return (&net.Dialer{Timeout: c.timeout}).DialContext(ctx, "unix", socketPath)
 			},
 		}
 	default:


### PR DESCRIPTION
Replace deprecated http.Transport.Dial and net.DialTimeout with DialContext to properly propagate context cancellation.

## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
https://github.com/influxdata/telegraf/pull/18984#discussion_r3312210344

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [ ] No AI generated code was used in this PR
- [x] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->


