### PR TITLE
docs(inputs.docker): Fix code-block language

### DIFF
--- a/plugins/inputs/docker/README.md
+++ b/plugins/inputs/docker/README.md
@@ -153,7 +153,7 @@ for containers that have no explicit hostname set, as defined by docker.
 Kubernetes may add many labels to your containers, if they are not needed you
 may prefer to exclude them:
 
-```json
+```toml
   docker_label_exclude = ["annotation.kubernetes*"]
 ```
 
@@ -162,7 +162,7 @@ may prefer to exclude them:
 Docker-compose will add labels to your containers. You can limit restrict labels
 to selected ones, e.g.
 
-```json
+```toml
   docker_label_include = [
     "com.docker.compose.config-hash",
     "com.docker.compose.container-number",


### PR DESCRIPTION
## Summary

This PR fixes the code-block language as the content is not JSON.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

resolves #19192 
