### PR TITLE
feat(inputs.elasticsearch_query): Add ES v7 support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -89,6 +89,7 @@ require (
 	github.com/eclipse/paho.mqtt.golang v1.5.1
 	github.com/elastic/go-elasticsearch/v5 v5.6.1
 	github.com/elastic/go-elasticsearch/v6 v6.8.10
+	github.com/elastic/go-elasticsearch/v7 v7.17.10
 	github.com/emiago/sipgo v1.4.3
 	github.com/facebook/time v0.0.0-20250903103710-a5911c32cdb9
 	github.com/fatih/color v1.19.0

--- a/go.sum
+++ b/go.sum
@@ -1189,6 +1189,8 @@ github.com/elastic/go-elasticsearch/v5 v5.6.1 h1:RnL2wcXepOT5SdoKMMO1j1OBX0vxHYb
 github.com/elastic/go-elasticsearch/v5 v5.6.1/go.mod h1:r7uV7HidpfkYh7D8SB4lkS13TNlNy3oa5GNmTZvuVqY=
 github.com/elastic/go-elasticsearch/v6 v6.8.10 h1:2lN0gJ93gMBXvkhwih5xquldszpm8FlUwqG5sPzr6a8=
 github.com/elastic/go-elasticsearch/v6 v6.8.10/go.mod h1:UwaDJsD3rWLM5rKNFzv9hgox93HoX8utj1kxD9aFUcI=
+github.com/elastic/go-elasticsearch/v7 v7.17.10 h1:TCQ8i4PmIJuBunvBS6bwT2ybzVFxxUhhltAs3Gyu1yo=
+github.com/elastic/go-elasticsearch/v7 v7.17.10/go.mod h1:OJ4wdbtDNk5g503kvlHLyErCgQwwzmDtaFC4XyOxXA4=
 github.com/elastic/go-sysinfo v1.8.1 h1:4Yhj+HdV6WjbCRgGdZpPJ8lZQlXZLKDAeIkmQ/VRvi4=
 github.com/elastic/go-sysinfo v1.8.1/go.mod h1:JfllUnzoQV/JRYymbH3dO1yggI3mV2oTKSXsDHM+uIM=
 github.com/elastic/go-windows v1.0.0 h1:qLURgZFkkrYyTTkvYpsZIgf83AUsdIHfvlJaqaZ7aSY=

--- a/plugins/inputs/elasticsearch_query/README.md
+++ b/plugins/inputs/elasticsearch_query/README.md
@@ -7,8 +7,7 @@ filtered by a query, aggregated per tag and to count the number of terms for a
 particular field.
 
 > [!IMPORTANT]
-> This plugin supports Elasticsearch 5.x, 6.x and 7.x but is known to break on
-> 8.x or higher.
+> This plugin supports Elasticsearch 5.x to 7.x only.
 > Node discovery is not supported with Elasticsearch 5.x.
 
 ⭐ Telegraf v1.20.0

--- a/plugins/inputs/elasticsearch_query/README.md
+++ b/plugins/inputs/elasticsearch_query/README.md
@@ -7,8 +7,8 @@ filtered by a query, aggregated per tag and to count the number of terms for a
 particular field.
 
 > [!IMPORTANT]
-> This plugins supports Elasticsearch 5.x and 6.x but is known to break on 7.x
-> or higher.
+> This plugin supports Elasticsearch 5.x, 6.x and 7.x but is known to break on
+> 8.x or higher.
 > Node discovery is not supported with Elasticsearch 5.x.
 
 ⭐ Telegraf v1.20.0

--- a/plugins/inputs/elasticsearch_query/client.go
+++ b/plugins/inputs/elasticsearch_query/client.go
@@ -153,7 +153,7 @@ func (a *aggregation) buildQueries() error {
 	queries := make([]queryData, 0, len(a.mapMetricFields)+len(a.Tags))
 	for k, v := range a.mapMetricFields {
 		switch v {
-		case "long", "float", "integer", "short", "double", "scaled_float":
+		case "long", "float", "integer", "short", "double", "scaled_float", "unsigned_long":
 		default:
 			continue
 		}

--- a/plugins/inputs/elasticsearch_query/client_v7.go
+++ b/plugins/inputs/elasticsearch_query/client_v7.go
@@ -35,7 +35,7 @@ func newClientV7(cfg clientConfig) (client, error) {
 
 	client := &clientV7{client: c, httpClient: cfg.httpClient, log: cfg.log}
 	if cfg.enableSniffer && cfg.discoveryInterval > 0 {
-		// The v7 client exposes only DiscoverNodes(), so in-flight calls cannot be canceled.
+		// The v7 connection-pool discovery API accepts no context, so in-flight calls cannot be canceled.
 		ctx, cancel := context.WithCancel(context.Background())
 		client.cancelDiscovery = cancel
 		client.discoveryWG.Add(1)

--- a/plugins/inputs/elasticsearch_query/client_v7.go
+++ b/plugins/inputs/elasticsearch_query/client_v7.go
@@ -1,0 +1,113 @@
+package elasticsearch_query
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync"
+
+	elasticsearch7 "github.com/elastic/go-elasticsearch/v7"
+
+	"github.com/influxdata/telegraf"
+)
+
+type clientV7 struct {
+	client          *elasticsearch7.Client
+	httpClient      *http.Client
+	log             telegraf.Logger
+	cancelDiscovery context.CancelFunc
+	discoveryWG     sync.WaitGroup
+}
+
+func newClientV7(cfg clientConfig) (client, error) {
+	c, err := elasticsearch7.NewClient(elasticsearch7.Config{
+		Addresses: cfg.urls,
+		Username:  cfg.username,
+		Password:  cfg.password,
+		Transport: roundTripper{client: cfg.httpClient},
+	})
+	if err != nil {
+		cfg.httpClient.CloseIdleConnections()
+		return nil, fmt.Errorf("creating ElasticSearch client failed: %w", err)
+	}
+
+	client := &clientV7{client: c, httpClient: cfg.httpClient, log: cfg.log}
+	if cfg.enableSniffer && cfg.discoveryInterval > 0 {
+		// The v7 client exposes only DiscoverNodes(), so in-flight calls cannot be canceled.
+		ctx, cancel := context.WithCancel(context.Background())
+		client.cancelDiscovery = cancel
+		client.discoveryWG.Add(1)
+		go func() {
+			defer client.discoveryWG.Done()
+			startDiscovery(ctx, cfg.discoveryInterval, func(context.Context) error {
+				return c.DiscoverNodes()
+			}, cfg.log)
+		}()
+	}
+	return client, nil
+}
+
+func (c *clientV7) close() {
+	if c.cancelDiscovery != nil {
+		c.cancelDiscovery()
+		c.discoveryWG.Wait()
+	}
+	if c.httpClient != nil {
+		c.httpClient.CloseIdleConnections()
+	}
+}
+
+func (c *clientV7) getFieldMapping(ctx context.Context, index, field string) (map[string]interface{}, error) {
+	res, err := c.client.Indices.GetFieldMapping(
+		[]string{field},
+		c.client.Indices.GetFieldMapping.WithContext(ctx),
+		c.client.Indices.GetFieldMapping.WithIndex(index),
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	if err := checkForError(res.StatusCode, res.Body); err != nil {
+		return nil, err
+	}
+
+	var result map[string]interface{}
+	if err := json.NewDecoder(res.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("decoding message body failed: %w", err)
+	}
+	return result, nil
+}
+
+func (c *clientV7) query(ctx context.Context, aggregation *aggregation) (interface{}, int64, error) {
+	data, err := aggregation.buildSearchBody(c.log)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	res, err := c.client.Search(
+		c.client.Search.WithContext(ctx),
+		c.client.Search.WithIndex(aggregation.Index),
+		c.client.Search.WithBody(bytes.NewReader(data)),
+		c.client.Search.WithTrackTotalHits(true),
+	)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer res.Body.Close()
+
+	if err := checkForError(res.StatusCode, res.Body); err != nil {
+		return nil, 0, err
+	}
+
+	var result searchResponse
+	if err := json.NewDecoder(res.Body).Decode(&result); err != nil {
+		return nil, 0, fmt.Errorf("decoding message body failed: %w", err)
+	}
+	if len(result.Aggregations) == 0 {
+		return nil, result.totalHits(), nil
+	}
+	return result.Aggregations, result.totalHits(), nil
+}

--- a/plugins/inputs/elasticsearch_query/elasticsearch_query.go
+++ b/plugins/inputs/elasticsearch_query/elasticsearch_query.go
@@ -114,9 +114,11 @@ func (e *ElasticsearchQuery) Start(telegraf.Accumulator) error {
 		c, err = newClientV5(cfg)
 	case 6:
 		c, err = newClientV6(cfg)
+	case 7:
+		c, err = newClientV7(cfg)
 	default:
 		httpClient.CloseIdleConnections()
-		return fmt.Errorf("server version %q not supported (currently supported versions are 5.x and 6.x)", version)
+		return fmt.Errorf("server version %q not supported (currently supported versions are 5.x, 6.x and 7.x)", version)
 	}
 	if err != nil {
 		return err
@@ -243,6 +245,16 @@ func getMetricField(response map[string]interface{}) (map[string]string, error) 
 				return nil, fmt.Errorf("unexpected type %T for types", t)
 			}
 
+			// Elasticsearch 7+ field-mapping responses omit the mapping type level.
+			// Each mapping entry is therefore a field descriptor with a string "full_name"
+			// in Elasticsearch 7+, while typed mappings contain field maps at this level.
+			// See https://www.elastic.co/guide/en/elasticsearch/reference/7.17/indices-get-field-mapping.html
+			_, typeless := fields["full_name"].(string)
+			if typeless {
+				// Process every field descriptor in the mappings map.
+				fields = types
+			}
+
 			for _, f := range fields {
 				field, ok := f.(map[string]interface{})
 				if !ok {
@@ -271,6 +283,11 @@ func getMetricField(response map[string]interface{}) (map[string]string, error) 
 					}
 					mapMetricFields[fullname] = ftype
 				}
+			}
+
+			if typeless {
+				// Avoid processing the entire mappings map again for each remaining entry.
+				break
 			}
 		}
 	}

--- a/plugins/inputs/elasticsearch_query/elasticsearch_query_test.go
+++ b/plugins/inputs/elasticsearch_query/elasticsearch_query_test.go
@@ -239,7 +239,7 @@ func TestClientV6Sniffer(t *testing.T) {
 	}
 }
 
-func TestClientV7PlusSniffer(t *testing.T) {
+func TestClientV7Discovery(t *testing.T) {
 	discovered := make(chan struct{}, 1)
 
 	var server *httptest.Server

--- a/plugins/inputs/elasticsearch_query/elasticsearch_query_test.go
+++ b/plugins/inputs/elasticsearch_query/elasticsearch_query_test.go
@@ -276,23 +276,12 @@ func TestClientV7Discovery(t *testing.T) {
 		log:               testutil.Logger{},
 	})
 	require.NoError(t, err)
+	defer c.close()
 
 	select {
 	case <-discovered:
 	case <-time.After(5 * time.Second):
 		t.Fatal("timed out waiting for node discovery")
-	}
-
-	stopped := make(chan struct{})
-	go func() {
-		c.close()
-		close(stopped)
-	}()
-
-	select {
-	case <-stopped:
-	case <-time.After(5 * time.Second):
-		t.Fatal("timed out stopping node discovery")
 	}
 }
 

--- a/plugins/inputs/elasticsearch_query/elasticsearch_query_test.go
+++ b/plugins/inputs/elasticsearch_query/elasticsearch_query_test.go
@@ -239,104 +239,146 @@ func TestClientV6Sniffer(t *testing.T) {
 	}
 }
 
