### PR TITLE
fix(inputs.elasticsearch_query): Release client on startup failure

### DIFF
--- a/plugins/inputs/elasticsearch_query/elasticsearch_query.go
+++ b/plugins/inputs/elasticsearch_query/elasticsearch_query.go
@@ -99,13 +99,16 @@ func (e *ElasticsearchQuery) Start(telegraf.Accumulator) error {
 	// Get the ElasticSearch version on first node and check if it's supported
 	version, err := e.client.version()
 	if err != nil {
+		e.Stop()
 		return fmt.Errorf("getting server version failed: %w", err)
 	}
 	ver, err := semver.NewVersion(version)
 	if err != nil {
+		e.Stop()
 		return fmt.Errorf("parsing server version %q failed: %w", version, err)
 	}
 	if ver.Major() < 5 || ver.Major() > 6 {
+		e.Stop()
 		return fmt.Errorf("server version %q not supported (currently supported versions are 5.x and 6.x)", version)
 	}
 
@@ -117,6 +120,7 @@ func (e *ElasticsearchQuery) Start(telegraf.Accumulator) error {
 	for i := range e.Aggregations {
 		agg := &e.Aggregations[i]
 		if err := e.initAggregation(ctx, agg); err != nil {
+			e.Stop()
 			return fmt.Errorf("initializing aggregation %q failed: %w", agg.MeasurementName, err)
 		}
 	}

--- a/plugins/inputs/elasticsearch_query/elasticsearch_query_test.go
+++ b/plugins/inputs/elasticsearch_query/elasticsearch_query_test.go
@@ -4,6 +4,8 @@ import (
 	"bufio"
 	"context"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -471,6 +473,29 @@ func TestGatherFailGatherIntegration(t *testing.T) {
 			require.ErrorContains(t, acc.GatherError(plugin.Gather), tt.expected)
 		})
 	}
+}
+
+func TestStartupFailureReleasesClient(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := w.Write([]byte(`{"version": {"number": "8.1.2"}}`)); err != nil {
+			t.Error(err)
+		}
+	}))
+	defer server.Close()
+
+	plugin := &ElasticsearchQuery{
+		URLs: []string{server.URL},
+		Log:  testutil.Logger{},
+	}
+	require.NoError(t, plugin.Init())
+
+	var acc testutil.Accumulator
+	require.ErrorContains(t, plugin.Start(&acc), "not supported")
+
+	// The failed start must release the client to not leak the
+	// health-check goroutine
+	require.Nil(t, plugin.client.(*clientV5).client)
 }
 
 func sendData(ctx context.Context, url string) error {

--- a/plugins/inputs/elasticsearch_query/elasticsearch_query_test.go
+++ b/plugins/inputs/elasticsearch_query/elasticsearch_query_test.go
@@ -485,8 +485,9 @@ func TestStartupFailureReleasesClient(t *testing.T) {
 	defer server.Close()
 
 	plugin := &ElasticsearchQuery{
-		URLs: []string{server.URL},
-		Log:  testutil.Logger{},
+		URLs:                []string{server.URL},
+		HealthCheckInterval: config.Duration(10 * time.Second),
+		Log:                 testutil.Logger{},
 	}
 	require.NoError(t, plugin.Init())
 


### PR DESCRIPTION
## Summary

In Start(), once the Elasticsearch client is created and stored on the plugin, the later error returns (version retrieval, version parsing, the supported-version check, and aggregation setup) did not release it. The olivere client starts a background health-check goroutine on creation (enabled by default via health_check_interval = 10s), so a startup failure after client creation leaked that goroutine and the HTTP client for the lifetime of the process.

This routes those error paths through Stop() so the client is released, and adds a test that drives Start() against an httptest server reporting an unsupported server version and asserts the client is released on the failure return.

## Checklist

- [x] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

related to #19188