### PR TITLE
chore: Make secret setting an optional secret-store interface

### DIFF
--- a/cmd/telegraf/cmd_secretstore.go
+++ b/cmd/telegraf/cmd_secretstore.go
@@ -11,6 +11,8 @@ import (
 	"github.com/awnumar/memguard"
 	"github.com/urfave/cli/v2"
 	"golang.org/x/term"
+
+	"github.com/influxdata/telegraf"
 )
 
 func processFilterOnlySecretStoreFlags(ctx *cli.Context) Filters {
@@ -234,6 +236,16 @@ you will be prompted to enter the value of the secret.
 						storeID := args.First()
 						key := args.Get(1)
 						value := args.Get(2)
+
+						store, err := m.GetSecretStore(storeID)
+						if err != nil {
+							return fmt.Errorf("unable to get secret store: %w", err)
+						}
+						editor, ok := store.(telegraf.SecretStoreEditor)
+						if !ok {
+							return fmt.Errorf("secret store %q does not support setting secrets", storeID)
+						}
+
 						if value == "" {
 							fmt.Printf("Enter secret value: ")
 							b, err := term.ReadPassword(int(os.Stdin.Fd()))
@@ -244,11 +256,7 @@ you will be prompted to enter the value of the secret.
 							value = string(b)
 						}
 
-						store, err := m.GetSecretStore(storeID)
-						if err != nil {
-							return fmt.Errorf("unable to get secret store: %w", err)
-						}
-						if err := store.Set(key, value); err != nil {
+						if err := editor.Set(key, value); err != nil {
 							return fmt.Errorf("unable to set secret: %w", err)
 						}
 

--- a/cmd/telegraf/main_test.go
+++ b/cmd/telegraf/main_test.go
@@ -66,6 +66,9 @@ func (*MockTelegraf) ListSecretStores() ([]string, error) {
 }
 
 func (*MockTelegraf) GetSecretStore(id string) (telegraf.SecretStore, error) {
+	if id == "readonly" {
+		return &MockReadOnlySecretStore{}, nil
+	}
 	v, found := secrets[id]
 	if !found {
 		return nil, errors.New("unknown secret store")
@@ -110,6 +113,44 @@ func (s *MockSecretStore) List() ([]string, error) {
 }
 
 func (s *MockSecretStore) GetResolver(key string) (telegraf.ResolveFunc, error) {
+	return func() ([]byte, bool, error) {
+		v, err := s.Get(key)
+		return v, false, err
+	}, nil
+}
+
+// MockReadOnlySecretStore only implements the mandatory telegraf.SecretStore
+// interface, not the optional telegraf.SecretStoreEditor, so it cannot set
+// secrets.
+type MockReadOnlySecretStore struct {
+	Secrets map[string][]byte
+}
+
+func (*MockReadOnlySecretStore) Init() error {
+	return nil
+}
+
+func (*MockReadOnlySecretStore) SampleConfig() string {
+	return "I'm just a dummy"
+}
+
+func (s *MockReadOnlySecretStore) Get(key string) ([]byte, error) {
+	v, found := s.Secrets[key]
+	if !found {
+		return nil, errors.New("not found")
+	}
+	return v, nil
+}
+
+func (s *MockReadOnlySecretStore) List() ([]string, error) {
+	keys := make([]string, 0, len(s.Secrets))
+	for k := range s.Secrets {
+		keys = append(keys, k)
+	}
+	return keys, nil
+}
+
+func (s *MockReadOnlySecretStore) GetResolver(key string) (telegraf.ResolveFunc, error) {
 	return func() ([]byte, bool, error) {
 		v, err := s.Get(key)
 		return v, false, err
@@ -281,6 +322,23 @@ func TestPluginDirectoryFlag(t *testing.T) {
 	args = append(args, "--plugin-directory", ".")
 	err := runApp(args, buf, NewMockServer(), NewMockConfig(buf), NewMockTelegraf())
 	require.ErrorContains(t, err, "go plugin support is not enabled")
+}
+
+func TestSecretsSet(t *testing.T) {
+	buf := new(bytes.Buffer)
+	args := os.Args[0:1]
+	args = append(args, "secrets", "set", "yoda", "episode4", "member")
+	err := runApp(args, buf, NewMockServer(), NewMockConfig(buf), NewMockTelegraf())
+	require.NoError(t, err)
+	require.Equal(t, []byte("member"), secrets["yoda"]["episode4"])
+}
+
+func TestSecretsSetUnsupported(t *testing.T) {
+	buf := new(bytes.Buffer)
+	args := os.Args[0:1]
+	args = append(args, "secrets", "set", "readonly", "key", "value")
+	err := runApp(args, buf, NewMockServer(), NewMockConfig(buf), NewMockTelegraf())
+	require.ErrorContains(t, err, `secret store "readonly" does not support setting secrets`)
 }
 
 func TestCommandConfig(t *testing.T) {

--- a/plugins/secretstores/docker/docker.go
+++ b/plugins/secretstores/docker/docker.go
@@ -70,10 +70,6 @@ func (d *Docker) List() ([]string, error) {
 	return secrets, nil
 }
 
-func (*Docker) Set(_, _ string) error {
-	return errors.New("secret store does not support creating secrets")
-}
-
 func (d *Docker) GetResolver(key string) (telegraf.ResolveFunc, error) {
 	resolver := func() ([]byte, bool, error) {
 		s, err := d.Get(key)

--- a/plugins/secretstores/docker/docker_test.go
+++ b/plugins/secretstores/docker/docker_test.go
@@ -25,25 +25,6 @@ func TestPathNonExistent(t *testing.T) {
 	require.ErrorContainsf(t, plugin.Init(), "accessing directory", "accessing directory %q failed: %v", plugin.Path, plugin.Init())
 }
 
-func TestSetNotAvailable(t *testing.T) {
-	testdir, err := filepath.Abs("testdata")
-	require.NoError(t, err, "testdata cannot be found")
-
-	plugin := &Docker{
-		ID:   "set_path_test",
-		Path: testdir,
-	}
-	require.NoError(t, plugin.Init())
-
-	// Try to Store the secrets, which this plugin should not let
-	secret := map[string]string{
-		"secret-file-1": "TryToSetThis",
-	}
-	for k, v := range secret {
-		require.ErrorContains(t, plugin.Set(k, v), "secret store does not support creating secrets")
-	}
-}
-
 func TestListGet(t *testing.T) {
 	// secret files name and their content to compare under the `testdata` directory
 	secrets := map[string]string{

--- a/plugins/secretstores/googlecloud/googlecloud.go
+++ b/plugins/secretstores/googlecloud/googlecloud.go
@@ -4,7 +4,6 @@ package googlecloud
 import (
 	"context"
 	_ "embed"
-	"errors"
 	"fmt"
 	"os"
 
@@ -87,11 +86,6 @@ func (g *GoogleCloud) Get(key string) ([]byte, error) {
 // List returns the list of secrets provided by this store.
 func (*GoogleCloud) List() ([]string, error) {
 	return []string{"token"}, nil
-}
-
-// Set is not supported for the gcloud secret store.
-func (*GoogleCloud) Set(_, _ string) error {
-	return errors.New("setting secrets is not supported")
 }
 
 // GetResolver returns a resolver function for the secret.

--- a/plugins/secretstores/http/http.go
+++ b/plugins/secretstores/http/http.go
@@ -105,10 +105,6 @@ func (h *HTTP) Get(key string) ([]byte, error) {
 	return []byte(v), nil
 }
 
-func (*HTTP) Set(_, _ string) error {
-	return errors.New("setting secrets not supported")
-}
-
 func (h *HTTP) List() ([]string, error) {
 	keys := make([]string, 0, len(h.cache))
 	for k := range h.cache {

--- a/plugins/secretstores/http/http_test.go
+++ b/plugins/secretstores/http/http_test.go
@@ -130,13 +130,6 @@ func TestInitErrors(t *testing.T) {
 	require.ErrorContains(t, plugin.Init(), "creating decryptor failed: unknown cipher")
 }
 
-func TestSetNotSupported(t *testing.T) {
-	plugin := &HTTP{}
-	require.NoError(t, plugin.Init())
-
-	require.ErrorContains(t, plugin.Set("key", "value"), "setting secrets not supported")
-}
-
 func TestGetErrors(t *testing.T) {
 	plugin := &HTTP{
 		decryptionConfig: decryptionConfig{

--- a/plugins/secretstores/jose/jose.go
+++ b/plugins/secretstores/jose/jose.go
@@ -81,6 +81,8 @@ func (j *Jose) Get(key string) ([]byte, error) {
 	return item.Data, nil
 }
 
+var _ telegraf.SecretStoreEditor = (*Jose)(nil)
+
 func (j *Jose) Set(key, value string) error {
 	item := keyring.Item{
 		Key:  key,

--- a/plugins/secretstores/oauth2/oauth2.go
+++ b/plugins/secretstores/oauth2/oauth2.go
@@ -167,10 +167,6 @@ func (o *OAuth2) Get(key string) ([]byte, error) {
 	return []byte(token.AccessToken), nil
 }
 
-func (*OAuth2) Set(_, _ string) error {
-	return errors.New("not supported")
-}
-
 func (o *OAuth2) List() ([]string, error) {
 	keys := make([]string, 0, len(o.sources))
 	for k := range o.sources {

--- a/plugins/secretstores/oauth2/oauth2_test.go
+++ b/plugins/secretstores/oauth2/oauth2_test.go
@@ -110,22 +110,6 @@ func TestInitFail(t *testing.T) {
 	}
 }
 
-func TestSetUnsupported(t *testing.T) {
-	plugin := &OAuth2{
-		Service:  "custom",
-		Endpoint: "http://localhost:8080",
-		TokenConfigs: []tokenConfig{
-			{
-				Key:          "test",
-				ClientID:     config.NewSecret([]byte("someone")),
-				ClientSecret: config.NewSecret([]byte("s3cr3t")),
-			},
-		},
-	}
-	require.NoError(t, plugin.Init())
-	require.ErrorContains(t, plugin.Set("foo", "bar"), "not supported")
-}
-
 func TestGetNonExisting(t *testing.T) {
 	plugin := &OAuth2{
 		Service:  "custom",

--- a/plugins/secretstores/os/os.go
+++ b/plugins/secretstores/os/os.go
@@ -67,6 +67,8 @@ func (o *OS) Get(key string) ([]byte, error) {
 	return item.Data, nil
 }
 
+var _ telegraf.SecretStoreEditor = (*OS)(nil)
+
 func (o *OS) Set(key, value string) error {
 	item := keyring.Item{
 		Key:  key,

--- a/plugins/secretstores/systemd/systemd.go
+++ b/plugins/secretstores/systemd/systemd.go
@@ -101,10 +101,6 @@ func (s *Systemd) List() ([]string, error) {
 	return secrets, nil
 }
 
-func (*Systemd) Set(_, _ string) error {
-	return errors.New("secret store does not support creating secrets")
-}
-
 func (s *Systemd) GetResolver(key string) (telegraf.ResolveFunc, error) {
 	resolver := func() ([]byte, bool, error) {
 		s, err := s.Get(key)

--- a/plugins/secretstores/systemd/systemd_test.go
+++ b/plugins/secretstores/systemd/systemd_test.go
@@ -76,17 +76,6 @@ func TestInit(t *testing.T) {
 	require.NoError(t, plugin.Init())
 }
 
-func TestSetNotAvailable(t *testing.T) {
-	getSystemdVersion = getSystemdVersionMin
-	t.Setenv("CREDENTIALS_DIRECTORY", "testdata")
-
-	plugin := &Systemd{Log: testutil.Logger{}}
-	require.NoError(t, plugin.Init())
-
-	// Try to Store the secrets, which this plugin should not let
-	require.ErrorContains(t, plugin.Set("foo", "bar"), "secret store does not support creating secrets")
-}
-
 func TestListGet(t *testing.T) {
 	getSystemdVersion = getSystemdVersionMin
 	t.Setenv("CREDENTIALS_DIRECTORY", "testdata")

--- a/plugins/secretstores/vault/vault.go
+++ b/plugins/secretstores/vault/vault.go
@@ -118,6 +118,8 @@ func (v *Vault) List() ([]string, error) {
 	return slices.Collect(maps.Keys(secret.Data)), nil
 }
 
+var _ telegraf.SecretStoreEditor = (*Vault)(nil)
+
 func (v *Vault) Set(key, value string) error {
 	// Vault's Put replaces the whole secret at the path instead of merging into
 	// it, so read the existing secrets first and set the key on top of them to

--- a/secretstore.go
+++ b/secretstore.go
@@ -8,14 +8,18 @@ type SecretStore interface {
 	// Get searches for the given key and return the secret
 	Get(key string) ([]byte, error)
 
-	// Set sets the given secret for the given key
-	Set(key, value string) error
-
 	// List lists all known secret keys
 	List() ([]string, error)
 
 	// GetResolver returns a function to resolve the given key.
 	GetResolver(key string) (ResolveFunc, error)
+}
+
+// SecretStoreEditor is an optional interface for secret stores that can create
+// or modify secrets. Stores backed by a read-only source do not implement it.
+type SecretStoreEditor interface {
+	// Set creates or modifies the secret for the given key
+	Set(key, value string) error
 }
 
 // ResolveFunc is a function to resolve the secret.


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
The `telegraf.SecretStore` interface required every store to implement `Set`, but only three of the eight stores (`os`, `jose`, `vault`) can actually write a secret. The other five (`docker`, `systemd`, `oauth2`, `http`, `googlecloud`) each implemented `Set` only to return a hand-rolled "not supported" error, so the interface advertised a capability most stores did not have and the failure only showed up when a user ran `telegraf secrets set` against one of them.

This moves `Set` out of the mandatory interface into a new optional `telegraf.SecretStoreEditor` interface. The three stores that can write secrets implement it and the other five drop their stub `Set` methods entirely. The `secrets set` command now type-asserts the store against the optional interface and, when it is not implemented, fails with a single framework-level message ("secret store <id> does not support setting secrets") instead of a per-plugin error. The support check runs before the interactive value prompt, so a read-only store is rejected before the user is asked to type a secret. Compile-time interface assertions on the three writable stores turn a future `Set` signature change into a build error rather than a silent runtime downgrade.

This is the setting half of the groundwork for optional secret manipulation. Adding `Remove` to the same optional interface and the `secrets remove` command follows in a separate PR.


## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

partially resolves #19294
related to #19246