### PR TITLE
feat(migrations): Add migration for inputs.openstack server_diagnotics option

### DIFF
--- a/migrations/all/inputs_openstack.go
+++ b/migrations/all/inputs_openstack.go
@@ -1,0 +1,5 @@
+//go:build !custom || (migrations && (inputs || inputs.openstack))
+
+package all
+
+import _ "github.com/influxdata/telegraf/migrations/inputs_openstack" // register migration

--- a/migrations/inputs_openstack/migration.go
+++ b/migrations/inputs_openstack/migration.go
@@ -1,0 +1,69 @@
+package inputs_openstack
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/influxdata/toml"
+	"github.com/influxdata/toml/ast"
+
+	"github.com/influxdata/telegraf/migrations"
+)
+
+// Migration function to migrate the deprecated 'server_diagnotics' option to its
+// replacement, adding 'serverdiagnostics' to the 'enabled_services' list. When
+// 'enabled_services' is unset the plugin uses a default set of services, so that
+// default is materialized before appending to preserve the original behavior.
+func migrate(tbl *ast.Table) ([]byte, string, error) {
+	// Decode the old data structure
+	var plugin map[string]interface{}
+	if err := toml.UnmarshalTable(tbl, &plugin); err != nil {
+		return nil, "", err
+	}
+
+	// Check for the deprecated option and migrate it
+	var applied bool
+	if rawOldValue, found := plugin["server_diagnotics"]; found {
+		applied = true
+
+		// Convert to the actual type
+		oldValue, ok := rawOldValue.(bool)
+		if !ok {
+			return nil, "", fmt.Errorf("unexpected type %T for 'server_diagnotics'", rawOldValue)
+		}
+
+		// Only a 'true' value had an effect, enabling the 'serverdiagnostics'
+		// service. A 'false' value is the default and can simply be dropped.
+		if oldValue {
+			services, _ := plugin["enabled_services"].([]interface{})
+			if len(services) == 0 {
+				// Mirror the plugin's default set of enabled services
+				services = []interface{}{"services", "projects", "hypervisors", "flavors", "networks", "volumes"}
+			}
+			if !slices.Contains(services, "serverdiagnostics") {
+				services = append(services, "serverdiagnostics")
+			}
+			plugin["enabled_services"] = services
+		}
+
+		// Remove the deprecated setting
+		delete(plugin, "server_diagnotics")
+	}
+
+	// No options migrated so we can exit early
+	if !applied {
+		return nil, "", migrations.ErrNotApplicable
+	}
+
+	// Create the corresponding plugin configuration
+	cfg := migrations.CreateTOMLStruct("inputs", "openstack")
+	cfg.Add("inputs", "openstack", plugin)
+
+	output, err := toml.Marshal(cfg)
+	return output, "", err
+}
+
+// Register the migration function for the plugin type
+func init() {
+	migrations.AddPluginOptionMigration("inputs.openstack", migrate)
+}

--- a/migrations/inputs_openstack/migration_test.go
+++ b/migrations/inputs_openstack/migration_test.go
@@ -1,0 +1,73 @@
+package inputs_openstack_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/influxdata/telegraf/config"
+	_ "github.com/influxdata/telegraf/migrations/inputs_openstack" // register migration
+	"github.com/influxdata/telegraf/plugins/inputs/openstack"      // register plugin
+)
+
+func TestNoMigration(t *testing.T) {
+	plugin := &openstack.OpenStack{}
+	defaultCfg := plugin.SampleConfig()
+
+	// Migrate and check that nothing changed
+	output, n, err := config.ApplyMigrations([]byte(defaultCfg))
+	require.NoError(t, err)
+	require.NotEmpty(t, output)
+	require.Zero(t, n)
+	require.Equal(t, defaultCfg, string(output))
+}
+
+func TestCases(t *testing.T) {
+	// Get all directories in testcases
+	folders, err := os.ReadDir("testcases")
+	require.NoError(t, err)
+
+	for _, f := range folders {
+		// Only handle folders
+		if !f.IsDir() {
+			continue
+		}
+
+		t.Run(f.Name(), func(t *testing.T) {
+			testcasePath := filepath.Join("testcases", f.Name())
+			inputFile := filepath.Join(testcasePath, "telegraf.conf")
+			expectedFile := filepath.Join(testcasePath, "expected.conf")
+
+			// Read the expected output
+			expected := config.NewConfig()
+			require.NoError(t, expected.LoadConfig(expectedFile))
+			require.NotEmpty(t, expected.Inputs)
+
+			// Read the input data
+			input, remote, err := config.LoadConfigFile(inputFile)
+			require.NoError(t, err)
+			require.False(t, remote)
+			require.NotEmpty(t, input)
+
+			// Migrate
+			output, n, err := config.ApplyMigrations(input)
+			require.NoError(t, err)
+			require.NotEmpty(t, output)
+			require.GreaterOrEqual(t, n, uint64(1))
+			actual := config.NewConfig()
+			require.NoError(t, actual.LoadConfigData(output, config.EmptySourcePath))
+
+			// Test the output
+			require.Len(t, actual.Inputs, len(expected.Inputs))
+			actualIDs := make([]string, 0, len(expected.Inputs))
+			expectedIDs := make([]string, 0, len(expected.Inputs))
+			for i := range actual.Inputs {
+				actualIDs = append(actualIDs, actual.Inputs[i].ID())
+				expectedIDs = append(expectedIDs, expected.Inputs[i].ID())
+			}
+			require.ElementsMatch(t, expectedIDs, actualIDs, string(output))
+		})
+	}
+}

