### PR TITLE
feat(common.socket): suppport for stream wrapper over udp

### DIFF
--- a/plugins/common/socket/conn.go
+++ b/plugins/common/socket/conn.go
@@ -1,0 +1,167 @@
+package socket
+
+import (
+	"bytes"
+	"net"
+	"os"
+	"sync"
+	"time"
+)
+
+var maxPayload = maxPacketSize - 64 // some overhead for headers
+
+var _ net.Conn = (*conn)(nil)
+
+// conn is a byte stream over the packets exchanged with a single
+// remote peer on a listener's net.PacketConn. Received packet payloads
+// are concatenated into a buffer, and writes are sent as one or more packets to the peer.
+type conn struct {
+	pc    net.PacketConn        // shared with the listener; not closed by conn
+	raddr net.Addr              // peer address: the packet source and write destination
+	ln    *PacketStreamListener // used to deregister on Close
+
+	mu   sync.Mutex
+	buf  bytes.Buffer
+	rerr error // returned by Read once buf drains (e.g. after the socket fails)
+
+	data      chan struct{} // buffered(1); pinged when new bytes are buffered
+	done      chan struct{} // closed by Close to broadcast shutdown to all waiters
+	closeOnce sync.Once
+
+	readDeadline  pipeDeadline
+	writeDeadline pipeDeadline
+}
+
+func newConn(ln *PacketStreamListener, raddr net.Addr) *conn {
+	return &conn{
+		pc:            ln.pc,
+		raddr:         raddr,
+		ln:            ln,
+		data:          make(chan struct{}, 1),
+		done:          make(chan struct{}),
+		readDeadline:  makePipeDeadline(),
+		writeDeadline: makePipeDeadline(),
+	}
+}
+
+// deliver appends one received packet's payload to the stream buffer.
+func (c *conn) deliver(payload []byte) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.rerr != nil || isClosedChan(c.done) {
+		return
+	}
+	c.buf.Write(payload)
+	c.signal()
+}
+
+// fail records a terminal read error (e.g. the socket closing) and wakes any
+// blocked reader
+func (c *conn) fail(err error) {
+	c.mu.Lock()
+	if c.rerr == nil {
+		c.rerr = err
+	}
+	c.mu.Unlock()
+	c.signal()
+}
+
+// signal performs a non-blocking wake of a reader parked on c.data.
+func (c *conn) signal() {
+	select {
+	case c.data <- struct{}{}:
+	default:
+	}
+}
+
+// Read implements the net.Conn interface, reading from the stream buffer.
+func (c *conn) Read(b []byte) (int, error) {
+	for {
+		c.mu.Lock()
+		if c.buf.Len() > 0 {
+			n, _ := c.buf.Read(b)
+			c.mu.Unlock()
+			return n, nil
+		}
+		rerr := c.rerr
+		c.mu.Unlock()
+
+		if rerr != nil {
+			return 0, rerr
+		}
+		if isClosedChan(c.done) {
+			return 0, net.ErrClosed
+		}
+		if isClosedChan(c.readDeadline.wait()) {
+			return 0, os.ErrDeadlineExceeded
+		}
+
+		select {
+		case <-c.data:
+			// New bytes may be buffered; loop to re-check under the lock.
+		case <-c.done:
+			return 0, net.ErrClosed
+		case <-c.readDeadline.wait():
+			return 0, os.ErrDeadlineExceeded
+		}
+	}
+}
+
+// Write implements the net.Conn interface, sending the given bytes as one or more packets to the peer.
+func (c *conn) Write(b []byte) (int, error) {
+	if len(b) == 0 {
+		return 0, nil
+	}
+
+	total := 0
+	for len(b) > 0 {
+		if isClosedChan(c.done) {
+			return total, net.ErrClosed
+		}
+		if isClosedChan(c.writeDeadline.wait()) {
+			return total, os.ErrDeadlineExceeded
+		}
+
+		n := min(len(b), maxPayload)
+		if _, err := c.pc.WriteTo(b[:n], c.raddr); err != nil {
+			return total, err
+		}
+		total += n
+		b = b[n:]
+	}
+	return total, nil
+}
+
+// Close implements the net.Conn interface, closing the stream and removing it from the listener.
+func (c *conn) Close() error {
+	c.closeOnce.Do(func() {
+		// close all the pending readers and writers
+		close(c.done)
+		// deregister from the listener so a later packet from the same peer starts a fresh stream
+		c.ln.remove(c)
+	})
+	return nil
+}
+
+func (c *conn) LocalAddr() net.Addr  { return c.pc.LocalAddr() }
+func (c *conn) RemoteAddr() net.Addr { return c.raddr }
+
+func (c *conn) SetDeadline(t time.Time) error {
+	err := c.SetReadDeadline(t)
+	if err != nil {
+		return err
+	}
+	err = c.SetWriteDeadline(t)
+	return err
+}
+
+func (c *conn) SetReadDeadline(t time.Time) error {
+	c.readDeadline.set(t)
+	c.signal() // wake a parked reader so it re-evaluates the deadline
+	return nil
+}
+
+func (c *conn) SetWriteDeadline(t time.Time) error {
+	c.writeDeadline.set(t)
+	return nil
+}

