### PR TITLE
feat(packaging): Extract govulncheck info from release binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /telegraf
 /telegraf.exe
 /telegraf.gz
+/telegraf-*.jsonl
 /tools/package_lxd_test/package_lxd_test
 /tools/license_checker/license_checker*
 /tools/readme_config_includer/generator

--- a/Makefile
+++ b/Makefile
@@ -97,8 +97,6 @@ help:
 	@echo '  clean        - delete build artifacts'
 	@echo '  package      - build all supported packages, override include_packages to only build a subset'
 	@echo '                 e.g.: make package include_packages="amd64.deb"'
-	@echo '  vuln-install - install govulncheck'
-	@echo '  vuln-extract - extract security information from the binary (requires govulncheck)'
 	@echo ''
 	@echo 'Possible values for include_packages variable'
 	@$(foreach package,$(include_packages),echo "  $(package)";)
@@ -211,11 +209,6 @@ lint-branch:
 	}
 	golangci-lint run
 
-.PHONY: vuln-install
-vuln-install:
-	@echo "Installing govulncheck"
-	$(HOSTGO) install golang.org/x/vuln/cmd/govulncheck@latest
-
 .PHONY: tidy
 tidy:
 	go mod verify
@@ -293,11 +286,8 @@ install: $(buildbin)
 $(buildbin):
 	@echo "building $(dir $@)..."
 	@mkdir -pv $(dir $@)
-	CGO_ENABLED=0 go build -o $(dir $@) -tags "$(BUILDTAGS)" -ldflags "-w -s $(LDFLAGS)" ./cmd/telegraf
 
-.PHONY: vuln-extract
-vuln-extract: build
-	govulncheck --mode=extract telegraf$(EXEEXT) > telegraf-$(FILETAG).jsonl
+	CGO_ENABLED=0 go build -o $(dir $@) -tags "$(BUILDTAGS)" -ldflags "-w -s $(LDFLAGS)" ./cmd/telegraf
 
 # Define packages Telegraf supports, organized by architecture with a rule to echo the list to limit include_packages
 # e.g. make package include_packages="$(make amd64)"
@@ -372,12 +362,12 @@ $(include_packages):
 
 	@mkdir -p $(pkgdir)
 
-	@if [ "$(RELEASE)" = "true" ] && [ ! -f "$(pkgdir)/telegraf-$(version)_$(basename $(basename $@)).jsonl.zip" ]; then \
-		export FILETAG="$(version)_$(basename $(basename $@))" && \
-		echo "Updating security info for $(version)_$(basename $(basename $@))..." && \
-		$(MAKE) vuln-install vuln-extract && \
-		zip $(pkgdir)/telegraf-$(version)_$(basename $(basename $@)).jsonl.zip telegraf-$(version)_$(basename $(basename $@)).jsonl && \
-		rm -f telegraf-$(version)_$(basename $(basename $@)).jsonl; \
+	@if [ "$(RELEASE)" = "true" ]; then \
+	    echo "Updating security info for $(version)_$(basename $(basename $@))..." && \
+		$(HOSTGO) install golang.org/x/vuln/cmd/govulncheck@v1.7.0 && \
+		$(MAKE) build && \
+		govulncheck --mode=extract telegraf$(EXEEXT) > telegraf-$(version)_$(basename $(basename $@)).jsonl && \
+		zip -m $(pkgdir)/telegraf-$(version)_$(basename $(basename $@)).jsonl.zip telegraf-$(version)_$(basename $(basename $@)).jsonl; \
 	fi
 
 	@$(MAKE) install

--- a/Makefile
+++ b/Makefile
@@ -248,6 +248,7 @@ check-deps:
 clean:
 	rm -f telegraf
 	rm -f telegraf.exe
+	rm -f telegraf-*.jsonl
 	rm -f etc/telegraf.conf
 	rm -rf build
 	rm -rf cmd/telegraf/resource.syso

--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,6 @@ embed_readme_%:
 config:
 	@echo "generating default config"
 	$(HOSTGO) run ./cmd/telegraf config > etc/telegraf.conf
-	echo "done"
 
 .PHONY: docs
 docs: build_tools embed_readme_common embed_readme_inputs embed_readme_outputs embed_readme_processors embed_readme_aggregators embed_readme_secretstores

--- a/Makefile
+++ b/Makefile
@@ -307,7 +307,7 @@ $(buildbin):
 .PHONY: vuln-extract
 vuln-extract: build
 	# Extract security information from unstripped binary
