### PR TITLE
fix(inputs.cisco_telemetry_mdt)!: Emit correct row numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 - PR [#19451](https://github.com/influxdata/telegraf/pull/19451) fixes an issue
   in `inputs.cisco_telemetry_mdt` by avoiding spurious metrics for RIB data.
   Please check your metrics and queries for the mentioned data.
+- PR [#19456](https://github.com/influxdata/telegraf/pull/19456) fixes the row
+  numbering for table data in `inputs.cisco_telemetry_mdt`.
+  Please check your metrics and queries for the mentioned data.
 
 ## v1.39.3 [2026-08-10]
 

--- a/plugins/inputs/cisco_telemetry_mdt/parser.go
+++ b/plugins/inputs/cisco_telemetry_mdt/parser.go
@@ -401,6 +401,7 @@ func (s *state) parseNXRows(rows []*telemetry.TelemetryField, prefix string, tag
 		// to make sure the metric is emitted
 		if len(row.Fields) == 1 {
 			errs = append(errs, s.parseField(row.Fields[0], "", tags, timestamp)...)
+			delete(tags, prefix)
 			continue
 		}
 

--- a/plugins/inputs/cisco_telemetry_mdt/parser.go
+++ b/plugins/inputs/cisco_telemetry_mdt/parser.go
@@ -337,9 +337,10 @@ func (s *state) parseDME(fields []*telemetry.TelemetryField, prefix string, tags
 		}
 	}
 
-	if len(rn) > 0 {
+	// Check for distinguished name being present
+	if rn != "" {
 		tags[prefix] = rn
-	} else if !dn { // Check for distinguished name being present
+	} else if !dn {
 		return []error{errors.New("failed while decoding NX-OS: missing 'dn' field")}
 	}
 
@@ -387,24 +388,25 @@ func (s *state) parseEvents(events []*telemetry.TelemetryField, prefix string, t
 func (s *state) parseNXRows(rows []*telemetry.TelemetryField, prefix string, tags map[string]string, timestamp time.Time) []error {
 	var errs []error
 
-	for _, row := range rows {
+	for i, row := range rows {
 		if len(row.Fields) == 0 {
 			continue
 		}
 
+		// First subfield contains the index, promote it from value to tag
 		tags[prefix] = decodeTag(row.Fields[0])
-		for i, field := range row.Fields {
-			if i == 0 { // First subfield contains the index, promote it from value to tag
-				// We can have subfield so recursively handle it.
-				if len(row.Fields) == 1 {
-					tags["row_number"] = strconv.FormatInt(int64(i), 10)
-					errs = append(errs, s.parseField(field, "", tags, timestamp)...)
-				}
-			} else {
-				errs = append(errs, s.parseField(field, "", tags, timestamp)...)
-			}
-			// Nxapi we can't identify keys always from prefix
-			tags["row_number"] = strconv.FormatInt(int64(i), 10)
+		tags["row_number"] = strconv.FormatInt(int64(i), 10)
+
+		// If we only have a single column in the row, add it as a field too
+		// to make sure the metric is emitted
+		if len(row.Fields) == 1 {
+			errs = append(errs, s.parseField(row.Fields[0], "", tags, timestamp)...)
+			continue
+		}
+
+		// Add all other columns to the metric
+		for _, field := range row.Fields[1:] {
+			errs = append(errs, s.parseField(field, "", tags, timestamp)...)
 		}
 		delete(tags, prefix)
 	}

--- a/plugins/inputs/cisco_telemetry_mdt/testcases/NXAPI/expected.out
+++ b/plugins/inputs/cisco_telemetry_mdt/testcases/NXAPI/expected.out
@@ -1,2 +1,2 @@
 nxapi,TABLE_nxapi=i1,foo=bar,path=show\ nxapi,row_number=0,source=hostname,subscription=subscription value="foo" 1543236572000000000
-nxapi,TABLE_nxapi=i2,foo=bar,path=show\ nxapi,row_number=0,source=hostname,subscription=subscription value="bar" 1543236572000000000
+nxapi,TABLE_nxapi=i2,foo=bar,path=show\ nxapi,row_number=1,source=hostname,subscription=subscription value="bar" 1543236572000000000

--- a/plugins/inputs/cisco_telemetry_mdt/testcases/NXAPI_table_multirow/expected.out
+++ b/plugins/inputs/cisco_telemetry_mdt/testcases/NXAPI_table_multirow/expected.out
@@ -1,0 +1,3 @@
+interfaces,TABLE_interface=eth1/1,host=foobar,path=show\ interface\ brief,row_number=0,source=hostname,subscription=subscription proto="up",state="up",vlan="1" 1543236572000000000
+interfaces,TABLE_interface=eth1/2,host=foobar,path=show\ interface\ brief,row_number=1,source=hostname,subscription=subscription proto="down",state="down",vlan="1" 1543236572000000000
+interfaces,TABLE_interface=eth2/1,host=foobar,path=show\ interface\ brief,row_number=2,source=hostname,subscription=subscription proto="up",state="up",vlan="2" 1543236572000000000

--- a/plugins/inputs/cisco_telemetry_mdt/testcases/NXAPI_table_multirow/packet.json
+++ b/plugins/inputs/cisco_telemetry_mdt/testcases/NXAPI_table_multirow/packet.json
@@ -1,0 +1,104 @@
+{
+    "nodeIdStr": "hostname",
+    "subscriptionIdStr": "subscription",
+    "encodingPath": "show interface brief",
+    "msgTimestamp": "1543236572000",
+    "dataGpbkv": [
+        {
+            "fields": [
+                {
+                    "name": "keys",
+                    "fields": [
+                        {
+                            "name": "host",
+                            "stringValue": "foobar"
+                        }
+                    ]
+                },
+                {
+                    "name": "content",
+                    "fields": [
+                        {
+                            "fields": [
+                                {
+                                    "name": "TABLE_interface",
+                                    "fields": [
+                                        {
+                                            "fields": [
+                                                {
+                                                    "name": "ROW_interface",
+                                                    "fields": [
+                                                        {
+                                                            "fields": [
+                                                                {
+                                                                    "name": "interface",
+                                                                    "stringValue": "eth1/1"
+                                                                },
+                                                                {
+                                                                    "name": "state",
+                                                                    "stringValue": "up"
+                                                                },
+                                                                {
+                                                                    "name": "proto",
+                                                                    "stringValue": "up"
+                                                                },
+                                                                {
+                                                                    "name": "vlan",
+                                                                    "stringValue": "1"
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "fields": [
+                                                                {
+                                                                    "name": "interface",
+                                                                    "stringValue": "eth1/2"
+                                                                },
+                                                                {
+                                                                    "name": "state",
+                                                                    "stringValue": "down"
+                                                                },
+                                                                {
+                                                                    "name": "proto",
+                                                                    "stringValue": "down"
+                                                                },
+                                                                {
+                                                                    "name": "vlan",
+                                                                    "stringValue": "1"
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "fields": [
+                                                                {
+                                                                    "name": "interface",
+                                                                    "stringValue": "eth2/1"
+                                                                },
+                                                                {
+                                                                    "name": "state",
+                                                                    "stringValue": "up"
+                                                                },
+                                                                {
+                                                                    "name": "proto",
+                                                                    "stringValue": "up"
+                                                                },
+                                                                {
+                                                                    "name": "vlan",
+                                                                    "stringValue": "2"
+                                                                }
+                                                            ]
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/plugins/inputs/cisco_telemetry_mdt/testcases/NXAPI_table_multirow/telegraf.conf
+++ b/plugins/inputs/cisco_telemetry_mdt/testcases/NXAPI_table_multirow/telegraf.conf
@@ -1,0 +1,6 @@
+ [[inputs.cisco_telemetry_mdt]]
+  transport = "tcp"
+  service_address = ":0"
+  [inputs.cisco_telemetry_mdt.aliases]
+    interfaces = "show interface brief"
+


### PR DESCRIPTION
## Summary

The current code will emit wrong row-indices as it will use the field aka column index instead of the row.

This PR uses the correct index and this fixes the issue.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

related to #10087 
