### PR TITLE
feat(inputs.webhooks.github): Add run_id field to workflow events 

### DIFF
--- a/plugins/inputs/webhooks/github/README.md
+++ b/plugins/inputs/webhooks/github/README.md
@@ -457,3 +457,4 @@ where the data is sourced from.
 * 'run_time' = `event.workflow_run.completed_at - event.workflow_run.run_started_at`
                 at `event.action = completed in milliseconds` int
 * 'head_branch' = `event.workflow_run.head_branch` string
+* 'run_id' = `event.workflow_run.id` int

--- a/plugins/inputs/webhooks/github/README.md
+++ b/plugins/inputs/webhooks/github/README.md
@@ -437,6 +437,7 @@ where the data is sourced from.
 * 'run_time' = `event.workflow_job.completed_at - event.workflow_job.started_at`
                 at `event.action = completed in milliseconds` int
 * 'head_branch' = `event.workflow_job.head_branch` string
+* 'run_id' = `event.workflow_job.run_id` int
 
 ### [`workflow_run` event](https://docs.github.com/en/webhooks/webhook-events-and-payloads#workflow_run)
 

--- a/plugins/inputs/webhooks/github/github_webhooks_models.go
+++ b/plugins/inputs/webhooks/github/github_webhooks_models.go
@@ -86,7 +86,7 @@ type workflowJob struct {
 }
 
 type workflowRun struct {
-	ID		 int64	   `json:"id"`
+	ID			 int64	   `json:"id"`
 	HeadBranch   string    `json:"head_branch"`
 	CreatedAt    time.Time `json:"created_at"`
 	RunStartedAt time.Time `json:"run_started_at"`

--- a/plugins/inputs/webhooks/github/github_webhooks_models.go
+++ b/plugins/inputs/webhooks/github/github_webhooks_models.go
@@ -86,7 +86,7 @@ type workflowJob struct {
 }
 
 type workflowRun struct {
-	ID			 int64	   `json:"id"`
+	ID           int64     `json:"id"`
 	HeadBranch   string    `json:"head_branch"`
 	CreatedAt    time.Time `json:"created_at"`
 	RunStartedAt time.Time `json:"run_started_at"`
@@ -734,7 +734,7 @@ func (s workflowRunEvent) newMetric() telegraf.Metric {
 		"run_attempt": s.WorkflowRun.RunAttempt,
 		"run_time":    runTimeMs,
 		"head_branch": s.WorkflowRun.HeadBranch,
-		"run_id": 	   s.WorkflowRun.ID,
+		"run_id":      s.WorkflowRun.ID,
 	}
 	m := metric.New(meas, t, f, time.Now())
 	return m

--- a/plugins/inputs/webhooks/github/github_webhooks_models.go
+++ b/plugins/inputs/webhooks/github/github_webhooks_models.go
@@ -86,6 +86,7 @@ type workflowJob struct {
 }
 
 type workflowRun struct {
+	ID		 int64	   `json:"id"`
 	HeadBranch   string    `json:"head_branch"`
 	CreatedAt    time.Time `json:"created_at"`
 	RunStartedAt time.Time `json:"run_started_at"`
@@ -733,6 +734,7 @@ func (s workflowRunEvent) newMetric() telegraf.Metric {
 		"run_attempt": s.WorkflowRun.RunAttempt,
 		"run_time":    runTimeMs,
 		"head_branch": s.WorkflowRun.HeadBranch,
+		"run_id": 	   s.WorkflowRun.ID,
 	}
 	m := metric.New(meas, t, f, time.Now())
 	return m

--- a/plugins/inputs/webhooks/github/github_webhooks_models.go
+++ b/plugins/inputs/webhooks/github/github_webhooks_models.go
@@ -76,6 +76,7 @@ type pullRequestReviewComment struct {
 }
 
 type workflowJob struct {
+	RunID       int64     `json:"run_id"`
 	RunAttempt  int       `json:"run_attempt"`
 	HeadBranch  string    `json:"head_branch"`
 	CreatedAt   time.Time `json:"created_at"`
@@ -701,6 +702,7 @@ func (s workflowJobEvent) newMetric() telegraf.Metric {
 		"queue_time":  queueTimeMs,
 		"run_time":    runTimeMs,
 		"head_branch": s.WorkflowJob.HeadBranch,
+		"run_id":      s.WorkflowJob.RunID,
 	}
 	m := metric.New(meas, t, f, time.Now())
 	return m

--- a/plugins/inputs/webhooks/github/github_webhooks_test.go
+++ b/plugins/inputs/webhooks/github/github_webhooks_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/metric"
 	"github.com/influxdata/telegraf/testutil"
-	
 )
 
 func githubWebhookRequest(t *testing.T, event, jsonString string) *testutil.Accumulator {
@@ -186,7 +185,6 @@ func TestWorkflowRun(t *testing.T) {
 	}
 	testutil.RequireMetricsEqual(t, expected, acc.GetTelegrafMetrics(), testutil.IgnoreTime())
 }
-		
 
 func TestCheckSignatureSuccess(t *testing.T) {
 	if !checkSignature("my_little_secret", []byte("random-signature-body"), "sha1=3dca279e731c97c38e3019a075dee9ebbd0a99f0") {

--- a/plugins/inputs/webhooks/github/github_webhooks_test.go
+++ b/plugins/inputs/webhooks/github/github_webhooks_test.go
@@ -5,13 +5,17 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/metric"
 	"github.com/influxdata/telegraf/testutil"
+	
 )
 
-func githubWebhookRequest(t *testing.T, event, jsonString string) {
+func githubWebhookRequest(t *testing.T, event, jsonString string) *testutil.Accumulator {
 	var acc testutil.Accumulator
 	gh := &Webhook{Path: "/github", acc: &acc, log: testutil.Logger{}}
 	req, err := http.NewRequest("POST", "/github", strings.NewReader(jsonString))
@@ -22,6 +26,7 @@ func githubWebhookRequest(t *testing.T, event, jsonString string) {
 	if w.Code != http.StatusOK {
 		t.Errorf("POST "+event+" returned HTTP status code %v.\nExpected %v", w.Code, http.StatusOK)
 	}
+	return &acc
 }
 
 func githubWebhookRequestWithSignature(t *testing.T, event, jsonString, signature string, expectedStatus int) {
@@ -127,12 +132,61 @@ func TestEventWithSignatureSuccess(t *testing.T) {
 }
 
 func TestWorkflowJob(t *testing.T) {
-	githubWebhookRequest(t, "workflow_job", WorkflowJobJSON())
+	acc := githubWebhookRequest(t, "workflow_job", WorkflowJobJSON())
+
+	expected := []telegraf.Metric{
+		metric.New(
+			"github_webhooks",
+			map[string]string{
+				"event":      "workflow_job",
+				"action":     "completed",
+				"repository": "DeusDeorum1/yhome-controller",
+				"private":    "true",
+				"user":       "DeusDeorum1",
+				"admin":      "false",
+				"name":       "Run build",
+				"conclusion": "success",
+			},
+			map[string]any{
+				"run_attempt": 1,
+				"queue_time":  int64(0),
+				"run_time":    int64(27000),
+				"head_branch": "feature/test",
+				"run_id":      int64(12537003369),
+			},
+			time.Unix(0, 0),
+		),
+	}
+	testutil.RequireMetricsEqual(t, expected, acc.GetTelegrafMetrics(), testutil.IgnoreTime())
 }
 
 func TestWorkflowRun(t *testing.T) {
-	githubWebhookRequest(t, "workflow_run", WorkflowRunJSON())
+	acc := githubWebhookRequest(t, "workflow_run", WorkflowRunJSON())
+	expected := []telegraf.Metric{
+		metric.New(
+			"github_webhooks",
+			map[string]string{
+				"event":      "workflow_run",
+				"action":     "completed",
+				"repository": "DeusDeorum1/yhome-controller",
+				"private":    "true",
+				"user":       "DeusDeorum1",
+				"admin":      "false",
+				"name":       ".NET",
+				"conclusion": "success",
+			},
+			map[string]any{
+				"run_attempt": 1,
+				"run_time":    int64(86000),
+				"head_branch": "feature/test",
+				"run_id":      int64(12537003369),
+			},
+			time.Unix(0, 0),
+		),
+	}
+	testutil.RequireMetricsEqual(t, expected, acc.GetTelegrafMetrics(), testutil.IgnoreTime())
 }
+		
 
 func TestCheckSignatureSuccess(t *testing.T) {
 	if !checkSignature("my_little_secret", []byte("random-signature-body"), "sha1=3dca279e731c97c38e3019a075dee9ebbd0a99f0") {


### PR DESCRIPTION

## Summary
Added run_id field to the Telegraf GitHub webhook plugin's workflow_run event parsing.

Changes:        
  - Added ID int64 to the workflowRun struct to deserialize the id field from the GitHub webhook JSON payload          
  - Added run_id to the InfluxDB fields map in workflowRunEvent.newMetric() so the value is stored in the database     
                                                                                                                       
  Why: The GitHub Actions run ID is the unique identifier used in GitHub Action URLs (/actions/runs/<run_id>). Without 
  storing it, there was no way to build direct links from the Grafana dashboard back to the specific GitHub Actions    
  run. This change enables linking each row in the dashboard to its corresponding GitHub Actions page.

## Checklist

- [x] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #19158
