### PR TITLE
docs(inputs.postgresql_extensible): Fix invalid line-continued queries

### DIFF
--- a/plugins/inputs/postgresql_extensible/README.md
+++ b/plugins/inputs/postgresql_extensible/README.md
@@ -131,8 +131,9 @@ using the postgresql extensions [pg_stat_statements][pg_stat_statements],
   withdbname=false
   tagvalue="db,username,state"
 [[inputs.postgresql_extensible.query]]
-  sqlquery="select setting as max_connections from pg_settings where \
-  name='max_connections'"
+  sqlquery="""\
+  select setting as max_connections from pg_settings where \
+  name='max_connections'"""
   version=801
   withdbname=false
   tagvalue=""
@@ -142,15 +143,17 @@ using the postgresql extensions [pg_stat_statements][pg_stat_statements],
   withdbname=false
   tagvalue=""
 [[inputs.postgresql_extensible.query]]
-  sqlquery="select setting as shared_buffers from pg_settings where \
-  name='shared_buffers'"
+  sqlquery="""\
+  select setting as shared_buffers from pg_settings where \
+  name='shared_buffers'"""
   version=801
   withdbname=false
   tagvalue=""
 [[inputs.postgresql_extensible.query]]
-  sqlquery="SELECT db, count( distinct blocking_pid ) AS num_blocking_sessions,\
+  sqlquery="""\
+  SELECT db, count( distinct blocking_pid ) AS num_blocking_sessions,\
   count( distinct blocked_pid) AS num_blocked_sessions FROM \
-  public.blocking_procs group by db"
+  public.blocking_procs group by db"""
   version=901
   withdbname=false
   tagvalue="db"


### PR DESCRIPTION
## Summary

Single-line TOML basic strings can't span lines with a trailing backslash, so
three `sqlquery` examples were invalid TOML. Convert them to multi-line basic
strings (`"""`), matching the convention already used by the last query in the
same example.

This fix is in a freestanding example block in the README prose, not the
generated `@sample.conf` block (which is separate in this README and
unaffected), so no `sample.conf` change or `make docs` run is needed.

Found while adding code-block linting to the InfluxData docs site, which
generates the published plugin docs from these READMEs.

Verified in Telegraf 1.39.1: before, `line 5: invalid TOML syntax`; after, the
config loads (`Loaded inputs: postgresql_extensible`).

## Checklist

- [x] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

Related to #19201 (tracking issue for this cleanup; item resolved in this PR)
