### PR TITLE
fix(inputs.sql): Respect timeout for unprepared query fallback

### DIFF
--- a/plugins/inputs/sql/sql.go
+++ b/plugins/inputs/sql/sql.go
@@ -352,7 +352,7 @@ func (s *SQL) executeQuery(ctx context.Context, acc telegraf.Accumulator, q quer
 	} else {
 		// Fallback to unprepared query
 		var err error
-		rows, err = s.db.Query(q.Query)
+		rows, err = s.db.QueryContext(ctx, q.Query)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Respect timeout in unprepared query fallback.

## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
