### PR TITLE
feat(outputs.kafka): Add configurable produce request timeouts

### DIFF
--- a/plugins/common/kafka/config.go
+++ b/plugins/common/kafka/config.go
@@ -33,6 +33,13 @@ type WriteConfig struct {
 	MaxRetry         int  `toml:"max_retry"`
 	MaxMessageBytes  int  `toml:"max_message_bytes"`
 	IdempotentWrites bool `toml:"idempotent_writes"`
+
+	// Timeouts bounding a produce request. All default to the sarama defaults
+	// when unset (zero).
+	NetDialTimeout  config.Duration `toml:"net_dial_timeout"`
+	NetReadTimeout  config.Duration `toml:"net_read_timeout"`
+	NetWriteTimeout config.Duration `toml:"net_write_timeout"`
+	ProducerTimeout config.Duration `toml:"producer_timeout"`
 }
 
 // SetConfig on the sarama.Config object from the WriteConfig struct.
@@ -47,6 +54,22 @@ func (k *WriteConfig) SetConfig(cfg *sarama.Config, log telegraf.Logger) error {
 	if cfg.Producer.Idempotent {
 		cfg.Net.MaxOpenRequests = 1
 	}
+
+	// Only override the sarama defaults if the user configured a value. Sarama
+	// rejects non-positive values for all of these in its own validation.
+	if k.NetDialTimeout > 0 {
+		cfg.Net.DialTimeout = time.Duration(k.NetDialTimeout)
+	}
+	if k.NetReadTimeout > 0 {
+		cfg.Net.ReadTimeout = time.Duration(k.NetReadTimeout)
+	}
+	if k.NetWriteTimeout > 0 {
+		cfg.Net.WriteTimeout = time.Duration(k.NetWriteTimeout)
+	}
+	if k.ProducerTimeout > 0 {
+		cfg.Producer.Timeout = time.Duration(k.ProducerTimeout)
+	}
+
 	return k.Config.SetConfig(cfg, log)
 }
 

--- a/plugins/common/kafka/config.go
+++ b/plugins/common/kafka/config.go
@@ -55,18 +55,19 @@ func (k *WriteConfig) SetConfig(cfg *sarama.Config, log telegraf.Logger) error {
 		cfg.Net.MaxOpenRequests = 1
 	}
 
