### PR TITLE
fix(common.socket): Add interface name extraction and validation

### DIFF
--- a/plugins/common/socket/socket.go
+++ b/plugins/common/socket/socket.go
@@ -55,25 +55,18 @@ type Socket struct {
 	listener listener
 }
 
-// extractIfNameRegex matches 4 different case.
+// extractIfNameRegex extracts and validates matches these case:
 //
-// 1. IPv6 with a zone id and a trailing interface name; or
-// 2. IPv6 with a zone id only; or
-// 3. IPv6 a trailing interface name only; or
-// 4. Any other IP or socket name with a zone id only
+// 1. IPv6 with zone id
+// 2. IPv6 with zone id and trailing interface name
+// 3. IPv6 with trailing interface name
+// 4. Any other hostname with trailing interface name (hostname does not contain a % or ])
 var extractIfNameRegex = regexp.MustCompile(
-	`\[[a-zA-Z0-9:]+%([^%]*)]:\w+%([^%]*)$|\[[a-zA-Z0-9:]+%([^%]*)]:\w+$|\[[a-zA-Z0-9:]+]:\w+%([^%]*)$|[^]]:\w+%([^%]*)$`,
+	`\[[^%]+%([^]]*)][^%]*$|\[[^%]+%([^]]*)][^%]*%(.*)$|\[[^%]]+][^%]*%(.*)$|[^%]]*%(.*)$`,
 )
-var validIfNameRegex = regexp.MustCompile(`^[^/:\s]{1,15}$`)
 