-	govulncheck --mode=extract telegraf > telegraf-$(version)-$(GOOS)-$(GOARCH)$(GOARM).jsonl
+	govulncheck --mode=extract telegraf$(EXEEXT) > telegraf-$(version)-$(GOOS)-$(GOARCH)$(GOARM).jsonl
 
 # Define packages Telegraf supports, organized by architecture with a rule to echo the list to limit include_packages
 # e.g. make package include_packages="$(make amd64)"

--- a/Makefile
+++ b/Makefile
@@ -376,7 +376,8 @@ $(include_packages):
 		export FILETAG="$(version)_$(basename $(basename $@))" && \
 		echo "Updating security info for $(version)_$(basename $(basename $@))..." && \
 		$(MAKE) vuln-install vuln-extract && \
-		zip $(pkgdir)/telegraf-$(version)_$(basename $(basename $@)).jsonl.zip telegraf-$(version)_$(basename $(basename $@)).jsonl; \
+		zip $(pkgdir)/telegraf-$(version)_$(basename $(basename $@)).jsonl.zip telegraf-$(version)_$(basename $(basename $@)).jsonl && \
+		rm -f telegraf-$(version)_$(basename $(basename $@)).jsonl; \
 	fi
 
 	@$(MAKE) install

--- a/Makefile
+++ b/Makefile
@@ -373,9 +373,9 @@ $(include_packages):
 	@mkdir -p $(pkgdir)
 
 	@if [ "$(RELEASE)" = "true" ] && [ ! -f "$(pkgdir)/telegraf-$(version)_$(basename $(basename $@)).jsonl.zip" ]; then \
-		export FILETAG="$(version)_$(basename $(basename $@))"; \
-		echo "Updating security info for $(version)_$(basename $(basename $@))..."; \
-		$(MAKE) vuln-install vuln-extract; \
+		export FILETAG="$(version)_$(basename $(basename $@))" && \
+		echo "Updating security info for $(version)_$(basename $(basename $@))..." && \
+		$(MAKE) vuln-install vuln-extract && \
 		zip $(pkgdir)/telegraf-$(version)_$(basename $(basename $@)).jsonl.zip telegraf-$(version)_$(basename $(basename $@)).jsonl; \
 	fi
 

--- a/Makefile
+++ b/Makefile
@@ -214,7 +214,7 @@ lint-branch:
 .PHONY: vuln-install
 vuln-install:
 	@echo "Installing govulncheck"
-	go install golang.org/x/vuln/cmd/govulncheck@latest
+	$(HOSTGO) install golang.org/x/vuln/cmd/govulncheck@latest
 
 .PHONY: vuln
 vuln:

--- a/Makefile
+++ b/Makefile
@@ -365,7 +365,7 @@ $(include_packages):
 	    echo "Updating security info for $(version)_$(basename $(basename $@))..." && \
 		$(HOSTGO) install golang.org/x/vuln/cmd/govulncheck@v1.7.0 && \
 		$(MAKE) build && \
-		govulncheck --mode=extract telegraf$(EXEEXT) | gzip - > $(pkgdir)/telegraf-$(version)_$(basename $(basename $@)).jsonl.gz; \
+		govulncheck --mode=extract telegraf$(EXEEXT) | gzip - > $(pkgdir)/symbols-$(version)_$(basename $(basename $@)).jsonl.gz; \
 	fi
 
 	@$(MAKE) install

--- a/Makefile
+++ b/Makefile
@@ -24,15 +24,6 @@ else ifeq ($(tag),)
 	deb_version := $(version)~$(commit)-0
 	deb_iteration := 0
 	tar_version := $(version)~$(commit)
-else ifneq ($(findstring -rc,$(tag)),)
-	version := $(word 1,$(subst -, ,$(tag)))
-	version := $(version:v%=%)
-	rc := $(word 2,$(subst -, ,$(tag)))
-	rpm_version := $(version)-0.$(rc)
-	rpm_iteration := 0.$(subst rc,,$(rc))
-	deb_version := $(version)~$(rc)-1
-	deb_iteration := 0
-	tar_version := $(version)~$(rc)
 else
 	version := $(tag:v%=%)
 	rpm_version := $(version)-1

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ tag := $(shell git describe --exact-match --tags 2>/dev/null)
 branch := $(shell git rev-parse --abbrev-ref HEAD)
 commit := $(shell git rev-parse --short=8 HEAD)
 
+RELEASE := false
 ifdef NIGHTLY
 	version := $(next_version)
 	rpm_version := nightly