-func TestClientV7Sniffer(t *testing.T) {
-	discovered := make(chan struct{}, 1)
-
-	var server *httptest.Server
-	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/_nodes/http" {
-			http.NotFound(w, r)
-			return
-		}
-
-		response := map[string]interface{}{
-			"nodes": map[string]interface{}{
-				"node": map[string]interface{}{
-					"name":  "node",
-					"roles": []string{"data", "ingest"},
-					"http": map[string]string{
-						"publish_address": strings.TrimPrefix(server.URL, "http://"),
-					},
-				},
-			},
-		}
-		if err := json.NewEncoder(w).Encode(response); err != nil {
-			t.Error(err)
-			return
-		}
-		discovered <- struct{}{}
-	}))
-	defer server.Close()
-
-	c, err := newClientV7(clientConfig{
-		urls:              []string{server.URL},
-		enableSniffer:     true,
-		discoveryInterval: time.Hour,
-		httpClient:        server.Client(),
-		log:               testutil.Logger{},
-	})
-	require.NoError(t, err)
-
-	select {
-	case <-discovered:
-	case <-time.After(5 * time.Second):
-		t.Fatal("timed out waiting for node discovery")
+func TestClientV7PlusSniffer(t *testing.T) {
+	tests := []struct {
+		name      string
+		newClient func(clientConfig) (client, error)
+	}{
+		{
+			name:      "v7",
+			newClient: newClientV7,
+		},
 	}
 
-	stopped := make(chan struct{})
-	go func() {
-		c.close()
-		close(stopped)
-	}()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			discovered := make(chan struct{}, 1)
 
-	select {
-	case <-stopped:
-	case <-time.After(5 * time.Second):
-		t.Fatal("timed out stopping node discovery")
+			var server *httptest.Server
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/_nodes/http" {
+					http.NotFound(w, r)
+					return
+				}
+
+				response := map[string]interface{}{
+					"nodes": map[string]interface{}{
+						"node": map[string]interface{}{
+							"name":  "node",
+							"roles": []string{"data", "ingest"},
+							"http": map[string]string{
+								"publish_address": strings.TrimPrefix(server.URL, "http://"),
+							},
+						},
+					},
+				}
+				if err := json.NewEncoder(w).Encode(response); err != nil {
+					t.Error(err)
+					return
+				}
+				discovered <- struct{}{}
+			}))
+			defer server.Close()
+
+			c, err := tt.newClient(clientConfig{
+				urls:              []string{server.URL},
+				enableSniffer:     true,
+				discoveryInterval: time.Hour,
+				httpClient:        server.Client(),
+				log:               testutil.Logger{},
+			})
+			require.NoError(t, err)
+
+			select {
+			case <-discovered:
+			case <-time.After(5 * time.Second):
+				t.Fatal("timed out waiting for node discovery")
+			}
+
+			stopped := make(chan struct{})
+			go func() {
+				c.close()
+				close(stopped)
+			}()
+
+			select {
+			case <-stopped:
+			case <-time.After(5 * time.Second):
+				t.Fatal("timed out stopping node discovery")
+			}
+		})
 	}
 }
 
