### PR TITLE
feat(inputs.ping): Add interface argument support for Windows (#17071)

### DIFF
--- a/plugins/inputs/ping/ping_windows.go
+++ b/plugins/inputs/ping/ping_windows.go
@@ -91,6 +91,10 @@ func (p *Ping) args(url string) []string {
 		args = append(args, "-w", strconv.FormatFloat(timeout*1000, 'f', 0, 64))
 	}
 
+	if p.Interface != "" {
+		args = append(args, "-S", p.Interface)
+	}
+
 	args = append(args, url)
 
 	return args


### PR DESCRIPTION
## Summary

Add support for the interface argument on Windows as discussed in #17071 

Please note, I am not familiar with Go and although this seemed to be a simple change I don't know how to build or test it.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

resolves #17071 
