### PR TITLE
chore(inputs.sql): Change sqlite build-tags to match the support matrix

### DIFF
--- a/plugins/inputs/sql/drivers_sqlite.go
+++ b/plugins/inputs/sql/drivers_sqlite.go
@@ -1,4 +1,5 @@
-//go:build !mips && !mipsle && !mips64 && !ppc64 && !riscv64 && !loong64 && !mips64le && !(windows && (386 || arm)) && !(freebsd && (386 || arm))
+// According to the support matrix at https://pkg.go.dev/modernc.org/sqlite
+//go:build (darwin && (amd64 || arm64)) || (freebsd && (amd64 || arm64)) || (linux && (386 || amd64 || arm || arm64 || loong64 || ppc64le || riscv64 || s390x)) || (openbsd && (amd64 || arm64)) || (windows && (386 || amd64 || arm64))
 
 package sql
 


### PR DESCRIPTION
## Summary

This PR changes the build constraints for the sqlite driver to match the support matrix. This will ensure Telegraf builds correctly also on exotic architectures and has a clear relation to documented upstream support.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
