### PR TITLE
feat(agent): Add command for removing secrets from a store

### DIFF
--- a/cmd/telegraf/cmd_secretstore.go
+++ b/cmd/telegraf/cmd_secretstore.go
@@ -263,6 +263,66 @@ you will be prompted to enter the value of the secret.
 						return nil
 					},
 				},
+				{
+					Name:  "remove",
+					Usage: "remove a secret from the given store",
+					Description: `
+The 'remove' command requires passing in your configuration file
+containing the secret store definitions you want to access. To get a
+list of available secret store plugins, please have a look at
+https://github.com/influxdata/telegraf/tree/master/plugins/secretstores.
+and use the 'secrets list' command to get the IDs of available stores and keys.
+
+For help on how to define secret stores, check the documentation of the
+different plugins.
+
+Assuming you use the default configuration file location, you can run
+the following command to remove a secret from an available secret store
+
+> telegraf secrets remove mystore mysecretkey
+
+This will remove the secret with the key 'mysecretkey' from the secret
+store with the ID 'mystore'. Removing a key that does not exist in that
+store results in an error.
+`,
+					ArgsUsage: "<secret store ID> <secret key>",
+					Action: func(cCtx *cli.Context) error {
+						// Only load the secret stores
+						filters := processFilterOnlySecretStoreFlags(cCtx)
+						g := GlobalFlags{
+							config:     cCtx.StringSlice("config"),
+							configDir:  cCtx.StringSlice("config-directory"),
+							plugindDir: cCtx.String("plugin-directory"),
+							password:   cCtx.String("password"),
+							debug:      cCtx.Bool("debug"),
+						}
+						w := WindowFlags{}
+						m.Init(nil, filters, g, w)
+
+						args := cCtx.Args()
+						if !args.Present() || args.Len() != 2 {
+							return errors.New("invalid number of arguments")
+						}
+
+						storeID := args.First()
+						key := args.Get(1)
+
+						store, err := m.GetSecretStore(storeID)
+						if err != nil {
+							return fmt.Errorf("unable to get secret store: %w", err)
+						}
+						editor, ok := store.(telegraf.SecretStoreEditor)
+						if !ok {
+							return fmt.Errorf("secret store %q does not support removing secrets", storeID)
+						}
+
+						if err := editor.Remove(key); err != nil {
+							return fmt.Errorf("unable to remove secret: %w", err)
+						}
+
+						return nil
+					},
+				},
 			},
 		},
 	}

--- a/cmd/telegraf/main_test.go
+++ b/cmd/telegraf/main_test.go
@@ -104,6 +104,15 @@ func (s *MockSecretStore) Set(key, value string) error {
 	s.Secrets[key] = []byte(value)
 	return nil
 }