-func TestClientV7Query(t *testing.T) {
-	var trackTotalHits string
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.Header().Set("X-Elastic-Product", "Elasticsearch")
-		switch r.URL.Path {
-		case "/":
-			if _, err := w.Write([]byte(`{"version":{"number":"7.17.29"}}`)); err != nil {
-				t.Error(err)
-			}
-		case "/test/_search":
-			trackTotalHits = r.URL.Query().Get("track_total_hits")
-			if _, err := w.Write([]byte(`{"hits":{"total":{"value":12345,"relation":"eq"}},"aggregations":{}}`)); err != nil {
-				t.Error(err)
-			}
-		default:
-			http.NotFound(w, r)
-		}
-	}))
-	defer server.Close()
-
-	c, err := newClientV7(clientConfig{
-		urls:       []string{server.URL},
-		httpClient: server.Client(),
-		log:        testutil.Logger{},
-	})
-	require.NoError(t, err)
-	defer c.close()
-
-	agg := &aggregation{
-		Index:       "test",
-		DateField:   "@timestamp",
-		FilterQuery: "*",
-		QueryPeriod: config.Duration(time.Minute),
-		queries:     make([]queryData, 0),
+func TestClientQuery(t *testing.T) {
+	tests := []struct {
+		name                   string
+		newClient              func(clientConfig) (client, error)
+		response               string
+		expectedTrackTotalHits string
+	}{
+		{
+			name:      "v5",
+			newClient: newClientV5,
+			response:  `{"hits":{"total":12345},"aggregations":{}}`,
+		},
+		{
+			name:      "v6",
+			newClient: newClientV6,
+			response:  `{"hits":{"total":12345},"aggregations":{}}`,
+		},
+		{
+			name:                   "v7",
+			newClient:              newClientV7,
+			response:               `{"hits":{"total":{"value":12345,"relation":"eq"}},"aggregations":{}}`,
+			expectedTrackTotalHits: "true",
+		},
 	}
-	result, hits, err := c.query(t.Context(), agg)
-	require.NoError(t, err)
-	require.Nil(t, result)
-	require.EqualValues(t, 12345, hits)
-	require.Equal(t, "true", trackTotalHits)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var trackTotalHits string
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.Header().Set("X-Elastic-Product", "Elasticsearch")
+				switch r.URL.Path {
+				case "/": // The V7 client performs an implicit product check before searching.
+					if _, err := w.Write([]byte("{}")); err != nil {
+						t.Error(err)
+					}
+				case "/test/_search":
+					trackTotalHits = r.URL.Query().Get("track_total_hits")
+					if _, err := w.Write([]byte(tt.response)); err != nil {
+						t.Error(err)
+					}
+				default:
+					http.NotFound(w, r)
+				}
+			}))
+			defer server.Close()
+
+			c, err := tt.newClient(clientConfig{
+				urls:       []string{server.URL},
+				httpClient: server.Client(),
+				log:        testutil.Logger{},
+			})
+			require.NoError(t, err)
+			defer c.close()
+
+			agg := &aggregation{
+				Index:       "test",
+				DateField:   "@timestamp",
+				FilterQuery: "*",
+				QueryPeriod: config.Duration(time.Minute),
+				queries:     make([]queryData, 0),
+			}
+			result, hits, err := c.query(t.Context(), agg)
+			require.NoError(t, err)
+			require.Nil(t, result)
+			require.EqualValues(t, 12345, hits)
+			require.Equal(t, tt.expectedTrackTotalHits, trackTotalHits)
+		})
+	}
 }
 
 type nginxlog struct {
@@ -921,9 +963,24 @@ func TestGatherV5Integration(t *testing.T) {
 	testutil.RequireMetricsEqual(t, expectedMetrics, acc.GetTelegrafMetrics(), testutil.SortMetrics(), testutil.IgnoreTime())
 }
 
-func TestGatherV7Integration(t *testing.T) {
+func TestGatherV7PlusIntegration(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
+	}
+
+	tests := []struct {
+		name  string
+		image string
+		env   map[string]string
+	}{
+		{
+			name:  "v7",
+			image: "docker.elastic.co/elasticsearch/elasticsearch:7.17.29",
+			env: map[string]string{
+				"discovery.type": "single-node",
+				"ES_JAVA_OPTS":   "-Xms1g -Xmx1g",
+			},
+		},
 	}
 
 	// Define expectations
@@ -1062,149 +1119,149 @@ func TestGatherV7Integration(t *testing.T) {
 			time.Date(2018, 6, 14, 5, 51, 53, 266176036, time.UTC),
 		),
 	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup the container
+			container := &testutil.Container{
+				Image:        tt.image,
+				ExposedPorts: []string{servicePort},
+				Env:          tt.env,
+				WaitingFor:   wait.ForHTTP("/").WithPort(servicePort).WithStartupTimeout(120 * time.Second),
+			}
+			require.NoError(t, container.Start(), "failed to start container")
+			defer container.Terminate()
 
-	// Setup the container
-	container := &testutil.Container{
-		Image:        "docker.elastic.co/elasticsearch/elasticsearch:7.17.29",
-		ExposedPorts: []string{servicePort},
-		Env: map[string]string{
-			"discovery.type": "single-node",
-			"ES_JAVA_OPTS":   "-Xms1g -Xmx1g",
-		},
-		WaitingFor: wait.ForHTTP("/").WithPort(servicePort).WithStartupTimeout(120 * time.Second),
+			addr := "http://" + container.Address + ":" + container.Ports[servicePort]
+
+			// Fill the database
+			require.NoError(t, sendData(t.Context(), addr))
+
+			// Setup the plugin
+			plugin := &ElasticsearchQuery{
+				URLs: []string{addr},
+				Aggregations: []aggregation{
+					{
+						Index:           testindex,
+						MeasurementName: "measurement1",
+						MetricFields:    []string{"size"},
+						FilterQuery:     "product_1",
+						MetricFunction:  "avg",
+						DateField:       "@timestamp",
+						QueryPeriod:     config.Duration(time.Second * 600),
+						Tags:            []string{"URI.keyword"},
+					},
+					{
+						Index:           testindex,
+						MeasurementName: "measurement2",
+						MetricFields:    []string{"size"},
+						FilterQuery:     "downloads",
+						MetricFunction:  "max",
+						DateField:       "@timestamp",
+						QueryPeriod:     config.Duration(time.Second * 600),
+						Tags:            []string{"URI.keyword"},
+					},
+					{
+						Index:           testindex,
+						MeasurementName: "measurement3",
+						MetricFields:    []string{"size"},
+						FilterQuery:     "downloads",
+						MetricFunction:  "sum",
+						DateField:       "@timestamp",
+						QueryPeriod:     config.Duration(time.Second * 600),
+						Tags:            []string{"response.keyword"},
+					},
+					{
+						Index:             testindex,
+						MeasurementName:   "measurement4",
+						MetricFields:      []string{"size", "response_time"},
+						FilterQuery:       "downloads",
+						MetricFunction:    "min",
+						DateField:         "@timestamp",
+						QueryPeriod:       config.Duration(time.Second * 600),
+						IncludeMissingTag: true,
+						MissingTagValue:   "missing",
+						Tags:              []string{"response.keyword", "URI.keyword", "method.keyword"},
+					},
+					{
+						Index:           testindex,
+						MeasurementName: "measurement5",
+						FilterQuery:     "product_2",
+						DateField:       "@timestamp",
+						QueryPeriod:     config.Duration(time.Second * 600),
+						Tags:            []string{"URI.keyword"},
+					},
+					{
+						Index:           testindex,
+						MeasurementName: "measurement6",
+						FilterQuery:     "response: 200",
+						DateField:       "@timestamp",
+						QueryPeriod:     config.Duration(time.Second * 600),
+						Tags:            []string{"URI.keyword", "response.keyword"},
+					},
+					{
+						Index:           testindex,
+						MeasurementName: "measurement7",
+						FilterQuery:     "response: 200",
+						DateField:       "@timestamp",
+						QueryPeriod:     config.Duration(time.Second * 600),
+					},
+					{
+						Index:           testindex,
+						MeasurementName: "measurement8",
+						MetricFields:    []string{"size"},
+						FilterQuery:     "downloads",
+						MetricFunction:  "max",
+						DateField:       "@timestamp",
+						QueryPeriod:     config.Duration(time.Second * 600),
+					},
+					{
+						Index:           testindex,
+						MeasurementName: "measurement12",
+						MetricFields:    []string{"size"},
+						MetricFunction:  "avg",
+						DateField:       "@notatimestamp",
+						QueryPeriod:     config.Duration(time.Second * 600),
+					},
+					{
+						Index:             testindex,
+						MeasurementName:   "measurement13",
+						MetricFields:      []string{"size"},
+						MetricFunction:    "avg",
+						DateField:         "@timestamp",
+						QueryPeriod:       config.Duration(time.Second * 600),
+						IncludeMissingTag: false,
+						Tags:              []string{"nothere"},
+					},
+				},
+				HTTPClientConfig: common_http.HTTPClientConfig{
+					Timeout: config.Duration(30 * time.Second),
+					TransportConfig: common_http.TransportConfig{
+						ResponseHeaderTimeout: config.Duration(30 * time.Second),
+					},
+				},
+				Log: testutil.Logger{},
+			}
+			require.NoError(t, plugin.Init())
+
+			var acc testutil.Accumulator
+			require.NoError(t, plugin.Start(&acc))
+			defer plugin.Stop()
+
+			// Check the ES field mapping
+			for i, agg := range plugin.Aggregations {
+				actual := agg.mapMetricFields
+				expected := expectedFields[i]
+				require.Equalf(t, expected, actual, "mismatch in aggregation %d", i)
+			}
+
+			// Collect metrics and check
+			require.NoError(t, acc.GatherError(plugin.Gather))
+			require.Empty(t, acc.Errors)
+
+			// Check the metrics
+			testutil.RequireMetricsEqual(t, expectedMetrics, acc.GetTelegrafMetrics(), testutil.SortMetrics(), testutil.IgnoreTime())
+		})
 	}