-// interfaceNameFromServiceAddress extract and validates interface names
-// Valid names folow the rules implemented in https://github.com/torvalds/linux/blob/11028ab62899e4191e074ee364c712b77823a9c4/net/core/dev.c#L1325
-// which comes down to:
-//   - No empty string
-//   - No string longer than 15 characters
-//   - Not exactly `.` or `..`
-//   - Contains no `/`, `:` or whitespace
-func interfaceNameFromServiceAddress(address string) (interfaceName string, valid error) {
+// interfaceNameFromServiceAddress extracts interface names
+func interfaceNameFromServiceAddress(address string) (string, error) {
 	matches := extractIfNameRegex.FindStringSubmatch(address)
 	if len(matches) < 2 {
 		return "", nil
@@ -92,8 +85,8 @@ func interfaceNameFromServiceAddress(address string) (interfaceName string, vali
 		}
 	}
 
-	if ifName == "." || ifName == ".." || !validIfNameRegex.MatchString(ifName) {
-		return "", fmt.Errorf("interface name %q is not valid", ifName)
+	if ifName == "" {
+		return "", fmt.Errorf("address %q is not valid", address)
 	}
 
 	return ifName, nil

--- a/plugins/common/socket/socket.go
+++ b/plugins/common/socket/socket.go
@@ -54,6 +54,34 @@ type Socket struct {
 	listener listener
 }
 
+var extractIfNameRegex = regexp.MustCompile(`%(.*)$`)
+var validIfNameRegex = regexp.MustCompile(`^[^/:\s]{1,15}$`)
+
+// interfaceNameFromServiceAddress extract and validates interface names
+// Valid names folow the rules implemented in https://github.com/torvalds/linux/blob/11028ab62899e4191e074ee364c712b77823a9c4/net/core/dev.c#L1325
+// which comes down to:
+//   - No empty string
+//   - No string longer than 15 characters
+//   - Not exactly `.` or `..`
+//   - Contains no `/`, `:` or whitespace
+func interfaceNameFromServiceAddress(address string) (interfaceName string, present bool, valid error) {
+	matches := extractIfNameRegex.FindStringSubmatch(address)
+	if len(matches) < 2 {
+		return "", false, nil
+	}
+
+	ifName := matches[1]
+	if ifName == "." || ifName == ".." {
+		return "", false, fmt.Errorf("interface name `%s` is not valid", ifName)
+	}
+
+	if !validIfNameRegex.MatchString(ifName) {
+		return "", false, fmt.Errorf("interface name `%s` is not valid", ifName)
+	}
+
+	return ifName, true, nil
+}
+
 func (cfg *Config) NewSocket(address string, splitcfg *SplitConfig, logger telegraf.Logger) (*Socket, error) {
 	s := &Socket{
 		Config: *cfg,
@@ -70,9 +98,13 @@ func (cfg *Config) NewSocket(address string, splitcfg *SplitConfig, logger teleg
 	}
 
 	// Resolve the interface to an address if any given
-	ifregex := regexp.MustCompile(`%([\w\.]+)`)
-	if matches := ifregex.FindStringSubmatch(address); len(matches) == 2 {
-		s.interfaceName = matches[1]
+	ifName, ifNamePresent, ifNameErr := interfaceNameFromServiceAddress(address)
+	if ifNameErr != nil {
+		return nil, ifNameErr
+	}
+
+	if ifNamePresent {
+		s.interfaceName = ifName
 		address = strings.Replace(address, "%"+s.interfaceName, "", 1)
 	}
 

--- a/plugins/common/socket/socket.go
+++ b/plugins/common/socket/socket.go
@@ -3,6 +3,7 @@ package socket
 import (
 	"bufio"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -54,7 +55,15 @@ type Socket struct {
 	listener listener
 }
 
-var extractIfNameRegex = regexp.MustCompile(`]?:\d+%(.*)$`)
+// extractIfNameRegex matches 4 different case.
+//
+// 1. IPv6 with a zone id and a trailing interface name; or
+// 2. IPv6 with a zone id only; or
+// 3. IPv6 a trailing interface name only; or
+// 4. Any other IP or socket name with a zone id only
+var extractIfNameRegex = regexp.MustCompile(
+	`\[[a-zA-Z0-9:]+%([^%]*)]:\w+%([^%]*)$|\[[a-zA-Z0-9:]+%([^%]*)]:\w+$|\[[a-zA-Z0-9:]+]:\w+%([^%]*)$|[^]]:\w+%([^%]*)$`,
+)
 var validIfNameRegex = regexp.MustCompile(`^[^/:\s]{1,15}$`)
 
 // interfaceNameFromServiceAddress extract and validates interface names
@@ -70,7 +79,19 @@ func interfaceNameFromServiceAddress(address string) (interfaceName string, vali
 		return "", nil
 	}
 
-	ifName := matches[1]
+	ifName := ""
+	matchCount := 0
+	for _, match := range matches[1:] {
+		if match != "" {
+			if matchCount > 0 {
+				return "", errors.New("ipv6 zone id and interface name are mutually exclusive")
+			}
+
+			ifName = match
+			matchCount++
+		}
+	}
+
 	if ifName == "." || ifName == ".." || !validIfNameRegex.MatchString(ifName) {
 		return "", fmt.Errorf("interface name %q is not valid", ifName)
 	}

--- a/plugins/common/socket/socket.go
+++ b/plugins/common/socket/socket.go
@@ -54,7 +54,7 @@ type Socket struct {
 	listener listener
 }
 
-var extractIfNameRegex = regexp.MustCompile(`%(.*)$`)
+var extractIfNameRegex = regexp.MustCompile(`]?:\d+%(.*)$`)
 var validIfNameRegex = regexp.MustCompile(`^[^/:\s]{1,15}$`)
 
 // interfaceNameFromServiceAddress extract and validates interface names
@@ -64,22 +64,18 @@ var validIfNameRegex = regexp.MustCompile(`^[^/:\s]{1,15}$`)
 //   - No string longer than 15 characters
 //   - Not exactly `.` or `..`
 //   - Contains no `/`, `:` or whitespace
-func interfaceNameFromServiceAddress(address string) (interfaceName string, present bool, valid error) {
+func interfaceNameFromServiceAddress(address string) (interfaceName string, valid error) {
 	matches := extractIfNameRegex.FindStringSubmatch(address)
 	if len(matches) < 2 {
-		return "", false, nil
+		return "", nil
 	}
 
 	ifName := matches[1]
-	if ifName == "." || ifName == ".." {
-		return "", false, fmt.Errorf("interface name `%s` is not valid", ifName)
+	if ifName == "." || ifName == ".." || !validIfNameRegex.MatchString(ifName) {
+		return "", fmt.Errorf("interface name %q is not valid", ifName)
 	}
 
-	if !validIfNameRegex.MatchString(ifName) {
-		return "", false, fmt.Errorf("interface name `%s` is not valid", ifName)
-	}
-
-	return ifName, true, nil
+	return ifName, nil
 }
 
 func (cfg *Config) NewSocket(address string, splitcfg *SplitConfig, logger telegraf.Logger) (*Socket, error) {
@@ -98,12 +94,12 @@ func (cfg *Config) NewSocket(address string, splitcfg *SplitConfig, logger teleg
 	}
 
 	// Resolve the interface to an address if any given
-	ifName, ifNamePresent, ifNameErr := interfaceNameFromServiceAddress(address)
+	ifName, ifNameErr := interfaceNameFromServiceAddress(address)
 	if ifNameErr != nil {
 		return nil, ifNameErr
 	}
 
-	if ifNamePresent {
+	if ifName != "" {
 		s.interfaceName = ifName
 		address = strings.Replace(address, "%"+s.interfaceName, "", 1)
 	}

--- a/plugins/common/socket/socket_test.go
+++ b/plugins/common/socket/socket_test.go
@@ -870,10 +870,13 @@ func TestNewSocketServiceAddressParsing(t *testing.T) {
 		{name: "udp all addresses no interface name", address: "udp://:8094", url: "udp://:8094"},
 		{name: "udp4 all interfaces no interface name", address: "udp4://:8094", url: "udp4://:8094"},
 		{name: "udp6 all interfaces no interface name", address: "udp6://:8094", url: "udp6://:8094"},
+		{name: "vsock with port", address: "vsock://cid:80", url: "vsock://cid:80"},
 		{name: "unix no interface name", address: "unix:///tmp/telegraf.sock", url: "unix:///tmp/telegraf.sock"},
 		{name: "unixgram no interface name", address: "unixgram:///tmp/telegraf.sock", url: "unixgram:///tmp/telegraf.sock"},
 		{name: "udp6 multicast no interface name", address: "udp6://[ff02::1]:8094", url: "udp6://[ff02::1]:8094"},
 		{name: "udp6 multicast with zone id", address: "udp6://[ff02::1%eth0]:8094", interfaceName: "eth0", url: "udp6://[ff02::1]:8094"},
+		{name: "udp6 ipv4 mapped host", address: "udp6://[::ffff:239.0.0.1]:8094%eth0",
+			url: "udp6://[::ffff:239.0.0.1]:8094", interfaceName: "eth0"},
 		{name: "udp4 multicast with interface name", address: "udp4://239.0.0.1:40000%enp101s0f1np1",
 			interfaceName: "enp101s0f1np1", url: "udp4://239.0.0.1:40000"},
 		{name: "tcp6 ipv6 with interface name", address: "tcp6://[2001:db8::1]:8094%br-interface",
@@ -892,55 +895,16 @@ func TestNewSocketServiceAddressParsing(t *testing.T) {
 	}
 }
 
-func TestInterfaceNameFromServiceAddressValid(t *testing.T) {
-	t.Parallel()
-	tests := []struct {
-		name     string
-		address  string
-		expected string
-	}{
-		{name: "tcp localhost no interface name", address: "tcp://localhost:400", expected: ""},
-		{name: "tcp all addresses no interface name", address: "tcp://:8094", expected: ""},
-		{name: "tcp4 all addresses no interface name", address: "tcp4://:8094", expected: ""},
-		{name: "tcp6 all addresses no interface name", address: "tcp6://:8094", expected: ""},
-		{name: "tcp6 ipv6 with port no interface name", address: "tcp6://[2001:db8::1]:8094", expected: ""},
-		{name: "udp all addresses no interface name", address: "udp://:8094", expected: ""},
-		{name: "udp4 all interfaces no interface name", address: "udp4://:8094", expected: ""},
-		{name: "udp6 all interfaces no interface name", address: "udp6://:8094", expected: ""},
-		{name: "unix no interface name", address: "unix:///tmp/telegraf.sock", expected: ""},
-		{name: "unixgram no interface name", address: "unixgram:///tmp/telegraf.sock", expected: ""},
-		{name: "vsock no interface name", address: "vsock://cid:80", expected: ""},
-		{name: "udp6 multicast with zone id", address: "udp6://[ff02::1%eth0]:8094", expected: "eth0"},
-		{name: "udp6 multicast no interface name", address: "udp6://[ff02::1]:8094", expected: ""},
-		{name: "udp4 multicast with interface name", address: "udp4://239.0.0.1:40000%enp101s0f1np1", expected: "enp101s0f1np1"},
-		{name: "tcp6 ipv6 with interface name", address: "tcp6://[2001:db8::1]:8094%br-interface", expected: "br-interface"},
-		{name: "tcp all addresses with interface name with period", address: "tcp://:8094%dev.name", expected: "dev.name"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			name, err := interfaceNameFromServiceAddress(tt.address)
-			require.NoError(t, err)
-			require.Equal(t, tt.expected, name)
-		})
-	}
-}
-
 func TestInterfaceNameFromServiceAddressInvalid(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name    string
 		address string
+		err     string
 	}{
-		{name: "empty string not allowed", address: "tcp://localhost:400%"},
-		{name: ". not allowed", address: "tcp://localhost:400%."},
-		{name: ".. not allowed", address: "udp4://127.0.0.1:40000%.."},
-		{name: "spaces not allowed", address: "tcp://127.0.0.1:http%hello thisismyinterface"},
-		{name: ": not allowed", address: "tcp4://:8094%this:ismyinterface"},
-		{name: "/ not allowed", address: "tcp6://:8094%this/is/my/interface"},
-		{name: "udp6 multicast with zone id and interface name", address: "udp6://[ff02::1%eth0]:8094%enp0"},
-		{name: "more than 15 chars not allowed", address: "tcp6://[2001:db8::1]:8094%thisnameistoolongtobeaninterface"},
+		{name: "empty string not allowed", address: "tcp://localhost:400%", err: "is not valid"},
+		{name: "udp6 multicast with zone id and interface name", address: "udp6://[ff02::1%eth0]:8094%enp0",
+			err: "ipv6 zone id and interface name are mutually exclusive"},
 	}
 
 	for _, tt := range tests {
@@ -948,7 +912,7 @@ func TestInterfaceNameFromServiceAddressInvalid(t *testing.T) {
 			t.Parallel()
 			name, err := interfaceNameFromServiceAddress(tt.address)
 			require.Empty(t, name)
-			require.Error(t, err)
+			require.ErrorContains(t, err, tt.err)
 		})
 	}
 }

--- a/plugins/common/socket/socket_test.go
+++ b/plugins/common/socket/socket_test.go
@@ -855,7 +855,6 @@ func createClient(endpoint string, addr net.Addr, tlsCfg *tls.Config) (net.Conn,
 }
 
 func TestNewSocketServiceAddressParsing(t *testing.T) {
-	t.Parallel()
 	tests := []struct {
 		name          string
 		address       string
@@ -886,8 +885,8 @@ func TestNewSocketServiceAddressParsing(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			s, err := (&Config{}).NewSocket(tt.address, nil, testutil.Logger{})
+			var cfg Config
+			s, err := cfg.NewSocket(tt.address, nil, testutil.Logger{})
 			require.NoError(t, err)
 			require.Equal(t, tt.interfaceName, s.interfaceName)
 			require.Equal(t, tt.url, s.url.String())
@@ -896,7 +895,6 @@ func TestNewSocketServiceAddressParsing(t *testing.T) {
 }
 
 func TestInterfaceNameFromServiceAddressInvalid(t *testing.T) {
-	t.Parallel()
 	tests := []struct {
 		name    string
 		address string
@@ -909,7 +907,6 @@ func TestInterfaceNameFromServiceAddressInvalid(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
 			name, err := interfaceNameFromServiceAddress(tt.address)
 			require.Empty(t, name)
 			require.ErrorContains(t, err, tt.err)

--- a/plugins/common/socket/socket_test.go
+++ b/plugins/common/socket/socket_test.go
@@ -854,6 +854,44 @@ func createClient(endpoint string, addr net.Addr, tlsCfg *tls.Config) (net.Conn,
 	return tls.Dial(protocol, addr.String(), tlsCfg)
 }
 
+func TestNewSocketServiceAddressParsing(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name          string
+		address       string
+		url           string
+		interfaceName string
+	}{
+		{name: "tcp localhost no interface name", address: "tcp://localhost:400", url: "tcp://localhost:400"},
+		{name: "tcp all addresses no interface name", address: "tcp://:8094", url: "tcp://:8094"},
+		{name: "tcp4 all addresses no interface name", address: "tcp4://:8094", url: "tcp4://:8094"},
+		{name: "tcp6 all addresses no interface name", address: "tcp6://:8094", url: "tcp6://:8094"},
+		{name: "tcp6 ipv6 with port no interface name", address: "tcp6://[2001:db8::1]:8094", url: "tcp6://[2001:db8::1]:8094"},
+		{name: "udp all addresses no interface name", address: "udp://:8094", url: "udp://:8094"},
+		{name: "udp4 all interfaces no interface name", address: "udp4://:8094", url: "udp4://:8094"},
+		{name: "udp6 all interfaces no interface name", address: "udp6://:8094", url: "udp6://:8094"},
+		{name: "unix no interface name", address: "unix:///tmp/telegraf.sock", url: "unix:///tmp/telegraf.sock"},
+		{name: "unixgram no interface name", address: "unixgram:///tmp/telegraf.sock", url: "unixgram:///tmp/telegraf.sock"},
+		{name: "udp6 multicast no interface name", address: "udp6://[ff02::1]:8094", url: "udp6://[ff02::1]:8094"},
+		{name: "udp6 multicast with zone id", address: "udp6://[ff02::1%eth0]:8094", interfaceName: "eth0", url: "udp6://[ff02::1]:8094"},
+		{name: "udp4 multicast with interface name", address: "udp4://239.0.0.1:40000%enp101s0f1np1",
+			interfaceName: "enp101s0f1np1", url: "udp4://239.0.0.1:40000"},
+		{name: "tcp6 ipv6 with interface name", address: "tcp6://[2001:db8::1]:8094%br-interface",
+			interfaceName: "br-interface", url: "tcp6://[2001:db8::1]:8094"},
+		{name: "tcp all addresses with interface name with period", address: "tcp://:8094%dev.name", interfaceName: "dev.name", url: "tcp://:8094"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			s, err := (&Config{}).NewSocket(tt.address, nil, testutil.Logger{})
+			require.NoError(t, err)
+			require.Equal(t, tt.interfaceName, s.interfaceName)
+			require.Equal(t, tt.url, s.url.String())
+		})
+	}
+}
+
 func TestInterfaceNameFromServiceAddressValid(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
@@ -863,7 +901,6 @@ func TestInterfaceNameFromServiceAddressValid(t *testing.T) {
 	}{
 		{name: "tcp localhost no interface name", address: "tcp://localhost:400", expected: ""},
 		{name: "tcp all addresses no interface name", address: "tcp://:8094", expected: ""},
-		{name: "tcp loopback address with string port no interface  name", address: "tcp://127.0.0.1:http", expected: ""},
 		{name: "tcp4 all addresses no interface name", address: "tcp4://:8094", expected: ""},
 		{name: "tcp6 all addresses no interface name", address: "tcp6://:8094", expected: ""},
 		{name: "tcp6 ipv6 with port no interface name", address: "tcp6://[2001:db8::1]:8094", expected: ""},
@@ -872,10 +909,9 @@ func TestInterfaceNameFromServiceAddressValid(t *testing.T) {
 		{name: "udp6 all interfaces no interface name", address: "udp6://:8094", expected: ""},
 		{name: "unix no interface name", address: "unix:///tmp/telegraf.sock", expected: ""},
 		{name: "unixgram no interface name", address: "unixgram:///tmp/telegraf.sock", expected: ""},
-		{name: "vsock no interface name", address: "vsock://cid:port", expected: ""},
-		{name: "udp6 multicast with zone id", address: "udp6://[ff02::1%eth0]:8094", expected: ""},
+		{name: "vsock no interface name", address: "vsock://cid:80", expected: ""},
+		{name: "udp6 multicast with zone id", address: "udp6://[ff02::1%eth0]:8094", expected: "eth0"},
 		{name: "udp6 multicast no interface name", address: "udp6://[ff02::1]:8094", expected: ""},
-		{name: "udp6 multicast with zone id and interface name", address: "udp6://[ff02::1%eth0]:8094%enp0", expected: "enp0"},
 		{name: "udp4 multicast with interface name", address: "udp4://239.0.0.1:40000%enp101s0f1np1", expected: "enp101s0f1np1"},
 		{name: "tcp6 ipv6 with interface name", address: "tcp6://[2001:db8::1]:8094%br-interface", expected: "br-interface"},
 		{name: "tcp all addresses with interface name with period", address: "tcp://:8094%dev.name", expected: "dev.name"},
@@ -900,9 +936,10 @@ func TestInterfaceNameFromServiceAddressInvalid(t *testing.T) {
 		{name: "empty string not allowed", address: "tcp://localhost:400%"},
 		{name: ". not allowed", address: "tcp://localhost:400%."},
 		{name: ".. not allowed", address: "udp4://127.0.0.1:40000%.."},
-		{name: " spaces not allowed", address: "tcp://127.0.0.1:http%hello thisismyinterface"},
+		{name: "spaces not allowed", address: "tcp://127.0.0.1:http%hello thisismyinterface"},
 		{name: ": not allowed", address: "tcp4://:8094%this:ismyinterface"},
 		{name: "/ not allowed", address: "tcp6://:8094%this/is/my/interface"},
+		{name: "udp6 multicast with zone id and interface name", address: "udp6://[ff02::1%eth0]:8094%enp0"},
 		{name: "more than 15 chars not allowed", address: "tcp6://[2001:db8::1]:8094%thisnameistoolongtobeaninterface"},
 	}
 
@@ -910,8 +947,8 @@ func TestInterfaceNameFromServiceAddressInvalid(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			name, err := interfaceNameFromServiceAddress(tt.address)
-			require.Error(t, err)
 			require.Empty(t, name)
+			require.Error(t, err)
 		})
 	}
 }

--- a/plugins/common/socket/socket_test.go
+++ b/plugins/common/socket/socket_test.go
@@ -854,54 +854,64 @@ func createClient(endpoint string, addr net.Addr, tlsCfg *tls.Config) (net.Conn,
 	return tls.Dial(protocol, addr.String(), tlsCfg)
 }
 
-func TestInterfaceNameFromServiceAddress(t *testing.T) {
+func TestInterfaceNameFromServiceAddressValid(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		ServiceAddress string
-		Expected       string
-		Invalid        bool
+		name     string
+		address  string
+		expected string
 	}{
-		{ServiceAddress: "tcp://localhost:400", Invalid: false, Expected: ""},
-		{ServiceAddress: "tcp://:8094", Invalid: false, Expected: ""},
-		{ServiceAddress: "tcp://127.0.0.1:http", Invalid: false, Expected: ""},
-		{ServiceAddress: "tcp4://:8094", Invalid: false, Expected: ""},
-		{ServiceAddress: "tcp6://:8094", Invalid: false, Expected: ""},
-		{ServiceAddress: "tcp6://[2001:db8::1]:8094", Invalid: false, Expected: ""},
-		{ServiceAddress: "udp://:8094", Invalid: false, Expected: ""},
-		{ServiceAddress: "udp4://:8094", Invalid: false, Expected: ""},
-		{ServiceAddress: "udp6://:8094", Invalid: false, Expected: ""},
-		{ServiceAddress: "unix:///tmp/telegraf.sock", Invalid: false, Expected: ""},
-		{ServiceAddress: "unixgram:///tmp/telegraf.sock", Invalid: false, Expected: ""},
-		{ServiceAddress: "vsock://cid:port", Invalid: false, Expected: ""},
-		{ServiceAddress: "tcp://localhost:400%.", Invalid: true, Expected: ""},
-		{ServiceAddress: "udp4://127.0.0.1:40000%..", Invalid: true, Expected: ""},
-		{ServiceAddress: "tcp://127.0.0.1:http%hello thisismyinterface", Invalid: true, Expected: ""},
-		{ServiceAddress: "tcp4://:8094%this:ismyinterface", Invalid: true, Expected: ""},
-		{ServiceAddress: "tcp6://:8094%this/is/my/interface", Invalid: true, Expected: ""},
-		{ServiceAddress: "tcp6://[2001:db8::1]:8094%thisnameistoolongtobeaninterface", Invalid: true, Expected: ""},
-		{ServiceAddress: "udp4://239.0.0.1:40000%enp101s0f1np1", Invalid: false, Expected: "enp101s0f1np1"},
-		{ServiceAddress: "tcp6://[2001:db8::1]:8094%br-interface", Invalid: false, Expected: "br-interface"},
-		{ServiceAddress: "udp4://239.0.0.1:40000%enp101s0f1np1", Invalid: false, Expected: "enp101s0f1np1"},
-		{ServiceAddress: "tcp://:8094%dev.name", Invalid: false, Expected: "dev.name"},
+		{name: "tcp localhost no interface name", address: "tcp://localhost:400", expected: ""},
+		{name: "tcp all addresses no interface name", address: "tcp://:8094", expected: ""},
+		{name: "tcp loopback address with string port no interface  name", address: "tcp://127.0.0.1:http", expected: ""},
+		{name: "tcp4 all addresses no interface name", address: "tcp4://:8094", expected: ""},
+		{name: "tcp6 all addresses no interface name", address: "tcp6://:8094", expected: ""},
+		{name: "tcp6 ipv6 with port no interface name", address: "tcp6://[2001:db8::1]:8094", expected: ""},
+		{name: "udp all addresses no interface name", address: "udp://:8094", expected: ""},
+		{name: "udp4 all interfaces no interface name", address: "udp4://:8094", expected: ""},
+		{name: "udp6 all interfaces no interface name", address: "udp6://:8094", expected: ""},
+		{name: "unix no interface name", address: "unix:///tmp/telegraf.sock", expected: ""},
+		{name: "unixgram no interface name", address: "unixgram:///tmp/telegraf.sock", expected: ""},
+		{name: "vsock no interface name", address: "vsock://cid:port", expected: ""},
+		{name: "udp6 multicast with zone id", address: "udp6://[ff02::1%eth0]:8094", expected: ""},
+		{name: "udp6 multicast no interface name", address: "udp6://[ff02::1]:8094", expected: ""},
+		{name: "udp6 multicast with zone id and interface name", address: "udp6://[ff02::1%eth0]:8094%enp0", expected: "enp0"},
+		{name: "udp4 multicast with interface name", address: "udp4://239.0.0.1:40000%enp101s0f1np1", expected: "enp101s0f1np1"},
+		{name: "tcp6 ipv6 with interface name", address: "tcp6://[2001:db8::1]:8094%br-interface", expected: "br-interface"},
+		{name: "tcp all addresses with interface name with period", address: "tcp://:8094%dev.name", expected: "dev.name"},
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.ServiceAddress, func(t *testing.T) {
+		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			name, present, err := interfaceNameFromServiceAddress(tt.ServiceAddress)
-			if tt.Invalid {
-				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
-			}
+			name, err := interfaceNameFromServiceAddress(tt.address)
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, name)
+		})
+	}
+}
 
-			if len(tt.Expected) == 0 {
-				require.Empty(t, name)
-				require.False(t, present)
-			} else {
-				require.Equal(t, tt.Expected, name)
-				require.True(t, present)
-			}
+func TestInterfaceNameFromServiceAddressInvalid(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		address string
+	}{
+		{name: "empty string not allowed", address: "tcp://localhost:400%"},
+		{name: ". not allowed", address: "tcp://localhost:400%."},
+		{name: ".. not allowed", address: "udp4://127.0.0.1:40000%.."},
+		{name: " spaces not allowed", address: "tcp://127.0.0.1:http%hello thisismyinterface"},
+		{name: ": not allowed", address: "tcp4://:8094%this:ismyinterface"},
+		{name: "/ not allowed", address: "tcp6://:8094%this/is/my/interface"},
+		{name: "more than 15 chars not allowed", address: "tcp6://[2001:db8::1]:8094%thisnameistoolongtobeaninterface"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			name, err := interfaceNameFromServiceAddress(tt.address)
+			require.Error(t, err)
+			require.Empty(t, name)
 		})
 	}
 }

--- a/plugins/common/socket/socket_test.go
+++ b/plugins/common/socket/socket_test.go
@@ -853,3 +853,55 @@ func createClient(endpoint string, addr net.Addr, tlsCfg *tls.Config) (net.Conn,
 	}
 	return tls.Dial(protocol, addr.String(), tlsCfg)
 }
+
+func TestInterfaceNameFromServiceAddress(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		ServiceAddress string
+		Expected       string
+		Invalid        bool
+	}{
+		{ServiceAddress: "tcp://localhost:400", Invalid: false, Expected: ""},
+		{ServiceAddress: "tcp://:8094", Invalid: false, Expected: ""},
+		{ServiceAddress: "tcp://127.0.0.1:http", Invalid: false, Expected: ""},
+		{ServiceAddress: "tcp4://:8094", Invalid: false, Expected: ""},
+		{ServiceAddress: "tcp6://:8094", Invalid: false, Expected: ""},
+		{ServiceAddress: "tcp6://[2001:db8::1]:8094", Invalid: false, Expected: ""},
+		{ServiceAddress: "udp://:8094", Invalid: false, Expected: ""},
+		{ServiceAddress: "udp4://:8094", Invalid: false, Expected: ""},
+		{ServiceAddress: "udp6://:8094", Invalid: false, Expected: ""},
+		{ServiceAddress: "unix:///tmp/telegraf.sock", Invalid: false, Expected: ""},
+		{ServiceAddress: "unixgram:///tmp/telegraf.sock", Invalid: false, Expected: ""},
+		{ServiceAddress: "vsock://cid:port", Invalid: false, Expected: ""},
+		{ServiceAddress: "tcp://localhost:400%.", Invalid: true, Expected: ""},
+		{ServiceAddress: "udp4://127.0.0.1:40000%..", Invalid: true, Expected: ""},
+		{ServiceAddress: "tcp://127.0.0.1:http%hello thisismyinterface", Invalid: true, Expected: ""},
+		{ServiceAddress: "tcp4://:8094%this:ismyinterface", Invalid: true, Expected: ""},
+		{ServiceAddress: "tcp6://:8094%this/is/my/interface", Invalid: true, Expected: ""},
+		{ServiceAddress: "tcp6://[2001:db8::1]:8094%thisnameistoolongtobeaninterface", Invalid: true, Expected: ""},
+		{ServiceAddress: "udp4://239.0.0.1:40000%enp101s0f1np1", Invalid: false, Expected: "enp101s0f1np1"},
+		{ServiceAddress: "tcp6://[2001:db8::1]:8094%br-interface", Invalid: false, Expected: "br-interface"},
+		{ServiceAddress: "udp4://239.0.0.1:40000%enp101s0f1np1", Invalid: false, Expected: "enp101s0f1np1"},
+		{ServiceAddress: "tcp://:8094%dev.name", Invalid: false, Expected: "dev.name"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.ServiceAddress, func(t *testing.T) {
+			t.Parallel()
+			name, present, err := interfaceNameFromServiceAddress(tt.ServiceAddress)
+			if tt.Invalid {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			if len(tt.Expected) == 0 {
+				require.Empty(t, name)
+				require.False(t, present)
+			} else {
+				require.Equal(t, tt.Expected, name)
+				require.True(t, present)
+			}
+		})
+	}
+}

--- a/plugins/inputs/socket_listener/README.md
+++ b/plugins/inputs/socket_listener/README.md
@@ -42,6 +42,8 @@ plugin ordering. See [CONFIGURATION.md][CONFIGURATION.md] for more details.
   # service_address = "udp://:8094"
   # service_address = "udp4://:8094"
   # service_address = "udp6://:8094"
+  # service_address = "udp6://[ff02::1%eth0]:8094"
+  # service_address = "udp6://[ff02::1]:8094%eth0"
   # service_address = "unix:///tmp/telegraf.sock"
   # service_address = "unixgram:///tmp/telegraf.sock"
   # service_address = "vsock://cid:80"
@@ -231,6 +233,10 @@ When using multicast, SSM's `multicast_source` is preferred over
   service_address = "udp4://239.0.0.1:40000%enp101s0f1np1"
   multicast_source = "10.65.4.2"
 ```
+
+Using an IPv6 address with multicast, can be done by either specifying a
+zone id or using a trailing interface name. These options are mutually
+exclusive.
 
 ## Metrics
 

--- a/plugins/inputs/socket_listener/README.md
+++ b/plugins/inputs/socket_listener/README.md
@@ -213,16 +213,17 @@ sysctl -w kern.ipc.maxsockbuf=9646900
 Listening to multicast packets can be done by specifying a multicast group
 address for the `service_address` value, e.g. `239.0.0.1`. To ensure the correct
 interface joins the multicast group, you can append its name at the end of the
-`service_address`. See the example below.
+`service_address` separated by a `%`. Valid interface names follow the Linux
+device naming rules. See the example below.
 
 In the example, SSM is also used to filter packets only coming from source
-`10.65.4.2`. The difference between SSM and `allowed_sources` is where the 
-data packets are accepted. With `multicast_source`, the packets are filtered at 
-the kernel level, while with `allowed_sources` the packets are filtered 
-within Telegraf. This means that with `allowed_sources` all packets are 
-accepted by the kernel, leading to a higher load on the network stack. 
+`10.65.4.2`. The difference between SSM and `allowed_sources` is where the
+data packets are accepted. With `multicast_source`, the packets are filtered at
+the kernel level, while with `allowed_sources` the packets are filtered
+within Telegraf. This means that with `allowed_sources` all packets are
+accepted by the kernel, leading to a higher load on the network stack.
 
-When using multicast, SSM's `multicast_source` is preferred over 
+When using multicast, SSM's `multicast_source` is preferred over
 `allowed_sources`. With unicast, `multicast_source` has no effect and
 `allowed_sources` is required for source filtering.
 

--- a/plugins/inputs/socket_listener/README.md
+++ b/plugins/inputs/socket_listener/README.md
@@ -41,13 +41,13 @@ plugin ordering. See [CONFIGURATION.md][CONFIGURATION.md] for more details.
   # service_address = "tcp6://[2001:db8::1]:8094"
   # service_address = "udp://:8094"
   # service_address = "udp4://:8094"
+  # service_address = "udp4://239.0.0.1:40000%enp101s0f1np1"
   # service_address = "udp6://:8094"
   # service_address = "udp6://[ff02::1%eth0]:8094"
   # service_address = "udp6://[ff02::1]:8094%eth0"
   # service_address = "unix:///tmp/telegraf.sock"
   # service_address = "unixgram:///tmp/telegraf.sock"
   # service_address = "vsock://cid:80"
-  # service_address = "udp4://239.0.0.1:40000%enp101s0f1np1"
 
   ## Permission for unix sockets (only available on unix sockets)
   ## This setting may not be respected by some platforms. To safely restrict

--- a/plugins/inputs/socket_listener/README.md
+++ b/plugins/inputs/socket_listener/README.md
@@ -36,7 +36,6 @@ plugin ordering. See [CONFIGURATION.md][CONFIGURATION.md] for more details.
 [[inputs.socket_listener]]
   ## URL to listen on
   # service_address = "tcp://:8094"
-  # service_address = "tcp://127.0.0.1:http"
   # service_address = "tcp4://:8094"
   # service_address = "tcp6://:8094"
   # service_address = "tcp6://[2001:db8::1]:8094"
@@ -45,7 +44,7 @@ plugin ordering. See [CONFIGURATION.md][CONFIGURATION.md] for more details.
   # service_address = "udp6://:8094"
   # service_address = "unix:///tmp/telegraf.sock"
   # service_address = "unixgram:///tmp/telegraf.sock"
-  # service_address = "vsock://cid:port"
+  # service_address = "vsock://cid:80"
   # service_address = "udp4://239.0.0.1:40000%enp101s0f1np1"
 
   ## Permission for unix sockets (only available on unix sockets)

--- a/plugins/inputs/socket_listener/README.md
+++ b/plugins/inputs/socket_listener/README.md
@@ -46,6 +46,7 @@ plugin ordering. See [CONFIGURATION.md][CONFIGURATION.md] for more details.
   # service_address = "unix:///tmp/telegraf.sock"
   # service_address = "unixgram:///tmp/telegraf.sock"
   # service_address = "vsock://cid:port"
+  # service_address = "udp4://239.0.0.1:40000%enp101s0f1np1"
 
   ## Permission for unix sockets (only available on unix sockets)
   ## This setting may not be respected by some platforms. To safely restrict
@@ -206,6 +207,22 @@ sysctl -w kern.ipc.maxsockbuf=9646900
 ```
 
 [kernel_source]: https://github.com/freebsd/freebsd/blob/master/sys/kern/uipc_sockbuf.c#L63-L64
+
+### Multicast
+
+Listening to multicast packets can be done by specifying a multicast group
+address for the `service_address` value, e.g. `239.0.0.1`. To ensure the correct
+interface joins the multicast group, you can append its name at the end of the
+`service_address`. See the example below.
+
+In the example, SSM is also used to filter packets only coming from source
+`10.65.4.2`.
+
+```toml
+[[inputs.socket_listener]]
+  service_address = "udp4://239.0.0.1:40000%enp101s0f1np1"
+  multicast_source = "10.65.4.2"
+```
 
 ## Metrics
 

--- a/plugins/inputs/socket_listener/README.md
+++ b/plugins/inputs/socket_listener/README.md
@@ -216,7 +216,15 @@ interface joins the multicast group, you can append its name at the end of the
 `service_address`. See the example below.
 
 In the example, SSM is also used to filter packets only coming from source
-`10.65.4.2`.
+`10.65.4.2`. The difference between SSM and `allowed_sources` is where the 
+data packets are accepted. With `multicast_source`, the packets are filtered at 
+the kernel level, while with `allowed_sources` the packets are filtered 
+within Telegraf. This means that with `allowed_sources` all packets are 
+accepted by the kernel, leading to a higher load on the network stack. 
+
+When using multicast, SSM's `multicast_source` is preferred over 
+`allowed_sources`. With unicast, `multicast_source` has no effect and
+`allowed_sources` is required for source filtering.
 
 ```toml
 [[inputs.socket_listener]]

--- a/plugins/inputs/socket_listener/sample.conf
+++ b/plugins/inputs/socket_listener/sample.conf
@@ -2,7 +2,6 @@
 [[inputs.socket_listener]]
   ## URL to listen on
   # service_address = "tcp://:8094"
-  # service_address = "tcp://127.0.0.1:http"
   # service_address = "tcp4://:8094"
   # service_address = "tcp6://:8094"
   # service_address = "tcp6://[2001:db8::1]:8094"
@@ -11,7 +10,7 @@
   # service_address = "udp6://:8094"
   # service_address = "unix:///tmp/telegraf.sock"
   # service_address = "unixgram:///tmp/telegraf.sock"
-  # service_address = "vsock://cid:port"
+  # service_address = "vsock://cid:80"
   # service_address = "udp4://239.0.0.1:40000%enp101s0f1np1"
 
   ## Permission for unix sockets (only available on unix sockets)

--- a/plugins/inputs/socket_listener/sample.conf
+++ b/plugins/inputs/socket_listener/sample.conf
@@ -12,6 +12,7 @@
   # service_address = "unix:///tmp/telegraf.sock"
   # service_address = "unixgram:///tmp/telegraf.sock"
   # service_address = "vsock://cid:port"
+  # service_address = "udp4://239.0.0.1:40000%enp101s0f1np1"
 
   ## Permission for unix sockets (only available on unix sockets)
   ## This setting may not be respected by some platforms. To safely restrict

--- a/plugins/inputs/socket_listener/sample.conf
+++ b/plugins/inputs/socket_listener/sample.conf
@@ -8,6 +8,8 @@
   # service_address = "udp://:8094"
   # service_address = "udp4://:8094"
   # service_address = "udp6://:8094"
+  # service_address = "udp6://[ff02::1%eth0]:8094"
+  # service_address = "udp6://[ff02::1]:8094%eth0"
   # service_address = "unix:///tmp/telegraf.sock"
   # service_address = "unixgram:///tmp/telegraf.sock"
   # service_address = "vsock://cid:80"

--- a/plugins/inputs/socket_listener/sample.conf
+++ b/plugins/inputs/socket_listener/sample.conf
@@ -7,13 +7,13 @@
   # service_address = "tcp6://[2001:db8::1]:8094"
   # service_address = "udp://:8094"
   # service_address = "udp4://:8094"
+  # service_address = "udp4://239.0.0.1:40000%enp101s0f1np1"
   # service_address = "udp6://:8094"
   # service_address = "udp6://[ff02::1%eth0]:8094"
   # service_address = "udp6://[ff02::1]:8094%eth0"
   # service_address = "unix:///tmp/telegraf.sock"
   # service_address = "unixgram:///tmp/telegraf.sock"
   # service_address = "vsock://cid:80"
-  # service_address = "udp4://239.0.0.1:40000%enp101s0f1np1"
 
   ## Permission for unix sockets (only available on unix sockets)
   ## This setting may not be respected by some platforms. To safely restrict

--- a/plugins/inputs/socket_listener/sample.conf.in
+++ b/plugins/inputs/socket_listener/sample.conf.in
@@ -2,7 +2,6 @@
 [[inputs.socket_listener]]
   ## URL to listen on
   # service_address = "tcp://:8094"
-  # service_address = "tcp://127.0.0.1:http"
   # service_address = "tcp4://:8094"
   # service_address = "tcp6://:8094"
   # service_address = "tcp6://[2001:db8::1]:8094"
@@ -11,7 +10,7 @@
   # service_address = "udp6://:8094"
   # service_address = "unix:///tmp/telegraf.sock"
   # service_address = "unixgram:///tmp/telegraf.sock"
-  # service_address = "vsock://cid:port"
+  # service_address = "vsock://cid:80"
   # service_address = "udp4://239.0.0.1:40000%enp101s0f1np1"
 
 {{template "/plugins/common/socket/socket.conf"}}

--- a/plugins/inputs/socket_listener/sample.conf.in
+++ b/plugins/inputs/socket_listener/sample.conf.in
@@ -7,13 +7,13 @@
   # service_address = "tcp6://[2001:db8::1]:8094"
   # service_address = "udp://:8094"
   # service_address = "udp4://:8094"
+  # service_address = "udp4://239.0.0.1:40000%enp101s0f1np1"
   # service_address = "udp6://:8094"
   # service_address = "udp6://[ff02::1%eth0]:8094"
   # service_address = "udp6://[ff02::1]:8094%eth0"
   # service_address = "unix:///tmp/telegraf.sock"
   # service_address = "unixgram:///tmp/telegraf.sock"
   # service_address = "vsock://cid:80"
-  # service_address = "udp4://239.0.0.1:40000%enp101s0f1np1"
 
 {{template "/plugins/common/socket/socket.conf"}}
 

--- a/plugins/inputs/socket_listener/sample.conf.in
+++ b/plugins/inputs/socket_listener/sample.conf.in
@@ -8,6 +8,8 @@
   # service_address = "udp://:8094"
   # service_address = "udp4://:8094"
   # service_address = "udp6://:8094"
+  # service_address = "udp6://[ff02::1%eth0]:8094"
+  # service_address = "udp6://[ff02::1]:8094%eth0"
   # service_address = "unix:///tmp/telegraf.sock"
   # service_address = "unixgram:///tmp/telegraf.sock"
   # service_address = "vsock://cid:80"

--- a/plugins/inputs/socket_listener/sample.conf.in
+++ b/plugins/inputs/socket_listener/sample.conf.in
@@ -12,6 +12,7 @@
   # service_address = "unix:///tmp/telegraf.sock"
   # service_address = "unixgram:///tmp/telegraf.sock"
   # service_address = "vsock://cid:port"
+  # service_address = "udp4://239.0.0.1:40000%enp101s0f1np1"
 
 {{template "/plugins/common/socket/socket.conf"}}
 


### PR DESCRIPTION
## Summary

Add explanation on how multicast group joining and SSM filtering can be configured. In addition to this the interface names are now properly extracted from the service address and validated. 

## Checklist
- [ ] No AI generated code was used in this PR
- [x] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

resolves #19361