--- a/plugins/common/socket/listener.go
+++ b/plugins/common/socket/listener.go
@@ -1,0 +1,112 @@
+package socket
+
+import (
+	"net"
+	"sync"
+)
+
+// amount of pending streams to accept before dropping packets from new peers
+const acceptBacklog = 16
+
+const maxPacketSize = 65536 // maximum UDP packet size, including headers
+
+var _ net.Listener = (*PacketStreamListener)(nil)
+
+type PacketStreamListener struct {
+	pc net.PacketConn
+
+	mu       sync.Mutex
+	conns    map[string]*conn
+	acceptCh chan *conn
+	closed   chan struct{}
+	once     sync.Once
+}
+
+// Listen builds a packet connection via newPacketConn and wraps it in a
+// stream net.Listener. Each remote address is treated as a separate stream.
+func Listen(newPacketConn func() (net.PacketConn, error)) (*PacketStreamListener, error) {
+	pc, err := newPacketConn()
+	if err != nil {
+		return nil, err
+	}
+	ln := &PacketStreamListener{
+		pc:       pc,
+		conns:    make(map[string]*conn),
+		acceptCh: make(chan *conn, acceptBacklog),
+		closed:   make(chan struct{}),
+	}
+	go ln.readLoop()
+	return ln, nil
+}
+
+// readLoop reads packets from the shared connection and routes each one to the
+// stream for its source address, creating (and offering to Accept) a new stream
+// the first time a peer is seen.
+func (ln *PacketStreamListener) readLoop() {
+	buf := make([]byte, maxPacketSize)
+	for {
+		n, raddr, err := ln.pc.ReadFrom(buf)
+		if err != nil {
+			return
+		}
+
+		key := raddr.String()
+		ln.mu.Lock()
+		c := ln.conns[key]
+		if c == nil {
+			c = newConn(ln, raddr)
+			ln.conns[key] = c
+			ln.mu.Unlock()
+
+			select {
+			case ln.acceptCh <- c:
+			case <-ln.closed:
+				ln.mu.Lock()
+				delete(ln.conns, key)
+				ln.mu.Unlock()
+				continue
+			}
+		} else {
+			ln.mu.Unlock()
+		}
+
+		c.deliver(buf[:n])
+	}
+}
+
+func (l *PacketStreamListener) Accept() (net.Conn, error) {
+	select {
+	case c := <-l.acceptCh:
+		return c, nil
+	case <-l.closed:
+		return nil, net.ErrClosed
+	}
+}
+
+func (l *PacketStreamListener) Addr() net.Addr {
+	return l.pc.LocalAddr()
+}
+
+func (l *PacketStreamListener) Close() error {
+	l.once.Do(func() {
+		close(l.closed)
+		l.pc.Close()
+
+		l.mu.Lock()
+		for _, c := range l.conns {
+			c.fail(net.ErrClosed)
+		}
+		l.mu.Unlock()
+	})
+	return nil
+}
+
+// remove deregisters an accepted stream so a later packet from the same peer
+// starts a fresh stream.
+func (ln *PacketStreamListener) remove(c *conn) {
+	ln.mu.Lock()
+	if ln.conns[c.raddr.String()] == c {
+		delete(ln.conns, c.raddr.String())
+	}
+	ln.mu.Unlock()
+}

