### PR TITLE
fix(inputs.jti_openconfig_telemetry): Remove duplicate sensors key

### DIFF
--- a/plugins/inputs/jti_openconfig_telemetry/README.md
+++ b/plugins/inputs/jti_openconfig_telemetry/README.md
@@ -60,12 +60,13 @@ plugin ordering. See [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
   ## We allow specifying sensor group level reporting rate. To do this, specify the
   ## reporting rate in Duration at the beginning of sensor paths / collection
-  ## name. For entries without reporting rate, we use configured sample frequency
-  sensors = [
-   "1000ms customReporting /interfaces /lldp",
-   "2000ms collection /components",
-   "/interfaces",
-  ]
+  ## name. For entries without reporting rate, we use configured sample frequency.
+  ## Use this form INSTEAD of the simple `sensors` list above:
+  # sensors = [
+  #  "1000ms customReporting /interfaces /lldp",
+  #  "2000ms collection /components",
+  #  "/interfaces",
+  # ]
 
   ## Timestamp Source
   ## Set to 'collection' for time of collection, and 'data' for using the time

--- a/plugins/inputs/jti_openconfig_telemetry/README.md
+++ b/plugins/inputs/jti_openconfig_telemetry/README.md
@@ -53,20 +53,14 @@ plugin ordering. See [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## When identifier is used, we can provide a list of space separated sensors.
   ## A single subscription will be created with all these sensors and data will
   ## be saved to measurement with this identifier name
-  sensors = [
-   "/interfaces/",
-   "collection /components/ /lldp",
-  ]
-
   ## We allow specifying sensor group level reporting rate. To do this, specify the
   ## reporting rate in Duration at the beginning of sensor paths / collection
   ## name. For entries without reporting rate, we use configured sample frequency.
-  ## Use this form INSTEAD of the simple `sensors` list above:
-  # sensors = [
-  #  "1000ms customReporting /interfaces /lldp",
-  #  "2000ms collection /components",
-  #  "/interfaces",
-  # ]
+  sensors = [
+   "/interfaces/",
+   "collection /components/ /lldp",
+   "1000ms customReporting /interfaces /lldp",
+  ]
 
   ## Timestamp Source
   ## Set to 'collection' for time of collection, and 'data' for using the time

--- a/plugins/inputs/jti_openconfig_telemetry/sample.conf
+++ b/plugins/inputs/jti_openconfig_telemetry/sample.conf
@@ -26,12 +26,13 @@
 
   ## We allow specifying sensor group level reporting rate. To do this, specify the
   ## reporting rate in Duration at the beginning of sensor paths / collection
-  ## name. For entries without reporting rate, we use configured sample frequency
-  sensors = [
-   "1000ms customReporting /interfaces /lldp",
-   "2000ms collection /components",
-   "/interfaces",
-  ]
+  ## name. For entries without reporting rate, we use configured sample frequency.
+  ## Use this form INSTEAD of the simple `sensors` list above:
+  # sensors = [
+  #  "1000ms customReporting /interfaces /lldp",
+  #  "2000ms collection /components",
+  #  "/interfaces",
+  # ]
 
   ## Timestamp Source
   ## Set to 'collection' for time of collection, and 'data' for using the time

--- a/plugins/inputs/jti_openconfig_telemetry/sample.conf
+++ b/plugins/inputs/jti_openconfig_telemetry/sample.conf
@@ -19,20 +19,14 @@
   ## When identifier is used, we can provide a list of space separated sensors.
   ## A single subscription will be created with all these sensors and data will
   ## be saved to measurement with this identifier name
-  sensors = [
-   "/interfaces/",
-   "collection /components/ /lldp",
-  ]
-
   ## We allow specifying sensor group level reporting rate. To do this, specify the
   ## reporting rate in Duration at the beginning of sensor paths / collection
   ## name. For entries without reporting rate, we use configured sample frequency.
-  ## Use this form INSTEAD of the simple `sensors` list above:
-  # sensors = [
-  #  "1000ms customReporting /interfaces /lldp",
-  #  "2000ms collection /components",
-  #  "/interfaces",
-  # ]
+  sensors = [
+   "/interfaces/",
+   "collection /components/ /lldp",
+   "1000ms customReporting /interfaces /lldp",
+  ]
 
   ## Timestamp Source
   ## Set to 'collection' for time of collection, and 'data' for using the time


### PR DESCRIPTION
## Summary

The sample config defined `sensors` twice, which is invalid TOML (duplicate key)
and fails to load. Comment out the alternative group-reporting-rate form so only
one `sensors` key is active.

The change is made in `sample.conf` and the README is regenerated, per the
guidance on #18830.

Found while adding code-block linting to the InfluxData docs site, which
generates the published plugin docs from these READMEs.

Verified in Telegraf 1.39.1: before, `line 34: key 'sensors' is in conflict with
line 25`; after, the config loads (`Loaded inputs: jti_openconfig_telemetry`).

## Checklist

- [x] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

Related to #19201 (tracking issue for this cleanup; item resolved in this PR)
