### PR TITLE
feat(migrations): Add migration for inputs.zookeeper TLS option

### DIFF
--- a/migrations/all/inputs_zookeeper.go
+++ b/migrations/all/inputs_zookeeper.go
@@ -1,0 +1,5 @@
+//go:build !custom || (migrations && (inputs || inputs.zookeeper))
+
+package all
+
+import _ "github.com/influxdata/telegraf/migrations/inputs_zookeeper" // register migration

--- a/migrations/inputs_zookeeper/migration.go
+++ b/migrations/inputs_zookeeper/migration.go
@@ -1,0 +1,65 @@
+package inputs_zookeeper
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/influxdata/toml"
+	"github.com/influxdata/toml/ast"
+
+	"github.com/influxdata/telegraf/migrations"
+)
+
+// Migration function to migrate the deprecated 'enable_tls' option to its
+// replacement 'tls_enable'.
+func migrate(tbl *ast.Table) ([]byte, string, error) {
+	// Decode the old data structure
+	var plugin map[string]interface{}
+	if err := toml.UnmarshalTable(tbl, &plugin); err != nil {
+		return nil, "", err
+	}
+
+	// Check for the deprecated option and migrate it
+	var applied bool
+	if rawOldValue, found := plugin["enable_tls"]; found {
+		applied = true
+
+		// Convert to the actual type
+		oldValue, ok := rawOldValue.(bool)
+		if !ok {
+			return nil, "", fmt.Errorf("unexpected type %T for 'enable_tls'", rawOldValue)
+		}
+
+		// Check if the new option already exists and if it has a contradicting
+		// value. If the new option is not present, migrate the old value.
+		if rawNewValue, found := plugin["tls_enable"]; found {
+			if newValue, ok := rawNewValue.(bool); !ok {
+				return nil, "", fmt.Errorf("unexpected type %T for 'tls_enable'", rawNewValue)
+			} else if newValue != oldValue {
+				return nil, "", errors.New("contradicting setting for 'tls_enable' and 'enable_tls'")
+			}
+		} else {
+			plugin["tls_enable"] = oldValue
+		}
+
+		// Remove the deprecated setting
+		delete(plugin, "enable_tls")
+	}
+
+	// No options migrated so we can exit early
+	if !applied {
+		return nil, "", migrations.ErrNotApplicable
+	}
+
+	// Create the corresponding plugin configuration
+	cfg := migrations.CreateTOMLStruct("inputs", "zookeeper")
+	cfg.Add("inputs", "zookeeper", plugin)
+
+	output, err := toml.Marshal(cfg)
+	return output, "", err
+}
+
+// Register the migration function for the plugin type
+func init() {
+	migrations.AddPluginOptionMigration("inputs.zookeeper", migrate)
+}

--- a/migrations/inputs_zookeeper/migration_test.go
+++ b/migrations/inputs_zookeeper/migration_test.go
@@ -1,0 +1,87 @@
+package inputs_zookeeper_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/influxdata/telegraf/config"
+	_ "github.com/influxdata/telegraf/migrations/inputs_zookeeper" // register migration
+	"github.com/influxdata/telegraf/plugins/inputs/zookeeper"      // register plugin
+)
+
+func TestNoMigration(t *testing.T) {
+	plugin := &zookeeper.Zookeeper{}
+	defaultCfg := plugin.SampleConfig()
+
+	// Migrate and check that nothing changed
+	output, n, err := config.ApplyMigrations([]byte(defaultCfg))
+	require.NoError(t, err)
+	require.NotEmpty(t, output)
+	require.Zero(t, n)
+	require.Equal(t, defaultCfg, string(output))
+}
+
+func TestEnableTLSConflict(t *testing.T) {
+	cfg := []byte(`
+[[inputs.zookeeper]]
+  servers = ["localhost:2181"]
+  enable_tls = true
+  tls_enable = false
+	`)
+	// Migrate and check that the contradicting settings are caught
+	output, n, err := config.ApplyMigrations(cfg)
+	require.ErrorContains(t, err, "contradicting setting for 'tls_enable' and 'enable_tls'")
+	require.Empty(t, output)
+	require.Zero(t, n)
+}
+
+func TestCases(t *testing.T) {
+	// Get all directories in testcases
+	folders, err := os.ReadDir("testcases")
+	require.NoError(t, err)
+
+	for _, f := range folders {
+		// Only handle folders
+		if !f.IsDir() {
+			continue
+		}
+
+		t.Run(f.Name(), func(t *testing.T) {
+			testcasePath := filepath.Join("testcases", f.Name())
+			inputFile := filepath.Join(testcasePath, "telegraf.conf")
+			expectedFile := filepath.Join(testcasePath, "expected.conf")
+
+			// Read the expected output
+			expected := config.NewConfig()
+			require.NoError(t, expected.LoadConfig(expectedFile))
+			require.NotEmpty(t, expected.Inputs)
+
+			// Read the input data
+			input, remote, err := config.LoadConfigFile(inputFile)
+			require.NoError(t, err)
+			require.False(t, remote)
+			require.NotEmpty(t, input)
+
+			// Migrate
+			output, n, err := config.ApplyMigrations(input)
+			require.NoError(t, err)
+			require.NotEmpty(t, output)
+			require.GreaterOrEqual(t, n, uint64(1))
+			actual := config.NewConfig()
+			require.NoError(t, actual.LoadConfigData(output, config.EmptySourcePath))
+
+			// Test the output
+			require.Len(t, actual.Inputs, len(expected.Inputs))
+			actualIDs := make([]string, 0, len(expected.Inputs))
+			expectedIDs := make([]string, 0, len(expected.Inputs))
+			for i := range actual.Inputs {
+				actualIDs = append(actualIDs, actual.Inputs[i].ID())
+				expectedIDs = append(expectedIDs, expected.Inputs[i].ID())
+			}
+			require.ElementsMatch(t, expectedIDs, actualIDs, string(output))
+		})
+	}
+}

