### PR TITLE
chore(inputs.system): Undeprecate the 'legacy' option

### DIFF
--- a/plugins/inputs/system/system.go
+++ b/plugins/inputs/system/system.go
@@ -42,9 +42,7 @@ func (*System) SampleConfig() string {
 }
 
 func (s *System) Init() error {
-	// Suppress deprecation warnings for default-only configs.
-	userSupplied := len(s.Include) > 0
-	if !userSupplied {
+	if len(s.Include) == 0 {
 		s.Include = []string{"legacy"}
 	}
 
@@ -54,20 +52,7 @@ func (s *System) Init() error {
 			continue
 		}
 		switch incl {
-		case "load", "users", "cpus", "uptime", "os", "dmi":
-		case "legacy":
-			if userSupplied {
-				config.PrintOptionValueDeprecationNotice(
-					"inputs.system",
-					"include",
-					"legacy",
-					telegraf.DeprecationInfo{
-						Since:     "1.39.0",
-						RemovalIn: "1.45.0",
-						Notice:    "use 'load', 'users', 'cpus' and 'uptime' instead",
-					},
-				)
-			}
+		case "legacy", "load", "users", "cpus", "uptime", "os", "dmi":
 		default:
 			return fmt.Errorf("invalid 'include' option %q", incl)
 		}


### PR DESCRIPTION
## Summary

This PR removes the deprecation notice to signal everyone we are keeping the legacy format.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

resolves #18953 