--- a/migrations/inputs_openstack/testcases/default_services/expected.conf
+++ b/migrations/inputs_openstack/testcases/default_services/expected.conf
@@ -1,0 +1,14 @@
+# Collects performance metrics from OpenStack services
+[[inputs.openstack]]
+  ## The identity endpoint to authenticate against and get the service catalog from.
+  authentication_endpoint = "https://my.openstack.cloud:5000"
+
+  ## User authentication credentials. Must have admin rights.
+  username = "admin"
+  password = "password"
+
+  ## Options for tags received from Openstack
+  tag_value = "true"
+
+  ## Services to query, mirroring the previous default set plus server diagnostics
+  enabled_services = ["services", "projects", "hypervisors", "flavors", "networks", "volumes", "serverdiagnostics"]

--- a/migrations/inputs_openstack/testcases/default_services/telegraf.conf
+++ b/migrations/inputs_openstack/testcases/default_services/telegraf.conf
@@ -1,0 +1,14 @@
+# Collects performance metrics from OpenStack services
+[[inputs.openstack]]
+  ## The identity endpoint to authenticate against and get the service catalog from.
+  authentication_endpoint = "https://my.openstack.cloud:5000"
+
+  ## User authentication credentials. Must have admin rights.
+  username = "admin"
+  password = "password"
+
+  ## Options for tags received from Openstack
+  tag_value = "true"
+
+  ## Collect server diagnostics using the deprecated option
+  server_diagnotics = true

--- a/migrations/inputs_openstack/testcases/disabled/expected.conf
+++ b/migrations/inputs_openstack/testcases/disabled/expected.conf
@@ -1,0 +1,13 @@
+# Collects performance metrics from OpenStack services
+[[inputs.openstack]]
+  ## The identity endpoint to authenticate against and get the service catalog from.
+  authentication_endpoint = "https://my.openstack.cloud:5000"
+
+  ## User authentication credentials. Must have admin rights.
+  username = "admin"
+  password = "password"
+
+  ## Options for tags received from Openstack
+  tag_value = "true"
+
+  ## Server diagnostics explicitly disabled

--- a/migrations/inputs_openstack/testcases/disabled/telegraf.conf
+++ b/migrations/inputs_openstack/testcases/disabled/telegraf.conf
@@ -1,0 +1,14 @@
+# Collects performance metrics from OpenStack services
+[[inputs.openstack]]
+  ## The identity endpoint to authenticate against and get the service catalog from.
+  authentication_endpoint = "https://my.openstack.cloud:5000"
+
+  ## User authentication credentials. Must have admin rights.
+  username = "admin"
+  password = "password"
+
+  ## Options for tags received from Openstack
+  tag_value = "true"
+
+  ## Server diagnostics explicitly disabled
+  server_diagnotics = false

--- a/migrations/inputs_openstack/testcases/enabled_services_set/expected.conf
+++ b/migrations/inputs_openstack/testcases/enabled_services_set/expected.conf
@@ -1,0 +1,14 @@
+# Collects performance metrics from OpenStack services
+[[inputs.openstack]]
+  ## The identity endpoint to authenticate against and get the service catalog from.
+  authentication_endpoint = "https://my.openstack.cloud:5000"
+
+  ## User authentication credentials. Must have admin rights.
+  username = "admin"
+  password = "password"
+
+  ## Options for tags received from Openstack
+  tag_value = "true"
+
+  ## Services to query
+  enabled_services = ["services", "networks", "serverdiagnostics"]

--- a/migrations/inputs_openstack/testcases/enabled_services_set/telegraf.conf
+++ b/migrations/inputs_openstack/testcases/enabled_services_set/telegraf.conf
@@ -1,0 +1,17 @@
+# Collects performance metrics from OpenStack services
+[[inputs.openstack]]
+  ## The identity endpoint to authenticate against and get the service catalog from.
+  authentication_endpoint = "https://my.openstack.cloud:5000"
+
+  ## User authentication credentials. Must have admin rights.
+  username = "admin"
+  password = "password"
+
+  ## Options for tags received from Openstack
+  tag_value = "true"
+
+  ## Services to query
+  enabled_services = ["services", "networks"]
+
+  ## Collect server diagnostics using the deprecated option
+  server_diagnotics = true


### PR DESCRIPTION
## Summary

The `server_diagnotics` option in `inputs.openstack` was deprecated in v1.32.0 for removal in v1.40.0, replaced by adding `serverdiagnostics` to `enabled_services`. This adds a migration that performs that rewrite on `telegraf config migrate`, materializing the previous default service set first when `enabled_services` is otherwise unset. The option removal ships separately (#19130) so users can run the migration while still on v1.39.x.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

related to #19086
