### PR TITLE
feat(migrations): Add migration for outputs.kafka TLS options

### DIFF
--- a/migrations/all/outputs_kafka.go
+++ b/migrations/all/outputs_kafka.go
@@ -1,0 +1,5 @@
+//go:build !custom || (migrations && (outputs || outputs.kafka))
+
+package all
+
+import _ "github.com/influxdata/telegraf/migrations/outputs_kafka" // register migration

--- a/migrations/outputs_kafka/migration.go
+++ b/migrations/outputs_kafka/migration.go
@@ -1,0 +1,74 @@
+package outputs_kafka
+
+import (
+	"fmt"
+
+	"github.com/influxdata/toml"
+	"github.com/influxdata/toml/ast"
+
+	"github.com/influxdata/telegraf/migrations"
+)
+
+// Migration function to migrate the deprecated TLS options to their
+// replacements.
+func migrate(tbl *ast.Table) ([]byte, string, error) {
+	// Decode the old data structure
+	var plugin map[string]interface{}
+	if err := toml.UnmarshalTable(tbl, &plugin); err != nil {
+		return nil, "", err
+	}
+
+	// Check for deprecated options and migrate them
+	var applied bool
+	renames := []struct {
+		from string
+		to   string
+	}{
+		{"ca", "tls_ca"},
+		{"certificate", "tls_cert"},
+		{"key", "tls_key"},
+	}
+	for _, rename := range renames {
+		rawOldValue, found := plugin[rename.from]
+		if !found {
+			continue
+		}
+		applied = true
+
+		// Convert to the actual type
+		oldValue, ok := rawOldValue.(string)
+		if !ok {
+			return nil, "", fmt.Errorf("unexpected type %T for %q", rawOldValue, rename.from)
+		}
+
+		// Check if the new option already exists and if it has a contradicting
+		// value. If the new option is not present, migrate the old value.
+		if rawNewValue, found := plugin[rename.to]; !found {
+			plugin[rename.to] = oldValue
+		} else if newValue, ok := rawNewValue.(string); !ok {
+			return nil, "", fmt.Errorf("unexpected type %T for %q", rawNewValue, rename.to)
+		} else if newValue != oldValue {
+			return nil, "", fmt.Errorf("contradicting setting for %q and %q", rename.to, rename.from)
+		}
+
+		// Remove the deprecated setting
+		delete(plugin, rename.from)
+	}
+
+	// No options migrated so we can exit early
+	if !applied {
+		return nil, "", migrations.ErrNotApplicable
+	}
+
+	// Create the corresponding plugin configuration
+	cfg := migrations.CreateTOMLStruct("outputs", "kafka")
+	cfg.Add("outputs", "kafka", plugin)
+
+	output, err := toml.Marshal(cfg)
+	return output, "", err
+}
+
+// Register the migration function for the plugin type
+func init() {
+	migrations.AddPluginOptionMigration("outputs.kafka", migrate)
+}

--- a/migrations/outputs_kafka/migration_test.go
+++ b/migrations/outputs_kafka/migration_test.go
@@ -1,0 +1,62 @@
+package outputs_kafka_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/influxdata/telegraf/config"
+	_ "github.com/influxdata/telegraf/migrations/outputs_kafka" // register migration
+	_ "github.com/influxdata/telegraf/plugins/outputs/kafka"    // register plugin
+	_ "github.com/influxdata/telegraf/plugins/serializers/all"  // register serializers
+)
+
+func TestCases(t *testing.T) {
+	// Get all directories in testcases
+	folders, err := os.ReadDir("testcases")
+	require.NoError(t, err)
+
+	for _, f := range folders {
+		// Only handle folders
+		if !f.IsDir() {
+			continue
+		}
+
+		t.Run(f.Name(), func(t *testing.T) {
+			testcasePath := filepath.Join("testcases", f.Name())
+			inputFile := filepath.Join(testcasePath, "telegraf.conf")
+			expectedFile := filepath.Join(testcasePath, "expected.conf")
+
+			// Read the expected output
+			expected := config.NewConfig()
+			require.NoError(t, expected.LoadConfig(expectedFile))
+			require.NotEmpty(t, expected.Outputs)
+
+			// Read the input data
+			input, remote, err := config.LoadConfigFile(inputFile)
+			require.NoError(t, err)
+			require.False(t, remote)
+			require.NotEmpty(t, input)
+
+			// Migrate
+			output, n, err := config.ApplyMigrations(input)
+			require.NoError(t, err)
+			require.NotEmpty(t, output)
+			require.GreaterOrEqual(t, n, uint64(1))
+			actual := config.NewConfig()
+			require.NoError(t, actual.LoadConfigData(output, config.EmptySourcePath))
+
+			// Test the output
+			require.Len(t, actual.Outputs, len(expected.Outputs))
+			actualIDs := make([]string, 0, len(expected.Outputs))
+			expectedIDs := make([]string, 0, len(expected.Outputs))
+			for i := range actual.Outputs {
+				actualIDs = append(actualIDs, actual.Outputs[i].ID())
+				expectedIDs = append(expectedIDs, expected.Outputs[i].ID())
+			}
+			require.ElementsMatchf(t, expectedIDs, actualIDs, "generated config: %s", string(output))
+		})
+	}
+}

