### PR TITLE
fix(inputs.temp): Use non-blocking read for hwmon temperatures

### DIFF
--- a/plugins/inputs/temp/temp_linux.go
+++ b/plugins/inputs/temp/temp_linux.go
@@ -165,9 +165,11 @@ func (t *Temperature) gatherHwmon(syspath string) ([]temperatureStat, error) {
 			additional: make(map[string]interface{}),
 		}
 
-		// Temperature (mandatory)
+		// Temperature (mandatory). Use a non-blocking read as the underlying
+		// hardware might be unavailable (e.g. asleep) and a blocking read would
+		// hang the gather cycle.
 		fn := filepath.Join(path, prefix+"_input")
-		buf, err := os.ReadFile(fn)
+		buf, err := readFileNonblocking(fn)
 		if err != nil {
 			t.Log.Debugf("Couldn't read temperature from %q: %v", fn, err)
 			continue
@@ -235,14 +237,15 @@ func (t *Temperature) gatherThermalZone(syspath string) ([]temperatureStat, erro
 		}
 		name := strings.TrimSpace(string(buf))
 
-		// Actual temperature
-		buf, err = readFileAsync(filepath.Join(path, "temp"))
+		// Actual temperature. On Linux EAGAIN and EWOULDBLOCK are the same errno.
+		buf, err = readFileNonblocking(filepath.Join(path, "temp"))
 		if err != nil {
-			if errors.Is(err, unix.EAGAIN) || errors.Is(err, unix.EWOULDBLOCK) {
+			if errors.Is(err, unix.EAGAIN) {
 				// Silently ignore this thermal-zone when the underlying hardware is unavailable
+				t.Log.Tracef("Skipping zone %q as the hardware is unavailable: %v", path, err)
 				continue
 			}
-			t.Log.Errorf("Cannot read temperature of zone %q", path)
+			t.Log.Errorf("Cannot read temperature of zone %q: %v", path, err)
 			continue
 		}
 		v, err := strconv.ParseFloat(strings.TrimSpace(string(buf)), 64)
@@ -257,15 +260,15 @@ func (t *Temperature) gatherThermalZone(syspath string) ([]temperatureStat, erro
 	return stats, nil
 }
 
-func readFileAsync(path string) ([]byte, error) {
+func readFileNonblocking(path string) ([]byte, error) {
 	fd, err := unix.Open(path, unix.O_RDONLY|unix.O_NONBLOCK, 0)
 	if err != nil {
 		return nil, err
 	}
 	defer unix.Close(fd)
 
-	// The kernal specifies the temparatures are expressed in millidegrees
-	// tempBuf of 8 bytes stores temperatures up-to 99999.999°C
+	// The kernel specifies the temperatures are expressed in millidegrees
+	// tempBuf of 8 bytes stores temperatures up to 99999.999°C
 	var tempBuf [8]byte
 
 	n, err := unix.Read(fd, tempBuf[:])

--- a/plugins/inputs/temp/temp_test.go
+++ b/plugins/inputs/temp/temp_test.go
@@ -345,7 +345,7 @@ func sensorsTemperaturesOld(syspath string) ([]sensors.TemperatureStat, error) {
 	return temperatures, nil
 }
 
-func TestReadFileAsync(t *testing.T) {
+func TestReadFileNonblocking(t *testing.T) {
 	// fds stores the in-memory file-descriptors
 	fds := make([]int, 2)
 	// Unnamed pipe to simulate EAGAIN
@@ -399,7 +399,7 @@ func TestReadFileAsync(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			data, err := readFileAsync(tt.path)
+			data, err := readFileNonblocking(tt.path)
 			require.ErrorIs(t, err, tt.expectedError)
 			require.Equal(t, tt.expectedValue, data)
 		})


### PR DESCRIPTION


## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
The hwmon temperature (_input) read used a blocking os.ReadFile, which could hang the gather cycle when the underlying hardware is unavailable (e.g. asleep), the same risk already handled for thermal zones.

Route the hwmon read through the shared non-blocking helper, rename it from readFileAsync to readFileNonblocking (the read is synchronous, not async), drop the redundant EWOULDBLOCK check (equal to EAGAIN on Linux), and include the underlying error in the thermal-zone log messages.

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
