### PR TITLE
fix(inputs.chrony): Apply read timeout so lost responses do not block collection

### DIFF
--- a/plugins/inputs/chrony/chrony.go
+++ b/plugins/inputs/chrony/chrony.go
@@ -145,8 +145,9 @@ func (c *Chrony) Start(_ telegraf.Accumulator) error {
 	}
 	c.Log.Debugf("Connected to %q...", c.Server)
 
-	// Initialize the client
-	c.client = &fbchrony.Client{Connection: c.conn}
+	// Initialize the client, bounding each request by the configured timeout so
+	// a lost response cannot block collection indefinitely (see issue #16495).
+	c.client = &fbchrony.Client{Connection: &deadlineConn{Conn: c.conn, timeout: time.Duration(c.Timeout)}}
 
 	return nil
 }
@@ -534,6 +535,24 @@ func (c *Chrony) gatherSourceStats(acc telegraf.Accumulator) error {
 		acc.AddFields("chrony_sourcestats", fields, tags)
 	}
 	return nil
+}
+
+// deadlineConn applies a read deadline before each read so a query to chronyd
+// cannot block forever if the response is lost, e.g. during a network
+// interruption to a remote server. Without it the plugin waits for the reply
+// indefinitely and never collects again until restarted (see issue #16495).
+type deadlineConn struct {
+	net.Conn
+	timeout time.Duration
+}
+
+func (c *deadlineConn) Read(b []byte) (int, error) {
+	if c.timeout > 0 {
+		if err := c.SetReadDeadline(time.Now().Add(c.timeout)); err != nil {
+			return 0, err
+		}
+	}
+	return c.Conn.Read(b)
 }
 
 func init() {

--- a/plugins/inputs/chrony/chrony_test.go
+++ b/plugins/inputs/chrony/chrony_test.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"net"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -17,6 +18,7 @@ import (
 	"github.com/testcontainers/testcontainers-go/wait"
 
 	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/metric"
 	"github.com/influxdata/telegraf/testutil"
 )
@@ -153,6 +155,59 @@ func TestGatherTracking(t *testing.T) {
 
 	actual := acc.GetTelegrafMetrics()
 	testutil.RequireMetricsEqual(t, expected, actual, options...)
+}
+
+func TestGatherTimeoutRecovers(t *testing.T) {
+	// Setup a mock server that stops replying to simulate a lost response,
+	// e.g. a network interruption to a remote chronyd (issue #16495).
+	server := Server{
+		TrackingInfo: &fbchrony.Tracking{
+			RefID:      0xA29FC87B,
+			IPAddr:     net.ParseIP("192.168.1.22"),
+			Stratum:    3,
+			LeapStatus: 0,
+			RefTime:    time.Now(),
+		},
+	}
+	addr, err := server.Listen(t)
+	require.NoError(t, err)
+	defer server.Shutdown()
+	server.silent.Store(true)
+
+	// Setup the plugin with a short timeout so the test does not wait long
+	plugin := &Chrony{
+		Server:  "udp://" + addr,
+		Timeout: config.Duration(100 * time.Millisecond),
+		Metrics: []string{"tracking"},
+		Log:     testutil.Logger{},
+	}
+	require.NoError(t, plugin.Init())
+
+	var acc testutil.Accumulator
+	require.NoError(t, plugin.Start(&acc))
+	defer plugin.Stop()
+
+	// The gather must return within the timeout instead of blocking forever
+	// waiting for a reply that never arrives.
+	gatherErr := make(chan error, 1)
+	go func() {
+		gatherErr <- plugin.Gather(&acc)
+	}()
+	select {
+	case err := <-gatherErr:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		require.FailNow(t, "gather blocked instead of timing out")
+	}
+	require.ErrorContains(t, acc.FirstError(), "querying tracking data failed")
+	require.Empty(t, acc.GetTelegrafMetrics())
+
+	// Once the server replies again, collection must recover on the next gather
+	server.silent.Store(false)
+	var accRecovered testutil.Accumulator
+	require.NoError(t, plugin.Gather(&accRecovered))
+	require.NoError(t, accRecovered.FirstError())
+	require.NotEmpty(t, accRecovered.GetTelegrafMetrics())
 }
 
 func TestGatherServerStats(t *testing.T) {
@@ -727,7 +782,8 @@ type Server struct {
 	ServerStatInfo interface{}
 	SourcesInfo    []source
 
-	conn net.PacketConn
+	conn   net.PacketConn
+	silent atomic.Bool
 }
 
 func (s *Server) Shutdown() {
@@ -757,6 +813,10 @@ func (s *Server) serve(t *testing.T) {
 		n, addr, err := s.conn.ReadFrom(buf)
 		if err != nil {
 			return
+		}
+		// Simulate a lost response by draining the request without replying.
+		if s.silent.Load() {
+			continue
 		}
 		t.Logf("mock server: received %d bytes from %q\n", n, addr.String())
 


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
The chrony plugin's `timeout` option was only applied when dialing the server, not to the request/response reads. For UDP that dial timeout is effectively a no-op, so when a response was lost (for example a network interruption to a remote chronyd) the underlying read blocked indefinitely. Because Gather holds the client lock for the whole cycle and the agent runs one gather at a time, every subsequent collection was skipped and the plugin never recovered until Telegraf was restarted. The same blocked read also stalled shutdown until systemd sent SIGKILL.

This wraps the connection so a read deadline derived from `timeout` is set before each read. A lost response now fails the current gather within the timeout and collection resumes on the next interval. A `timeout` of 0 keeps the previous unbounded behavior.

**Known limitation**
Over UDP a delayed (not lost) response can arrive after the deadline, stay queued, and be read by the next gather. The upstream fbchrony client does not match reply sequence numbers to requests, so a late reply can be decoded as the answer to the following request, yielding stale data for one cycle. This is inherent to the UDP transport and still strictly better than blocking collection forever until restart. Hardening it further (draining on timeout or rejecting
mismatched sequences) is left for a follow-up.


## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #16495
