### PR TITLE
chore: Move the psutil mock into a test-only package

### DIFF
--- a/plugins/common/psutil/psutiltest/mock_ps.go
+++ b/plugins/common/psutil/psutiltest/mock_ps.go
@@ -1,4 +1,7 @@
-package psutil
+// Package psutiltest provides mock implementations of the psutil interfaces
+// for testing. It is a separate package to keep the mocks and their testing
+// dependencies out of the shipped binary.
+package psutiltest
 
 import (
 	"os"
@@ -8,17 +11,19 @@ import (
 	"github.com/shirou/gopsutil/v4/mem"
 	"github.com/shirou/gopsutil/v4/net"
 	"github.com/stretchr/testify/mock"
+
+	"github.com/influxdata/telegraf/plugins/common/psutil"
 )
 
 // MockPS is a mock implementation of the PS interface for testing purposes.
 type MockPS struct {
 	mock.Mock
-	PSDiskDeps
+	psutil.PSDiskDeps
 }
 
 // MockPSDisk is a mock implementation of the PSDiskDeps interface for testing purposes.
 type MockPSDisk struct {
-	*SystemPS
+	*psutil.SystemPS
 	*mock.Mock
 }
 

--- a/plugins/inputs/conntrack/conntrack_test.go
+++ b/plugins/inputs/conntrack/conntrack_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/influxdata/telegraf/plugins/common/psutil"
+	"github.com/influxdata/telegraf/plugins/common/psutil/psutiltest"
 	"github.com/influxdata/telegraf/testutil"
 )
 
