### PR TITLE
fix(inputs.win_eventlog): Do not replay the channel on restart

### DIFF
--- a/plugins/inputs/win_eventlog/syscall_windows.go
+++ b/plugins/inputs/win_eventlog/syscall_windows.go
@@ -23,6 +23,16 @@ const (
 	evtSubscribeStartAfterBookmark  evtSubscribeFlag = 3
 )
 
+// evtQueryFlag defines the possible values that specify what to query and in which order to return the results.
+type evtQueryFlag uint32
+
+// EVT_QUERY_FLAGS enumeration
+// https://learn.microsoft.com/en-us/windows/win32/api/winevt/ne-winevt-evt_query_flags
+const (
+	evtQueryChannelPath      evtQueryFlag = 0x1
+	evtQueryReverseDirection evtQueryFlag = 0x200
+)
+
 // evtRenderFlag uint32
 type evtRenderFlag uint32
 

--- a/plugins/inputs/win_eventlog/win_eventlog.go
+++ b/plugins/inputs/win_eventlog/win_eventlog.go
@@ -128,6 +128,27 @@ func (w *WinEventLog) SetState(state interface{}) error {
 		return fmt.Errorf("invalid type %T for state", state)
 	}
 
+	// An empty state is what GetState returns if rendering the bookmark failed.
+	if bookmarkXML == "" {
+		return nil
+	}
+
+	// Bookmarks are only advanced for events we actually received, so a run that saw no event renders as a
+	// well-formed but positionless bookmark list. Passing such a bookmark to EvtSubscribe together with
+	// evtSubscribeStartAfterBookmark makes Windows start at the channel's oldest record and replay its whole
+	// history. As it carries no more information than no state at all, keep the bookmark and the subscription
+	// flag Init derived from from_beginning instead.
+	var bookmarkList struct {
+		Bookmarks []struct{} `xml:"Bookmark"`
+	}
+	if err := xml.Unmarshal([]byte(bookmarkXML), &bookmarkList); err != nil {
+		return fmt.Errorf("unmarshalling bookmark failed: %w", err)
+	}
+	if len(bookmarkList.Bookmarks) == 0 {
+		w.Log.Debug("Restored bookmark holds no position, keeping the configured subscription start")
+		return nil
+	}
+
 	ptr, err := syscall.UTF16PtrFromString(bookmarkXML)
 	if err != nil {
 		return fmt.Errorf("conversion to pointer failed: %w", err)
@@ -333,6 +354,17 @@ func (w *WinEventLog) evtSubscribe() (evtHandle, error) {
 		return 0, err
 	}
 
+	// Without an anchor the bookmark stays positionless until the first event arrives, so a state file written by
+	// a quiet run cannot resume anything and events showing up while Telegraf is stopped are lost on the next
+	// start. Anchoring costs nothing for the current run, as starting after the newest event collects the same
+	// events as subscribing to the future ones. Falling back to the configured start point on failure is safe,
+	// because that is the behavior without an anchor, and the subscription below reports a broken channel anyway.
+	if w.subscriptionFlag == evtSubscribeToFutureEvents {
+		if err := w.anchorBookmark(); err != nil {
+			w.Log.Warnf("Anchoring bookmark to the newest event failed: %v", err)
+		}
+	}
+
 	var bookmark evtHandle
 	if w.subscriptionFlag == evtSubscribeStartAfterBookmark {
 		bookmark = w.bookmark
@@ -343,6 +375,52 @@ func (w *WinEventLog) evtSubscribe() (evtHandle, error) {
 	}
 
 	return subsHandle, nil
+}
+
+// anchorBookmark points the bookmark at the newest event currently matching the query and switches the
+// subscription to start after it. A channel without any matching event leaves both untouched.
+func (w *WinEventLog) anchorBookmark() error {
+	// EvtQuery expects a NULL channel when the query names the channels itself
+	var logNamePtr *uint16
+	if w.EventlogName != "" {
+		var err error
+		if logNamePtr, err = syscall.UTF16PtrFromString(w.EventlogName); err != nil {
+			return err
+		}
+	}
+
+	xqueryPtr, err := syscall.UTF16PtrFromString(w.Query)
+	if err != nil {
+		return err
+	}
+
+	queryHandle, err := evtQuery(0, logNamePtr, xqueryPtr, evtQueryChannelPath|evtQueryReverseDirection)
+	if err != nil {
+		return fmt.Errorf("querying eventlog failed: %w", err)
+	}
+	//nolint:errcheck // ending the query, error can be ignored
+	defer evtClose(queryHandle)
+
+	var eventHandle evtHandle
+	var returned uint32
+	if err := evtNext(queryHandle, 1, &eventHandle, 0, 0, &returned); err != nil {
+		if errors.Is(err, errNoMoreItems) || errors.Is(err, errInvalidOperation) {
+			return nil
+		}
+		return fmt.Errorf("getting newest event failed: %w", err)
+	}
+	if returned == 0 || eventHandle == 0 {
+		return nil
+	}
+	//nolint:errcheck // ending the event, error can be ignored
+	defer evtClose(eventHandle)
+
+	if err := evtUpdateBookmark(w.bookmark, eventHandle); err != nil {
+		return fmt.Errorf("updating bookmark failed: %w", err)
+	}
+	w.subscriptionFlag = evtSubscribeStartAfterBookmark
+
+	return nil
 }
 
 func (w *WinEventLog) fetchEventHandles(subsHandle evtHandle) ([]evtHandle, error) {

--- a/plugins/inputs/win_eventlog/win_eventlog.go
+++ b/plugins/inputs/win_eventlog/win_eventlog.go
@@ -341,11 +341,9 @@ func (w *WinEventLog) evtSubscribe() (evtHandle, error) {
 	// while Telegraf was down. Falling back to the configured start point on failure is safe, because that is
 	// the behavior without an anchor, and the subscription below reports a broken channel anyway.
 	if w.subscriptionFlag == evtSubscribeToFutureEvents {
-		anchored, err := w.anchorBookmark()
-		switch {
-		case err != nil:
+		if anchored, err := w.anchorBookmark(); err != nil {
 			w.Log.Warnf("Anchoring bookmark to the newest event failed: %v", err)
-		case anchored:
+		} else if anchored {
 			w.subscriptionFlag = evtSubscribeStartAfterBookmark
 		}
 	}

--- a/plugins/inputs/win_eventlog/win_eventlog.go
+++ b/plugins/inputs/win_eventlog/win_eventlog.go
@@ -389,7 +389,7 @@ func (w *WinEventLog) anchorBookmark() (bool, error) {
 	var eventHandle evtHandle
 	var returned uint32
 	if err := evtNext(queryHandle, 1, &eventHandle, 0, 0, &returned); err != nil {
-		if errors.Is(err, errNoMoreItems) || errors.Is(err, errInvalidOperation) {
+		if errors.Is(err, errNoMoreItems) || (errors.Is(err, errInvalidOperation) && returned == 0) {
 			return false, nil
 		}
 		return false, fmt.Errorf("getting newest event failed: %w", err)

--- a/plugins/inputs/win_eventlog/win_eventlog.go
+++ b/plugins/inputs/win_eventlog/win_eventlog.go
@@ -7,7 +7,6 @@ import (
 	"bufio"
 	"bytes"
 	_ "embed"
-	"encoding/json"
 	"encoding/xml"
 	"errors"
 	"fmt"
@@ -54,40 +53,6 @@ type WinEventLog struct {
 	tagFilter        filter.Filter
 	fieldFilter      filter.Filter
 	fieldEmptyFilter filter.Filter
-
-	// Internal flags
-	atChannelStart bool
-}
-
-// persistedState is what the plugin stores between runs. Earlier Telegraf versions persisted the bookmark
-// XML as a plain string, which UnmarshalJSON still accepts.
-type persistedState struct {
-	Bookmark string `json:"bookmark"`
-
-	// AtChannelStart marks a bookmark that holds no position because the query had not matched any event
-	// yet, i.e. we left at the beginning of the stream. A positionless bookmark on its own does not tell
-	// us that, so the two must not be treated alike.
-	AtChannelStart bool `json:"at_channel_start"`
-}
-
-// UnmarshalJSON restores the state, accepting the plain bookmark string persisted by earlier Telegraf
-// versions as a state without the marker.
-func (s *persistedState) UnmarshalJSON(data []byte) error {
-	var bookmarkXML string
-	if err := json.Unmarshal(data, &bookmarkXML); err == nil {
-		s.Bookmark = bookmarkXML
-		return nil
-	}
-
-	// Alias the type to not recurse into this method
-	type state persistedState
-	var restored state
-	if err := json.Unmarshal(data, &restored); err != nil {
-		return err
-	}
-	*s = persistedState(restored)
-
-	return nil
 }
 
 func (*WinEventLog) SampleConfig() string {
@@ -152,52 +117,18 @@ func (w *WinEventLog) GetState() interface{} {
 	bookmarkXML, err := w.renderBookmark()
 	if err != nil {
 		w.Log.Errorf("State-persistence failed, cannot render bookmark: %v", err)
-		return persistedState{}
+		return ""
 	}
-
-	positioned, err := bookmarkPositioned(bookmarkXML)
-	if err != nil {
-		w.Log.Errorf("State-persistence failed, cannot parse bookmark: %v", err)
-		return persistedState{}
-	}
-
-	return persistedState{Bookmark: bookmarkXML, AtChannelStart: !positioned && w.atChannelStart}
+	return bookmarkXML
 }
 
 func (w *WinEventLog) SetState(state interface{}) error {
-	restored, ok := state.(persistedState)
+	bookmarkXML, ok := state.(string)
 	if !ok {
 		return fmt.Errorf("invalid type %T for state", state)
 	}
 
-	// An empty state is what GetState returns if rendering the bookmark failed.
-	if restored.Bookmark == "" {
-		return nil
-	}
-
-	positioned, err := bookmarkPositioned(restored.Bookmark)
-	if err != nil {
-		return fmt.Errorf("unmarshalling bookmark failed: %w", err)
-	}
-
-	// Passing a positionless bookmark to EvtSubscribe together with evtSubscribeStartAfterBookmark makes
-	// Windows start at the channel's oldest record and replay its whole history. Such a bookmark is only
-	// known to be the beginning of the stream if the state says so, and then that is where we continue.
-	// Without the marker, as written by earlier Telegraf versions, it carries no more information than no
-	// state at all, so keep the subscription flag Init derived from from_beginning instead.
-	if !positioned {
-		if !restored.AtChannelStart {
-			w.Log.Debug("Restored bookmark holds no position, keeping the configured subscription start")
-			return nil
-		}
-
-		w.atChannelStart = true
-		w.subscriptionFlag = evtSubscribeStartAtOldestRecord
-
-		return nil
-	}
-
-	ptr, err := syscall.UTF16PtrFromString(restored.Bookmark)
+	ptr, err := syscall.UTF16PtrFromString(bookmarkXML)
 	if err != nil {
 		return fmt.Errorf("conversion to pointer failed: %w", err)
 	}
@@ -402,13 +333,13 @@ func (w *WinEventLog) evtSubscribe() (evtHandle, error) {
 		return 0, err
 	}
 
-	// Without an anchor the bookmark stays positionless until the first event arrives, so a state file written by
-	// a quiet run cannot resume anything and events showing up while Telegraf is stopped are lost on the next
-	// start. Anchoring costs nothing for the current run, as starting after the newest event collects the same
-	// events as subscribing to the future ones. A channel without a matching event has no position to anchor to,
-	// but knowing that we start at its beginning is what lets the next run continue there. Falling back to the
-	// configured start point on failure is safe, because that is the behavior without an anchor, and the
-	// subscription below reports a broken channel anyway.
+	// Without an anchor the bookmark stays positionless until the first event arrives, so a state file written
+	// by a quiet run carries no position and the next start replays the whole channel. Anchoring changes
+	// nothing for the current run, as starting after the newest event collects the same events as subscribing
+	// to the future ones. A channel without a matching event has no position to anchor to, but then the empty
+	// bookmark is correct: restoring it starts at the oldest record, so the next run picks up whatever arrived
+	// while Telegraf was down. Falling back to the configured start point on failure is safe, because that is
+	// the behavior without an anchor, and the subscription below reports a broken channel anyway.
 	if w.subscriptionFlag == evtSubscribeToFutureEvents {
 		anchored, err := w.anchorBookmark()
 		switch {
@@ -416,8 +347,6 @@ func (w *WinEventLog) evtSubscribe() (evtHandle, error) {
 			w.Log.Warnf("Anchoring bookmark to the newest event failed: %v", err)
 		case anchored:
 			w.subscriptionFlag = evtSubscribeStartAfterBookmark
-		default:
-			w.atChannelStart = true
 		}
 	}
 
@@ -476,20 +405,6 @@ func (w *WinEventLog) anchorBookmark() (bool, error) {
 	}
 
 	return true, nil
-}
-
-// bookmarkPositioned reports whether a rendered bookmark holds a position. Bookmarks are only advanced for
-// events we actually received, so a run that saw neither an event nor an anchor renders as a well-formed but
-// empty bookmark list.
-func bookmarkPositioned(bookmarkXML string) (bool, error) {
-	var bookmarkList struct {
-		Bookmarks []struct{} `xml:"Bookmark"`
-	}
-	if err := xml.Unmarshal([]byte(bookmarkXML), &bookmarkList); err != nil {
-		return false, err
-	}
-
-	return len(bookmarkList.Bookmarks) > 0, nil
 }
 
 func (w *WinEventLog) fetchEventHandles(subsHandle evtHandle) ([]evtHandle, error) {

--- a/plugins/inputs/win_eventlog/win_eventlog.go
+++ b/plugins/inputs/win_eventlog/win_eventlog.go
@@ -7,6 +7,7 @@ import (
 	"bufio"
 	"bytes"
 	_ "embed"
+	"encoding/json"
 	"encoding/xml"
 	"errors"
 	"fmt"
@@ -53,6 +54,40 @@ type WinEventLog struct {
 	tagFilter        filter.Filter
 	fieldFilter      filter.Filter
 	fieldEmptyFilter filter.Filter
+
+	// Internal flags
+	atChannelStart bool
+}
+
+// persistedState is what the plugin stores between runs. Earlier Telegraf versions persisted the bookmark
+// XML as a plain string, which UnmarshalJSON still accepts.
+type persistedState struct {
+	Bookmark string `json:"bookmark"`
+
+	// AtChannelStart marks a bookmark that holds no position because the query had not matched any event
+	// yet, i.e. we left at the beginning of the stream. A positionless bookmark on its own does not tell
+	// us that, so the two must not be treated alike.
+	AtChannelStart bool `json:"at_channel_start"`
+}
+
+// UnmarshalJSON restores the state, accepting the plain bookmark string persisted by earlier Telegraf
+// versions as a state without the marker.
+func (s *persistedState) UnmarshalJSON(data []byte) error {
+	var bookmarkXML string
+	if err := json.Unmarshal(data, &bookmarkXML); err == nil {
+		s.Bookmark = bookmarkXML
+		return nil
+	}
+
+	// Alias the type to not recurse into this method
+	type state persistedState
+	var restored state
+	if err := json.Unmarshal(data, &restored); err != nil {
+		return err
+	}
+	*s = persistedState(restored)
+
+	return nil
 }
 
 func (*WinEventLog) SampleConfig() string {
@@ -117,39 +152,52 @@ func (w *WinEventLog) GetState() interface{} {
 	bookmarkXML, err := w.renderBookmark()
 	if err != nil {
 		w.Log.Errorf("State-persistence failed, cannot render bookmark: %v", err)
-		return ""
+		return persistedState{}
 	}
-	return bookmarkXML
+
+	positioned, err := bookmarkPositioned(bookmarkXML)
+	if err != nil {
+		w.Log.Errorf("State-persistence failed, cannot parse bookmark: %v", err)
+		return persistedState{}
+	}
+
+	return persistedState{Bookmark: bookmarkXML, AtChannelStart: !positioned && w.atChannelStart}
 }
 
 func (w *WinEventLog) SetState(state interface{}) error {
-	bookmarkXML, ok := state.(string)
+	restored, ok := state.(persistedState)
 	if !ok {
 		return fmt.Errorf("invalid type %T for state", state)
 	}
 
 	// An empty state is what GetState returns if rendering the bookmark failed.
-	if bookmarkXML == "" {
+	if restored.Bookmark == "" {
 		return nil
 	}
 
-	// Bookmarks are only advanced for events we actually received, so a run that saw no event renders as a
-	// well-formed but positionless bookmark list. Passing such a bookmark to EvtSubscribe together with
-	// evtSubscribeStartAfterBookmark makes Windows start at the channel's oldest record and replay its whole
-	// history. As it carries no more information than no state at all, keep the bookmark and the subscription
-	// flag Init derived from from_beginning instead.
-	var bookmarkList struct {
-		Bookmarks []struct{} `xml:"Bookmark"`
-	}
-	if err := xml.Unmarshal([]byte(bookmarkXML), &bookmarkList); err != nil {
+	positioned, err := bookmarkPositioned(restored.Bookmark)
+	if err != nil {
 		return fmt.Errorf("unmarshalling bookmark failed: %w", err)
 	}
-	if len(bookmarkList.Bookmarks) == 0 {
-		w.Log.Debug("Restored bookmark holds no position, keeping the configured subscription start")
+
+	// Passing a positionless bookmark to EvtSubscribe together with evtSubscribeStartAfterBookmark makes
+	// Windows start at the channel's oldest record and replay its whole history. Such a bookmark is only
+	// known to be the beginning of the stream if the state says so, and then that is where we continue.
+	// Without the marker, as written by earlier Telegraf versions, it carries no more information than no
+	// state at all, so keep the subscription flag Init derived from from_beginning instead.
+	if !positioned {
+		if !restored.AtChannelStart {
+			w.Log.Debug("Restored bookmark holds no position, keeping the configured subscription start")
+			return nil
+		}
+
+		w.atChannelStart = true
+		w.subscriptionFlag = evtSubscribeStartAtOldestRecord
+
 		return nil
 	}
 
-	ptr, err := syscall.UTF16PtrFromString(bookmarkXML)
+	ptr, err := syscall.UTF16PtrFromString(restored.Bookmark)
 	if err != nil {
 		return fmt.Errorf("conversion to pointer failed: %w", err)
 	}
@@ -357,11 +405,19 @@ func (w *WinEventLog) evtSubscribe() (evtHandle, error) {
 	// Without an anchor the bookmark stays positionless until the first event arrives, so a state file written by
 	// a quiet run cannot resume anything and events showing up while Telegraf is stopped are lost on the next
 	// start. Anchoring costs nothing for the current run, as starting after the newest event collects the same
-	// events as subscribing to the future ones. Falling back to the configured start point on failure is safe,
-	// because that is the behavior without an anchor, and the subscription below reports a broken channel anyway.
+	// events as subscribing to the future ones. A channel without a matching event has no position to anchor to,
+	// but knowing that we start at its beginning is what lets the next run continue there. Falling back to the
+	// configured start point on failure is safe, because that is the behavior without an anchor, and the
+	// subscription below reports a broken channel anyway.
 	if w.subscriptionFlag == evtSubscribeToFutureEvents {
-		if err := w.anchorBookmark(); err != nil {
+		anchored, err := w.anchorBookmark()
+		switch {
+		case err != nil:
 			w.Log.Warnf("Anchoring bookmark to the newest event failed: %v", err)
+		case anchored:
+			w.subscriptionFlag = evtSubscribeStartAfterBookmark
+		default:
+			w.atChannelStart = true
 		}
 	}
 
@@ -377,26 +433,26 @@ func (w *WinEventLog) evtSubscribe() (evtHandle, error) {
 	return subsHandle, nil
 }
 
-// anchorBookmark points the bookmark at the newest event currently matching the query and switches the
-// subscription to start after it. A channel without any matching event leaves both untouched.
-func (w *WinEventLog) anchorBookmark() error {
+// anchorBookmark points the bookmark at the newest event currently matching the query and reports whether it
+// did so. A channel without any matching event leaves the bookmark untouched.
+func (w *WinEventLog) anchorBookmark() (bool, error) {
 	// EvtQuery expects a NULL channel when the query names the channels itself
 	var logNamePtr *uint16
 	if w.EventlogName != "" {
 		var err error
 		if logNamePtr, err = syscall.UTF16PtrFromString(w.EventlogName); err != nil {
-			return err
+			return false, err
 		}
 	}
 
 	xqueryPtr, err := syscall.UTF16PtrFromString(w.Query)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	queryHandle, err := evtQuery(0, logNamePtr, xqueryPtr, evtQueryChannelPath|evtQueryReverseDirection)
 	if err != nil {
-		return fmt.Errorf("querying eventlog failed: %w", err)
+		return false, fmt.Errorf("querying eventlog failed: %w", err)
 	}
 	//nolint:errcheck // ending the query, error can be ignored
 	defer evtClose(queryHandle)
@@ -405,22 +461,35 @@ func (w *WinEventLog) anchorBookmark() error {
 	var returned uint32
 	if err := evtNext(queryHandle, 1, &eventHandle, 0, 0, &returned); err != nil {
 		if errors.Is(err, errNoMoreItems) || errors.Is(err, errInvalidOperation) {
-			return nil
+			return false, nil
 		}
-		return fmt.Errorf("getting newest event failed: %w", err)
+		return false, fmt.Errorf("getting newest event failed: %w", err)
 	}
 	if returned == 0 || eventHandle == 0 {
-		return nil
+		return false, nil
 	}
 	//nolint:errcheck // ending the event, error can be ignored
 	defer evtClose(eventHandle)
 
 	if err := evtUpdateBookmark(w.bookmark, eventHandle); err != nil {
-		return fmt.Errorf("updating bookmark failed: %w", err)
+		return false, fmt.Errorf("updating bookmark failed: %w", err)
 	}
-	w.subscriptionFlag = evtSubscribeStartAfterBookmark
 
-	return nil
+	return true, nil
+}
+
+// bookmarkPositioned reports whether a rendered bookmark holds a position. Bookmarks are only advanced for
+// events we actually received, so a run that saw neither an event nor an anchor renders as a well-formed but
+// empty bookmark list.
+func bookmarkPositioned(bookmarkXML string) (bool, error) {
+	var bookmarkList struct {
+		Bookmarks []struct{} `xml:"Bookmark"`
+	}
+	if err := xml.Unmarshal([]byte(bookmarkXML), &bookmarkList); err != nil {
+		return false, err
+	}
+
+	return len(bookmarkList.Bookmarks) > 0, nil
 }
 
 func (w *WinEventLog) fetchEventHandles(subsHandle evtHandle) ([]evtHandle, error) {

--- a/plugins/inputs/win_eventlog/win_eventlog_test.go
+++ b/plugins/inputs/win_eventlog/win_eventlog_test.go
@@ -3,115 +3,12 @@
 package win_eventlog
 
 import (
-	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/influxdata/telegraf/testutil"
 )
-
-func TestSetStateBookmark(t *testing.T) {
-	tests := []struct {
-		name         string
-		state        persistedState
-		expectedFlag evtSubscribeFlag
-		expectedErr  string
-	}{
-		{
-			name:         "no state",
-			state:        persistedState{},
-			expectedFlag: evtSubscribeToFutureEvents,
-		},
-		{
-			// What earlier Telegraf versions persist for a run that received no event
-			name:         "bookmark without position",
-			state:        persistedState{Bookmark: "<BookmarkList>\r\n</BookmarkList>"},
-			expectedFlag: evtSubscribeToFutureEvents,
-		},
-		{
-			name:         "empty bookmark list",
-			state:        persistedState{Bookmark: "<BookmarkList/>"},
-			expectedFlag: evtSubscribeToFutureEvents,
-		},
-		{
-			name:         "bookmark without position at the channel start",
-			state:        persistedState{Bookmark: "<BookmarkList>\r\n</BookmarkList>", AtChannelStart: true},
-			expectedFlag: evtSubscribeStartAtOldestRecord,
-		},
-		{
-			name: "bookmark with position",
-			state: persistedState{
-				Bookmark: "<BookmarkList>\r\n  <Bookmark Channel='Application' RecordId='1' IsCurrent='true'/>\r\n</BookmarkList>",
-			},
-			expectedFlag: evtSubscribeStartAfterBookmark,
-		},
-		{
-			name:        "malformed bookmark",
-			state:       persistedState{Bookmark: "<BookmarkList>"},
-			expectedErr: "unmarshalling bookmark failed",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			plugin := &WinEventLog{EventlogName: "Application", Log: testutil.Logger{}}
-			require.NoError(t, plugin.Init())
-			require.Equal(t, evtSubscribeToFutureEvents, plugin.subscriptionFlag)
-
-			if tt.expectedErr != "" {
-				require.ErrorContains(t, plugin.SetState(tt.state), tt.expectedErr)
-				return
-			}
-			require.NoError(t, plugin.SetState(tt.state))
-			require.Equal(t, tt.expectedFlag, plugin.subscriptionFlag)
-		})
-	}
-}
-
-func TestSetStateBookmarkFromBeginning(t *testing.T) {
-	plugin := &WinEventLog{EventlogName: "Application", FromBeginning: true, Log: testutil.Logger{}}
-	require.NoError(t, plugin.Init())
-	require.Equal(t, evtSubscribeStartAtOldestRecord, plugin.subscriptionFlag)
-
-	require.NoError(t, plugin.SetState(persistedState{Bookmark: "<BookmarkList>\r\n</BookmarkList>"}))
-	require.Equal(t, evtSubscribeStartAtOldestRecord, plugin.subscriptionFlag)
-}
-
-func TestSetStateInvalidType(t *testing.T) {
-	plugin := &WinEventLog{EventlogName: "Application", Log: testutil.Logger{}}
-	require.NoError(t, plugin.Init())
-
-	require.ErrorContains(t, plugin.SetState("<BookmarkList/>"), "invalid type string for state")
-}
-
-func TestStateUnmarshal(t *testing.T) {
-	tests := []struct {
-		name       string
-		serialized string
-		expected   persistedState
-	}{
-		{
-			// What earlier Telegraf versions write
-			name:       "plain bookmark",
-			serialized: `"<BookmarkList/>"`,
-			expected:   persistedState{Bookmark: "<BookmarkList/>"},
-		},
-		{
-			name:       "bookmark and marker",
-			serialized: `{"bookmark":"<BookmarkList/>","at_channel_start":true}`,
-			expected:   persistedState{Bookmark: "<BookmarkList/>", AtChannelStart: true},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			var state persistedState
-			require.NoError(t, json.Unmarshal([]byte(tt.serialized), &state))
-			require.Equal(t, tt.expected, state)
-		})
-	}
-}
 
 func TestStartAnchorsBookmark(t *testing.T) {
 	plugin := &WinEventLog{EventlogName: "Application", Log: testutil.Logger{}}
@@ -123,10 +20,9 @@ func TestStartAnchorsBookmark(t *testing.T) {
 
 	require.Equal(t, evtSubscribeStartAfterBookmark, plugin.subscriptionFlag)
 
-	state, ok := plugin.GetState().(persistedState)
+	state, ok := plugin.GetState().(string)
 	require.True(t, ok)
-	require.Contains(t, state.Bookmark, "<Bookmark ")
-	require.False(t, state.AtChannelStart)
+	require.Contains(t, state, "<Bookmark ")
 }
 
 func TestStartWithoutMatchingEvent(t *testing.T) {
@@ -143,16 +39,15 @@ func TestStartWithoutMatchingEvent(t *testing.T) {
 
 	require.Equal(t, evtSubscribeToFutureEvents, plugin.subscriptionFlag)
 
-	state, ok := plugin.GetState().(persistedState)
+	// The bookmark holds no position, which is what makes the next run continue at the channel start
+	state, ok := plugin.GetState().(string)
 	require.True(t, ok)
-	require.NotContains(t, state.Bookmark, "<Bookmark ")
-	require.True(t, state.AtChannelStart)
+	require.NotContains(t, state, "<Bookmark ")
 
-	// Restoring that state continues where the quiet run left, i.e. at the beginning of the channel
 	restarted := &WinEventLog{EventlogName: "Application", Query: plugin.Query, Log: testutil.Logger{}}
 	require.NoError(t, restarted.Init())
 	require.NoError(t, restarted.SetState(state))
-	require.Equal(t, evtSubscribeStartAtOldestRecord, restarted.subscriptionFlag)
+	require.Equal(t, evtSubscribeStartAfterBookmark, restarted.subscriptionFlag)
 }
 
 func TestWinEventLog_shouldExcludeEmptyField(t *testing.T) {

--- a/plugins/inputs/win_eventlog/win_eventlog_test.go
+++ b/plugins/inputs/win_eventlog/win_eventlog_test.go
@@ -48,6 +48,11 @@ func TestStartWithoutMatchingEvent(t *testing.T) {
 	require.NoError(t, restarted.Init())
 	require.NoError(t, restarted.SetState(state))
 	require.Equal(t, evtSubscribeStartAfterBookmark, restarted.subscriptionFlag)
+
+	// Subscribing after a positionless bookmark must work, as this is how
+	// the next run continues at the channel start
+	require.NoError(t, restarted.Start(&acc))
+	restarted.Stop()
 }
 
 func TestWinEventLog_shouldExcludeEmptyField(t *testing.T) {

--- a/plugins/inputs/win_eventlog/win_eventlog_test.go
+++ b/plugins/inputs/win_eventlog/win_eventlog_test.go
@@ -6,7 +6,96 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/influxdata/telegraf/testutil"
 )
+
+func TestSetStateBookmark(t *testing.T) {
+	tests := []struct {
+		name         string
+		state        string
+		expectedFlag evtSubscribeFlag
+		expectedErr  string
+	}{
+		{
+			name:         "no state",
+			state:        "",
+			expectedFlag: evtSubscribeToFutureEvents,
+		},
+		{
+			// What a run that received no event persists
+			name:         "bookmark without position",
+			state:        "<BookmarkList>\r\n</BookmarkList>",
+			expectedFlag: evtSubscribeToFutureEvents,
+		},
+		{
+			name:         "empty bookmark list",
+			state:        "<BookmarkList/>",
+			expectedFlag: evtSubscribeToFutureEvents,
+		},
+		{
+			name:         "bookmark with position",
+			state:        "<BookmarkList>\r\n  <Bookmark Channel='Application' RecordId='1' IsCurrent='true'/>\r\n</BookmarkList>",
+			expectedFlag: evtSubscribeStartAfterBookmark,
+		},
+		{
+			name:        "malformed bookmark",
+			state:       "<BookmarkList>",
+			expectedErr: "unmarshalling bookmark failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			plugin := &WinEventLog{EventlogName: "Application", Log: testutil.Logger{}}
+			require.NoError(t, plugin.Init())
+			require.Equal(t, evtSubscribeToFutureEvents, plugin.subscriptionFlag)
+
+			if tt.expectedErr != "" {
+				require.ErrorContains(t, plugin.SetState(tt.state), tt.expectedErr)
+				return
+			}
+			require.NoError(t, plugin.SetState(tt.state))
+			require.Equal(t, tt.expectedFlag, plugin.subscriptionFlag)
+		})
+	}
+}
+
+func TestSetStateBookmarkFromBeginning(t *testing.T) {
+	plugin := &WinEventLog{EventlogName: "Application", FromBeginning: true, Log: testutil.Logger{}}
+	require.NoError(t, plugin.Init())
+	require.Equal(t, evtSubscribeStartAtOldestRecord, plugin.subscriptionFlag)
+
+	require.NoError(t, plugin.SetState("<BookmarkList>\r\n</BookmarkList>"))
+	require.Equal(t, evtSubscribeStartAtOldestRecord, plugin.subscriptionFlag)
+}
+
+func TestStartAnchorsBookmark(t *testing.T) {
+	plugin := &WinEventLog{EventlogName: "Application", Log: testutil.Logger{}}
+	require.NoError(t, plugin.Init())
+
+	var acc testutil.Accumulator
+	require.NoError(t, plugin.Start(&acc))
+	defer plugin.Stop()
+
+	require.Equal(t, evtSubscribeStartAfterBookmark, plugin.subscriptionFlag)
+	require.Contains(t, plugin.GetState(), "<Bookmark ")
+}
+
+func TestStartWithoutMatchingEvent(t *testing.T) {
+	plugin := &WinEventLog{
+		EventlogName: "Application",
+		Query:        "*[System[(EventID=999999)]]",
+		Log:          testutil.Logger{},
+	}
+	require.NoError(t, plugin.Init())
+
+	var acc testutil.Accumulator
+	require.NoError(t, plugin.Start(&acc))
+	defer plugin.Stop()
+
+	require.Equal(t, evtSubscribeToFutureEvents, plugin.subscriptionFlag)
+}
 
 func TestWinEventLog_shouldExcludeEmptyField(t *testing.T) {
 	type args struct {

--- a/plugins/inputs/win_eventlog/win_eventlog_test.go
+++ b/plugins/inputs/win_eventlog/win_eventlog_test.go
@@ -3,6 +3,7 @@
 package win_eventlog
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -13,34 +14,41 @@ import (
 func TestSetStateBookmark(t *testing.T) {
 	tests := []struct {
 		name         string
-		state        string
+		state        persistedState
 		expectedFlag evtSubscribeFlag
 		expectedErr  string
 	}{
 		{
 			name:         "no state",
-			state:        "",
+			state:        persistedState{},
 			expectedFlag: evtSubscribeToFutureEvents,
 		},
 		{
-			// What a run that received no event persists
+			// What earlier Telegraf versions persist for a run that received no event
 			name:         "bookmark without position",
-			state:        "<BookmarkList>\r\n</BookmarkList>",
+			state:        persistedState{Bookmark: "<BookmarkList>\r\n</BookmarkList>"},
 			expectedFlag: evtSubscribeToFutureEvents,
 		},
 		{
 			name:         "empty bookmark list",
-			state:        "<BookmarkList/>",
+			state:        persistedState{Bookmark: "<BookmarkList/>"},
 			expectedFlag: evtSubscribeToFutureEvents,
 		},
 		{
-			name:         "bookmark with position",
-			state:        "<BookmarkList>\r\n  <Bookmark Channel='Application' RecordId='1' IsCurrent='true'/>\r\n</BookmarkList>",
+			name:         "bookmark without position at the channel start",
+			state:        persistedState{Bookmark: "<BookmarkList>\r\n</BookmarkList>", AtChannelStart: true},
+			expectedFlag: evtSubscribeStartAtOldestRecord,
+		},
+		{
+			name: "bookmark with position",
+			state: persistedState{
+				Bookmark: "<BookmarkList>\r\n  <Bookmark Channel='Application' RecordId='1' IsCurrent='true'/>\r\n</BookmarkList>",
+			},
 			expectedFlag: evtSubscribeStartAfterBookmark,
 		},
 		{
 			name:        "malformed bookmark",
-			state:       "<BookmarkList>",
+			state:       persistedState{Bookmark: "<BookmarkList>"},
 			expectedErr: "unmarshalling bookmark failed",
 		},
 	}
@@ -66,8 +74,43 @@ func TestSetStateBookmarkFromBeginning(t *testing.T) {
 	require.NoError(t, plugin.Init())
 	require.Equal(t, evtSubscribeStartAtOldestRecord, plugin.subscriptionFlag)
 
-	require.NoError(t, plugin.SetState("<BookmarkList>\r\n</BookmarkList>"))
+	require.NoError(t, plugin.SetState(persistedState{Bookmark: "<BookmarkList>\r\n</BookmarkList>"}))
 	require.Equal(t, evtSubscribeStartAtOldestRecord, plugin.subscriptionFlag)
+}
+
+func TestSetStateInvalidType(t *testing.T) {
+	plugin := &WinEventLog{EventlogName: "Application", Log: testutil.Logger{}}
+	require.NoError(t, plugin.Init())
+
+	require.ErrorContains(t, plugin.SetState("<BookmarkList/>"), "invalid type string for state")
+}
+
+func TestStateUnmarshal(t *testing.T) {
+	tests := []struct {
+		name       string
+		serialized string
+		expected   persistedState
+	}{
+		{
+			// What earlier Telegraf versions write
+			name:       "plain bookmark",
+			serialized: `"<BookmarkList/>"`,
+			expected:   persistedState{Bookmark: "<BookmarkList/>"},
+		},
+		{
+			name:       "bookmark and marker",
+			serialized: `{"bookmark":"<BookmarkList/>","at_channel_start":true}`,
+			expected:   persistedState{Bookmark: "<BookmarkList/>", AtChannelStart: true},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var state persistedState
+			require.NoError(t, json.Unmarshal([]byte(tt.serialized), &state))
+			require.Equal(t, tt.expected, state)
+		})
+	}
 }
 
 func TestStartAnchorsBookmark(t *testing.T) {
@@ -79,7 +122,11 @@ func TestStartAnchorsBookmark(t *testing.T) {
 	defer plugin.Stop()
 
 	require.Equal(t, evtSubscribeStartAfterBookmark, plugin.subscriptionFlag)
-	require.Contains(t, plugin.GetState(), "<Bookmark ")
+
+	state, ok := plugin.GetState().(persistedState)
+	require.True(t, ok)
+	require.Contains(t, state.Bookmark, "<Bookmark ")
+	require.False(t, state.AtChannelStart)
 }
 
 func TestStartWithoutMatchingEvent(t *testing.T) {
@@ -95,6 +142,17 @@ func TestStartWithoutMatchingEvent(t *testing.T) {
 	defer plugin.Stop()
 
 	require.Equal(t, evtSubscribeToFutureEvents, plugin.subscriptionFlag)
+
+	state, ok := plugin.GetState().(persistedState)
+	require.True(t, ok)
+	require.NotContains(t, state.Bookmark, "<Bookmark ")
+	require.True(t, state.AtChannelStart)
+
+	// Restoring that state continues where the quiet run left, i.e. at the beginning of the channel
+	restarted := &WinEventLog{EventlogName: "Application", Query: plugin.Query, Log: testutil.Logger{}}
+	require.NoError(t, restarted.Init())
+	require.NoError(t, restarted.SetState(state))
+	require.Equal(t, evtSubscribeStartAtOldestRecord, restarted.subscriptionFlag)
 }
 
 func TestWinEventLog_shouldExcludeEmptyField(t *testing.T) {

--- a/plugins/inputs/win_eventlog/zsyscall_windows.go
+++ b/plugins/inputs/win_eventlog/zsyscall_windows.go
@@ -59,6 +59,7 @@ var (
 	modwevtapi = windows.NewLazySystemDLL("wevtapi.dll")
 
 	procEvtSubscribe             = modwevtapi.NewProc("EvtSubscribe")
+	procEvtQuery                 = modwevtapi.NewProc("EvtQuery")
 	procEvtRender                = modwevtapi.NewProc("EvtRender")
 	procEvtClose                 = modwevtapi.NewProc("EvtClose")
 	procEvtNext                  = modwevtapi.NewProc("EvtNext")
@@ -88,6 +89,27 @@ func evtSubscribe(
 		uintptr(bookmark),
 		context,
 		uintptr(callback),
+		uintptr(flags),
+	)
+
+	var err error
+	handle := evtHandle(r0)
+	if handle == 0 {
+		if e1 != 0 {
+			err = errnoErr(e1)
+		} else {
+			err = syscall.EINVAL
+		}
+	}
+	return handle, err
+}
+
+func evtQuery(session evtHandle, channelPath, query *uint16, flags evtQueryFlag) (evtHandle, error) {
+	r0, _, e1 := syscall.SyscallN(
+		procEvtQuery.Addr(),
+		uintptr(session),
+		uintptr(unsafe.Pointer(channelPath)), //nolint:gosec // G103: Valid use of unsafe call to pass channelPath
+		uintptr(unsafe.Pointer(query)),       //nolint:gosec // G103: Valid use of unsafe call to pass query
 		uintptr(flags),
 	)
 


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
With `from_beginning = false` and a `statefile`, the plugin replays a channel's entire history on every start after the first, for as long as the channel stays quiet. The bookmark is only advanced for events we actually receive, so a run that receives none persists a well-formed but positionless bookmark, and Windows cannot resume from that: it starts at the channel's oldest record instead.

The subscription now anchors the bookmark at the newest event matching the query before subscribing, so the state carries a real position from the first start. The current run collects the same events, as starting after the newest event and subscribing to the future ones are the same thing.

A channel that holds no event matching the query has no position to anchor to, but there the empty bookmark is already correct: it means we are at the beginning of the stream, and restoring it starts at the oldest record, so the next run picks up everything that arrived while Telegraf was stopped. The persisted state is unchanged, still the bookmark XML. A state file written by an earlier version replays the channel once on the first start after the upgrade and carries a real position from then on.

`from_beginning = true` is left alone, and a failed anchoring query warns and keeps the configured start point.

This needs `EvtQuery`, which was not bound yet.

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #19355
