### PR TITLE
feat(serializers.splunkmetric): add multimetric string, prefix, and measurement options

### DIFF
--- a/plugins/serializers/splunkmetric/README.md
+++ b/plugins/serializers/splunkmetric/README.md
@@ -61,8 +61,22 @@ your CPU stats in one JSON struct, an example event looks like:
 }
 ```
 
-In order to enable this mode, there's a new option `splunkmetric_multimetric`
-that you set in the appropriate output module you plan on using.
+In order to enable this mode, set `splunkmetric_multimetric = true` in the
+appropriate output plugin configuration.
+
+### Omitting the metric name prefix
+
+By default, multi-metric field keys are prefixed with `metric_name:measurementName.`
+(e.g. `metric_name:cpu.usage_idle`). If your Splunk schema does not require this
+prefix, you can omit it with `splunkmetric_omit_metric_name_prefix = true`, which
+will emit the bare field key instead (e.g. `usage_idle`).
+
+### Adding a measurement field
+
+Setting `splunkmetric_add_measurement_field = true` adds a `"measurement"` field
+to the event containing the measurement name (e.g. `"measurement": "cpu"`). This
+can be useful for filtering or grouping in Splunk when the metric name prefix has
+been omitted.
 
 ## Using with the HTTP output
 
@@ -102,6 +116,9 @@ sample config for an HTTP output:
   splunkmetric_hec_routing = true
   # splunkmetric_multimetric = true
   # splunkmetric_omit_event_tag = false
+  # splunkmetric_omit_metric_name_prefix = false
+  # splunkmetric_permit_field_string_values = false
+  # splunkmetric_add_measurement_field = false
 
   ## Additional HTTP headers
   [outputs.http.headers]
@@ -187,14 +204,28 @@ An example configuration of a file based output is:
    splunkmetric_hec_routing = false
    splunkmetric_multimetric = true
    splunkmetric_omit_event_tag = false
+   # splunkmetric_omit_metric_name_prefix = false
+   # splunkmetric_permit_field_string_values = false
+   # splunkmetric_add_measurement_field = false
 ```
 
 ## Non-numeric metric values
 
