### PR TITLE
fix(inputs.nvidia_smi): Parse integer fields as 64 bit

### DIFF
--- a/plugins/inputs/nvidia_smi/common/setters.go
+++ b/plugins/inputs/nvidia_smi/common/setters.go
@@ -34,7 +34,7 @@ func SetIfUsed(t string, m map[string]interface{}, k, v string) {
 		}
 	case "int":
 		if val != "" && val != "N/A" {
-			i, err := strconv.Atoi(val)
+			i, err := strconv.ParseInt(val, 10, 64)
 			if err == nil {
 				m[k] = i
 			}

--- a/plugins/inputs/nvidia_smi/common/setters_test.go
+++ b/plugins/inputs/nvidia_smi/common/setters_test.go
@@ -1,0 +1,96 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetIfUsed(t *testing.T) {
+	tests := []struct {
+		name     string
+		datatype string
+		key      string
+		value    string
+		expected map[string]interface{}
+	}{
+		{
+			name:     "unit is stripped",
+			datatype: "int",
+			key:      "memory_total",
+			value:    "20475 MiB",
+			expected: map[string]interface{}{"memory_total": int64(20475)},
+		},
+		{
+			name:     "value exceeding 32 bit",
+			datatype: "int",
+			key:      "clocks_event_reasons_counters_sw_power_cap",
+			value:    "4251825415 us",
+			expected: map[string]interface{}{"clocks_event_reasons_counters_sw_power_cap": int64(4251825415)},
+		},
+		{
+			name:     "negative value",
+			datatype: "int",
+			key:      "temperature_max_tlimit_threshold",
+			value:    "-7 C",
+			expected: map[string]interface{}{"temperature_max_tlimit_threshold": int64(-7)},
+		},
+		{
+			name:     "link width suffix is stripped",
+			datatype: "int",
+			key:      "pcie_link_width_current",
+			value:    "16x",
+			expected: map[string]interface{}{"pcie_link_width_current": int64(16)},
+		},
+		{
+			name:     "float",
+			datatype: "float",
+			key:      "power_draw",
+			value:    "8.44 W",
+			expected: map[string]interface{}{"power_draw": 8.44},
+		},
+		{
+			name:     "string",
+			datatype: "str",
+			key:      "driver_version",
+			value:    "595.84",
+			expected: map[string]interface{}{"driver_version": "595.84"},
+		},
+		{
+			name:     "unsupported value is skipped",
+			datatype: "int",
+			key:      "memory_temp",
+			value:    "N/A",
+			expected: map[string]interface{}{},
+		},
+		{
+			name:     "empty value is skipped",
+			datatype: "int",
+			key:      "fan_speed",
+			value:    "",
+			expected: map[string]interface{}{},
+		},
+		{
+			name:     "unparsable value is skipped",
+			datatype: "int",
+			key:      "fan_speed",
+			value:    "Unknown Error",
+			expected: map[string]interface{}{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := make(map[string]interface{})
+			SetIfUsed(tt.datatype, actual, tt.key, tt.value)
+			require.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
+func TestSetTagIfUsed(t *testing.T) {
+	actual := make(map[string]string)
+	SetTagIfUsed(actual, "name", "NVIDIA RTX 4000 SFF Ada Generation")
+	SetTagIfUsed(actual, "arch", "")
+	require.Equal(t, map[string]string{"name": "NVIDIA RTX 4000 SFF Ada Generation"}, actual)
+}


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

`common.SetIfUsed` parses every integer field with `strconv.Atoi`, which is defined as `ParseInt(s, 10, 0)` — that is, `int`-sized. On the 32-bit platforms Telegraf ships (`linux_i386`, `linux_armhf`, `freebsd_i386` and `windows_i386`, per the `i386` and `armhf` targets in the `Makefile`), any value above `2147483647` fails with `ErrRange`.

`SetIfUsed` discards the parse error, so the field is not set and the metric is emitted without it. 

`nvidia-smi` reports the clock-event throttle counters as microsecond accumulators, and my machine frequently runs into power caps so this can be an issue.

```console
$ nvidia-smi -q -x | grep sw_power_cap
    <clocks_event_reasons_counters_sw_power_cap>4251825415 us</clocks_event_reasons_counters_sw_power_cap>
```

Reproduced directly:

```console
$ GOARCH=386 go run ./atoi.go
strconv.Atoi: parsing "4251825415": value out of range
```

Switching to `strconv.ParseInt(val, 10, 64)` should fix it on every architecture.

## Checklist

- [ ] No AI generated code was used in this PR
- [x] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

related to #19404
