### PR TITLE
chore(inputs.kafka_consumer)!: Remove deprecated connection_strategy option

### DIFF
--- a/plugins/inputs/kafka_consumer/kafka_consumer.go
+++ b/plugins/inputs/kafka_consumer/kafka_consumer.go
@@ -51,7 +51,6 @@ type KafkaConsumer struct {
 	ConsumerFetchDefault                 config.Size     `toml:"consumer_fetch_default"`
 	ConsumerFetchMin                     config.Size     `toml:"consumer_fetch_min"`
 	ConsumerFetchMaxWait                 config.Duration `toml:"consumer_fetch_max_wait"`
-	ConnectionStrategy                   string          `toml:"connection_strategy" deprecated:"1.33.0;1.40.0;use 'startup_error_behavior' instead"`
 	ResolveCanonicalBootstrapServersOnly bool            `toml:"resolve_canonical_bootstrap_servers_only"`
 	Log                                  telegraf.Logger `toml:"-"`
 	kafka.ReadConfig
@@ -200,12 +199,6 @@ func (k *KafkaConsumer) Init() error {
 		cfg.Consumer.MaxWaitTime = time.Duration(k.ConsumerFetchMaxWait)
 	}
 
-	switch strings.ToLower(k.ConnectionStrategy) {
-	default:
-		return fmt.Errorf("invalid connection strategy %q", k.ConnectionStrategy)
-	case "defer", "startup", "":
-	}
-
 	k.config = cfg
 
 	if len(k.TopicRegexps) == 0 {
@@ -231,8 +224,6 @@ func (k *KafkaConsumer) SetParser(parser telegraf.Parser) {
 }
 
 func (k *KafkaConsumer) Start(acc telegraf.Accumulator) error {
-	var err error
-
 	// If TopicRegexps is set, add matches to Topics
 	if len(k.TopicRegexps) > 0 {
 		if err := k.refreshTopics(); err != nil {
@@ -243,32 +234,18 @@ func (k *KafkaConsumer) Start(acc telegraf.Accumulator) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	k.cancel = cancel
 
-	if k.ConnectionStrategy != "defer" {
-		err = k.create()
-		if err != nil {
-			return &internal.StartupError{
-				Err:   fmt.Errorf("create consumer: %w", err),
-				Retry: errors.Is(err, sarama.ErrOutOfBrokers),
-			}
+	if err := k.create(); err != nil {
+		return &internal.StartupError{
+			Err:   fmt.Errorf("create consumer: %w", err),
+			Retry: errors.Is(err, sarama.ErrOutOfBrokers),
 		}
-		k.startErrorAdder(acc)
 	}
+	k.startErrorAdder(acc)
 
 	// Start consumer goroutine
 	k.wg.Add(1)
 	go func() {
-		var err error
 		defer k.wg.Done()
-
-		if k.consumer == nil {
-			err = k.create()
-			if err != nil {
-				acc.AddError(fmt.Errorf("create consumer async: %w", err))
-				return
-			}
-		}
-
-		k.startErrorAdder(acc)
 
 		for ctx.Err() == nil {
 			handler := newConsumerGroupHandler(acc, k.MaxUndeliveredMessages, k.parser, k.Log)
@@ -300,8 +277,7 @@ func (k *KafkaConsumer) Start(acc telegraf.Accumulator) error {
 				internal.SleepContext(ctx, reconnectDelay) //nolint:errcheck // ignore returned error as we cannot do anything about it anyway
 			}
 		}
-		err = k.consumer.Close()
-		if err != nil {
+		if err := k.consumer.Close(); err != nil {
 			acc.AddError(fmt.Errorf("close: %w", err))
 		}
 	}()

--- a/plugins/inputs/kafka_consumer/kafka_consumer_test.go
+++ b/plugins/inputs/kafka_consumer/kafka_consumer_test.go
@@ -591,77 +591,60 @@ func TestKafkaRoundTripIntegration(t *testing.T) {
 		t.Skip("Skipping integration test in short mode")
 	}
 
-	var tests = []struct {
-		name                 string
-		connectionStrategy   string
-		topics               []string
-		topicRegexps         []string
-		topicRefreshInterval config.Duration
-	}{
-		{"connection strategy startup", "startup", []string{"Test"}, nil, config.Duration(0)},
-		{"connection strategy defer", "defer", []string{"Test"}, nil, config.Duration(0)},
+	kafkaContainer, err := kafkacontainer.Run(t.Context(), "confluentinc/confluent-local:7.5.0")
+	require.NoError(t, err)
+	defer kafkaContainer.Terminate(t.Context()) //nolint:errcheck // ignored
+
+	brokers, err := kafkaContainer.Brokers(t.Context())
+	require.NoError(t, err)
+
+	// Make kafka output
+	t.Logf("rt: starting output plugin")
+	creator := outputs.Outputs["kafka"]
+	output, ok := creator().(*outputs_kafka.Kafka)
+	require.True(t, ok)
+
+	s := &serializers_influx.Serializer{}
+	require.NoError(t, s.Init())
+	output.SetSerializer(s)
+	output.Brokers = brokers
+	output.Topic = "Test"
+	output.Log = testutil.Logger{}
+
+	require.NoError(t, output.Init())
+	require.NoError(t, output.Connect())
+
+	// Make kafka input
+	t.Logf("rt: starting input plugin")
+	input := KafkaConsumer{
+		Brokers:                brokers,
+		Log:                    testutil.Logger{},
+		Topics:                 []string{"Test"},
+		MaxUndeliveredMessages: 1,
 	}
+	parser := &influx.Parser{}
+	require.NoError(t, parser.Init())
+	input.SetParser(parser)
+	require.NoError(t, input.Init())
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			kafkaContainer, err := kafkacontainer.Run(t.Context(), "confluentinc/confluent-local:7.5.0")
-			require.NoError(t, err)
-			defer kafkaContainer.Terminate(t.Context()) //nolint:errcheck // ignored
+	acc := testutil.Accumulator{}
+	require.NoError(t, input.Start(&acc))
 
-			brokers, err := kafkaContainer.Brokers(t.Context())
-			require.NoError(t, err)
+	// Shove some metrics through
+	expected := testutil.MockMetrics()
+	t.Logf("rt: writing")
+	require.NoError(t, output.Write(expected))
 
-			// Make kafka output
-			t.Logf("rt: starting output plugin")
-			creator := outputs.Outputs["kafka"]
-			output, ok := creator().(*outputs_kafka.Kafka)
-			require.True(t, ok)
+	// Check that they were received
+	t.Logf("rt: expecting")
+	acc.Wait(len(expected))
+	testutil.RequireMetricsEqual(t, expected, acc.GetTelegrafMetrics())
 
-			s := &serializers_influx.Serializer{}
-			require.NoError(t, s.Init())
-			output.SetSerializer(s)
-			output.Brokers = brokers
-			output.Topic = "Test"
-			output.Log = testutil.Logger{}
+	t.Logf("rt: shutdown")
+	require.NoError(t, output.Close())
+	input.Stop()
 
-			require.NoError(t, output.Init())
-			require.NoError(t, output.Connect())
-
-			// Make kafka input
-			t.Logf("rt: starting input plugin")
-			input := KafkaConsumer{
-				Brokers:                brokers,
-				Log:                    testutil.Logger{},
-				Topics:                 tt.topics,
-				TopicRegexps:           tt.topicRegexps,
-				MaxUndeliveredMessages: 1,
-				ConnectionStrategy:     tt.connectionStrategy,
-			}
-			parser := &influx.Parser{}
-			require.NoError(t, parser.Init())
-			input.SetParser(parser)
-			require.NoError(t, input.Init())
-
-			acc := testutil.Accumulator{}
-			require.NoError(t, input.Start(&acc))
-
-			// Shove some metrics through
-			expected := testutil.MockMetrics()
-			t.Logf("rt: writing")
-			require.NoError(t, output.Write(expected))
-
-			// Check that they were received
-			t.Logf("rt: expecting")
-			acc.Wait(len(expected))
-			testutil.RequireMetricsEqual(t, expected, acc.GetTelegrafMetrics())
-
-			t.Logf("rt: shutdown")
-			require.NoError(t, output.Close())
-			input.Stop()
-
-			t.Logf("rt: done")
-		})
-	}
+	t.Logf("rt: done")
 }
 
 func TestKafkaTimestampSourceIntegration(t *testing.T) {


### PR DESCRIPTION
## Summary

The `connection_strategy` option in `inputs.kafka_consumer` was deprecated in v1.33.0 for removal in v1.40.0, replaced by `startup_error_behavior`. This removes the option and its `Start()` handling. The migration mapping the old values ships separately (#19121) and should merge first so users can migrate while still on v1.39.x.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #19085
