### PR TITLE
fix(inputs.smartctl): Parse stdout only to avoid corrupting JSON

### DIFF
--- a/plugins/inputs/smartctl/smartctl_device.go
+++ b/plugins/inputs/smartctl/smartctl_device.go
@@ -17,7 +17,7 @@ func (s *Smartctl) scanDevice(acc telegraf.Accumulator, deviceName, deviceType s
 	}
 
 	var device smartctlDeviceJSON
-	out, err := internal.CombinedOutputTimeout(cmd, time.Duration(s.Timeout))
+	out, err := internal.StdOutputTimeout(cmd, time.Duration(s.Timeout))
 	if err != nil {
 		// Error running the command and unable to parse the JSON, then bail
 		if jsonErr := json.Unmarshal(out, &device); jsonErr != nil {

--- a/plugins/inputs/smartctl/smartctl_scan.go
+++ b/plugins/inputs/smartctl/smartctl_scan.go
@@ -21,7 +21,7 @@ func (s *Smartctl) scan() ([]scanDevice, error) {
 	if s.UseSudo {
 		cmd = execCommand("sudo", append([]string{"-n", s.Path}, scanArgs...)...)
 	}
-	out, err := internal.CombinedOutputTimeout(cmd, time.Duration(s.Timeout))
+	out, err := internal.StdOutputTimeout(cmd, time.Duration(s.Timeout))
 	if err != nil {
 		return nil, fmt.Errorf("error running smartctl with %s: %w", scanArgs, err)
 	}

--- a/plugins/inputs/smartctl/smartctl_test.go
+++ b/plugins/inputs/smartctl/smartctl_test.go
@@ -93,6 +93,9 @@ func TestScanHelperProcess(*testing.T) {
 		os.Exit(42)
 	}
 
+	// Emit a warning to stderr to ensure it does not corrupt the JSON parsed
+	// from stdout (see issue #19165)
+	fmt.Fprintln(os.Stderr, "/dev/sda: warning emitted to stderr")
 	fmt.Fprint(os.Stdout, string(scanBytes))
 	//nolint:revive // os.Exit called intentionally
 	os.Exit(0)
@@ -228,6 +231,9 @@ func TestDeviceHelperProcess(t *testing.T) {
 
 	scanBytes, err := os.ReadFile(filename)
 	require.NoError(t, err)
+	// Emit a warning to stderr to ensure it does not corrupt the JSON parsed
+	// from stdout (see issue #19165)
+	fmt.Fprintln(os.Stderr, "/dev/sda: warning emitted to stderr")
 	fmt.Fprint(os.Stdout, string(scanBytes))
 	os.Exit(0) //nolint:revive // os.Exit called intentionally
 }


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
The `smartctl` plugin parsed the **combined stdout and stderr** of the `smartctl` command as JSON. smartctl writes its JSON document, including its own warning and error messages, to stdout, while environmental noise (e.g. `sudo-rs` diagnostics on Ubuntu 26, or per-device open warnings) goes to stderr. Merging the two streams prepended non-JSON lines to the document and broke unmarshalling with:

```
error while scanning system: error unmarshalling smartctl scan output: invalid character '/' looking for beginning of value
```

This reproduced even when `smartctl --json --scan-open` returned valid JSON when run manually, because a terminal renders stdout and stderr together while Telegraf concatenated them into a single buffer fed to the JSON parser. The first stray stderr line (typically beginning with `/dev/...`) corrupts the parse.

The fix switches both the scan and device collection paths from `internal.CombinedOutputTimeout` to `internal.StdOutputTimeout`, so only stdout is parsed and stderr is discarded. No diagnostic information is lost: smartctl's own warning/error detail is already carried inside the JSON `messages` array on stdout, and the existing "non-zero exit but still has parseable JSON" recovery path continues to work since that JSON is on stdout.

A regression guard is added by having the test helper processes emit a `/dev/...` line to stderr before writing the JSON to stdout, turning every existing scan and device test case into a contamination check. Reverting the fix reproduces the exact `invalid character '/'` failure across the suite.


## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #19165
related to #19168