### PR TITLE
fix(serializers.prometheusremotewrite): Accumulate histogram samples in a batch

### DIFF
--- a/plugins/serializers/prometheusremotewrite/prometheusremotewrite.go
+++ b/plugins/serializers/prometheusremotewrite/prometheusremotewrite.go
@@ -2,6 +2,7 @@ package prometheusremotewrite
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"hash/fnv"
 	"sort"
@@ -52,15 +53,12 @@ func (s *Serializer) SerializeBatch(metrics []telegraf.Metric) ([]byte, error) {
 		if metric.Type() == telegraf.Histogram {
 			if metrickey, data := tryConvertToNativeHistogram(metric, labels); data != nil {
 				// A batch of metrics can contain multiple values for a single
-				// Prometheus histogram. If this metric is older than the existing
-				// histogram then we can skip over it.
-				if m, found := entries[metrickey]; found {
-					if metric.Time().UnixMilli() < m.Histograms[0].Timestamp {
-						traceAndKeepErr("metric %q has histograms with timestamp %v older than already registered before", metric.Name(), metric.Time())
-						continue
-					}
+				// Prometheus histogram. Accumulate the histograms on the
+				// existing time series instead of replacing it, so none of
+				// them are dropped.
+				if err := accumulateHistogram(entries, metrickey, *data); err != nil {
+					traceAndKeepErr("dropping histogram of metric %q with timestamp %v: %w", metric.Name(), metric.Time(), err)
 				}
-				entries[metrickey] = *data
 				continue
 			}
 		}
@@ -148,9 +146,12 @@ func (s *Serializer) SerializeBatch(metrics []telegraf.Metric) ([]byte, error) {
 						Name:  "le",
 						Value: "+Inf",
 					}
+					// The +Inf bucket holds the same value as the count, so
+					// accumulate it here to keep it in sync with the other
+					// buckets of the histogram.
 					metrickeyinf, promtsinf := getPromTS(metricName+"_bucket", labels, float64(count), metric.Time(), extraLabel)
-					if minf, ok := entries[metrickeyinf]; !ok || minf.Samples[0].Value == 0 {
-						entries[metrickeyinf] = promtsinf
+					if err := accumulateSample(entries, metrickeyinf, promtsinf); err != nil {
+						traceAndKeepErr("dropping +Inf bucket of metric %q with timestamp %v: %w", metric.Name(), metric.Time(), err)
 					}
 
 					metrickey, promts = getPromTS(metricName+"_count", labels, float64(count), metric.Time())
@@ -206,25 +207,9 @@ func (s *Serializer) SerializeBatch(metrics []telegraf.Metric) ([]byte, error) {
 			// A batch of metrics can contain multiple values for a single
 			// Prometheus series. Accumulate the samples on the existing time
 			// series instead of replacing it, so no samples are dropped.
-			if existing, found := entries[metrickey]; found {
-				tsSample := promts.Samples[0].Timestamp
-				tsExisting := existing.Samples[len(existing.Samples)-1].Timestamp
-				switch {
-				case tsSample < tsExisting:
-					// This sample is older than the latest one already
-					// registered, so we skip over it.
-					traceAndKeepErr("metric %q has samples with timestamp %v older than already registered before", metric.Name(), metric.Time())
-					continue
-				case tsSample == tsExisting:
-					// Duplicate timestamp, keep the latest value.
-					existing.Samples[len(existing.Samples)-1] = promts.Samples[0]
-				default:
-					existing.Samples = append(existing.Samples, promts.Samples[0])
-				}
-				entries[metrickey] = existing
-				continue
+			if err := accumulateSample(entries, metrickey, promts); err != nil {
+				traceAndKeepErr("dropping sample of metric %q with timestamp %v: %w", metric.Name(), metric.Time(), err)
 			}
-			entries[metrickey] = promts
 		}
 	}
 
@@ -273,6 +258,62 @@ func (s *Serializer) SerializeBatch(metrics []telegraf.Metric) ([]byte, error) {
 	encoded := snappy.Encode(nil, data)
 	buf.Write(encoded)
 	return buf.Bytes(), nil
+}
+
+// accumulateSample adds the sample of the given series to the series already
+// registered under the given key, keeping the samples in chronological order.
+// For a duplicated timestamp the later value wins.
+func accumulateSample(entries map[metricKey]prompb.TimeSeries, key metricKey, series prompb.TimeSeries) error {
+	entry, found := entries[key]
+	if !found {
+		entries[key] = series
+		return nil
+	}
+	if len(entry.Samples) == 0 {
+		return errors.New("series is already registered as native histogram")
+	}
+
+	sample := series.Samples[0]
+	last := len(entry.Samples) - 1
+	switch {
+	case sample.Timestamp < entry.Samples[last].Timestamp:
+		return errors.New("sample is older than the last registered one")
+	case sample.Timestamp == entry.Samples[last].Timestamp:
+		entry.Samples[last] = sample
+	default:
+		entry.Samples = append(entry.Samples, sample)
+	}
+	entries[key] = entry
+
+	return nil
+}
+
+// accumulateHistogram adds the native histogram of the given series to the
+// series already registered under the given key, keeping the histograms in
+// chronological order. For a duplicated timestamp the later histogram wins.
+func accumulateHistogram(entries map[metricKey]prompb.TimeSeries, key metricKey, series prompb.TimeSeries) error {
+	entry, found := entries[key]
+	if !found {
+		entries[key] = series
+		return nil
+	}
+	if len(entry.Histograms) == 0 {
+		return errors.New("series is already registered with samples")
+	}
+
+	hist := series.Histograms[0]
+	last := len(entry.Histograms) - 1
+	switch {
+	case hist.Timestamp < entry.Histograms[last].Timestamp:
+		return errors.New("histogram is older than the last registered one")
+	case hist.Timestamp == entry.Histograms[last].Timestamp:
+		entry.Histograms[last] = hist
+	default:
+		entry.Histograms = append(entry.Histograms, hist)
+	}
+	entries[key] = entry
+
+	return nil
 }
 
 func hasLabel(name string, labels []prompb.Label) bool {

--- a/plugins/serializers/prometheusremotewrite/prometheusremotewrite_test.go
+++ b/plugins/serializers/prometheusremotewrite/prometheusremotewrite_test.go
@@ -799,6 +799,286 @@ rpc_duration_seconds_sum 17560473
 	}
 }
 
+func TestRemoteWriteAccumulateSamples(t *testing.T) {
+	tests := []struct {
+		name     string
+		metrics  []telegraf.Metric
+		expected []prompb.TimeSeries
+	}{
+		{
+			name: "samples of a series are kept in order",
+			metrics: []telegraf.Metric{
+				metric.New(
+					"cpu",
+					map[string]string{"host": "one.example.org"},
+					map[string]interface{}{"time_idle": 1.0},
+					time.Unix(0, 0),
+				),
+				metric.New(
+					"cpu",
+					map[string]string{"host": "one.example.org"},
+					map[string]interface{}{"time_idle": 2.0},
+					time.Unix(1, 0),
+				),
+			},
+			expected: []prompb.TimeSeries{
+				{
+					Labels: []prompb.Label{
+						{Name: "__name__", Value: "cpu_time_idle"},
+						{Name: "host", Value: "one.example.org"},
+					},
+					Samples: []prompb.Sample{
+						{Value: 1, Timestamp: 0},
+						{Value: 2, Timestamp: 1000},
+					},
+				},
+			},
+		},
+		{
+			name: "duplicate timestamp keeps the last value",
+			metrics: []telegraf.Metric{
+				metric.New(
+					"cpu",
+					map[string]string{},
+					map[string]interface{}{"time_idle": 1.0},
+					time.Unix(1, 0),
+				),
+				metric.New(
+					"cpu",
+					map[string]string{},
+					map[string]interface{}{"time_idle": 2.0},
+					time.Unix(1, 0),
+				),
+			},
+			expected: []prompb.TimeSeries{
+				{
+					Labels:  []prompb.Label{{Name: "__name__", Value: "cpu_time_idle"}},
+					Samples: []prompb.Sample{{Value: 2, Timestamp: 1000}},
+				},
+			},
+		},
+		{
+			name: "sample older than the last one is dropped",
+			metrics: []telegraf.Metric{
+				metric.New(
+					"cpu",
+					map[string]string{},
+					map[string]interface{}{"time_idle": 1.0},
+					time.Unix(1, 0),
+				),
+				metric.New(
+					"cpu",
+					map[string]string{},
+					map[string]interface{}{"time_idle": 2.0},
+					time.Unix(0, 0),
+				),
+			},
+			expected: []prompb.TimeSeries{
+				{
+					Labels:  []prompb.Label{{Name: "__name__", Value: "cpu_time_idle"}},
+					Samples: []prompb.Sample{{Value: 1, Timestamp: 1000}},
+				},
+			},
+		},
+		{
+			name: "every series of a histogram gets a sample per scrape",
+			metrics: []telegraf.Metric{
+				metric.New(
+					"prometheus",
+					map[string]string{"le": "0.05"},
+					map[string]interface{}{"http_request_duration_seconds_bucket": 0.0},
+					time.Unix(1, 0),
+					telegraf.Histogram,
+				),
+				metric.New(
+					"prometheus",
+					map[string]string{},
+					map[string]interface{}{
+						"http_request_duration_seconds_count": 0.0,
+						"http_request_duration_seconds_sum":   0.0,
+					},
+					time.Unix(1, 0),
+					telegraf.Histogram,
+				),
+				metric.New(
+					"prometheus",
+					map[string]string{"le": "0.05"},
+					map[string]interface{}{"http_request_duration_seconds_bucket": 3.0},
+					time.Unix(2, 0),
+					telegraf.Histogram,
+				),
+				metric.New(
+					"prometheus",
+					map[string]string{},
+					map[string]interface{}{
+						"http_request_duration_seconds_count": 5.0,
+						"http_request_duration_seconds_sum":   7.0,
+					},
+					time.Unix(2, 0),
+					telegraf.Histogram,
+				),
+			},
+			expected: []prompb.TimeSeries{
+				{
+					Labels: []prompb.Label{{Name: "__name__", Value: "http_request_duration_seconds_count"}},
+					Samples: []prompb.Sample{
+						{Value: 0, Timestamp: 1000},
+						{Value: 5, Timestamp: 2000},
+					},
+				},
+				{
+					Labels: []prompb.Label{{Name: "__name__", Value: "http_request_duration_seconds_sum"}},
+					Samples: []prompb.Sample{
+						{Value: 0, Timestamp: 1000},
+						{Value: 7, Timestamp: 2000},
+					},
+				},
+				{
+					Labels: []prompb.Label{
+						{Name: "__name__", Value: "http_request_duration_seconds_bucket"},
+						{Name: "le", Value: "+Inf"},
+					},
+					Samples: []prompb.Sample{
+						{Value: 0, Timestamp: 1000},
+						{Value: 5, Timestamp: 2000},
+					},
+				},
+				{
+					Labels: []prompb.Label{
+						{Name: "__name__", Value: "http_request_duration_seconds_bucket"},
+						{Name: "le", Value: "0.05"},
+					},
+					Samples: []prompb.Sample{
+						{Value: 0, Timestamp: 1000},
+						{Value: 3, Timestamp: 2000},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &Serializer{
+				Log:         &testutil.CaptureLogger{},
+				SortMetrics: true,
+			}
+			data, err := s.SerializeBatch(tt.metrics)
+			require.NoError(t, err)
+
+			actual, err := prompbToTimeseries(data)
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
+func TestRemoteWriteAccumulateNativeHistograms(t *testing.T) {
+	nativeHistogram := func(timestamp time.Time, count float64) telegraf.Metric {
+		return metric.New(
+			"rpc_duration_seconds",
+			map[string]string{"host": "example.org"},
+			map[string]interface{}{
+				"count":                  count,
+				"sum":                    float64(10),
+				"schema":                 int64(0),
+				"counter_reset_hint":     uint64(1),
+				"zero_threshold":         float64(0.001),
+				"zero_count":             float64(2),
+				"positive_span_0_offset": int64(0),
+				"positive_span_0_length": uint64(2),
+				"positive_bucket_0":      float64(3),
+				"positive_bucket_1":      float64(5),
+			},
+			timestamp,
+			telegraf.Histogram,
+		)
+	}
+
+	s := &Serializer{
+		Log:         &testutil.CaptureLogger{},
+		SortMetrics: true,
+	}
+	data, err := s.SerializeBatch([]telegraf.Metric{
+		nativeHistogram(time.Unix(1, 0), 20),
+		nativeHistogram(time.Unix(2, 0), 30),
+	})
+	require.NoError(t, err)
+
+	series, err := prompbToTimeseries(data)
+	require.NoError(t, err)
+	require.Len(t, series, 1)
+	require.Len(t, series[0].Histograms, 2)
+	require.Equal(t, int64(1000), series[0].Histograms[0].Timestamp)
+	require.InDelta(t, float64(20), series[0].Histograms[0].ToFloatHistogram().Count, testutil.DefaultDelta)
+	require.Equal(t, int64(2000), series[0].Histograms[1].Timestamp)
+	require.InDelta(t, float64(30), series[0].Histograms[1].ToFloatHistogram().Count, testutil.DefaultDelta)
+}
+
+func TestRemoteWriteNativeHistogramNameCollision(t *testing.T) {
+	// Both metrics end up with the same name and labels, but one carries a
+	// sample and the other a native histogram, so the latter of the two has to
+	// be dropped instead of being merged into the series of the former.
+	nativeHistogram := metric.New(
+		"rpc_duration_seconds",
+		map[string]string{"host": "example.org"},
+		map[string]interface{}{
+			"count":                  float64(20),
+			"sum":                    float64(10),
+			"schema":                 int64(0),
+			"counter_reset_hint":     uint64(1),
+			"zero_threshold":         float64(0.001),
+			"zero_count":             float64(2),
+			"positive_span_0_offset": int64(0),
+			"positive_span_0_length": uint64(2),
+			"positive_bucket_0":      float64(3),
+			"positive_bucket_1":      float64(5),
+		},
+		time.Unix(1, 0),
+		telegraf.Histogram,
+	)
+	classic := metric.New(
+		"prometheus",
+		map[string]string{"host": "example.org"},
+		map[string]interface{}{"rpc_duration_seconds": 42.0},
+		time.Unix(2, 0),
+	)
+
+	tests := []struct {
+		name    string
+		metrics []telegraf.Metric
+	}{
+		{
+			name:    "native histogram first",
+			metrics: []telegraf.Metric{nativeHistogram, classic},
+		},
+		{
+			name:    "classic series first",
+			metrics: []telegraf.Metric{classic, nativeHistogram},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger := &testutil.CaptureLogger{}
+			s := &Serializer{
+				Log:         logger,
+				SortMetrics: true,
+			}
+			data, err := s.SerializeBatch(tt.metrics)
+			require.NoError(t, err)
+
+			series, err := prompbToTimeseries(data)
+			require.NoError(t, err)
+			require.Len(t, series, 1)
+
+			warnings := logger.Warnings()
+			require.Len(t, warnings, 1)
+			require.Contains(t, warnings[0], "series is already registered")
+		})
+	}
+}
+
 func TestRemoteWriteSerializeNativeHistogram(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -873,6 +1153,19 @@ func prompbToText(data []byte) ([]byte, error) {
 	}
 
 	return buf.Bytes(), nil
+}
+
+func prompbToTimeseries(data []byte) ([]prompb.TimeSeries, error) {
+	protobuff, err := snappy.Decode(nil, data)
+	if err != nil {
+		return nil, err
+	}
+	var req prompb.WriteRequest
+	if err := req.Unmarshal(protobuff); err != nil {
+		return nil, err
+	}
+
+	return req.Timeseries, nil
 }
 
 func protoToSamples(req *prompb.WriteRequest) model.Samples {


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
PR #19325 stopped the serializer from dropping samples of a series in a batch, but two paths in `SerializeBatch` still replaced the stored series instead of appending to it, so a batch spanning multiple scrapes lost data points.

The `+Inf` bucket derived from a `_count` field was overwritten whenever the already stored series started with a zero value, which is exactly the placeholder the bucket path seeds. A two-scrape histogram therefore reached the endpoint with `_sum`, `_count` and the regular buckets carrying a sample per scrape while `le="+Inf"` carried only the last one. Native histograms were replaced outright, so only the newest histogram of a series survived the batch.

Both paths now share the same accumulation rules as the sample path: append when newer, keep the later data point on a duplicated timestamp, skip when older. A colliding key, which happens when a classic series and a native histogram end up with the same name and labels, used to index into an empty slice and panic the agent. It is now reported through the existing trace and warning path instead.

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #19298
