### PR TITLE
chore(inputs.tail)!: Remove deprecated from_beginning option

### DIFF
--- a/plugins/inputs/tail/tail.go
+++ b/plugins/inputs/tail/tail.go
@@ -39,7 +39,6 @@ var (
 
 type Tail struct {
 	Files               []string `toml:"files"`
-	FromBeginning       bool     `toml:"from_beginning" deprecated:"1.34.0;1.40.0;use 'initial_read_offset' with value 'beginning' instead"`
 	InitialReadOffset   string   `toml:"initial_read_offset"`
 	Pipe                bool     `toml:"pipe"`
 	WatchMethod         string   `toml:"watch_method"`
@@ -82,15 +81,6 @@ func (t *Tail) SetParserFunc(fn telegraf.ParserFunc) {
 }
 
 func (t *Tail) Init() error {
-	// Backward compatibility setting
-	if t.InitialReadOffset == "" {
-		if t.FromBeginning {
-			t.InitialReadOffset = "beginning"
-		} else {
-			t.InitialReadOffset = "saved-or-end"
-		}
-	}
-
 	// Check settings
 	switch t.InitialReadOffset {
 	case "":

--- a/plugins/inputs/tail/tail_test.go
+++ b/plugins/inputs/tail/tail_test.go
@@ -996,56 +996,19 @@ func TestInvalidInitialReadOffset(t *testing.T) {
 	require.ErrorContains(t, plugin.Init(), "invalid 'initial_read_offset' setting")
 }
 
-func TestSetInitialValueForInitialReadOffset(t *testing.T) {
-	tests := []struct {
-		name              string
-		InitialReadOffset string
-		FromBeginning     bool
-		expected          string
-	}{
-		{
-			name:          "Set InitialReadOffset to beginning when from_beginning set to true and initial_read_offset not set",
-			FromBeginning: true,
-			expected:      "beginning",
-		},
-		{
-			name:     "Set InitialReadOffset to saved-or-end when from_beginning set to false and initial_read_offset not set",
-			expected: "saved-or-end",
-		},
-		{
-			name:              "Ignore from_beginning when initial_read_offset is set",
-			InitialReadOffset: "end",
-			expected:          "end",
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			tt := newTail()
-			tt.FromBeginning = test.FromBeginning
-			tt.InitialReadOffset = test.InitialReadOffset
-			require.NoError(t, tt.Init())
-			require.Equal(t, test.expected, tt.InitialReadOffset)
-		})
-	}
-}
-
 func TestInitInitialReadOffset(t *testing.T) {
 	tests := []struct {
 		name              string
-		InitialReadOffset string
-		FromBeginning     bool
+		initialReadOffset string
 		expected          string
 	}{
 		{
-			name:          "Set InitialReadOffset to beginning when from_beginning set to true and initial_read_offset not set",
-			FromBeginning: true,
-			expected:      "beginning",
+			name:     "Default to saved-or-end when initial_read_offset not set",
+			expected: "saved-or-end",
 		},
 		{
-			name:              "Ignore from_beginning when initial_read_offset is set",
-			FromBeginning:     true,
-			InitialReadOffset: "end",
+			name:              "Keep initial_read_offset when set",
+			initialReadOffset: "end",
 			expected:          "end",
 		},
 	}
@@ -1053,8 +1016,7 @@ func TestInitInitialReadOffset(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			tt := newTail()
-			tt.FromBeginning = test.FromBeginning
-			tt.InitialReadOffset = test.InitialReadOffset
+			tt.InitialReadOffset = test.initialReadOffset
 			require.NoError(t, tt.Init())
 			require.Equal(t, test.expected, tt.InitialReadOffset)
 		})


### PR DESCRIPTION
## Summary

The `from_beginning` option in `inputs.tail` was deprecated in v1.34.0 for removal in v1.40.0, replaced by `initial_read_offset` with value `beginning`. This removes the option and its backward-compatibility handling in `Init()`. The migration mapping the old values ships separately (#19117) and should merge first so users can migrate while still on v1.39.x.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

resolves #19088
