### PR TITLE
fix(inputs.redfish): Add URL and content type to JSON parse error

### DIFF
--- a/plugins/inputs/redfish/redfish.go
+++ b/plugins/inputs/redfish/redfish.go
@@ -236,7 +236,7 @@ func (r *Redfish) getData(address string, payload interface{}) error {
 
 	err = json.Unmarshal(body, &payload)
 	if err != nil {
-		return fmt.Errorf("error parsing input: %w", err)
+		return fmt.Errorf("error parsing input from %s (Content-Type %q): %w", address, resp.Header.Get("Content-Type"), err)
 	}
 
 	return nil

--- a/plugins/inputs/redfish/redfish_test.go
+++ b/plugins/inputs/redfish/redfish_test.go
@@ -854,7 +854,7 @@ func TestInvalidDellJSON(t *testing.T) {
 			var acc testutil.Accumulator
 			err := plugin.Gather(&acc)
 			require.Error(t, err)
-			require.Contains(t, err.Error(), "error parsing input:")
+			require.ErrorContains(t, err, "error parsing input from")
 		})
 	}
 }
@@ -925,9 +925,39 @@ func TestInvalidHPJSON(t *testing.T) {
 			var acc testutil.Accumulator
 			err := plugin.Gather(&acc)
 			require.Error(t, err)
-			require.Contains(t, err.Error(), "error parsing input:")
+			require.ErrorContains(t, err, "error parsing input from")
 		})
 	}
+}
+
+func TestParseErrorIncludesContext(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !checkAuth(r, "test", "test") {
+			http.Error(w, "Unauthorized.", http.StatusUnauthorized)
+			return
+		}
+		// Return an HTML page with a 200 status, as some BMCs do when they
+		// serve a web-UI/login page instead of the Redfish JSON resource.
+		w.Header().Set("Content-Type", "text/html")
+		if _, err := w.Write([]byte("<html><body>login</body></html>")); err != nil {
+			t.Error(err)
+		}
+	}))
+	defer ts.Close()
+
+	plugin := &Redfish{
+		Address:          ts.URL,
+		Username:         config.NewSecret([]byte("test")),
+		Password:         config.NewSecret([]byte("test")),
+		ComputerSystemID: "System.Embedded.1",
+		IncludeMetrics:   []string{"thermal", "power"},
+	}
+	require.NoError(t, plugin.Init())
+
+	var acc testutil.Accumulator
+	err := plugin.Gather(&acc)
+	require.ErrorContains(t, err, ts.URL+"/redfish/v1/Systems/System.Embedded.1")
+	require.ErrorContains(t, err, "text/html")
 }
 
 func TestIncludeTagSetsConfiguration(t *testing.T) {


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
When a Redfish endpoint returns a non-JSON body (for example a BMC serving an HTML web-UI or login page, or a proxy returning an HTML error page), the plugin failed with a bare `error parsing input: invalid character '<' looking for beginning of value` that did not say which of its several per-gather requests failed or what the body was.

This wraps the parse error with the request URL and the response Content-Type, matching the address-in-error style already used for the status-code check, so the failing request and its actual content type are visible without extra debugging.

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

related to #19289