@@ -95,7 +96,7 @@ func TestConfigsUsed(t *testing.T) {
 }
 
 func TestCollectStats(t *testing.T) {
-	var mps psutil.MockPS
+	var mps psutiltest.MockPS
 	defer mps.AssertExpectations(t)
 	var acc testutil.Accumulator
 
@@ -163,7 +164,7 @@ func TestCollectStats(t *testing.T) {
 }
 
 func TestCollectStatsPerCpu(t *testing.T) {
-	var mps psutil.MockPS
+	var mps psutiltest.MockPS
 	defer mps.AssertExpectations(t)
 	var acc testutil.Accumulator
 

--- a/plugins/inputs/disk/disk_test.go
+++ b/plugins/inputs/disk/disk_test.go
@@ -16,12 +16,13 @@ import (
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/metric"
 	"github.com/influxdata/telegraf/plugins/common/psutil"
+	"github.com/influxdata/telegraf/plugins/common/psutil/psutiltest"
 	"github.com/influxdata/telegraf/testutil"
 )
 
 func TestDiskUsage(t *testing.T) {
 	mck := &mock.Mock{}
-	mps := psutil.MockPSDisk{SystemPS: &psutil.SystemPS{PSDiskDeps: &psutil.MockDiskUsage{Mock: mck}}, Mock: mck}
+	mps := psutiltest.MockPSDisk{SystemPS: &psutil.SystemPS{PSDiskDeps: &psutiltest.MockDiskUsage{Mock: mck}}, Mock: mck}
 	defer mps.AssertExpectations(t)
 
 	var acc testutil.Accumulator
@@ -345,7 +346,7 @@ func TestDiskUsageHostMountPrefix(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mck := &mock.Mock{}
-			mps := psutil.MockPSDisk{SystemPS: &psutil.SystemPS{PSDiskDeps: &psutil.MockDiskUsage{Mock: mck}}, Mock: mck}
+			mps := psutiltest.MockPSDisk{SystemPS: &psutil.SystemPS{PSDiskDeps: &psutiltest.MockDiskUsage{Mock: mck}}, Mock: mck}
 			defer mps.AssertExpectations(t)
 
 			var acc testutil.Accumulator
@@ -368,7 +369,7 @@ func TestDiskUsageHostMountPrefix(t *testing.T) {
 }
 
 func TestDiskStats(t *testing.T) {
-	var mps psutil.MockPS
+	var mps psutiltest.MockPS
 	defer mps.AssertExpectations(t)
 	var acc testutil.Accumulator
 	var err error
@@ -698,7 +699,7 @@ func TestDiskUsageIssues(t *testing.T) {
 
 			// Mock the disk usage
 			mck := &mock.Mock{}
-			mps := psutil.MockPSDisk{SystemPS: &psutil.SystemPS{PSDiskDeps: &psutil.MockDiskUsage{Mock: mck}}, Mock: mck}
+			mps := psutiltest.MockPSDisk{SystemPS: &psutil.SystemPS{PSDiskDeps: &psutiltest.MockDiskUsage{Mock: mck}}, Mock: mck}
 			defer mps.AssertExpectations(t)
 
 			mps.On("Partitions", true).Return(partitions, nil)

--- a/plugins/inputs/diskio/diskio_test.go
+++ b/plugins/inputs/diskio/diskio_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/shirou/gopsutil/v4/disk"
 	"github.com/stretchr/testify/require"
 
-	"github.com/influxdata/telegraf/plugins/common/psutil"
+	"github.com/influxdata/telegraf/plugins/common/psutil/psutiltest"
 	"github.com/influxdata/telegraf/testutil"
 )
 
@@ -129,7 +129,7 @@ func TestDiskIO(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var mps psutil.MockPS
+			var mps psutiltest.MockPS
 			mps.On("DiskIO").Return(tt.result.stats, tt.result.err)
 
 			var acc testutil.Accumulator
@@ -189,7 +189,7 @@ func TestDiskIOUtil(t *testing.T) {
 	}
 
 	var acc testutil.Accumulator
-	var mps psutil.MockPS
+	var mps psutiltest.MockPS
 	mps.On("DiskIO").Return(cts, nil)
 	diskio := &DiskIO{
 		Log:     testutil.Logger{},
@@ -202,7 +202,7 @@ func TestDiskIOUtil(t *testing.T) {
 	// sleep
 	time.Sleep(1 * time.Second)
 	// gather twice
-	mps2 := psutil.MockPS{}
+	mps2 := psutiltest.MockPS{}
 	mps2.On("DiskIO").Return(cts2, nil)
 	diskio.ps = &mps2
 
@@ -242,7 +242,7 @@ func TestCounterWraparound(t *testing.T) {
 	}
 
 	var acc testutil.Accumulator
-	var mps psutil.MockPS
+	var mps psutiltest.MockPS
 	mps.On("DiskIO").Return(cts, nil)
 	diskio := &DiskIO{
 		Log:     testutil.Logger{},
@@ -255,7 +255,7 @@ func TestCounterWraparound(t *testing.T) {
 	require.NoError(t, diskio.Gather(&acc))
 
 	// Second gather with wrapped counters
-	mps2 := psutil.MockPS{}
+	mps2 := psutiltest.MockPS{}
 	mps2.On("DiskIO").Return(cts2, nil)
 	diskio.ps = &mps2
 

--- a/plugins/inputs/mem/mem_linux_test.go
+++ b/plugins/inputs/mem/mem_linux_test.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/metric"
-	"github.com/influxdata/telegraf/plugins/common/psutil"
+	"github.com/influxdata/telegraf/plugins/common/psutil/psutiltest"
 	"github.com/influxdata/telegraf/testutil"
 )
 
@@ -88,7 +88,7 @@ func TestMemStatsCollectExtended(t *testing.T) {
 			require.NoError(t, err)
 			t.Setenv("HOST_PROC", hostProc)
 
-			var mps psutil.MockPS
+			var mps psutiltest.MockPS
 			defer mps.AssertExpectations(t)
 
 			vms := &mem.VirtualMemoryStat{

--- a/plugins/inputs/mem/mem_test.go
+++ b/plugins/inputs/mem/mem_test.go
@@ -9,12 +9,12 @@ import (
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/metric"
-	"github.com/influxdata/telegraf/plugins/common/psutil"
+	"github.com/influxdata/telegraf/plugins/common/psutil/psutiltest"
 	"github.com/influxdata/telegraf/testutil"
 )
 
 func TestMemStats(t *testing.T) {
-	var mps psutil.MockPS
+	var mps psutiltest.MockPS
 	var err error
 	defer mps.AssertExpectations(t)
 	var acc testutil.Accumulator

--- a/plugins/inputs/net/net_test.go
+++ b/plugins/inputs/net/net_test.go
@@ -10,12 +10,12 @@ import (
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/metric"
-	"github.com/influxdata/telegraf/plugins/common/psutil"
+	"github.com/influxdata/telegraf/plugins/common/psutil/psutiltest"
 	"github.com/influxdata/telegraf/testutil"
 )
 
 func TestNetIOStats(t *testing.T) {
-	var mps psutil.MockPS
+	var mps psutiltest.MockPS
 	defer mps.AssertExpectations(t)
 
 	netio := net.IOCountersStat{
@@ -62,7 +62,7 @@ func TestNetIOStats(t *testing.T) {
 }
 
 func TestNetIOStatsSpeedUnsupported(t *testing.T) {
-	var mps psutil.MockPS
+	var mps psutiltest.MockPS
 	defer mps.AssertExpectations(t)
 
 	netio := net.IOCountersStat{
@@ -109,7 +109,7 @@ func TestNetIOStatsSpeedUnsupported(t *testing.T) {
 }
 
 func TestNetIOStatsNoSpeedFile(t *testing.T) {
-	var mps psutil.MockPS
+	var mps psutiltest.MockPS
 	defer mps.AssertExpectations(t)
 
 	netio := net.IOCountersStat{

--- a/plugins/inputs/netstat/netstat_test.go
+++ b/plugins/inputs/netstat/netstat_test.go
@@ -10,12 +10,12 @@ import (
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/metric"
-	"github.com/influxdata/telegraf/plugins/common/psutil"
+	"github.com/influxdata/telegraf/plugins/common/psutil/psutiltest"
 	"github.com/influxdata/telegraf/testutil"
 )
 
 func TestNetStats(t *testing.T) {
-	var mps psutil.MockPS
+	var mps psutiltest.MockPS
 	defer mps.AssertExpectations(t)
 	mps.On("NetConnections").Return([]net.ConnectionStat{
 		{

--- a/plugins/inputs/swap/swap_test.go
+++ b/plugins/inputs/swap/swap_test.go
@@ -6,12 +6,12 @@ import (
 	"github.com/shirou/gopsutil/v4/mem"
 	"github.com/stretchr/testify/require"
 
-	"github.com/influxdata/telegraf/plugins/common/psutil"
+	"github.com/influxdata/telegraf/plugins/common/psutil/psutiltest"
 	"github.com/influxdata/telegraf/testutil"
 )
 
 func TestSwapStats(t *testing.T) {
-	var mps psutil.MockPS
+	var mps psutiltest.MockPS
 	var err error
 	defer mps.AssertExpectations(t)
 	var acc testutil.Accumulator


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
`plugins/common/psutil/mock_ps.go` is a regular build file, so `testify/mock` and its own dependencies are linked into the shipped binary and their init functions run on every start. The file cannot simply be renamed to `*_test.go` because `MockPS`, `MockPSDisk` and `MockDiskUsage` are used by the tests of seven other plugins.

The mock now lives in `plugins/common/psutil/psutiltest`, which nothing outside of tests imports, so `plugins/common/psutil` no longer pulls in a testing dependency while the mock stays available across package boundaries. The consumers only change the package qualifier.


## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #19375
