### PR TITLE
docs(serializers.splunkmetric): Fix code-block language

### DIFF
--- a/plugins/serializers/splunkmetric/README.md
+++ b/plugins/serializers/splunkmetric/README.md
@@ -12,7 +12,7 @@ an HTTP POST per metric.
 
 An example event looks like:
 
-```javascript
+```json
 {
   "time": 1529708430,
   "event": "metric",
@@ -39,7 +39,7 @@ Starting with Splunk Enterprise and Splunk Cloud 8.0, you can now send multiple
 metric values in one payload. This means, for example, that you can send all of
 your CPU stats in one JSON struct, an example event looks like:
 
-```javascript
+```json
 {
   "time": 1572469920,
   "event": "metric",
@@ -56,7 +56,7 @@ your CPU stats in one JSON struct, an example event looks like:
     "metric_name:telegraf.cpu.usage_softirq": 0,
     "metric_name:telegraf.cpu.usage_steal": 0,
     "metric_name:telegraf.cpu.usage_system": 10.2,
-    "metric_name:telegraf.cpu.usage_user": 24.7,
+    "metric_name:telegraf.cpu.usage_user": 24.7
   }
 }
 ```
@@ -143,7 +143,7 @@ forwarder.
 
 A sample event when `hec_routing` is false (or unset) looks like:
 
-```javascript
+```json
 {
     "_value": 0.6,
     "cpu": "cpu0",


### PR DESCRIPTION
## Summary

Fix documentation code-block language.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

resolves #19200
resolves #19201 
