### PR TITLE
test(inputs.sip): Fix panic from assertions in handler goroutines

### DIFF
--- a/plugins/inputs/sip/sip_test.go
+++ b/plugins/inputs/sip/sip_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"strconv"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -317,12 +318,11 @@ func TestSecureProtocolWithoutTLSConfig(t *testing.T) {
 }
 
 func TestSIPServerSuccess(t *testing.T) {
-	server, err := newMockServer(sip.OPTIONS, func(req *sip.Request, tx sip.ServerTransaction) {
-		res := sip.NewResponseFromRequest(req, 200, "OK", nil)
-		require.NoError(t, tx.Respond(res))
+	server, err := newMockServer(sip.OPTIONS, func(req *sip.Request) *sip.Response {
+		return sip.NewResponseFromRequest(req, 200, "OK", nil)
 	})
 	require.NoError(t, err)
-	defer server.close()
+	defer server.close(t)
 
 	plugin := &SIP{
 		Server:   "sip://" + server.addr,
@@ -360,12 +360,11 @@ func TestSIPServerSuccess(t *testing.T) {
 }
 
 func TestSIPServerErrorResponse(t *testing.T) {
-	server, err := newMockServer(sip.OPTIONS, func(req *sip.Request, tx sip.ServerTransaction) {
-		res := sip.NewResponseFromRequest(req, 404, "Not Found", nil)
-		require.NoError(t, tx.Respond(res))
+	server, err := newMockServer(sip.OPTIONS, func(req *sip.Request) *sip.Response {
+		return sip.NewResponseFromRequest(req, 404, "Not Found", nil)
 	})
 	require.NoError(t, err)
-	defer server.close()
+	defer server.close(t)
 
 	plugin := &SIP{
 		Server:   "sip://" + server.addr,
@@ -403,11 +402,12 @@ func TestSIPServerErrorResponse(t *testing.T) {
 }
 
 func TestSIPServerTimeout(t *testing.T) {
-	server, err := newMockServer(sip.OPTIONS, func(_ *sip.Request, _ sip.ServerTransaction) {
+	server, err := newMockServer(sip.OPTIONS, func(*sip.Request) *sip.Response {
 		// Intentionally no response to trigger timeout
+		return nil
 	})
 	require.NoError(t, err)
-	defer server.close()
+	defer server.close(t)
 
 	plugin := &SIP{
 		Server:   "sip://" + server.addr,
@@ -451,13 +451,12 @@ func TestSIPServerTimeout(t *testing.T) {
 }
 
 func TestSIPServerDelayedResponse(t *testing.T) {
-	server, err := newMockServer(sip.OPTIONS, func(req *sip.Request, tx sip.ServerTransaction) {
+	server, err := newMockServer(sip.OPTIONS, func(req *sip.Request) *sip.Response {
 		time.Sleep(50 * time.Millisecond)
-		res := sip.NewResponseFromRequest(req, 200, "OK", nil)
-		require.NoError(t, tx.Respond(res))
+		return sip.NewResponseFromRequest(req, 200, "OK", nil)
 	})
 	require.NoError(t, err)
-	defer server.close()
+	defer server.close(t)
 
 	plugin := &SIP{
 		Server:   "sip://" + server.addr,
@@ -527,12 +526,11 @@ func TestSIPDifferentStatusCodes(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			server, err := newMockServer(sip.OPTIONS, func(req *sip.Request, tx sip.ServerTransaction) {
-				res := sip.NewResponseFromRequest(req, tt.statusCode, tt.reason, nil)
-				require.NoError(t, tx.Respond(res))
+			server, err := newMockServer(sip.OPTIONS, func(req *sip.Request) *sip.Response {
+				return sip.NewResponseFromRequest(req, tt.statusCode, tt.reason, nil)
 			})
 			require.NoError(t, err)
-			defer server.close()
+			defer server.close(t)
 
 			plugin := &SIP{
 				Server:   "sip://" + server.addr,
@@ -572,15 +570,15 @@ func TestSIPDifferentStatusCodes(t *testing.T) {
 }
 
 func TestSIPAuthenticationRequired(t *testing.T) {
-	server, err := newMockServer(sip.OPTIONS, func(req *sip.Request, tx sip.ServerTransaction) {
+	server, err := newMockServer(sip.OPTIONS, func(req *sip.Request) *sip.Response {
 		// Respond with 401 Unauthorized to require authentication
 		res := sip.NewResponseFromRequest(req, 401, "Unauthorized", nil)
 		// Add WWW-Authenticate header (required for digest auth)
 		res.AppendHeader(sip.NewHeader("WWW-Authenticate", `Digest realm="test", nonce="abc123"`))
-		require.NoError(t, tx.Respond(res))
+		return res
 	})
 	require.NoError(t, err)
-	defer server.close()
+	defer server.close(t)
 
 	// Test without credentials - should get auth_required
 	plugin := &SIP{
@@ -625,26 +623,21 @@ func TestSIPAuthenticationSuccess(t *testing.T) {
 	)
 
 	var attemptCount atomic.Int32
-	server, err := newMockServer(sip.OPTIONS, func(req *sip.Request, tx sip.ServerTransaction) {
+	server, err := newMockServer(sip.OPTIONS, func(req *sip.Request) *sip.Response {
 		attemptCount.Add(1)
 
-		// Check if Authorization header is present
-		authHeader := req.GetHeader("Authorization")
-
-		if authHeader == nil {
+		if req.GetHeader("Authorization") == nil {
 			// First attempt without auth - send 401 challenge
 			res := sip.NewResponseFromRequest(req, 401, "Unauthorized", nil)
 			res.AppendHeader(sip.NewHeader("WWW-Authenticate", `Digest realm="test", nonce="abc123", algorithm=MD5`))
-			require.NoError(t, tx.Respond(res))
-			return
+			return res
 		}
 
 		// Second attempt with auth - validate it exists and respond with 200
-		res := sip.NewResponseFromRequest(req, 200, "OK", nil)
-		require.NoError(t, tx.Respond(res))
+		return sip.NewResponseFromRequest(req, 200, "OK", nil)
 	})
 	require.NoError(t, err)
-	defer server.close()
+	defer server.close(t)
 
 	// Create plugin with valid credentials
 	username := config.NewSecret([]byte(validUsername))
@@ -706,16 +699,14 @@ func TestSIPAuthenticationSuccess(t *testing.T) {
 }
 
 func TestSIPMethodINVITE(t *testing.T) {
-	server, err := newMockServer(sip.INVITE, func(req *sip.Request, tx sip.ServerTransaction) {
-		// Verify we received an INVITE request
-		require.Equal(t, "INVITE", req.Method.String())
-
+	// The handler only runs for INVITE, so a 200 in the metric below is proof
+	// the plugin sent one
+	server, err := newMockServer(sip.INVITE, func(req *sip.Request) *sip.Response {
 		// INVITE typically gets a 200 OK or 180 Ringing
-		res := sip.NewResponseFromRequest(req, 200, "OK", nil)
-		require.NoError(t, tx.Respond(res))
+		return sip.NewResponseFromRequest(req, 200, "OK", nil)
 	})
 	require.NoError(t, err)
-	defer server.close()
+	defer server.close(t)
 
 	plugin := &SIP{
 		Server:   "sip://" + server.addr,
@@ -754,16 +745,14 @@ func TestSIPMethodINVITE(t *testing.T) {
 }
 
 func TestSIPMethodMESSAGE(t *testing.T) {
-	server, err := newMockServer(sip.MESSAGE, func(req *sip.Request, tx sip.ServerTransaction) {
-		// Verify we received a MESSAGE request
-		require.Equal(t, "MESSAGE", req.Method.String())
-
+	// The handler only runs for MESSAGE, so a 200 in the metric below is proof
+	// the plugin sent one
+	server, err := newMockServer(sip.MESSAGE, func(req *sip.Request) *sip.Response {
 		// MESSAGE typically gets a 200 OK or 202 Accepted
-		res := sip.NewResponseFromRequest(req, 200, "OK", nil)
-		require.NoError(t, tx.Respond(res))
+		return sip.NewResponseFromRequest(req, 200, "OK", nil)
 	})
 	require.NoError(t, err)
-	defer server.close()
+	defer server.close(t)
 
 	plugin := &SIP{
 		Server:   "sip://" + server.addr,
@@ -807,9 +796,16 @@ type mockServer struct {
 	ua     *sipgo.UserAgent
 	server *sipgo.Server
 	addr   string
+
+	// Errors collected while responding to requests
+	mu   sync.Mutex
+	errs []error
 }
 
-func newMockServer(method sip.RequestMethod, handler func(*sip.Request, sip.ServerTransaction)) (*mockServer, error) {
+// newMockServer starts a SIP server answering the given method with the response
+// returned by the handler. Returning a nil response sends nothing, leaving the
+// client to time out.
+func newMockServer(method sip.RequestMethod, handler func(*sip.Request) *sip.Response) (*mockServer, error) {
 	ua, err := sipgo.NewUA(
 		sipgo.WithUserAgent("Test SIP Server"),
 	)
@@ -823,8 +819,23 @@ func newMockServer(method sip.RequestMethod, handler func(*sip.Request, sip.Serv
 		return nil, fmt.Errorf("creating server: %w", err)
 	}
 
-	// Register handler for the specified method
-	server.OnRequest(method, handler)
+	s := &mockServer{ua: ua, server: server}
+
+	// Register handler for the specified method. The library runs the handler on
+	// a goroutine that can outlive the test function, so responding and
+	// collecting the errors has to happen here instead of in the handler where
+	// reporting a failure would panic the test binary.
+	server.OnRequest(method, func(req *sip.Request, tx sip.ServerTransaction) {
+		res := handler(req)
+		if res == nil {
+			return
+		}
+		if err := tx.Respond(res); err != nil {
+			s.mu.Lock()
+			s.errs = append(s.errs, err)
+			s.mu.Unlock()
+		}
+	})
 
 	// Create UDP listener ourselves to know the address before serving.
 	// This avoids a data race in sipgo where GetListenPort reads the
@@ -835,21 +846,23 @@ func newMockServer(method sip.RequestMethod, handler func(*sip.Request, sip.Serv
 		_ = ua.Close()
 		return nil, fmt.Errorf("listening udp: %w", err)
 	}
-	addr := udpConn.LocalAddr().String()
+	s.addr = udpConn.LocalAddr().String()
 
 	go func() {
 		//nolint:errcheck // Background server for testing, errors are not critical
 		server.ServeUDP(udpConn)
 	}()
 
-	return &mockServer{
-		ua:     ua,
-		server: server,
-		addr:   addr,
-	}, nil
+	return s, nil
 }
 
-func (s *mockServer) close() {
+func (s *mockServer) close(t *testing.T) {
+	t.Helper()
+
 	_ = s.server.Close()
 	_ = s.ua.Close()
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	require.Empty(t, s.errs, "responding to request failed")
 }


### PR DESCRIPTION


## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
The mock server handlers asserted with require on the testing.T, but sipgo runs them on goroutines nothing joins, so a handler outliving its test reported a failure on a completed testing.T and panicked the test binary. Handlers now return the response to send, leaving tx.Respond and the error collection to the mock server, which the test asserts on close.

Seen on https://circleci.com/gh/influxdata/telegraf/538775, where a leftover handler from TestSIPServerDelayedResponse panicked during TestSIPDifferentStatusCodes.

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
