### PR TITLE
fix(secretstores.vault): Preserve sibling keys when setting a secret

### DIFF
--- a/plugins/secretstores/vault/vault.go
+++ b/plugins/secretstores/vault/vault.go
@@ -119,7 +119,17 @@ func (v *Vault) List() ([]string, error) {
 }
 
 func (v *Vault) Set(key, value string) error {
-	secretsData := map[string]interface{}{key: value}
+	// Vault's Put replaces the whole secret at the path instead of merging into
+	// it, so read the existing secrets first and set the key on top of them to
+	// avoid removing the sibling keys.
+	secretsData := make(map[string]any)
+	switch secret, err := v.getSecret(); {
+	case err == nil && secret != nil && secret.Data != nil:
+		maps.Copy(secretsData, secret.Data)
+	case err != nil && !errors.Is(err, vault.ErrSecretNotFound):
+		return fmt.Errorf("unable to read secret: %w", err)
+	}
+	secretsData[key] = value
 
 	if v.Engine == "kv-v1" {
 		return v.client.KVv1(v.MountPath).Put(context.Background(), v.SecretPath, secretsData)

--- a/plugins/secretstores/vault/vault_test.go
+++ b/plugins/secretstores/vault/vault_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"path/filepath"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -241,6 +242,98 @@ func TestIntegrationAppRoleSecretWrapped(t *testing.T) {
 	secret, err := plugin.Get(secretName)
 	require.NoError(t, err)
 	require.Equal(t, secretValue, string(secret))
+}
+
+func TestIntegrationSetKeepsSiblingsKVv1(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	testSetKeepsSiblings(t, "kv-v1")
+}
+
+func TestIntegrationSetKeepsSiblingsKVv2(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	testSetKeepsSiblings(t, "kv-v2")
+}
+
+func testSetKeepsSiblings(t *testing.T, engine string) {
+	t.Helper()
+
+	mountPath := "my-mount-path"
+	secretPath := "my-secret-path"
+
+	container, closer := createContainer(t, []string{
+		fmt.Sprintf("secrets enable -path=%s %s", mountPath, engine),
+		fmt.Sprintf("kv put -mount=%s %s alpha=one beta=two", mountPath, secretPath),
+	})
+	defer closer()
+
+	addr, err := container.HttpHostAddress(context.Background())
+	require.NoError(t, err)
+
+	plugin := &Vault{
+		ID:         "test_" + engine,
+		Address:    addr,
+		MountPath:  mountPath,
+		SecretPath: secretPath,
+		Engine:     engine,
+		Token:      config.NewSecret([]byte("SomeToken")),
+	}
+	require.NoError(t, plugin.Init())
+
+	require.NoError(t, plugin.Set("gamma", "three"))
+
+	keys, err := plugin.List()
+	require.NoError(t, err)
+	slices.Sort(keys)
+	require.Equal(t, []string{"alpha", "beta", "gamma"}, keys)
+}
+
+func TestIntegrationSetCreatesNewPathKVv1(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	testSetCreatesNewPath(t, "kv-v1")
+}
+
+func TestIntegrationSetCreatesNewPathKVv2(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	testSetCreatesNewPath(t, "kv-v2")
+}
+
+func testSetCreatesNewPath(t *testing.T, engine string) {
+	t.Helper()
+
+	mountPath := "my-mount-path"
+	secretPath := "my-secret-path"
+
+	container, closer := createContainer(t, []string{
+		fmt.Sprintf("secrets enable -path=%s %s", mountPath, engine),
+	})
+	defer closer()
+
+	addr, err := container.HttpHostAddress(context.Background())
+	require.NoError(t, err)
+
+	plugin := &Vault{
+		ID:         "test_" + engine,
+		Address:    addr,
+		MountPath:  mountPath,
+		SecretPath: secretPath,
+		Engine:     engine,
+		Token:      config.NewSecret([]byte("SomeToken")),
+	}
+	require.NoError(t, plugin.Init())
+
+	require.NoError(t, plugin.Set("gamma", "three"))
+
+	value, err := plugin.Get("gamma")
+	require.NoError(t, err)
+	require.Equal(t, "three", string(value))
 }
 
 func TestInitAuthValidation(t *testing.T) {


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Setting a secret with `telegraf secrets set` wrote only the new key to the secret path, and Vault's `Put` replaces the whole secret at the path rather than merging, so every other key stored at that path was silently removed.

This reads the existing secrets at the path first and sets the new key on top of them before writing back. A not-found path is treated as empty so setting into a brand-new path still works, while any other read error aborts the write so a transient failure cannot overwrite existing secrets.


## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #19287
