### PR TITLE
chore(inputs.procstat)!: Remove deprecated options

### DIFF
--- a/plugins/inputs/procstat/procstat.go
+++ b/plugins/inputs/procstat/procstat.go
@@ -18,7 +18,6 @@ import (
 	gopsprocess "github.com/shirou/gopsutil/v4/process"
 
 	"github.com/influxdata/telegraf"
-	"github.com/influxdata/telegraf/internal/choice"
 	"github.com/influxdata/telegraf/plugins/inputs"
 )
 
@@ -36,15 +35,12 @@ type Procstat struct {
 	Exe                    string          `toml:"exe"`
 	Pattern                string          `toml:"pattern"`
 	Prefix                 string          `toml:"prefix"`
-	CmdLineTag             bool            `toml:"cmdline_tag" deprecated:"1.29.0;1.40.0;use 'tag_with' instead"`
 	ProcessName            string          `toml:"process_name"`
 	User                   string          `toml:"user"`
 	SystemdUnit            string          `toml:"systemd_unit"`
-	SupervisorUnit         []string        `toml:"supervisor_unit" deprecated:"1.29.0;1.40.0;use 'supervisor_units' instead"`
 	SupervisorUnits        []string        `toml:"supervisor_units"`
 	IncludeSystemdChildren bool            `toml:"include_systemd_children"`
 	CGroup                 string          `toml:"cgroup"`
-	PidTag                 bool            `toml:"pid_tag" deprecated:"1.29.0;1.40.0;use 'tag_with' instead"`
 	WinService             string          `toml:"win_service"`
 	Mode                   string          `toml:"mode"`
 	Properties             []string        `toml:"properties"`
@@ -84,14 +80,6 @@ func (*Procstat) SampleConfig() string {
 }
 
 func (p *Procstat) Init() error {
-	// Keep the old settings for compatibility
-	if p.PidTag && !choice.Contains("pid", p.TagWith) {
-		p.TagWith = append(p.TagWith, "pid")
-	}
-	if p.CmdLineTag && !choice.Contains("cmdline", p.TagWith) {
-		p.TagWith = append(p.TagWith, "cmdline")
-	}
-
 	// Configure metric collection features
 	p.cfg.solarisMode = strings.EqualFold(p.Mode, "solaris")
 
@@ -146,13 +134,6 @@ func (p *Procstat) Init() error {
 	// operation mode.
 	p.oldMode = len(p.Filter) == 0
 	if p.oldMode {
-		// Keep the old settings for compatibility
-		for _, u := range p.SupervisorUnit {
-			if !choice.Contains(u, p.SupervisorUnits) {
-				p.SupervisorUnits = append(p.SupervisorUnits, u)
-			}
-		}
-
 		// Check filtering
 		switch {
 		case len(p.SupervisorUnits) > 0, p.SystemdUnit != "", p.WinService != "",
@@ -189,8 +170,8 @@ func (p *Procstat) Init() error {
 		// Check for mixed mode
 		switch {
 		case p.PidFile != "", p.Exe != "", p.Pattern != "", p.User != "",
-			p.SystemdUnit != "", len(p.SupervisorUnit) > 0,
-			len(p.SupervisorUnits) > 0, p.CGroup != "", p.WinService != "":
+			p.SystemdUnit != "", len(p.SupervisorUnits) > 0, p.CGroup != "",
+			p.WinService != "":
 			return errors.New("cannot operate in mixed mode with filters and old-style config")
 		}
 

--- a/plugins/inputs/procstat/procstat_test.go
+++ b/plugins/inputs/procstat/procstat_test.go
@@ -397,7 +397,7 @@ func TestGather_NoPidTag(t *testing.T) {
 func TestGather_PidTag(t *testing.T) {
 	p := Procstat{
 		Exe:           exe,
-		PidTag:        true,
+		TagWith:       []string{"pid"},
 		PidFinder:     "test",
 		Properties:    []string{"cpu", "memory", "mmap"},
 		Log:           testutil.Logger{},
@@ -510,7 +510,7 @@ func TestGather_PercentFirstPass(t *testing.T) {
 
 	p := Procstat{
 		Pattern:       "foo",
-		PidTag:        true,
+		TagWith:       []string{"pid"},
 		PidFinder:     "test",
 		Properties:    []string{"cpu", "memory", "mmap"},
 		Log:           testutil.Logger{},
@@ -531,7 +531,7 @@ func TestGather_PercentSecondPass(t *testing.T) {
 
 	p := Procstat{
 		Pattern:       "foo",
-		PidTag:        true,
+		TagWith:       []string{"pid"},
 		PidFinder:     "test",
 		Properties:    []string{"cpu", "memory", "mmap"},
 		Log:           testutil.Logger{},


### PR DESCRIPTION


## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
The 'cmdline_tag', 'pid_tag', and 'supervisor_unit' options in inputs.procstat were deprecated in v1.29.0 for removal in v1.40.0, replaced by 'tag_with' and 'supervisor_units'. The existing migration under migrations/inputs_procstat already covers all three.

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #19087
