### PR TITLE
feat(inputs.filecount): Adding timeout option

### DIFF
--- a/plugins/inputs/filecount/README.md
+++ b/plugins/inputs/filecount/README.md
@@ -50,10 +50,8 @@ plugin ordering. See [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## touched in this duration. Defaults to "0s".
   mtime = "0s"
 
-  ## Stop counting after this duration has passed.
-  ## Acceptable units: ns, us (µs), ms, s, m, h.
-  ## Defaults to "0s" (disabled).
-  timeout = "0s"
+  ## Stop counting after this duration has passed (disabled by default)
+  # timeout = "0s"
 ```
 
 ## Metrics
@@ -61,7 +59,6 @@ plugin ordering. See [CONFIGURATION.md][CONFIGURATION.md] for more details.
 - filecount
   - tags:
     - directory (the directory path)
-    - filecount_status (status of the count: "ok" or "timeout")
   - fields:
     - count (integer)
     - size_bytes (integer)
@@ -71,6 +68,6 @@ plugin ordering. See [CONFIGURATION.md][CONFIGURATION.md] for more details.
 ## Example Output
 
 ```text
-filecount,directory=/var/cache/apt,filecount_status=ok count=7i,size_bytes=7438336i,oldest_file_timestamp=1507152973123456789i,newest_file_timestamp=1507152973123456789i 1530034445000000000
-filecount,directory=/tmp,filecount_status=ok count=17i,size_bytes=28934786i,oldest_file_timestamp=1507152973123456789i,newest_file_timestamp=1507152973123456789i 1530034445000000000
+filecount,directory=/var/cache/apt,count=7i,size_bytes=7438336i,oldest_file_timestamp=1507152973123456789i,newest_file_timestamp=1507152973123456789i 1530034445000000000
+filecount,directory=/tmp,count=17i,size_bytes=28934786i,oldest_file_timestamp=1507152973123456789i,newest_file_timestamp=1507152973123456789i 1530034445000000000
 ```

--- a/plugins/inputs/filecount/README.md
+++ b/plugins/inputs/filecount/README.md
@@ -68,6 +68,6 @@ plugin ordering. See [CONFIGURATION.md][CONFIGURATION.md] for more details.
 ## Example Output
 
 ```text
-filecount,directory=/var/cache/apt,count=7i,size_bytes=7438336i,oldest_file_timestamp=1507152973123456789i,newest_file_timestamp=1507152973123456789i 1530034445000000000
-filecount,directory=/tmp,count=17i,size_bytes=28934786i,oldest_file_timestamp=1507152973123456789i,newest_file_timestamp=1507152973123456789i 1530034445000000000
+filecount,directory=/var/cache/apt count=7i,size_bytes=7438336i,oldest_file_timestamp=1507152973123456789i,newest_file_timestamp=1507152973123456789i 1530034445000000000
+filecount,directory=/tmp count=17i,size_bytes=28934786i,oldest_file_timestamp=1507152973123456789i,newest_file_timestamp=1507152973123456789i 1530034445000000000
 ```

--- a/plugins/inputs/filecount/README.md
+++ b/plugins/inputs/filecount/README.md
@@ -49,6 +49,11 @@ plugin ordering. See [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## duration. If mtime is negative, only count files that have been
   ## touched in this duration. Defaults to "0s".
   mtime = "0s"
+
+  ## Stop counting after this duration has passed.
+  ## Acceptable units: ns, us (µs), ms, s, m, h.
+  ## Defaults to "0s" (disabled).
+  timeout = "0s"
 ```
 
 ## Metrics
@@ -56,6 +61,7 @@ plugin ordering. See [CONFIGURATION.md][CONFIGURATION.md] for more details.
 - filecount
   - tags:
     - directory (the directory path)
+    - filecount_status (status of the count: "ok" or "timeout")
   - fields:
     - count (integer)
     - size_bytes (integer)
@@ -65,6 +71,6 @@ plugin ordering. See [CONFIGURATION.md][CONFIGURATION.md] for more details.
 ## Example Output
 
 ```text
-filecount,directory=/var/cache/apt count=7i,size_bytes=7438336i,oldest_file_timestamp=1507152973123456789i,newest_file_timestamp=1507152973123456789i 1530034445000000000
-filecount,directory=/tmp count=17i,size_bytes=28934786i,oldest_file_timestamp=1507152973123456789i,newest_file_timestamp=1507152973123456789i 1530034445000000000
+filecount,directory=/var/cache/apt,filecount_status=ok count=7i,size_bytes=7438336i,oldest_file_timestamp=1507152973123456789i,newest_file_timestamp=1507152973123456789i 1530034445000000000
+filecount,directory=/tmp,filecount_status=ok count=17i,size_bytes=28934786i,oldest_file_timestamp=1507152973123456789i,newest_file_timestamp=1507152973123456789i 1530034445000000000
 ```

--- a/plugins/inputs/filecount/filecount.go
+++ b/plugins/inputs/filecount/filecount.go
@@ -37,8 +37,6 @@ type FileCount struct {
 	globPaths   []globpath.GlobPath
 }
 
-var errTimeout = errors.New("filecount: timeout exceeded")
-
 type fileFilterFunc func(os.FileInfo) (bool, error)
 
 func (*FileCount) SampleConfig() string {
@@ -155,8 +153,8 @@ func (fc *FileCount) count(acc telegraf.Accumulator, basedir string, glob globpa
 	}
 
 	walkFn := func(path string, _ *godirwalk.Dirent) error {
-		if ctx.Err() != nil {
-			return errTimeout
+		if err := ctx.Err(); err != nil {
+			return err
 		}
 
 		rel, err := filepath.Rel(basedir, path)
@@ -202,9 +200,6 @@ func (fc *FileCount) count(acc telegraf.Accumulator, basedir string, glob globpa
 			gauge["newest_file_timestamp"] = newestFileTimestamp[path]
 
 			tags := map[string]string{"directory": path}
-			if fc.Timeout > 0 {
-				tags["filecount_status"] = "ok"
-			}
 
 			acc.AddGauge("filecount", gauge, tags)
 		}
@@ -239,23 +234,11 @@ func (fc *FileCount) count(acc telegraf.Accumulator, basedir string, glob globpa
 			return godirwalk.Halt
 		},
 	})
-	if err != nil && !errors.Is(err, errTimeout) {
-		acc.AddError(err)
-		return
-	}
-
-	if errors.Is(err, errTimeout) && glob.MatchString(basedir) {
-		gauge := map[string]interface{}{
-			"count":                 childCount[basedir],
-			"size_bytes":            childSize[basedir],
-			"oldest_file_timestamp": oldestFileTimestamp[basedir],
-			"newest_file_timestamp": newestFileTimestamp[basedir],
+	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			fc.Log.Warnf("Timeout exceeded while walking %q; results not emitted", basedir)
+			return
 		}
-		tags := map[string]string{
-			"directory":        basedir,
-			"filecount_status": "timeout",
-		}
-		acc.AddGauge("filecount", gauge, tags)
 	}
 }
 

--- a/plugins/inputs/filecount/filecount.go
+++ b/plugins/inputs/filecount/filecount.go
@@ -29,6 +29,7 @@ type FileCount struct {
 	Size           config.Size     `toml:"size"`
 	MTime          config.Duration `toml:"mtime"`
 	Log            telegraf.Logger `toml:"-"`
+	Timeout        config.Duration `toml:"timeout"`
 
 	fs          fileSystem
 	fileFilters []fileFilterFunc
@@ -143,7 +144,13 @@ func (fc *FileCount) count(acc telegraf.Accumulator, basedir string, glob globpa
 	oldestFileTimestamp := make(map[string]int64)
 	newestFileTimestamp := make(map[string]int64)
 
+	start := time.Now()
+
 	walkFn := func(path string, _ *godirwalk.Dirent) error {
+		if fc.Timeout > 0 && time.Since(start) > time.Duration(fc.Timeout) {
+			return filepath.SkipDir
+		}
+
 		rel, err := filepath.Rel(basedir, path)
 		if err == nil && rel == "." {
 			return nil
@@ -185,10 +192,15 @@ func (fc *FileCount) count(acc telegraf.Accumulator, basedir string, glob globpa
 			}
 			gauge["oldest_file_timestamp"] = oldestFileTimestamp[path]
 			gauge["newest_file_timestamp"] = newestFileTimestamp[path]
-			acc.AddGauge("filecount", gauge,
-				map[string]string{
-					"directory": path,
-				})
+
+			tags := map[string]string{"directory": path}
+			if fc.Timeout > 0 && time.Since(start) > time.Duration(fc.Timeout) {
+				tags["filecount_status"] = "timeout"
+			} else {
+				tags["filecount_status"] = "ok"
+			}
+
+			acc.AddGauge("filecount", gauge, tags)
 		}
 		parent := filepath.Dir(path)
 		if fc.Recursive {
@@ -302,6 +314,7 @@ func newFileCount() *FileCount {
 		MTime:          config.Duration(0),
 		fileFilters:    nil,
 		fs:             osFS{},
+		Timeout:        config.Duration(0),
 	}
 }
 

--- a/plugins/inputs/filecount/filecount.go
+++ b/plugins/inputs/filecount/filecount.go
@@ -198,10 +198,10 @@ func (fc *FileCount) count(acc telegraf.Accumulator, basedir string, glob globpa
 			}
 			gauge["oldest_file_timestamp"] = oldestFileTimestamp[path]
 			gauge["newest_file_timestamp"] = newestFileTimestamp[path]
-
-			tags := map[string]string{"directory": path}
-
-			acc.AddGauge("filecount", gauge, tags)
+			acc.AddGauge("filecount", gauge,
+				map[string]string{
+					"directory": path,
+				})
 		}
 		parent := filepath.Dir(path)
 		if fc.Recursive {

--- a/plugins/inputs/filecount/filecount.go
+++ b/plugins/inputs/filecount/filecount.go
@@ -48,9 +48,20 @@ func (fc *FileCount) Gather(acc telegraf.Accumulator) error {
 		fc.initGlobPaths(acc)
 	}
 
+	ctx := context.Background()
+	if fc.Timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, time.Duration(fc.Timeout))
+		defer cancel()
+	}
+
 	for _, glob := range fc.globPaths {
 		for _, dir := range fc.onlyDirectories(glob.GetRoots()) {
-			fc.count(acc, dir, glob)
+			if ctx.Err() != nil {
+				fc.Log.Warn("Timeout exceeded, stopping further directory traversal")
+				return nil
+			}
+			fc.count(ctx, acc, dir, glob)
 		}
 	}
 
@@ -139,18 +150,11 @@ func (fc *FileCount) initFileFilters() {
 	fc.fileFilters = rejectNilFilters(filters)
 }
 
-func (fc *FileCount) count(acc telegraf.Accumulator, basedir string, glob globpath.GlobPath) {
+func (fc *FileCount) count(ctx context.Context, acc telegraf.Accumulator, basedir string, glob globpath.GlobPath) {
 	childCount := make(map[string]int64)
 	childSize := make(map[string]int64)
 	oldestFileTimestamp := make(map[string]int64)
 	newestFileTimestamp := make(map[string]int64)
-
-	ctx := context.Background()
-	if fc.Timeout > 0 {
-		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, time.Duration(fc.Timeout))
-		defer cancel()
-	}
 
 	walkFn := func(path string, _ *godirwalk.Dirent) error {
 		if err := ctx.Err(); err != nil {
@@ -237,9 +241,9 @@ func (fc *FileCount) count(acc telegraf.Accumulator, basedir string, glob globpa
 	if err != nil {
 		if errors.Is(err, context.DeadlineExceeded) {
 			fc.Log.Warnf("Timeout exceeded while walking %q", basedir)
-			return
+		} else {
+			acc.AddError(err)
 		}
-		acc.AddError(err)
 	}
 }
 

--- a/plugins/inputs/filecount/filecount.go
+++ b/plugins/inputs/filecount/filecount.go
@@ -2,6 +2,7 @@
 package filecount
 
 import (
+	"context"
 	_ "embed"
 	"errors"
 	"io/fs"
@@ -28,13 +29,15 @@ type FileCount struct {
 	FollowSymlinks bool            `toml:"follow_symlinks"`
 	Size           config.Size     `toml:"size"`
 	MTime          config.Duration `toml:"mtime"`
-	Log            telegraf.Logger `toml:"-"`
 	Timeout        config.Duration `toml:"timeout"`
+	Log            telegraf.Logger `toml:"-"`
 
 	fs          fileSystem
 	fileFilters []fileFilterFunc
 	globPaths   []globpath.GlobPath
 }
+
+var errTimeout = errors.New("filecount: timeout exceeded")
 
 type fileFilterFunc func(os.FileInfo) (bool, error)
 
@@ -144,11 +147,16 @@ func (fc *FileCount) count(acc telegraf.Accumulator, basedir string, glob globpa
 	oldestFileTimestamp := make(map[string]int64)
 	newestFileTimestamp := make(map[string]int64)
 
-	start := time.Now()
+	ctx := context.Background()
+	if fc.Timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, time.Duration(fc.Timeout))
+		defer cancel()
+	}
 
 	walkFn := func(path string, _ *godirwalk.Dirent) error {
-		if fc.Timeout > 0 && time.Since(start) > time.Duration(fc.Timeout) {
-			return filepath.SkipDir
+		if ctx.Err() != nil {
+			return errTimeout
 		}
 
 		rel, err := filepath.Rel(basedir, path)
@@ -194,9 +202,7 @@ func (fc *FileCount) count(acc telegraf.Accumulator, basedir string, glob globpa
 			gauge["newest_file_timestamp"] = newestFileTimestamp[path]
 
 			tags := map[string]string{"directory": path}
-			if fc.Timeout > 0 && time.Since(start) > time.Duration(fc.Timeout) {
-				tags["filecount_status"] = "timeout"
-			} else {
+			if fc.Timeout > 0 {
 				tags["filecount_status"] = "ok"
 			}
 
@@ -233,8 +239,23 @@ func (fc *FileCount) count(acc telegraf.Accumulator, basedir string, glob globpa
 			return godirwalk.Halt
 		},
 	})
-	if err != nil {
+	if err != nil && !errors.Is(err, errTimeout) {
 		acc.AddError(err)
+		return
+	}
+
+	if errors.Is(err, errTimeout) && glob.MatchString(basedir) {
+		gauge := map[string]interface{}{
+			"count":                 childCount[basedir],
+			"size_bytes":            childSize[basedir],
+			"oldest_file_timestamp": oldestFileTimestamp[basedir],
+			"newest_file_timestamp": newestFileTimestamp[basedir],
+		}
+		tags := map[string]string{
+			"directory":        basedir,
+			"filecount_status": "timeout",
+		}
+		acc.AddGauge("filecount", gauge, tags)
 	}
 }
 
@@ -314,7 +335,6 @@ func newFileCount() *FileCount {
 		MTime:          config.Duration(0),
 		fileFilters:    nil,
 		fs:             osFS{},
-		Timeout:        config.Duration(0),
 	}
 }
 

--- a/plugins/inputs/filecount/filecount.go
+++ b/plugins/inputs/filecount/filecount.go
@@ -236,9 +236,10 @@ func (fc *FileCount) count(acc telegraf.Accumulator, basedir string, glob globpa
 	})
 	if err != nil {
 		if errors.Is(err, context.DeadlineExceeded) {
-			fc.Log.Warnf("Timeout exceeded while walking %q; results not emitted", basedir)
+			fc.Log.Warnf("Timeout exceeded while walking %q", basedir)
 			return
 		}
+		acc.AddError(err)
 	}
 }
 

--- a/plugins/inputs/filecount/filecount_test.go
+++ b/plugins/inputs/filecount/filecount_test.go
@@ -196,6 +196,33 @@ func TestTimeoutExceeded(t *testing.T) {
 	require.Empty(t, acc.GetTelegrafMetrics())
 }
 
+func TestTimeoutSharedAcrossDirectories(t *testing.T) {
+	fc := getNoFilterFileCount()
+	fc.Directories = []string{getTestdataDir(), getTestdataDir() + "/subdir"}
+	fc.Timeout = config.Duration(1 * time.Nanosecond)
+
+	acc := testutil.Accumulator{}
+	require.NoError(t, acc.GatherError(fc.Gather))
+	require.Empty(t, acc.GetTelegrafMetrics())
+}
+
+func TestTimeoutGatherWideWarning(t *testing.T) {
+	logger := &testutil.CaptureLogger{}
+	fc := getNoFilterFileCount()
+	fc.Log = logger
+	fc.Directories = []string{getTestdataDir(), getTestdataDir() + "/subdir"}
+	fc.Timeout = config.Duration(1 * time.Nanosecond)
+
+	acc := testutil.Accumulator{}
+	require.NoError(t, acc.GatherError(fc.Gather))
+
+	require.Empty(t, acc.GetTelegrafMetrics())
+
+	warnings := logger.Warnings()
+	require.Len(t, warnings, 1)
+	require.Contains(t, warnings[0], "Timeout")
+}
+
 func TestTimeoutDisabled(t *testing.T) {
 	fc := getNoFilterFileCount()
 	fc.Timeout = config.Duration(0)

--- a/plugins/inputs/filecount/filecount_test.go
+++ b/plugins/inputs/filecount/filecount_test.go
@@ -35,7 +35,7 @@ func TestNoFiltersOnChildDir(t *testing.T) {
 	matches := []string{"subdir/quux", "subdir/quuz",
 		"subdir/nested2/qux", "subdir/nested2"}
 
-	tags := map[string]string{"directory": getTestdataDir() + "/subdir", "filecount_status": "ok"}
+	tags := map[string]string{"directory": getTestdataDir() + "/subdir"}
 	acc := testutil.Accumulator{}
 	require.NoError(t, acc.GatherError(fc.Gather))
 	require.True(t, acc.HasPoint("filecount", tags, "count", int64(len(matches))))
@@ -50,7 +50,7 @@ func TestNoRecursiveButSuperMeta(t *testing.T) {
 	fc.Directories = []string{getTestdataDir() + "/**"}
 	matches := []string{"subdir/quux", "subdir/quuz", "subdir/nested2"}
 
-	tags := map[string]string{"directory": getTestdataDir() + "/subdir", "filecount_status": "ok"}
+	tags := map[string]string{"directory": getTestdataDir() + "/subdir"}
 	acc := testutil.Accumulator{}
 	require.NoError(t, acc.GatherError(fc.Gather))
 
@@ -80,7 +80,7 @@ func TestDoubleAndSimpleStar(t *testing.T) {
 	fc.Directories = []string{getTestdataDir() + "/**/*"}
 	matches := []string{"qux"}
 
-	tags := map[string]string{"directory": getTestdataDir() + "/subdir/nested2", "filecount_status": "ok"}
+	tags := map[string]string{"directory": getTestdataDir() + "/subdir/nested2"}
 
 	acc := testutil.Accumulator{}
 	require.NoError(t, acc.GatherError(fc.Gather))
@@ -160,8 +160,7 @@ func TestDirectoryWithTrailingSlash(t *testing.T) {
 		metric.New(
 			"filecount",
 			map[string]string{
-				"directory":        getTestdataDir(),
-				"filecount_status": "ok",
+				"directory": getTestdataDir(),
 			},
 			map[string]interface{}{
 				"count":                 9,
@@ -206,7 +205,7 @@ func TestTimeoutDisabled(t *testing.T) {
 	fc := getNoFilterFileCount()
 	fc.Timeout = config.Duration(0)
 
-	tags := map[string]string{"directory": getTestdataDir(), "filecount_status": "ok"}
+	tags := map[string]string{"directory": getTestdataDir()}
 	acc := testutil.Accumulator{}
 	require.NoError(t, acc.GatherError(fc.Gather))
 	require.True(t, acc.HasPoint("filecount", tags, "count", int64(9)))
@@ -264,7 +263,7 @@ func getFakeFileSystem(basePath string) fakeFileSystem {
 }
 
 func fileCountEquals(t *testing.T, fc FileCount, expectedCount, expectedSize int) {
-	tags := map[string]string{"directory": getTestdataDir(), "filecount_status": "ok"}
+	tags := map[string]string{"directory": getTestdataDir()}
 	acc := testutil.Accumulator{}
 	require.NoError(t, acc.GatherError(fc.Gather))
 	require.True(t, acc.HasPoint("filecount", tags, "count", int64(expectedCount)))

--- a/plugins/inputs/filecount/filecount_test.go
+++ b/plugins/inputs/filecount/filecount_test.go
@@ -176,6 +176,36 @@ func TestDirectoryWithTrailingSlash(t *testing.T) {
 	testutil.RequireMetricsEqual(t, expected, acc.GetTelegrafMetrics(), testutil.IgnoreTime())
 }
 
+func TestTimeout(t *testing.T) {
+	fc := getNoFilterFileCount()
+	fc.Timeout = config.Duration(5 * time.Second)
+
+	tags := map[string]string{"directory": getTestdataDir()}
+	acc := testutil.Accumulator{}
+	require.NoError(t, acc.GatherError(fc.Gather))
+	require.True(t, acc.HasPoint("filecount", tags, "count", int64(9)))
+	require.True(t, acc.HasPoint("filecount", tags, "size_bytes", int64(5096)))
+}
+
+func TestTimeoutExceeded(t *testing.T) {
+	fc := getNoFilterFileCount()
+	fc.Timeout = config.Duration(1 * time.Nanosecond)
+
+	acc := testutil.Accumulator{}
+	require.NoError(t, acc.GatherError(fc.Gather))
+	require.Empty(t, acc.GetTelegrafMetrics())
+}
+
+func TestTimeoutDisabled(t *testing.T) {
+	fc := getNoFilterFileCount()
+	fc.Timeout = config.Duration(0)
+
+	tags := map[string]string{"directory": getTestdataDir()}
+	acc := testutil.Accumulator{}
+	require.NoError(t, acc.GatherError(fc.Gather))
+	require.True(t, acc.HasPoint("filecount", tags, "count", int64(9)))
+}
+
 func getNoFilterFileCount() FileCount {
 	return FileCount{
 		Log:         testutil.Logger{},
@@ -188,27 +218,6 @@ func getNoFilterFileCount() FileCount {
 		fileFilters: nil,
 		fs:          getFakeFileSystem(getTestdataDir()),
 	}
-}
-
-func TestTimeout(t *testing.T) {
-	fc := getNoFilterFileCount()
-	fc.Timeout = config.Duration(5 * time.Second)
-
-	tags := map[string]string{"directory": getTestdataDir(), "filecount_status": "ok"}
-	acc := testutil.Accumulator{}
-	require.NoError(t, acc.GatherError(fc.Gather))
-	require.True(t, acc.HasPoint("filecount", tags, "count", int64(9)))
-	require.True(t, acc.HasPoint("filecount", tags, "size_bytes", int64(5096)))
-}
-
-func TestTimeoutDisabled(t *testing.T) {
-	fc := getNoFilterFileCount()
-	fc.Timeout = config.Duration(0)
-
-	tags := map[string]string{"directory": getTestdataDir()}
-	acc := testutil.Accumulator{}
-	require.NoError(t, acc.GatherError(fc.Gather))
-	require.True(t, acc.HasPoint("filecount", tags, "count", int64(9)))
 }
 
 func getTestdataDir() string {

--- a/plugins/inputs/filecount/filecount_test.go
+++ b/plugins/inputs/filecount/filecount_test.go
@@ -35,7 +35,7 @@ func TestNoFiltersOnChildDir(t *testing.T) {
 	matches := []string{"subdir/quux", "subdir/quuz",
 		"subdir/nested2/qux", "subdir/nested2"}
 
-	tags := map[string]string{"directory": getTestdataDir() + "/subdir"}
+	tags := map[string]string{"directory": getTestdataDir() + "/subdir", "filecount_status": "ok"}
 	acc := testutil.Accumulator{}
 	require.NoError(t, acc.GatherError(fc.Gather))
 	require.True(t, acc.HasPoint("filecount", tags, "count", int64(len(matches))))
@@ -50,7 +50,7 @@ func TestNoRecursiveButSuperMeta(t *testing.T) {
 	fc.Directories = []string{getTestdataDir() + "/**"}
 	matches := []string{"subdir/quux", "subdir/quuz", "subdir/nested2"}
 
-	tags := map[string]string{"directory": getTestdataDir() + "/subdir"}
+	tags := map[string]string{"directory": getTestdataDir() + "/subdir", "filecount_status": "ok"}
 	acc := testutil.Accumulator{}
 	require.NoError(t, acc.GatherError(fc.Gather))
 
@@ -80,7 +80,7 @@ func TestDoubleAndSimpleStar(t *testing.T) {
 	fc.Directories = []string{getTestdataDir() + "/**/*"}
 	matches := []string{"qux"}
 
-	tags := map[string]string{"directory": getTestdataDir() + "/subdir/nested2"}
+	tags := map[string]string{"directory": getTestdataDir() + "/subdir/nested2", "filecount_status": "ok"}
 
 	acc := testutil.Accumulator{}
 	require.NoError(t, acc.GatherError(fc.Gather))
@@ -160,7 +160,8 @@ func TestDirectoryWithTrailingSlash(t *testing.T) {
 		metric.New(
 			"filecount",
 			map[string]string{
-				"directory": getTestdataDir(),
+				"directory":        getTestdataDir(),
+				"filecount_status": "ok",
 			},
 			map[string]interface{}{
 				"count":                 9,
@@ -188,6 +189,27 @@ func getNoFilterFileCount() FileCount {
 		fileFilters: nil,
 		fs:          getFakeFileSystem(getTestdataDir()),
 	}
+}
+
+func TestTimeout(t *testing.T) {
+	fc := getNoFilterFileCount()
+	fc.Timeout = config.Duration(5 * time.Second)
+
+	tags := map[string]string{"directory": getTestdataDir(), "filecount_status": "ok"}
+	acc := testutil.Accumulator{}
+	require.NoError(t, acc.GatherError(fc.Gather))
+	require.True(t, acc.HasPoint("filecount", tags, "count", int64(9)))
+	require.True(t, acc.HasPoint("filecount", tags, "size_bytes", int64(5096)))
+}
+
+func TestTimeoutDisabled(t *testing.T) {
+	fc := getNoFilterFileCount()
+	fc.Timeout = config.Duration(0)
+
+	tags := map[string]string{"directory": getTestdataDir(), "filecount_status": "ok"}
+	acc := testutil.Accumulator{}
+	require.NoError(t, acc.GatherError(fc.Gather))
+	require.True(t, acc.HasPoint("filecount", tags, "count", int64(9)))
 }
 
 func getTestdataDir() string {
@@ -242,7 +264,7 @@ func getFakeFileSystem(basePath string) fakeFileSystem {
 }
 
 func fileCountEquals(t *testing.T, fc FileCount, expectedCount, expectedSize int) {
-	tags := map[string]string{"directory": getTestdataDir()}
+	tags := map[string]string{"directory": getTestdataDir(), "filecount_status": "ok"}
 	acc := testutil.Accumulator{}
 	require.NoError(t, acc.GatherError(fc.Gather))
 	require.True(t, acc.HasPoint("filecount", tags, "count", int64(expectedCount)))

--- a/plugins/inputs/filecount/sample.conf
+++ b/plugins/inputs/filecount/sample.conf
@@ -30,3 +30,8 @@
   ## duration. If mtime is negative, only count files that have been
   ## touched in this duration. Defaults to "0s".
   mtime = "0s"
+
+  ## Stop counting after this duration has passed.
+  ## Acceptable units: ns, us (µs), ms, s, m, h.
+  ## Defaults to "0s" (disabled).
+  timeout = "0s"

--- a/plugins/inputs/filecount/sample.conf
+++ b/plugins/inputs/filecount/sample.conf
@@ -31,7 +31,5 @@
   ## touched in this duration. Defaults to "0s".
   mtime = "0s"
 
-  ## Stop counting after this duration has passed.
-  ## Acceptable units: ns, us (µs), ms, s, m, h.
-  ## Defaults to "0s" (disabled).
-  timeout = "0s"
+  ## Stop counting after this duration has passed (disabled by default)
+  # timeout = "0s"


### PR DESCRIPTION
## Summary
Use Case

filecount can very easily over stress a machine resources like CPU.

Expected behavior

It would be great if it will have a timeout mechanism so it wont count files until collection interval is reached.
i imagine it something like this

  [[inputs.filecount]]
    directories = ["D:/AidocData/Temp/IncomingDicoms"]
    name = "*.dcm"
    size = "0B"
    timeout = "10s"
or, another possible solution is setting a maximum of files it can collect and stopping after it (also adding a field that indicates that the maximum is reached)

  [[inputs.filecount]]
    directories = ["D:/Temp/IncomingData"]
    name = "*.txt"
    size = "0B"
    maximum_files = "1000000"
example:

filecount,directory=/var/cache/apt is_maximum_reached=true,count=1000000,size_bytes=7438336i,oldest_file_timestamp=1507152973123456789i,newest_file_timestamp=1507152973123456789i 1530034445000000000

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #16357
related to #19096