### PR TITLE
fix(common.socket): interface name extraction and validation

### DIFF
--- a/plugins/common/socket/socket.go
+++ b/plugins/common/socket/socket.go
@@ -54,6 +54,34 @@ type Socket struct {
 	listener listener
 }
 
+var extractIfNameRegex = regexp.MustCompile(`%(.*)$`)
+var validIfNameRegex = regexp.MustCompile(`^[^/:\s]{1,15}$`)
+
+// interfaceNameFromServiceAddress extract and validates interface names
+// Valid names folow the rules implemented in https://github.com/torvalds/linux/blob/11028ab62899e4191e074ee364c712b77823a9c4/net/core/dev.c#L1325
+// which comes down to:
+//   - No empty string
+//   - No string longer than 15 characters
+//   - Not exactly `.` or `..`
+//   - Contains no `/`, `:` or whitespace
+func interfaceNameFromServiceAddress(address string) (interfaceName string, present bool, valid error) {
+	matches := extractIfNameRegex.FindStringSubmatch(address)
+	if len(matches) < 2 {
+		return "", false, nil
+	}
+
+	ifName := matches[1]
+	if ifName == "." || ifName == ".." {
+		return "", false, fmt.Errorf("interface name `%s` is not valid", ifName)
+	}
+
+	if !validIfNameRegex.MatchString(ifName) {
+		return "", false, fmt.Errorf("interface name `%s` is not valid", ifName)
+	}
+
+	return ifName, true, nil
+}
+
 func (cfg *Config) NewSocket(address string, splitcfg *SplitConfig, logger telegraf.Logger) (*Socket, error) {
 	s := &Socket{
 		Config: *cfg,
@@ -70,9 +98,13 @@ func (cfg *Config) NewSocket(address string, splitcfg *SplitConfig, logger teleg
 	}
 
 	// Resolve the interface to an address if any given
-	ifregex := regexp.MustCompile(`%([\w\.]+)`)
-	if matches := ifregex.FindStringSubmatch(address); len(matches) == 2 {
-		s.interfaceName = matches[1]
+	ifName, ifNamePresent, ifNameErr := interfaceNameFromServiceAddress(address)
+	if ifNameErr != nil {
+		return nil, ifNameErr
+	}
+
+	if ifNamePresent {
+		s.interfaceName = ifName
 		address = strings.Replace(address, "%"+s.interfaceName, "", 1)
 	}
 

--- a/plugins/common/socket/socket_test.go
+++ b/plugins/common/socket/socket_test.go
@@ -853,3 +853,55 @@ func createClient(endpoint string, addr net.Addr, tlsCfg *tls.Config) (net.Conn,
 	}
 	return tls.Dial(protocol, addr.String(), tlsCfg)
 }
+
+func TestInterfaceNameFromServiceAddress(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		ServiceAddress string
+		Expected       string
+		Invalid        bool
+	}{
+		{ServiceAddress: "tcp://localhost:400", Invalid: false, Expected: ""},
+		{ServiceAddress: "tcp://:8094", Invalid: false, Expected: ""},
+		{ServiceAddress: "tcp://127.0.0.1:http", Invalid: false, Expected: ""},
+		{ServiceAddress: "tcp4://:8094", Invalid: false, Expected: ""},
+		{ServiceAddress: "tcp6://:8094", Invalid: false, Expected: ""},
+		{ServiceAddress: "tcp6://[2001:db8::1]:8094", Invalid: false, Expected: ""},
+		{ServiceAddress: "udp://:8094", Invalid: false, Expected: ""},
+		{ServiceAddress: "udp4://:8094", Invalid: false, Expected: ""},
+		{ServiceAddress: "udp6://:8094", Invalid: false, Expected: ""},
+		{ServiceAddress: "unix:///tmp/telegraf.sock", Invalid: false, Expected: ""},
+		{ServiceAddress: "unixgram:///tmp/telegraf.sock", Invalid: false, Expected: ""},
+		{ServiceAddress: "vsock://cid:port", Invalid: false, Expected: ""},
+		{ServiceAddress: "tcp://localhost:400%.", Invalid: true, Expected: ""},
+		{ServiceAddress: "udp4://127.0.0.1:40000%..", Invalid: true, Expected: ""},
+		{ServiceAddress: "tcp://127.0.0.1:http%hello thisismyinterface", Invalid: true, Expected: ""},
+		{ServiceAddress: "tcp4://:8094%this:ismyinterface", Invalid: true, Expected: ""},
+		{ServiceAddress: "tcp6://:8094%this/is/my/interface", Invalid: true, Expected: ""},
+		{ServiceAddress: "tcp6://[2001:db8::1]:8094%thisnameistoolongtobeaninterface", Invalid: true, Expected: ""},
+		{ServiceAddress: "udp4://239.0.0.1:40000%enp101s0f1np1", Invalid: false, Expected: "enp101s0f1np1"},
+		{ServiceAddress: "tcp6://[2001:db8::1]:8094%br-interface", Invalid: false, Expected: "br-interface"},
+		{ServiceAddress: "udp4://239.0.0.1:40000%enp101s0f1np1", Invalid: false, Expected: "enp101s0f1np1"},
+		{ServiceAddress: "tcp://:8094%dev.name", Invalid: false, Expected: "dev.name"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.ServiceAddress, func(t *testing.T) {
+			t.Parallel()
+			name, present, err := interfaceNameFromServiceAddress(tt.ServiceAddress)
+			if tt.Invalid {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			if len(tt.Expected) == 0 {
+				require.Empty(t, name)
+				require.False(t, present)
+			} else {
+				require.Equal(t, tt.Expected, name)
+				require.True(t, present)
+			}
+		})
+	}
+}

--- a/plugins/inputs/socket_listener/README.md
+++ b/plugins/inputs/socket_listener/README.md
@@ -213,16 +213,17 @@ sysctl -w kern.ipc.maxsockbuf=9646900
 Listening to multicast packets can be done by specifying a multicast group
 address for the `service_address` value, e.g. `239.0.0.1`. To ensure the correct
 interface joins the multicast group, you can append its name at the end of the
-`service_address`. See the example below.
+`service_address` separated by a `%`. Valid interface names follow the Linux
+device naming rules. See the example below.
 
 In the example, SSM is also used to filter packets only coming from source
-`10.65.4.2`. The difference between SSM and `allowed_sources` is where the 
-data packets are accepted. With `multicast_source`, the packets are filtered at 
-the kernel level, while with `allowed_sources` the packets are filtered 
-within Telegraf. This means that with `allowed_sources` all packets are 
-accepted by the kernel, leading to a higher load on the network stack. 
+`10.65.4.2`. The difference between SSM and `allowed_sources` is where the
+data packets are accepted. With `multicast_source`, the packets are filtered at
+the kernel level, while with `allowed_sources` the packets are filtered
+within Telegraf. This means that with `allowed_sources` all packets are
+accepted by the kernel, leading to a higher load on the network stack.
 
-When using multicast, SSM's `multicast_source` is preferred over 
+When using multicast, SSM's `multicast_source` is preferred over
 `allowed_sources`. With unicast, `multicast_source` has no effect and
 `allowed_sources` is required for source filtering.
 

--- a/plugins/inputs/socket_listener/README.md
+++ b/plugins/inputs/socket_listener/README.md
@@ -46,6 +46,7 @@ plugin ordering. See [CONFIGURATION.md][CONFIGURATION.md] for more details.
   # service_address = "unix:///tmp/telegraf.sock"
   # service_address = "unixgram:///tmp/telegraf.sock"
   # service_address = "vsock://cid:port"
+  # service_address = "udp4://239.0.0.1:40000%enp101s0f1np1"
 
   ## Permission for unix sockets (only available on unix sockets)
   ## This setting may not be respected by some platforms. To safely restrict
@@ -206,6 +207,22 @@ sysctl -w kern.ipc.maxsockbuf=9646900
 ```
 
 [kernel_source]: https://github.com/freebsd/freebsd/blob/master/sys/kern/uipc_sockbuf.c#L63-L64
+
+### Multicast
+
+Listening to multicast packets can be done by specifying a multicast group
+address for the `service_address` value, e.g. `239.0.0.1`. To ensure the correct
+interface joins the multicast group, you can append its name at the end of the
+`service_address`. See the example below.
+
+In the example, SSM is also used to filter packets only coming from source
+`10.65.4.2`.
+
+```toml
+[[inputs.socket_listener]]
+  service_address = "udp4://239.0.0.1:40000%enp101s0f1np1"
+  multicast_source = "10.65.4.2"
+```
 
 ## Metrics
 

--- a/plugins/inputs/socket_listener/README.md
+++ b/plugins/inputs/socket_listener/README.md
@@ -216,7 +216,15 @@ interface joins the multicast group, you can append its name at the end of the
 `service_address`. See the example below.
 
 In the example, SSM is also used to filter packets only coming from source
-`10.65.4.2`.
+`10.65.4.2`. The difference between SSM and `allowed_sources` is where the 
+data packets are accepted. With `multicast_source`, the packets are filtered at 
+the kernel level, while with `allowed_sources` the packets are filtered 
+within Telegraf. This means that with `allowed_sources` all packets are 
+accepted by the kernel, leading to a higher load on the network stack. 
+
+When using multicast, SSM's `multicast_source` is preferred over 
+`allowed_sources`. With unicast, `multicast_source` has no effect and
+`allowed_sources` is required for source filtering.
 
 ```toml
 [[inputs.socket_listener]]

--- a/plugins/inputs/socket_listener/sample.conf
+++ b/plugins/inputs/socket_listener/sample.conf
@@ -12,6 +12,7 @@
   # service_address = "unix:///tmp/telegraf.sock"
   # service_address = "unixgram:///tmp/telegraf.sock"
   # service_address = "vsock://cid:port"
+  # service_address = "udp4://239.0.0.1:40000%enp101s0f1np1"
 
   ## Permission for unix sockets (only available on unix sockets)
   ## This setting may not be respected by some platforms. To safely restrict

--- a/plugins/inputs/socket_listener/sample.conf.in
+++ b/plugins/inputs/socket_listener/sample.conf.in
@@ -12,6 +12,7 @@
   # service_address = "unix:///tmp/telegraf.sock"
   # service_address = "unixgram:///tmp/telegraf.sock"
   # service_address = "vsock://cid:port"
+  # service_address = "udp4://239.0.0.1:40000%enp101s0f1np1"
 
 {{template "/plugins/common/socket/socket.conf"}}
 


### PR DESCRIPTION
## Summary
As pointed out in #19358 currently, interface names like `br-lan` are not properly extracted and supported. I have implemented it following the Linux device naming rules as implemented (but nowhere documented it seems) here: https://github.com/torvalds/linux/blob/11028ab62899e4191e074ee364c712b77823a9c4/net/core/dev.c#L1325

## Checklist
- [ ] No AI generated code was used in this PR
- [x] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

resolves #