-Splunk supports only numeric field values, so serializer would silently drop
-metrics with the string values. For some cases it is possible to workaround
-using the [enum processor][enum_plugin]. Example, provided below doing this for
-the `docker_container_health.health_status` metric:
+Splunk's metric store requires `_value` to be numeric. The serializer therefore
+drops string-valued fields by default. There are two ways to overcome this limitation:
+
+**Option 1:** Use `splunkmetric_permit_field_string_values = true` (multi-metric
+mode only) to allow string-valued fields to be emitted directly:
+
+```toml
+data_format = "splunkmetric"
+splunkmetric_multimetric = true
+splunkmetric_permit_field_string_values = true
+```
+
+**Option 2:** Map string values to integers before serialization using the
+[enum processor][enum_plugin]. This works in both single and multi-metric mode.
+Example for `docker_container_health.health_status`:
 
 ```toml
 # splunkmetric does not support string values

--- a/plugins/serializers/splunkmetric/splunkmetric.go
+++ b/plugins/serializers/splunkmetric/splunkmetric.go
@@ -9,9 +9,21 @@ import (
 )
 
 type Serializer struct {
-	HecRouting   bool `toml:"splunkmetric_hec_routing"`
-	MultiMetric  bool `toml:"splunkmetric_multimetric"`
+	// HecRouting routes metrics through the Splunk HTTP Event Collector (HEC) envelope format.
+	HecRouting bool `toml:"splunkmetric_hec_routing"`
+	// MultiMetric emits all fields of a metric in a single event instead of one event per field.
+	MultiMetric bool `toml:"splunkmetric_multimetric"`
+	// OmitEventTag omits the "event":"metric" tag from HEC output.
 	OmitEventTag bool `toml:"splunkmetric_omit_event_tag"`
+	// OmitMetricNamePrefix omits the "metric_name:measurementName" prefix from field keys.
+	// Only applies when MultiMetric (splunkmetric_multimetric) is true.
+	OmitMetricNamePrefix bool `toml:"splunkmetric_omit_metric_name_prefix"`
+	// PermitFieldStringValues allows string-valued fields; by default string fields are dropped.
+	// Only applies when MultiMetric (splunkmetric_multimetric) is true.
+	PermitFieldStringValues bool `toml:"splunkmetric_permit_field_string_values"`
+	// AddMeasurementField adds a "measurement" field containing the measurement name (metric.Name()).
+	// Only applies when MultiMetric (splunkmetric_multimetric) is true.
+	AddMeasurementField bool `toml:"splunkmetric_add_measurement_field"`
 }
 
 type commonTags struct {
@@ -56,7 +68,8 @@ func (s *Serializer) createMulti(metric telegraf.Metric, dataGroup hecTimeSeries
 	** event payload. This only works when the time, host, and dimensions are the same for every name=value pair
 	** in the timeseries data.
 	**
-	** The format for multimetric data is 'metric_name:nameOfMetric = valueOfMetric'
+	** The format for multimetric data is 'metric_name:measurementName.fieldKey: fieldValue' unless OmitMetricNamePrefix is true,
+	** then the format is 'fieldKey: fieldValue'.
 	 */
 	var metricJSON []byte
 
@@ -69,16 +82,22 @@ func (s *Serializer) createMulti(metric telegraf.Metric, dataGroup hecTimeSeries
 	dataGroup.Index = commonTags.Index
 	dataGroup.Source = commonTags.Source
 	dataGroup.Fields = commonTags.Fields
+	if s.AddMeasurementField {
+		dataGroup.Fields["measurement"] = metric.Name()
+	}
 
 	// Stuff the metric data into the structure.
 	for _, field := range metric.FieldList() {
-		value, valid := verifyValue(field.Value)
+		value, valid := s.verifyValue(field.Value)
 
 		if !valid {
 			log.Printf("D! Can not parse value: %v for key: %v", field.Value, field.Key)
 			continue
 		}
-
+		if s.OmitMetricNamePrefix {
+			dataGroup.Fields[field.Key] = value
+			continue
+		}
 		dataGroup.Fields["metric_name:"+metric.Name()+"."+field.Key] = value
 	}
 
@@ -110,7 +129,7 @@ func (s *Serializer) createSingle(metric telegraf.Metric, dataGroup hecTimeSerie
 	var metricJSON []byte
 
 	for _, field := range metric.FieldList() {
-		value, valid := verifyValue(field.Value)
+		value, valid := s.verifyValue(field.Value)
 
 		if !valid {
 			log.Printf("D! Can not parse value: %v for key: %v", field.Value, field.Key)
@@ -186,11 +205,16 @@ func (s *Serializer) createObject(metric telegraf.Metric) ([]byte, error) {
 	return s.createSingle(metric, dataGroup, commonTags)
 }
 
-func verifyValue(v interface{}) (value interface{}, valid bool) {
+func (s *Serializer) verifyValue(v interface{}) (value interface{}, valid bool) {
 	switch v.(type) {
 	case string:
-		valid = false
-		value = v
+		if s.MultiMetric && s.PermitFieldStringValues {
+			valid = true
+			value = v
+		} else {
+			valid = false
+			value = v
+		}
 	case bool:
 		if v == bool(true) {
 			// Store 1 for a "true" value

--- a/plugins/serializers/splunkmetric/splunkmetric_test.go
+++ b/plugins/serializers/splunkmetric/splunkmetric_test.go
@@ -268,6 +268,185 @@ func TestSerializeOmitEvent(t *testing.T) {
 	require.Equal(t, expS, string(buf))
 }
 
+func TestSerializeMultiOmitMetricPrefix(t *testing.T) {
+	m := metric.New(
+		"cpu",
+		map[string]string{},
+		map[string]interface{}{
+			"user":   42.0,
+			"system": 8.0,
+		},
+		time.Unix(0, 0),
+	)
+
+	metrics := []telegraf.Metric{m}
+	s := &Serializer{MultiMetric: true, OmitMetricNamePrefix: true}
+	buf, err := s.SerializeBatch(metrics)
+	require.NoError(t, err)
+
+	expS := `{"system":8,"time":0,"user":42}`
+	require.Equal(t, expS, string(buf))
+}
+
+func TestSerializeMultiOmitMetricPrefixHec(t *testing.T) {
+	m := metric.New(
+		"cpu",
+		map[string]string{},
+		map[string]interface{}{
+			"usage":  42.0,
+			"system": 8.0,
+		},
+		time.Unix(0, 0),
+	)
+
+	metrics := []telegraf.Metric{m}
+	s := &Serializer{
+		HecRouting:           true,
+		MultiMetric:          true,
+		OmitMetricNamePrefix: true,
+	}
+	buf, err := s.SerializeBatch(metrics)
+	require.NoError(t, err)
+
+	expS := `{"time":0,"event":"metric","fields":{"system":8,"usage":42}}`
+	require.Equal(t, expS, string(buf))
+}
+
+func TestSerializeMultiDropStringValues(t *testing.T) {
+	m := metric.New(
+		"cpu",
+		map[string]string{},
+		map[string]interface{}{
+			"processorType": "ARMv7 Processor rev 4 (v7l)",
+			"usage_idle":    42.0,
+		},
+		time.Unix(0, 0),
+	)
+
+	metrics := []telegraf.Metric{m}
+	s := &Serializer{MultiMetric: true} // PermitFieldStringValues defaults to false
+	buf, err := s.SerializeBatch(metrics)
+	require.NoError(t, err)
+
+	// String field should be dropped; only the numeric field appears
+	expS := `{"metric_name:cpu.usage_idle":42,"time":0}`
+	require.Equal(t, expS, string(buf))
+}
+
+func TestSerializeMultiPermitStringValues(t *testing.T) {
+	m := metric.New(
+		"cpu",
+		map[string]string{},
+		map[string]interface{}{
+			"processorType": "ARMv7 Processor rev 4 (v7l)",
+			"usage_idle":    42.0,
+		},
+		time.Unix(0, 0),
+	)
+
+	metrics := []telegraf.Metric{m}
+	s := &Serializer{MultiMetric: true, PermitFieldStringValues: true}
+	buf, err := s.SerializeBatch(metrics)
+	require.NoError(t, err)
+
+	expS := `{"metric_name:cpu.processorType":"ARMv7 Processor rev 4 (v7l)","metric_name:cpu.usage_idle":42,"time":0}`
+	require.Equal(t, expS, string(buf))
+}
+
+func TestSerializeMultiAddMeasurementField(t *testing.T) {
+	m := metric.New(
+		"cpu",
+		map[string]string{},
+		map[string]interface{}{
+			"user":   42.0,
+			"system": 8.0,
+		},
+		time.Unix(0, 0),
+	)
+
+	metrics := []telegraf.Metric{m}
+	s := &Serializer{MultiMetric: true, AddMeasurementField: true}
+	buf, err := s.SerializeBatch(metrics)
+	require.NoError(t, err)
+
+	expS := `{"measurement":"cpu","metric_name:cpu.system":8,"metric_name:cpu.user":42,"time":0}`
+	require.Equal(t, expS, string(buf))
+}
+
+func TestSerializeMultiAddMeasurementFieldHec(t *testing.T) {
+	m := metric.New(
+		"cpu",
+		map[string]string{},
+		map[string]interface{}{
+			"user":   42.0,
+			"system": 8.0,
+		},
+		time.Unix(0, 0),
+	)
+
+	metrics := []telegraf.Metric{m}
+	s := &Serializer{
+		HecRouting:          true,
+		MultiMetric:         true,
+		AddMeasurementField: true,
+	}
+	buf, err := s.SerializeBatch(metrics)
+	require.NoError(t, err)
+
+	expS := `{"time":0,"event":"metric","fields":{"measurement":"cpu","metric_name:cpu.system":8,"metric_name:cpu.user":42}}`
+	require.Equal(t, expS, string(buf))
+}
+
+func TestSerializeMultiAddMeasurementFieldOmitMetricPrefix(t *testing.T) {
+	m := metric.New(
+		"cpu",
+		map[string]string{},
+		map[string]interface{}{
+			"user":   42.0,
+			"system": 8.0,
+		},
+		time.Unix(0, 0),
+	)
+
+	metrics := []telegraf.Metric{m}
+	s := &Serializer{
+		MultiMetric:          true,
+		AddMeasurementField:  true,
+		OmitMetricNamePrefix: true,
+	}
+	buf, err := s.SerializeBatch(metrics)
+	require.NoError(t, err)
+
+	// Fields have no metric_name: prefix; measurement key is still added
+	expS := `{"measurement":"cpu","system":8,"time":0,"user":42}`
+	require.Equal(t, expS, string(buf))
+}
+
+func TestSerializeMultiAddMeasurementFieldOmitMetricPrefixHec(t *testing.T) {
+	m := metric.New(
+		"cpu",
+		map[string]string{},
+		map[string]interface{}{
+			"user":   42.0,
+			"system": 8.0,
+		},
+		time.Unix(0, 0),
+	)
+
+	metrics := []telegraf.Metric{m}
+	s := &Serializer{
+		HecRouting:           true,
+		MultiMetric:          true,
+		AddMeasurementField:  true,
+		OmitMetricNamePrefix: true,
+	}
+	buf, err := s.SerializeBatch(metrics)
+	require.NoError(t, err)
+
+	expS := `{"time":0,"event":"metric","fields":{"measurement":"cpu","system":8,"user":42}}`
+	require.Equal(t, expS, string(buf))
+}
+
 func BenchmarkSerialize(b *testing.B) {
 	s := &Serializer{}
 	metrics := serializers.BenchmarkMetrics(b)


### PR DESCRIPTION
new features for splunkmetric serializer

## Summary
Added support for OmitMetricPrefix, PermitFieldStringValues, AddMeasurementField in the splunkmetric serializer.

## Checklist

- [ ] No AI generated code was used in this PR
- [x] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
# TODO
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