@@ -39,6 +40,7 @@ else
 	deb_version := $(version)-1
 	deb_iteration := 1
 	tar_version := $(version)
+	RELEASE = true
 endif
 
 MAKEFLAGS += --no-print-directory
@@ -48,10 +50,8 @@ HOSTGO := env -u GOOS -u GOARCH -u GOARM -- go
 INTERNAL_PKG=github.com/influxdata/telegraf/internal
 LDFLAGS := $(LDFLAGS) -X $(INTERNAL_PKG).Commit=$(commit) -X $(INTERNAL_PKG).Branch=$(branch)
 ifneq ($(tag),)
-	RELEASE = true
 	LDFLAGS += -X $(INTERNAL_PKG).Version=$(version)
 else
-	RELEASE = false
 	LDFLAGS += -X $(INTERNAL_PKG).Version=$(version)-$(commit)
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -233,7 +233,6 @@ check-deps:
 clean:
 	rm -f telegraf
 	rm -f telegraf.exe
-	rm -f telegraf-*.jsonl
 	rm -f etc/telegraf.conf
 	rm -rf build
 	rm -rf cmd/telegraf/resource.syso
@@ -366,8 +365,7 @@ $(include_packages):
 	    echo "Updating security info for $(version)_$(basename $(basename $@))..." && \
 		$(HOSTGO) install golang.org/x/vuln/cmd/govulncheck@v1.7.0 && \
 		$(MAKE) build && \
-		govulncheck --mode=extract telegraf$(EXEEXT) > telegraf-$(version)_$(basename $(basename $@)).jsonl && \
-		zip -m $(pkgdir)/telegraf-$(version)_$(basename $(basename $@)).jsonl.zip telegraf-$(version)_$(basename $(basename $@)).jsonl; \
+		govulncheck --mode=extract telegraf$(EXEEXT) | gzip - > $(pkgdir)/telegraf-$(version)_$(basename $(basename $@)).jsonl.gz; \
 	fi
 
 	@$(MAKE) install

--- a/Makefile
+++ b/Makefile
@@ -48,8 +48,10 @@ HOSTGO := env -u GOOS -u GOARCH -u GOARM -- go
 INTERNAL_PKG=github.com/influxdata/telegraf/internal
 LDFLAGS := $(LDFLAGS) -X $(INTERNAL_PKG).Commit=$(commit) -X $(INTERNAL_PKG).Branch=$(branch)
 ifneq ($(tag),)
+	RELEASE = true
 	LDFLAGS += -X $(INTERNAL_PKG).Version=$(version)
 else
+	RELEASE = false
 	LDFLAGS += -X $(INTERNAL_PKG).Version=$(version)-$(commit)
 endif
 
@@ -95,6 +97,7 @@ help:
 	@echo '  clean        - delete build artifacts'
 	@echo '  package      - build all supported packages, override include_packages to only build a subset'
 	@echo '                 e.g.: make package include_packages="amd64.deb"'
+	@echo '  secinfo      - extract security information from the binary (requires govulncheck)'
 	@echo ''
 	@echo 'Possible values for include_packages variable'
 	@$(foreach package,$(include_packages),echo "  $(package)";)
@@ -122,13 +125,14 @@ build_tools:
 	$(HOSTGO) build -o ./tools/readme_linter/readme_linter$(EXEEXT) ./tools/readme_linter
 
 embed_readme_%:
-	go generate -run="tools/config_includer/generator" ./plugins/$*/...
-	go generate -run="tools/readme_config_includer/generator" ./plugins/$*/...
+	$(HOSTGO) generate -run="tools/config_includer/generator" ./plugins/$*/...
+	$(HOSTGO) generate -run="tools/readme_config_includer/generator" ./plugins/$*/...
 
 .PHONY: config
 config:
 	@echo "generating default config"
-	go run ./cmd/telegraf config > etc/telegraf.conf
+	$(HOSTGO) run ./cmd/telegraf config > etc/telegraf.conf
+	echo "done"
 
 .PHONY: docs
 docs: build_tools embed_readme_common embed_readme_inputs embed_readme_outputs embed_readme_processors embed_readme_aggregators embed_readme_secretstores
@@ -294,9 +298,16 @@ install: $(buildbin)
 # directory.
 .PHONY: $(buildbin)
 $(buildbin):
-	echo $(GOOS)
+	@echo $(GOOS)-$(GOARCH)$(GOARM)
 	@mkdir -pv $(dir $@)
