### PR TITLE
feat(inputs.proxmox): Add disk and network I/O metrics

### DIFF
--- a/plugins/inputs/proxmox/README.md
+++ b/plugins/inputs/proxmox/README.md
@@ -94,9 +94,13 @@ See this [Proxmox docs example][docs] for further details.
     - disk_total
     - disk_free
     - disk_used_percentage
+    - disk_read_bytes
+    - disk_write_bytes
+    - net_in_bytes
+    - net_out_bytes
 
 ## Example Output
 
 ```text
-proxmox,host=pxnode,node_fqdn=pxnode.example.com,vm_fqdn=vm1.example.com,vm_id=112,vm_name=vm1,vm_type=lxc cpuload=0.147998116735236,disk_free=4461129728i,disk_total=5217320960i,disk_used=756191232i,disk_used_percentage=14,mem_free=1046827008i,mem_total=1073741824i,mem_used=26914816i,mem_used_percentage=2,status="running",swap_free=536698880i,swap_total=536870912i,swap_used=172032i,swap_used_percentage=0,uptime=1643793i 1595457277000000000
+proxmox,host=pxnode,node_fqdn=pxnode.example.com,vm_fqdn=vm1.example.com,vm_id=112,vm_name=vm1,vm_type=lxc cpuload=0.147998116735236,disk_free=4461129728i,disk_total=5217320960i,disk_used=756191232i,disk_used_percentage=14,disk_read_bytes=8604417024i,disk_write_bytes=2481549824i,net_in_bytes=1469711887i,net_out_bytes=58448585i,mem_free=1046827008i,mem_total=1073741824i,mem_used=26914816i,mem_used_percentage=2,status="running",swap_free=536698880i,swap_total=536870912i,swap_used=172032i,swap_used_percentage=0,uptime=1643793i 1595457277000000000
 ```

--- a/plugins/inputs/proxmox/proxmox.go
+++ b/plugins/inputs/proxmox/proxmox.go
@@ -198,6 +198,10 @@ func (px *Proxmox) gatherVMData(acc telegraf.Accumulator, rt resourceType) {
 			"disk_total":           diskMetrics.total,
 			"disk_free":            diskMetrics.free,
 			"disk_used_percentage": diskMetrics.usedPercentage,
+			"disk_read_bytes":      jsonNumberToInt64(currentVMStatus.DiskRead),
+			"disk_write_bytes":     jsonNumberToInt64(currentVMStatus.DiskWrite),
+			"net_in_bytes":         jsonNumberToInt64(currentVMStatus.NetIn),
+			"net_out_bytes":        jsonNumberToInt64(currentVMStatus.NetOut),
 		}
 		acc.AddFields("proxmox", fields, tags)
 	}