-	require.NoError(t, container.Start(), "failed to start container")
-	defer container.Terminate()
-
-	addr := "http://" + container.Address + ":" + container.Ports[servicePort]
-
-	// Fill the database
-	require.NoError(t, sendData(t.Context(), addr))
-
-	// Setup the plugin
-	plugin := &ElasticsearchQuery{
-		URLs: []string{addr},
-		Aggregations: []aggregation{
-			{
-				Index:           testindex,
-				MeasurementName: "measurement1",
-				MetricFields:    []string{"size"},
-				FilterQuery:     "product_1",
-				MetricFunction:  "avg",
-				DateField:       "@timestamp",
-				QueryPeriod:     config.Duration(time.Second * 600),
-				Tags:            []string{"URI.keyword"},
-			},
-			{
-				Index:           testindex,
-				MeasurementName: "measurement2",
-				MetricFields:    []string{"size"},
-				FilterQuery:     "downloads",
-				MetricFunction:  "max",
-				DateField:       "@timestamp",
-				QueryPeriod:     config.Duration(time.Second * 600),
-				Tags:            []string{"URI.keyword"},
-			},
-			{
-				Index:           testindex,
-				MeasurementName: "measurement3",
-				MetricFields:    []string{"size"},
-				FilterQuery:     "downloads",
-				MetricFunction:  "sum",
-				DateField:       "@timestamp",
-				QueryPeriod:     config.Duration(time.Second * 600),
-				Tags:            []string{"response.keyword"},
-			},
-			{
-				Index:             testindex,
-				MeasurementName:   "measurement4",
-				MetricFields:      []string{"size", "response_time"},
-				FilterQuery:       "downloads",
-				MetricFunction:    "min",
-				DateField:         "@timestamp",
-				QueryPeriod:       config.Duration(time.Second * 600),
-				IncludeMissingTag: true,
-				MissingTagValue:   "missing",
-				Tags:              []string{"response.keyword", "URI.keyword", "method.keyword"},
-			},
-			{
-				Index:           testindex,
-				MeasurementName: "measurement5",
-				FilterQuery:     "product_2",
-				DateField:       "@timestamp",
-				QueryPeriod:     config.Duration(time.Second * 600),
-				Tags:            []string{"URI.keyword"},
-			},
-			{
-				Index:           testindex,
-				MeasurementName: "measurement6",
-				FilterQuery:     "response: 200",
-				DateField:       "@timestamp",
-				QueryPeriod:     config.Duration(time.Second * 600),
-				Tags:            []string{"URI.keyword", "response.keyword"},
-			},
-			{
-				Index:           testindex,
-				MeasurementName: "measurement7",
-				FilterQuery:     "response: 200",
-				DateField:       "@timestamp",
-				QueryPeriod:     config.Duration(time.Second * 600),
-			},
-			{
-				Index:           testindex,
-				MeasurementName: "measurement8",
-				MetricFields:    []string{"size"},
-				FilterQuery:     "downloads",
-				MetricFunction:  "max",
-				DateField:       "@timestamp",
-				QueryPeriod:     config.Duration(time.Second * 600),
-			},
-			{
-				Index:           testindex,
-				MeasurementName: "measurement12",
-				MetricFields:    []string{"size"},
-				MetricFunction:  "avg",
-				DateField:       "@notatimestamp",
-				QueryPeriod:     config.Duration(time.Second * 600),
-			},
-			{
-				Index:             testindex,
-				MeasurementName:   "measurement13",
-				MetricFields:      []string{"size"},
-				MetricFunction:    "avg",
-				DateField:         "@timestamp",
-				QueryPeriod:       config.Duration(time.Second * 600),
-				IncludeMissingTag: false,
-				Tags:              []string{"nothere"},
-			},
-		},
-		HTTPClientConfig: common_http.HTTPClientConfig{
-			Timeout: config.Duration(30 * time.Second),
-			TransportConfig: common_http.TransportConfig{
-				ResponseHeaderTimeout: config.Duration(30 * time.Second),
-			},
-		},
-		Log: testutil.Logger{},
-	}
-	require.NoError(t, plugin.Init())
-
-	var acc testutil.Accumulator
-	require.NoError(t, plugin.Start(&acc))
-	defer plugin.Stop()
-
-	// Check the ES field mapping
-	for i, agg := range plugin.Aggregations {
-		actual := agg.mapMetricFields
-		expected := expectedFields[i]
-		require.Equalf(t, expected, actual, "mismatch in aggregation %d", i)
-	}
-
-	// Collect metrics and check
-	require.NoError(t, acc.GatherError(plugin.Gather))
-	require.Empty(t, acc.Errors)
-
-	// Check the metrics
-	testutil.RequireMetricsEqual(t, expectedMetrics, acc.GetTelegrafMetrics(), testutil.SortMetrics(), testutil.IgnoreTime())
 }
 
 func TestGatherFailStartIntegration(t *testing.T) {

--- a/plugins/inputs/elasticsearch_query/elasticsearch_query_test.go
+++ b/plugins/inputs/elasticsearch_query/elasticsearch_query_test.go
@@ -86,10 +86,9 @@ func TestGetMetricField(t *testing.T) {
 		},
 	}
 	tests := []struct {
-		name      string
-		mappings  map[string]interface{}
-		expected  map[string]string
-		wantError bool
+		name     string
+		mappings map[string]interface{}
+		expected map[string]string
 	}{
 		{
 			name: "typed mapping",
@@ -123,18 +122,6 @@ func TestGetMetricField(t *testing.T) {
 			},
 			expected: map[string]string{"full_name": "keyword", "mapping": "long"},
 		},
-		{
-			name: "invalid full name",
-			mappings: map[string]interface{}{
-				"size": map[string]interface{}{
-					"full_name": 42,
-					"mapping": map[string]interface{}{
-						"size": map[string]interface{}{"type": "long"},
-					},
-				},
-			},
-			wantError: true,
-		},
 	}
 
 	for _, tt := range tests {
@@ -144,15 +131,28 @@ func TestGetMetricField(t *testing.T) {
 			}
 
 			actual, err := getMetricField(response)
-			if tt.wantError {
-				require.Error(t, err)
-				return
-			}
-
 			require.NoError(t, err)
 			require.Equal(t, tt.expected, actual)
 		})
 	}
