### PR TITLE
feat(parsers.grok): Allow parsing messages longer than 64KiB

### DIFF
--- a/plugins/inputs/tail/tail_behavior_test.go
+++ b/plugins/inputs/tail/tail_behavior_test.go
@@ -1031,12 +1031,9 @@ func TestLongLine(t *testing.T) {
 
 		offsets: maps.Clone(offsets),
 	}
-	var maxSize config.Size
-	require.NoError(t, maxSize.UnmarshalText([]byte("128KiB")))
 	plugin.SetParserFunc(func() (telegraf.Parser, error) {
 		parser := &grok.Parser{
 			Measurement: "tail_grok",
-			MaxLineSize: maxSize,
 			Patterns:    []string{`%{GREEDYDATA:message}`},
 			Log:         testutil.Logger{},
 		}

--- a/plugins/inputs/tail/tail_behavior_test.go
+++ b/plugins/inputs/tail/tail_behavior_test.go
@@ -1036,7 +1036,7 @@ func TestLongLine(t *testing.T) {
 	plugin.SetParserFunc(func() (telegraf.Parser, error) {
 		parser := &grok.Parser{
 			Measurement: "tail_grok",
-			MaxSize:     maxSize,
+			MaxLineSize: maxSize,
 			Patterns:    []string{`%{GREEDYDATA:message}`},
 			Log:         testutil.Logger{},
 		}

--- a/plugins/inputs/tail/tail_behavior_test.go
+++ b/plugins/inputs/tail/tail_behavior_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -995,4 +996,63 @@ func TestStopIncompleteMultiline(t *testing.T) {
 			require.Equal(t, map[string]int64{fn: 45}, state)
 		})
 	}
+}
+
+func TestLongLine(t *testing.T) {
+	// Get a temporary filename for testing
+	fn := filepath.Join(t.TempDir(), "test.log")
+
+	// Create a file with a long content exceeding the default of 64KiB
+	msg := strings.Repeat("Error123", 1000) // 80,000 characters
+	require.NoError(t, os.WriteFile(fn, []byte(msg+"\n"), 0600))
+
+	// Define the expected metrics in each step
+	expected := []telegraf.Metric{
+		metric.New(
+			"tail_grok",
+			map[string]string{
+				"path": fn,
+			},
+			map[string]interface{}{
+				"message": msg,
+			},
+			time.Unix(0, 0),
+		),
+	}
+
+	// Setup the plugin
+	plugin := &Tail{
+		Files:               []string{fn},
+		MaxUndeliveredLines: 1000,
+		InitialReadOffset:   "beginning",
+		WatchMethod:         "poll",
+		PathTag:             "path",
+		Log:                 testutil.Logger{},
+
+		offsets: maps.Clone(offsets),
+	}
+	var maxSize config.Size
+	require.NoError(t, maxSize.UnmarshalText([]byte("128KiB")))
+	plugin.SetParserFunc(func() (telegraf.Parser, error) {
+		parser := &grok.Parser{
+			Measurement: "tail_grok",
+			MaxSize:     maxSize,
+			Patterns:    []string{`%{GREEDYDATA:message}`},
+			Log:         testutil.Logger{},
+		}
+		err := parser.Init()
+		return parser, err
+	})
+	require.NoError(t, plugin.Init())
+
+	// Start the plugin
+	var acc testutil.Accumulator
+	require.NoError(t, plugin.Start(&acc))
+	defer plugin.Stop()
+
+	// Check the metrics read
+	require.Eventually(t, func() bool {
+		return acc.NMetrics() >= uint64(len(expected))
+	}, 3*time.Second, 100*time.Millisecond)
+	testutil.RequireMetricsEqual(t, expected, acc.GetTelegrafMetrics(), testutil.IgnoreTime())
 }

--- a/plugins/parsers/grok/README.md
+++ b/plugins/parsers/grok/README.md
@@ -127,6 +127,10 @@ If you need help building patterns to match your logs, you will find the
 
   ## Enable multiline messages to be processed.
   # grok_multiline = false
+
+  ## Set the maximum size of the line to parse
+  ## No metric might be emitted if a line to parse exceeds the given size.
+  # grok_maximum_size = "64KiB"
 ```
 
 ### Timestamp Examples

--- a/plugins/parsers/grok/README.md
+++ b/plugins/parsers/grok/README.md
@@ -130,7 +130,7 @@ If you need help building patterns to match your logs, you will find the
 
   ## Set the maximum size of the line to parse
   ## No metric might be emitted if a line to parse exceeds the given size.
-  # grok_maximum_size = "64KiB"
+  # grok_max_line_size = "64KiB"
 ```
 
 ### Timestamp Examples

--- a/plugins/parsers/grok/README.md
+++ b/plugins/parsers/grok/README.md
@@ -127,10 +127,6 @@ If you need help building patterns to match your logs, you will find the
 
   ## Enable multiline messages to be processed.
   # grok_multiline = false
-
-  ## Set the maximum size of the line to parse
-  ## No metric might be emitted if a line to parse exceeds the given size.
-  # grok_max_line_size = "64KiB"
 ```
 
 ### Timestamp Examples

--- a/plugins/parsers/grok/parser.go
+++ b/plugins/parsers/grok/parser.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"math"
 	"os"
 	"regexp"
 	"strconv"
@@ -15,7 +14,6 @@ import (
 	"github.com/vjeantet/grok"
 
 	"github.com/influxdata/telegraf"
-	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/internal"
 	"github.com/influxdata/telegraf/metric"
 	"github.com/influxdata/telegraf/plugins/parsers"
@@ -78,7 +76,6 @@ type Parser struct {
 	Multiline          bool              `toml:"grok_multiline"`
 	Timezone           string            `toml:"grok_timezone"`
 	UniqueTimestamp    string            `toml:"grok_unique_timestamp"`
-	MaxLineSize        config.Size       `toml:"grok_max_line_size"`
 	Measurement        string            `toml:"-"`
 	DefaultTags        map[string]string `toml:"-"`
 	Log                telegraf.Logger   `toml:"-"`
@@ -104,10 +101,6 @@ func (p *Parser) Init() error {
 
 	if p.Timezone == "" {
 		p.Timezone = "UTC"
-	}
-
-	if p.MaxLineSize < 0 || p.MaxLineSize > math.MaxInt {
-		return fmt.Errorf("'grok_max_line_size' has to be greater than 0 and less than %d", math.MaxInt)
 	}
 
 	p.typeMap = make(map[string]map[string]string)
@@ -373,13 +366,15 @@ func (p *Parser) Parse(buf []byte) ([]telegraf.Metric, error) {
 		return metrics, nil
 	}
 
-	scanner := bufio.NewScanner(bytes.NewReader(buf))
-	if p.MaxLineSize > 0 {
-		scanner.Buffer(nil, int(p.MaxLineSize))
-	}
-	for scanner.Scan() {
-		line := scanner.Text()
-		m, err := p.ParseLine(line)
+	for line := range bytes.Lines(buf) {
+		end := len(line)
+		if end > 0 && line[end-1] == '\n' {
+			end--
+		}
+		if end > 0 && line[end-1] == '\r' {
+			end--
+		}
+		m, err := p.ParseLine(string(line[:end]))
 		if err != nil {
 			return nil, err
 		}
@@ -389,9 +384,7 @@ func (p *Parser) Parse(buf []byte) ([]telegraf.Metric, error) {
 		}
 		metrics = append(metrics, m)
 	}
-	if err := scanner.Err(); err != nil {
-		return metrics, fmt.Errorf("scanning failed: %w", err)
-	}
+
 	return metrics, nil
 }
 

--- a/plugins/parsers/grok/parser.go
+++ b/plugins/parsers/grok/parser.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"math"
 	"os"
 	"regexp"
 	"strconv"
@@ -77,7 +78,7 @@ type Parser struct {
 	Multiline          bool              `toml:"grok_multiline"`
 	Timezone           string            `toml:"grok_timezone"`
 	UniqueTimestamp    string            `toml:"grok_unique_timestamp"`
-	MaxSize            config.Size       `toml:"grok_maximum_size"`
+	MaxLineSize        config.Size       `toml:"grok_max_line_size"`
 	Measurement        string            `toml:"-"`
 	DefaultTags        map[string]string `toml:"-"`
 	Log                telegraf.Logger   `toml:"-"`
@@ -103,6 +104,10 @@ func (p *Parser) Init() error {
 
 	if p.Timezone == "" {
 		p.Timezone = "UTC"
+	}
+
+	if p.MaxLineSize < 0 || p.MaxLineSize > math.MaxInt {
+		return fmt.Errorf("'grok_max_line_size' has to be greater than 0 and less than %d", math.MaxInt)
 	}
 
 	p.typeMap = make(map[string]map[string]string)
@@ -369,8 +374,8 @@ func (p *Parser) Parse(buf []byte) ([]telegraf.Metric, error) {
 	}
 
 	scanner := bufio.NewScanner(bytes.NewReader(buf))
-	if p.MaxSize > 0 {
-		scanner.Buffer(make([]byte, p.MaxSize), int(p.MaxSize))
+	if p.MaxLineSize > 0 {
+		scanner.Buffer(make([]byte, p.MaxLineSize), int(p.MaxLineSize))
 	}
 	for scanner.Scan() {
 		line := scanner.Text()

--- a/plugins/parsers/grok/parser.go
+++ b/plugins/parsers/grok/parser.go
@@ -375,7 +375,7 @@ func (p *Parser) Parse(buf []byte) ([]telegraf.Metric, error) {
 
 	scanner := bufio.NewScanner(bytes.NewReader(buf))
 	if p.MaxLineSize > 0 {
-		scanner.Buffer(make([]byte, p.MaxLineSize), int(p.MaxLineSize))
+		scanner.Buffer(nil, int(p.MaxLineSize))
 	}
 	for scanner.Scan() {
 		line := scanner.Text()

--- a/plugins/parsers/grok/parser.go
+++ b/plugins/parsers/grok/parser.go
@@ -389,7 +389,9 @@ func (p *Parser) Parse(buf []byte) ([]telegraf.Metric, error) {
 		}
 		metrics = append(metrics, m)
 	}
-
+	if err := scanner.Err(); err != nil {
+		return metrics, fmt.Errorf("scanning failed: %w", err)
+	}
 	return metrics, nil
 }
 

--- a/plugins/parsers/grok/parser.go
+++ b/plugins/parsers/grok/parser.go
@@ -14,6 +14,7 @@ import (
 	"github.com/vjeantet/grok"
 
 	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/internal"
 	"github.com/influxdata/telegraf/metric"
 	"github.com/influxdata/telegraf/plugins/parsers"
@@ -76,6 +77,7 @@ type Parser struct {
 	Multiline          bool              `toml:"grok_multiline"`
 	Timezone           string            `toml:"grok_timezone"`
 	UniqueTimestamp    string            `toml:"grok_unique_timestamp"`
+	MaxSize            config.Size       `toml:"grok_maximum_size"`
 	Measurement        string            `toml:"-"`
 	DefaultTags        map[string]string `toml:"-"`
 	Log                telegraf.Logger   `toml:"-"`
@@ -367,6 +369,9 @@ func (p *Parser) Parse(buf []byte) ([]telegraf.Metric, error) {
 	}
 
 	scanner := bufio.NewScanner(bytes.NewReader(buf))
+	if p.MaxSize > 0 {
+		scanner.Buffer(make([]byte, p.MaxSize), int(p.MaxSize))
+	}
 	for scanner.Scan() {
 		line := scanner.Text()
 		m, err := p.ParseLine(line)

--- a/plugins/parsers/grok/parser_test.go
+++ b/plugins/parsers/grok/parser_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/influxdata/telegraf"
-	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/metric"
 	"github.com/influxdata/telegraf/testutil"
 )
@@ -1189,7 +1188,6 @@ func TestMultilineNilMetric(t *testing.T) {
 func TestLongLine(t *testing.T) {
 	parser := Parser{
 		Measurement: "test",
-		MaxLineSize: config.Size(128 * 1024), // 128KiB
 		Patterns:    []string{"%{GREEDYDATA:message}"},
 		Log:         &testutil.Logger{},
 	}
@@ -1201,24 +1199,6 @@ func TestLongLine(t *testing.T) {
 
 	expected := []telegraf.Metric{
 		metric.New("test", map[string]string{}, map[string]interface{}{"message": msg}, time.Unix(0, 0)),
-	}
-	testutil.RequireMetricsEqual(t, expected, m, testutil.IgnoreTime())
-}
-
-func TestTooLongLine(t *testing.T) {
-	parser := Parser{
-		Measurement: "test",
-		Patterns:    []string{"%{GREEDYDATA:message}"},
-		Log:         &testutil.Logger{},
-	}
-	require.NoError(t, parser.Init())
-
-	msg := strings.Repeat("Long", 20000) + " message" // 80,008 characters
-	m, err := parser.Parse([]byte("short info\n" + msg + "\n"))
-	require.ErrorContains(t, err, "token too long")
-
-	expected := []telegraf.Metric{
-		metric.New("test", map[string]string{}, map[string]interface{}{"message": "short info"}, time.Unix(0, 0)),
 	}
 	testutil.RequireMetricsEqual(t, expected, m, testutil.IgnoreTime())
 }

--- a/plugins/parsers/grok/parser_test.go
+++ b/plugins/parsers/grok/parser_test.go
@@ -1205,6 +1205,24 @@ func TestLongLine(t *testing.T) {
 	testutil.RequireMetricsEqual(t, expected, m, testutil.IgnoreTime())
 }
 
+func TestTooLongLine(t *testing.T) {
+	parser := Parser{
+		Measurement: "test",
+		Patterns:    []string{"%{GREEDYDATA:message}"},
+		Log:         &testutil.Logger{},
+	}
+	require.NoError(t, parser.Init())
+
+	msg := strings.Repeat("Long", 20000) + " message" // 80,008 characters
+	m, err := parser.Parse([]byte("short info\n" + msg + "\n"))
+	require.ErrorContains(t, err, "token too long")
+
+	expected := []telegraf.Metric{
+		metric.New("test", map[string]string{}, map[string]interface{}{"message": "short info"}, time.Unix(0, 0)),
+	}
+	testutil.RequireMetricsEqual(t, expected, m, testutil.IgnoreTime())
+}
+
 const benchmarkData = `benchmark 5 1653643421 source=myhost tags_platform=python tags_sdkver=3.11.5
 benchmark 4 1653643422 source=myhost tags_platform=python tags_sdkver=3.11.4
 `

--- a/plugins/parsers/grok/parser_test.go
+++ b/plugins/parsers/grok/parser_test.go
@@ -3,12 +3,14 @@ package grok
 import (
 	"log"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/metric"
 	"github.com/influxdata/telegraf/testutil"
 )
@@ -1182,6 +1184,25 @@ func TestMultilineNilMetric(t *testing.T) {
 	actual, err := p.Parse(buf)
 	require.NoError(t, err)
 	require.Empty(t, actual)
+}
+
+func TestLongLine(t *testing.T) {
+	parser := Parser{
+		Measurement: "test",
+		MaxSize:     config.Size(128 * 1024), // 128KiB
+		Patterns:    []string{"%{GREEDYDATA:message}"},
+		Log:         &testutil.Logger{},
+	}
+	require.NoError(t, parser.Init())
+
+	msg := strings.Repeat("Long", 20000) + " message" // 80,008 characters
+	m, err := parser.Parse([]byte(msg + "\n"))
+	require.NoError(t, err)
+
+	expected := []telegraf.Metric{
+		metric.New("test", map[string]string{}, map[string]interface{}{"message": msg}, time.Unix(0, 0)),
+	}
+	testutil.RequireMetricsEqual(t, expected, m, testutil.IgnoreTime())
 }
 
 const benchmarkData = `benchmark 5 1653643421 source=myhost tags_platform=python tags_sdkver=3.11.5

--- a/plugins/parsers/grok/parser_test.go
+++ b/plugins/parsers/grok/parser_test.go
@@ -1189,7 +1189,7 @@ func TestMultilineNilMetric(t *testing.T) {
 func TestLongLine(t *testing.T) {
 	parser := Parser{
 		Measurement: "test",
-		MaxSize:     config.Size(128 * 1024), // 128KiB
+		MaxLineSize: config.Size(128 * 1024), // 128KiB
 		Patterns:    []string{"%{GREEDYDATA:message}"},
 		Log:         &testutil.Logger{},
 	}


### PR DESCRIPTION
## Summary

When calling `Parse()` of the `grok` parser, the given message will be split by line using a `bufio.Scanner`. This scanner has a default buffer of 64KiB and will stop parsing if a line exceeds that length resulting in no metric being emitted.

This PR allows to specify a `grok_maximum_size` to increase that buffer size if required to allow parsing long lines.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

resolves #19362 
