### PR TITLE
test(outputs.mongodb): Cover metadata_keys wildcards and batch path

### DIFF
--- a/plugins/outputs/mongodb/mongodb_test.go
+++ b/plugins/outputs/mongodb/mongodb_test.go
@@ -790,6 +790,188 @@ func TestWriteIntegration(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:  "metadata wildcard batch",
+			batch: true,
+			meta:  []string{"*"},
+			expected: map[string][]bson.D{
+				"test1": {
+					bson.D{
+						primitive.E{Key: "timestamp", Value: primitive.DateTime(0)},
+						primitive.E{Key: "metadata", Value: bson.D{
+							primitive.E{Key: "source", Value: "foo"},
+							primitive.E{Key: "version", Value: "v1.2"},
+						}},
+						primitive.E{Key: "tags", Value: bson.D{
+							primitive.E{Key: "source", Value: "foo"},
+							primitive.E{Key: "version", Value: "v1.2"},
+						}},
+						primitive.E{Key: "value", Value: int64(1)},
+					},
+					bson.D{
+						primitive.E{Key: "timestamp", Value: primitive.DateTime(10000)},
+						primitive.E{Key: "metadata", Value: bson.D{
+							primitive.E{Key: "source", Value: "foo"},
+							primitive.E{Key: "version", Value: "v1.2"},
+						}},
+						primitive.E{Key: "tags", Value: bson.D{
+							primitive.E{Key: "source", Value: "foo"},
+							primitive.E{Key: "version", Value: "v1.2"},
+						}},
+						primitive.E{Key: "value", Value: int64(2)},
+					},
+					bson.D{
+						primitive.E{Key: "timestamp", Value: primitive.DateTime(20000)},
+						primitive.E{Key: "metadata", Value: bson.D{
+							primitive.E{Key: "source", Value: "foo"},
+							primitive.E{Key: "version", Value: "v1.2"},
+						}},
+						primitive.E{Key: "tags", Value: bson.D{
+							primitive.E{Key: "source", Value: "foo"},
+							primitive.E{Key: "version", Value: "v1.2"},
+						}},
+						primitive.E{Key: "value", Value: int64(3)},
+					},
+				},
+				"test2": {
+					bson.D{
+						primitive.E{Key: "timestamp", Value: primitive.DateTime(0)},
+						primitive.E{Key: "metadata", Value: bson.D{
+							primitive.E{Key: "source", Value: "bar"},
+							primitive.E{Key: "version", Value: "v1.2"},
+						}},
+						primitive.E{Key: "tags", Value: bson.D{
+							primitive.E{Key: "source", Value: "bar"},
+							primitive.E{Key: "version", Value: "v1.2"},
+						}},
+						primitive.E{Key: "value", Value: int64(10)},
+					},
+					bson.D{
+						primitive.E{Key: "timestamp", Value: primitive.DateTime(10000)},
+						primitive.E{Key: "metadata", Value: bson.D{
+							primitive.E{Key: "source", Value: "bar"},
+							primitive.E{Key: "version", Value: "v1.2"},
+						}},
+						primitive.E{Key: "tags", Value: bson.D{
+							primitive.E{Key: "source", Value: "bar"},
+							primitive.E{Key: "version", Value: "v1.2"},
+						}},
+						primitive.E{Key: "value", Value: int64(20)},
+					},
+					bson.D{
+						primitive.E{Key: "timestamp", Value: primitive.DateTime(20000)},
+						primitive.E{Key: "metadata", Value: bson.D{
+							primitive.E{Key: "source", Value: "bar"},
+							primitive.E{Key: "version", Value: "v1.2"},
+						}},
+						primitive.E{Key: "tags", Value: bson.D{
+							primitive.E{Key: "source", Value: "bar"},
+							primitive.E{Key: "version", Value: "v1.2"},
+						}},
+						primitive.E{Key: "value", Value: int64(30)},
+					},
+					bson.D{
+						primitive.E{Key: "timestamp", Value: primitive.DateTime(30000)},
+						primitive.E{Key: "metadata", Value: bson.D{
+							primitive.E{Key: "source", Value: "bar"},
+							primitive.E{Key: "version", Value: "v1.2"},
+						}},
+						primitive.E{Key: "tags", Value: bson.D{
+							primitive.E{Key: "source", Value: "bar"},
+							primitive.E{Key: "version", Value: "v1.2"},
+						}},
+						primitive.E{Key: "value", Value: int64(40)},
+					},
+				},
+			},
+		},
+		{
+			name: "metadata prefix wildcard",
+			meta: []string{"sour*"},
+			expected: map[string][]bson.D{
+				"test1": {
+					bson.D{
+						primitive.E{Key: "timestamp", Value: primitive.DateTime(0)},
+						primitive.E{Key: "metadata", Value: bson.D{
+							primitive.E{Key: "source", Value: "foo"},
+						}},
+						primitive.E{Key: "tags", Value: bson.D{
+							primitive.E{Key: "source", Value: "foo"},
+							primitive.E{Key: "version", Value: "v1.2"},
+						}},
+						primitive.E{Key: "value", Value: int64(1)},
+					},
+					bson.D{
+						primitive.E{Key: "timestamp", Value: primitive.DateTime(10000)},
+						primitive.E{Key: "metadata", Value: bson.D{
+							primitive.E{Key: "source", Value: "foo"},
+						}},
+						primitive.E{Key: "tags", Value: bson.D{
+							primitive.E{Key: "source", Value: "foo"},
+							primitive.E{Key: "version", Value: "v1.2"},
+						}},
+						primitive.E{Key: "value", Value: int64(2)},
+					},
+					bson.D{
+						primitive.E{Key: "timestamp", Value: primitive.DateTime(20000)},
+						primitive.E{Key: "metadata", Value: bson.D{
+							primitive.E{Key: "source", Value: "foo"},
+						}},
+						primitive.E{Key: "tags", Value: bson.D{
+							primitive.E{Key: "source", Value: "foo"},
+							primitive.E{Key: "version", Value: "v1.2"},
+						}},
+						primitive.E{Key: "value", Value: int64(3)},
+					},
+				},
+				"test2": {
+					bson.D{
+						primitive.E{Key: "timestamp", Value: primitive.DateTime(0)},
+						primitive.E{Key: "metadata", Value: bson.D{
+							primitive.E{Key: "source", Value: "bar"},
+						}},
+						primitive.E{Key: "tags", Value: bson.D{
+							primitive.E{Key: "source", Value: "bar"},
+							primitive.E{Key: "version", Value: "v1.2"},
+						}},
+						primitive.E{Key: "value", Value: int64(10)},
+					},
+					bson.D{
+						primitive.E{Key: "timestamp", Value: primitive.DateTime(10000)},
+						primitive.E{Key: "metadata", Value: bson.D{
+							primitive.E{Key: "source", Value: "bar"},
+						}},
+						primitive.E{Key: "tags", Value: bson.D{
+							primitive.E{Key: "source", Value: "bar"},
+							primitive.E{Key: "version", Value: "v1.2"},
+						}},
+						primitive.E{Key: "value", Value: int64(20)},
+					},
+					bson.D{
+						primitive.E{Key: "timestamp", Value: primitive.DateTime(20000)},
+						primitive.E{Key: "metadata", Value: bson.D{
+							primitive.E{Key: "source", Value: "bar"},
+						}},
+						primitive.E{Key: "tags", Value: bson.D{
+							primitive.E{Key: "source", Value: "bar"},
+							primitive.E{Key: "version", Value: "v1.2"},
+						}},
+						primitive.E{Key: "value", Value: int64(30)},
+					},
+					bson.D{
+						primitive.E{Key: "timestamp", Value: primitive.DateTime(30000)},
+						primitive.E{Key: "metadata", Value: bson.D{
+							primitive.E{Key: "source", Value: "bar"},
+						}},
+						primitive.E{Key: "tags", Value: bson.D{
+							primitive.E{Key: "source", Value: "bar"},
+							primitive.E{Key: "version", Value: "v1.2"},
+						}},
+						primitive.E{Key: "value", Value: int64(40)},
+					},
+				},
+			},
+		},
 	}
 
 	// Setup the input metrics and expected results


### PR DESCRIPTION


## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
The existing TestWriteIntegration metadata cases only exercised a single literal key with WriteBatch disabled. Add two subtests:

- "metadata wildcard batch": a match-all "*" key with batching enabled, verifying the writeBatch/marshal path emits metadata and that multiple matching tags are all picked up into the metadata field.
- "metadata prefix wildcard": a "sour*" prefix key, verifying wildcard matching keeps the non-matching tag out of metadata while retaining it in tags.

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