+}
+
+func TestGetMetricFieldError(t *testing.T) {
+	response := map[string]interface{}{
+		"index": map[string]interface{}{
+			"mappings": map[string]interface{}{
+				"size": map[string]interface{}{
+					"full_name": 42,
+					"mapping": map[string]interface{}{
+						"size": map[string]interface{}{"type": "long"},
+					},
+				},
+			},
+		},
+	}
+
+	_, err := getMetricField(response)
+	require.ErrorContains(t, err, "unexpected type int for full_name field")
 }
 
 func TestClientV5Sniffer(t *testing.T) {

--- a/plugins/inputs/elasticsearch_query/elasticsearch_query_test.go
+++ b/plugins/inputs/elasticsearch_query/elasticsearch_query_test.go
@@ -326,12 +326,11 @@ func TestClientV7Query(t *testing.T) {
 	defer c.close()
 
 	agg := &aggregation{
-		Index:        "test",
-		DateField:    "@timestamp",
-		FilterQuery:  "*",
-		QueryPeriod:  config.Duration(time.Minute),
-		queries:      make([]queryData, 0),
-		measurements: map[string]map[string]string{},
+		Index:       "test",
+		DateField:   "@timestamp",
+		FilterQuery: "*",
+		QueryPeriod: config.Duration(time.Minute),
+		queries:     make([]queryData, 0),
 	}
 	result, hits, err := c.query(t.Context(), agg)
 	require.NoError(t, err)

--- a/plugins/inputs/elasticsearch_query/elasticsearch_query_test.go
+++ b/plugins/inputs/elasticsearch_query/elasticsearch_query_test.go
@@ -240,73 +240,59 @@ func TestClientV6Sniffer(t *testing.T) {
 }
 
 func TestClientV7PlusSniffer(t *testing.T) {
-	tests := []struct {
-		name      string
-		newClient func(clientConfig) (client, error)
-	}{
-		{
-			name:      "v7",
-			newClient: newClientV7,
-		},
+	discovered := make(chan struct{}, 1)
+
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/_nodes/http" {
+			http.NotFound(w, r)
+			return
+		}
+
+		response := map[string]interface{}{
+			"nodes": map[string]interface{}{
+				"node": map[string]interface{}{
+					"name":  "node",
+					"roles": []string{"data", "ingest"},
+					"http": map[string]string{
+						"publish_address": strings.TrimPrefix(server.URL, "http://"),
+					},
+				},
+			},
+		}
+		if err := json.NewEncoder(w).Encode(response); err != nil {
+			t.Error(err)
+			return
+		}
+		discovered <- struct{}{}
+	}))
+	defer server.Close()
+
+	c, err := newClientV7(clientConfig{
+		urls:              []string{server.URL},
+		enableSniffer:     true,
+		discoveryInterval: time.Hour,
+		httpClient:        server.Client(),
+		log:               testutil.Logger{},
+	})
+	require.NoError(t, err)
+
+	select {
+	case <-discovered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for node discovery")
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			discovered := make(chan struct{}, 1)
+	stopped := make(chan struct{})
+	go func() {
+		c.close()
+		close(stopped)
+	}()
 
-			var server *httptest.Server
-			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				if r.URL.Path != "/_nodes/http" {
-					http.NotFound(w, r)
-					return
-				}
-
-				response := map[string]interface{}{
-					"nodes": map[string]interface{}{
-						"node": map[string]interface{}{
-							"name":  "node",
-							"roles": []string{"data", "ingest"},
-							"http": map[string]string{
-								"publish_address": strings.TrimPrefix(server.URL, "http://"),
-							},
-						},
-					},
-				}
-				if err := json.NewEncoder(w).Encode(response); err != nil {
-					t.Error(err)
-					return
-				}
-				discovered <- struct{}{}
-			}))
-			defer server.Close()
-
-			c, err := tt.newClient(clientConfig{
-				urls:              []string{server.URL},
-				enableSniffer:     true,
-				discoveryInterval: time.Hour,
-				httpClient:        server.Client(),
-				log:               testutil.Logger{},
-			})
-			require.NoError(t, err)
-
-			select {
-			case <-discovered:
-			case <-time.After(5 * time.Second):
-				t.Fatal("timed out waiting for node discovery")
-			}
-
-			stopped := make(chan struct{})
-			go func() {
-				c.close()
-				close(stopped)
-			}()
-
-			select {
-			case <-stopped:
-			case <-time.After(5 * time.Second):
-				t.Fatal("timed out stopping node discovery")
-			}
-		})
+	select {
+	case <-stopped:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out stopping node discovery")
 	}
 }
 

