### PR TITLE
test(inputs.sip): Fix race condition

### DIFF
--- a/plugins/inputs/sip/sip_test.go
+++ b/plugins/inputs/sip/sip_test.go
@@ -798,8 +798,8 @@ type mockServer struct {
 	addr   string
 
 	// Errors collected while responding to requests
-	mu   sync.Mutex
 	errs []error
+	sync.Mutex
 }
 
 // newMockServer starts a SIP server answering the given method with the response
@@ -826,14 +826,15 @@ func newMockServer(method sip.RequestMethod, handler func(*sip.Request) *sip.Res
 	// collecting the errors has to happen here instead of in the handler where
 	// reporting a failure would panic the test binary.
 	server.OnRequest(method, func(req *sip.Request, tx sip.ServerTransaction) {
+		s.Lock()
+		defer s.Unlock()
+
 		res := handler(req)
 		if res == nil {
 			return
 		}
 		if err := tx.Respond(res); err != nil {
-			s.mu.Lock()
 			s.errs = append(s.errs, err)
-			s.mu.Unlock()
 		}
 	})
 
@@ -859,10 +860,11 @@ func newMockServer(method sip.RequestMethod, handler func(*sip.Request) *sip.Res
 func (s *mockServer) close(t *testing.T) {
 	t.Helper()
 
+	s.Lock()
+	defer s.Unlock()
+
 	_ = s.server.Close()
 	_ = s.ua.Close()
 
-	s.mu.Lock()
-	defer s.mu.Unlock()
 	require.Empty(t, s.errs, "responding to request failed")
 }


### PR DESCRIPTION
## Summary

The mock server implemented for testing the sip plugin faces a race condition in cases where `close` and the `OnRequest` handler method are running concurrently. This leads to a panic because the server is no longer available and transactions might be invalid.

The PR introduces a mutex to make sure the handler and the `close` methods are not running concurrently.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