--- a/migrations/inputs_zookeeper/testcases/existing/expected.conf
+++ b/migrations/inputs_zookeeper/testcases/existing/expected.conf
@@ -1,0 +1,8 @@
+# Reads 'mntr' stats from one or many zookeeper servers
+[[inputs.zookeeper]]
+  ## An array of address to gather stats about. Specify an ip or hostname
+  ## with port. ie localhost:2181, 10.0.0.1:2181, etc.
+  servers = ["localhost:2181"]
+
+  ## Both the deprecated and the new option set to the same value
+  tls_enable = true

--- a/migrations/inputs_zookeeper/testcases/existing/telegraf.conf
+++ b/migrations/inputs_zookeeper/testcases/existing/telegraf.conf
@@ -1,0 +1,9 @@
+# Reads 'mntr' stats from one or many zookeeper servers
+[[inputs.zookeeper]]
+  ## An array of address to gather stats about. Specify an ip or hostname
+  ## with port. ie localhost:2181, 10.0.0.1:2181, etc.
+  servers = ["localhost:2181"]
+
+  ## Both the deprecated and the new option set to the same value
+  enable_tls = true
+  tls_enable = true

--- a/migrations/inputs_zookeeper/testcases/minimal/expected.conf
+++ b/migrations/inputs_zookeeper/testcases/minimal/expected.conf
@@ -1,0 +1,8 @@
+# Reads 'mntr' stats from one or many zookeeper servers
+[[inputs.zookeeper]]
+  ## An array of address to gather stats about. Specify an ip or hostname
+  ## with port. ie localhost:2181, 10.0.0.1:2181, etc.
+  servers = ["localhost:2181"]
+
+  ## Enable TLS using the deprecated option
+  tls_enable = true

--- a/migrations/inputs_zookeeper/testcases/minimal/telegraf.conf
+++ b/migrations/inputs_zookeeper/testcases/minimal/telegraf.conf
@@ -1,0 +1,8 @@
+# Reads 'mntr' stats from one or many zookeeper servers
+[[inputs.zookeeper]]
+  ## An array of address to gather stats about. Specify an ip or hostname
+  ## with port. ie localhost:2181, 10.0.0.1:2181, etc.
+  servers = ["localhost:2181"]
+
+  ## Enable TLS using the deprecated option
+  enable_tls = true

--- a/plugins/inputs/zookeeper/zookeeper.go
+++ b/plugins/inputs/zookeeper/zookeeper.go
@@ -30,7 +30,6 @@ type Zookeeper struct {
 	Timeout     config.Duration `toml:"timeout"`
 	ParseFloats string          `toml:"parse_floats"`
 
-	EnableTLS bool `toml:"enable_tls" deprecated:"1.37.0;1.40.0;use 'tls_enable' instead"`
 	common_tls.ClientConfig
 
 	tlsConfig *tls.Config
@@ -41,7 +40,6 @@ func (*Zookeeper) SampleConfig() string {
 }
 
 func (z *Zookeeper) Init() error {
-	z.ClientConfig.Enable = &z.EnableTLS
 	tlsConfig, err := z.ClientConfig.TLSConfig()
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
The `enable_tls` option in `inputs.zookeeper` was deprecated in v1.37.0 for removal in v1.40.0, replaced by `tls_enable`. 

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #19089
