### PR TITLE
fix(inputs.internet_speed): Honor the local address setting

### DIFF
--- a/plugins/inputs/internet_speed/README.md
+++ b/plugins/inputs/internet_speed/README.md
@@ -33,9 +33,9 @@ plugin ordering. See [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## Caches the closest server location
   # cache = false
 
-  ## Bind to the given local IP address during server connection. Data will
-  ## attempt to be sent/received from this IP address.
-  # local_address = "192.168.1.101"
+  ## Local IP address to bind to when connecting to the servers
+  ## Use the local address assigned by the operating system by default.
+  # local_address = ""
 
   ## Number of concurrent connections
   ## By default or set to zero, the number of CPU cores is used. Use this to

--- a/plugins/inputs/internet_speed/internet_speed.go
+++ b/plugins/inputs/internet_speed/internet_speed.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"net"
 	"os"
 	"time"
 
@@ -42,6 +43,7 @@ type InternetSpeed struct {
 	server       *speedtest.Server // The main(best) server
 	servers      speedtest.Servers // Auxiliary servers
 	serverFilter filter.Filter
+	localAddr    *net.TCPAddr
 }
 
 func (*InternetSpeed) SampleConfig() string {
@@ -63,6 +65,16 @@ func (is *InternetSpeed) Init() error {
 		return fmt.Errorf("error compiling server ID filters: %w", err)
 	}
 
+	// The speedtest library only logs a resolution failure in its debug output
+	// and then silently uses the default route, so resolve the address the same
+	// way it does to reject unusable values here.
+	if is.LocalAddress != "" {
+		is.localAddr, err = net.ResolveTCPAddr("tcp", net.JoinHostPort(is.LocalAddress, "0"))
+		if err != nil {
+			return fmt.Errorf("resolving local address failed: %w", err)
+		}
+	}
+
 	return nil
 }
 
@@ -81,10 +93,23 @@ func (is *InternetSpeed) Gather(acc telegraf.Accumulator) error {
 		return fmt.Errorf("ping test failed: %w", err)
 	}
 
-	analyzer := speedtest.NewPacketLossAnalyzer(&speedtest.PacketLossAnalyzerOptions{
+	// The analyzer creates its own dialers and does not use the source address
+	// of the client, so set the dialers explicitly to keep the packet-loss test
+	// on the same link as the other measurements. The sending timeout is set to
+	// the library default as it is also the timeout of those dialers.
+	options := &speedtest.PacketLossAnalyzerOptions{
 		PacketSendingInterval: time.Millisecond * 100,
+		PacketSendingTimeout:  time.Second * 5,
 		SamplingDuration:      time.Second * 15,
-	})
+	}
+	if is.localAddr != nil {
+		options.TCPDialer = &net.Dialer{Timeout: options.PacketSendingTimeout, LocalAddr: is.localAddr}
+		options.UDPDialer = &net.Dialer{
+			Timeout:   options.PacketSendingTimeout,
+			LocalAddr: &net.UDPAddr{IP: is.localAddr.IP, Zone: is.localAddr.Zone},
+		}
+	}
+	analyzer := speedtest.NewPacketLossAnalyzer(options)
 
 	var pLoss *transport.PLoss
 

--- a/plugins/inputs/internet_speed/internet_speed.go
+++ b/plugins/inputs/internet_speed/internet_speed.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"math"
 	"net"
+	"net/netip"
 	"os"
 	"time"
 
@@ -65,14 +66,17 @@ func (is *InternetSpeed) Init() error {
 		return fmt.Errorf("error compiling server ID filters: %w", err)
 	}
 
-	// The speedtest library only logs a resolution failure in its debug output
-	// and then silently uses the default route, so resolve the address the same
-	// way it does to reject unusable values here.
+	// The speedtest library only logs an unusable local address in its debug
+	// output and then silently uses the default route, so reject such values
+	// here. The address is parsed instead of resolved to keep Init off the
+	// network; whether it is assigned is left to the bind during the tests,
+	// which is retried every interval.
 	if is.LocalAddress != "" {
-		is.localAddr, err = net.ResolveTCPAddr("tcp", net.JoinHostPort(is.LocalAddress, "0"))
+		addr, err := netip.ParseAddr(is.LocalAddress)
 		if err != nil {
-			return fmt.Errorf("resolving local address failed: %w", err)
+			return fmt.Errorf("parsing local address failed: %w", err)
 		}
+		is.localAddr = net.TCPAddrFromAddrPort(netip.AddrPortFrom(addr, 0))
 	}
 
 	return nil

--- a/plugins/inputs/internet_speed/internet_speed_test.go
+++ b/plugins/inputs/internet_speed/internet_speed_test.go
@@ -1,6 +1,7 @@
 package internet_speed
 
 import (
+	"net"
 	"testing"
 	"time"
 
@@ -97,6 +98,68 @@ func TestSelectServerError(t *testing.T) {
 	}
 
 	require.ErrorContains(t, plugin.selectServer(), "filter excluded all servers")
+}
+
+func TestLocalAddress(t *testing.T) {
+	tests := []struct {
+		name         string
+		localAddress string
+		expected     *net.TCPAddr
+	}{
+		{
+			name:     "unset",
+			expected: nil,
+		},
+		{
+			name:         "IPv4 address",
+			localAddress: "127.0.0.1",
+			expected:     &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1)},
+		},
+		{
+			name:         "IPv6 address",
+			localAddress: "::1",
+			expected:     &net.TCPAddr{IP: net.IPv6loopback},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			plugin := &InternetSpeed{
+				LocalAddress: tt.localAddress,
+				Log:          testutil.Logger{},
+			}
+			require.NoError(t, plugin.Init())
+			require.Equal(t, tt.expected, plugin.localAddr)
+		})
+	}
+}
+
+func TestLocalAddressInvalid(t *testing.T) {
+	tests := []struct {
+		name         string
+		localAddress string
+	}{
+		{
+			// The underlying library only accepts an interface name on Linux and
+			// silently falls back to the default route everywhere else
+			name:         "interface name",
+			localAddress: "eth0",
+		},
+		{
+			name:         "address with port",
+			localAddress: "127.0.0.1:8080",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			plugin := &InternetSpeed{
+				LocalAddress: tt.localAddress,
+				Log:          testutil.Logger{},
+			}
+			require.ErrorContains(t, plugin.Init(), "resolving local address failed")
+		})
+	}
 }
 
 func TestGathering(t *testing.T) {

--- a/plugins/inputs/internet_speed/internet_speed_test.go
+++ b/plugins/inputs/internet_speed/internet_speed_test.go
@@ -113,12 +113,17 @@ func TestLocalAddress(t *testing.T) {
 		{
 			name:         "IPv4 address",
 			localAddress: "127.0.0.1",
-			expected:     &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1)},
+			expected:     &net.TCPAddr{IP: net.IP{127, 0, 0, 1}},
 		},
 		{
 			name:         "IPv6 address",
 			localAddress: "::1",
 			expected:     &net.TCPAddr{IP: net.IPv6loopback},
+		},
+		{
+			name:         "IPv6 address with zone",
+			localAddress: "fe80::1%eth0",
+			expected:     &net.TCPAddr{IP: net.ParseIP("fe80::1"), Zone: "eth0"},
 		},
 	}
 
