### PR TITLE
docs(inputs.puppetagent): Mention new default path for puppet 7+

### DIFF
--- a/plugins/inputs/puppetagent/README.md
+++ b/plugins/inputs/puppetagent/README.md
@@ -23,8 +23,12 @@ plugin ordering. See [CONFIGURATION.md][CONFIGURATION.md] for more details.
 # Reads last_run_summary.yaml file and converts to measurements
 [[inputs.puppetagent]]
   ## Location of puppet last run summary file
+  ## Use the following path for puppet version 7+ ($publicdir/last_run_summary.yaml)
+  ##   location = "/opt/puppetlabs/puppet/public/last_run_summary.yaml"
   location = "/var/lib/puppet/state/last_run_summary.yaml"
 ```
+
+If you use a distro packaged puppet the `$publicdir` might be different from above.
 
 ## Metrics
 

--- a/plugins/inputs/puppetagent/README.md
+++ b/plugins/inputs/puppetagent/README.md
@@ -30,6 +30,9 @@ plugin ordering. See [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 If you use a distro packaged puppet the `$publicdir` might be different from above.
 
+By default, this file is not readable by the `telegraf` user.
+You can adjust file permissions by configuring the `lastrunfile` setting in Puppet.
+
 ## Metrics
 
 ### PuppetAgent int64 measurements

--- a/plugins/inputs/puppetagent/sample.conf
+++ b/plugins/inputs/puppetagent/sample.conf
@@ -1,4 +1,6 @@
 # Reads last_run_summary.yaml file and converts to measurements
 [[inputs.puppetagent]]
   ## Location of puppet last run summary file
+  ## Use the following path for puppet version 7+ ($publicdir/last_run_summary.yaml)
+  ##   location = "/opt/puppetlabs/puppet/public/last_run_summary.yaml"
   location = "/var/lib/puppet/state/last_run_summary.yaml"


### PR DESCRIPTION
## Summary
This fixes #19256.
Update the path to the new default to make it clear which file is meant.
I also added a hint to necessary puppet config adjustments to get the plugin to work correctly.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
resolves #19256 
