### PR TITLE
docs(inputs.opcua_listener): Use TOML comments in group example

### DIFF
--- a/plugins/inputs/opcua_listener/README.md
+++ b/plugins/inputs/opcua_listener/README.md
@@ -580,9 +580,9 @@ This example group configuration shows how to use group settings:
      identifier = "5678"
 
     node_ids = [
-      {identifier="Sensor1"}, // default values will be used for namespace and identifier_type
-      {namespace="2", identifier="TemperatureSensor"}, // default values will be used for identifier_type
-      {namespace="5", identifier_type="i", identifier="2002"} // no default values will be used
+      {identifier="Sensor1"}, # default values will be used for namespace and identifier_type
+      {namespace="2", identifier="TemperatureSensor"}, # default values will be used for identifier_type
+      {namespace="5", identifier_type="i", identifier="2002"} # no default values will be used
     ]
 ```
 


### PR DESCRIPTION
## Summary

The `node_ids` group example used C-style `//` comments, which are invalid in
TOML. Use `#` so the snippet parses if copied as-is.

This fix is in a freestanding example block in the README prose, not the
generated `@sample.conf` block (which is separate in this README and
unaffected), so no `sample.conf` change or `make docs` run is needed.

Found while adding code-block linting to the InfluxData docs site, which
generates the published plugin docs from these READMEs.

Verified in Telegraf 1.39.1: before, `line 4: invalid TOML syntax` on the `//`;
after, the block passes TOML parsing.

Note: the same example also uses an outdated inline-array form for `node_ids`,
tracked separately in #19189 and out of scope here.

## Checklist

- [x] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

Related to #19201 (tracking issue for this cleanup; item resolved in this PR)
