### PR TITLE
docs(outputs.dynatrace): Use TOML comment in api_token example

### DIFF
--- a/plugins/outputs/dynatrace/README.md
+++ b/plugins/outputs/dynatrace/README.md
@@ -91,7 +91,7 @@ The endpoint for the Dynatrace Metrics API v2 is
   url = "https://{your-environment-id}.live.dynatrace.com/api/v2/metrics/ingest"
 
   ## API token is required if a URL is specified and should be restricted to the 'Ingest metrics' scope
-  api_token = "your API token here" // hard-coded for illustration only, should be read from environment
+  api_token = "your API token here" # hard-coded for illustration only, should be read from environment
 ```
 
 You can learn more about how to use the [Dynatrace API][api].


### PR DESCRIPTION
## Summary

The `api_token` example used a C-style `//` comment, which is invalid in TOML.
Use `#` so the snippet parses if copied as-is.

This fix is in a freestanding example block in the README prose, not the
generated `@sample.conf` block (which is separate in this README and
unaffected), so no `sample.conf` change or `make docs` run is needed.

Found while adding code-block linting to the InfluxData docs site, which
generates the published plugin docs from these READMEs.

Verified in Telegraf 1.39.1: before, `line 4: invalid TOML syntax`; after, the
config loads (`Loaded inputs: cpu`).

## Checklist

- [x] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

Related to #19201 (tracking issue for this cleanup; item resolved in this PR)
