### PR TITLE
fix(inputs.opcua): Close session on stop to prevent reload leak

### DIFF
--- a/plugins/inputs/opcua/opcua.go
+++ b/plugins/inputs/opcua/opcua.go
@@ -35,11 +35,30 @@ func (o *OpcUA) Init() (err error) {
 	return err
 }
 
-// Start implements the ServiceInput interface so the agent calls Stop on
-// shutdown and config reload. The connection itself is established lazily in
-// Gather to keep tolerating a server that is unavailable at startup.
 func (*OpcUA) Start(telegraf.Accumulator) error {
 	return nil
+}
+
+func (o *OpcUA) Stop() {
+	if o.client == nil {
+		return
+	}
+	if state := o.client.State(); state == opcua.Closed || state == opcua.Disconnected {
+		return
+	}
+
+	// Bound the disconnect by the configured request timeout so a stuck server
+	// cannot hang shutdown. A zero timeout means "no limit", so fall back to a
+	// sane default to avoid an immediately-expired context.
+	timeout := time.Duration(o.client.Config.RequestTimeout)
+	if timeout <= 0 {
+		timeout = 10 * time.Second
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	if err := o.client.Disconnect(ctx); err != nil {
+		o.Log.Warnf("Disconnecting from OPC UA server failed: %v", err)
+	}
 }
 
 func (o *OpcUA) Gather(acc telegraf.Accumulator) error {
@@ -78,31 +97,6 @@ func (o *OpcUA) Gather(acc telegraf.Accumulator) error {
 	o.Log.Tracef("Gather complete: %d metrics added to accumulator in %s, total gather time %s",
 		len(metrics), time.Since(addStart), time.Since(gatherStart))
 	return nil
-}
-
-// Stop releases the OPC UA session so it is not orphaned on the server during
-// shutdown or config reload. Without this the session lingers until the
-// server's session timeout, and repeated reloads can exhaust the session limit.
-func (o *OpcUA) Stop() {
-	if o.client == nil {
-		return
-	}
-	if state := o.client.State(); state != opcua.Connected && state != opcua.Connecting {
-		return
-	}
-
-	// Bound the disconnect by the configured request timeout so a stuck server
-	// cannot hang shutdown. A zero timeout means "no limit", so fall back to a
-	// sane default to avoid an immediately-expired context.
-	timeout := time.Duration(o.client.Config.RequestTimeout)
-	if timeout <= 0 {
-		timeout = 10 * time.Second
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
-	if err := o.client.Disconnect(ctx); err != nil {
-		o.Log.Warnf("Disconnecting from OPC UA server failed: %v", err)
-	}
 }
 
 func init() {

--- a/plugins/inputs/opcua/opcua.go
+++ b/plugins/inputs/opcua/opcua.go
@@ -2,6 +2,7 @@
 package opcua
 
 import (
+	"context"
 	_ "embed"
 	"time"
 
@@ -32,6 +33,13 @@ func (*OpcUA) SampleConfig() string {
 func (o *OpcUA) Init() (err error) {
 	o.client, err = o.readClientConfig.createReadClient(o.Log)
 	return err
+}
+
+// Start implements the ServiceInput interface so the agent calls Stop on
+// shutdown and config reload. The connection itself is established lazily in
+// Gather to keep tolerating a server that is unavailable at startup.
+func (*OpcUA) Start(telegraf.Accumulator) error {
+	return nil
 }
 
 func (o *OpcUA) Gather(acc telegraf.Accumulator) error {
@@ -70,6 +78,24 @@ func (o *OpcUA) Gather(acc telegraf.Accumulator) error {
 	o.Log.Tracef("Gather complete: %d metrics added to accumulator in %s, total gather time %s",
 		len(metrics), time.Since(addStart), time.Since(gatherStart))
 	return nil
+}
+
+// Stop releases the OPC UA session so it is not orphaned on the server during
+// shutdown or config reload. Without this the session lingers until the
+// server's session timeout, and repeated reloads can exhaust the session limit.
+func (o *OpcUA) Stop() {
+	if o.client == nil {
+		return
+	}
+	if state := o.client.State(); state != opcua.Connected && state != opcua.Connecting {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := o.client.Disconnect(ctx); err != nil {
+		o.Log.Warnf("Disconnecting from OPC UA server failed: %v", err)
+	}
 }
 
 func init() {

--- a/plugins/inputs/opcua/opcua.go
+++ b/plugins/inputs/opcua/opcua.go
@@ -91,7 +91,14 @@ func (o *OpcUA) Stop() {
 		return
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	// Bound the disconnect by the configured request timeout so a stuck server
+	// cannot hang shutdown. A zero timeout means "no limit", so fall back to a
+	// sane default to avoid an immediately-expired context.
+	timeout := time.Duration(o.client.Config.RequestTimeout)
+	if timeout <= 0 {
+		timeout = 10 * time.Second
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 	if err := o.client.Disconnect(ctx); err != nil {
 		o.Log.Warnf("Disconnecting from OPC UA server failed: %v", err)

--- a/plugins/inputs/opcua/opcua_test.go
+++ b/plugins/inputs/opcua/opcua_test.go
@@ -663,6 +663,89 @@ func TestConsecutiveSessionErrorRecoveryIntegration(t *testing.T) {
 	require.Equal(t, uint64(0), o.consecutiveErrors, "Should reset consecutive errors after recovery")
 }
 
+func TestStopWithoutConnect(t *testing.T) {
+	o := &OpcUA{
+		readClientConfig: readClientConfig{
+			InputClientConfig: input.InputClientConfig{
+				OpcUAClientConfig: opcua.OpcUAClientConfig{
+					Endpoint:       "opc.tcp://localhost:4840",
+					SecurityPolicy: "None",
+					SecurityMode:   "None",
+					AuthMethod:     "Anonymous",
+					ConnectTimeout: config.Duration(10 * time.Second),
+					RequestTimeout: config.Duration(1 * time.Second),
+				},
+				MetricName: "testing",
+				RootNodes: []input.NodeSettings{
+					mapOPCTag(opcTags{"ProductName", "0", "i", "2261", "open62541 OPC UA Server"}),
+				},
+			},
+		},
+		Log: testutil.Logger{},
+	}
+
+	require.NoError(t, o.Init())
+
+	// Stop before any successful connect must be a no-op and must not panic.
+	require.NotPanics(t, o.Stop)
+	require.Equal(t, opcua.Disconnected, o.client.State())
+}
+
+func TestStopClosesSessionIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	container := testutil.Container{
+		Image:        "open62541/open62541",
+		ExposedPorts: []string{servicePort},
+		WaitingFor: wait.ForAll(
+			wait.ForListeningPort(servicePort),
+			wait.ForLog("TCP network layer listening on opc.tcp://"),
+		),
+	}
+	require.NoError(t, container.Start(), "failed to start container")
+	defer container.Terminate()
+
+	o := &OpcUA{
+		readClientConfig: readClientConfig{
+			InputClientConfig: input.InputClientConfig{
+				OpcUAClientConfig: opcua.OpcUAClientConfig{
+					Endpoint:       fmt.Sprintf("opc.tcp://%s:%s", container.Address, container.Ports[servicePort]),
+					SecurityPolicy: "None",
+					SecurityMode:   "None",
+					AuthMethod:     "Anonymous",
+					ConnectTimeout: config.Duration(10 * time.Second),
+					RequestTimeout: config.Duration(1 * time.Second),
+				},
+				MetricName: "testing",
+				RootNodes: []input.NodeSettings{
+					mapOPCTag(opcTags{"ProductName", "0", "i", "2261", "open62541 OPC UA Server"}),
+				},
+			},
+		},
+		Log: testutil.Logger{},
+	}
+
+	require.NoError(t, o.Init())
+
+	var acc testutil.Accumulator
+	// The first gather establishes the session.
+	require.NoError(t, o.Gather(&acc))
+	require.Equal(t, opcua.Connected, o.client.State())
+
+	// Stop must release the session instead of leaving it orphaned on the server.
+	o.Stop()
+	require.Equal(t, opcua.Disconnected, o.client.State())
+
+	// A subsequent gather must reconnect lazily so a stop/restart cycle (such as
+	// a config reload) keeps collecting.
+	acc.ClearMetrics()
+	require.NoError(t, o.Gather(&acc))
+	require.Equal(t, opcua.Connected, o.client.State())
+	require.Len(t, acc.Metrics, 1)
+}
+
 func TestReconnectErrorThresholdDefaultIntegration(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
  The polling `inputs.opcua` plugin only implements `Init()`/`Gather()`, so `RunningInput.Stop()` (which only forwards to `ServiceInput` plugins) never closes its OPC UA session on shutdown or config reload (`--watch-config`). The session and gopcua monitor goroutine are orphaned until `session_timeout`, and under repeated reloads they stack up to `BadTooManySessions`, the same symptom #18813 fixed for the server-restart path.
  
This makes `*OpcUA` a `ServiceInput`: `Start()` is a no-op (connection stays lazy in `Gather`, preserving tolerance for a server that is down at startup) and `Stop()` disconnects when connected, sending the previously-missing `CloseSessionRequest`. A never-connected instance is a clean no-op.

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
