### PR TITLE
fix(inputs.procstat): Switch to more robust PidExists for liveness checks

### DIFF
--- a/plugins/inputs/procstat/procstat.go
+++ b/plugins/inputs/procstat/procstat.go
@@ -367,8 +367,19 @@ func (p *Procstat) gatherNew(acc telegraf.Accumulator) error {
 			count += len(g.processes)
 			level := strconv.Itoa(g.level)
 			for _, gp := range g.processes {
-				// Skip over non-running processes
-				if isRunning, err := gp.IsRunning(); err != nil || !isRunning {
+				// Skip over processes that vanished between filtering and now.
+				// Do not use 'IsRunning()' here as it compares the creation
+				// time of the process which is derived from the system's
+				// boot-time. When running in a container, that boot-time is
+				// only estimated from the current time and the uptime and thus
+				// jitters, causing the check to randomly fail for perfectly
+				// alive processes.
+				exists, err := gopsprocess.PidExists(gp.Pid)
+				if err != nil {
+					p.Log.Debugf("Checking existence of process %d in filter %q failed: %v", gp.Pid, f.Name, err)
+					continue
+				}
+				if !exists {
 					continue
 				}
 


### PR DESCRIPTION
## Summary

This PR changes from `IsRunning()` to `PidExists` for checking if a process is still alive as the latter is more stable, especially in container environments. Using `PidExists()` is okay as we just want to know if the process collected earlier is still alive and that check happens only a few milliseconds apart. So a false-detection would require the unlikely situation of a process being restarted within a few milliseconds reusing the exactly same PID.

Background:

Gopsutil's `IsRunning()` function checks the creation time of the process against a freshly aquired creation time for the same PID. To compute the creation time that function uses the system boot-time and the uptime of the process. However, the system boot-time is estimates as `now - /proc/uptime` rounded to seconds (see [code](https://github.com/shirou/gopsutil/blob/48ad2fadc6beabce39bcf3c97486efb4c8bec19b/internal/common/common_linux.go#L103)) instead of reading the system's boot time from the kernel (e.g. `btime` from `/proc/stat`). That estimate jitters by a few milliseconds, so it randomly truncates to two different whole seconds leading to a difference in creation time. This difference makes `IsRunning()` returning `false` for a perfectly alive process and, as a consequence, the plugin will not emit a metric for said process.

The issue surfaced from the randomly failing `TestGather_MultipleFiltersMatchingSameProcess` test reporting `map[string]int{"filter_two":1} does not contain "filter_one` which exactly triggered the issue described above on heavy workloads within a docker container.

## Checklist

- [ ] No AI generated code was used in this PR
- [x] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
