### PR TITLE
docs(inputs.smartctl): Fix no_check option name in example

### DIFF
--- a/plugins/inputs/smartctl/README.md
+++ b/plugins/inputs/smartctl/README.md
@@ -57,7 +57,7 @@ plugin ordering. See [CONFIGURATION.md][CONFIGURATION.md] for more details.
     ##   * sleep: check the device unless it is in sleep mode
     ##   * standby: check the device unless it is in sleep or standby mode
     ##   * idle: check the device unless it is in sleep, standby, or idle mode
-    # nocheck = "standby"
+    # no_check = "standby"
 
     ## Metric version changes the naming of tags in the smartctl_attributes
     ## outputs. Currently "smartctl_attribute" metrics include the attribute

--- a/plugins/inputs/smartctl/sample.conf
+++ b/plugins/inputs/smartctl/sample.conf
@@ -24,7 +24,7 @@
     ##   * sleep: check the device unless it is in sleep mode
     ##   * standby: check the device unless it is in sleep or standby mode
     ##   * idle: check the device unless it is in sleep, standby, or idle mode
-    # nocheck = "standby"
+    # no_check = "standby"
 
     ## Metric version changes the naming of tags in the smartctl_attributes
     ## outputs. Currently "smartctl_attribute" metrics include the attribute


### PR DESCRIPTION
## Summary

The `inputs.smartctl` example config used `nocheck`, but the option is registered
as `no_check` (`plugins/inputs/smartctl/smartctl.go`), so copying the example
silently had no effect. Corrected the key in `sample.conf` and the generated
`README.md`. The `--nocheck` references elsewhere in the README are the smartctl
CLI flag and are left as-is.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

resolves #19363
