### PR TITLE
docs(inputs.chrony): Align timeout docs with dial and request defaults

### DIFF
--- a/plugins/inputs/chrony/README.md
+++ b/plugins/inputs/chrony/README.md
@@ -29,8 +29,8 @@ plugin ordering. See [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## and "udp://[::1]:323".
   # server = ""
 
-  ## Timeout for establishing the connection
-  # timeout = "5s"
+  ## Timeout for establishing the connection and for each request/response
+  # timeout = "3s"
 
   ## Try to resolve received addresses to host-names via DNS lookups
   ## Disabled by default to avoid DNS queries especially for slow DNS servers.

--- a/plugins/inputs/chrony/sample.conf
+++ b/plugins/inputs/chrony/sample.conf
@@ -6,8 +6,8 @@
   ## and "udp://[::1]:323".
   # server = ""
 
-  ## Timeout for establishing the connection
-  # timeout = "5s"
+  ## Timeout for establishing the connection and for each request/response
+  # timeout = "3s"
 
   ## Try to resolve received addresses to host-names via DNS lookups
   ## Disabled by default to avoid DNS queries especially for slow DNS servers.


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
The sample config still described timeout as dial-only and showed 5s, while the plugin default is 3s and, since #19223, the same value also bounds each request/response read.

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [X] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy
