### PR TITLE
docs(inputs.clickhouse): Clarify auto_discovery with default example clusters

### DIFF
--- a/plugins/inputs/clickhouse/README.md
+++ b/plugins/inputs/clickhouse/README.md
@@ -53,6 +53,11 @@ plugin ordering. See [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## - https://clickhouse.tech/docs/en/operations/server_settings/settings/#server_settings_remote_servers
   ## - https://clickhouse.tech/docs/en/operations/table_engines/distributed/
   ## - https://clickhouse.tech/docs/en/operations/table_engines/replication/#creating-replicated-tables
+  ## Note: a default ClickHouse install ships built-in example clusters in
+  ## "system.clusters" whose hosts point at localhost. With discovery enabled
+  ## these redirect scraping to the Telegraf host instead of the configured
+  ## server. For a standalone server set "auto_discovery = false", or use
+  ## "cluster_exclude" to drop the example clusters.
   # auto_discovery = true
 
   ## Filter cluster names in "system.clusters" when "auto_discovery" is "true"

--- a/plugins/inputs/clickhouse/sample.conf
+++ b/plugins/inputs/clickhouse/sample.conf
@@ -30,6 +30,11 @@
   ## - https://clickhouse.tech/docs/en/operations/server_settings/settings/#server_settings_remote_servers
   ## - https://clickhouse.tech/docs/en/operations/table_engines/distributed/
   ## - https://clickhouse.tech/docs/en/operations/table_engines/replication/#creating-replicated-tables
+  ## Note: a default ClickHouse install ships built-in example clusters in
+  ## "system.clusters" whose hosts point at localhost. With discovery enabled
+  ## these redirect scraping to the Telegraf host instead of the configured
+  ## server. For a standalone server set "auto_discovery = false", or use
+  ## "cluster_exclude" to drop the example clusters.
   # auto_discovery = true
 
   ## Filter cluster names in "system.clusters" when "auto_discovery" is "true"


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
With `auto_discovery = true` (the default), the plugin queries `system.clusters` and scrapes each discovered `host_name`. A default ClickHouse install ships built-in example clusters (`test_shard_localhost` and friends) whose hosts point at localhost, so on a standalone server discovery redirects every scrape to the Telegraf host instead of the configured server.

This isn't something the plugin should silently rewrite. The existing options already cover it: set `auto_discovery = false` for a single configured server, or use `cluster_exclude` to drop the example clusters. This documents that behavior under the `auto_discovery` option in `sample.conf`/`README.md` so the default is no longer surprising.

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #19094