@@ -157,7 +162,7 @@ func TestLocalAddressInvalid(t *testing.T) {
 				LocalAddress: tt.localAddress,
 				Log:          testutil.Logger{},
 			}
-			require.ErrorContains(t, plugin.Init(), "resolving local address failed")
+			require.ErrorContains(t, plugin.Init(), "parsing local address failed")
 		})
 	}
 }

--- a/plugins/inputs/internet_speed/sample.conf
+++ b/plugins/inputs/internet_speed/sample.conf
@@ -11,9 +11,9 @@
   ## Caches the closest server location
   # cache = false
 
-  ## Bind to the given local IP address during server connection. Data will
-  ## attempt to be sent/received from this IP address.
-  # local_address = "192.168.1.101"
+  ## Local IP address to bind to when connecting to the servers
+  ## Use the local address assigned by the operating system by default.
+  # local_address = ""
 
   ## Number of concurrent connections
   ## By default or set to zero, the number of CPU cores is used. Use this to


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
The `local_address` option added in #19377 is not applied reliably. The speedtest library only reports a failure to resolve the configured address through its debug output, which the plugin never enables, and then falls back to the address chosen by the operating system. A typo in the address, or an interface name on a platform other than Linux, therefore produces a perfectly plausible set of metrics measured over the default route. On the dual-WAN setup the option was requested for, that means the plugin silently reports on the wrong link. The address is now resolved in `Init()` the same way the library resolves it, so an unusable value is reported at startup instead.

The packet loss analyzer creates its own TCP and UDP dialers and does not pick up the source address of the client, so `packet_loss` kept using the default route even when the other measurements were bound. Both dialers are now created with the configured local address, which keeps all fields of a metric on the same link. The analyzer option intended for this, `SourceInterface`, is not used because it expects a host and port and discards the resolution error, so a plain address would silently have no effect.

The commented value of the option in the sample configuration is now the default, and the wording matches the other plugins offering `local_address`.

Note that binding to an interface name is not supported. The library only implements it on Linux and ignores it elsewhere, and such a value is now rejected during startup. Adding a separate option for it, as suggested in the review of #19377, can be done in a follow-up.

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->



- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #19071
