### PR TITLE
fix(parsers.json_v2): Reset sub-path results for each object config

### DIFF
--- a/plugins/parsers/json_v2/parser.go
+++ b/plugins/parsers/json_v2/parser.go
@@ -534,6 +534,10 @@ func (p *Parser) processObjects(input []byte, objects []Object, timestamp time.T
 	for _, c := range objects {
 		p.objectConfig = c
 
+		// The path results of a previous object are relative to that object's
+		// JSON and must not be matched against this one.
+		p.subPathResults = nil
+
 		if c.Path == "" {
 			return nil, errors.New("the GJSON path is required")
 		}

--- a/plugins/parsers/json_v2/testdata/object_fields_with_same_path/expected.out
+++ b/plugins/parsers/json_v2/testdata/object_fields_with_same_path/expected.out
@@ -1,0 +1,2 @@
+energy production=100
+energy consumption=200

--- a/plugins/parsers/json_v2/testdata/object_fields_with_same_path/input.json
+++ b/plugins/parsers/json_v2/testdata/object_fields_with_same_path/input.json
@@ -1,0 +1,12 @@
+{
+    "production": {
+        "eim": {
+            "wattHoursLifetime": 100
+        }
+    },
+    "consumption": {
+        "eim": {
+            "wattHoursLifetime": 200
+        }
+    }
+}

--- a/plugins/parsers/json_v2/testdata/object_fields_with_same_path/telegraf.conf
+++ b/plugins/parsers/json_v2/testdata/object_fields_with_same_path/telegraf.conf
@@ -1,0 +1,19 @@
+# Example taken from: https://github.com/influxdata/telegraf/issues/16361
+
+[[inputs.file]]
+    files = ["./testdata/object_fields_with_same_path/input.json"]
+    data_format = "json_v2"
+    [[inputs.file.json_v2]]
+        measurement_name = "energy"
+        [[inputs.file.json_v2.object]]
+            path = "production.eim"
+            disable_prepend_keys = true
+            [[inputs.file.json_v2.object.field]]
+                path = "wattHoursLifetime"
+                rename = "production"
+        [[inputs.file.json_v2.object]]
+            path = "consumption.eim"
+            disable_prepend_keys = true
+            [[inputs.file.json_v2.object.field]]
+                path = "wattHoursLifetime"
+                rename = "consumption"


### PR DESCRIPTION

## Summary
`processObjects` appended object config's field/tag path results to the shared `subPathResults` slice without clearing it between objects. The recorded indexes are byte offsets within each object's own scoped JSON, when two objects had structurally similar sub-documents, a field in a later object matched an earlier object's entry and took its rename and type. With two objects each selecting a field at the same relative path, both fields were emitted under the first object's rename.

this resets `subPathResults` at the start of each object iteration so path results are only matched within the object they belong to.

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [ ] No AI generated code was used in this PR
- [x] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
resolves #16361
