### PR TITLE
fix(build): Create tarballs correctly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -426,7 +426,7 @@ $(include_packages):
 	elif [ "$(suffix $@)" = ".zip" ]; then \
 		(cd $(dir $(DESTDIR)) && zip -r - ./*) > $(pkgdir)/telegraf-$(tar_version)_$@ ;\
 	elif [ "$(suffix $@)" = ".gz" ]; then \
-		tar --owner 0 --group 0 -czvf $(pkgdir)/telegraf-$(tar_version)_$@ -C $(dir $(DESTDIR)) . ;\
+		tar --owner 0 --group 0 -czvf $(pkgdir)/telegraf-$(tar_version)_$@ -C $(dir $(DESTDIR)) $(notdir $(DESTDIR)) ;\
 	fi
 
 amd64.deb x86_64.rpm linux_amd64.tar.gz: export GOOS := linux

--- a/scripts/mac-signing.sh
+++ b/scripts/mac-signing.sh
@@ -104,7 +104,7 @@ do
 
   # Sign telegraf binary
   echo "Extract $tarFile to $RootAppDir/Resources"
-  tar -xzvf "$tarFile" --strip-components=2 -C "$RootAppDir/Resources"
+  tar -xzvf "$tarFile" --strip-components=1 -C "$RootAppDir/Resources"
   printf "\n"
   TelegrafBinPath="$RootAppDir/Resources/usr/bin/telegraf"
   codesign --force -s "$DeveloperID" --timestamp --options=runtime "$TelegrafBinPath"


### PR DESCRIPTION
## Summary

This PR implements the suggestion in #19075 to fix

```
tar: .: Cannot utime: Operation not permitted
tar: .: Cannot change mode to rwxr-xr-t: Operation not permitted
tar: Exiting with failure status due to previous errors
```

errors when untaring Telegraf packages.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

resolves #19075 
