### PR TITLE
feat(secretstores.os): Add support for removing secrets

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -529,7 +529,7 @@ linters:
 
       # revive:exported
       - path: (.+)\.go$
-        text: exported method .*\.(Init |SampleConfig |Gather |Start |Stop |GetState |SetState |SetParser |SetParserFunc |SetTranslator |Probe |Add |Push |Reset |Serialize |SerializeBatch |Get |Set |List |GetResolver |Apply |SetSerializer )should have comment or be unexported
+        text: exported method .*\.(Init |SampleConfig |Gather |Start |Stop |GetState |SetState |SetParser |SetParserFunc |SetTranslator |Probe |Add |Push |Reset |Serialize |SerializeBatch |Get |Set |Remove |List |GetResolver |Apply |SetSerializer )should have comment or be unexported
 
       # EXC0001 errcheck: Almost all programs ignore errors on these functions, and in most cases it's ok
       - path: (.+)\.go$

--- a/plugins/secretstores/os/os.go
+++ b/plugins/secretstores/os/os.go
@@ -78,6 +78,10 @@ func (o *OS) Set(key, value string) error {
 	return o.ring.Set(item)
 }
 
+func (o *OS) Remove(key string) error {
+	return o.ring.Remove(key)
+}
+
 func (o *OS) List() ([]string, error) {
 	return o.ring.Keys()
 }

--- a/plugins/secretstores/os/os_test.go
+++ b/plugins/secretstores/os/os_test.go
@@ -3,8 +3,10 @@
 package os
 
 import (
+	"slices"
 	"testing"
 
+	"github.com/99designs/keyring"
 	"github.com/stretchr/testify/require"
 
 	"github.com/influxdata/telegraf/internal/choice"
@@ -86,4 +88,25 @@ func TestGetNonExisting(t *testing.T) {
 	}
 	_, err = plugin.Get(testKey)
 	require.EqualError(t, err, "The specified item could not be found in the keyring")
+}
+
+func TestRemoveNonExisting(t *testing.T) {
+	plugin := &OS{ID: "test"}
+
+	// In docker, access to the keyring is disabled by default
+	// see https://docs.docker.com/engine/security/seccomp/.
+	err := plugin.Init()
+	if err != nil && err.Error() == dockerErr {
+		t.Skip("Kernel keyring not available!")
+	}
+	require.NoError(t, err)
+
+	// Make sure the key does not exist and try to remove that key
+	testKey := "foobar secret key"
+	keys, err := plugin.List()
+	require.NoError(t, err)
+	for slices.Contains(keys, testKey) {
+		testKey += "x"
+	}
+	require.ErrorIs(t, plugin.Remove(testKey), keyring.ErrKeyNotFound)
 }


### PR DESCRIPTION


## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
The `os` secret store can write secrets but has no way to erase one, so a secret created with `telegraf secrets set` stays in the OS keyring until the user removes it by hand with the platform's own tooling. This adds a `Remove` method backed by the keyring library's `Remove`, which is the missing half of the store's write support.

Removing a key that does not exist fails on every backend this store can select. keychain on darwin, keyctl and secret-service on linux, wincred on windows and pass all report a missing key as `keyring.ErrKeyNotFound`, so the behaviour is the same on all supported platforms and the new test asserts it.

The method name is added to the revive exported-method exclusion list in `.golangci.yml`, which already covers the other secret-store interface methods such as `Get`, `Set` and `List`.

This is the first of four PRs. The `jose` and `vault` stores get the same method in their own PRs, and the last one adds `Remove` to the optional `telegraf.SecretStoreEditor` interface along with a `secrets remove` command.

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->
partially resolves #19294
related to #19246