--- a/plugins/common/socket/listener_test.go
+++ b/plugins/common/socket/listener_test.go
@@ -1,0 +1,291 @@
+package socket
+
+import (
+	"bytes"
+	"io"
+	"math/rand"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// the following are ai-generated tests for manually chosen properties
+
+// newLoopbackListener starts a PacketStreamListener over a real loopback UDP
+// socket and returns it together with the address peers should send to.
+func newLoopbackListener(t *testing.T) (*PacketStreamListener, net.Addr) {
+	t.Helper()
+	ln, err := Listen(func() (net.PacketConn, error) {
+		return net.ListenPacket("udp", "127.0.0.1:0")
+	})
+	require.NoError(t, err)
+	return ln, ln.Addr()
+}
+
+// dialLoopback opens a connected UDP socket towards addr. Each call gets a
+// distinct temporary source port, so the listener sees it as a separate peer.
+func dialLoopback(t *testing.T, addr net.Addr) *net.UDPConn {
+	t.Helper()
+	c, err := net.Dial("udp", addr.String())
+	require.NoError(t, err)
+	return c.(*net.UDPConn)
+}
+
+// readN reads exactly n bytes from c, guarding against a hang with a deadline.
+func readN(t *testing.T, c net.Conn, n int) []byte {
+	t.Helper()
+	require.NoError(t, c.SetReadDeadline(time.Now().Add(3*time.Second)))
+	buf := make([]byte, n)
+	_, err := io.ReadFull(c, buf)
+	require.NoError(t, err)
+	require.NoError(t, c.SetReadDeadline(time.Time{}))
+	return buf
+}
+
+// acceptStreamsByRemote accepts n streams and keys them by their peer address.
+func acceptStreamsByRemote(t *testing.T, ln *PacketStreamListener, n int) map[string]net.Conn {
+	t.Helper()
+	out := make(map[string]net.Conn, n)
+	for i := 0; i < n; i++ {
+		c, err := ln.Accept()
+		require.NoError(t, err)
+		out[c.RemoteAddr().String()] = c
+	}
+	return out
+}
+
+func randomBytes(r *rand.Rand, n int) []byte {
+	b := make([]byte, n)
+	r.Read(b)
+	return b
+}
+
+func randomPackets(r *rand.Rand, count int) [][]byte {
+	packets := make([][]byte, count)
+	for i := range packets {
+		packets[i] = randomBytes(r, r.Intn(64)+1)
+	}
+	return packets
+}
+
+// Property: for any interleaving of packets from two distinct peers, each peer
+// is surfaced as its own stream and each stream reconstructs exactly the byte
+// sequence that peer sent, in order.
+func TestPropertyDemuxAlternatingHosts(t *testing.T) {
+	seed := time.Now().UnixNano()
+	t.Logf("seed=%d", seed)
+	r := rand.New(rand.NewSource(seed))
+
+	const iterations = 40
+	for iter := 0; iter < iterations; iter++ {
+		func() {
+			ln, addr := newLoopbackListener(t)
+			defer ln.Close()
+			clientA := dialLoopback(t, addr)
+			defer clientA.Close()
+			clientB := dialLoopback(t, addr)
+			defer clientB.Close()
+
+			packetsA := randomPackets(r, r.Intn(6)+1)
+			packetsB := randomPackets(r, r.Intn(6)+1)
+
+			// Interleave the two peers' packets in a random order.
+			ia, ib := 0, 0
+			for ia < len(packetsA) || ib < len(packetsB) {
+				if ia < len(packetsA) && (ib >= len(packetsB) || r.Intn(2) == 0) {
+					_, err := clientA.Write(packetsA[ia])
+					require.NoError(t, err)
+					ia++
+				} else {
+					_, err := clientB.Write(packetsB[ib])
+					require.NoError(t, err)
+					ib++
+				}
+			}
+
+			streams := acceptStreamsByRemote(t, ln, 2)
+			streamA := streams[clientA.LocalAddr().String()]
+			streamB := streams[clientB.LocalAddr().String()]
+			require.NotNil(t, streamA, "no stream for peer A")
+			require.NotNil(t, streamB, "no stream for peer B")
+
+			wantA := bytes.Join(packetsA, nil)
+			wantB := bytes.Join(packetsB, nil)
+			require.Equal(t, wantA, readN(t, streamA, len(wantA)))
+			require.Equal(t, wantB, readN(t, streamB, len(wantB)))
+		}()
+	}
+}
+
+// Property: multiple packets from a single peer are concatenated into one
+// stream, preserving the bytes across arbitrary packet boundaries.
+func TestPropertyStreamAcrossPackets(t *testing.T) {
+	seed := time.Now().UnixNano()
+	t.Logf("seed=%d", seed)
+	r := rand.New(rand.NewSource(seed))
+
+	const iterations = 40
+	for iter := 0; iter < iterations; iter++ {
+		func() {
+			ln, addr := newLoopbackListener(t)
+			defer ln.Close()
+			client := dialLoopback(t, addr)
+			defer client.Close()
+
+			packets := make([][]byte, r.Intn(20)+1)
+			for i := range packets {
+				packets[i] = randomBytes(r, r.Intn(200)+1)
+				_, err := client.Write(packets[i])
+				require.NoError(t, err)
+			}
+
+			c, err := ln.Accept()
+			require.NoError(t, err)
+
+			want := bytes.Join(packets, nil)
+			require.Equal(t, want, readN(t, c, len(want)))
+		}()
+	}
+}
+
+// Property: a stream write larger than a single UDP packet is split across
+// multiple packets transparently and reassembled intact by the peer.
+func TestPropertyMessageLargerThanPacket(t *testing.T) {
+	seed := time.Now().UnixNano()
+	t.Logf("seed=%d", seed)
+	r := rand.New(rand.NewSource(seed))
+
+	const iterations = 20
+	for iter := 0; iter < iterations; iter++ {
+		func() {
+			ln, addr := newLoopbackListener(t)
+			defer ln.Close()
+			client := dialLoopback(t, addr)
+			defer client.Close()
+
+			// Establish the stream so the listener has a peer to write back to.
+			_, err := client.Write([]byte("open"))
+			require.NoError(t, err)
+			c, err := ln.Accept()
+			require.NoError(t, err)
+			readN(t, c, len("open"))
+
+			// Build a message that spans two or three UDP packets.
+			spans := r.Intn(2) + 2
+			size := maxPayload*(spans-1) + r.Intn(maxPayload) + 1
+			msg := randomBytes(r, size)
+
+			// Read on the peer concurrently so the listener's writes are not
+			// dropped by a full receive buffer.
+			got := make([]byte, size)
+			readErr := make(chan error, 1)
+			go func() {
+				if err := client.SetReadDeadline(time.Now().Add(5 * time.Second)); err != nil {
+					readErr <- err
+					return
+				}
+				_, err := io.ReadFull(client, got)
+				readErr <- err
+			}()
+
+			n, err := c.Write(msg)
+			require.NoError(t, err)
+			require.Equal(t, size, n)
+
+			require.NoError(t, <-readErr)
+			require.Equal(t, msg, got)
+		}()
+	}
+}
+
+// Property: closing a stream deregisters its peer, so a later packet from the
+// same source address starts a fresh stream rather than resurrecting the
+// closed one.
+func TestPropertyClosedStreamReopens(t *testing.T) {
+	seed := time.Now().UnixNano()
+	t.Logf("seed=%d", seed)
+	r := rand.New(rand.NewSource(seed))
+
+	const iterations = 20
+	for iter := 0; iter < iterations; iter++ {
+		func() {
+			ln, addr := newLoopbackListener(t)
+			defer ln.Close()
+			client := dialLoopback(t, addr)
+			defer client.Close()
+
+			first := randomBytes(r, r.Intn(64)+1)
+			_, err := client.Write(first)
+			require.NoError(t, err)
+
+			s1, err := ln.Accept()
+			require.NoError(t, err)
+			require.Equal(t, first, readN(t, s1, len(first)))
+			require.NoError(t, s1.Close())
+
+			// A new packet from the same source port must yield a new stream
+			// carrying the new bytes, not the closed one.
+			second := randomBytes(r, r.Intn(64)+1)
+			_, err = client.Write(second)
+			require.NoError(t, err)
+
+			s2, err := ln.Accept()
+			require.NoError(t, err)
+			require.Equal(t, s1.RemoteAddr().String(), s2.RemoteAddr().String())
+			require.NotSame(t, s1.(*conn), s2.(*conn))
+			require.Equal(t, second, readN(t, s2, len(second)))
+		}()
+	}
+}
+
+// Property: closing the listener terminates every live stream (reads report
+// net.ErrClosed once buffered bytes drain) and stops Accept.
+func TestPropertyClosedListenerClosesStreams(t *testing.T) {
+	seed := time.Now().UnixNano()
+	t.Logf("seed=%d", seed)
+	r := rand.New(rand.NewSource(seed))
+
+	const iterations = 20
+	for iter := 0; iter < iterations; iter++ {
+		func() {
+			ln, addr := newLoopbackListener(t)
+
+			n := r.Intn(4) + 1
+			clients := make([]*net.UDPConn, n)
+			payloads := make([][]byte, n)
+			for i := range clients {
+				clients[i] = dialLoopback(t, addr)
+				defer clients[i].Close()
+				payloads[i] = randomBytes(r, r.Intn(32)+1)
+				_, err := clients[i].Write(payloads[i])
+				require.NoError(t, err)
+			}
+
+			// Accept every peer and drain its initial payload so the buffers
+			// are empty before the listener closes.
+			byRemote := acceptStreamsByRemote(t, ln, n)
+			streams := make([]net.Conn, n)
+			for i := range clients {
+				s := byRemote[clients[i].LocalAddr().String()]
+				require.NotNil(t, s, "no stream for peer %d", i)
+				require.Equal(t, payloads[i], readN(t, s, len(payloads[i])))
+				streams[i] = s
+			}
+
+			require.NoError(t, ln.Close())
+
+			// Every accepted stream now reports closed on read.
+			for i, s := range streams {
+				require.NoError(t, s.SetReadDeadline(time.Now().Add(3*time.Second)))
+				_, err := s.Read(make([]byte, 1))
+				require.ErrorIsf(t, err, net.ErrClosed, "stream %d", i)
+			}
+
+			// Accept no longer yields streams.
+			_, err := ln.Accept()
+			require.ErrorIs(t, err, net.ErrClosed)
+		}()
+	}
+}

--- a/plugins/common/socket/pipedeadline.go
+++ b/plugins/common/socket/pipedeadline.go
@@ -1,0 +1,78 @@
+package socket
+
+import (
+	"sync"
+	"time"
+)
+
+// Copyright 2010 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// pipeDeadline is an abstraction for handling timeouts.
+type pipeDeadline struct {
+	mu     sync.Mutex // Guards timer and cancel
+	timer  *time.Timer
+	cancel chan struct{} // Must be non-nil
+}
+
+func makePipeDeadline() pipeDeadline {
+	return pipeDeadline{cancel: make(chan struct{})}
+}
+
+// set sets the point in time when the deadline will time out.
+// A timeout event is signaled by closing the channel returned by waiter.
+// Once a timeout has occurred, the deadline can be refreshed by specifying a
+// t value in the future.
+//
+// A zero value for t prevents timeout.
+func (d *pipeDeadline) set(t time.Time) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if d.timer != nil && !d.timer.Stop() {
+		<-d.cancel // Wait for the timer callback to finish and close cancel
+	}
+	d.timer = nil
+
+	// Time is zero, then there is no deadline.
+	closed := isClosedChan(d.cancel)
+	if t.IsZero() {
+		if closed {
+			d.cancel = make(chan struct{})
+		}
+		return
+	}
+
+	// Time in the future, setup a timer to cancel in the future.
+	if dur := time.Until(t); dur > 0 {
+		if closed {
+			d.cancel = make(chan struct{})
+		}
+		d.timer = time.AfterFunc(dur, func() {
+			close(d.cancel)
+		})
+		return
+	}
+
+	// Time in the past, so close immediately.
+	if !closed {
+		close(d.cancel)
+	}
+}
+
+// wait returns a channel that is closed when the deadline is exceeded.
+func (d *pipeDeadline) wait() chan struct{} {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.cancel
+}
+
+func isClosedChan(c <-chan struct{}) bool {
+	select {
+	case <-c:
+		return true
+	default:
+		return false
+	}
+}

