### PR TITLE
docs(inputs.kafka_consumer): Fix sarama package reference

### DIFF
--- a/plugins/inputs/kafka_consumer/README.md
+++ b/plugins/inputs/kafka_consumer/README.md
@@ -79,7 +79,7 @@ to use them.
   ## from 1.0.0 separated by dot. This setting enables the use of new
   ## Kafka features and APIs. Must be 0.10.2.0(used as default) or greater.
   ## Please, check the list of supported versions at
-  ## https://pkg.go.dev/github.com/Shopify/sarama#SupportedVersions
+  ## https://pkg.go.dev/github.com/IBM/sarama#SupportedVersions
   ##   ex: kafka_version = "2.6.0"
   ##   ex: kafka_version = "0.10.2.0"
   # kafka_version = "0.10.2.0"

--- a/plugins/inputs/kafka_consumer/sample.conf
+++ b/plugins/inputs/kafka_consumer/sample.conf
@@ -8,7 +8,7 @@
   ## from 1.0.0 separated by dot. This setting enables the use of new
   ## Kafka features and APIs. Must be 0.10.2.0(used as default) or greater.
   ## Please, check the list of supported versions at
-  ## https://pkg.go.dev/github.com/Shopify/sarama#SupportedVersions
+  ## https://pkg.go.dev/github.com/IBM/sarama#SupportedVersions
   ##   ex: kafka_version = "2.6.0"
   ##   ex: kafka_version = "0.10.2.0"
   # kafka_version = "0.10.2.0"


### PR DESCRIPTION
## Summary
The `kafka_version` setting links to `pkg.go.dev/github.com/Shopify/sarama`, which is the archived. Telegraf's own `go.mod` already depends on `github.com/IBM/sarama` (current maintainer). The link now points to the correct package.

## Checklist

- [X] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
N/A