### PR TITLE
chore(outputs.sql): Change sqlite build-tags to match the support matrix

### DIFF
--- a/plugins/outputs/sql/README.md
+++ b/plugins/outputs/sql/README.md
@@ -225,10 +225,10 @@ docs](https://github.com/jackc/pgx) for more details.
 
 ### modernc.org/sqlite
 
-It is not supported on windows/386, mips, and mips64 platforms.
+The DSN is a filename or url with scheme `file://`. See the
+[driver docs][sqlite-driver] for details.
 
-The DSN is a filename or url with scheme "file:". See the [driver
-docs](https://modernc.org/sqlite) for details.
+[sqlite-driver]: (https://modernc.org/sqlite)
 
 ### clickhouse
 

--- a/plugins/outputs/sql/README.md
+++ b/plugins/outputs/sql/README.md
@@ -225,10 +225,15 @@ docs](https://github.com/jackc/pgx) for more details.
 
 ### modernc.org/sqlite
 
-The DSN is a filename or url with scheme `file://`. See the
+The DSN is a filename or url with scheme `file:`. See the
 [driver docs][sqlite-driver] for details.
 
-[sqlite-driver]: (https://modernc.org/sqlite)
+> [!IMPORTANT]
+> The sqlite driver is not available on all architectures and platforms. Check
+> the driver's [support matrix][sqlite-supported-platforms] for details.
+
+[sqlite-driver]: https://modernc.org/sqlite
+[sqlite-supported-platforms]: https://pkg.go.dev/modernc.org/sqlite#hdr-Supported_platforms_and_architectures
 
 ### clickhouse
 

--- a/plugins/outputs/sql/sqlite.go
+++ b/plugins/outputs/sql/sqlite.go
@@ -1,10 +1,8 @@
-//go:build !mips && !mipsle && !mips64 && !ppc64 && !riscv64 && !loong64 && !mips64le && !(windows && (386 || arm)) && !(freebsd && (386 || arm))
+// According to the support matrix at https://pkg.go.dev/modernc.org/sqlite
+//go:build (darwin && (amd64 || arm64)) || (freebsd && (amd64 || arm64)) || (linux && (386 || amd64 || arm || arm64 || loong64 || ppc64le || riscv64 || s390x)) || (openbsd && (amd64 || arm64)) || (windows && (386 || amd64 || arm64))
 
 package sql
 
-// The modernc.org sqlite driver isn't supported on all
-// platforms. Register it with build constraints to prevent build
-// failures on unsupported platforms.
 import (
 	_ "modernc.org/sqlite" // Register sqlite sql driver
 )

--- a/plugins/outputs/sql/sqlite_test.go
+++ b/plugins/outputs/sql/sqlite_test.go
@@ -1,4 +1,5 @@
-//go:build !mips && !mipsle && !mips64 && !ppc64 && !riscv64 && !loong64 && !mips64le && !(windows && (386 || arm)) && !(freebsd && (386 || arm))
+// According to the support matrix at https://pkg.go.dev/modernc.org/sqlite
+//go:build (darwin && (amd64 || arm64)) || (freebsd && (amd64 || arm64)) || (linux && (386 || amd64 || arm || arm64 || loong64 || ppc64le || riscv64 || s390x)) || (openbsd && (amd64 || arm64)) || (windows && (386 || amd64 || arm64))
 
 package sql
 


### PR DESCRIPTION
## Summary

This PR changes the build constraints for the sqlite driver to match the support matrix. This will ensure Telegraf builds correctly also on exotic architectures and has a clear relation to documented upstream support.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

