### PR TITLE
chore(inputs.cisco_telemetry_mdt): Migrate parsing to own class

### DIFF
--- a/plugins/inputs/cisco_telemetry_mdt/cisco_telemetry_mdt.go
+++ b/plugins/inputs/cisco_telemetry_mdt/cisco_telemetry_mdt.go
@@ -4,11 +4,9 @@ package cisco_telemetry_mdt
 import (
 	_ "embed"
 	"encoding/hex"
-	"encoding/json"
 	"fmt"
+	"maps"
 	"net"
-	"path"
-	"strings"
 	"sync"
 	"time"
 
@@ -23,7 +21,6 @@ import (
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
-	"github.com/influxdata/telegraf/metric"
 	common_tls "github.com/influxdata/telegraf/plugins/common/tls"
 	"github.com/influxdata/telegraf/plugins/inputs"
 )
@@ -46,23 +43,14 @@ type CiscoTelemetryMDT struct {
 	Log                telegraf.Logger       `toml:"-"`
 	common_tls.ServerConfig
 
-	// Internal listener / client handle
-	grpcServer *grpc.Server
-	listener   net.Listener
-
-	// Internal state
-	internalAliases map[string]string
-	warned          map[string]bool
-	dmesFuncs       map[string]string
-	extraTags       map[string]map[string]bool
-	nxpathMap       map[string]map[string]string // per path map
-	propMap         map[string]func(*telemetry.TelemetryField) interface{}
-
 	serverOptions []grpc.ServerOption
+	grpcServer    *grpc.Server
+	listener      net.Listener
 
-	acc   telegraf.Accumulator
-	mutex sync.Mutex
-	wg    sync.WaitGroup
+	parser *parser
+
+	acc telegraf.Accumulator
+	wg  sync.WaitGroup
 
 	// Though unused in the code, required by protoc-gen-go-grpc to maintain compatibility
 	mdtdialout.UnimplementedGRPCMdtDialoutServer
@@ -122,68 +110,8 @@ func (c *CiscoTelemetryMDT) Init() error {
 		c.SourceFieldName = "mdt_source"
 	}
 
-	// Invert aliases list
-	c.warned = make(map[string]bool)
-	c.internalAliases = make(map[string]string, len(c.Aliases))
-	for alias, encodingPath := range c.Aliases {
-		c.internalAliases[encodingPath] = alias
-	}
-
-	// Initialize the path mappings
-	c.nxpathMap = createDatabase()
-
-	// Initialize property conversion map
-	c.propMap = make(map[string]func(field *telemetry.TelemetryField) interface{}, len(c.Dmes)+4)
-	c.propMap["test"] = nxosValueXformUint64Toint64
-	c.propMap["asn"] = nxosValueXformUint64ToString            // uint64 to string.
-	c.propMap["subscriptionId"] = nxosValueXformUint64ToString // uint64 to string.
-	c.propMap["operState"] = nxosValueXformUint64ToString      // uint64 to string.
-
-	c.dmesFuncs = make(map[string]string, len(c.Dmes))
-	for dme, dmeKey := range c.Dmes {
-		c.dmesFuncs[dmeKey] = dme
-		switch dmeKey {
-		case "uint64 to int":
-			c.propMap[dme] = nxosValueXformUint64Toint64
-		case "uint64 to string":
-			c.propMap[dme] = nxosValueXformUint64ToString
-		case "string to float64":
-			c.propMap[dme] = nxosValueXformStringTofloat
-		case "string to uint64":
-			c.propMap[dme] = nxosValueXformStringToUint64
-		case "string to int64":
-			c.propMap[dme] = nxosValueXformStringToInt64
-		case "auto-float-xfrom":
-			c.propMap[dme] = nxosValueAutoXformFloatProp
-		default:
-			if !strings.HasPrefix(dme, "dnpath") {
-				// Ignore non-path based property map
-				continue
-			}
-
-			var payload nxPayloadXfromStructure
-			if err := json.Unmarshal([]byte(dmeKey), &payload); err != nil {
-				continue
-			}
-
-			// Build 2 level Hash nxpathMap Key = jsStruct.Name, Value = map of jsStruct.Prop
-			// It will override the default of code if same path is provided in configuration.
-			c.nxpathMap[payload.Name] = make(map[string]string, len(payload.Prop))
-			for _, prop := range payload.Prop {
-				c.nxpathMap[payload.Name][prop.Key] = prop.Value
-			}
-		}
-	}
-
-	// Fill extra tags
-	c.extraTags = make(map[string]map[string]bool)
-	for _, tag := range c.EmbeddedTags {
-		dir := strings.ReplaceAll(path.Dir(tag), "-", "_")
-		if _, found := c.extraTags[dir]; !found {
-			c.extraTags[dir] = make(map[string]bool)
-		}
-		c.extraTags[dir][path.Base(tag)] = true
-	}
+	// Initialize parser
+	c.parser = newParser(c.IncludeDeleteField, c.Aliases, c.Dmes, c.EmbeddedTags, c.Log)
 
 	return nil
 }
@@ -255,7 +183,6 @@ func (c *CiscoTelemetryMDT) handleTelemetry(data []byte) {
 		}
 	}
 
