### PR TITLE
chore(inputs.directory_monitor): Simplify output file close and timestamp restore

### DIFF
--- a/plugins/inputs/directory_monitor/directory_monitor.go
+++ b/plugins/inputs/directory_monitor/directory_monitor.go
@@ -423,7 +423,6 @@ func (monitor *DirectoryMonitor) moveFile(srcPath, dstBaseDir string) {
 	if err != nil {
 		monitor.Log.Errorf("Could not open output file: %s", err)
 	}
-	defer outputFile.Close()
 
 	_, err = io.Copy(outputFile, inputFile)
 	if err != nil {
@@ -447,12 +446,8 @@ func (monitor *DirectoryMonitor) moveFile(srcPath, dstBaseDir string) {
 		srcTimes, err := times.Stat(srcPath)
 		if err != nil {
 			monitor.Log.Errorf("Could not read timestamps of %q: %v", srcPath, err)
-		}
-
-		if srcTimes != nil {
-			if err := os.Chtimes(dstPath, srcTimes.AccessTime(), srcTimes.ModTime()); err != nil {
-				monitor.Log.Errorf("Could not preserve timestamps on %q: %v", dstPath, err)
-			}
+		} else if err := os.Chtimes(dstPath, srcTimes.AccessTime(), srcTimes.ModTime()); err != nil {
+			monitor.Log.Errorf("Could not preserve timestamps on %q: %v", dstPath, err)
 		}
 	}
 


### PR DESCRIPTION


## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Two small cleanups in `moveFile`:

1. Drop the deferred `outputFile.Close()`. The file is already closed explicitly before the timestamp restore (the explicit close is required so the data is flushed before `os.Chtimes`), so the deferred call closed it a second time. `moveFile` has no early returns, so the explicit close is always reached.
2. Collapse the timestamp-restore error handling into a single `else if` chain, so `os.Chtimes` runs directly on the success path instead of a separate `if srcTimes != nil` guard.

No behavior change: on a `times.Stat` error the source times are unavailable, so the restore is skipped exactly as before.

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

related to #16885