--- a/plugins/inputs/proxmox/proxmox_test.go
+++ b/plugins/inputs/proxmox/proxmox_test.go
@@ -15,7 +15,7 @@ import (
 
 var nodeSearchDomainTestData = `{"data":{"search":"test.example.com","dns1":"1.0.0.1"}}`
 var qemuTestData = `{"data":[{"name":"qemu1","status":"running","maxdisk":10737418240,"cpu":0.029336643550795,"vmid":"113","uptime":2159739,` +
-	`"disk":0,"maxmem":2147483648,"mem":1722451796}]}`
+	`"disk":0,"maxmem":2147483648,"mem":1722451796,"diskread":8604417024,"diskwrite":2481549824,"netin":1469711887,"netout":58448585}]}`
 var qemuConfigTestData = `{"data":{"hostname":"qemu1","searchdomain":"test.example.com"}}`
 var lxcTestData = `{"data":[{"vmid":"111","type":"lxc","uptime":2078164,"swap":9412608,"disk":"744189952","maxmem":536870912,"mem":98500608,` +
 	`"maxswap":536870912,"cpu":0.00371567669193613,"status":"running","maxdisk":"5217320960","name":"container1"},{"vmid":112,"type":"lxc",` +
@@ -23,9 +23,10 @@ var lxcTestData = `{"data":[{"vmid":"111","type":"lxc","uptime":2078164,"swap":9
 	`"status":"running","maxdisk":"5217320960","name":"container2"}]}`
 var lxcConfigTestData = `{"data":{"hostname":"container1","searchdomain":"test.example.com"}}`
 var lxcCurrentStatusTestData = `{"data":{"vmid":"111","type":"lxc","uptime":2078164,"swap":9412608,"disk":"744189952","maxmem":536870912,` +
-	`"mem":98500608,"maxswap":536870912,"cpu":0.00371567669193613,"status":"running","maxdisk":"5217320960","name":"container1"}}`
+	`"mem":98500608,"maxswap":536870912,"cpu":0.00371567669193613,"status":"running","maxdisk":"5217320960","name":"container1",` +
+	`"diskread":123456789,"diskwrite":98765432,"netin":111222333,"netout":444555666}}`
 var qemuCurrentStatusTestData = `{"data":{"name":"qemu1","status":"running","maxdisk":10737418240,"cpu":0.029336643550795,"vmid":"113",` +
-	`"uptime":2159739,"disk":0,"maxmem":2147483648,"mem":1722451796}}`
+	`"uptime":2159739,"disk":0,"maxmem":2147483648,"mem":1722451796,"diskread":8604417024,"diskwrite":2481549824,"netin":1469711887,"netout":58448585}}`
 
 func performTestRequest(apiURL, _ string, _ url.Values) ([]byte, error) {
 	var bytedata = []byte("")
@@ -98,6 +99,10 @@ func TestGatherLxcData(t *testing.T) {
 				"disk_total":           int64(5217320960),
 				"disk_free":            int64(4473131008),
 				"disk_used_percentage": float64(14.26383306117322),
+				"disk_read_bytes":      int64(123456789),
+				"disk_write_bytes":     int64(98765432),
+				"net_in_bytes":         int64(111222333),
+				"net_out_bytes":        int64(444555666),
 			},
 			time.Unix(0, 0),
 		),
@@ -142,6 +147,10 @@ func TestGatherQemuData(t *testing.T) {
 				"disk_total":           int64(10737418240),
 				"disk_free":            int64(10737418240),
 				"disk_used_percentage": float64(0),
+				"disk_read_bytes":      int64(8604417024),
+				"disk_write_bytes":     int64(2481549824),
+				"net_in_bytes":         int64(1469711887),
+				"net_out_bytes":        int64(58448585),
 			},
 			time.Unix(0, 0),
 		),
@@ -188,6 +197,10 @@ func TestGatherLxcDataWithID(t *testing.T) {
 				"disk_total":           int64(5217320960),
 				"disk_free":            int64(4473131008),
 				"disk_used_percentage": float64(14.26383306117322),
+				"disk_read_bytes":      int64(123456789),
+				"disk_write_bytes":     int64(98765432),
+				"net_in_bytes":         int64(111222333),
+				"net_out_bytes":        int64(444555666),
 			},
 			time.Unix(0, 0),
 		),
@@ -234,6 +247,10 @@ func TestGatherQemuDataWithID(t *testing.T) {
 				"disk_total":           int64(10737418240),
 				"disk_free":            int64(10737418240),
 				"disk_used_percentage": float64(0),
+				"disk_read_bytes":      int64(8604417024),
+				"disk_write_bytes":     int64(2481549824),
+				"net_in_bytes":         int64(1469711887),
+				"net_out_bytes":        int64(58448585),
 			},
 			time.Unix(0, 0),
 		),
@@ -253,5 +270,5 @@ func TestGather(t *testing.T) {
 	require.NoError(t, px.Gather(&acc))
 
 	// Results from both tests above
-	require.Equal(t, 30, acc.NFields())
+	require.Equal(t, 38, acc.NFields())
 }

--- a/plugins/inputs/proxmox/structs.go
+++ b/plugins/inputs/proxmox/structs.go
@@ -20,21 +20,21 @@ type vmCurrentStats struct {
 }
 
 type vmStat struct {
-	ID         json.Number `json:"vmid"`
-	Name       string      `json:"name"`
-	Status     string      `json:"status"`
-	UsedMem    json.Number `json:"mem"`
-	TotalMem   json.Number `json:"maxmem"`
-	UsedDisk   json.Number `json:"disk"`
-	TotalDisk  json.Number `json:"maxdisk"`
-	UsedSwap   json.Number `json:"swap"`
-	TotalSwap  json.Number `json:"maxswap"`
-	Uptime     json.Number `json:"uptime"`
-	CPULoad    json.Number `json:"cpu"`
-	DiskRead   json.Number `json:"diskread"`
-	DiskWrite  json.Number `json:"diskwrite"`
-	NetIn      json.Number `json:"netin"`
-	NetOut     json.Number `json:"netout"`
+	ID        json.Number `json:"vmid"`
+	Name      string      `json:"name"`
+	Status    string      `json:"status"`
+	UsedMem   json.Number `json:"mem"`
+	TotalMem  json.Number `json:"maxmem"`
+	UsedDisk  json.Number `json:"disk"`
+	TotalDisk json.Number `json:"maxdisk"`
+	UsedSwap  json.Number `json:"swap"`
+	TotalSwap json.Number `json:"maxswap"`
+	Uptime    json.Number `json:"uptime"`
+	CPULoad   json.Number `json:"cpu"`
+	DiskRead  json.Number `json:"diskread"`
+	DiskWrite json.Number `json:"diskwrite"`
+	NetIn     json.Number `json:"netin"`
+	NetOut    json.Number `json:"netout"`
 }
 
 type vmConfig struct {

--- a/plugins/inputs/proxmox/structs.go
+++ b/plugins/inputs/proxmox/structs.go
@@ -20,17 +20,21 @@ type vmCurrentStats struct {
 }
 
 type vmStat struct {
-	ID        json.Number `json:"vmid"`
-	Name      string      `json:"name"`
-	Status    string      `json:"status"`
-	UsedMem   json.Number `json:"mem"`
-	TotalMem  json.Number `json:"maxmem"`
-	UsedDisk  json.Number `json:"disk"`
-	TotalDisk json.Number `json:"maxdisk"`
-	UsedSwap  json.Number `json:"swap"`
-	TotalSwap json.Number `json:"maxswap"`
-	Uptime    json.Number `json:"uptime"`
-	CPULoad   json.Number `json:"cpu"`
+	ID         json.Number `json:"vmid"`
+	Name       string      `json:"name"`
+	Status     string      `json:"status"`
+	UsedMem    json.Number `json:"mem"`
+	TotalMem   json.Number `json:"maxmem"`
+	UsedDisk   json.Number `json:"disk"`
+	TotalDisk  json.Number `json:"maxdisk"`
+	UsedSwap   json.Number `json:"swap"`
+	TotalSwap  json.Number `json:"maxswap"`
+	Uptime     json.Number `json:"uptime"`
+	CPULoad    json.Number `json:"cpu"`
+	DiskRead   json.Number `json:"diskread"`
+	DiskWrite  json.Number `json:"diskwrite"`
+	NetIn      json.Number `json:"netin"`
+	NetOut     json.Number `json:"netout"`
 }
 
 type vmConfig struct {


### PR DESCRIPTION
## Summary
Add `disk_read_bytes`, `disk_write_bytes`, `net_in_bytes`, `net_out_bytes` fields to the proxmox input plugin. These cumulative byte counters are available from the Proxmox VE API (`/nodes/{node}/{qemu|lxc}/{vmid}/status/current`) but were previously not collected.

These metrics enable monitoring VM-level disk I/O throughput and network traffic using `rate()` in Prometheus/VictoriaMetrics/Grafana.

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [ ] No AI generated code was used in this PR
- [x] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #