### PR TITLE
feat(migrations): Add migration for inputs.aerospike

### DIFF
--- a/migrations/all/inputs_aerospike.go
+++ b/migrations/all/inputs_aerospike.go
@@ -1,0 +1,5 @@
+//go:build !custom || (migrations && (inputs || inputs.aerospike))
+
+package all
+
+import _ "github.com/influxdata/telegraf/migrations/inputs_aerospike" // register migration

--- a/migrations/inputs_aerospike/migration.go
+++ b/migrations/inputs_aerospike/migration.go
@@ -1,0 +1,22 @@
+package inputs_aerospike
+
+import (
+	"github.com/influxdata/toml/ast"
+
+	"github.com/influxdata/telegraf/migrations"
+)
+
+const msg = `
+    This plugin cannot be migrated automatically and requires manual intervention!
+    Please use 'inputs.prometheus' with the Aerospike Prometheus Exporter instead.
+`
+
+// Migration function
+func migrate(_ *ast.Table) ([]byte, string, error) {
+	return nil, msg, nil
+}
+
+// Register the migration function for the plugin type
+func init() {
+	migrations.AddPluginMigration("inputs.aerospike", migrate)
+}

--- a/migrations/inputs_aerospike/migration_test.go
+++ b/migrations/inputs_aerospike/migration_test.go
@@ -1,0 +1,28 @@
+package inputs_aerospike_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/influxdata/telegraf/config"
+	_ "github.com/influxdata/telegraf/migrations/inputs_aerospike" // register migration
+)
+
+func TestMigration(t *testing.T) {
+	input := []byte(`
+[[inputs.aerospike]]
+  servers = ["localhost:3000"]
+  username = "telegraf"
+  password = "secret"
+  enable_tls = true
+  tls_name = "tlsname"
+`)
+
+	// The plugin cannot be migrated automatically, so it is dropped with a notice
+	output, n, err := config.ApplyMigrations(input)
+	require.NoError(t, err)
+	require.Empty(t, strings.TrimSpace(string(output)))
+	require.Equal(t, uint64(1), n)
+}


### PR DESCRIPTION
## Summary

The `inputs.aerospike` plugin was deprecated in v1.30.0 for removal in v1.40.0 in favor of `inputs.prometheus` with the Aerospike Prometheus Exporter. This adds a migration that flags the configuration for manual intervention on `telegraf config migrate`, since the replacement requires an external exporter and cannot be rewritten automatically. The plugin removal ships separately so users can run the migration while still on v1.39.x.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

related to #19082
