### PR TITLE
feat(input): Adding max files option for filecount input plugin

### DIFF
--- a/plugins/inputs/filecount/README.md
+++ b/plugins/inputs/filecount/README.md
@@ -50,11 +50,6 @@ plugin ordering. See [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## touched in this duration. Defaults to "0s".
   mtime = "0s"
 
-  ## Stop counting after this duration has passed.
-  ## Acceptable units: ns, us (µs), ms, s, m, h.
-  ## Defaults to "0s" (disabled).
-  timeout = "0s"
-
   ## Stop counting after this many files have been processed.
   ## Defaults to 0 (disabled).
   maximum_files = 0
@@ -65,8 +60,7 @@ plugin ordering. See [CONFIGURATION.md][CONFIGURATION.md] for more details.
 - filecount
   - tags:
     - directory (the directory path)
-    - filecount_status (status of the count: "ok", "timeout",
-    or "maximum")
+    - filecount_status (status of the count: "ok" or "maximum")
   - fields:
     - count (integer)
     - size_bytes (integer)

--- a/plugins/inputs/filecount/README.md
+++ b/plugins/inputs/filecount/README.md
@@ -49,6 +49,15 @@ plugin ordering. See [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## duration. If mtime is negative, only count files that have been
   ## touched in this duration. Defaults to "0s".
   mtime = "0s"
+
+  ## Stop counting after this duration has passed.
+  ## Acceptable units: ns, us (µs), ms, s, m, h.
+  ## Defaults to "0s" (disabled).
+  timeout = "0s"
+
+  ## Stop counting after this many files have been processed.
+  ## Defaults to 0 (disabled).
+  maximum_files = 0
 ```
 
 ## Metrics
@@ -56,6 +65,8 @@ plugin ordering. See [CONFIGURATION.md][CONFIGURATION.md] for more details.
 - filecount
   - tags:
     - directory (the directory path)
+    - filecount_status (status of the count: "ok", "timeout",
+    or "maximum")
   - fields:
     - count (integer)
     - size_bytes (integer)
@@ -65,6 +76,6 @@ plugin ordering. See [CONFIGURATION.md][CONFIGURATION.md] for more details.
 ## Example Output
 
 ```text
-filecount,directory=/var/cache/apt count=7i,size_bytes=7438336i,oldest_file_timestamp=1507152973123456789i,newest_file_timestamp=1507152973123456789i 1530034445000000000
-filecount,directory=/tmp count=17i,size_bytes=28934786i,oldest_file_timestamp=1507152973123456789i,newest_file_timestamp=1507152973123456789i 1530034445000000000
+filecount,directory=/var/cache/apt,filecount_status=ok count=7i,size_bytes=7438336i,oldest_file_timestamp=1507152973123456789i,newest_file_timestamp=1507152973123456789i 1530034445000000000
+filecount,directory=/tmp,filecount_status=ok count=17i,size_bytes=28934786i,oldest_file_timestamp=1507152973123456789i,newest_file_timestamp=1507152973123456789i 1530034445000000000
 ```

--- a/plugins/inputs/filecount/filecount.go
+++ b/plugins/inputs/filecount/filecount.go
@@ -30,7 +30,7 @@ type FileCount struct {
 	MTime          config.Duration `toml:"mtime"`
 	Log            telegraf.Logger `toml:"-"`
 	Timeout        config.Duration `toml:"timeout"`
-    MaximumFiles   int64           `toml:"maximum_files"`
+	MaximumFiles   int64           `toml:"maximum_files"`
 
 	fs          fileSystem
 	fileFilters []fileFilterFunc
@@ -146,19 +146,19 @@ func (fc *FileCount) count(acc telegraf.Accumulator, basedir string, glob globpa
 	newestFileTimestamp := make(map[string]int64)
 
 	start := time.Now()
-    totalFiles := int64(0)
-    maxReached := false
+	totalFiles := int64(0)
+	maxReached := false
 
 	walkFn := func(path string, _ *godirwalk.Dirent) error {
 		// Timeout check (priority)
-        if fc.Timeout > 0 && time.Since(start) > time.Duration(fc.Timeout) {
-            return filepath.SkipDir
-        }
-        // Maximum files check
-        if fc.MaximumFiles > 0 && totalFiles >= fc.MaximumFiles {
-            maxReached = true
-            return filepath.SkipDir
-        }
+		if fc.Timeout > 0 && time.Since(start) > time.Duration(fc.Timeout) {
+			return filepath.SkipDir
+		}
+		// Maximum files check
+		if fc.MaximumFiles > 0 && totalFiles >= fc.MaximumFiles {
+			maxReached = true
+			return filepath.SkipDir
+		}
 
 		rel, err := filepath.Rel(basedir, path)
 		if err == nil && rel == "." {
@@ -327,7 +327,7 @@ func newFileCount() *FileCount {
 		fileFilters:    nil,
 		fs:             osFS{},
 		Timeout:        config.Duration(0),
-        MaximumFiles:   0,
+		MaximumFiles:   0,
 	}
 }
 

--- a/plugins/inputs/filecount/filecount.go
+++ b/plugins/inputs/filecount/filecount.go
@@ -29,7 +29,6 @@ type FileCount struct {
 	Size           config.Size     `toml:"size"`
 	MTime          config.Duration `toml:"mtime"`
 	Log            telegraf.Logger `toml:"-"`
-	Timeout        config.Duration `toml:"timeout"`
 	MaximumFiles   int64           `toml:"maximum_files"`
 
 	fs          fileSystem
@@ -145,16 +144,10 @@ func (fc *FileCount) count(acc telegraf.Accumulator, basedir string, glob globpa
 	oldestFileTimestamp := make(map[string]int64)
 	newestFileTimestamp := make(map[string]int64)
 
-	start := time.Now()
 	totalFiles := int64(0)
 	maxReached := false
 
 	walkFn := func(path string, _ *godirwalk.Dirent) error {
-		// Timeout check (priority)
-		if fc.Timeout > 0 && time.Since(start) > time.Duration(fc.Timeout) {
-			return filepath.SkipDir
-		}
-		// Maximum files check
 		if fc.MaximumFiles > 0 && totalFiles >= fc.MaximumFiles {
 			maxReached = true
 			return filepath.SkipDir
@@ -206,8 +199,6 @@ func (fc *FileCount) count(acc telegraf.Accumulator, basedir string, glob globpa
 			tags := map[string]string{"directory": path}
 			if maxReached {
 				tags["filecount_status"] = "maximum"
-			} else if fc.Timeout > 0 && time.Since(start) > time.Duration(fc.Timeout) {
-				tags["filecount_status"] = "timeout"
 			} else {
 				tags["filecount_status"] = "ok"
 			}
@@ -326,7 +317,6 @@ func newFileCount() *FileCount {
 		MTime:          config.Duration(0),
 		fileFilters:    nil,
 		fs:             osFS{},
-		Timeout:        config.Duration(0),
 		MaximumFiles:   0,
 	}
 }

--- a/plugins/inputs/filecount/filecount.go
+++ b/plugins/inputs/filecount/filecount.go
@@ -29,6 +29,8 @@ type FileCount struct {
 	Size           config.Size     `toml:"size"`
 	MTime          config.Duration `toml:"mtime"`
 	Log            telegraf.Logger `toml:"-"`
+	Timeout        config.Duration `toml:"timeout"`
+    MaximumFiles   int64           `toml:"maximum_files"`
 
 	fs          fileSystem
 	fileFilters []fileFilterFunc
@@ -143,7 +145,21 @@ func (fc *FileCount) count(acc telegraf.Accumulator, basedir string, glob globpa
 	oldestFileTimestamp := make(map[string]int64)
 	newestFileTimestamp := make(map[string]int64)
 
+	start := time.Now()
+    totalFiles := int64(0)
+    maxReached := false
+
 	walkFn := func(path string, _ *godirwalk.Dirent) error {
+		// Timeout check (priority)
+        if fc.Timeout > 0 && time.Since(start) > time.Duration(fc.Timeout) {
+            return filepath.SkipDir
+        }
+        // Maximum files check
+        if fc.MaximumFiles > 0 && totalFiles >= fc.MaximumFiles {
+            maxReached = true
+            return filepath.SkipDir
+        }
+
 		rel, err := filepath.Rel(basedir, path)
 		if err == nil && rel == "." {
 			return nil
@@ -161,6 +177,7 @@ func (fc *FileCount) count(acc telegraf.Accumulator, basedir string, glob globpa
 			return nil
 		}
 		if match {
+			totalFiles++
 			parent := filepath.Dir(path)
 			childCount[parent]++
 			childSize[parent] += file.Size()
@@ -185,10 +202,17 @@ func (fc *FileCount) count(acc telegraf.Accumulator, basedir string, glob globpa
 			}
 			gauge["oldest_file_timestamp"] = oldestFileTimestamp[path]
 			gauge["newest_file_timestamp"] = newestFileTimestamp[path]
-			acc.AddGauge("filecount", gauge,
-				map[string]string{
-					"directory": path,
-				})
+
+			tags := map[string]string{"directory": path}
+			if maxReached {
+				tags["filecount_status"] = "maximum"
+			} else if fc.Timeout > 0 && time.Since(start) > time.Duration(fc.Timeout) {
+				tags["filecount_status"] = "timeout"
+			} else {
+				tags["filecount_status"] = "ok"
+			}
+
+			acc.AddGauge("filecount", gauge, tags)
 		}
 		parent := filepath.Dir(path)
 		if fc.Recursive {
@@ -302,6 +326,8 @@ func newFileCount() *FileCount {
 		MTime:          config.Duration(0),
 		fileFilters:    nil,
 		fs:             osFS{},
+		Timeout:        config.Duration(0),
+        MaximumFiles:   0,
 	}
 }
 

--- a/plugins/inputs/filecount/filecount_test.go
+++ b/plugins/inputs/filecount/filecount_test.go
@@ -35,7 +35,7 @@ func TestNoFiltersOnChildDir(t *testing.T) {
 	matches := []string{"subdir/quux", "subdir/quuz",
 		"subdir/nested2/qux", "subdir/nested2"}
 
-	tags := map[string]string{"directory": getTestdataDir() + "/subdir"}
+	tags := map[string]string{"directory": getTestdataDir() + "/subdir", "filecount_status": "ok"}
 	acc := testutil.Accumulator{}
 	require.NoError(t, acc.GatherError(fc.Gather))
 	require.True(t, acc.HasPoint("filecount", tags, "count", int64(len(matches))))
@@ -50,7 +50,7 @@ func TestNoRecursiveButSuperMeta(t *testing.T) {
 	fc.Directories = []string{getTestdataDir() + "/**"}
 	matches := []string{"subdir/quux", "subdir/quuz", "subdir/nested2"}
 
-	tags := map[string]string{"directory": getTestdataDir() + "/subdir"}
+	tags := map[string]string{"directory": getTestdataDir() + "/subdir", "filecount_status": "ok"}
 	acc := testutil.Accumulator{}
 	require.NoError(t, acc.GatherError(fc.Gather))
 
@@ -80,7 +80,7 @@ func TestDoubleAndSimpleStar(t *testing.T) {
 	fc.Directories = []string{getTestdataDir() + "/**/*"}
 	matches := []string{"qux"}
 
-	tags := map[string]string{"directory": getTestdataDir() + "/subdir/nested2"}
+	tags := map[string]string{"directory": getTestdataDir() + "/subdir/nested2", "filecount_status": "ok"}
 
 	acc := testutil.Accumulator{}
 	require.NoError(t, acc.GatherError(fc.Gather))
@@ -160,7 +160,8 @@ func TestDirectoryWithTrailingSlash(t *testing.T) {
 		metric.New(
 			"filecount",
 			map[string]string{
-				"directory": getTestdataDir(),
+				"directory":        getTestdataDir(),
+				"filecount_status": "ok",
 			},
 			map[string]interface{}{
 				"count":                 9,
@@ -174,6 +175,57 @@ func TestDirectoryWithTrailingSlash(t *testing.T) {
 	}
 
 	testutil.RequireMetricsEqual(t, expected, acc.GetTelegrafMetrics(), testutil.IgnoreTime())
+}
+
+func TestMaximumFiles(t *testing.T) {
+	fc := getNoFilterFileCount()
+	fc.MaximumFiles = 3
+
+	tags := map[string]string{"directory": getTestdataDir(), "filecount_status": "maximum"}
+	acc := testutil.Accumulator{}
+	require.NoError(t, acc.GatherError(fc.Gather))
+	require.True(t, acc.HasPoint("filecount", tags, "count", int64(3)))
+}
+
+func TestMaximumFilesDisabled(t *testing.T) {
+	fc := getNoFilterFileCount()
+	fc.MaximumFiles = 0
+
+	tags := map[string]string{"directory": getTestdataDir(), "filecount_status": "ok"}
+	acc := testutil.Accumulator{}
+	require.NoError(t, acc.GatherError(fc.Gather))
+	require.True(t, acc.HasPoint("filecount", tags, "count", int64(9)))
+}
+
+func TestTimeout(t *testing.T) {
+	fc := getNoFilterFileCount()
+	fc.Timeout = config.Duration(5 * time.Second)
+
+	tags := map[string]string{"directory": getTestdataDir(), "filecount_status": "ok"}
+	acc := testutil.Accumulator{}
+	require.NoError(t, acc.GatherError(fc.Gather))
+	require.True(t, acc.HasPoint("filecount", tags, "count", int64(9)))
+	require.True(t, acc.HasPoint("filecount", tags, "size_bytes", int64(5096)))
+}
+
+func TestTimeoutDisabled(t *testing.T) {
+	fc := getNoFilterFileCount()
+	fc.Timeout = config.Duration(0)
+
+	tags := map[string]string{"directory": getTestdataDir(), "filecount_status": "ok"}
+	acc := testutil.Accumulator{}
+	require.NoError(t, acc.GatherError(fc.Gather))
+	require.True(t, acc.HasPoint("filecount", tags, "count", int64(9)))
+}
+
+func TestMaximumFilesLargerThanTotal(t *testing.T) {
+	fc := getNoFilterFileCount()
+	fc.MaximumFiles = 100
+
+	tags := map[string]string{"directory": getTestdataDir(), "filecount_status": "ok"}
+	acc := testutil.Accumulator{}
+	require.NoError(t, acc.GatherError(fc.Gather))
+	require.True(t, acc.HasPoint("filecount", tags, "count", int64(9)))
 }
 
 func getNoFilterFileCount() FileCount {
@@ -242,7 +294,7 @@ func getFakeFileSystem(basePath string) fakeFileSystem {
 }
 
 func fileCountEquals(t *testing.T, fc FileCount, expectedCount, expectedSize int) {
-	tags := map[string]string{"directory": getTestdataDir()}
+	tags := map[string]string{"directory": getTestdataDir(), "filecount_status": "ok"}
 	acc := testutil.Accumulator{}
 	require.NoError(t, acc.GatherError(fc.Gather))
 	require.True(t, acc.HasPoint("filecount", tags, "count", int64(expectedCount)))

--- a/plugins/inputs/filecount/filecount_test.go
+++ b/plugins/inputs/filecount/filecount_test.go
@@ -197,27 +197,6 @@ func TestMaximumFilesDisabled(t *testing.T) {
 	require.True(t, acc.HasPoint("filecount", tags, "count", int64(9)))
 }
 
-func TestTimeout(t *testing.T) {
-	fc := getNoFilterFileCount()
-	fc.Timeout = config.Duration(5 * time.Second)
-
-	tags := map[string]string{"directory": getTestdataDir(), "filecount_status": "ok"}
-	acc := testutil.Accumulator{}
-	require.NoError(t, acc.GatherError(fc.Gather))
-	require.True(t, acc.HasPoint("filecount", tags, "count", int64(9)))
-	require.True(t, acc.HasPoint("filecount", tags, "size_bytes", int64(5096)))
-}
-
-func TestTimeoutDisabled(t *testing.T) {
-	fc := getNoFilterFileCount()
-	fc.Timeout = config.Duration(0)
-
-	tags := map[string]string{"directory": getTestdataDir(), "filecount_status": "ok"}
-	acc := testutil.Accumulator{}
-	require.NoError(t, acc.GatherError(fc.Gather))
-	require.True(t, acc.HasPoint("filecount", tags, "count", int64(9)))
-}
-
 func TestMaximumFilesLargerThanTotal(t *testing.T) {
 	fc := getNoFilterFileCount()
 	fc.MaximumFiles = 100

--- a/plugins/inputs/filecount/sample.conf
+++ b/plugins/inputs/filecount/sample.conf
@@ -30,3 +30,12 @@
   ## duration. If mtime is negative, only count files that have been
   ## touched in this duration. Defaults to "0s".
   mtime = "0s"
+
+  ## Stop counting after this duration has passed.
+  ## Acceptable units: ns, us (µs), ms, s, m, h.
+  ## Defaults to "0s" (disabled).
+  timeout = "0s"
+
+  ## Stop counting after this many files have been processed.
+  ## Defaults to 0 (disabled).
+  maximum_files = 0

--- a/plugins/inputs/filecount/sample.conf
+++ b/plugins/inputs/filecount/sample.conf
@@ -31,11 +31,6 @@
   ## touched in this duration. Defaults to "0s".
   mtime = "0s"
 
-  ## Stop counting after this duration has passed.
-  ## Acceptable units: ns, us (µs), ms, s, m, h.
-  ## Defaults to "0s" (disabled).
-  timeout = "0s"
-
   ## Stop counting after this many files have been processed.
   ## Defaults to 0 (disabled).
   maximum_files = 0


### PR DESCRIPTION
## Summary
Use Case

filecount can very easily over stress a machine resources like CPU.

Expected behavior

It would be great if it will have a timeout mechanism so it wont count files until collection interval is reached.
i imagine it something like this

  [[inputs.filecount]]
    directories = ["D:/AidocData/Temp/IncomingDicoms"]
    name = "*.dcm"
    size = "0B"
    timeout = "10s"
or, another possible solution is setting a maximum of files it can collect and stopping after it (also adding a field that indicates that the maximum is reached)

  [[inputs.filecount]]
    directories = ["D:/Temp/IncomingData"]
    name = "*.txt"
    size = "0B"
    maximum_files = "1000000"
example:

filecount,directory=/var/cache/apt is_maximum_reached=true,count=1000000,size_bytes=7438336i,oldest_file_timestamp=1507152973123456789i,newest_file_timestamp=1507152973123456789i 1530034445000000000

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #16357

Related PR - https://github.com/influxdata/telegraf/pull/19135