### PR TITLE
feat(config): Add default stdout output plugin

### DIFF
--- a/cmd/telegraf/printer.go
+++ b/cmd/telegraf/printer.go
@@ -24,7 +24,7 @@ var (
 	inputDefaults = []string{"cpu", "mem", "swap", "system", "kernel", "processes", "disk", "diskio"}
 
 	// Default output plugins
-	outputDefaults = make([]string, 0)
+	outputDefaults = []string{"file"}
 )
 
 var header = `# Telegraf Configuration

--- a/cmd/telegraf/telegraf_config_test.go
+++ b/cmd/telegraf/telegraf_config_test.go
@@ -13,7 +13,7 @@ func TestPrintSampleConfigDefaultOutputIsFile(t *testing.T) {
 	var buf bytes.Buffer
 	printSampleConfig(&buf, Filters{})
 
-	output := buf.string()
+	output := buf.String()
 	require.Contains(t, output, "[[outputs.file]]")
 	require.Contains(t, output, `files = ["stdout"]`)
 }

--- a/cmd/telegraf/telegraf_config_test.go
+++ b/cmd/telegraf/telegraf_config_test.go
@@ -15,7 +15,7 @@ func TestPrintSampleConfigDefaultOutputIsFile(t *testing.T) {
 
 	output := buf.String()
 	require.Contains(t, output, "\n[[outputs.file]]")
-	require.Contains(t, output, "\n files = [\"stdout\"]")
+	require.Contains(t, output, "\n  files = [\"stdout\"]")
 }
 
 func TestLoadConfigurationTestModeSkipsDiskOutputBuffer(t *testing.T) {

--- a/cmd/telegraf/telegraf_config_test.go
+++ b/cmd/telegraf/telegraf_config_test.go
@@ -1,12 +1,22 @@
 package main
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/influxdata/telegraf/internal"
 )
+
+func TestPrintSampleConfigDefaultOutputIsFile(t *Testing.T) {
+	var buf bytes.Buffer
+	printSampleConfig(&buf, Filters{})
+
+	output := bug.string()
+	require.Contains(t, output, "[[outputs.file]]")
+	require.Contains(t, output, `files = ["stdout"]`)
+}
 
 func TestLoadConfigurationTestModeSkipsDiskOutputBuffer(t *testing.T) {
 	savedVersion := internal.Version

--- a/cmd/telegraf/telegraf_config_test.go
+++ b/cmd/telegraf/telegraf_config_test.go
@@ -9,11 +9,11 @@ import (
 	"github.com/influxdata/telegraf/internal"
 )
 
-func TestPrintSampleConfigDefaultOutputIsFile(t *Testing.T) {
+func TestPrintSampleConfigDefaultOutputIsFile(t *testing.T) {
 	var buf bytes.Buffer
 	printSampleConfig(&buf, Filters{})
 
-	output := bug.string()
+	output := buf.string()
 	require.Contains(t, output, "[[outputs.file]]")
 	require.Contains(t, output, `files = ["stdout"]`)
 }

--- a/cmd/telegraf/telegraf_config_test.go
+++ b/cmd/telegraf/telegraf_config_test.go
@@ -14,8 +14,8 @@ func TestPrintSampleConfigDefaultOutputIsFile(t *testing.T) {
 	printSampleConfig(&buf, Filters{})
 
 	output := buf.String()
-	require.Contains(t, output, "[[outputs.file]]")
-	require.Contains(t, output, `files = ["stdout"]`)
+	require.Contains(t, output, "\n[[outputs.file]]")
+	require.Contains(t, output, "\n files = [\"stdout\"]")
 }
 
 func TestLoadConfigurationTestModeSkipsDiskOutputBuffer(t *testing.T) {

--- a/plugins/outputs/file/README.md
+++ b/plugins/outputs/file/README.md
@@ -23,7 +23,8 @@ plugin ordering. See [CONFIGURATION.md][CONFIGURATION.md] for more details.
 # Send telegraf metrics to file(s)
 [[outputs.file]]
   ## Files to write to, "stdout" is a specially handled file.
-  files = ["stdout", "/tmp/metrics.out"]
+  # files = ["stdout", "/tmp/metrics.out"]
+  files = ["stdout"]
 
   ## Use batch serialization format instead of line based delimiting.  The
   ## batch format allows for the production of non line based output formats and

--- a/plugins/outputs/file/README.md
+++ b/plugins/outputs/file/README.md
@@ -23,7 +23,7 @@ plugin ordering. See [CONFIGURATION.md][CONFIGURATION.md] for more details.
 # Send telegraf metrics to file(s)
 [[outputs.file]]
   ## Files to write to, "stdout" is a specially handled file.
-  # files = ["stdout", "/tmp/metrics.out"]
+  ## ex: files = ["stdout", "/tmp/metrics.out"]
   files = ["stdout"]
 
   ## Use batch serialization format instead of line based delimiting.  The

--- a/plugins/outputs/file/sample.conf
+++ b/plugins/outputs/file/sample.conf
@@ -1,7 +1,7 @@
 # Send telegraf metrics to file(s)
 [[outputs.file]]
   ## Files to write to, "stdout" is a specially handled file.
-  # files = ["stdout", "/tmp/metrics.out"]
+  ## ex: files = ["stdout", "/tmp/metrics.out"]
   files = ["stdout"]
 
   ## Use batch serialization format instead of line based delimiting.  The

--- a/plugins/outputs/file/sample.conf
+++ b/plugins/outputs/file/sample.conf
@@ -1,7 +1,8 @@
 # Send telegraf metrics to file(s)
 [[outputs.file]]
   ## Files to write to, "stdout" is a specially handled file.
-  files = ["stdout", "/tmp/metrics.out"]
+  # files = ["stdout", "/tmp/metrics.out"]
+  files = ["stdout"]
 
   ## Use batch serialization format instead of line based delimiting.  The
   ## batch format allows for the production of non line based output formats and


### PR DESCRIPTION
## Summary
Addresses open issue: https://github.com/influxdata/telegraf/issues/16718

Modern applications use an approach called zero configuration, in which the default configuration file is 100% valid.

Today, telegraf takes a more classical approach, requiring the user to customize configuration. Otherwise the application crashes. That's an awful out of the box experience.

Instead of bombing out with generic parse error messages on the stock configuration file, telegraf should automatically set outputs.file to ["stdout"].

By the way, the default configuration file has many gaps in terms of failing to mention the default configuration, for about half of the assorted fields. Many of the fields fail to nest comments, further complicating the default behavior.

The documentation occasionally hints at a need to customize outputs, but that's still a far cry from zeroconf.

Expected behavior

Output to stdout by default, so that the telegraf config default configuration file finally becomes 100% valid.

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #16718
