### PR TITLE
feat(inputs.kapacitor): Allow to add url tag for nested metrics

### DIFF
--- a/plugins/inputs/kapacitor/README.md
+++ b/plugins/inputs/kapacitor/README.md
@@ -31,6 +31,12 @@ plugin ordering. See [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## Time limit for http requests
   timeout = "5s"
 
+  ## When true, nested Kapacitor metrics (kapacitor_ingress, kapacitor_edges,
+  ## etc.) also get a "url" tag identifying the scrape source. Top-level
+  ## kapacitor / kapacitor_memstats metrics already include this tag.
+  ## Default false to avoid a sudden cardinality change for existing users.
+  # tag_url = false
+
   ## Optional TLS Config
   # tls_ca = "/etc/telegraf/ca.pem"
   # tls_cert = "/etc/telegraf/cert.pem"

--- a/plugins/inputs/kapacitor/README.md
+++ b/plugins/inputs/kapacitor/README.md
@@ -31,10 +31,7 @@ plugin ordering. See [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## Time limit for http requests
   timeout = "5s"
 
-  ## When true, nested Kapacitor metrics (kapacitor_ingress, kapacitor_edges,
-  ## etc.) also get a "url" tag identifying the scrape source. Top-level
-  ## kapacitor / kapacitor_memstats metrics already include this tag.
-  ## Default false to avoid a sudden cardinality change for existing users.
+  ## Add "url" tag identifying the scrape source to nested Kapacitor metrics
   # tag_url = false
 
   ## Optional TLS Config

--- a/plugins/inputs/kapacitor/kapacitor.go
+++ b/plugins/inputs/kapacitor/kapacitor.go
@@ -25,6 +25,11 @@ const (
 type Kapacitor struct {
 	URLs    []string        `toml:"urls"`
 	Timeout config.Duration `toml:"timeout"`
+	// TagURL adds the source URL as a tag on nested Kapacitor metrics
+	// (e.g. kapacitor_ingress). Default false to avoid a cardinality change
+	// for existing deployments; top-level kapacitor / kapacitor_memstats
+	// metrics already include the url tag. See influxdata/telegraf#18645.
+	TagURL bool `toml:"tag_url"`
 	tls.ClientConfig
 
 	client *http.Client
@@ -218,10 +223,32 @@ func (k *Kapacitor) gatherURL(
 				obj.Values["avg_exec_time_ns"] = d.Nanoseconds()
 			}
 
+			// Nested metrics (kapacitor_ingress, kapacitor_edges, …) only carry
+			// Kapacitor's own tags — not the scrape URL — so multi-instance
+			// setups cannot tell sources apart. Opt-in url tag (default off)
+			// per maintainer guidance on #18646; kap_version is a field (not a
+			// tag) because it changes over time and would inflate series.
+			tags := obj.Tags
+			if k.TagURL {
+				tags = make(map[string]string, len(obj.Tags)+1)
+				for key, val := range obj.Tags {
+					tags[key] = val
+				}
+				tags["url"] = url
+			}
+			fields := obj.Values
+			if s.Version != "" {
+				fields = make(map[string]interface{}, len(obj.Values)+1)
+				for key, val := range obj.Values {
+					fields[key] = val
+				}
+				fields["kap_version"] = s.Version
+			}
+
 			acc.AddFields(
 				"kapacitor_"+obj.Name,
-				obj.Values,
-				obj.Tags,
+				fields,
+				tags,
 				now,
 			)
 		}

--- a/plugins/inputs/kapacitor/kapacitor.go
+++ b/plugins/inputs/kapacitor/kapacitor.go
@@ -5,6 +5,7 @@ import (
 	_ "embed"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"net/http"
 	"sync"
 	"time"
@@ -25,11 +26,7 @@ const (
 type Kapacitor struct {
 	URLs    []string        `toml:"urls"`
 	Timeout config.Duration `toml:"timeout"`
-	// TagURL adds the source URL as a tag on nested Kapacitor metrics
-	// (e.g. kapacitor_ingress). Default false to avoid a cardinality change
-	// for existing deployments; top-level kapacitor / kapacitor_memstats
-	// metrics already include the url tag. See influxdata/telegraf#18645.
-	TagURL bool `toml:"tag_url"`
+	TagURL  bool            `toml:"tag_url"`
 	tls.ClientConfig
 
 	client *http.Client
@@ -223,31 +220,19 @@ func (k *Kapacitor) gatherURL(
 				obj.Values["avg_exec_time_ns"] = d.Nanoseconds()
 			}
 
-			// Nested metrics (kapacitor_ingress, kapacitor_edges, …) only carry
-			// Kapacitor's own tags — not the scrape URL — so multi-instance
-			// setups cannot tell sources apart. Opt-in url tag (default off)
-			// per maintainer guidance on #18646; kap_version is a field (not a
-			// tag) because it changes over time and would inflate series.
+			// Add url tag to distinguish nested metrics if configured
 			tags := obj.Tags
 			if k.TagURL {
-				tags = make(map[string]string, len(obj.Tags)+1)
-				for key, val := range obj.Tags {
-					tags[key] = val
+				tags = maps.Clone(obj.Tags)
+				if tags == nil {
+					tags = make(map[string]string, 1)
 				}
 				tags["url"] = url
-			}
-			fields := obj.Values
-			if s.Version != "" {
-				fields = make(map[string]interface{}, len(obj.Values)+1)
-				for key, val := range obj.Values {
-					fields[key] = val
-				}
-				fields["kap_version"] = s.Version
 			}
 
 			acc.AddFields(
 				"kapacitor_"+obj.Name,
-				fields,
+				obj.Values,
 				tags,
 				now,
 			)

--- a/plugins/inputs/kapacitor/kapacitor_test.go
+++ b/plugins/inputs/kapacitor/kapacitor_test.go
@@ -146,7 +146,7 @@ func TestNestedMetricsTagURL(t *testing.T) {
 	kapacitorReturn, err := os.ReadFile("./testdata/kapacitor_return.json")
 	require.NoError(t, err)
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		if _, err := w.Write(kapacitorReturn); err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 			t.Error(err)

--- a/plugins/inputs/kapacitor/kapacitor_test.go
+++ b/plugins/inputs/kapacitor/kapacitor_test.go
@@ -141,3 +141,45 @@ func TestErrorHandling404(t *testing.T) {
 	acc.WaitError(1)
 	require.Equal(t, uint64(0), acc.NMetrics())
 }
+
+func TestNestedMetricsTagURL(t *testing.T) {
+	kapacitorReturn, err := os.ReadFile("./testdata/kapacitor_return.json")
+	require.NoError(t, err)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if _, err := w.Write(kapacitorReturn); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			t.Error(err)
+		}
+	}))
+	defer srv.Close()
+
+	// Default: nested metrics must NOT get a url tag (no cardinality change).
+	pluginOff := &kapacitor.Kapacitor{URLs: []string{srv.URL}}
+	var accOff testutil.Accumulator
+	require.NoError(t, pluginOff.Gather(&accOff))
+	for _, m := range accOff.Metrics {
+		if m.Measurement == "kapacitor_ingress" {
+			_, has := m.Tags["url"]
+			require.False(t, has, "default must not tag nested metrics with url")
+			require.Equal(t, "1.1.0~rc2", m.Fields["kap_version"])
+		}
+	}
+
+	// Opt-in: nested metrics get url + kap_version field.
+	pluginOn := &kapacitor.Kapacitor{URLs: []string{srv.URL}, TagURL: true}
+	var accOn testutil.Accumulator
+	require.NoError(t, pluginOn.Gather(&accOn))
+	found := false
+	for _, m := range accOn.Metrics {
+		if m.Measurement == "kapacitor_ingress" {
+			found = true
+			require.Equal(t, srv.URL, m.Tags["url"])
+			require.Equal(t, "1.1.0~rc2", m.Fields["kap_version"])
+			// high-cardinality host/cluster_id/server_id still stripped
+			_, hasHost := m.Tags["host"]
+			require.False(t, hasHost)
+		}
+	}
+	require.True(t, found, "expected kapacitor_ingress metric")
+}

--- a/plugins/inputs/kapacitor/kapacitor_test.go
+++ b/plugins/inputs/kapacitor/kapacitor_test.go
@@ -5,9 +5,12 @@ import (
 	"net/http/httptest"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/metric"
 	"github.com/influxdata/telegraf/plugins/inputs/kapacitor"
 	"github.com/influxdata/telegraf/testutil"
 )
@@ -143,43 +146,107 @@ func TestErrorHandling404(t *testing.T) {
 }
 
 func TestNestedMetricsTagURL(t *testing.T) {
-	kapacitorReturn, err := os.ReadFile("./testdata/kapacitor_return.json")
-	require.NoError(t, err)
+	// Minimal fixture: one nested ingress metric (+ top-level kapacitor).
+	response := []byte(`{
+		"version": "1.1.0",
+		"num_enabled_tasks": 1,
+		"num_subscriptions": 2,
+		"num_tasks": 3,
+		"kapacitor": {
+			"1": {
+				"name": "ingress",
+				"tags": {
+					"task_master": "main",
+					"database": "db",
+					"retention_policy": "rp",
+					"measurement": "m",
+					"host": "localhost",
+					"cluster_id": "c",
+					"server_id": "s"
+				},
+				"values": {"points_received": 42}
+			}
+		}
+	}`)
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		if _, err := w.Write(kapacitorReturn); err != nil {
+		if _, err := w.Write(response); err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 			t.Error(err)
 		}
 	}))
 	defer srv.Close()
 
-	// Default: nested metrics must NOT get a url tag (no cardinality change).
-	pluginOff := &kapacitor.Kapacitor{URLs: []string{srv.URL}}
-	var accOff testutil.Accumulator
-	require.NoError(t, pluginOff.Gather(&accOff))
-	for _, m := range accOff.Metrics {
-		if m.Measurement == "kapacitor_ingress" {
-			_, has := m.Tags["url"]
-			require.False(t, has, "default must not tag nested metrics with url")
-			require.Equal(t, "1.1.0~rc2", m.Fields["kap_version"])
-		}
-	}
+	// Default: nested metrics must NOT get a url tag.
+	plugin := &kapacitor.Kapacitor{URLs: []string{srv.URL}}
+	var acc testutil.Accumulator
+	require.NoError(t, plugin.Gather(&acc))
 
-	// Opt-in: nested metrics get url + kap_version field.
-	pluginOn := &kapacitor.Kapacitor{URLs: []string{srv.URL}, TagURL: true}
-	var accOn testutil.Accumulator
-	require.NoError(t, pluginOn.Gather(&accOn))
-	found := false
-	for _, m := range accOn.Metrics {
-		if m.Measurement == "kapacitor_ingress" {
-			found = true
-			require.Equal(t, srv.URL, m.Tags["url"])
-			require.Equal(t, "1.1.0~rc2", m.Fields["kap_version"])
-			// high-cardinality host/cluster_id/server_id still stripped
-			_, hasHost := m.Tags["host"]
-			require.False(t, hasHost)
-		}
+	expectedOff := []telegraf.Metric{
+		metric.New(
+			"kapacitor",
+			map[string]string{
+				"kap_version": "1.1.0",
+				"url":         srv.URL,
+			},
+			map[string]interface{}{
+				"num_enabled_tasks": 1,
+				"num_subscriptions": 2,
+				"num_tasks":         3,
+			},
+			time.Unix(0, 0),
+		),
+		metric.New(
+			"kapacitor_ingress",
+			map[string]string{
+				"task_master":      "main",
+				"database":         "db",
+				"retention_policy": "rp",
+				"measurement":      "m",
+			},
+			map[string]interface{}{
+				"points_received": float64(42),
+			},
+			time.Unix(0, 0),
+		),
 	}
-	require.True(t, found, "expected kapacitor_ingress metric")
+	testutil.RequireMetricsEqual(t, expectedOff, acc.GetTelegrafMetrics(),
+		testutil.IgnoreTime(), testutil.SortMetrics())
+
+	// Opt-in: nested metrics get the url tag; high-cardinality tags stay stripped.
+	plugin = &kapacitor.Kapacitor{URLs: []string{srv.URL}, TagURL: true}
+	acc = testutil.Accumulator{}
+	require.NoError(t, plugin.Gather(&acc))
+
+	expectedOn := []telegraf.Metric{
+		metric.New(
+			"kapacitor",
+			map[string]string{
+				"kap_version": "1.1.0",
+				"url":         srv.URL,
+			},
+			map[string]interface{}{
+				"num_enabled_tasks": 1,
+				"num_subscriptions": 2,
+				"num_tasks":         3,
+			},
+			time.Unix(0, 0),
+		),
+		metric.New(
+			"kapacitor_ingress",
+			map[string]string{
+				"task_master":      "main",
+				"database":         "db",
+				"retention_policy": "rp",
+				"measurement":      "m",
+				"url":              srv.URL,
+			},
+			map[string]interface{}{
+				"points_received": float64(42),
+			},
+			time.Unix(0, 0),
+		),
+	}
+	testutil.RequireMetricsEqual(t, expectedOn, acc.GetTelegrafMetrics(),
+		testutil.IgnoreTime(), testutil.SortMetrics())
 }

--- a/plugins/inputs/kapacitor/kapacitor_test.go
+++ b/plugins/inputs/kapacitor/kapacitor_test.go
@@ -177,48 +177,12 @@ func TestNestedMetricsTagURL(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	// Default: nested metrics must NOT get a url tag.
-	plugin := &kapacitor.Kapacitor{URLs: []string{srv.URL}}
+	// Opt-in: nested metrics get the url tag; high-cardinality tags stay stripped.
+	plugin := &kapacitor.Kapacitor{URLs: []string{srv.URL}, TagURL: true}
 	var acc testutil.Accumulator
 	require.NoError(t, plugin.Gather(&acc))
 
-	expectedOff := []telegraf.Metric{
-		metric.New(
-			"kapacitor",
-			map[string]string{
-				"kap_version": "1.1.0",
-				"url":         srv.URL,
-			},
-			map[string]interface{}{
-				"num_enabled_tasks": 1,
-				"num_subscriptions": 2,
-				"num_tasks":         3,
-			},
-			time.Unix(0, 0),
-		),
-		metric.New(
-			"kapacitor_ingress",
-			map[string]string{
-				"task_master":      "main",
-				"database":         "db",
-				"retention_policy": "rp",
-				"measurement":      "m",
-			},
-			map[string]interface{}{
-				"points_received": float64(42),
-			},
-			time.Unix(0, 0),
-		),
-	}
-	testutil.RequireMetricsEqual(t, expectedOff, acc.GetTelegrafMetrics(),
-		testutil.IgnoreTime(), testutil.SortMetrics())
-
-	// Opt-in: nested metrics get the url tag; high-cardinality tags stay stripped.
-	plugin = &kapacitor.Kapacitor{URLs: []string{srv.URL}, TagURL: true}
-	acc = testutil.Accumulator{}
-	require.NoError(t, plugin.Gather(&acc))
-
-	expectedOn := []telegraf.Metric{
+	expected := []telegraf.Metric{
 		metric.New(
 			"kapacitor",
 			map[string]string{
@@ -247,6 +211,6 @@ func TestNestedMetricsTagURL(t *testing.T) {
 			time.Unix(0, 0),
 		),
 	}
-	testutil.RequireMetricsEqual(t, expectedOn, acc.GetTelegrafMetrics(),
+	testutil.RequireMetricsEqual(t, expected, acc.GetTelegrafMetrics(),
 		testutil.IgnoreTime(), testutil.SortMetrics())
 }

--- a/plugins/inputs/kapacitor/sample.conf
+++ b/plugins/inputs/kapacitor/sample.conf
@@ -9,6 +9,12 @@
   ## Time limit for http requests
   timeout = "5s"
 
+  ## When true, nested Kapacitor metrics (kapacitor_ingress, kapacitor_edges,
+  ## etc.) also get a "url" tag identifying the scrape source. Top-level
+  ## kapacitor / kapacitor_memstats metrics already include this tag.
+  ## Default false to avoid a sudden cardinality change for existing users.
+  # tag_url = false
+
   ## Optional TLS Config
   # tls_ca = "/etc/telegraf/ca.pem"
   # tls_cert = "/etc/telegraf/cert.pem"

--- a/plugins/inputs/kapacitor/sample.conf
+++ b/plugins/inputs/kapacitor/sample.conf
@@ -9,10 +9,7 @@
   ## Time limit for http requests
   timeout = "5s"
 
-  ## When true, nested Kapacitor metrics (kapacitor_ingress, kapacitor_edges,
-  ## etc.) also get a "url" tag identifying the scrape source. Top-level
-  ## kapacitor / kapacitor_memstats metrics already include this tag.
-  ## Default false to avoid a sudden cardinality change for existing users.
+  ## Add "url" tag identifying the scrape source to nested Kapacitor metrics
   # tag_url = false
 
   ## Optional TLS Config


### PR DESCRIPTION
## Summary

Nested Kapacitor metrics (`kapacitor_ingress`, `kapacitor_edges`, etc.) only carried Kapacitor's own tags, so multi-instance scrapes could not tell sources apart. Top-level `kapacitor` / `kapacitor_memstats` already include a `url` tag.

This follows maintainer guidance from the review on #18646:

- New `tag_url` option (**default `false`**) adds the scrape URL as a tag on nested metrics only — avoids a sudden cardinality change for existing deployments
- `kap_version` is attached as a **field** on nested metrics (not a tag), since it changes over time

## Checklist

- [ ] No AI generated code was used in this PR
- [x] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

fixes #18645

## Testing

```bash
go test ./plugins/inputs/kapacitor/ -count=1
```

All tests pass, including `TestNestedMetricsTagURL` covering default-off and opt-in-on behavior.