-	grouper := metric.NewSeriesGrouper()
 	for _, gpbkv := range msg.DataGpbkv {
 		// Top-level field may have measurement timestamp, if not use message timestamp
 		measured := gpbkv.Timestamp
@@ -281,22 +208,17 @@ func (c *CiscoTelemetryMDT) handleTelemetry(data []byte) {
 		}
 
 		// Produce metadata tags
-		var tags map[string]string
+		tags := make(map[string]string, 3)
 		if keys != nil {
-			tags = make(map[string]string, len(keys.Fields)+3)
 			for _, subfield := range keys.Fields {
-				c.parseKeyField(tags, subfield, "")
+				maps.Copy(tags, parseKeys(subfield, ""))
 			}
 
 			// If incoming MDT contains source key, copy to mdt_src
 			if _, ok := tags["source"]; ok {
 				tags[c.SourceFieldName] = tags["source"]
 			}
-		} else {
-			tags = make(map[string]string, 3)
 		}
-
-		// Parse keys
 		tags["source"] = msg.GetNodeIdStr()
 		if msgID := msg.GetSubscriptionIdStr(); msgID != "" {
 			tags["subscription"] = msgID
@@ -304,32 +226,8 @@ func (c *CiscoTelemetryMDT) handleTelemetry(data []byte) {
 		encodingPath := msg.GetEncodingPath()
 		tags["path"] = encodingPath
 
-		if content != nil {
-			// Parse values
-			for _, subfield := range content.Fields {
-				prefix := ""
-				switch subfield.Name {
-				case "operation-metric":
-					if len(subfield.Fields[0].Fields) > 0 {
-						prefix = subfield.Fields[0].Fields[0].GetStringValue()
-					}
-				case "class-stats":
-					if len(subfield.Fields[0].Fields) > 1 {
-						prefix = subfield.Fields[0].Fields[1].GetStringValue()
-					}
-				}
-				// Parse the content with and without prefix
-				c.parseContentField(grouper, subfield, prefix, encodingPath, tags, timestamp)
-				c.parseContentField(grouper, subfield, "", encodingPath, tags, timestamp)
-			}
-		}
-		if c.IncludeDeleteField {
-			grouper.Add(c.getMeasurementName(encodingPath), tags, timestamp, "delete", gpbkv.GetDelete())
-		}
-	}
-
-	for _, groupedMetric := range grouper.Metrics() {
-		c.acc.AddMetric(groupedMetric)
+		// Parse the "content" field if any
+		c.parser.parse(c.acc, content, encodingPath, gpbkv.GetDelete(), tags, timestamp)
 	}
 }
 

--- a/plugins/inputs/cisco_telemetry_mdt/cisco_telemetry_mdt.go
+++ b/plugins/inputs/cisco_telemetry_mdt/cisco_telemetry_mdt.go
@@ -5,7 +5,6 @@ import (
 	_ "embed"
 	"encoding/hex"
 	"fmt"
-	"maps"
 	"net"
 	"sync"
 	"time"
@@ -211,7 +210,7 @@ func (c *CiscoTelemetryMDT) handleTelemetry(data []byte) {
 		tags := make(map[string]string, 3)
 		if keys != nil {
 			for _, subfield := range keys.Fields {
-				maps.Copy(tags, parseKeys(subfield, ""))
+				parseKeys(subfield, "", tags)
 			}
 
 			// If incoming MDT contains source key, copy to mdt_src

--- a/plugins/inputs/cisco_telemetry_mdt/cisco_telemetry_mdt.go
+++ b/plugins/inputs/cisco_telemetry_mdt/cisco_telemetry_mdt.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
+	"github.com/influxdata/telegraf/metric"
 	common_tls "github.com/influxdata/telegraf/plugins/common/tls"
 	"github.com/influxdata/telegraf/plugins/inputs"
 )
@@ -182,6 +183,9 @@ func (c *CiscoTelemetryMDT) handleTelemetry(data []byte) {
 		}
 	}
 
+	// Create a grouper to accumulate the fields for a series
+	grouper := metric.NewSeriesGrouper()
+
 	for _, gpbkv := range msg.DataGpbkv {
 		// Top-level field may have measurement timestamp, if not use message timestamp
 		measured := gpbkv.Timestamp
@@ -226,7 +230,14 @@ func (c *CiscoTelemetryMDT) handleTelemetry(data []byte) {
 		tags["path"] = encodingPath
 
 		// Parse the "content" field if any
-		c.parser.parse(c.acc, content, encodingPath, gpbkv.GetDelete(), tags, timestamp)
+		errs := c.parser.parse(grouper, content, encodingPath, gpbkv.GetDelete(), tags, timestamp)
+		for _, err := range errs {
+			c.acc.AddError(err)
+		}
+	}
+
+	for _, groupedMetric := range grouper.Metrics() {
+		c.acc.AddMetric(groupedMetric)
 	}
 }
 

--- a/plugins/inputs/cisco_telemetry_mdt/parser.go
+++ b/plugins/inputs/cisco_telemetry_mdt/parser.go
@@ -1,18 +1,196 @@
 package cisco_telemetry_mdt
 
 import (
+	"encoding/json"
 	"errors"
+	"maps"
+	"path"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	telemetry "github.com/cisco-ie/nx-telemetry-proto/telemetry_bis"
 
+	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/metric"
 )
 
-// Recursively parse tag fields
-func (c *CiscoTelemetryMDT) parseKeyField(tags map[string]string, field *telemetry.TelemetryField, prefix string) {
+type parser struct {
+	includeDelete bool
+	aliases       map[string]string
+	extraTags     map[string]map[string]bool
+	propMap       map[string]func(*telemetry.TelemetryField) interface{}
+	nxpathMap     map[string]map[string]string // per path map
+
+	log telegraf.Logger
+
+	warned map[string]bool
+	sync.Mutex
+}
+
+type state struct {
+	path        string
+	measurement string
+	tagPrefix   string
+	isNXOS      bool
+	isEvent     bool
+
+	extraTags map[string]map[string]bool
+	propMap   map[string]func(*telemetry.TelemetryField) interface{}
+	nxpathMap map[string]string // per path map
+
+	grouper *metric.SeriesGrouper
+}
+
+func newParser(includeDelete bool, aliases, dmes map[string]string, embeddedTags []string, log telegraf.Logger) *parser {
+	p := &parser{
+		includeDelete: includeDelete,
+		aliases:       make(map[string]string, len(aliases)),
+		extraTags:     make(map[string]map[string]bool),
+		propMap:       make(map[string]func(field *telemetry.TelemetryField) interface{}, len(dmes)+4),
+		nxpathMap:     createDatabase(),
+		warned:        make(map[string]bool),
+		log:           log,
+	}
+
+	// Fill the parser aliases with the inverted list
+	for alias, encodingPath := range aliases {
+		p.aliases[encodingPath] = alias
+	}
+
+	// Fill extra tags
+	for _, tag := range embeddedTags {
+		dir := strings.ReplaceAll(path.Dir(tag), "-", "_")
+		if _, found := p.extraTags[dir]; !found {
+			p.extraTags[dir] = make(map[string]bool)
+		}
+		p.extraTags[dir][path.Base(tag)] = true
+	}
+
+	// Initialize property conversion map
+	p.propMap["test"] = nxosValueXformUint64Toint64
+	p.propMap["asn"] = nxosValueXformUint64ToString            // uint64 to string.
+	p.propMap["subscriptionId"] = nxosValueXformUint64ToString // uint64 to string.
+	p.propMap["operState"] = nxosValueXformUint64ToString      // uint64 to string.
+
+	for dme, dmeKey := range dmes {
+		switch dmeKey {
+		case "uint64 to int":
+			p.propMap[dme] = nxosValueXformUint64Toint64
+		case "uint64 to string":
+			p.propMap[dme] = nxosValueXformUint64ToString
+		case "string to float64":
+			p.propMap[dme] = nxosValueXformStringTofloat
+		case "string to uint64":
+			p.propMap[dme] = nxosValueXformStringToUint64
+		case "string to int64":
+			p.propMap[dme] = nxosValueXformStringToInt64
+		case "auto-float-xfrom":
+			p.propMap[dme] = nxosValueAutoXformFloatProp
+		default:
+			if !strings.HasPrefix(dme, "dnpath") {
+				// Ignore non-path based property map
+				continue
+			}
+
+			var payload nxPayloadXfromStructure
+			if err := json.Unmarshal([]byte(dmeKey), &payload); err != nil {
+				continue
+			}
+
+			// Build 2 level Hash nxpathMap Key = jsStruct.Name, Value = map of jsStruct.Prop
+			// It will override the default of code if same path is provided in configuration.
+			p.nxpathMap[payload.Name] = make(map[string]string, len(payload.Prop))
+			for _, prop := range payload.Prop {
+				p.nxpathMap[payload.Name][prop.Key] = prop.Value
+			}
+		}
+	}
+
+	return p
+}
+
+func (p *parser) parse(
+	acc telegraf.Accumulator,
+	content *telemetry.TelemetryField,
+	encodingPath string,
+	isDeleted bool,
+	tags map[string]string,
+	timestamp time.Time,
+) {
+	// Do alias lookup, to shorten measurement names
+	measurement := encodingPath
+	if alias, ok := p.aliases[encodingPath]; ok {
+		measurement = alias
+	} else {
+		p.Lock()
+		if !p.warned[encodingPath] {
+			p.log.Debugf("No measurement alias for encoding path: %s", encodingPath)
+			p.warned[encodingPath] = true
+		}
+		p.Unlock()
+	}
+
+	// Determine what OS we are on and if the message encodes events
+	// IOS-XR and IOS-XE have a colon in their encoding path, NX-OS does not
+	isNXOS := !strings.ContainsRune(encodingPath, ':')
+	isEvent := isNXOS && strings.Contains(encodingPath, "EVENT-LIST")
+
+	// Create a grouper to accumulate the fields for a series
+	grouper := metric.NewSeriesGrouper()
+
+	// Initialize the parsing state
+	state := &state{
+		path:        encodingPath,
+		measurement: measurement,
+		tagPrefix:   strings.ReplaceAll(encodingPath, "-", "_"),
+		isNXOS:      isNXOS,
+		isEvent:     isEvent,
+		extraTags:   p.extraTags,
+		propMap:     p.propMap,
+		nxpathMap:   p.nxpathMap[encodingPath],
+		grouper:     grouper,
+	}
+
+	// Parse the content if any
+	if content != nil {
+		for _, subfield := range content.Fields {
+			var prefix string
+			switch subfield.Name {
+			case "operation-metric":
+				if len(subfield.Fields[0].Fields) > 0 {
+					prefix = subfield.Fields[0].Fields[0].GetStringValue()
+				}
+			case "class-stats":
+				if len(subfield.Fields[0].Fields) > 1 {
+					prefix = subfield.Fields[0].Fields[1].GetStringValue()
+				}
+			}
+			// Parse the content with and without prefix
+			errs := state.parseField(subfield, prefix, tags, timestamp)
+			for _, err := range errs {
+				acc.AddError(err)
+			}
+			errs = state.parseField(subfield, "", tags, timestamp)
+			for _, err := range errs {
+				acc.AddError(err)
+			}
+		}
+	}
+	if p.includeDelete {
+		grouper.Add(measurement, tags, timestamp, "delete", isDeleted)
+	}
+
+	for _, groupedMetric := range grouper.Metrics() {
+		acc.AddMetric(groupedMetric)
+	}
+}
+
+// Recursively parse the "keys" element and convert to tags
+func parseKeys(field *telemetry.TelemetryField, prefix string) map[string]string {
+	tags := make(map[string]string)
+
 	localname := strings.ReplaceAll(field.Name, "-", "_")
 	name := localname
 	if len(localname) == 0 {
@@ -30,39 +208,42 @@ func (c *CiscoTelemetryMDT) parseKeyField(tags map[string]string, field *telemet
 	}
 
 	for _, subfield := range field.Fields {
-		c.parseKeyField(tags, subfield, name)
+		maps.Copy(tags, parseKeys(subfield, name))
 	}
+
+	return tags
 }
 
-func (c *CiscoTelemetryMDT) parseContentField(
-	grouper *metric.SeriesGrouper,
-	field *telemetry.TelemetryField,
-	prefix, encodingPath string,
-	tags map[string]string,
-	timestamp time.Time,
-) {
+func (s *state) parseField(field *telemetry.TelemetryField, prefix string, tags map[string]string, timestamp time.Time) []error {
 	name := strings.ReplaceAll(field.Name, "-", "_")
 
+	// Exit early on fields to ignore
 	if (name == "modTs" || name == "createTs") && decode(field) == "never" {
-		return
+		return nil
 	}
+
+	// Prefix the name if necessary
 	if len(name) == 0 {
 		name = prefix
 	} else if prefix != "" {
 		name = prefix + "/" + name
 	}
 
-	extraTags := c.extraTags[strings.ReplaceAll(encodingPath, "-", "_")+"/"+name]
+	// Decode scalar fields if present and exit
 	if value := decode(field); value != nil {
-		measurement := c.getMeasurementName(encodingPath)
-		if val := c.nxosValueXform(field, encodingPath); val != nil {
-			grouper.Add(measurement, tags, timestamp, name, val)
-		} else {
-			grouper.Add(measurement, tags, timestamp, name, value)
+		if s.isNXOS {
+			// NXOS specific values take precedence if existing
+			if val := nxosValueXform(field, s.propMap, s.nxpathMap); val != nil {
+				value = val
+			}
 		}
-		return
+		s.grouper.Add(s.measurement, tags, timestamp, name, value)
+
+		return nil
 	}
 
+	// Get extra-tags defined by the user in embedded_tags
+	extraTags := s.extraTags[s.tagPrefix+"/"+name]
 	if len(extraTags) > 0 {
 		for _, subfield := range field.Fields {
 			if _, isExtraTag := extraTags[subfield.Name]; isExtraTag {
@@ -71,16 +252,14 @@ func (c *CiscoTelemetryMDT) parseContentField(
 		}
 	}
 
+	// Extract special field elements
+	var errs []error
 	var nxAttributes, nxChildren, nxRows *telemetry.TelemetryField
-	isNXOS := !strings.ContainsRune(encodingPath, ':') // IOS-XR and IOS-XE have a colon in their encoding path, NX-OS does not
-	isEVENT := isNXOS && strings.Contains(encodingPath, "EVENT-LIST")
-	nxChildren = nil
-	nxAttributes = nil
 	for _, subfield := range field.Fields {
-		if isNXOS && subfield.Name == "attributes" && len(subfield.Fields) > 0 {
+		if s.isNXOS && subfield.Name == "attributes" && len(subfield.Fields) > 0 {
 			nxAttributes = subfield.Fields[0]
-		} else if isNXOS && subfield.Name == "children" && len(subfield.Fields) > 0 {
-			if !isEVENT {
+		} else if s.isNXOS && subfield.Name == "children" && len(subfield.Fields) > 0 {
+			if !s.isEvent {
 				nxChildren = subfield
 			} else {
 				sub := subfield.Fields
@@ -92,22 +271,26 @@ func (c *CiscoTelemetryMDT) parseContentField(
 					}
 				}
 			}
-			// if nxAttributes == NULL then class based query.
+
+			// If we did not see any attributes yet walk the sub-fields and parse
+			// according to the class received
 			if nxAttributes == nil {
 				// call function walking over walking list.
 				for _, sub := range subfield.Fields {
-					c.parseClassAttributeField(grouper, sub, encodingPath, tags, timestamp)
+					errs = append(errs, s.parseClassAttributeField(sub, tags, timestamp)...)
 				}
 			}
-		} else if isNXOS && strings.HasPrefix(subfield.Name, "ROW_") {
+		} else if s.isNXOS && strings.HasPrefix(subfield.Name, "ROW_") {
+			// TODO: Verify if it is safe to override the nxRows variable. Can there be multiple ROW_abc entires?
 			nxRows = subfield
-		} else if _, isExtraTag := extraTags[subfield.Name]; !isExtraTag { // Regular telemetry decoding
-			c.parseContentField(grouper, subfield, name, encodingPath, tags, timestamp)
+		} else if _, isExtraTag := extraTags[subfield.Name]; !isExtraTag {
+			// Continue with regular telemetry decoding of the tree
+			errs = append(errs, s.parseField(subfield, name, tags, timestamp)...)
 		}
 	}
 
 	if nxAttributes == nil && nxRows == nil {
-		return
+		return nil
 	}
 	if nxRows != nil {
 		// NXAPI structure: https://developer.cisco.com/docs/cisco-nexus-9000-series-nx-api-cli-reference-release-9-2x/
@@ -118,17 +301,17 @@ func (c *CiscoTelemetryMDT) parseContentField(
 					// We can have subfield so recursively handle it.
 					if len(row.Fields) == 1 {
 						tags["row_number"] = strconv.FormatInt(int64(i), 10)
-						c.parseContentField(grouper, subfield, "", encodingPath, tags, timestamp)
+						errs = append(errs, s.parseField(subfield, "", tags, timestamp)...)
 					}
 				} else {
-					c.parseContentField(grouper, subfield, "", encodingPath, tags, timestamp)
+					errs = append(errs, s.parseField(subfield, "", tags, timestamp)...)
 				}
 				// Nxapi we can't identify keys always from prefix
 				tags["row_number"] = strconv.FormatInt(int64(i), 10)
 			}
 			delete(tags, prefix)
 		}
-		return
+		return nil
 	}
 
 	// DME structure: https://developer.cisco.com/site/nxapi-dme-model-reference-api/
@@ -146,53 +329,47 @@ func (c *CiscoTelemetryMDT) parseContentField(
 	if len(rn) > 0 {
 		tags[prefix] = rn
 	} else if !dn { // Check for distinguished name being present
-		c.acc.AddError(errors.New("failed while decoding NX-OS: missing 'dn' field"))
-		return
+		return []error{errors.New("failed while decoding NX-OS: missing 'dn' field")}
 	}
 
 	for _, subfield := range nxAttributes.Fields {
 		if subfield.Name != "rn" {
-			c.parseContentField(grouper, subfield, "", encodingPath, tags, timestamp)
+			errs = append(errs, s.parseField(subfield, "", tags, timestamp)...)
 		}
 	}
 
 	if nxChildren != nil {
 		// This is a nested structure, children will inherit relative name keys of parent
 		for _, subfield := range nxChildren.Fields {
-			c.parseContentField(grouper, subfield, prefix, encodingPath, tags, timestamp)
+			errs = append(errs, s.parseField(subfield, prefix, tags, timestamp)...)
 		}
 	}
 	delete(tags, prefix)
+
+	return errs
 }
 
-func (c *CiscoTelemetryMDT) parseClassAttributeField(
-	grouper *metric.SeriesGrouper,
-	field *telemetry.TelemetryField,
-	encodingPath string,
-	tags map[string]string,
-	timestamp time.Time,
-) {
-	// DME structure: https://developer.cisco.com/site/nxapi-dme-model-reference-api/
-	var nxAttributes *telemetry.TelemetryField
-	isDme := strings.Contains(encodingPath, "sys/")
-	if encodingPath == "rib" {
+func (s *state) parseClassAttributeField(field *telemetry.TelemetryField, tags map[string]string, timestamp time.Time) []error {
+	if s.path == "rib" {
 		// handle native data path rib
-		parseRib(grouper, field, encodingPath, tags, timestamp)
-		return
+		s.parseRib(field, tags, timestamp)
+		return nil
 	}
-	if encodingPath == "microburst" {
-		// dump microburst
-		parseMicroburst(grouper, field, encodingPath, tags, timestamp)
-		return
+	if s.path == "microburst" {
+		s.parseMicroburst(field, tags, timestamp)
+		return nil
 	}
+
+	// DME structure: https://developer.cisco.com/site/nxapi-dme-model-reference-api/
+	isDme := strings.Contains(s.path, "sys/")
 	if field == nil || !isDme || len(field.Fields) == 0 || len(field.Fields[0].Fields) == 0 || len(field.Fields[0].Fields[0].Fields) == 0 {
-		return
+		return nil
 	}
 
 	if field.Fields[0] != nil && field.Fields[0].Fields != nil && field.Fields[0].Fields[0] != nil && field.Fields[0].Fields[0].Fields[0].Name != "attributes" {
-		return
+		return nil
 	}
-	nxAttributes = field.Fields[0].Fields[0].Fields[0].Fields[0]
+	nxAttributes := field.Fields[0].Fields[0].Fields[0].Fields[0]
 
 	// Find dn tag among list of attributes
 	for _, subfield := range nxAttributes.Fields {
@@ -201,41 +378,52 @@ func (c *CiscoTelemetryMDT) parseClassAttributeField(
 			break
 		}
 	}
+
 	// Add attributes to grouper with consistent dn tag
+	var errs []error //nolint:prealloc // We expect the errors to be empty in most cases
 	for _, subfield := range nxAttributes.Fields {
-		c.parseContentField(grouper, subfield, "", encodingPath, tags, timestamp)
+		errs = append(errs, s.parseField(subfield, "", tags, timestamp)...)
 	}
+
 	// Delete dn tag to prevent it from being added to the next node's attributes
 	delete(tags, "dn")
+
+	return errs
 }
 
-func (c *CiscoTelemetryMDT) getMeasurementName(encodingPath string) string {
-	// Do alias lookup, to shorten measurement names
-	measurement := encodingPath
-	if alias, ok := c.internalAliases[encodingPath]; ok {
-		measurement = alias
-	} else {
-		c.mutex.Lock()
-		if !c.warned[encodingPath] {
-			c.Log.Debugf("No measurement alias for encoding path: %s", encodingPath)
-			c.warned[encodingPath] = true
+func (s *state) parseRib(field *telemetry.TelemetryField, tags map[string]string, timestamp time.Time) {
+	for _, subfield := range field.Fields {
+		// For Every table fill the keys which are vrfName, address and masklen
+		switch subfield.Name {
+		case "vrfName", "address", "maskLen":
+			tags[subfield.Name] = decodeTag(subfield)
 		}
-		c.mutex.Unlock()
+		if value := decode(subfield); value != nil {
+			s.grouper.Add(s.measurement, tags, timestamp, subfield.Name, value)
+		}
+		if subfield.Name != "nextHop" {
+			continue
+		}
+		// For next hop table fill the keys in the tag - which is address and vrfname
+		for _, subf := range subfield.Fields {
+			for _, ff := range subf.Fields {
+				switch ff.Name {
+				case "address", "vrfName":
+					key := "nextHop/" + ff.Name
+					tags[key] = decodeTag(ff)
+				}
+				if value := decode(ff); value != nil {
+					name := "nextHop/" + ff.Name
+					s.grouper.Add(s.measurement, tags, timestamp, name, value)
+				}
+			}
+		}
 	}
-	return measurement
 }
 
-func parseMicroburst(
-	grouper *metric.SeriesGrouper,
-	field *telemetry.TelemetryField,
-	encodingPath string,
-	tags map[string]string,
-	timestamp time.Time,
-) {
+func (s *state) parseMicroburst(field *telemetry.TelemetryField, tags map[string]string, timestamp time.Time) {
 	var nxMicro *telemetry.TelemetryField
 	var nxMicro1 *telemetry.TelemetryField
-	// Microburst
-	measurement := encodingPath
 	if len(field.Fields) > 3 {
 		nxMicro = field.Fields[2]
 		if len(nxMicro.Fields) > 0 {
@@ -266,45 +454,7 @@ func parseMicroburst(
 				tags[subf.Name] = decodeTag(subf)
 			}
 			if value := decode(subf); value != nil {
-				grouper.Add(measurement, tags, timestamp, subf.Name, value)
-			}
-		}
-	}
-}
-
-func parseRib(
-	grouper *metric.SeriesGrouper,
-	field *telemetry.TelemetryField,
-	encodingPath string,
-	tags map[string]string,
-	timestamp time.Time,
-) {
-	// RIB
-	measurement := encodingPath
-	for _, subfield := range field.Fields {
-		// For Every table fill the keys which are vrfName, address and masklen
-		switch subfield.Name {
-		case "vrfName", "address", "maskLen":
-			tags[subfield.Name] = decodeTag(subfield)
-		}
-		if value := decode(subfield); value != nil {
-			grouper.Add(measurement, tags, timestamp, subfield.Name, value)
-		}
-		if subfield.Name != "nextHop" {
-			continue
-		}
-		// For next hop table fill the keys in the tag - which is address and vrfname
-		for _, subf := range subfield.Fields {
-			for _, ff := range subf.Fields {
-				switch ff.Name {
-				case "address", "vrfName":
-					key := "nextHop/" + ff.Name
-					tags[key] = decodeTag(ff)
-				}
-				if value := decode(ff); value != nil {
-					name := "nextHop/" + ff.Name
-					grouper.Add(measurement, tags, timestamp, name, value)
-				}
+				s.grouper.Add(s.path, tags, timestamp, subf.Name, value)
 			}
 		}
 	}

--- a/plugins/inputs/cisco_telemetry_mdt/parser.go
+++ b/plugins/inputs/cisco_telemetry_mdt/parser.go
@@ -388,7 +388,7 @@ func (s *state) parseRib(field *telemetry.TelemetryField, tags map[string]string
 			tags[subfield.Name] = decodeTag(subfield)
 		}
 		if value := decode(subfield); value != nil {
-			s.grouper.Add(s.measurement, tags, timestamp, subfield.Name, value)
+			s.grouper.Add(s.path, tags, timestamp, subfield.Name, value)
 		}
 		if subfield.Name != "nextHop" {
 			continue
@@ -403,7 +403,7 @@ func (s *state) parseRib(field *telemetry.TelemetryField, tags map[string]string
 				}
 				if value := decode(ff); value != nil {
 					name := "nextHop/" + ff.Name
-					s.grouper.Add(s.measurement, tags, timestamp, name, value)
+					s.grouper.Add(s.path, tags, timestamp, name, value)
 				}
 			}
 		}

--- a/plugins/inputs/cisco_telemetry_mdt/parser.go
+++ b/plugins/inputs/cisco_telemetry_mdt/parser.go
@@ -111,13 +111,13 @@ func newParser(includeDelete bool, aliases, dmes map[string]string, embeddedTags
 }
 
 func (p *parser) parse(
-	acc telegraf.Accumulator,
+	grouper *metric.SeriesGrouper,
 	content *telemetry.TelemetryField,
 	encodingPath string,
 	isDeleted bool,
 	tags map[string]string,
 	timestamp time.Time,
-) {
+) []error {
 	// Do alias lookup, to shorten measurement names
 	measurement := encodingPath
 	if alias, ok := p.aliases[encodingPath]; ok {
@@ -136,9 +136,6 @@ func (p *parser) parse(
 	isNXOS := !strings.ContainsRune(encodingPath, ':')
 	isEvent := isNXOS && strings.Contains(encodingPath, "EVENT-LIST")
 
-	// Create a grouper to accumulate the fields for a series
-	grouper := metric.NewSeriesGrouper()
-
 	// Initialize the parsing state
 	state := &state{
 		path:        encodingPath,
@@ -153,6 +150,7 @@ func (p *parser) parse(
 	}
 
 	// Parse the content if any
+	var errs []error
 	if content != nil {
 		for _, subfield := range content.Fields {
 			var prefix string
@@ -167,23 +165,17 @@ func (p *parser) parse(
 				}
 			}
 			// Parse the content with and without prefix
-			errs := state.parseField(subfield, prefix, tags, timestamp)
-			for _, err := range errs {
-				acc.AddError(err)
-			}
-			errs = state.parseField(subfield, "", tags, timestamp)
-			for _, err := range errs {
-				acc.AddError(err)
-			}
+			errs = append(errs, state.parseField(subfield, prefix, tags, timestamp)...)
+			errs = append(errs, state.parseField(subfield, "", tags, timestamp)...)
 		}
 	}
+
+	// Add a delete field if configured
 	if p.includeDelete {
 		grouper.Add(measurement, tags, timestamp, "delete", isDeleted)
 	}
 
-	for _, groupedMetric := range grouper.Metrics() {
-		acc.AddMetric(groupedMetric)
-	}
+	return errs
 }
 
 // Recursively parse the "keys" element and convert to tags

--- a/plugins/inputs/cisco_telemetry_mdt/parser.go
+++ b/plugins/inputs/cisco_telemetry_mdt/parser.go
@@ -3,7 +3,6 @@ package cisco_telemetry_mdt
 import (
 	"encoding/json"
 	"errors"
-	"maps"
 	"path"
 	"strconv"
 	"strings"
@@ -188,30 +187,28 @@ func (p *parser) parse(
 }
 
 // Recursively parse the "keys" element and convert to tags
-func parseKeys(field *telemetry.TelemetryField, prefix string) map[string]string {
-	tags := make(map[string]string)
-
-	localname := strings.ReplaceAll(field.Name, "-", "_")
-	name := localname
-	if len(localname) == 0 {
-		name = prefix
-	} else if len(prefix) > 0 {
-		name = prefix + "/" + localname
+func parseKeys(field *telemetry.TelemetryField, prefix string, tags map[string]string) {
+	name := strings.ReplaceAll(field.Name, "-", "_")
+	fullName := prefix
+	if fullName != "" {
+		fullName += "/"
 	}
+	fullName += name
 
-	if tag := decodeTag(field); len(name) > 0 && len(tag) > 0 {
-		if _, exists := tags[localname]; !exists { // Use short keys whenever possible
-			tags[localname] = tag
+	// Store the tag with the short-key if possible, otherwise use the full
+	// tag-key containing the element path
+	if value := decodeTag(field); name != "" && value != "" {
+		if _, exists := tags[name]; !exists {
+			tags[name] = value
 		} else {
-			tags[name] = tag
+			tags[fullName] = value
 		}
 	}
 
+	// Iterate over potential sub-elements
 	for _, subfield := range field.Fields {
-		maps.Copy(tags, parseKeys(subfield, name))
+		parseKeys(subfield, fullName, tags)
 	}
-
-	return tags
 }
 
 func (s *state) parseField(field *telemetry.TelemetryField, prefix string, tags map[string]string, timestamp time.Time) []error {

--- a/plugins/inputs/cisco_telemetry_mdt/testcases/duplicate_nested_keys/expected.out
+++ b/plugins/inputs/cisco_telemetry_mdt/testcases/duplicate_nested_keys/expected.out
@@ -1,0 +1,2 @@
+alias,name=foo,entity=server,machine/name=foo.example.com,location=Offenbach,path=type:model/some/path,source=hostname,subscription=subscription bool=true 1543236572000000000
+alias,name=bar,entity=mainframe,machine/name=bar.example.com,location=Offenbach,path=type:model/some/path,source=hostname,subscription=subscription bool=false 1543236572000000000

--- a/plugins/inputs/cisco_telemetry_mdt/testcases/duplicate_nested_keys/packet.json
+++ b/plugins/inputs/cisco_telemetry_mdt/testcases/duplicate_nested_keys/packet.json
@@ -1,0 +1,86 @@
+{
+    "nodeIdStr": "hostname",
+    "subscriptionIdStr": "subscription",
+    "encodingPath": "type:model/some/path",
+    "msgTimestamp": "1543236572000",
+    "dataGpbkv": [
+        {
+            "fields": [
+                {
+                    "name": "keys",
+                    "fields": [
+                        {
+                            "name": "name",
+                            "stringValue": "foo"
+                        },
+                        {
+                            "name": "entity",
+                            "stringValue": "server"
+                        },
+                        {
+                            "name": "machine",
+                            "fields": [
+                                {
+                                    "name": "name",
+                                    "stringValue": "foo.example.com"
+                                }
+                            ]
+                        },
+                        {
+                            "name": "location",
+                            "stringValue": "Offenbach"
+                        }
+                    ]
+                },
+                {
+                    "name": "content",
+                    "fields": [
+                        {
+                            "name": "bool",
+                            "boolValue": true
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "fields": [
+                {
+                    "name": "keys",
+                    "fields": [
+                        {
+                            "name": "name",
+                            "stringValue": "bar"
+                        },
+                        {
+                            "name": "entity",
+                            "stringValue": "mainframe"
+                        },
+                        {
+                            "name": "machine",
+                            "fields": [
+                                {
+                                    "name": "name",
+                                    "stringValue": "bar.example.com"
+                                }
+                            ]
+                        },
+                        {
+                            "name": "location",
+                            "stringValue": "Offenbach"
+                        }
+                    ]
+                },
+                {
+                    "name": "content",
+                    "fields": [
+                        {
+                            "name": "bool",
+                            "boolValue": false
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/plugins/inputs/cisco_telemetry_mdt/testcases/duplicate_nested_keys/telegraf.conf
+++ b/plugins/inputs/cisco_telemetry_mdt/testcases/duplicate_nested_keys/telegraf.conf
@@ -1,0 +1,6 @@
+ [[inputs.cisco_telemetry_mdt]]
+  transport = "tcp"
+  service_address = ":0"
+  [inputs.cisco_telemetry_mdt.aliases]
+    alias = "type:model/some/path"
+

--- a/plugins/inputs/cisco_telemetry_mdt/utils.go
+++ b/plugins/inputs/cisco_telemetry_mdt/utils.go
@@ -2,7 +2,6 @@ package cisco_telemetry_mdt
 
 import (
 	"strconv"
-	"strings"
 
 	telemetry "github.com/cisco-ie/nx-telemetry-proto/telemetry_bis"
 
@@ -111,26 +110,20 @@ func nxosValueXformUint64ToString(field *telemetry.TelemetryField) interface{} {
 }
 
 // Xform value field.
-func (c *CiscoTelemetryMDT) nxosValueXform(field *telemetry.TelemetryField, path string) interface{} {
-	if strings.ContainsRune(path, ':') {
-		// not NXOS
-		return nil
-	}
-
+func nxosValueXform(field *telemetry.TelemetryField, propMap map[string]func(*telemetry.TelemetryField) interface{}, prop map[string]string) interface{} {
 	value := decode(field)
 	if value == nil {
 		return nil
 	}
 
-	if _, ok := c.propMap[field.Name]; ok {
-		return c.propMap[field.Name](field)
+	if _, ok := propMap[field.Name]; ok {
+		return propMap[field.Name](field)
 	}
 	// check if we want auto xformation
-	if _, ok := c.propMap["auto-prop-xfromi"]; ok {
-		return c.propMap["auto-prop-xfrom"](field)
+	if _, ok := propMap["auto-prop-xfromi"]; ok {
+		return propMap["auto-prop-xfrom"](field)
 	}
 	// Now check path based conversion; if a mapping exists apply the transformation
-	prop := c.nxpathMap[path]
 	if prop == nil {
 		return nil
 	}


### PR DESCRIPTION
## Summary

This PR restructures parsing by abstracting parsing related data into two classes, one being constant for the parser's lifetime and one for representing the parsing state for a given message.
While doing this, the PR cleans the parsing functions to make the code more readable.

More to come...

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

related to #10087 
