### PR TITLE
feat(secretstores.vault): Add support for removing secrets

### DIFF
--- a/plugins/secretstores/vault/vault.go
+++ b/plugins/secretstores/vault/vault.go
@@ -141,6 +141,38 @@ func (v *Vault) Set(key, value string) error {
 	return err
 }
 
+func (v *Vault) Remove(key string) error {
+	// Vault has no way to delete a single key, so read the existing secrets
+	// first and write back all of them except the one to remove.
+	secret, err := v.getSecret()
+	if err != nil {
+		return fmt.Errorf("unable to read secret: %w", err)
+	}
+	if secret == nil || secret.Data[key] == nil {
+		return fmt.Errorf("secret %q not found", key)
+	}
+	delete(secret.Data, key)
+
+	// The kv-v1 engine rejects writing a secret without any data, so delete the
+	// secret at the path once its last key is gone. Do the same for kv-v2 to
+	// keep both engines behaving alike.
+	if v.Engine == "kv-v1" {
+		kv := v.client.KVv1(v.MountPath)
+		if len(secret.Data) == 0 {
+			return kv.Delete(context.Background(), v.SecretPath)
+		}
+		return kv.Put(context.Background(), v.SecretPath, secret.Data)
+	}
+
+	kv := v.client.KVv2(v.MountPath)
+	if len(secret.Data) == 0 {
+		return kv.Delete(context.Background(), v.SecretPath)
+	}
+
+	_, err = kv.Put(context.Background(), v.SecretPath, secret.Data)
+	return err
+}
+
 func (v *Vault) GetResolver(key string) (telegraf.ResolveFunc, error) {
 	resolver := func() ([]byte, bool, error) {
 		s, err := v.Get(key)

--- a/plugins/secretstores/vault/vault_test.go
+++ b/plugins/secretstores/vault/vault_test.go
@@ -291,6 +291,72 @@ func testSetKeepsSiblings(t *testing.T, engine string) {
 	require.Equal(t, []string{"alpha", "beta", "gamma"}, keys)
 }
 
+func TestIntegrationRemove(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	tests := []struct {
+		engine string
+		// Error reported by the engine for a path without any secret
+		expectedEmpty string
+	}{
+		{
+			engine:        "kv-v1",
+			expectedEmpty: "secret not found",
+		},
+		{
+			engine:        "kv-v2",
+			expectedEmpty: "no secret data found",
+		},
+	}
+
+	mountPath := "my-mount-path"
+	secretPath := "my-secret-path"
+
+	for _, tt := range tests {
+		t.Run(tt.engine, func(t *testing.T) {
+			container, closer := createContainer(t, []string{
+				fmt.Sprintf("secrets enable -path=%s %s", mountPath, tt.engine),
+				fmt.Sprintf("kv put -mount=%s %s alpha=one beta=two", mountPath, secretPath),
+			})
+			defer closer()
+
+			addr, err := container.HttpHostAddress(context.Background())
+			require.NoError(t, err)
+
+			plugin := &Vault{
+				ID:         "test_" + tt.engine,
+				Address:    addr,
+				MountPath:  mountPath,
+				SecretPath: secretPath,
+				Engine:     tt.engine,
+				Token:      config.NewSecret([]byte("SomeToken")),
+			}
+			require.NoError(t, plugin.Init())
+
+			// Removing a secret must keep the sibling secrets at the same path
+			require.NoError(t, plugin.Remove("beta"))
+
+			keys, err := plugin.List()
+			require.NoError(t, err)
+			require.Equal(t, []string{"alpha"}, keys)
+
+			value, err := plugin.Get("alpha")
+			require.NoError(t, err)
+			require.Equal(t, "one", string(value))
+
+			// Removing a secret that does not exist must fail
+			require.ErrorContains(t, plugin.Remove("beta"), `secret "beta" not found`)
+
+			// Removing the last secret must remove the secret at the path completely
+			require.NoError(t, plugin.Remove("alpha"))
+			_, err = plugin.List()
+			require.ErrorContains(t, err, tt.expectedEmpty)
+		})
+	}
+}
+
 func TestIntegrationSetCreatesNewPathKVv1(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
The `vault` secret store can write secrets but has no way to erase one. Vault offers no operation to delete a single key of a secret, so `Remove` reads the secret at the configured path first and writes back all keys except the one to remove, mirroring what `Set` already does to keep the sibling keys. Removing a key that is not stored at the path fails instead of silently rewriting the same secret.

Removing the last key needs a different path: the kv-v1 engine rejects writing a secret without any data with `400 missing data fields`, so the secret at the path is deleted instead once its last key is gone. The kv-v2 engine accepts an empty write, but does the same here so both engines end up in the same state rather than one keeping an empty secret around.

Both engines are covered by integration tests that remove a key and check the siblings survive, that removing an unknown key fails, and that removing the last key leaves no secret at the path.

This PR is based on the `os` and `jose` store PRs.


## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

partially resolves #19294
related to #19246
