### PR TITLE
docs(processors.converter): Fix unterminated string in timestamp example

### DIFF
--- a/plugins/processors/converter/README.md
+++ b/plugins/processors/converter/README.md
@@ -131,7 +131,7 @@ Set the metric timestamp from a tag:
 [[processors.converter]]
   [processors.converter.tags]
     timestamp = ["time"]
-    timestamp_format = "unix
+    timestamp_format = "unix"
 ```
 
 ```diff


### PR DESCRIPTION
## Summary

The `timestamp_format` example was missing its closing quote, so the TOML
snippet was invalid if copied as-is. Add the quote.

This fix is in a freestanding example block in the README prose, not the
generated `@sample.conf` block (which is separate in this README and
unaffected), so no `sample.conf` change or `make docs` run is needed.

Found while adding code-block linting to the InfluxData docs site, which
generates the published plugin docs from these READMEs.

Verified in Telegraf 1.39.1: before, `line 6: invalid TOML syntax`; after, the
config loads (`Loaded inputs: cpu`).

## Checklist

- [x] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

Related to #19201 (tracking issue for this cleanup; item resolved in this PR)