--- a/migrations/outputs_kafka/testcases/existing/expected.conf
+++ b/migrations/outputs_kafka/testcases/existing/expected.conf
@@ -1,0 +1,16 @@
+# Configuration for the Kafka server to send metrics to
+[[outputs.kafka]]
+  ## URLs of kafka brokers
+  brokers = ["localhost:9092"]
+
+  ## Kafka topic for producer messages
+  topic = "telegraf"
+
+  ## Optional TLS Config with both the deprecated and the new option set to
+  ## the same value
+  tls_ca = "../../testutil/pki/cacert.pem"
+  tls_cert = "../../testutil/pki/clientcert.pem"
+  tls_key = "../../testutil/pki/clientkey.pem"
+
+  ## Data format to output.
+  data_format = "influx"

--- a/migrations/outputs_kafka/testcases/existing/telegraf.conf
+++ b/migrations/outputs_kafka/testcases/existing/telegraf.conf
@@ -1,0 +1,17 @@
+# Configuration for the Kafka server to send metrics to
+[[outputs.kafka]]
+  ## URLs of kafka brokers
+  brokers = ["localhost:9092"]
+
+  ## Kafka topic for producer messages
+  topic = "telegraf"
+
+  ## Optional TLS Config with both the deprecated and the new option set to
+  ## the same value
+  ca = "../../testutil/pki/cacert.pem"
+  tls_ca = "../../testutil/pki/cacert.pem"
+  certificate = "../../testutil/pki/clientcert.pem"
+  key = "../../testutil/pki/clientkey.pem"
+
+  ## Data format to output.
+  data_format = "influx"

--- a/migrations/outputs_kafka/testcases/minimal/expected.conf
+++ b/migrations/outputs_kafka/testcases/minimal/expected.conf
@@ -1,0 +1,15 @@
+# Configuration for the Kafka server to send metrics to
+[[outputs.kafka]]
+  ## URLs of kafka brokers
+  brokers = ["localhost:9092"]
+
+  ## Kafka topic for producer messages
+  topic = "telegraf"
+
+  ## Optional TLS Config
+  tls_ca = "../../testutil/pki/cacert.pem"
+  tls_cert = "../../testutil/pki/clientcert.pem"
+  tls_key = "../../testutil/pki/clientkey.pem"
+
+  ## Data format to output.
+  data_format = "influx"

--- a/migrations/outputs_kafka/testcases/minimal/telegraf.conf
+++ b/migrations/outputs_kafka/testcases/minimal/telegraf.conf
@@ -1,0 +1,15 @@
+# Configuration for the Kafka server to send metrics to
+[[outputs.kafka]]
+  ## URLs of kafka brokers
+  brokers = ["localhost:9092"]
+
+  ## Kafka topic for producer messages
+  topic = "telegraf"
+
+  ## Optional TLS Config
+  ca = "../../testutil/pki/cacert.pem"
+  certificate = "../../testutil/pki/clientcert.pem"
+  key = "../../testutil/pki/clientkey.pem"
+
+  ## Data format to output.
+  data_format = "influx"

--- a/plugins/outputs/kafka/kafka.go
+++ b/plugins/outputs/kafka/kafka.go
@@ -41,11 +41,6 @@ type Kafka struct {
 	proxy.Socks5ProxyConfig
 	kafka.WriteConfig
 
-	// Legacy TLS config options
-	Certificate string `toml:"certificate" deprecated:"1.36.0;1.40.0;please use 'tls_cert' instead"`
-	Key         string `toml:"key" deprecated:"1.36.0;1.40.0;please use 'tls_cert' instead"`
-	CA          string `toml:"ca" deprecated:"1.36.0;1.40.0;please use 'tls_ca' instead"`
-
 	saramaConfig *sarama.Config
 	producerFunc func(addrs []string, config *sarama.Config) (sarama.SyncProducer, error)
 	producer     sarama.SyncProducer
@@ -77,13 +72,6 @@ func (k *Kafka) Init() error {
 		// Do nothing, those are valid
 	default:
 		return fmt.Errorf("unknown topic suffix method provided: %s", k.TopicSuffix.Method)
-	}
-
-	// Legacy support ssl config
-	if k.Certificate != "" {
-		k.TLSCert = k.Certificate
-		k.TLSCA = k.CA
-		k.TLSKey = k.Key
 	}
 
 	// Legacy support for metric_name_header


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
The `ca`, `certificate`, and `key` options in `outputs.kafka` were deprecated in v1.36.0 for removal in v1.40.0, replaced by `tls_ca`, `tls_cert`, and `tls_key`.
This removes them and adds a migration that renames the old options on `telegraf config migrate`, erroring on contradicting values. 

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #19090
