### PR TITLE
fix(inputs.redfish): Skip resources without a reference

### DIFF
--- a/plugins/inputs/redfish/redfish.go
+++ b/plugins/inputs/redfish/redfish.go
@@ -39,6 +39,7 @@ type Redfish struct {
 	IncludeTagSets   []string        `toml:"include_tag_sets"`
 	Workarounds      []string        `toml:"workarounds"`
 	Timeout          config.Duration `toml:"timeout"`
+	Log              telegraf.Logger `toml:"-"`
 
 	tagSet map[string]bool
 	client http.Client
@@ -163,6 +164,13 @@ func (r *Redfish) Gather(acc telegraf.Accumulator) error {
 	}
 
 	for _, link := range system.Links.Chassis {
+		// References are resolved against the configured address, so an empty
+		// one would request the device's web root instead of a Redfish resource
+		if link.Ref == "" {
+			r.Log.Warn("Skipping chassis without reference")
+			continue
+		}
+
 		chassis, err := r.getChassis(link.Ref)
 		if err != nil {
 			return err
@@ -172,8 +180,16 @@ func (r *Redfish) Gather(acc telegraf.Accumulator) error {
 			var err error
 			switch metric {
 			case "thermal":
+				if chassis.Thermal.Ref == "" {
+					r.Log.Warnf("Skipping thermal data of chassis %q without reference", link.Ref)
+					continue
+				}
 				err = r.gatherThermal(acc, address, system, chassis)
 			case "power":
+				if chassis.Power.Ref == "" {
+					r.Log.Warnf("Skipping power data of chassis %q without reference", link.Ref)
+					continue
+				}
 				err = r.gatherPower(acc, address, system, chassis)
 			default:
 				return fmt.Errorf("unknown metric requested: %s", metric)

--- a/plugins/inputs/redfish/redfish_test.go
+++ b/plugins/inputs/redfish/redfish_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"sync"
 	"testing"
 	"time"
 
@@ -986,6 +987,102 @@ func TestParseErrorIncludesContext(t *testing.T) {
 	err := plugin.Gather(&acc)
 	require.ErrorContains(t, err, ts.URL+"/redfish/v1/Systems/System.Embedded.1")
 	require.ErrorContains(t, err, "text/html")
+}
+
+func TestSkipChassisWithoutReference(t *testing.T) {
+	var mu sync.Mutex
+	var requested []string
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !checkAuth(r, "test", "test") {
+			http.Error(w, "Unauthorized.", http.StatusUnauthorized)
+			return
+		}
+
+		mu.Lock()
+		requested = append(requested, r.URL.Path)
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := w.Write([]byte(`{"Links": {"Chassis": [{"@odata.id": ""}]}}`)); err != nil {
+			t.Error(err)
+		}
+	}))
+	defer ts.Close()
+
+	plugin := &Redfish{
+		Address:          ts.URL,
+		Username:         config.NewSecret([]byte("test")),
+		Password:         config.NewSecret([]byte("test")),
+		ComputerSystemID: "1",
+		IncludeMetrics:   []string{"thermal", "power"},
+		Log:              testutil.Logger{},
+	}
+	require.NoError(t, plugin.Init())
+
+	var acc testutil.Accumulator
+	require.NoError(t, plugin.Gather(&acc))
+	require.Empty(t, acc.GetTelegrafMetrics())
+
+	// The empty reference must not be requested as it resolves to the web root
+	mu.Lock()
+	defer mu.Unlock()
+	require.Equal(t, []string{"/redfish/v1/Systems/1"}, requested)
+}
+
+func TestSkipChassisWithoutThermalAndPowerReference(t *testing.T) {
+	var mu sync.Mutex
+	var requested []string
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !checkAuth(r, "test", "test") {
+			http.Error(w, "Unauthorized.", http.StatusUnauthorized)
+			return
+		}
+
+		mu.Lock()
+		requested = append(requested, r.URL.Path)
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+
+		var body string
+		switch r.URL.Path {
+		case "/redfish/v1/Systems/1":
+			body = `{"Links": {"Chassis": [{"@odata.id": "/redfish/v1/Chassis/1"}]}}`
+		case "/redfish/v1/Chassis/1":
+			// Firmware exposing the newer ThermalSubsystem and PowerSubsystem
+			// resources does not provide the Thermal and Power ones
+			body = `{"ChassisType": "RackMount", "Model": "AS-1116CS-TN"}`
+		default:
+			t.Errorf("unexpected request for %q", r.URL.Path)
+			return
+		}
+
+		if _, err := w.Write([]byte(body)); err != nil {
+			t.Error(err)
+		}
+	}))
+	defer ts.Close()
+
+	plugin := &Redfish{
+		Address:          ts.URL,
+		Username:         config.NewSecret([]byte("test")),
+		Password:         config.NewSecret([]byte("test")),
+		ComputerSystemID: "1",
+		IncludeMetrics:   []string{"thermal", "power"},
+		Log:              testutil.Logger{},
+	}
+	require.NoError(t, plugin.Init())
+
+	var acc testutil.Accumulator
+	require.NoError(t, plugin.Gather(&acc))
+	require.Empty(t, acc.GetTelegrafMetrics())
+
+	// The missing references must not be requested as they resolve to the web root
+	mu.Lock()
+	defer mu.Unlock()
+	require.Equal(t, []string{"/redfish/v1/Systems/1", "/redfish/v1/Chassis/1"}, requested)
 }
 
 func TestIncludeTagSetsConfiguration(t *testing.T) {


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
References returned by the device are resolved against the configured address, so an empty reference collapses to the address itself and the plugin requests the device's web root. BMCs serve their HTML web interface there, so the request succeeds with a 200 and an HTML body, and the user sees `invalid character '<' looking for beginning of value` with no indication of which resource is actually missing. Three places take a reference straight from the device and fetch it: the chassis links of the computer system, and the thermal and power references of each chassis.

This skips a chassis, thermal or power resource that has no reference and logs a warning naming the chassis, so a device that does not expose one of those resources produces a clear message rather than a parse error against its web interface. Metrics from the resources the device does expose are still collected instead of the whole gather failing.

The plugin gains a `Log` field for those warnings, which it did not have before.

Reported on a Supermicro AS-1116CS-TN whose firmware appears to expose the newer ThermalSubsystem and PowerSubsystem resources rather than the deprecated Thermal and Power ones. Supporting those resources is separate work and not part of this change.


## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

related to #19289
