### PR TITLE
feat(inputs.vsphere): Collect data for not poweredOn VMs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 <!-- markdownlint-disable MD013 MD024 -->
 # Changelog
 
+### Important Changes
+
+- PR [#19291](https://github.com/influxdata/telegraf/pull/19291) now reports
+  powered-off VMs in the `inputs.vsphere` plugin. Please drop those machines
+  using `tagpass = {"powerstate" = ["poweredOn"]}` in your config if you don't
+  need them.
+
 ## v1.39.1 [2026-06-29]
 
 ### Bugfixes

--- a/plugins/inputs/vsphere/endpoint.go
+++ b/plugins/inputs/vsphere/endpoint.go
@@ -792,11 +792,12 @@ func getVMs(ctx context.Context, e *endpoint, rf *resourceFilter) (objectMap, er
 		r := &resources[i]
 
 		guest := "unknown"
+		rpname := ""
 		uuid := ""
 		lookup := make(map[string]string)
 		// get the name of the VM resource pool
 		if r.Runtime.PowerState == "poweredOn" {
-			rpname := getResourcePoolName(*r.ResourcePool, resourcePools)
+			rpname = getResourcePoolName(*r.ResourcePool, resourcePools)
 		}
 		// Extract host name
 		if r.Guest != nil && r.Guest.HostName != "" {

--- a/plugins/inputs/vsphere/endpoint.go
+++ b/plugins/inputs/vsphere/endpoint.go
@@ -791,15 +791,13 @@ func getVMs(ctx context.Context, e *endpoint, rf *resourceFilter) (objectMap, er
 	for i := range resources {
 		r := &resources[i]
 
-		if r.Runtime.PowerState != "poweredOn" {
-			continue
-		}
 		guest := "unknown"
 		uuid := ""
 		lookup := make(map[string]string)
 		// get the name of the VM resource pool
-		rpname := getResourcePoolName(*r.ResourcePool, resourcePools)
-
+		if r.Runtime.PowerState == "poweredOn" {
+			rpname := getResourcePoolName(*r.ResourcePool, resourcePools)
+		}
 		// Extract host name
 		if r.Guest != nil && r.Guest.HostName != "" {
 			lookup["guesthostname"] = r.Guest.HostName


### PR DESCRIPTION
## Summary
Collect data for not poweredOn VMs.

## Checklist
- [X] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

resolves #19290