-	CGO_ENABLED=0 go build -o $(dir $@) -tags "$(BUILDTAGS)" -ldflags "$(LDFLAGS)" ./cmd/telegraf
+
+	# Build stripped release binary
+	CGO_ENABLED=0 go build -o $(dir $@) -tags "$(BUILDTAGS)" -ldflags "-w -s $(LDFLAGS)" ./cmd/telegraf
+
+.PHONY: vuln-extract
+vuln-extract: build
+	# Extract security information from unstripped binary
+	govulncheck --mode=extract telegraf > telegraf-$(version)-$(GOOS)-$(GOARCH)$(GOARM).jsonl
 
 # Define packages Telegraf supports, organized by architecture with a rule to echo the list to limit include_packages
 # e.g. make package include_packages="$(make amd64)"
@@ -365,10 +376,19 @@ package: docs config $(include_packages)
 
 .PHONY: $(include_packages)
 $(include_packages):
-	if [ "$(suffix $@)" = ".zip" ]; then go generate cmd/telegraf/telegraf_windows.go; fi
+	@if [ "$(suffix $@)" = ".zip" ]; then \
+		go generate cmd/telegraf/telegraf_windows.go; \
+	fi
+
+	@mkdir -p $(pkgdir)
+
+	@if [ "$(RELEASE)" = "true" ] && [ ! -f "$(pkgdir)/telegraf-$(version)-$(GOOS)-$(GOARCH)$(GOARM).jsonl.zip" ]; then \
+		echo "Updating security info for $(version)-$(GOOS)-$(GOARCH)$(GOARM)..."; \
+		$(MAKE) vuln-install vuln-extract; \
+		zip $(pkgdir)/telegraf-$(version)-$(GOOS)-$(GOARCH)$(GOARM).jsonl.zip telegraf-$(version)-$(GOOS)-$(GOARCH)$(GOARM).jsonl; \
+	fi
 
 	@$(MAKE) install
-	@mkdir -p $(pkgdir)
 
 	@if [ "$(suffix $@)" = ".rpm" ]; then \
 		echo "# DO NOT EDIT OR REMOVE" > $(DESTDIR)$(sysconfdir)/telegraf/telegraf.d/.ignore; \
@@ -514,4 +534,3 @@ windows_i386.zip windows_amd64.zip windows_arm64.zip: export EXEEXT := .exe
 
 %.deb %.rpm %.tar.gz %.zip: export DESTDIR = build/$(GOOS)-$(GOARCH)$(GOARM)-$(pkg)/telegraf-$(version)
 %.deb %.rpm %.tar.gz %.zip: export buildbin = build/$(GOOS)-$(GOARCH)$(GOARM)/telegraf$(EXEEXT)
-%.deb %.rpm %.tar.gz %.zip: export LDFLAGS = -w -s

--- a/Makefile
+++ b/Makefile
@@ -216,14 +216,6 @@ vuln-install:
 	@echo "Installing govulncheck"
 	$(HOSTGO) install golang.org/x/vuln/cmd/govulncheck@latest
 
-.PHONY: vuln
-vuln:
-	@which govulncheck >/dev/null 2>&1 || { \
-		echo "govulncheck not found, please run: make vuln-install"; \
-		exit 1; \
-	}
-	govulncheck ./...
-
 .PHONY: tidy
 tidy:
 	go mod verify
@@ -308,7 +300,7 @@ $(buildbin):
 .PHONY: vuln-extract
 vuln-extract: build
 	# Extract security information from unstripped binary
-	govulncheck --mode=extract telegraf$(EXEEXT) > telegraf-$(version)-$(GOOS)-$(GOARCH)$(GOARM).jsonl
+	govulncheck --mode=extract telegraf$(EXEEXT) > telegraf-$(version)_$(GOOS)_$(GOARCH)$(GOARM).jsonl
 
 # Define packages Telegraf supports, organized by architecture with a rule to echo the list to limit include_packages
 # e.g. make package include_packages="$(make amd64)"
@@ -383,10 +375,10 @@ $(include_packages):
 
 	@mkdir -p $(pkgdir)
 
-	@if [ "$(RELEASE)" = "true" ] && [ ! -f "$(pkgdir)/telegraf-$(version)-$(GOOS)-$(GOARCH)$(GOARM).jsonl.zip" ]; then \
-		echo "Updating security info for $(version)-$(GOOS)-$(GOARCH)$(GOARM)..."; \
+	@if [ "$(RELEASE)" = "true" ] && [ ! -f "$(pkgdir)/telegraf-$(version)_$(GOOS)_$(GOARCH)$(GOARM).jsonl.zip" ]; then \
+		echo "Updating security info for $(version)_$(GOOS)_$(GOARCH)$(GOARM)..."; \
 		$(MAKE) vuln-install vuln-extract; \
