### PR TITLE
test(inputs.ping): Cover Windows source-interface argument

### DIFF
--- a/plugins/inputs/ping/ping_windows_test.go
+++ b/plugins/inputs/ping/ping_windows_test.go
@@ -145,6 +145,25 @@ func TestArguments(t *testing.T) {
 	require.Equal(t, actual, arguments)
 }
 
+func TestArgumentsInterface(t *testing.T) {
+	p := Ping{
+		Log:       testutil.Logger{},
+		Count:     2,
+		Interface: "192.168.1.1",
+	}
+
+	require.Equal(t, []string{"-n", "2", "-S", "192.168.1.1", "www.google.com"}, p.args("www.google.com"))
+}
+
+func TestArgumentsNoInterface(t *testing.T) {
+	p := Ping{
+		Log:   testutil.Logger{},
+		Count: 2,
+	}
+
+	require.NotContains(t, p.args("www.google.com"), "-S")
+}
+
 var lossyPingOutput = `
 Badanie thecodinglove.com [66.6.44.4] z 9800 bajtami danych:
 Upłynął limit czasu żądania.


### PR DESCRIPTION


## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
The Windows `args()` builder appends `-S <interface>` when the `interface` option is set, but no test exercised that branch. The non-Windows side already covers the equivalent per-system source flag in `ping_notwindows_test.go`.

This adds two focused cases to `ping_windows_test.go`:

- `TestArgumentsInterface`: with `interface` set, the built args contain `-S <interface>`.
- `TestArgumentsNoInterface`: with `interface` unset, `-S` is omitted.

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

related to #17071
