### PR TITLE
feat(secretstores.jose): Add support for removing secrets

### DIFF
--- a/plugins/secretstores/jose/jose.go
+++ b/plugins/secretstores/jose/jose.go
@@ -92,6 +92,10 @@ func (j *Jose) Set(key, value string) error {
 	return j.ring.Set(item)
 }
 
+func (j *Jose) Remove(key string) error {
+	return j.ring.Remove(key)
+}
+
 func (j *Jose) List() ([]string, error) {
 	return j.ring.Keys()
 }

--- a/plugins/secretstores/jose/jose_test.go
+++ b/plugins/secretstores/jose/jose_test.go
@@ -1,6 +1,7 @@
 package jose
 
 import (
+	"io/fs"
 	"os"
 	"testing"
 
@@ -101,6 +102,61 @@ func TestSetListGet(t *testing.T) {
 		require.True(t, found)
 		require.Equal(t, v, string(value))
 	}
+}
+
+func TestRemove(t *testing.T) {
+	secrets := map[string]string{
+		"a secret":    "I won't tell",
+		"another one": "secret",
+		"foo":         "bar",
+	}
+
+	// Create a temporary directory we can use to store the secrets
+	testdir := t.TempDir()
+
+	// Initialize the plugin
+	plugin := &Jose{
+		ID:       "test",
+		Password: config.NewSecret([]byte("test")),
+		Path:     testdir,
+	}
+	require.NoError(t, plugin.Init())
+
+	// Store the secrets
+	for k, v := range secrets {
+		require.NoError(t, plugin.Set(k, v))
+	}
+
+	// Remove one of the secrets and make sure the remaining ones are untouched
+	require.NoError(t, plugin.Remove("another one"))
+
+	keys, err := plugin.List()
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"a secret", "foo"}, keys)
+
+	value, err := plugin.Get("foo")
+	require.NoError(t, err)
+	require.Equal(t, "bar", string(value))
+
+	// The removed secret must not be accessible anymore
+	_, err = plugin.Get("another one")
+	require.EqualError(t, err, "The specified item could not be found in the keyring")
+}
+
+func TestRemoveNonExistent(t *testing.T) {
+	// Create a temporary directory we can use to store the secrets
+	testdir := t.TempDir()
+
+	// Initialize the plugin
+	plugin := &Jose{
+		ID:       "test",
+		Password: config.NewSecret([]byte("test")),
+		Path:     testdir,
+	}
+	require.NoError(t, plugin.Init())
+	require.NoError(t, plugin.Set("a secret", "I won't tell"))
+
+	require.ErrorIs(t, plugin.Remove("foo"), fs.ErrNotExist)
 }
 
 func TestResolver(t *testing.T) {


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
The `jose` secret store can write secrets but has no way to erase one, so a secret created with `telegraf secrets set` stays in the store's directory until the user deletes the file by hand. This adds a `Remove` method backed by the keyring library's `Remove`, which deletes the file holding the secret and leaves the sibling secrets at the same path untouched.

Note that this store reports a missing key differently from the `os` store: the keyring file backend calls `os.Remove` directly, so removing a key that does not exist returns a not-exist path error rather than `keyring.ErrKeyNotFound`. Both are errors, which is what the caller needs to know, and the tests pin the behaviour of each store to what its backend actually does.

This PR is based on the `os` store PR because that one carries the revive exclusion for the `Remove` method name, which this store needs as well.


## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->
partially resolves #19294
related to #19246
