### PR TITLE
fix(inputs.opcua): Skip client certificate on unsecured None channel

### DIFF
--- a/plugins/common/opcua/client.go
+++ b/plugins/common/opcua/client.go
@@ -278,7 +278,11 @@ func (o *OpcUAClient) SetupOptions() error {
 		}
 	}
 
-	if o.Config.SecurityPolicy != "None" || o.Config.SecurityMode != "None" {
+	// A client certificate is only needed when the channel is actually secured.
+	// Setting either security_policy or security_mode to "None" collapses the
+	// channel to None, so skip certificate creation (which may fail on a
+	// read-only filesystem) unless both request security.
+	if o.Config.SecurityPolicy != "None" && o.Config.SecurityMode != "None" {
 		if err := o.determineOrCreateCertificates(); err != nil {
 			return err
 		}

--- a/plugins/common/opcua/client_test.go
+++ b/plugins/common/opcua/client_test.go
@@ -1,7 +1,9 @@
 package opcua
 
 import (
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/gopcua/opcua/ua"
 	"github.com/stretchr/testify/require"
@@ -278,4 +280,55 @@ func TestGenerateClientOptsExtras(t *testing.T) {
 			require.Len(t, opts, len(baseOpts)+1)
 		})
 	}
+}
+
+func TestGenerateClientOptsNoChannelCertForNoneChannel(t *testing.T) {
+	dir := t.TempDir()
+	certFile := filepath.Join(dir, "cert.pem")
+	keyFile := filepath.Join(dir, "key.pem")
+	_, _, err := generateCert("urn:telegraf:gopcua:client", 2048, certFile, keyFile, time.Hour)
+	require.NoError(t, err)
+
+	endpoints := []*ua.EndpointDescription{
+		{
+			EndpointURL:        "opc.tcp://localhost:4840",
+			SecurityPolicyURI:  ua.SecurityPolicyURINone,
+			SecurityMode:       ua.MessageSecurityModeNone,
+			SecurityLevel:      0,
+			UserIdentityTokens: []*ua.UserTokenPolicy{{TokenType: ua.UserTokenTypeAnonymous}},
+		},
+		{
+			EndpointURL:        "opc.tcp://localhost:4840",
+			SecurityPolicyURI:  ua.SecurityPolicyURIPrefix + "Basic256Sha256",
+			SecurityMode:       ua.MessageSecurityModeSignAndEncrypt,
+			SecurityLevel:      100,
+			UserIdentityTokens: []*ua.UserTokenPolicy{{TokenType: ua.UserTokenTypeAnonymous}},
+		},
+	}
+
+	newClient := func(policy, mode string) *OpcUAClient {
+		return &OpcUAClient{
+			Config: &OpcUAClientConfig{
+				Endpoint:       "opc.tcp://localhost:4840",
+				SecurityPolicy: policy,
+				SecurityMode:   mode,
+				AuthMethod:     "Anonymous",
+				Certificate:    certFile,
+				PrivateKey:     keyFile,
+			},
+			Log: &testutil.Logger{},
+		}
+	}
+
+	// A genuinely secured channel attaches the client certificate and private key.
+	secureOpts, err := newClient("Basic256Sha256", "SignAndEncrypt").generateClientOpts(endpoints)
+	require.NoError(t, err)
+
+	// security_mode "None" collapses the channel to None. The client certificate
+	// must not be attached, otherwise the OpenSecureChannel request carries a
+	// SenderCertificate under security policy None and strict servers reject it.
+	noneOpts, err := newClient("Basic256Sha256", "None").generateClientOpts(endpoints)
+	require.NoError(t, err)
+
+	require.Len(t, noneOpts, len(secureOpts)-2)
 }

--- a/plugins/common/opcua/opcua_util.go
+++ b/plugins/common/opcua/opcua_util.go
@@ -240,7 +240,10 @@ func (o *OpcUAClient) generateClientOpts(endpoints []*ua.EndpointDescription) ([
 	mode := o.Config.SecurityMode
 	var err error
 	if certFile == "" && keyFile == "" {
-		if policy != "None" || mode != "None" {
+		// A certificate is only needed when the channel is actually secured.
+		// Setting either policy or mode to "None" collapses the channel to None
+		// (see below), so generate only when neither is "None".
+		if policy != "None" && mode != "None" {
 			certFile, keyFile, err = generateCert(appuri, 2048, certFile, keyFile, 365*24*time.Hour)
 			if err != nil {
 				return nil, err
@@ -262,7 +265,6 @@ func (o *OpcUAClient) generateClientOpts(endpoints []*ua.EndpointDescription) ([
 			}
 			pk = pkTemp
 			cert = c.Certificate[0]
-			opts = append(opts, opcua.PrivateKey(pk), opcua.Certificate(cert))
 		}
 	}
 
@@ -374,6 +376,15 @@ func (o *OpcUAClient) generateClientOpts(endpoints []*ua.EndpointDescription) ([
 	err = validateEndpointConfig(endpoints, secPolicy, secMode, authMode)
 	if err != nil {
 		return nil, fmt.Errorf("endpoint validation failed: %w", err)
+	}
+
+	// Attach the client certificate to the secure channel only when the
+	// negotiated channel actually uses security. On a None channel the OPN's
+	// SenderCertificate field must be empty; attaching it makes the OPN carry a
+	// certificate under security policy None, which strict servers reject with
+	// an ERRF, closing the connection.
+	if secMode != ua.MessageSecurityModeNone && cert != nil && pk != nil {
+		opts = append(opts, opcua.PrivateKey(pk), opcua.Certificate(cert))
 	}
 
 	opts = append(opts, opcua.SecurityFromEndpoint(serverEndpoint, authMode))


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
When security_policy and security_mode disagree (e.g. Basic256Sha256 with None), the channel collapses to None but a client certificate was still generated and attached, so the OpenSecureChannel request carried a certificate under security policy None. Strict servers reject this with an ERRF, surfacing as a readChunk EOF.

Only generate and attach the client certificate when the negotiated channel actually uses security. This also avoids certificate creation on read-only filesystems when the channel ends up being None.

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #19155
