### PR TITLE
fix(inputs.execd): Respect influx parser parameters

### DIFF
--- a/plugins/inputs/execd/execd.go
+++ b/plugins/inputs/execd/execd.go
@@ -126,7 +126,10 @@ func (e *Execd) cmdReadOut(out io.Reader) {
 }
 
 func (e *Execd) cmdReadOutStream(out io.Reader) {
-	parser := influx.NewStreamParser(out)
+	// Type assertions cannot fail because the function is only executed with
+	// both assertions being fine
+	unwrapped := e.parser.(*models.RunningParser)
+	parser := unwrapped.Parser.(*influx.Parser).CreateStreamParser(out)
 
 	for {
 		metric, err := parser.Next()

--- a/plugins/parsers/influx/parser.go
+++ b/plugins/parsers/influx/parser.go
@@ -128,7 +128,6 @@ func (p *Parser) Parse(input []byte) ([]telegraf.Metric, error) {
 		if metric == nil {
 			continue
 		}
-
 		metrics = append(metrics, metric)
 	}
 
@@ -184,6 +183,17 @@ type StreamParser struct {
 
 func NewStreamParser(r io.Reader) *StreamParser {
 	handler := NewMetricHandler()
+	return &StreamParser{
+		machine: NewStreamMachine(r, handler),
+		handler: handler,
+	}
+}
+
+func (p *Parser) CreateStreamParser(r io.Reader) *StreamParser {
+	handler := &MetricHandler{
+		timePrecision: p.handler.timePrecision,
+		timeFunc:      p.handler.timeFunc,
+	}
 	return &StreamParser{
 		machine: NewStreamMachine(r, handler),
 		handler: handler,


### PR DESCRIPTION
## Summary

The execd plugin uses a streaming parser for processing the output if the script in case the data-format is line-protocol. However, when creating the streaming parser the code creates a plain parser with defaults ignoring all set parser parameters completely.

This PR introduces a way to derive a line-protocol streaming parser from an existing parser preserving all set parameters.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

resolves #19324 