--- a/plugins/common/socket/socket.go
+++ b/plugins/common/socket/socket.go
@@ -92,7 +92,7 @@ func (cfg *Config) NewSocket(address string, splitcfg *SplitConfig, logger teleg
 
 	switch s.url.Scheme {
 	case "tcp", "tcp4", "tcp6", "unix", "unixpacket",
-		"udp", "udp4", "udp6", "ip", "ip4", "ip6", "unixgram", "vsock":
+		"udp", "udp4", "udp6", "udpstream", "ip", "ip4", "ip6", "unixgram", "vsock":
 	default:
 		return nil, fmt.Errorf("unknown protocol %q in %q", u.Scheme, address)
 	}
@@ -122,6 +122,17 @@ func (s *Socket) Setup() error {
 		)
 
 		if err := l.setupUnix(s.url, s.tlsCfg, s.SocketMode); err != nil {
+			return err
+		}
+		s.listener = l
+	case "udpstream":
+		l := newStreamListener(
+			s.Config,
+			s.splitter,
+			s.log,
+		)
+
+		if err := l.setupUDPStream(s.url, s.interfaceName, s.MulticastSource, int(s.ReadBufferSize)); err != nil {
 			return err
 		}
 		s.listener = l

--- a/plugins/common/socket/stream.go
+++ b/plugins/common/socket/stream.go
@@ -79,6 +79,59 @@ func (l *streamListener) setupTCP(u *url.URL, tlsCfg *tls.Config) error {
 	return err
 }
 
+// setup copied from datagram, wrapped in stream listener
+func (l *streamListener) setupUDPStream(u *url.URL, ifname, multicastSource string, bufferSize int) error {
+	network := strings.TrimSuffix(u.Scheme, "stream")
+
+	listener, err := Listen(func() (net.PacketConn, error) {
+		addr, err := net.ResolveUDPAddr(network, u.Host)
+		if err != nil {
+			return nil, fmt.Errorf("resolving UDP address failed: %w", err)
+		}
+
+		var conn *net.UDPConn
+		if addr.IP.IsMulticast() {
+			var iface *net.Interface
+			if ifname != "" {
+				iface, err = net.InterfaceByName(ifname)
+				if err != nil {
+					return nil, fmt.Errorf("resolving address of %q failed: %w", ifname, err)
+				}
+			}
+
+			if multicastSource != "" {
+				conn, err = listenSSM(network, iface, addr, multicastSource)
+			} else {
+				conn, err = net.ListenMulticastUDP(network, iface, addr)
+			}
+			if err != nil {
+				if conn != nil {
+					conn.Close()
+				}
+				return nil, fmt.Errorf("listening (udp multicast) failed: %w", err)
+			}
+		} else {
+			conn, err = net.ListenUDP(network, addr)
+			if err != nil {
+				return nil, fmt.Errorf("listening (udp) failed: %w", err)
+			}
+		}
+
+		if bufferSize > 0 {
+			if err := conn.SetReadBuffer(bufferSize); err != nil {
+				l.Log.Warnf("Setting read buffer on %s socket failed: %v", u.Scheme, err)
+			}
+		}
+
+		return conn, nil
+	})
+	if err != nil {
+		return err
+	}
+	l.listener = listener
+	return nil
+}
+
 func (l *streamListener) setupUnix(u *url.URL, tlsCfg *tls.Config, socketMode string) error {
 	l.path = filepath.FromSlash(u.Path)
 	if runtime.GOOS == "windows" && strings.Contains(l.path, ":") {

--- a/plugins/inputs/socket_listener/socket_listener_test.go
+++ b/plugins/inputs/socket_listener/socket_listener_test.go
@@ -91,6 +91,11 @@ func TestSocketListener(t *testing.T) {
 			encoding:   "gzip",
 		},
 		{
+			name:       "UDP stream",
+			schema:     "udpstream",
+			buffersize: config.Size(1024),
+		},
+		{
 			name:       "unix socket",
 			schema:     "unix",
 			buffersize: config.Size(1024),
@@ -122,7 +127,7 @@ func TestSocketListener(t *testing.T) {
 			var serverAddr string
 			var tlsCfg *tls.Config
 			switch proto {
-			case "tcp", "udp":
+			case "tcp", "udp", "udpstream":
 				serverAddr = "127.0.0.1:0"
 			case "unix", "unixgram":
 				if runtime.GOOS == "windows" {
@@ -512,6 +517,9 @@ func createClient(endpoint string, addr net.Addr, tlsCfg *tls.Config) (net.Conn,
 		return nil, fmt.Errorf("invalid endpoint %q", endpoint)
 	}
 	protocol := parts[0]
+	if protocol == "udpstream" {
+		protocol = "udp"
+	}
 
 	if tlsCfg == nil {
 		return net.Dial(protocol, addr.String())


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Defines a Stream wrapper which implements the net.Listener interface for Packet Connections. Adds a `udpstream` instance plugins/common/socket, which uses the wrapper on a UDP connection.
## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [ ] No AI generated code was used in this PR
- [x] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