--- a/plugins/inputs/elasticsearch_query/elasticsearch_query_test.go
+++ b/plugins/inputs/elasticsearch_query/elasticsearch_query_test.go
@@ -138,9 +138,14 @@ func TestGetMetricField(t *testing.T) {
 }
 
 func TestGetMetricFieldError(t *testing.T) {
-	response := map[string]interface{}{
-		"index": map[string]interface{}{
-			"mappings": map[string]interface{}{
+	tests := []struct {
+		name          string
+		mappings      map[string]interface{}
+		expectedError string
+	}{
+		{
+			name: "typed invalid full name",
+			mappings: map[string]interface{}{
 				"document": map[string]interface{}{
 					"size": map[string]interface{}{
 						"full_name": 42,
@@ -150,11 +155,30 @@ func TestGetMetricFieldError(t *testing.T) {
 					},
 				},
 			},
+			expectedError: "unexpected type int for full_name field",
+		},
+		{
+			name: "typeless invalid mapping",
+			mappings: map[string]interface{}{
+				"size": map[string]interface{}{
+					"full_name": "size",
+					"mapping":   42,
+				},
+			},
+			expectedError: "unexpected type int for mapping field",
 		},
 	}
 
-	_, err := getMetricField(response)
-	require.ErrorContains(t, err, "unexpected type int for full_name field")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			response := map[string]interface{}{
+				"index": map[string]interface{}{"mappings": tt.mappings},
+			}
+
+			_, err := getMetricField(response)
+			require.ErrorContains(t, err, tt.expectedError)
+		})
+	}
 }
 
 func TestClientV5Sniffer(t *testing.T) {

--- a/plugins/inputs/elasticsearch_query/elasticsearch_query_test.go
+++ b/plugins/inputs/elasticsearch_query/elasticsearch_query_test.go
@@ -330,7 +330,7 @@ func TestClientV7Query(t *testing.T) {
 		DateField:    "@timestamp",
 		FilterQuery:  "*",
 		QueryPeriod:  config.Duration(time.Minute),
-		queries:      []queryData{},
+		queries:      make([]queryData, 0),
 		measurements: map[string]map[string]string{},
 	}
 	result, hits, err := c.query(t.Context(), agg)

--- a/plugins/inputs/elasticsearch_query/elasticsearch_query_test.go
+++ b/plugins/inputs/elasticsearch_query/elasticsearch_query_test.go
@@ -78,6 +78,83 @@ func TestCheckForError(t *testing.T) {
 	}
 }
 
+func TestGetMetricField(t *testing.T) {
+	field := map[string]interface{}{
+		"full_name": "size",
+		"mapping": map[string]interface{}{
+			"size": map[string]interface{}{"type": "long"},
+		},
+	}
+	tests := []struct {
+		name      string
+		mappings  map[string]interface{}
+		expected  map[string]string
+		wantError bool
+	}{
+		{
+			name: "typed mapping",
+			mappings: map[string]interface{}{
+				"document": map[string]interface{}{"size": field},
+			},
+			expected: map[string]string{"size": "long"},
+		},
+		{
+			name:     "typeless mapping",
+			mappings: map[string]interface{}{"size": field},
+			expected: map[string]string{"size": "long"},
+		},
+		{
+			name: "typed mapping with field-entry key names",
+			mappings: map[string]interface{}{
+				"document": map[string]interface{}{
+					"full_name": map[string]interface{}{
+						"full_name": "full_name",
+						"mapping": map[string]interface{}{
+							"full_name": map[string]interface{}{"type": "keyword"},
+						},
+					},
+					"mapping": map[string]interface{}{
+						"full_name": "mapping",
+						"mapping": map[string]interface{}{
+							"mapping": map[string]interface{}{"type": "long"},
+						},
+					},
+				},
+			},
+			expected: map[string]string{"full_name": "keyword", "mapping": "long"},
+		},
+		{
+			name: "invalid full name",
+			mappings: map[string]interface{}{
+				"size": map[string]interface{}{
+					"full_name": 42,
+					"mapping": map[string]interface{}{
+						"size": map[string]interface{}{"type": "long"},
+					},
+				},
+			},
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			response := map[string]interface{}{
+				"index": map[string]interface{}{"mappings": tt.mappings},
+			}
+
+			actual, err := getMetricField(response)
+			if tt.wantError {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
 func TestClientV5Sniffer(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -160,6 +237,107 @@ func TestClientV6Sniffer(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("timed out stopping node discovery")
 	}
+}
+
+func TestClientV7Sniffer(t *testing.T) {
+	discovered := make(chan struct{}, 1)
+
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/_nodes/http" {
+			http.NotFound(w, r)
+			return
+		}
+
+		response := map[string]interface{}{
+			"nodes": map[string]interface{}{
+				"node": map[string]interface{}{
+					"name":  "node",
+					"roles": []string{"data", "ingest"},
+					"http": map[string]string{
+						"publish_address": strings.TrimPrefix(server.URL, "http://"),
+					},
+				},
+			},
+		}
+		if err := json.NewEncoder(w).Encode(response); err != nil {
+			t.Error(err)
+			return
+		}
+		discovered <- struct{}{}
+	}))
+	defer server.Close()
+
+	c, err := newClientV7(clientConfig{
+		urls:              []string{server.URL},
+		enableSniffer:     true,
+		discoveryInterval: time.Hour,
+		httpClient:        server.Client(),
+		log:               testutil.Logger{},
+	})
+	require.NoError(t, err)
+
+	select {
+	case <-discovered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for node discovery")
+	}
+
+	stopped := make(chan struct{})
+	go func() {
+		c.close()
+		close(stopped)
+	}()
+
+	select {
+	case <-stopped:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out stopping node discovery")
+	}
+}
+
+func TestClientV7Query(t *testing.T) {
+	var trackTotalHits string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-Elastic-Product", "Elasticsearch")
+		switch r.URL.Path {
+		case "/":
+			if _, err := w.Write([]byte(`{"version":{"number":"7.17.29"}}`)); err != nil {
+				t.Error(err)
+			}
+		case "/test/_search":
+			trackTotalHits = r.URL.Query().Get("track_total_hits")
+			if _, err := w.Write([]byte(`{"hits":{"total":{"value":12345,"relation":"eq"}},"aggregations":{}}`)); err != nil {
+				t.Error(err)
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	c, err := newClientV7(clientConfig{
+		urls:       []string{server.URL},
+		httpClient: server.Client(),
+		log:        testutil.Logger{},
+	})
+	require.NoError(t, err)
+	defer c.close()
+
+	agg := &aggregation{
+		Index:        "test",
+		DateField:    "@timestamp",
+		FilterQuery:  "*",
+		QueryPeriod:  config.Duration(time.Minute),
+		queries:      []queryData{},
+		measurements: map[string]map[string]string{},
+	}
+	result, hits, err := c.query(t.Context(), agg)
+	require.NoError(t, err)
+	require.Nil(t, result)
+	require.EqualValues(t, 12345, hits)
+	require.Equal(t, "true", trackTotalHits)
 }
 
 type nginxlog struct {
@@ -609,6 +787,292 @@ func TestGatherV5Integration(t *testing.T) {
 		ExposedPorts: []string{servicePort},
 		Env:          map[string]string{"ES_JAVA_OPTS": "-Xms512m -Xmx512m"},
 		WaitingFor:   wait.ForHTTP("/").WithPort(servicePort).WithStartupTimeout(5 * time.Minute),
+	}
+	require.NoError(t, container.Start(), "failed to start container")
+	defer container.Terminate()
+
+	addr := "http://" + container.Address + ":" + container.Ports[servicePort]
+
+	// Fill the database
+	require.NoError(t, sendData(t.Context(), addr))
+
+	// Setup the plugin
+	plugin := &ElasticsearchQuery{
+		URLs: []string{addr},
+		Aggregations: []aggregation{
+			{
+				Index:           testindex,
+				MeasurementName: "measurement1",
+				MetricFields:    []string{"size"},
+				FilterQuery:     "product_1",
+				MetricFunction:  "avg",
+				DateField:       "@timestamp",
+				QueryPeriod:     config.Duration(time.Second * 600),
+				Tags:            []string{"URI.keyword"},
+			},
+			{
+				Index:           testindex,
+				MeasurementName: "measurement2",
+				MetricFields:    []string{"size"},
+				FilterQuery:     "downloads",
+				MetricFunction:  "max",
+				DateField:       "@timestamp",
+				QueryPeriod:     config.Duration(time.Second * 600),
+				Tags:            []string{"URI.keyword"},
+			},
+			{
+				Index:           testindex,
+				MeasurementName: "measurement3",
+				MetricFields:    []string{"size"},
+				FilterQuery:     "downloads",
+				MetricFunction:  "sum",
+				DateField:       "@timestamp",
+				QueryPeriod:     config.Duration(time.Second * 600),
+				Tags:            []string{"response.keyword"},
+			},
+			{
+				Index:             testindex,
+				MeasurementName:   "measurement4",
+				MetricFields:      []string{"size", "response_time"},
+				FilterQuery:       "downloads",
+				MetricFunction:    "min",
+				DateField:         "@timestamp",
+				QueryPeriod:       config.Duration(time.Second * 600),
+				IncludeMissingTag: true,
+				MissingTagValue:   "missing",
+				Tags:              []string{"response.keyword", "URI.keyword", "method.keyword"},
+			},
+			{
+				Index:           testindex,
+				MeasurementName: "measurement5",
+				FilterQuery:     "product_2",
+				DateField:       "@timestamp",
+				QueryPeriod:     config.Duration(time.Second * 600),
+				Tags:            []string{"URI.keyword"},
+			},
+			{
+				Index:           testindex,
+				MeasurementName: "measurement6",
+				FilterQuery:     "response: 200",
+				DateField:       "@timestamp",
+				QueryPeriod:     config.Duration(time.Second * 600),
+				Tags:            []string{"URI.keyword", "response.keyword"},
+			},
+			{
+				Index:           testindex,
+				MeasurementName: "measurement7",
+				FilterQuery:     "response: 200",
+				DateField:       "@timestamp",
+				QueryPeriod:     config.Duration(time.Second * 600),
+			},
+			{
+				Index:           testindex,
+				MeasurementName: "measurement8",
+				MetricFields:    []string{"size"},
+				FilterQuery:     "downloads",
+				MetricFunction:  "max",
+				DateField:       "@timestamp",
+				QueryPeriod:     config.Duration(time.Second * 600),
+			},
+			{
+				Index:           testindex,
+				MeasurementName: "measurement12",
+				MetricFields:    []string{"size"},
+				MetricFunction:  "avg",
+				DateField:       "@notatimestamp",
+				QueryPeriod:     config.Duration(time.Second * 600),
+			},
+			{
+				Index:             testindex,
+				MeasurementName:   "measurement13",
+				MetricFields:      []string{"size"},
+				MetricFunction:    "avg",
+				DateField:         "@timestamp",
+				QueryPeriod:       config.Duration(time.Second * 600),
+				IncludeMissingTag: false,
+				Tags:              []string{"nothere"},
+			},
+		},
+		HTTPClientConfig: common_http.HTTPClientConfig{
+			Timeout: config.Duration(30 * time.Second),
+			TransportConfig: common_http.TransportConfig{
+				ResponseHeaderTimeout: config.Duration(30 * time.Second),
+			},
+		},
+		Log: testutil.Logger{},
+	}
+	require.NoError(t, plugin.Init())
+
+	var acc testutil.Accumulator
+	require.NoError(t, plugin.Start(&acc))
+	defer plugin.Stop()
+
+	// Check the ES field mapping
+	for i, agg := range plugin.Aggregations {
+		actual := agg.mapMetricFields
+		expected := expectedFields[i]
+		require.Equalf(t, expected, actual, "mismatch in aggregation %d", i)
+	}
+
+	// Collect metrics and check
+	require.NoError(t, acc.GatherError(plugin.Gather))
+	require.Empty(t, acc.Errors)
+
+	// Check the metrics
+	testutil.RequireMetricsEqual(t, expectedMetrics, acc.GetTelegrafMetrics(), testutil.SortMetrics(), testutil.IgnoreTime())
+}
+
+func TestGatherV7Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	// Define expectations
+	expectedFields := []map[string]string{
+		{"size": "long"},
+		{"size": "long"},
+		{"size": "long"},
+		{"size": "long", "response_time": "long"},
+		{},
+		{},
+		{},
+		{"size": "long"},
+		{"size": "long"},
+		{"size": "long"},
+	}
+
+	expectedMetrics := []telegraf.Metric{
+		metric.New(
+			"measurement1",
+			map[string]string{"URI_keyword": "/downloads/product_1"},
+			map[string]interface{}{"size_avg": float64(202.30038022813687), "doc_count": int64(263)},
+			time.Date(2018, 6, 14, 5, 51, 53, 266176036, time.UTC),
+		),
+		metric.New(
+			"measurement2",
+			map[string]string{"URI_keyword": "/downloads/product_1"},
+			map[string]interface{}{"size_max": float64(3301), "doc_count": int64(263)},
+			time.Date(2018, 6, 14, 5, 51, 53, 266176036, time.UTC),
+		),
+		metric.New(
+			"measurement2",
+			map[string]string{"URI_keyword": "/downloads/product_2"},
+			map[string]interface{}{"size_max": float64(3318), "doc_count": int64(237)},
+			time.Date(2018, 6, 14, 5, 51, 53, 266176036, time.UTC),
+		),
+		metric.New(
+			"measurement3",
+			map[string]string{"response_keyword": "200"},
+			map[string]interface{}{"size_sum": float64(22790), "doc_count": int64(22)},
+			time.Date(2018, 6, 14, 5, 51, 53, 266176036, time.UTC),
+		),
+		metric.New(
+			"measurement3",
+			map[string]string{"response_keyword": "304"},
+			map[string]interface{}{"size_sum": float64(0), "doc_count": int64(219)},
+			time.Date(2018, 6, 14, 5, 51, 53, 266176036, time.UTC),
+		),
+		metric.New(
+			"measurement3",
+			map[string]string{"response_keyword": "404"},
+			map[string]interface{}{"size_sum": float64(86932), "doc_count": int64(259)},
+			time.Date(2018, 6, 14, 5, 51, 53, 266176036, time.UTC),
+		),
+		metric.New(
+			"measurement4",
+			map[string]string{"response_keyword": "404", "URI_keyword": "/downloads/product_1", "method_keyword": "GET"},
+			map[string]interface{}{"size_min": float64(318), "response_time_min": float64(126), "doc_count": int64(146)},
+			time.Date(2018, 6, 14, 5, 51, 53, 266176036, time.UTC),
+		),
+		metric.New(
+			"measurement4",
+			map[string]string{"response_keyword": "304", "URI_keyword": "/downloads/product_1", "method_keyword": "GET"},
+			map[string]interface{}{"size_min": float64(0), "response_time_min": float64(71), "doc_count": int64(113)},
+			time.Date(2018, 6, 14, 5, 51, 53, 266176036, time.UTC),
+		),
+		metric.New(
+			"measurement4",
+			map[string]string{"response_keyword": "200", "URI_keyword": "/downloads/product_1", "method_keyword": "GET"},
+			map[string]interface{}{"size_min": float64(490), "response_time_min": float64(1514), "doc_count": int64(3)},
+			time.Date(2018, 6, 14, 5, 51, 53, 266176036, time.UTC),
+		),
+		metric.New(
+			"measurement4",
+			map[string]string{"response_keyword": "404", "URI_keyword": "/downloads/product_2", "method_keyword": "GET"},
+			map[string]interface{}{"size_min": float64(318), "response_time_min": float64(237), "doc_count": int64(113)},
+			time.Date(2018, 6, 14, 5, 51, 53, 266176036, time.UTC),
+		),
+		metric.New(
+			"measurement4",
+			map[string]string{"response_keyword": "304", "URI_keyword": "/downloads/product_2", "method_keyword": "GET"},
+			map[string]interface{}{"size_min": float64(0), "response_time_min": float64(134), "doc_count": int64(106)},
+			time.Date(2018, 6, 14, 5, 51, 53, 266176036, time.UTC),
+		),
+		metric.New(
+			"measurement4",
+			map[string]string{"response_keyword": "200", "URI_keyword": "/downloads/product_2", "method_keyword": "GET"},
+			map[string]interface{}{"size_min": float64(490), "response_time_min": float64(2), "doc_count": int64(13)},
+			time.Date(2018, 6, 14, 5, 51, 53, 266176036, time.UTC),
+		),
+		metric.New(
+			"measurement4",
+			map[string]string{"response_keyword": "200", "URI_keyword": "/downloads/product_1", "method_keyword": "HEAD"},
+			map[string]interface{}{"size_min": float64(0), "response_time_min": float64(8479), "doc_count": int64(1)},
+			time.Date(2018, 6, 14, 5, 51, 53, 266176036, time.UTC),
+		),
+		metric.New(
+			"measurement4",
+			map[string]string{"response_keyword": "200", "URI_keyword": "/downloads/product_2", "method_keyword": "HEAD"},
+			map[string]interface{}{"size_min": float64(0), "response_time_min": float64(1059), "doc_count": int64(5)},
+			time.Date(2018, 6, 14, 5, 51, 53, 266176036, time.UTC),
+		),
+		metric.New(
+			"measurement5",
+			map[string]string{"URI_keyword": "/downloads/product_2"},
+			map[string]interface{}{"doc_count": int64(237)},
+			time.Date(2018, 6, 14, 5, 51, 53, 266176036, time.UTC),
+		),
+		metric.New(
+			"measurement6",
+			map[string]string{"response_keyword": "200", "URI_keyword": "/downloads/product_1"},
+			map[string]interface{}{"doc_count": int64(4)},
+			time.Date(2018, 6, 14, 5, 51, 53, 266176036, time.UTC),
+		),
+		metric.New(
+			"measurement6",
+			map[string]string{"response_keyword": "200", "URI_keyword": "/downloads/product_2"},
+			map[string]interface{}{"doc_count": int64(18)},
+			time.Date(2018, 6, 14, 5, 51, 53, 266176036, time.UTC),
+		),
+		metric.New(
+			"measurement7",
+			map[string]string{},
+			map[string]interface{}{"doc_count": int64(22)},
+			time.Date(2018, 6, 14, 5, 51, 53, 266176036, time.UTC),
+		),
+		metric.New(
+			"measurement8",
+			map[string]string{},
+			map[string]interface{}{"size_max": float64(3318)},
+			time.Date(2018, 6, 14, 5, 51, 53, 266176036, time.UTC),
+		),
+		metric.New(
+			"measurement12",
+			map[string]string{},
+			map[string]interface{}{"size_avg": float64(0)},
+			time.Date(2018, 6, 14, 5, 51, 53, 266176036, time.UTC),
+		),
+	}
+
+	// Setup the container
+	container := &testutil.Container{
+		Image:        "docker.elastic.co/elasticsearch/elasticsearch:7.17.29",
+		ExposedPorts: []string{servicePort},
+		Env: map[string]string{
+			"discovery.type": "single-node",
+			"ES_JAVA_OPTS":   "-Xms1g -Xmx1g",
+		},
+		WaitingFor: wait.ForHTTP("/").WithPort(servicePort).WithStartupTimeout(120 * time.Second),
 	}
 	require.NoError(t, container.Start(), "failed to start container")
 	defer container.Terminate()

--- a/plugins/inputs/elasticsearch_query/elasticsearch_query_test.go
+++ b/plugins/inputs/elasticsearch_query/elasticsearch_query_test.go
@@ -254,8 +254,7 @@ func TestClientV7PlusDiscovery(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			discovered := make(chan struct{}, 1)
 
-			var server *httptest.Server
-			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if r.URL.Path != "/_nodes/http" {
 					http.NotFound(w, r)
 					return

--- a/plugins/inputs/elasticsearch_query/elasticsearch_query_test.go
+++ b/plugins/inputs/elasticsearch_query/elasticsearch_query_test.go
@@ -249,18 +249,18 @@ func TestClientV7PlusSniffer(t *testing.T) {
 			return
 		}
 
-		response := map[string]interface{}{
-			"nodes": map[string]interface{}{
-				"node": map[string]interface{}{
-					"name":  "node",
-					"roles": []string{"data", "ingest"},
-					"http": map[string]string{
-						"publish_address": strings.TrimPrefix(server.URL, "http://"),
-					},
-				},
-			},
-		}
-		if err := json.NewEncoder(w).Encode(response); err != nil {
+		const response = `{
+  "nodes": {
+    "node": {
+      "name": "node",
+      "roles": ["data", "ingest"],
+      "http": {
+        "publish_address": "127.0.0.1:9200"
+      }
+    }
+  }
+}`
+		if _, err := w.Write([]byte(response)); err != nil {
 			t.Error(err)
 			return
 		}

--- a/plugins/inputs/elasticsearch_query/elasticsearch_query_test.go
+++ b/plugins/inputs/elasticsearch_query/elasticsearch_query_test.go
@@ -239,17 +239,29 @@ func TestClientV6Sniffer(t *testing.T) {
 	}
 }
 
-func TestClientV7Discovery(t *testing.T) {
-	discovered := make(chan struct{}, 1)
+func TestClientV7PlusDiscovery(t *testing.T) {
+	tests := []struct {
+		name      string
+		newClient func(clientConfig) (client, error)
+	}{
+		{
+			name:      "v7",
+			newClient: newClientV7,
+		},
+	}
 
-	var server *httptest.Server
-	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/_nodes/http" {
-			http.NotFound(w, r)
-			return
-		}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			discovered := make(chan struct{}, 1)
 
-		const response = `{
+			var server *httptest.Server
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/_nodes/http" {
+					http.NotFound(w, r)
+					return
+				}
+
+				const response = `{
   "nodes": {
     "node": {
       "name": "node",
@@ -260,28 +272,30 @@ func TestClientV7Discovery(t *testing.T) {
     }
   }
 }`
-		if _, err := w.Write([]byte(response)); err != nil {
-			t.Error(err)
-			return
-		}
-		discovered <- struct{}{}
-	}))
-	defer server.Close()
+				if _, err := w.Write([]byte(response)); err != nil {
+					t.Error(err)
+					return
+				}
+				discovered <- struct{}{}
+			}))
+			defer server.Close()
 
-	c, err := newClientV7(clientConfig{
-		urls:              []string{server.URL},
-		enableSniffer:     true,
-		discoveryInterval: time.Hour,
-		httpClient:        server.Client(),
-		log:               testutil.Logger{},
-	})
-	require.NoError(t, err)
-	defer c.close()
+			c, err := tt.newClient(clientConfig{
+				urls:              []string{server.URL},
+				enableSniffer:     true,
+				discoveryInterval: time.Hour,
+				httpClient:        server.Client(),
+				log:               testutil.Logger{},
+			})
+			require.NoError(t, err)
+			defer c.close()
 
-	select {
-	case <-discovered:
-	case <-time.After(5 * time.Second):
-		t.Fatal("timed out waiting for node discovery")
+			select {
+			case <-discovered:
+			case <-time.After(5 * time.Second):
+				t.Fatal("timed out waiting for node discovery")
+			}
+		})
 	}
 }
 

--- a/plugins/inputs/elasticsearch_query/elasticsearch_query_test.go
+++ b/plugins/inputs/elasticsearch_query/elasticsearch_query_test.go
@@ -141,10 +141,12 @@ func TestGetMetricFieldError(t *testing.T) {
 	response := map[string]interface{}{
 		"index": map[string]interface{}{
 			"mappings": map[string]interface{}{
-				"size": map[string]interface{}{
-					"full_name": 42,
-					"mapping": map[string]interface{}{
-						"size": map[string]interface{}{"type": "long"},
+				"document": map[string]interface{}{
+					"size": map[string]interface{}{
+						"full_name": 42,
+						"mapping": map[string]interface{}{
+							"size": map[string]interface{}{"type": "long"},
+						},
 					},
 				},
 			},


### PR DESCRIPTION
## Summary

Adds Elasticsearch v7 support to Elasticsearch Query input plugin using official `github.com/elastic/go-elasticsearch/v7` client.

Notable changes:
  - adds handling of nuances in v7+ regarding typeless mapping and total hits retrieval
  - adds `unsigned_long` to supported type
  - adds discovery and integration tests 

Tests notes:
  - existing v6 and new v7+ sniffer tests share most behavior, but in order to keep diff minimal, v6 is unchanged
  - v5/v6 and new v7+ integration tests also share most behavior; for the same reason not to create unrelated large diff, existing tests are untouched

Noticeable increase of size (~14 MB) is largely caused by the full `esapi.API` facade linked with `elasticsearch.Client`. An alternative is to use `estransport.Client` directly with only the required API request types. My local uncommitted  experiment estimates binary-size increase ~6 MB (+2%). The use of `estransport.Client` requires like extra 25 lines of code that mostly replicates what `elasticsearch.NewClient` does, omitting what is not needed.

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [ ] No AI generated code was used in this PR
- [x] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #12099
resolves #19213 
