### PR TITLE
docs(inputs.smart): Document sudo-rs incompatibility

### DIFF
--- a/plugins/inputs/smart/README.md
+++ b/plugins/inputs/smart/README.md
@@ -112,6 +112,12 @@ telegraf  ALL=(ALL) NOPASSWD: NVME
 Defaults!NVME !logfile, !syslog, !pam_session
 ```
 
+> [!NOTE]
+> 🪲 If you are using `sudo-rs` instead of GNU `sudo`, the `Defaults!SMARTCTL`
+> and `Defaults!NVME` lines have to be removed as these logging options are not
+> currently supported and will cause errors running sudo until that is resolved.
+> See trifectatechfoundation/sudo-rs#1181.
+
 To run smartctl or nvme with `sudo` wrapper script can be
 created. `path_smartctl` or `path_nvme` in the configuration should be set to
 execute this script.


### PR DESCRIPTION
## Summary

The `smart` plugin's sudoers setup in the README ships the `Defaults!SMARTCTL`
and `Defaults!NVME` lines, which use the `!logfile`, `!syslog`, and
`!pam_session` options. These are not supported by `sudo-rs` (the Rust sudo
replacement that ships by default on Ubuntu 26) and cause an error on every
sudo invocation:

```text
/etc/sudoers.d/telegraf:3:20: unknown setting: 'logfile'
```

This adds the same sudo-rs note already present in the `smartctl` plugin
README, telling sudo-rs users to remove those two `Defaults!` lines.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

related to #19168
