### PR TITLE
fix(outputs.amqp): Return error when the broker is unavailable

### DIFF
--- a/plugins/outputs/amqp/amqp.go
+++ b/plugins/outputs/amqp/amqp.go
@@ -162,11 +162,13 @@ func (q *AMQP) Write(metrics []telegraf.Metric) error {
 				if err != nil {
 					return err
 				}
-			} else if q.client != nil {
-				if err := q.client.Close(); err != nil {
-					q.Log.Errorf("Closing connection failed: %v", err)
+			} else {
+				if q.client != nil {
+					if err := q.client.Close(); err != nil {
+						q.Log.Errorf("Closing connection failed: %v", err)
+					}
+					q.client = nil
 				}
-				q.client = nil
 				return err
 			}
 		}

--- a/plugins/outputs/amqp/amqp.go
+++ b/plugins/outputs/amqp/amqp.go
@@ -152,23 +152,23 @@ func (q *AMQP) Write(metrics []telegraf.Metric) error {
 
 		err = q.publish(key, body)
 		if err != nil {
-			// If this is the first attempt to publish and the connection is
-			// closed, try to reconnect and retry once.
-
+			// Only a closed connection on the first attempt is recoverable:
+			// reconnect and retry once. Any other error must be returned so
+			// the metrics stay buffered for retry instead of being dropped.
 			var aerr *amqp.Error
-			if first && errors.As(err, &aerr) && errors.Is(aerr, amqp.ErrClosed) {
-				q.client = nil
-				err := q.publish(key, body)
-				if err != nil {
-					return err
-				}
-			} else {
+			recoverable := first && errors.As(err, &aerr) && errors.Is(aerr, amqp.ErrClosed)
+			if !recoverable {
 				if q.client != nil {
 					if err := q.client.Close(); err != nil {
 						q.Log.Errorf("Closing connection failed: %v", err)
 					}
 					q.client = nil
 				}
+				return err
+			}
+
+			q.client = nil
+			if err := q.publish(key, body); err != nil {
 				return err
 			}
 		}

--- a/plugins/outputs/amqp/amqp.go
+++ b/plugins/outputs/amqp/amqp.go
@@ -155,19 +155,18 @@ func (q *AMQP) Write(metrics []telegraf.Metric) error {
 			// Only a closed connection on the first attempt is recoverable:
 			// reconnect and retry once. Any other error must be returned so
 			// the metrics stay buffered for retry instead of being dropped.
+			if q.client != nil {
+				if err := q.client.Close(); err != nil {
+					q.Log.Errorf("Closing connection failed: %v", err)
+				}
+			}
+			q.client = nil
+
 			var aerr *amqp.Error
 			recoverable := first && errors.As(err, &aerr) && errors.Is(aerr, amqp.ErrClosed)
 			if !recoverable {
-				if q.client != nil {
-					if err := q.client.Close(); err != nil {
-						q.Log.Errorf("Closing connection failed: %v", err)
-					}
-					q.client = nil
-				}
 				return err
 			}
-
-			q.client = nil
 			if err := q.publish(key, body); err != nil {
 				return err
 			}

--- a/plugins/outputs/amqp/amqp_test.go
+++ b/plugins/outputs/amqp/amqp_test.go
@@ -1,6 +1,7 @@
 package amqp
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -8,6 +9,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/influxdata/telegraf/config"
+	"github.com/influxdata/telegraf/plugins/serializers/influx"
+	"github.com/influxdata/telegraf/testutil"
 )
 
 type MockClient struct {
@@ -157,4 +160,28 @@ func TestConnect(t *testing.T) {
 			tt.errFunc(t, tt.output, err)
 		})
 	}
+}
+
+func TestWriteReturnsErrorWhenBrokerUnavailable(t *testing.T) {
+	serializer := &influx.Serializer{}
+	require.NoError(t, serializer.Init())
+
+	q := &AMQP{
+		Brokers:      []string{DefaultURL},
+		ExchangeType: DefaultExchangeType,
+		AuthMethod:   DefaultAuthMethod,
+		Timeout:      config.Duration(5 * time.Second),
+		Log:          testutil.Logger{},
+		connect: func(*ClientConfig) (Client, error) {
+			return nil, errors.New("could not connect to any broker")
+		},
+	}
+	require.NoError(t, q.Init())
+	q.SetSerializer(serializer)
+
+	// The broker is unreachable, so publish() calls connect() (q.client is
+	// nil) and gets back a plain error that is not amqp.ErrClosed. Write must
+	// surface that error so the framework keeps the metrics buffered for
+	// retry instead of silently dropping them.
+	require.Error(t, q.Write(testutil.MockMetrics()))
 }


### PR DESCRIPTION

## Summary

When RabbitMQ is unreachable, the AMQP output reports success and drops the batch instead of keeping it buffered.

In `Write()`, a publish failure only returned the error if it was a first-attempt `amqp.ErrClosed` reconnect or if `q.client` was still set. When the broker is down, `publish()` calls `connect()`, which fails with a plain (non-ErrClosed) error and leaves q.client nil, neither branch fired, the error was swallowed. The framework then flushed the buffer and the metrics were lost.

Made the fallback branch always return the error (nil-guarding the close), so a failed publish keeps the metrics buffered for the next flush.

Added a unit test that drives the broker-down path through the injectable connect and asserts Write returns an error.

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [ ] No AI generated code was used in this PR
- [x] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

Fixes #11660


