### PR TITLE
feat(inputs.ping): Add support for unprivileged SOCK_DGRAM sockets

### DIFF
--- a/plugins/inputs/ping/README.md
+++ b/plugins/inputs/ping/README.md
@@ -63,7 +63,7 @@ plugin ordering. See [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## Select the ICMP socket type (native only). If privileged, raw sockets are
   ## used and the CAP_NET_RAW capability (or root) is required. The
   ## unprivileged mode uses ICMP datagram sockets requiring the process GID to
-  ## be within the range in sysctl's net.ipv4.ping_group_range and no further
+  ## be within the range in the net.ipv4.ping_group_range sysctl and no further
   ## capabilities.
   # privileged = true
 

--- a/plugins/inputs/ping/README.md
+++ b/plugins/inputs/ping/README.md
@@ -60,11 +60,11 @@ plugin ordering. See [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## Percentiles to calculate. This only works with the native method.
   # percentiles = [50, 95, 99]
 
-  ## For the "native" method, select the ICMP socket type. When true or
-  ## unspecified (default) raw sockets are used and the CAP_NET_RAW capability
-  ## (or root) is required. When false, unprivileged ICMP datagram sockets
-  ## (SOCK_DGRAM) are used, which require the process GID to be within the
-  ## range in net.ipv4.ping_group_range.
+  ## Select the ICMP socket type (native only). If privileged, raw sockets are
+  ## used and the CAP_NET_RAW capability (or root) is required. The
+  ## unprivileged mode uses ICMP datagram sockets requiring the process GID to
+  ## be within the range in sysctl's net.ipv4.ping_group_range and no further
+  ## capabilities.
   # privileged = true
 
   ## Specify the ping executable binary.

--- a/plugins/inputs/ping/README.md
+++ b/plugins/inputs/ping/README.md
@@ -60,6 +60,13 @@ plugin ordering. See [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## Percentiles to calculate. This only works with the native method.
   # percentiles = [50, 95, 99]
 
+  ## For the "native" method, select the ICMP socket type. When true or
+  ## unspecified (default) raw sockets are used and the CAP_NET_RAW capability
+  ## (or root) is required. When false, unprivileged ICMP datagram sockets
+  ## (SOCK_DGRAM) are used, which require the process GID to be within the
+  ## range in net.ipv4.ping_group_range.
+  # privileged = true
+
   ## Specify the ping executable binary.
   # binary = "ping"
 
@@ -102,7 +109,11 @@ the system `ping` command. Therefore, this method doesn't have external
 dependencies.
 
 With `method = "native"`, the `timeout` option is ignored. Use `deadline` to
-control the total runtime instead.
+control the total runtime instead. The `privileged` option indicates which type
+of socket will be used with `method = "native"`; `true` or `nil` uses raw
+sockets, whereas `false` uses SOCK_DGRAM. The former requires CAP_NET_RAW or
+root, the latter requires your process GID to fall in the range of
+the `net.ipv4.ping_group_range` sysctl.
 
 ### File Limit
 

--- a/plugins/inputs/ping/README.md
+++ b/plugins/inputs/ping/README.md
@@ -110,8 +110,8 @@ dependencies.
 
 With `method = "native"`, the `timeout` option is ignored. Use `deadline` to
 control the total runtime instead. The `privileged` option indicates which type
-of socket will be used with `method = "native"`; `true` or `nil` uses raw
-sockets, whereas `false` uses SOCK_DGRAM. The former requires CAP_NET_RAW or
+of socket will be used with `method = "native"`; `true` uses raw sockets,
+whereas `false` uses SOCK_DGRAM. The former requires CAP_NET_RAW or
 root, the latter requires your process GID to fall in the range of
 the `net.ipv4.ping_group_range` sysctl.
 

--- a/plugins/inputs/ping/ping.go
+++ b/plugins/inputs/ping/ping.go
@@ -43,15 +43,11 @@ type Ping struct {
 	Percentiles  []int           `toml:"percentiles"`   // Calculate the given percentiles when using native method
 	Binary       string          `toml:"binary"`        // Ping executable binary
 	// Arguments for ping command. When arguments are not empty, system binary will be used and other options (ping_interval, timeout, etc.) will be ignored
-	Arguments []string    `toml:"arguments"`
-	IPv4      bool        `toml:"ipv4"` // Whether to resolve addresses using ipv4 or not.
-	IPv6      bool        `toml:"ipv6"` // Whether to resolve addresses using ipv6 or not.
-	Size      config.Size `toml:"size"` // Packet size
-	// When using "native" method, false means unprivileged SOCK_DGRAM
-	// sockets, which requires process GID to be in the range of
-	// net.ipv4.ping_group_range sysctl, nil or true means raw ICMP
-	// sockets, which require CAP_NET_RAW.
-	Privileged *bool           `toml:"privileged"`
+	Arguments  []string        `toml:"arguments"`
+	IPv4       bool            `toml:"ipv4"` // Whether to resolve addresses using ipv4 or not.
+	IPv6       bool            `toml:"ipv6"` // Whether to resolve addresses using ipv6 or not.
+	Size       config.Size     `toml:"size"` // Packet size
+	Privileged bool            `toml:"privileged"`
 	Log        telegraf.Logger `toml:"-"`
 
 	wg             sync.WaitGroup // wg is used to wait for ping with multiple URLs
@@ -210,13 +206,7 @@ func (p *Ping) nativePing(destination string, id int) (*pingStats, error) {
 	// responses between multiple pingers and present wrong results
 	pinger.SetID(id)
 
-	// Default to raw ICMP sockets to preserve prior behavior; allow opting
-	// into SOCK_DGRAM sockets.
-	privileged := true
-	if p.Privileged != nil {
-		privileged = *p.Privileged
-	}
-	pinger.SetPrivileged(privileged)
+	pinger.SetPrivileged(p.Privileged)
 
 	if p.IPv4 && p.IPv6 {
 		pinger.SetNetwork("ip")
@@ -388,6 +378,7 @@ func init() {
 		return &Ping{
 			PingInterval: config.Duration(1 * time.Second),
 			Deadline:     config.Duration(10 * time.Second),
+			Privileged:   true,
 		}
 	})
 }

--- a/plugins/inputs/ping/ping.go
+++ b/plugins/inputs/ping/ping.go
@@ -43,10 +43,10 @@ type Ping struct {
 	Percentiles  []int           `toml:"percentiles"`   // Calculate the given percentiles when using native method
 	Binary       string          `toml:"binary"`        // Ping executable binary
 	// Arguments for ping command. When arguments are not empty, system binary will be used and other options (ping_interval, timeout, etc.) will be ignored
-	Arguments []string        `toml:"arguments"`
-	IPv4      bool            `toml:"ipv4"` // Whether to resolve addresses using ipv4 or not.
-	IPv6      bool            `toml:"ipv6"` // Whether to resolve addresses using ipv6 or not.
-	Size      config.Size     `toml:"size"` // Packet size
+	Arguments []string    `toml:"arguments"`
+	IPv4      bool        `toml:"ipv4"` // Whether to resolve addresses using ipv4 or not.
+	IPv6      bool        `toml:"ipv6"` // Whether to resolve addresses using ipv6 or not.
+	Size      config.Size `toml:"size"` // Packet size
 	// When using "native" method, false means unprivileged SOCK_DGRAM
 	// sockets, which requires process GID to be in the range of
 	// net.ipv4.ping_group_range sysctl, nil or true means raw ICMP
@@ -270,7 +270,8 @@ func (p *Ping) nativePing(destination string, id int) (*pingStats, error) {
 	if err != nil {
 		if strings.Contains(err.Error(), "operation not permitted") {
 			if runtime.GOOS == "linux" {
-				return nil, errors.New("permission changes required, enable CAP_NET_RAW capabilities or use privileged = false (refer to the ping plugin's README.md for more info)")
+				return nil, errors.New("permission changes required, enable CAP_NET_RAW capabilities or use privileged = false (refer to " +
+					"the ping plugin's README.md for more info)")
 			}
 
 			return nil, errors.New("permission changes required, refer to the ping plugin's README.md for more info")

--- a/plugins/inputs/ping/ping.go
+++ b/plugins/inputs/ping/ping.go
@@ -260,7 +260,7 @@ func (p *Ping) nativePing(destination string, id int) (*pingStats, error) {
 	if err != nil {
 		if strings.Contains(err.Error(), "operation not permitted") {
 			if runtime.GOOS == "linux" {
-				return nil, errors.New("permission changes required, enable CAP_NET_RAW capabilities or use unpriviledged ping (refer to " +
+				return nil, errors.New("permission changes required, enable CAP_NET_RAW capabilities or use unprivileged ping (refer to " +
 					"the ping plugin's README.md for more info)")
 			}
 

--- a/plugins/inputs/ping/ping.go
+++ b/plugins/inputs/ping/ping.go
@@ -260,7 +260,7 @@ func (p *Ping) nativePing(destination string, id int) (*pingStats, error) {
 	if err != nil {
 		if strings.Contains(err.Error(), "operation not permitted") {
 			if runtime.GOOS == "linux" {
-				return nil, errors.New("permission changes required, enable CAP_NET_RAW capabilities or use privileged = false (refer to " +
+				return nil, errors.New("permission changes required, enable CAP_NET_RAW capabilities or use unpriviledged ping (refer to " +
 					"the ping plugin's README.md for more info)")
 			}
 

--- a/plugins/inputs/ping/ping.go
+++ b/plugins/inputs/ping/ping.go
@@ -47,7 +47,12 @@ type Ping struct {
 	IPv4      bool            `toml:"ipv4"` // Whether to resolve addresses using ipv4 or not.
 	IPv6      bool            `toml:"ipv6"` // Whether to resolve addresses using ipv6 or not.
 	Size      config.Size     `toml:"size"` // Packet size
-	Log       telegraf.Logger `toml:"-"`
+	// When using "native" method, false means unprivileged SOCK_DGRAM
+	// sockets, which requires process GID to be in the range of
+	// net.ipv4.ping_group_range sysctl, nil or true means raw ICMP
+	// sockets, which require CAP_NET_RAW.
+	Privileged *bool           `toml:"privileged"`
+	Log        telegraf.Logger `toml:"-"`
 
 	wg             sync.WaitGroup // wg is used to wait for ping with multiple URLs
 	calcInterval   time.Duration  // Pre-calculated interval and timeout
@@ -205,7 +210,13 @@ func (p *Ping) nativePing(destination string, id int) (*pingStats, error) {
 	// responses between multiple pingers and present wrong results
 	pinger.SetID(id)
 
-	pinger.SetPrivileged(true)
+	// Default to raw ICMP sockets to preserve prior behavior; allow opting
+	// into SOCK_DGRAM sockets.
+	privileged := true
+	if p.Privileged != nil {
+		privileged = *p.Privileged
+	}
+	pinger.SetPrivileged(privileged)
 
 	if p.IPv4 && p.IPv6 {
 		pinger.SetNetwork("ip")

--- a/plugins/inputs/ping/ping.go
+++ b/plugins/inputs/ping/ping.go
@@ -270,7 +270,7 @@ func (p *Ping) nativePing(destination string, id int) (*pingStats, error) {
 	if err != nil {
 		if strings.Contains(err.Error(), "operation not permitted") {
 			if runtime.GOOS == "linux" {
-				return nil, errors.New("permission changes required, enable CAP_NET_RAW capabilities (refer to the ping plugin's README.md for more info)")
+				return nil, errors.New("permission changes required, enable CAP_NET_RAW capabilities or use privileged = false (refer to the ping plugin's README.md for more info)")
 			}
 
 			return nil, errors.New("permission changes required, refer to the ping plugin's README.md for more info")

--- a/plugins/inputs/ping/sample.conf
+++ b/plugins/inputs/ping/sample.conf
@@ -36,11 +36,11 @@
   ## Percentiles to calculate. This only works with the native method.
   # percentiles = [50, 95, 99]
 
-  ## For the "native" method, select the ICMP socket type. When true or
-  ## unspecified (default) raw sockets are used and the CAP_NET_RAW capability
-  ## (or root) is required. When false, unprivileged ICMP datagram sockets
-  ## (SOCK_DGRAM) are used, which require the process GID to be within the
-  ## range in net.ipv4.ping_group_range.
+  ## Select the ICMP socket type (native only). If privileged, raw sockets are
+  ## used and the CAP_NET_RAW capability (or root) is required. The
+  ## unprivileged mode uses ICMP datagram sockets requiring the process GID to
+  ## be within the range in sysctl's net.ipv4.ping_group_range and no further
+  ## capabilities.
   # privileged = true
 
   ## Specify the ping executable binary.

--- a/plugins/inputs/ping/sample.conf
+++ b/plugins/inputs/ping/sample.conf
@@ -36,6 +36,13 @@
   ## Percentiles to calculate. This only works with the native method.
   # percentiles = [50, 95, 99]
 
+  ## For the "native" method, select the ICMP socket type. When true or
+  ## unspecified (default) raw sockets are used and the CAP_NET_RAW capability
+  ## (or root) is required. When false, unprivileged ICMP datagram sockets
+  ## (SOCK_DGRAM) are used, which require the process GID to be within the
+  ## range in net.ipv4.ping_group_range.
+  # privileged = true
+
   ## Specify the ping executable binary.
   # binary = "ping"
 

--- a/plugins/inputs/ping/sample.conf
+++ b/plugins/inputs/ping/sample.conf
@@ -39,7 +39,7 @@
   ## Select the ICMP socket type (native only). If privileged, raw sockets are
   ## used and the CAP_NET_RAW capability (or root) is required. The
   ## unprivileged mode uses ICMP datagram sockets requiring the process GID to
-  ## be within the range in sysctl's net.ipv4.ping_group_range and no further
+  ## be within the range in the net.ipv4.ping_group_range sysctl and no further
   ## capabilities.
   # privileged = true
 


### PR DESCRIPTION
## Summary
The native ping method does not work when the process's UID is not root and does not have CAP_NET_RAW.

## Checklist

- [ ] No AI generated code was used in this PR
- [x] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

resolves #19079 