-	// Only override the sarama defaults if the user configured a value. Sarama
-	// rejects non-positive values for all of these in its own validation.
-	if k.NetDialTimeout > 0 {
+	// Only override the sarama defaults if the user configured a value.
+	// Negative values are passed through so sarama's own validation
+	// rejects them instead of silently keeping the default.
+	if k.NetDialTimeout != 0 {
 		cfg.Net.DialTimeout = time.Duration(k.NetDialTimeout)
 	}
-	if k.NetReadTimeout > 0 {
+	if k.NetReadTimeout != 0 {
 		cfg.Net.ReadTimeout = time.Duration(k.NetReadTimeout)
 	}
-	if k.NetWriteTimeout > 0 {
+	if k.NetWriteTimeout != 0 {
 		cfg.Net.WriteTimeout = time.Duration(k.NetWriteTimeout)
 	}
-	if k.ProducerTimeout > 0 {
+	if k.ProducerTimeout != 0 {
 		cfg.Producer.Timeout = time.Duration(k.ProducerTimeout)
 	}
 

--- a/plugins/common/kafka/config_test.go
+++ b/plugins/common/kafka/config_test.go
@@ -56,3 +56,41 @@ func TestWriteConfigTimeouts(t *testing.T) {
 	require.Equal(t, 4*time.Second, cfg.Producer.Timeout)
 	require.NoError(t, cfg.Validate())
 }
+
+func TestWriteConfigTimeoutsNegative(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   WriteConfig
+		expected string
+	}{
+		{
+			name:     "dial",
+			config:   WriteConfig{NetDialTimeout: config.Duration(-time.Second)},
+			expected: "Net.DialTimeout must be > 0",
+		},
+		{
+			name:     "read",
+			config:   WriteConfig{NetReadTimeout: config.Duration(-time.Second)},
+			expected: "Net.ReadTimeout must be > 0",
+		},
+		{
+			name:     "write",
+			config:   WriteConfig{NetWriteTimeout: config.Duration(-time.Second)},
+			expected: "Net.WriteTimeout must be > 0",
+		},
+		{
+			name:     "producer",
+			config:   WriteConfig{ProducerTimeout: config.Duration(-time.Second)},
+			expected: "Producer.Timeout must be > 0",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Negative values must reach sarama's validation instead of
+			// silently falling back to the default
+			cfg := sarama.NewConfig()
+			require.NoError(t, tt.config.SetConfig(cfg, testutil.Logger{}))
+			require.ErrorContains(t, cfg.Validate(), tt.expected)
+		})
+	}
+}

--- a/plugins/common/kafka/config_test.go
+++ b/plugins/common/kafka/config_test.go
@@ -4,7 +4,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/IBM/sarama"
 	"github.com/stretchr/testify/require"
+
+	"github.com/influxdata/telegraf/config"
+	"github.com/influxdata/telegraf/testutil"
 )
 
 func TestBackoffFunc(t *testing.T) {
@@ -19,4 +23,36 @@ func TestBackoffFunc(t *testing.T) {
 
 	f = makeBackoffFunc(b, 0)      // max = 0 means no max
 	require.Equal(t, b*8, f(3, 0)) // with no max, it's 2000
+}
+
+func TestWriteConfigTimeoutsDefault(t *testing.T) {
+	cfg := sarama.NewConfig()
+	defaults := sarama.NewConfig()
+
+	k := WriteConfig{}
+	require.NoError(t, k.SetConfig(cfg, testutil.Logger{}))
+
+	// Leaving the options unset must not change what sarama defaults to
+	require.Equal(t, defaults.Net.DialTimeout, cfg.Net.DialTimeout)
+	require.Equal(t, defaults.Net.ReadTimeout, cfg.Net.ReadTimeout)
+	require.Equal(t, defaults.Net.WriteTimeout, cfg.Net.WriteTimeout)
+	require.Equal(t, defaults.Producer.Timeout, cfg.Producer.Timeout)
+}
+
+func TestWriteConfigTimeouts(t *testing.T) {
+	cfg := sarama.NewConfig()
+
+	k := WriteConfig{
+		NetDialTimeout:  config.Duration(time.Second),
+		NetReadTimeout:  config.Duration(2 * time.Second),
+		NetWriteTimeout: config.Duration(3 * time.Second),
+		ProducerTimeout: config.Duration(4 * time.Second),
+	}
+	require.NoError(t, k.SetConfig(cfg, testutil.Logger{}))
+
+	require.Equal(t, time.Second, cfg.Net.DialTimeout)
+	require.Equal(t, 2*time.Second, cfg.Net.ReadTimeout)
+	require.Equal(t, 3*time.Second, cfg.Net.WriteTimeout)
+	require.Equal(t, 4*time.Second, cfg.Producer.Timeout)
+	require.NoError(t, cfg.Validate())
 }

--- a/plugins/outputs/kafka/README.md
+++ b/plugins/outputs/kafka/README.md
@@ -128,6 +128,23 @@ to use them.
   ## smaller than the broker's 'message.max.bytes'.
   # max_message_bytes = 1000000
 
+  ## Timeouts bounding a produce request
+  ## All of these default to the underlying client library's defaults if unset
+  ## or zero. Lower them to detect an unresponsive broker faster, at the cost
+  ## of failing writes that a slow but healthy broker would have completed.
+  ##   net_dial_timeout:  connecting to a broker
+  ##   net_read_timeout:  waiting for a response from a broker, including the
+  ##                      acknowledgement of a produce request
+  ##   net_write_timeout: sending a request to a broker
+  ##   producer_timeout:  how long the broker waits for the number of
+  ##                      acknowledgements set by 'required_acks'
+  ## Note that a single flush may exceed these timeouts, as 'max_retry'
+  ## retries are attempted within it.
+  # net_dial_timeout = "30s"
+  # net_read_timeout = "30s"
+  # net_write_timeout = "30s"
+  # producer_timeout = "10s"
+
   ## Producer timestamp
   ## This option sets the timestamp of the kafka producer message, choose from:
   ##   * metric: Uses the metric's timestamp
@@ -264,3 +281,18 @@ increase during downtime.
 The option is similar to the
 [retries](https://kafka.apache.org/documentation/#producerconfigs) Producer
 option in the Java Kafka Producer.
+
+### Timeouts
+
+The `net_dial_timeout`, `net_read_timeout`, `net_write_timeout` and
+`producer_timeout` options bound the individual network operations a produce
+request performs. They map to the corresponding options of the underlying
+[sarama][sarama] client, and are left at its defaults (30s for the network
+operations, 10s for the acknowledgement wait) when unset.
+
+Lowering them makes an unresponsive broker surface as a write error sooner
+instead of stalling the flush. Note that they bound the individual operations
+and not the whole write: with `max_retry` greater than `0` a single flush may
+retry, and so take longer than any one of these timeouts.
+
+[sarama]: https://github.com/IBM/sarama

--- a/plugins/outputs/kafka/sample.conf
+++ b/plugins/outputs/kafka/sample.conf
@@ -81,6 +81,23 @@
   ## smaller than the broker's 'message.max.bytes'.
   # max_message_bytes = 1000000
 
+  ## Timeouts bounding a produce request
+  ## All of these default to the underlying client library's defaults if unset
+  ## or zero. Lower them to detect an unresponsive broker faster, at the cost
+  ## of failing writes that a slow but healthy broker would have completed.
+  ##   net_dial_timeout:  connecting to a broker
+  ##   net_read_timeout:  waiting for a response from a broker, including the
+  ##                      acknowledgement of a produce request
+  ##   net_write_timeout: sending a request to a broker
+  ##   producer_timeout:  how long the broker waits for the number of
+  ##                      acknowledgements set by 'required_acks'
+  ## Note that a single flush may exceed these timeouts, as 'max_retry'
+  ## retries are attempted within it.
+  # net_dial_timeout = "30s"
+  # net_read_timeout = "30s"
+  # net_write_timeout = "30s"
+  # producer_timeout = "10s"
+
   ## Producer timestamp
   ## This option sets the timestamp of the kafka producer message, choose from:
   ##   * metric: Uses the metric's timestamp


### PR DESCRIPTION
## Summary

Reworked per review: this PR is now just the "set the client library's own
timeouts" half of the fix, as suggested by @srebhan. The context-aware output
interface has been taken out of it and is being proposed separately as a spec
in #19460, so this one can be reviewed and merged on its own.

`outputs.kafka` relied entirely on sarama's built-in defaults for the timeouts
around a produce request, with no way to change them:

| sarama option | default | now configurable as |
| --- | --- | --- |
| `Net.DialTimeout` | 30s | `net_dial_timeout` |
| `Net.ReadTimeout` | 30s | `net_read_timeout` |
| `Net.WriteTimeout` | 30s | `net_write_timeout` |
| `Producer.Timeout` | 10s | `producer_timeout` |

Each option overrides the corresponding sarama field only when set; unset or
zero keeps sarama's default, so existing configurations behave exactly as
before. The options live on `WriteConfig` in `plugins/common/kafka`, which is
used only by `outputs.kafka`, so no other plugin's config surface changes.

`Net.ReadTimeout` is the interesting one for a stuck write: sarama sets a read
deadline while waiting for the broker's response to a produce request, so
lowering it is what makes an unresponsive broker surface as an error sooner
instead of stalling the flush.

## Naming

The options are named after the sarama fields they set rather than as a
generic `write_timeout`, for two reasons: it keeps them distinct from a
Telegraf-level write timeout (see #19460), and it is honest about what they
bound. They bound individual network operations, not the whole write — with
`max_retry` greater than `0`, one flush can retry and outlive any single one
of them.

## What this does and does not fix

It gives operators a knob to detect an unresponsive broker faster, and it
helps during normal operation when an endpoint goes down, which is the case
@srebhan raised.

It is not a complete fix for #19446. These timeouts bound individual
operations inside sarama; they are not a cancellation mechanism, so they
cannot be triggered by agent shutdown and cannot bound a call that retries
internally. The incident in #19446 was a `SendMessages()` that never returned
a terminal result at all, with the agent unable to interrupt it. Bounding that
class of failure needs a cancellation path from the agent into the plugin,
which is what #19460 specifies. I have therefore left #19446 open and
referenced rather than closed here.

## Testing

- New unit tests asserting the options are applied to the sarama config, and
  that leaving them unset does not change sarama's defaults.
- `go test -race -short ./plugins/common/kafka/... ./plugins/outputs/kafka/...`
  passes. The Kafka integration test needs Docker, which I don't have locally —
  it runs in CI.
- `golangci-lint` (v2.11.4, repo config) clean on the touched packages;
  `make docs` clean.

## Checklist

- [ ] No AI generated code was used in this PR
- [x] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

Parts of this change were written with AI assistance. I have reviewed,
understand, and tested all of it, and I take responsibility for it per the CLA
(signed).

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

related to #19446
related to #19460
related to #11427
related to #8349