-		zip $(pkgdir)/telegraf-$(version)-$(GOOS)-$(GOARCH)$(GOARM).jsonl.zip telegraf-$(version)-$(GOOS)-$(GOARCH)$(GOARM).jsonl; \
+		zip $(pkgdir)/telegraf-$(version)_$(GOOS)_$(GOARCH)$(GOARM).jsonl.zip telegraf-$(version)_$(GOOS)_$(GOARCH)$(GOARM).jsonl; \
 	fi
 
 	@$(MAKE) install

--- a/Makefile
+++ b/Makefile
@@ -291,16 +291,13 @@ install: $(buildbin)
 # directory.
 .PHONY: $(buildbin)
 $(buildbin):
-	@echo $(GOOS)-$(GOARCH)$(GOARM)
+	@echo "building $(dir $@)..."
 	@mkdir -pv $(dir $@)
-
-	# Build stripped release binary
 	CGO_ENABLED=0 go build -o $(dir $@) -tags "$(BUILDTAGS)" -ldflags "-w -s $(LDFLAGS)" ./cmd/telegraf
 
 .PHONY: vuln-extract
 vuln-extract: build
-	# Extract security information from unstripped binary
-	govulncheck --mode=extract telegraf$(EXEEXT) > telegraf-$(version)_$(GOOS)_$(GOARCH)$(GOARM).jsonl
+	govulncheck --mode=extract telegraf$(EXEEXT) > telegraf-$(FILETAG).jsonl
 
 # Define packages Telegraf supports, organized by architecture with a rule to echo the list to limit include_packages
 # e.g. make package include_packages="$(make amd64)"
@@ -375,10 +372,11 @@ $(include_packages):
 
 	@mkdir -p $(pkgdir)
 
-	@if [ "$(RELEASE)" = "true" ] && [ ! -f "$(pkgdir)/telegraf-$(version)_$(GOOS)_$(GOARCH)$(GOARM).jsonl.zip" ]; then \
-		echo "Updating security info for $(version)_$(GOOS)_$(GOARCH)$(GOARM)..."; \
+	@if [ "$(RELEASE)" = "true" ] && [ ! -f "$(pkgdir)/telegraf-$(version)_$(basename $(basename $@)).jsonl.zip" ]; then \
+		export FILETAG="$(version)_$(basename $(basename $@))"; \
+		echo "Updating security info for $(version)_$(basename $(basename $@))..."; \
 		$(MAKE) vuln-install vuln-extract; \
-		zip $(pkgdir)/telegraf-$(version)_$(GOOS)_$(GOARCH)$(GOARM).jsonl.zip telegraf-$(version)_$(GOOS)_$(GOARCH)$(GOARM).jsonl; \
+		zip $(pkgdir)/telegraf-$(version)_$(basename $(basename $@)).jsonl.zip telegraf-$(version)_$(basename $(basename $@)).jsonl; \
 	fi
 
 	@$(MAKE) install

--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,8 @@ help:
 	@echo '  clean        - delete build artifacts'
 	@echo '  package      - build all supported packages, override include_packages to only build a subset'
 	@echo '                 e.g.: make package include_packages="amd64.deb"'
-	@echo '  secinfo      - extract security information from the binary (requires govulncheck)'
+	@echo '  vuln-install - install govulncheck'
+	@echo '  vuln-extract - extract security information from the binary (requires govulncheck)'
 	@echo ''
 	@echo 'Possible values for include_packages variable'
 	@$(foreach package,$(include_packages),echo "  $(package)";)

--- a/scripts/sign-windows.sh
+++ b/scripts/sign-windows.sh
@@ -21,7 +21,7 @@ base64 -d "$SM_CLIENT_CERT_FILE.b64" > "$SM_CLIENT_CERT_FILE"
 # Loop through and sign + verify the binaries
 artifactDirectory="./dist"
 extractDirectory="$artifactDirectory/extracted"
-for file in "$artifactDirectory"/*windows*; do
+for file in "$artifactDirectory"/telegraf-*windows*.zip; do
     7zz x "$file" -o$extractDirectory
     subDirectoryPath=$(find $extractDirectory -mindepth 1 -maxdepth 1 -type d)
     telegrafExePath="$subDirectoryPath/telegraf.exe"


### PR DESCRIPTION
## Summary

This PR adds steps to extract govulncheck information from the (unstripped) release binaries when building packages. This information can be used to check for security issues.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
