### PR TITLE
feat(inputs.elasticsearch_query): Add ES v8 support

### DIFF
--- a/docs/LICENSE_OF_DEPENDENCIES.md
+++ b/docs/LICENSE_OF_DEPENDENCIES.md
@@ -149,6 +149,7 @@ following works:
 - github.com/ebitengine/purego [Apache License 2.0](https://github.com/ebitengine/purego/blob/main/LICENSE)
 - github.com/eclipse/paho.golang [Eclipse Public License - v 2.0](https://github.com/eclipse/paho.golang/blob/master/LICENSE)
 - github.com/eclipse/paho.mqtt.golang [Eclipse Public License - v 2.0](https://github.com/eclipse/paho.mqtt.golang/blob/master/LICENSE)
+- github.com/elastic/elastic-transport-go [Apache License 2.0](https://github.com/elastic/elastic-transport-go/blob/main/LICENSE)
 - github.com/elastic/go-elasticsearch [Apache License 2.0](https://github.com/elastic/go-elasticsearch/blob/main/LICENSE)
 - github.com/elastic/go-sysinfo [Apache License 2.0](https://github.com/elastic/go-sysinfo/blob/main/LICENSE.txt)
 - github.com/elastic/go-windows [Apache License 2.0](https://github.com/elastic/go-windows/blob/main/LICENSE.txt)

--- a/go.mod
+++ b/go.mod
@@ -90,6 +90,7 @@ require (
 	github.com/elastic/go-elasticsearch/v5 v5.6.1
 	github.com/elastic/go-elasticsearch/v6 v6.8.10
 	github.com/elastic/go-elasticsearch/v7 v7.17.10
+	github.com/elastic/go-elasticsearch/v8 v8.19.6
 	github.com/emiago/sipgo v1.4.3
 	github.com/facebook/time v0.0.0-20250903103710-a5911c32cdb9
 	github.com/fatih/color v1.19.0
@@ -359,6 +360,7 @@ require (
 	github.com/eapache/go-resiliency v1.7.0 // indirect
 	github.com/ebitengine/purego v0.10.1 // indirect
 	github.com/echlebek/timeproxy v1.0.0 // indirect
+	github.com/elastic/elastic-transport-go/v8 v8.9.0 // indirect
 	github.com/elastic/go-sysinfo v1.8.1 // indirect
 	github.com/elastic/go-windows v1.0.0 // indirect
 	github.com/emicklei/go-restful/v3 v3.13.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1185,12 +1185,16 @@ github.com/eclipse/paho.golang v0.23.0 h1:KHgl2wz6EJo7cMBmkuhpt7C576vP+kpPv7jjvS
 github.com/eclipse/paho.golang v0.23.0/go.mod h1:nQRhTkoZv8EAiNs5UU0/WdQIx2NrnWUpL9nsGJTQN04=
 github.com/eclipse/paho.mqtt.golang v1.5.1 h1:/VSOv3oDLlpqR2Epjn1Q7b2bSTplJIeV2ISgCl2W7nE=
 github.com/eclipse/paho.mqtt.golang v1.5.1/go.mod h1:1/yJCneuyOoCOzKSsOTUc0AJfpsItBGWvYpBLimhArU=
+github.com/elastic/elastic-transport-go/v8 v8.9.0 h1:KeT/2P54F0xS0S8Y3Pf+tFDg4HmBgReQMB+BMz8dDAs=
+github.com/elastic/elastic-transport-go/v8 v8.9.0/go.mod h1:ssMTvNS2hwf7CaiGsRRsx4gQHFZ/jS/DkLcISxekWzc=
 github.com/elastic/go-elasticsearch/v5 v5.6.1 h1:RnL2wcXepOT5SdoKMMO1j1OBX0vxHYbBtkQNL2E3xs4=
 github.com/elastic/go-elasticsearch/v5 v5.6.1/go.mod h1:r7uV7HidpfkYh7D8SB4lkS13TNlNy3oa5GNmTZvuVqY=
 github.com/elastic/go-elasticsearch/v6 v6.8.10 h1:2lN0gJ93gMBXvkhwih5xquldszpm8FlUwqG5sPzr6a8=
 github.com/elastic/go-elasticsearch/v6 v6.8.10/go.mod h1:UwaDJsD3rWLM5rKNFzv9hgox93HoX8utj1kxD9aFUcI=
 github.com/elastic/go-elasticsearch/v7 v7.17.10 h1:TCQ8i4PmIJuBunvBS6bwT2ybzVFxxUhhltAs3Gyu1yo=
 github.com/elastic/go-elasticsearch/v7 v7.17.10/go.mod h1:OJ4wdbtDNk5g503kvlHLyErCgQwwzmDtaFC4XyOxXA4=
+github.com/elastic/go-elasticsearch/v8 v8.19.6 h1:4qa7ecJkr5rLsoHKIVGbaqcFt2o57CnOHQJi9Pts/rk=
+github.com/elastic/go-elasticsearch/v8 v8.19.6/go.mod h1:jeWebApE1oFEW/hKZqx/IRYmP/aa2+WMJkOfk+AduSI=
 github.com/elastic/go-sysinfo v1.8.1 h1:4Yhj+HdV6WjbCRgGdZpPJ8lZQlXZLKDAeIkmQ/VRvi4=
 github.com/elastic/go-sysinfo v1.8.1/go.mod h1:JfllUnzoQV/JRYymbH3dO1yggI3mV2oTKSXsDHM+uIM=
 github.com/elastic/go-windows v1.0.0 h1:qLURgZFkkrYyTTkvYpsZIgf83AUsdIHfvlJaqaZ7aSY=

--- a/plugins/inputs/elasticsearch_query/README.md
+++ b/plugins/inputs/elasticsearch_query/README.md
@@ -7,7 +7,7 @@ filtered by a query, aggregated per tag and to count the number of terms for a
 particular field.
 
 > [!IMPORTANT]
-> This plugin supports Elasticsearch 5.x to 7.x only.
+> This plugin supports Elasticsearch 5.x to 8.x only.
 > Node discovery is not supported with Elasticsearch 5.x.
 
 ⭐ Telegraf v1.20.0

--- a/plugins/inputs/elasticsearch_query/client_v8.go
+++ b/plugins/inputs/elasticsearch_query/client_v8.go
@@ -1,0 +1,125 @@
+package elasticsearch_query
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync"
+
+	elasticsearch8 "github.com/elastic/go-elasticsearch/v8"
+	esapi8 "github.com/elastic/go-elasticsearch/v8/esapi"
+
+	"github.com/influxdata/telegraf"
+)
+
+type clientV8 struct {
+	client          *elasticsearch8.BaseClient
+	httpClient      *http.Client
+	log             telegraf.Logger
+	cancelDiscovery context.CancelFunc
+	discoveryWG     sync.WaitGroup
+	closeOnce       sync.Once
+}
+
+func newClientV8(cfg clientConfig) (client, error) {
+	// Use the base client to avoid retaining the full esapi API tree because this
+	// plugin only uses two request types.
+	c, err := elasticsearch8.NewBaseClient(elasticsearch8.Config{
+		Addresses: cfg.urls,
+		Username:  cfg.username,
+		Password:  cfg.password,
+		Transport: roundTripper{client: cfg.httpClient},
+	})
+	if err != nil {
+		cfg.httpClient.CloseIdleConnections()
+		return nil, fmt.Errorf("creating ElasticSearch client failed: %w", err)
+	}
+
+	client := &clientV8{client: c, httpClient: cfg.httpClient, log: cfg.log}
+	if cfg.enableSniffer && cfg.discoveryInterval > 0 {
+		// The v8 base client exposes only DiscoverNodes(), so in-flight calls
+		// cannot be canceled.
+		ctx, cancel := context.WithCancel(context.Background())
+		client.cancelDiscovery = cancel
+		client.discoveryWG.Add(1)
+		go func() {
+			defer client.discoveryWG.Done()
+			startDiscovery(ctx, cfg.discoveryInterval, func(context.Context) error {
+				return c.DiscoverNodes()
+			}, cfg.log)
+		}()
+	}
+	return client, nil
+}
+
+func (c *clientV8) close() {
+	c.closeOnce.Do(func() {
+		if c.cancelDiscovery != nil {
+			c.cancelDiscovery()
+			c.discoveryWG.Wait()
+		}
+		if c.client != nil {
+			if err := c.client.Close(context.Background()); err != nil {
+				c.log.Errorf("Closing ElasticSearch client failed: %v", err)
+			}
+		}
+		if c.httpClient != nil {
+			c.httpClient.CloseIdleConnections()
+		}
+	})
+}
+
+func (c *clientV8) getFieldMapping(ctx context.Context, index, field string) (map[string]interface{}, error) {
+	req := esapi8.IndicesGetFieldMappingRequest{
+		Index:  []string{index},
+		Fields: []string{field},
+	}
+	res, err := req.Do(ctx, c.client)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	if err := checkForError(res.StatusCode, res.Body); err != nil {
+		return nil, err
+	}
+
+	var result map[string]interface{}
+	if err := json.NewDecoder(res.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("decoding message body failed: %w", err)
+	}
+	return result, nil
+}
+
+func (c *clientV8) query(ctx context.Context, aggregation *aggregation) (interface{}, int64, error) {
+	data, err := aggregation.buildSearchBody(c.log)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	req := esapi8.SearchRequest{
+		Index:          []string{aggregation.Index},
+		Body:           bytes.NewReader(data),
+		TrackTotalHits: true,
+	}
+	res, err := req.Do(ctx, c.client)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer res.Body.Close()
+
+	if err := checkForError(res.StatusCode, res.Body); err != nil {
+		return nil, 0, err
+	}
+
+	var result searchResponse
+	if err := json.NewDecoder(res.Body).Decode(&result); err != nil {
+		return nil, 0, fmt.Errorf("decoding message body failed: %w", err)
+	}
+	if len(result.Aggregations) == 0 {
+		return nil, result.totalHits(), nil
+	}
+	return result.Aggregations, result.totalHits(), nil
+}

--- a/plugins/inputs/elasticsearch_query/elasticsearch_query.go
+++ b/plugins/inputs/elasticsearch_query/elasticsearch_query.go
@@ -116,9 +116,11 @@ func (e *ElasticsearchQuery) Start(telegraf.Accumulator) error {
 		c, err = newClientV6(cfg)
 	case 7:
 		c, err = newClientV7(cfg)
+	case 8:
+		c, err = newClientV8(cfg)
 	default:
 		httpClient.CloseIdleConnections()
-		return fmt.Errorf("server version %q not supported (currently supported versions are 5.x, 6.x and 7.x)", version)
+		return fmt.Errorf("server version %q not supported (currently supported versions are 5.x, 6.x, 7.x and 8.x)", version)
 	}
 	if err != nil {
 		return err

--- a/plugins/inputs/elasticsearch_query/elasticsearch_query_test.go
+++ b/plugins/inputs/elasticsearch_query/elasticsearch_query_test.go
@@ -274,6 +274,10 @@ func TestClientV7PlusDiscovery(t *testing.T) {
 			name:      "v7",
 			newClient: newClientV7,
 		},
+		{
+			name:      "v8",
+			newClient: newClientV8,
+		},
 	}
 
 	for _, tt := range tests {
@@ -344,6 +348,12 @@ func TestClientQuery(t *testing.T) {
 		{
 			name:                   "v7",
 			newClient:              newClientV7,
+			response:               `{"hits":{"total":{"value":12345,"relation":"eq"}},"aggregations":{}}`,
+			expectedTrackTotalHits: "true",
+		},
+		{
+			name:                   "v8",
+			newClient:              newClientV8,
 			response:               `{"hits":{"total":{"value":12345,"relation":"eq"}},"aggregations":{}}`,
 			expectedTrackTotalHits: "true",
 		},
@@ -995,6 +1005,16 @@ func TestGatherV7PlusIntegration(t *testing.T) {
 				"ES_JAVA_OPTS":   "-Xms1g -Xmx1g",
 			},
 		},
+		// Security is enabled by default starting with Elasticsearch 8.
+		{
+			name:  "v8",
+			image: "docker.elastic.co/elasticsearch/elasticsearch:8.19.18",
+			env: map[string]string{
+				"discovery.type":         "single-node",
+				"xpack.security.enabled": "false",
+				"ES_JAVA_OPTS":           "-Xms1g -Xmx1g",
+			},
+		},
 	}
 
 	// Define expectations
@@ -1460,7 +1480,7 @@ func TestInvalidServerVersion(t *testing.T) {
 func TestStartupFailureReleasesClient(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		if _, err := w.Write([]byte(`{"version": {"number": "8.1.2"}}`)); err != nil {
+		if _, err := w.Write([]byte(`{"version": {"number": "9.1.2"}}`)); err != nil {
 			t.Error(err)
 		}
 	}))


### PR DESCRIPTION
## Summary

Adds Elasticsearch v8 support to Elasticsearch Query input plugin using official `github.com/elastic/go-elasticsearch/v8` client.

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [ ] No AI generated code was used in this PR
- [x] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #19214 
