### PR TITLE
chore(ci): Increase integration test timeout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,7 +178,7 @@ jobs:
       - run:
           name: "Run integration tests"
           command: make test-integration
-          no_output_timeout: 15m
+          no_output_timeout: 30m
           environment:
             AZURE_EVENT_HUBS_EMULATOR_ACCEPT_EULA: yes
   test-go-mac:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,6 +178,7 @@ jobs:
       - run:
           name: "Run integration tests"
           command: make test-integration
+          no_output_timeout: 15m
           environment:
             AZURE_EVENT_HUBS_EMULATOR_ACCEPT_EULA: yes
   test-go-mac:


### PR DESCRIPTION
## Summary

When a PR adds new (larger) package dependency, compilation phase without output may exceed default `10m` timeout. Reproducible with PR #19392, where integration test step fails because of this.

This PR increases the default `10m` "no output" timeout to `15m`.

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #19409 
related to #19392 
