### PR TITLE
docs(outputs.elasticsearch): Move HTTP operations out of JSON block

### DIFF
--- a/plugins/outputs/elasticsearch/README.md
+++ b/plugins/outputs/elasticsearch/README.md
@@ -203,10 +203,9 @@ clients to properly work when the version needs to be checked. To enable
 compatibility mode users need to set the `override_main_response_version` to
 `true`.
 
-On existing clusters run:
+On existing clusters run `PUT /_cluster/settings` with
 
 ```json
-PUT /_cluster/settings
 {
   "persistent" : {
     "compatibility.override_main_response_version" : true
@@ -214,10 +213,11 @@ PUT /_cluster/settings
 }
 ```
 
-And on new clusters set the option to true under advanced options:
+And on new clusters execute
+`POST https://es.us-east-1.amazonaws.com/2021-01-01/opensearch/upgradeDomain`and
+set the option to `true` under advanced options
 
 ```json
-POST https://es.us-east-1.amazonaws.com/2021-01-01/opensearch/upgradeDomain
 {
   "DomainName": "domain-name",
   "TargetVersion": "OpenSearch_1.0",


### PR DESCRIPTION
## Summary

Move the HTTP operations text out of the JSON code-block.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

resolves #19196 
resolves #19301 
