### PR TITLE
test(inputs.sip): Ignore requests dispatched after server close

### DIFF
--- a/plugins/inputs/sip/sip_test.go
+++ b/plugins/inputs/sip/sip_test.go
@@ -799,6 +799,8 @@ type mockServer struct {
 
 	// Errors collected while responding to requests
 	errs []error
+	// Flag denoting the server was closed
+	closed bool
 	sync.Mutex
 }
 
@@ -828,6 +830,12 @@ func newMockServer(method sip.RequestMethod, handler func(*sip.Request) *sip.Res
 	server.OnRequest(method, func(req *sip.Request, tx sip.ServerTransaction) {
 		s.Lock()
 		defer s.Unlock()
+
+		// Requests dispatched after the server was closed can never be answered,
+		// so drop them instead of collecting the inevitable error.
+		if s.closed {
+			return
+		}
 
 		res := handler(req)
 		if res == nil {
@@ -863,6 +871,7 @@ func (s *mockServer) close(t *testing.T) {
 	s.Lock()
 	defer s.Unlock()
 
+	s.closed = true
 	_ = s.server.Close()
 	_ = s.ua.Close()
 


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
The mock server serialises its request handlers against `close` with a mutex, but a handler that was already dispatched while `close` holds the lock still runs once the lock is released, and then tries to respond on a server that is already gone. That response always fails, so the error is appended to `errs` after `close` has made its `require.Empty` assertion, where nothing looks at it again. Setting a `closed` flag under the same lock lets those handlers return early instead of doing work that cannot succeed, which keeps the error list meaningful: everything in it is a real failure to respond rather than the expected fallout of shutting the server down.

Firing fifty raw OPTIONS packets at the mock server and closing it right away collects seven such post-close errors without the flag and none with it.

This is the follow-up agreed on in #19359, on top of the mutex from that PR and the handler rework from #19357.

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

related to #19357
related to #19359