+
+func (s *MockSecretStore) Remove(key string) error {
+	if _, found := s.Secrets[key]; !found {
+		return errors.New("not found")
+	}
+	delete(s.Secrets, key)
+	return nil
+}
+
 func (s *MockSecretStore) List() ([]string, error) {
 	keys := make([]string, 0, len(s.Secrets))
 	for k := range s.Secrets {
@@ -339,6 +348,32 @@ func TestSecretsSetUnsupported(t *testing.T) {
 	args = append(args, "secrets", "set", "readonly", "key", "value")
 	err := runApp(args, buf, NewMockServer(), NewMockConfig(buf), NewMockTelegraf())
 	require.ErrorContains(t, err, `secret store "readonly" does not support setting secrets`)
+}
+
+func TestSecretsRemove(t *testing.T) {
+	buf := new(bytes.Buffer)
+	args := os.Args[0:1]
+	args = append(args, "secrets", "remove", "oppo_rancisis", "episode2")
+	err := runApp(args, buf, NewMockServer(), NewMockConfig(buf), NewMockTelegraf())
+	require.NoError(t, err)
+	require.NotContains(t, secrets["oppo_rancisis"], "episode2")
+	require.Contains(t, secrets["oppo_rancisis"], "episode1")
+}
+
+func TestSecretsRemoveNonExisting(t *testing.T) {
+	buf := new(bytes.Buffer)
+	args := os.Args[0:1]
+	args = append(args, "secrets", "remove", "coleman_kcaj", "episode1")
+	err := runApp(args, buf, NewMockServer(), NewMockConfig(buf), NewMockTelegraf())
+	require.ErrorContains(t, err, "unable to remove secret: not found")
+}
+
+func TestSecretsRemoveUnsupported(t *testing.T) {
+	buf := new(bytes.Buffer)
+	args := os.Args[0:1]
+	args = append(args, "secrets", "remove", "readonly", "key")
+	err := runApp(args, buf, NewMockServer(), NewMockConfig(buf), NewMockTelegraf())
+	require.ErrorContains(t, err, `secret store "readonly" does not support removing secrets`)
 }
 
 func TestCommandConfig(t *testing.T) {

--- a/docs/SECRETSTORES.md
+++ b/docs/SECRETSTORES.md
@@ -5,6 +5,10 @@ This section is for developers who want to create a new secret store plugin.
 ## Secret Store Plugin Guidelines
 
 * A secret store must conform to telegraf's [`SecretStore` interface][interface].
+* Secret stores able to create, modify or erase secrets should additionally
+  implement the optional [`SecretStoreEditor` interface][editor interface].
+  Stores backed by a read-only source must not implement it, the `secrets set`
+  and `secrets remove` commands reject those stores.
 * Secret stores should call `secretstores.Add` in their `init` function to register
   themselves. See below for a quick example.
 * To be available within Telegraf itself, plugins must register themselves
@@ -21,6 +25,7 @@ This section is for developers who want to create a new secret store plugin.
 * Follow the recommended [Code Style][].
 
 [interface]: https://pkg.go.dev/github.com/influxdata/telegraf?utm_source=godoc#SecretStore
+[editor interface]: https://pkg.go.dev/github.com/influxdata/telegraf?utm_source=godoc#SecretStoreEditor
 [Sample Config]: https://github.com/influxdata/telegraf/blob/master/docs/developers/SAMPLE_CONFIG.md
 [Code Style]: https://github.com/influxdata/telegraf/blob/master/docs/developers/CODE_STYLE.md
 
@@ -85,6 +90,15 @@ func (p *Printer) Get(key string) ([]byte, error) {
 // Set sets the given secret for the given key
 func (p *Printer) Set(key, value string) error {
     p.cache[key] = value
+    return nil
+}
+
+// Remove erases the secret for the given key
+func (p *Printer) Remove(key string) error {
+    if _, found := p.cache[key]; !found {
+        return errors.New("not found")
+    }
+    delete(p.cache, key)
     return nil
 }
 

--- a/secretstore.go
+++ b/secretstore.go
@@ -15,11 +15,16 @@ type SecretStore interface {
 	GetResolver(key string) (ResolveFunc, error)
 }
 
-// SecretStoreEditor is an optional interface for secret stores that can create
-// or modify secrets. Stores backed by a read-only source do not implement it.
+// SecretStoreEditor is an optional interface for secret stores that can create,
+// modify or erase secrets. Stores backed by a read-only source do not implement
+// it.
 type SecretStoreEditor interface {
 	// Set creates or modifies the secret for the given key
 	Set(key, value string) error
+
+	// Remove erases the secret for the given key and returns an error if there
+	// is no secret stored under that key
+	Remove(key string) error
 }
 
 // ResolveFunc is a function to resolve the secret.


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
The `secrets` command help has always claimed it is for "listing, adding and removing secrets", but there was no way to remove one, so a secret written with `telegraf secrets set` could only be erased with the store backend's own tooling. This adds `Remove` to the optional `telegraf.SecretStoreEditor` interface, which the `os`, `jose` and `vault` stores implement in the preceding PRs, and exposes it as a `telegraf secrets remove <store> <key>` command.

Keeping the capability optional means the five read-only stores (`docker`, `systemd`, `oauth2`, `http` and `googlecloud`) do not have to grow a stub method that only returns a "not supported" error. The command type-asserts the store against the interface and fails with a single framework-level message, "secret store <id> does not support removing secrets", exactly the way `secrets set` does. Removing a key that does not exist is an error rather than a silent success, so a typo in the key name is visible to the user.

The secret store developer documentation is updated as well: it still described `Set` as part of the mandatory interface, which stopped being true when setting became optional, so it now covers the optional editor interface and the example store implements both methods.

Removing all secrets of a store in one go, the `--all` flag asked for in #19246, is deliberately left out here and can follow separately.


## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #19294
resolves #19246
