### PR TITLE
test(inputs.knx_listener): Fix race condition while waiting for error

### DIFF
--- a/plugins/inputs/knx_listener/knx_listener_test.go
+++ b/plugins/inputs/knx_listener/knx_listener_test.go
@@ -257,10 +257,12 @@ func TestReconnect(t *testing.T) {
 	require.Eventually(t, func() bool {
 		return !listener.connected.Load()
 	}, 3*time.Second, 100*time.Millisecond, "no disconnect")
-	acc.Lock()
-	err := acc.FirstError()
-	acc.Unlock()
-	require.ErrorContains(t, err, "disconnected from bus")
+	require.Eventually(t, func() bool {
+		acc.Lock()
+		defer acc.Unlock()
+		return acc.FirstError() != nil
+	}, 3*time.Second, 100*time.Millisecond, "no error message")
+	require.ErrorContains(t, acc.FirstError(), "disconnected from bus")
 
 	require.NoError(t, listener.Gather(&acc))
 	require.Eventually(t, func() bool {


### PR DESCRIPTION
## Summary
This PR fixes the flaky test leading to 

```
2026/07/22 14:16:57 I! [knx_listener] Ignoring message {Command:Write Source:0.0.0 Destination:1/1/2 Data:[0]} for unknown GA "1/1/2"
    knx_listener_test.go:263: 
                Error Trace:    C:/Users/circleci/project/plugins/inputs/knx_listener/knx_listener_test.go:263
                Error:          An error is expected but got nil.
                Test:           TestReconnect
panic: close of closed channel [recovered, repanicked]

goroutine 23 [running]:
testing.tRunner.func1.2({0x7ff7862a7140, 0x7ff78633def0})
        C:/Program Files/Go/src/testing/testing.go:1974 +0x239
testing.tRunner.func1()
        C:/Program Files/Go/src/testing/testing.go:1977 +0x349
panic({0x7ff7862a7140?, 0x7ff78633def0?})
        C:/Program Files/Go/src/runtime/panic.go:860 +0x13a
github.com/influxdata/telegraf/plugins/inputs/knx_listener.(*knxDummyInterface).Close(0x17bf17b33bc8?)
        C:/Users/circleci/project/plugins/inputs/knx_listener/knx_dummy_interface.go:30 +0x16
github.com/influxdata/telegraf/plugins/inputs/knx_listener.(*KNXListener).Stop(0x17bf17c3b480)
        C:/Users/circleci/project/plugins/inputs/knx_listener/knx_listener.go:144 +0x26
runtime.Goexit()
        C:/Program Files/Go/src/runtime/panic.go:694 +0x5e
testing.(*common).FailNow(0x17bf17c97000)
        C:/Program Files/Go/src/testing/testing.go:1022 +0x4a
github.com/stretchr/testify/require.ErrorContains({0x7ff786340e68, 0x17bf17c97000}, {0x0, 0x0}, {0x7ff786322ccf, 0x15}, {0x0, 0x0, 0x0})
        C:/Users/circleci/go/pkg/mod/github.com/stretchr/testify@v1.11.1/require/require.go:348 +0xff
github.com/influxdata/telegraf/plugins/inputs/knx_listener.TestReconnect(0x17bf17c97000)
        C:/Users/circleci/project/plugins/inputs/knx_listener/knx_listener_test.go:263 +0x750
testing.tRunner(0x17bf17c97000, 0x7ff78633add0)
        C:/Program Files/Go/src/testing/testing.go:2036 +0xc3
created by testing.(*T).Run in goroutine 1
        C:/Program Files/Go/src/testing/testing.go:2101 +0x4a9

DONE 8679 tests, 415 skipped, 1 failure in 1022.388s
```

when the plugin`s listener go-routine reports a disconnect in the flag but the error message is not yet recorded in the accumulator.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
