### PR TITLE
docs(agent): Clarify order of metric filtering operations

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -762,6 +762,37 @@ The inverse of `taginclude`. Tags with a tag key matching one of the patterns
 will be discarded from the metric.  Any tag can be filtered including global
 tags and the agent `host` tag.
 
+### Order of Operations
+
+The time at which filters are applied depends on the plugin type. Understanding
+this ordering is important because it determines whether the filter acts on the
+metrics entering the plugin or on the metrics it produces.
+
+- **Input plugins** apply both selectors and modifiers *after* the plugin has
+  gathered its metrics. Only metrics that pass the selectors, with their tags
+  and fields adjusted by any modifiers, are emitted downstream.
+
+- **Processor plugins** apply filters *before* processing. Metrics matching the
+  selectors are handed to the processor (with modifiers already applied), while
+  metrics that do not match bypass the processor and are passed on unchanged.
+
+- **Aggregator plugins** apply filters *before* the metric is passed to `Add`.
+  Selected metrics (with modifiers applied) are fed into the aggregation, while
+  metrics that do not match are passed downstream. Whether the original,
+  matching metrics are also forwarded to subsequent output plugins is controlled
+  by the aggregator's `drop_original` setting.
+
+- **Output plugins** apply filters *before* writing. Only metrics that pass the
+  selectors, with their tags and fields adjusted by any modifiers, are sent to
+  the remote destination.
+
+In all cases, selectors ([`namepass`/`namedrop`](#selectors),
+[`tagpass`/`tagdrop`](#selectors), [`fieldpass`/`fielddrop`](#selectors), and
+[`metricpass`](#selectors)) decide *whether* a metric is handled by the plugin,
+while modifiers ([`fieldinclude`/`fieldexclude`](#modifiers) and
+[`taginclude`/`tagexclude`](#modifiers)) decide *which tags and fields* remain
+on the metrics that are handled.
+
 ### Filtering Examples
 
 #### Using tagpass and tagdrop

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -776,7 +776,7 @@ metrics entering the plugin or on the metrics it produces.
   selectors are handed to the processor (with modifiers already applied), while
   metrics that do not match bypass the processor and are passed on unchanged.
 
-- **Aggregator plugins** apply filters *before* the metric is passed to `Add`.
+- **Aggregator plugins** apply filters *before* aggregation.
   Selected metrics (with modifiers applied) are fed into the aggregation, while
   metrics that do not match are passed downstream. Whether the original,
   matching metrics are also forwarded to subsequent output plugins is controlled
@@ -786,12 +786,9 @@ metrics entering the plugin or on the metrics it produces.
   selectors, with their tags and fields adjusted by any modifiers, are sent to
   the remote destination.
 
-In all cases, selectors ([`namepass`/`namedrop`](#selectors),
-[`tagpass`/`tagdrop`](#selectors), [`fieldpass`/`fielddrop`](#selectors), and
-[`metricpass`](#selectors)) decide *whether* a metric is handled by the plugin,
-while modifiers ([`fieldinclude`/`fieldexclude`](#modifiers) and
-[`taginclude`/`tagexclude`](#modifiers)) decide *which tags and fields* remain
-on the metrics that are handled.
+In all cases, [selectors](#selectors) determine *whether* a metric is handled
+by the plugin, while [modifiers](#modifiers)) determine *which tags and fields*
+remain on the metrics passed to the plugin.
 
 ### Filtering Examples
 


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [ ] No AI generated code was used in this PR
- [x] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #19209
