### PR TITLE
fix(ci): Prevent expression injection when checking target branch

### DIFF
--- a/.github/workflows/pr-target-branch.yml
+++ b/.github/workflows/pr-target-branch.yml
@@ -16,7 +16,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: debug
-        run: echo Target is ${{ github.event.pull_request.base.ref }}
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: echo "Target is ${BASE_REF}"
       - name: success
         if: github.event.pull_request.base.ref == 'master'
         run: exit 0


### PR DESCRIPTION
## Summary

The `debug` step in `.github/workflows/pr-target-branch.yml` interpolated `github.event.pull_request.base.ref` straight into the `run:` shell line:

```yaml
run: echo Target is ${{ github.event.pull_request.base.ref }}
```

GitHub expands `${{ ... }}` into the script before the shell runs, so any shell metacharacters in the value would be evaluated by the runner rather than treated as text. This change moves the value into a step-level `env:` variable and references it as a quoted shell variable instead, which is the interpolation pattern from GitHub's security hardening guidance for Actions:

```yaml
env:
  BASE_REF: ${{ github.event.pull_request.base.ref }}
run: echo "Target is ${BASE_REF}"
```

This is a defense-in-depth hardening rather than a fix for a live exploit. For a `pull_request` event `base.ref` is the branch the PR targets in this repository, so it is limited to branch names that already exist here and is not freely attacker-controlled the way a fork's head ref is. The workflow also runs as plain `pull_request` (not `pull_request_target`) with `permissions: contents: read` and no secrets, so it is unprivileged. Even so, keeping untrusted expressions out of `run:` lines is the correct pattern, silences Actions security scanners, and avoids the sink becoming exploitable if the step is later reused in a more privileged context.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues


