### PR TITLE
fix(serializers.prometheusremotewrite): Accumulate multiple samples per series in a batch

### DIFF
--- a/plugins/serializers/prometheusremotewrite/prometheusremotewrite.go
+++ b/plugins/serializers/prometheusremotewrite/prometheusremotewrite.go
@@ -204,13 +204,25 @@ func (s *Serializer) SerializeBatch(metrics []telegraf.Metric) ([]byte, error) {
 			}
 
 			// A batch of metrics can contain multiple values for a single
-			// Prometheus sample. If this metric is older than the existing
-			// sample then we can skip over it.
-			if m, found := entries[metrickey]; found {
-				if metric.Time().UnixMilli() < m.Samples[0].Timestamp {
+			// Prometheus series. Accumulate the samples on the existing time
+			// series instead of replacing it, so no samples are dropped.
+			if existing, found := entries[metrickey]; found {
+				tsSample := promts.Samples[0].Timestamp
+				tsExisting := existing.Samples[len(existing.Samples)-1].Timestamp
+				switch {
+				case tsSample < tsExisting:
+					// This sample is older than the latest one already
+					// registered, so we skip over it.
 					traceAndKeepErr("metric %q has samples with timestamp %v older than already registered before", metric.Name(), metric.Time())
 					continue
+				case tsSample == tsExisting:
+					// Duplicate timestamp, keep the latest value.
+					existing.Samples[len(existing.Samples)-1] = promts.Samples[0]
+				default:
+					existing.Samples = append(existing.Samples, promts.Samples[0])
 				}
+				entries[metrickey] = existing
+				continue
 			}
 			entries[metrickey] = promts
 		}

--- a/plugins/serializers/prometheusremotewrite/prometheusremotewrite_test.go
+++ b/plugins/serializers/prometheusremotewrite/prometheusremotewrite_test.go
@@ -505,6 +505,35 @@ cpu_time_idle 43
 `),
 		},
 		{
+			name: "multiple samples for the same series",
+			metrics: []telegraf.Metric{
+				metric.New(
+					"cpu",
+					map[string]string{
+						"host": "one.example.org",
+					},
+					map[string]interface{}{
+						"time_idle": 1.0,
+					},
+					time.Unix(0, 0),
+				),
+				metric.New(
+					"cpu",
+					map[string]string{
+						"host": "one.example.org",
+					},
+					map[string]interface{}{
+						"time_idle": 2.0,
+					},
+					time.Unix(1, 0),
+				),
+			},
+			expected: []byte(`
+cpu_time_idle{host="one.example.org"} 1
+cpu_time_idle{host="one.example.org"} 2
+`),
+		},
+		{
 			name: "colons are not replaced in metric name from measurement",
 			metrics: []telegraf.Metric{
 				metric.New(


### PR DESCRIPTION
## Summary

When serializing a batch, prometheus remote-write serializer dropped samples of the series (identical metric name and tags) within the batch.


On a key hit it replaced the stored `prompb.TimeSeries` (and its single-element `Samples` slice) instead of appending only the last sample for each  survived. 


For example, a batch containing two `cpu_time_idle{host="one.example.org"}` points at different timestamps emitted only one of them.

This appends the new sample to the series instead of replacing it.


## Checklist

- [ ] No AI generated code was used in this PR
- [x] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

resolves #19298