### PR TITLE
test(processors.snmp_lookup): Fix race condition

### DIFF
--- a/plugins/processors/snmp_lookup/store_test.go
+++ b/plugins/processors/snmp_lookup/store_test.go
@@ -96,8 +96,11 @@ func TestLookup(t *testing.T) {
 	time.Sleep(minUpdateInterval)
 
 	// Third lookup should directly update
-	// Block the update so we can check for the inflight flag
+	// Block the update so we can check for the inflight flag. Make sure we
+	// unblock the update in case of error...
 	blockUpdate.Store(true)
+	defer blockUpdate.Store(false)
+
 	s.lookup("127.0.0.1", "999")
 	require.Eventually(t, func() bool {
 		_, inflight := s.inflight.Load("127.0.0.1")

--- a/plugins/processors/snmp_lookup/store_test.go
+++ b/plugins/processors/snmp_lookup/store_test.go
@@ -43,7 +43,12 @@ func TestLookup(t *testing.T) {
 	cacheTTL := config.Duration(10 * minUpdateInterval)
 	var notifyCount atomic.Uint64
 	s := newStore(defaultCacheSize, cacheTTL, defaultParallelLookups, config.Duration(minUpdateInterval))
+
+	var blockUpdate atomic.Bool
 	s.update = func(string) *tagMap {
+		for blockUpdate.Load() {
+			time.Sleep(100 * time.Millisecond)
+		}
 		return &tagMap{
 			created: time.Now(),
 			rows:    tmr,
@@ -91,9 +96,14 @@ func TestLookup(t *testing.T) {
 	time.Sleep(minUpdateInterval)
 
 	// Third lookup should directly update
+	// Block the update so we can check for the inflight flag
+	blockUpdate.Store(true)
 	s.lookup("127.0.0.1", "999")
-	_, inflight := s.inflight.Load("127.0.0.1")
-	require.True(t, inflight)
+	require.Eventually(t, func() bool {
+		_, inflight := s.inflight.Load("127.0.0.1")
+		return inflight
+	}, time.Second, time.Millisecond)
+	blockUpdate.Store(false)
 	require.Eventually(t, func() bool {
 		return notifyCount.Load() == 4
 	}, time.Second, time.Millisecond)


### PR DESCRIPTION
## Summary

Fix a race condition when checking for `inflight`.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
