### PR TITLE
fix(inputs.tail): Prevent panic when closing tailers under load

### DIFF
--- a/plugins/inputs/tail/tail.go
+++ b/plugins/inputs/tail/tail.go
@@ -534,11 +534,12 @@ func (t *Tail) receiver(parser telegraf.Parser, tailer *tail.Tail) {
 		select {
 		case <-t.ctx.Done():
 			return
-		// Tail is trying to close so drain the sem to allow the receiver
-		// to exit. This condition is hit when the tailer may have hit the
-		// maximum undelivered lines and is trying to close.
+		// The tailer is closing, e.g. on shutdown or when the file is rotated
+		// or removed. Drop the current line but keep draining tailer.Lines so
+		// the tailer can stop. Do not release t.sem here: freeing a slot
+		// without a matching delivery lets another tailer add to an already
+		// full delivery channel and panic with "channel is full" (#19073).
 		case <-tailer.Dying():
-			<-t.sem
 		case t.sem <- empty{}:
 			t.acc.AddTrackingMetricGroup(metrics)
 		}

--- a/plugins/inputs/tail/tail_shutdown_test.go
+++ b/plugins/inputs/tail/tail_shutdown_test.go
@@ -1,0 +1,78 @@
+package tail
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/agent"
+	"github.com/influxdata/telegraf/logger"
+	"github.com/influxdata/telegraf/testutil"
+)
+
+// trackingMaker is a minimal agent.MetricMaker so the test can drive the real
+// tracking accumulator, whose delivery channel is sized to the in-flight
+// budget and is what panics with "channel is full" in issue #19073.
+type trackingMaker struct{}
+
+func (trackingMaker) LogName() string                              { return "tail" }
+func (trackingMaker) MakeMetric(m telegraf.Metric) telegraf.Metric { return m }
+func (trackingMaker) Log() telegraf.Logger                         { return logger.New("inputs", "tail", "") }
+
+// TestTailNoSemaphoreLeakOnClose reproduces issue #19073. With multiple
+// tailers sharing a single in-flight budget, closing a tailer that is blocked
+// adding a line must not free a budget slot without a matching delivery.
+// Releasing a slot lets another tailer add beyond the budget and overflow the
+// accumulator delivery channel.
+func TestTailNoSemaphoreLeakOnClose(t *testing.T) {
+	const maxUndelivered = 1
+
+	dir := t.TempDir()
+	files := []string{
+		filepath.Join(dir, "a.log"),
+		filepath.Join(dir, "b.log"),
+		filepath.Join(dir, "c.log"),
+	}
+	// Many lines per file so that, once one line takes the single in-flight
+	// slot, every receiver stays blocked trying to add a further line.
+	content := bytes.Repeat([]byte("m value=1\n"), 50)
+	for _, f := range files {
+		require.NoError(t, os.WriteFile(f, content, 0600))
+	}
+
+	plugin := newTestTail()
+	plugin.Log = testutil.Logger{}
+	plugin.InitialReadOffset = "beginning"
+	plugin.MaxUndeliveredLines = maxUndelivered
+	plugin.Files = files
+	plugin.SetParserFunc(newInfluxParser)
+	require.NoError(t, plugin.Init())
+
+	// Real tracking accumulator with a delivery channel sized to the budget.
+	// Metrics are collected but never accepted, i.e. deliveries are withheld,
+	// so the budget can only be freed by an erroneous release. The number of
+	// collected metrics therefore equals the in-flight count.
+	src := make(chan telegraf.Metric, 1000)
+	acc := agent.NewAccumulator(trackingMaker{}, src).WithTracking(maxUndelivered)
+
+	require.NoError(t, plugin.Start(acc))
+
+	// Wait until the budget is taken, after which every receiver is blocked
+	// trying to add its next line.
+	require.Eventually(t, func() bool {
+		return len(src) == maxUndelivered
+	}, 5*time.Second, 10*time.Millisecond)
+
+	// Closing the tailers must not free a budget slot without a delivery.
+	plugin.Stop()
+
+	// Start() and Stop() join all receiver goroutines, so the in-flight count
+	// is now final. It must never exceed the configured budget.
+	require.LessOrEqual(t, len(src), maxUndelivered,
+		"in-flight metrics exceeded max_undelivered_lines after closing tailers")
+}


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
All tailers share one semaphore (`t.sem`) sized to `max_undelivered_lines`, kept in lockstep with the tracking accumulator's delivery channel of the same size: a receiver must acquire a slot before `AddTrackingMetricGroup`, and a slot is freed only when the drain goroutine sees a delivery on `Delivered()`. This keeps the in-flight count at or below the delivery channel capacity.

The `<-tailer.Dying()` branch in `receiver` (added in #15649 to avoid a close-time deadlock) released a semaphore slot without a corresponding delivery. With more than one tailer, another receiver that was blocked adding a line then took the freed slot and pushed the in-flight count past the budget. The next delivery overflowed the channel and hit the `panic("channel is full")` guard in the tracking accumulator. A single-file setup cannot trigger it, which is why it only shows up on busy multi-file hosts.

## Fix

Drop the current line on close without releasing the semaphore. The receiver still exits through the dying branch and keeps draining `tailer.Lines` so `tailer.Stop()` can complete, so the deadlock #15649 fixed does not return. Data-loss behavior is unchanged: that branch already dropped the blocked line; it only additionally and incorrectly freed a budget slot.

The `panic` guard in the accumulator is left as is. It is an intentional programming-error signal; the defect was tail over-subscribing the budget.

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #19073
