### PR TITLE
fix(disk-buffer): Cache length when closing buffer to avoid panic with --once

### DIFF
--- a/models/buffer_disk.go
+++ b/models/buffer_disk.go
@@ -33,6 +33,10 @@ type DiskBuffer struct {
 	// transaction. Metrics at those offsets should not be contained in new
 	// batches.
 	mask []int
+
+	// Cache the buffer length for informatory calls to Len() e.g. when running
+	// Telegraf with --once. See https://github.com/influxdata/telegraf/issues/19248
+	closedLength *int
 }
 
 func NewDiskBuffer(id, path string, stats BufferStats, diskSync bool) (*DiskBuffer, error) {
@@ -60,6 +64,10 @@ func NewDiskBuffer(id, path string, stats BufferStats, diskSync bool) (*DiskBuff
 }
 
 func (b *DiskBuffer) Len() int {
+	if b.closedLength != nil {
+		return *b.closedLength
+	}
+
 	b.Lock()
 	defer b.Unlock()
 	return b.length()
@@ -262,9 +270,13 @@ func (b *DiskBuffer) Stats() BufferStats {
 }
 
 func (b *DiskBuffer) Close() error {
+	// Cache the length before closing the buffer
+	b.closedLength = new(b.Len())
+
 	if err := b.file.Close(); err != nil {
 		return fmt.Errorf("closing buffer failed: %w", err)
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
## Summary

The `--once` code-path tries to get the number metrics remaining in the buffer after it was closed. This leads to a panic as you cannot determine the buffer-length on a closed WAL file.

Therefore, this PR caches the buffer length before closing the buffer to avoid accessing the closed WAL file and in turn to avoid the panic.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

resolves #19248 
