### PR TITLE
feat(migrations): Add migration for inputs.openweathermap query_style option

### DIFF
--- a/migrations/all/inputs_openweathermap.go
+++ b/migrations/all/inputs_openweathermap.go
@@ -1,0 +1,5 @@
+//go:build !custom || (migrations && (inputs || inputs.openweathermap))
+
+package all
+
+import _ "github.com/influxdata/telegraf/migrations/inputs_openweathermap" // register migration

--- a/migrations/inputs_openweathermap/migration.go
+++ b/migrations/inputs_openweathermap/migration.go
@@ -1,0 +1,37 @@
+package inputs_openweathermap
+
+import (
+	"github.com/influxdata/toml"
+	"github.com/influxdata/toml/ast"
+
+	"github.com/influxdata/telegraf/migrations"
+)
+
+// Migration function to remove the deprecated 'query_style' option. The option
+// is ignored at runtime since the upstream OpenWeatherMap v2.5 group API was
+// removed, so it has no replacement and is simply dropped.
+func migrate(tbl *ast.Table) ([]byte, string, error) {
+	// Decode the old data structure
+	var plugin map[string]interface{}
+	if err := toml.UnmarshalTable(tbl, &plugin); err != nil {
+		return nil, "", err
+	}
+
+	// Check for the deprecated option and remove it
+	if _, found := plugin["query_style"]; !found {
+		return nil, "", migrations.ErrNotApplicable
+	}
+	delete(plugin, "query_style")
+
+	// Create the corresponding plugin configuration
+	cfg := migrations.CreateTOMLStruct("inputs", "openweathermap")
+	cfg.Add("inputs", "openweathermap", plugin)
+
+	output, err := toml.Marshal(cfg)
+	return output, "", err
+}
+
+// Register the migration function for the plugin type
+func init() {
+	migrations.AddPluginOptionMigration("inputs.openweathermap", migrate)
+}

--- a/migrations/inputs_openweathermap/migration_test.go
+++ b/migrations/inputs_openweathermap/migration_test.go
@@ -1,0 +1,73 @@
+package inputs_openweathermap_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/influxdata/telegraf/config"
+	_ "github.com/influxdata/telegraf/migrations/inputs_openweathermap" // register migration
+	"github.com/influxdata/telegraf/plugins/inputs/openweathermap"      // register plugin
+)
+
+func TestNoMigration(t *testing.T) {
+	plugin := &openweathermap.OpenWeatherMap{}
+	defaultCfg := plugin.SampleConfig()
+
+	// Migrate and check that nothing changed
+	output, n, err := config.ApplyMigrations([]byte(defaultCfg))
+	require.NoError(t, err)
+	require.NotEmpty(t, output)
+	require.Zero(t, n)
+	require.Equal(t, defaultCfg, string(output))
+}
+
+func TestCases(t *testing.T) {
+	// Get all directories in testcases
+	folders, err := os.ReadDir("testcases")
+	require.NoError(t, err)
+
+	for _, f := range folders {
+		// Only handle folders
+		if !f.IsDir() {
+			continue
+		}
+
+		t.Run(f.Name(), func(t *testing.T) {
+			testcasePath := filepath.Join("testcases", f.Name())
+			inputFile := filepath.Join(testcasePath, "telegraf.conf")
+			expectedFile := filepath.Join(testcasePath, "expected.conf")
+
+			// Read the expected output
+			expected := config.NewConfig()
+			require.NoError(t, expected.LoadConfig(expectedFile))
+			require.NotEmpty(t, expected.Inputs)
+
+			// Read the input data
+			input, remote, err := config.LoadConfigFile(inputFile)
+			require.NoError(t, err)
+			require.False(t, remote)
+			require.NotEmpty(t, input)
+
+			// Migrate
+			output, n, err := config.ApplyMigrations(input)
+			require.NoError(t, err)
+			require.NotEmpty(t, output)
+			require.GreaterOrEqual(t, n, uint64(1))
+			actual := config.NewConfig()
+			require.NoError(t, actual.LoadConfigData(output, config.EmptySourcePath))
+
+			// Test the output
+			require.Len(t, actual.Inputs, len(expected.Inputs))
+			actualIDs := make([]string, 0, len(expected.Inputs))
+			expectedIDs := make([]string, 0, len(expected.Inputs))
+			for i := range actual.Inputs {
+				actualIDs = append(actualIDs, actual.Inputs[i].ID())
+				expectedIDs = append(expectedIDs, expected.Inputs[i].ID())
+			}
+			require.ElementsMatch(t, expectedIDs, actualIDs, string(output))
+		})
+	}
+}

--- a/migrations/inputs_openweathermap/testcases/query_style/expected.conf
+++ b/migrations/inputs_openweathermap/testcases/query_style/expected.conf
@@ -1,0 +1,5 @@
+# Read current weather and forecasts data from openweathermap.org
+[[inputs.openweathermap]]
+  app_id = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+  city_id = ["5391959"]
+  units = "metric"

--- a/migrations/inputs_openweathermap/testcases/query_style/telegraf.conf
+++ b/migrations/inputs_openweathermap/testcases/query_style/telegraf.conf
@@ -1,0 +1,8 @@
+# Read current weather and forecasts data from openweathermap.org
+[[inputs.openweathermap]]
+  app_id = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+  city_id = ["5391959"]
+  units = "metric"
+
+  ## Deprecated option, ignored due to the upstream API change
+  query_style = "batch"


### PR DESCRIPTION
## Summary

The `query_style` option in `inputs.openweathermap` was deprecated in v1.39.1 for removal in v1.45.0 and is ignored at runtime since the upstream OpenWeatherMap v2.5 group API was removed (#19076). This adds a migration that drops the option on `telegraf config migrate`, as it has no replacement.

## Checklist

- [x] No AI generated code was used in this PR

## Related issues

related to #19076
