### PR TITLE
test(secretstores.googlecloud): Cover scope defaulting and clarify README

### DIFF
--- a/plugins/secretstores/googlecloud/README.md
+++ b/plugins/secretstores/googlecloud/README.md
@@ -50,6 +50,13 @@ store usage.
 
 This plugin only supports reading the secrets, it cannot create or modify them.
 
+The `scopes` option is only defaulted to `cloud-platform` for credential files
+of `type: "service_account"`, which is the kind downloaded from the Google
+Cloud Console. Other OAuth2-scope-consuming credential types such as
+`authorized_user`, `external_account`, and `impersonated_service_account` must
+set `scopes` manually. For `gdch_service_account` credentials only the
+`sts_audience` option is evaluated and `scopes` is ignored.
+
 To generate a Google-Distributed-Cloud-Hosted service account credentials file
 check the [Manage service accounts][gdch_service_docs] page.
 

--- a/plugins/secretstores/googlecloud/googlecloud_test.go
+++ b/plugins/secretstores/googlecloud/googlecloud_test.go
@@ -87,6 +87,50 @@ func TestInitFail(t *testing.T) {
 	}
 }
 
+func TestInitScopeDefaulting(t *testing.T) {
+	tests := []struct {
+		name     string
+		plugin   *GoogleCloud
+		scopes   []string
+		expected []string
+	}{
+		{
+			name: "service account without scopes defaults to cloud-platform",
+			plugin: &GoogleCloud{
+				Log:             testutil.Logger{},
+				CredentialsFile: "./testdata/service-account-key.json",
+			},
+			expected: []string{"https://www.googleapis.com/auth/cloud-platform"},
+		},
+		{
+			name: "service account with scopes is not overwritten",
+			plugin: &GoogleCloud{
+				Log:             testutil.Logger{},
+				CredentialsFile: "./testdata/service-account-key.json",
+			},
+			scopes:   []string{"https://www.googleapis.com/auth/devstorage.read_only"},
+			expected: []string{"https://www.googleapis.com/auth/devstorage.read_only"},
+		},
+		{
+			name: "non service account without scopes stays empty",
+			plugin: &GoogleCloud{
+				Log:             testutil.Logger{},
+				CredentialsFile: "./testdata/gdch.json",
+				STSAudience:     "https://localhost",
+			},
+			expected: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.plugin.Scopes = tc.scopes
+			require.NoError(t, tc.plugin.Init())
+			require.Equal(t, tc.expected, tc.plugin.Scopes)
+		})
+	}
+}
+
 func TestGetSuccess(t *testing.T) {
 	plugin := &GoogleCloud{
 		credentials: auth.NewCredentials(&auth.CredentialsOptions{

--- a/plugins/secretstores/googlecloud/testdata/service-account-key.json
+++ b/plugins/secretstores/googlecloud/testdata/service-account-key.json
@@ -1,0 +1,10 @@
+{
+    "type": "service_account",
+    "project_id": "itia-test",
+    "private_key_id": "b02a10dd-a1c8-4d39-aeca-00d8791d6fc1",
+    "private_key": "-----BEGIN PRIVATE KEY-----\nMIIEvwIBADANBgkqhkiG9w0BAQEFAASCBKkwggSlAgEAAoIBAQDKCqrpyEE3bC/x\nVf5hlxMIh6qjeJl4Cg47WnUuSKNYfk3E3OWT0AjvGMyqD5Pvi6AtBh7dGC1hEDq1\nJ9umYIL/0BmVkQCZ7OEXOesScaK9OF2TZh1twkcahiFZihGi6x87DGDWhuyDWzjC\nDnU1pAZMWt25HoJVp/4PgaIF7vhrioFyKFUCE6WNgVayc9eM/pxMEFO4UA+L3eir\nhxYHEEPG614wB6Xl5GnxIFvJDs4LbIDGbo+qNSW3NHipthp2K+3SG/Fo1+mZFGs0\nv/fsUGHbXo/Ip14uQfDBAvNiF4me4jCh3N/R8NzuAPmnQyqdrkPyrNhrrXXRLYxh\nNQc7NtwVAgMBAAECggEACK4HpK6BOr/PmXcfzBKA81NcvdQfB7yq2trqgNgHCHS4\no5X32O9NivQOStoLeXWOppCGP+pbfLmFRCYXtiCcUCAhET9e/r3h96z5z9uI6ccj\nogL3jbEUe+u6QA4B7vVZ7J/+Awld3NDM8e1MFMdcq+gVcXABmmtyqzje/JFFI92G\nR746KNQTZmbSH94molz7gpHQmwkUvuQPeMuH+K1yNSTtrDIXG9ldUSyfmFHF3+AM\ntpX+LuAAmRi13n9TwBMcdZPTLg9tWref2HUI1EfqepdxiVDQuWJ7GIsKVvH97jq0\naGfkHropxQfUr/FyYuZL1SZ2OZQtUeQ3tHB2PZU9oQKBgQD8Q7wwImwCOdvs1ozU\nZ8Aa1MJwZSTqcEOm2ScAX3B0UJnhURcUjAu636lWwi8jeyW7arrcMfjQiA0o/iLM\njSraUN6qIwAskDzsjlotn6WldtPLcaw+Cp3PW6YTUnjawAQpI7EV9ZEH/7n411Yd\nlI1ZIeD/AQtNnAyt2kTGEGZhsQKBgQDNCI0opFmmGh2o5gP4x1puaZcoZW1zCIah\nNypqGvhtb8JjWuRycSAuc3E4rXXyswRL6kyohnLYShW4Za537TMJWXqszSE2uY6R\nJVcUa5rM5R4N3+2HUji/4F9LoHqkfCfZHGY0pEsOPdPq39NhSrbsOtV0B/0LyYPV\nJcUMeNR1pQKBgQCfnkxpOJ6XGf0qcudRTwSi9ZTCgX1GShrEbArdlYYWUxnLFABC\npAqYCAWiO+SP0tAhMnth8My7RhrtoUBrpbdDxH/fr53glLO4CqrMy4OImxOQWzDd\nYOJR3m/LMhf+chkv3sGiX2uRYCJQbhCzTtfRWjp/oC2CwgbTypRRrvbZQQKBgQDK\ncJsPedaaTkbisNlTFWKQiekZlavPXKexHgre4OpRA3vnJaNR66hetNUhpQNEMsUX\nP6uY6ccTD3MKsjrlZmpx3MtnOtKEegnt/fRQ0T3y+HYINQUOC3zE1wDAZx8wsPWX\nRJcVevIwiZNn4L+Q3HhoHl8LRafvr3RfS/+XJOaBkQKBgQDEKay4VK9j1kLCiLkf\ndRR1ncp3P93kQMVm1YYlJKmxrhUQCQyKhpg2sKDGf28cRi63YgAEjpp+C621qqWc\nLkMFRvEvszpOfRAUmG9U00t+/hXtdVUWDQzgzBeYudNTwb5Yi+hsmh3l6hzbqLh5\nkGkLCVaWD9jswW1KamwP6yXR7g==\n-----END PRIVATE KEY-----\n",
+    "client_email": "itia-test-sa@itia-test.iam.gserviceaccount.com",
+    "client_id": "123456789012345678901",
+    "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+    "token_uri": "https://oauth2.googleapis.com/token"
+}


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Follow-up to #18785: add tests for the cloud-platform scope default(only the GDCH path was covered) and a service_account testdata fixture.
  Also clarify in the README that the default applies only to type: service_account credentials; other OAuth2-scope types must set scopes manually.

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

related to #16326
