### PR TITLE
docs(outputs.sql): Document oracle driver support

### DIFF
--- a/plugins/outputs/sql/README.md
+++ b/plugins/outputs/sql/README.md
@@ -93,7 +93,8 @@ how to use them.
 [[outputs.sql]]
   ## Database driver
   ## Valid options: mssql (Microsoft SQL Server), mysql (MySQL), pgx (Postgres),
-  ##  sqlite (SQLite3), snowflake (snowflake.com) clickhouse (ClickHouse)
+  ##  sqlite (SQLite3), snowflake (snowflake.com), clickhouse (ClickHouse),
+  ##  oracle (Oracle)
   driver = ""
 
   ## Data source name
@@ -310,3 +311,41 @@ The following configuration makes the mapping compatible with mssql:
 
 Telegraf doesn't have unit tests for gosnowflake so it should be treated as
 experimental.
+
+### sijms/go-ora
+
+#### Oracle DSN
+
+The following format for the DSN applies to oracle. For more information and
+additional configuration options refer to the [go-ora documentation][go-ora-doc].
+
+[go-ora-doc]: https://github.com/sijms/go-ora
+
+```toml
+data_source_name = "oracle://username:password@host:port/service"
+```
+
+#### Oracle templates
+
+Oracle does not support `LIMIT`, so the `table_exists_template` default is
+adjusted automatically. To enable schema updates, set `table_update_template`
+to the Oracle `ALTER TABLE` syntax (no `COLUMN` keyword):
+
+```toml
+  table_update_template = "ALTER TABLE {TABLE} ADD {COLUMN}"
+```
+
+#### Oracle metric type to SQL type conversion
+
+The following configuration makes the mapping compatible with oracle:
+
+```toml
+  [outputs.sql.convert]
+    integer              = "NUMBER(38)"
+    real                 = "NUMBER"
+    text                 = "VARCHAR2(4000)"
+    timestamp            = "TIMESTAMP"
+    defaultvalue         = "VARCHAR2(4000)"
+    unsigned             = ""
+    bool                 = "BOOLEAN"
+```

--- a/plugins/outputs/sql/sample.conf
+++ b/plugins/outputs/sql/sample.conf
@@ -2,7 +2,8 @@
 [[outputs.sql]]
   ## Database driver
   ## Valid options: mssql (Microsoft SQL Server), mysql (MySQL), pgx (Postgres),
-  ##  sqlite (SQLite3), snowflake (snowflake.com) clickhouse (ClickHouse)
+  ##  sqlite (SQLite3), snowflake (snowflake.com), clickhouse (ClickHouse),
+  ##  oracle (Oracle)
   driver = ""
 
   ## Data source name


### PR DESCRIPTION
## Summary

Follow-up to #19036, which added the oracle driver to `outputs.sql` but did not
update the plugin documentation. This adds:

- `oracle` to the list of valid drivers in `sample.conf`
- An Oracle driver section in the README covering the DSN format, the
  `ALTER TABLE ... ADD {COLUMN}` template needed for schema updates, and the
  metric-to-SQL type mapping

Docs-only change; no functional changes.

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

related to #18959