### PR TITLE
feat(migrations): Add migration for outputs.amon

### DIFF
--- a/migrations/all/outputs_amon.go
+++ b/migrations/all/outputs_amon.go
@@ -1,0 +1,5 @@
+//go:build !custom || (migrations && (outputs || outputs.amon))
+
+package all
+
+import _ "github.com/influxdata/telegraf/migrations/outputs_amon" // register migration

--- a/migrations/outputs_amon/migration.go
+++ b/migrations/outputs_amon/migration.go
@@ -1,0 +1,23 @@
+package outputs_amon
+
+import (
+	"github.com/influxdata/toml/ast"
+
+	"github.com/influxdata/telegraf/migrations"
+)
+
+const msg = `
+    The 'outputs.amon' plugin has been removed as the Amon service no longer
+    exists. There is no replacement; please remove the plugin from your
+    configuration.
+`
+
+// Migration function
+func migrate(_ *ast.Table) ([]byte, string, error) {
+	return nil, msg, nil
+}
+
+// Register the migration function for the plugin type
+func init() {
+	migrations.AddPluginMigration("outputs.amon", migrate)
+}

--- a/migrations/outputs_amon/migration_test.go
+++ b/migrations/outputs_amon/migration_test.go
@@ -1,0 +1,26 @@
+package outputs_amon_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/influxdata/telegraf/config"
+	_ "github.com/influxdata/telegraf/migrations/outputs_amon" // register migration
+)
+
+func TestMigration(t *testing.T) {
+	input := []byte(`
+[[outputs.amon]]
+  server_key = "my-server-key"
+  amon_instance = "https://youramoninstance"
+  timeout = "5s"
+`)
+
+	// The plugin has no replacement, so the migration drops it
+	output, n, err := config.ApplyMigrations(input)
+	require.NoError(t, err)
+	require.Empty(t, strings.TrimSpace(string(output)))
+	require.Equal(t, uint64(1), n)
+}


### PR DESCRIPTION
## Summary

The `outputs.amon` plugin was deprecated in v1.37.0 for removal in v1.40.0 because the Amon service no longer exists and the platform code is unmaintained. This adds a migration that drops the plugin from the configuration on `telegraf config migrate`, as there is no replacement. The plugin removal ships separately so users can run the migration while still on v1.39.x.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

related to #19084
