### PR TITLE
feat(inputs.win_eventlog): Mark subscription failures as retriable startup errors

### DIFF
--- a/plugins/inputs/win_eventlog/README.md
+++ b/plugins/inputs/win_eventlog/README.md
@@ -21,6 +21,23 @@ plugin ordering. See [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
 [CONFIGURATION.md]: ../../../docs/CONFIGURATION.md#plugins
 
+## Startup error behavior options <!-- @/docs/includes/startup_error_behavior.md -->
+
+In addition to the plugin-specific and global configuration settings the plugin
+supports options for specifying the behavior when experiencing startup errors
+using the `startup_error_behavior` setting. Available values are:
+
+- `error`:  Telegraf with stop and exit in case of startup errors. This is the
+            default behavior.
+- `ignore`: Telegraf will ignore startup errors for this plugin and disables it
+            but continues processing for all other plugins.
+- `retry`:  Telegraf will try to startup the plugin in every gather or write
+            cycle in case of startup errors. The plugin is disabled until
+            the startup succeeds.
+- `probe`:  Telegraf will probe the plugin's function (if possible) and disables
+            the plugin in case probing fails. If the plugin does not support
+            probing, Telegraf will behave as if `ignore` was set instead.
+
 ## Configuration
 
 ```toml @sample.conf

--- a/plugins/inputs/win_eventlog/win_eventlog.go
+++ b/plugins/inputs/win_eventlog/win_eventlog.go
@@ -106,19 +106,20 @@ func (w *WinEventLog) Init() error {
 func (w *WinEventLog) Start(telegraf.Accumulator) error {
 	subscription, err := w.evtSubscribe()
 	if err != nil {
-		// Mark this as a retriable startup error rather than a plain one: the
-		// channel this plugin subscribes to may be temporarily unavailable (e.g.
-		// disabled by policy, or a feature not yet started) or permanently gone
-		// (e.g. an optional Windows feature was never installed or was removed).
+		startupErr := fmt.Errorf("subscription of Windows Event Log failed: %w", err)
 		return &internal.StartupError{
-			Err:   fmt.Errorf("subscription of Windows Event Log failed: %w", err),
-			Retry: true,
+			Err:   startupErr,
+			Retry: isRetriableSubscriptionError(err),
 		}
 	}
 	w.subscription = subscription
 	w.Log.Debug("Subscription handle id:", w.subscription)
 
 	return nil
+}
+
+func isRetriableSubscriptionError(err error) bool {
+	return errors.Is(err, windows.ERROR_EVT_CHANNEL_NOT_FOUND)
 }
 
 func (w *WinEventLog) GetState() interface{} {

--- a/plugins/inputs/win_eventlog/win_eventlog.go
+++ b/plugins/inputs/win_eventlog/win_eventlog.go
@@ -110,7 +110,6 @@ func (w *WinEventLog) Start(telegraf.Accumulator) error {
 		// channel this plugin subscribes to may be temporarily unavailable (e.g.
 		// disabled by policy, or a feature not yet started) or permanently gone
 		// (e.g. an optional Windows feature was never installed or was removed).
-
 		return &internal.StartupError{
 			Err:   fmt.Errorf("subscription of Windows Event Log failed: %w", err),
 			Retry: true,

--- a/plugins/inputs/win_eventlog/win_eventlog.go
+++ b/plugins/inputs/win_eventlog/win_eventlog.go
@@ -21,6 +21,7 @@ import (
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/filter"
+	"github.com/influxdata/telegraf/internal"
 	"github.com/influxdata/telegraf/plugins/inputs"
 )
 
@@ -105,7 +106,21 @@ func (w *WinEventLog) Init() error {
 func (w *WinEventLog) Start(telegraf.Accumulator) error {
 	subscription, err := w.evtSubscribe()
 	if err != nil {
-		return fmt.Errorf("subscription of Windows Event Log failed: %w", err)
+		// Mark this as a retriable startup error rather than a plain one: the
+		// channel this plugin subscribes to may be temporarily unavailable (e.g.
+		// disabled by policy, or a feature not yet started) or permanently gone
+		// (e.g. an optional Windows feature was never installed or was removed).
+		// Without this, any evtSubscribe failure here is treated as fatal to the
+		// whole agent (see agent.startInputs), taking down every other configured
+		// input along with it. Wrapping it lets users opt in per-instance via
+		// startup_error_behavior = "retry" (keep trying on a schedule, in case the
+		// channel becomes available later) or "ignore" (drop just this plugin,
+		// everything else keeps running) instead of losing the entire agent over
+		// one missing/inaccessible event log channel.
+		return &internal.StartupError{
+			Err:   fmt.Errorf("subscription of Windows Event Log failed: %w", err),
+			Retry: true,
+		}
 	}
 	w.subscription = subscription
 	w.Log.Debug("Subscription handle id:", w.subscription)

--- a/plugins/inputs/win_eventlog/win_eventlog.go
+++ b/plugins/inputs/win_eventlog/win_eventlog.go
@@ -110,13 +110,7 @@ func (w *WinEventLog) Start(telegraf.Accumulator) error {
 		// channel this plugin subscribes to may be temporarily unavailable (e.g.
 		// disabled by policy, or a feature not yet started) or permanently gone
 		// (e.g. an optional Windows feature was never installed or was removed).
-		// Without this, any evtSubscribe failure here is treated as fatal to the
-		// whole agent (see agent.startInputs), taking down every other configured
-		// input along with it. Wrapping it lets users opt in per-instance via
-		// startup_error_behavior = "retry" (keep trying on a schedule, in case the
-		// channel becomes available later) or "ignore" (drop just this plugin,
-		// everything else keeps running) instead of losing the entire agent over
-		// one missing/inaccessible event log channel.
+
 		return &internal.StartupError{
 			Err:   fmt.Errorf("subscription of Windows Event Log failed: %w", err),
 			Retry: true,


### PR DESCRIPTION
## Summary
This PR wraps the failure as `&internal.StartupError{Err: ..., Retry: true}`,
matching the existing pattern already used in `mavlink.go` and
`mqtt_consumer.go`. This lets users opt in per-instance via
`startup_error_behavior = "retry"` (keep retrying on a schedule, in case the
channel becomes available later) or `"ignore"` (drop just this one plugin
instance, everything else keeps running), instead of losing the whole agent
over one missing/inaccessible channel.

- Seems to work as expected, telegraf does not exit with an error upon startup, but prints error messages in the logs.

## Checklist

- [ ] No AI generated code was used in this PR
- [x] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
none

resolves #

`Start()` in `plugins/inputs/win_eventlog/win_eventlog.go` wraps a failed
`evtSubscribe()` call in a plain `fmt.Errorf(...)`. Per `agent.startInputs`,
an error that isn't recognized as an `internal.StartupError` is treated as
**fatal to the whole agent** — the agent fails to start at all, taking down
every other configured input along with it.

This means one event log channel that's temporarily unavailable (disabled by
policy, an optional Windows feature not yet started) or permanently gone (an
optional feature/role that was never installed, or was removed after the
config was written) can prevent Telegraf from collecting *any* metrics at all,
not just from that one channel.

This PR wraps the failure as `&internal.StartupError{Err: ..., Retry: true}`,
matching the existing pattern already used in `mavlink.go` and
`mqtt_consumer.go`. This lets users opt in per-instance via
`startup_error_behavior = "retry"` (keep retrying on a schedule, in case the
channel becomes available later) or `"ignore"` (drop just this one plugin
instance, everything else keeps running), instead of losing the whole agent
over one missing/inaccessible channel.
