### PR TITLE
fix(inputs.cisco_telemetry_mdt): Check attribute message length

### DIFF
--- a/plugins/inputs/cisco_telemetry_mdt/parser.go
+++ b/plugins/inputs/cisco_telemetry_mdt/parser.go
@@ -362,7 +362,10 @@ func (s *state) parseEvents(events []*telemetry.TelemetryField, prefix string, t
 		} else if events[0].Fields[1].Name == "subscriptionId" {
 			attrFields = events[0].Fields[0].Fields
 		}
-		if len(attrFields) > 0 && len(attrFields[0].Fields) > 0 && len(attrFields[0].Fields[0].Fields) > 0 && len(attrFields[0].Fields[0].Fields[0].Fields) > 0 && len(attrFields[0].Fields[0].Fields[0].Fields[0].Fields) > 0 {
+		valid := len(attrFields) > 0 && len(attrFields[0].Fields) > 0 && len(attrFields[0].Fields[0].Fields) > 0
+		valid = valid && len(attrFields[0].Fields[0].Fields[0].Fields) > 0
+		valid = valid && len(attrFields[0].Fields[0].Fields[0].Fields[0].Fields) > 0
+		if valid {
 			attrs = attrFields[0].Fields[0].Fields[0].Fields[0].Fields[0]
 		}
 	}

--- a/plugins/inputs/cisco_telemetry_mdt/parser.go
+++ b/plugins/inputs/cisco_telemetry_mdt/parser.go
@@ -356,24 +356,28 @@ func (s *state) parseDME(fields []*telemetry.TelemetryField, prefix string, tags
 func (s *state) parseEvents(events []*telemetry.TelemetryField, prefix string, tags map[string]string, timestamp time.Time) []error {
 	var attrs *telemetry.TelemetryField
 	if events[0] != nil && len(events[0].Fields) >= 2 {
-		if events[0].Fields[0].Name == "subscriptionId" {
-			attrs = events[0].Fields[1].Fields[0].Fields[0].Fields[0].Fields[0].Fields[0]
+		var attrFields []*telemetry.TelemetryField
+		if events[0].Fields[0].Name == "subscriptionId" && len(events[0].Fields[1].Fields) > 0 {
+			attrFields = events[0].Fields[1].Fields
 		} else if events[0].Fields[1].Name == "subscriptionId" {
-			attrs = events[0].Fields[0].Fields[0].Fields[0].Fields[0].Fields[0].Fields[0]
+			attrFields = events[0].Fields[0].Fields
+		}
+		if len(attrFields) > 0 && len(attrFields[0].Fields) > 0 && len(attrFields[0].Fields[0].Fields) > 0 && len(attrFields[0].Fields[0].Fields[0].Fields) > 0 && len(attrFields[0].Fields[0].Fields[0].Fields[0].Fields) > 0 {
+			attrs = attrFields[0].Fields[0].Fields[0].Fields[0].Fields[0]
 		}
 	}
 
 	// Parse the attribute subfields according to their class
-	if attrs == nil {
-		//nolint:prealloc // We expect errors to be empty by default
-		var errs []error
-		for _, sub := range events {
-			errs = append(errs, s.parseClassAttributeField(sub, tags, timestamp)...)
-		}
-		return errs
+	if attrs != nil {
+		return s.parseDME(attrs.Fields, prefix, tags, timestamp)
 	}
 
-	return s.parseDME(attrs.Fields, prefix, tags, timestamp)
+	//nolint:prealloc // We expect errors to be empty by default
+	var errs []error
+	for _, sub := range events {
+		errs = append(errs, s.parseClassAttributeField(sub, tags, timestamp)...)
+	}
+	return errs
 }
 
 // NXAPI structure: https://developer.cisco.com/docs/cisco-nexus-9000-series-nx-api-cli-reference-release-9-2x/


### PR DESCRIPTION
## Summary

This PR ensures the attributes message has enough data to prevent potential panics for short or malformed messages.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

related to #10087 
