### PR TITLE
feat(serializers.avro): Add Avro serializer plugin

### DIFF
--- a/docs/DATA_FORMATS_OUTPUT.md
+++ b/docs/DATA_FORMATS_OUTPUT.md
@@ -5,6 +5,7 @@ standard data formats that may be selected from when configuring many output
 plugins.
 
 1. [InfluxDB Line Protocol](/plugins/serializers/influx)
+1. [Avro](/plugins/serializers/avro)
 1. [Binary](/plugins/serializers/binary)
 1. [Carbon2](/plugins/serializers/carbon2)
 1. [CloudEvents](/plugins/serializers/cloudevents)

--- a/plugins/serializers/all/avro.go
+++ b/plugins/serializers/all/avro.go
@@ -1,0 +1,7 @@
+//go:build !custom || serializers || serializers.avro
+
+package all
+
+import (
+	_ "github.com/influxdata/telegraf/plugins/serializers/avro" // register plugin
+)

--- a/plugins/serializers/avro/README.md
+++ b/plugins/serializers/avro/README.md
@@ -1,0 +1,77 @@
+# Avro Serializer Plugin
+
+The `avro` output data format encodes metrics into Avro using a schema you
+provide. Each metric becomes one Avro record. Tag values, field values and,
+optionally, the measurement name and timestamp are matched to the schema fields
+by name, so the schema decides what ends up in the output and in what order.
+
+This is the counterpart to the [Avro parser][parser]. It emits bare Avro binary
+(or Avro JSON), not Confluent wire format, so there's no schema-registry
+interaction and no schema ID prefix on the output.
+
+[parser]: /plugins/parsers/avro
+
+## Configuration
+
+```toml
+[[outputs.file]]
+  files = ["stdout"]
+
+  ## Data format to output.
+  data_format = "avro"
+
+  ## Avro schema used to encode the metrics. Required.
+  ## Must be a record schema. Fields the schema doesn't name are dropped;
+  ## schema fields with no matching tag/field must be nullable or have a
+  ## default, otherwise encoding fails.
+  avro_schema = '''
+    {
+      "type": "record",
+      "name": "metric",
+      "fields": [
+        {"name": "host", "type": "string"},
+        {"name": "value", "type": "double"},
+        {"name": "timestamp", "type": "long"}
+      ]
+    }
+  '''
+
+  ## Output encoding: "binary" (default) or "json".
+  # avro_format = "binary"
+
+  ## Schema field to receive the measurement name. Leave empty to skip.
+  # avro_measurement_field = ""
+
+  ## Schema field to receive the timestamp. Leave empty to skip.
+  # avro_timestamp = "timestamp"
+
+  ## How to encode the timestamp when avro_timestamp is set.
+  ## One of "unix" (seconds, default), "unix_ms", "unix_us", "unix_ns".
+  # avro_timestamp_format = "unix"
+```
+
+### Type coercion
+
+Telegraf field values are coerced to the Avro type declared for the matching
+schema field, so an `int64` metric field maps cleanly onto a `double` or
+`float` schema field and a numeric field maps onto `string`. Supported target
+types are `boolean`, `int`, `long`, `float`, `double`, `string` and `bytes`.
+
+A union of the form `["null", T]` is handled by emitting `null` for a missing
+value and the `T` branch otherwise. More complex types (records, arrays, maps,
+logical types) are passed through to the encoder unchanged.
+
+## Example
+
+With the schema above and the timestamp field configured, the line protocol
+metric
+
+```text
+metric,host=server01 value=42.5 1600000000000000000
+```
+
+serializes to an Avro record equivalent to
+
+```json
+{"host": "server01", "value": 42.5, "timestamp": 1600000000}
+```

--- a/plugins/serializers/avro/avro.go
+++ b/plugins/serializers/avro/avro.go
@@ -1,0 +1,271 @@
+package avro
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/linkedin/goavro/v2"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/internal"
+	"github.com/influxdata/telegraf/plugins/serializers"
+)
+
+type Serializer struct {
+	Schema           string          `toml:"avro_schema"`
+	Format           string          `toml:"avro_format"`
+	MeasurementField string          `toml:"avro_measurement_field"`
+	Timestamp        string          `toml:"avro_timestamp"`
+	TimestampFormat  string          `toml:"avro_timestamp_format"`
+	Log              telegraf.Logger `toml:"-"`
+
+	codec      *goavro.Codec
+	fieldTypes map[string]interface{}
+}
+
+func (s *Serializer) Init() error {
+	switch s.Format {
+	case "":
+		s.Format = "binary"
+	case "binary", "json":
+		// Valid settings
+	default:
+		return fmt.Errorf("unknown 'avro_format' %q", s.Format)
+	}
+
+	switch s.TimestampFormat {
+	case "":
+		s.TimestampFormat = "unix"
+	case "unix", "unix_ms", "unix_us", "unix_ns":
+		// Valid settings
+	default:
+		return fmt.Errorf("invalid 'avro_timestamp_format' %q", s.TimestampFormat)
+	}
+
+	if s.Schema == "" {
+		return errors.New("'avro_schema' is required")
+	}
+
+	codec, err := goavro.NewCodec(s.Schema)
+	if err != nil {
+		return fmt.Errorf("parsing schema failed: %w", err)
+	}
+	s.codec = codec
+
+	// Pull out the declared type of every field in the (record) schema so we
+	// can coerce Telegraf's Go values to something goavro accepts.
+	types, err := schemaFieldTypes(s.Schema)
+	if err != nil {
+		return err
+	}
+	s.fieldTypes = types
+
+	return nil
+}
+
+func (s *Serializer) Serialize(metric telegraf.Metric) ([]byte, error) {
+	return s.encode(s.record(metric))
+}
+
+func (s *Serializer) SerializeBatch(metrics []telegraf.Metric) ([]byte, error) {
+	var buf []byte
+	for _, m := range metrics {
+		b, err := s.encode(s.record(m))
+		if err != nil {
+			return nil, err
+		}
+		buf = append(buf, b...)
+	}
+	return buf, nil
+}
+
+func (s *Serializer) encode(record map[string]interface{}) ([]byte, error) {
+	switch s.Format {
+	case "binary":
+		return s.codec.BinaryFromNative(nil, record)
+	case "json":
+		return s.codec.TextualFromNative(nil, record)
+	default:
+		return nil, fmt.Errorf("unknown format %q", s.Format)
+	}
+}
+
+// record flattens a metric into a name-keyed map ready for Avro encoding.
+// Tags and fields sharing a name collide; fields win since that matches how the
+// parser round-trips them. goavro ignores map keys the schema doesn't mention,
+// so we can hand it everything and let the schema select what it wants.
+func (s *Serializer) record(metric telegraf.Metric) map[string]interface{} {
+	record := make(map[string]interface{}, len(metric.TagList())+len(metric.FieldList())+2)
+
+	for _, tag := range metric.TagList() {
+		record[tag.Key] = s.coerce(tag.Key, tag.Value)
+	}
+	for _, field := range metric.FieldList() {
+		record[field.Key] = s.coerce(field.Key, field.Value)
+	}
+
+	if s.MeasurementField != "" {
+		record[s.MeasurementField] = s.coerce(s.MeasurementField, metric.Name())
+	}
+	if s.Timestamp != "" {
+		t := metric.Time()
+		var ts int64
+		switch s.TimestampFormat {
+		case "unix":
+			ts = t.Unix()
+		case "unix_ms":
+			ts = t.UnixNano() / 1e6
+		case "unix_us":
+			ts = t.UnixNano() / 1e3
+		case "unix_ns":
+			ts = t.UnixNano()
+		}
+		record[s.Timestamp] = s.coerce(s.Timestamp, ts)
+	}
+
+	return record
+}
+
+// coerce converts a Telegraf value into the concrete Go type goavro wants for
+// the schema field of the same name. Fields the schema doesn't declare, or
+// types we don't special-case (records, arrays, maps, logical types), are
+// passed through untouched.
+func (s *Serializer) coerce(name string, value interface{}) interface{} {
+	avroType, ok := s.fieldTypes[name]
+	if !ok {
+		return value
+	}
+	return coerceTo(avroType, value, s.Log)
+}
+
+func coerceTo(avroType, value interface{}, log telegraf.Logger) interface{} {
+	switch t := avroType.(type) {
+	case string:
+		return coercePrimitive(t, value, log)
+	case []interface{}:
+		// A union, e.g. ["null", "long"]. Encode null as nil and otherwise
+		// wrap the value in the first non-null branch we understand.
+		if value == nil {
+			return nil
+		}
+		for _, branch := range t {
+			name, ok := branch.(string)
+			if !ok || name == "null" {
+				continue
+			}
+			return goavro.Union(name, coercePrimitive(name, value, log))
+		}
+		return value
+	default:
+		// Complex or logical type: leave it for goavro to handle.
+		return value
+	}
+}
+
+func coercePrimitive(avroType string, value interface{}, log telegraf.Logger) interface{} {
+	switch avroType {
+	case "string":
+		s, err := internal.ToString(value)
+		if err != nil {
+			if log != nil {
+				log.Warnf("Could not convert %v to string: %v", value, err)
+			}
+			return value
+		}
+		return s
+	case "int":
+		v, err := internal.ToInt64(value)
+		if err != nil {
+			logConvErr(log, value, avroType, err)
+			return value
+		}
+		return int32(v)
+	case "long":
+		v, err := internal.ToInt64(value)
+		if err != nil {
+			logConvErr(log, value, avroType, err)
+			return value
+		}
+		return v
+	case "float":
+		v, err := internal.ToFloat64(value)
+		if err != nil {
+			logConvErr(log, value, avroType, err)
+			return value
+		}
+		return float32(v)
+	case "double":
+		v, err := internal.ToFloat64(value)
+		if err != nil {
+			logConvErr(log, value, avroType, err)
+			return value
+		}
+		return v
+	case "boolean":
+		v, err := internal.ToBool(value)
+		if err != nil {
+			logConvErr(log, value, avroType, err)
+			return value
+		}
+		return v
+	case "bytes":
+		switch v := value.(type) {
+		case []byte:
+			return v
+		case string:
+			return []byte(v)
+		default:
+			s, err := internal.ToString(value)
+			if err != nil {
+				logConvErr(log, value, avroType, err)
+				return value
+			}
+			return []byte(s)
+		}
+	default:
+		return value
+	}
+}
+
+func logConvErr(log telegraf.Logger, value, avroType interface{}, err error) {
+	if log != nil {
+		log.Warnf("Could not convert %v to %v: %v", value, avroType, err)
+	}
+}
+
+// schemaFieldTypes reads a record schema and returns a map of field name to its
+// declared Avro type. Non-record schemas yield an empty map, which just means
+// no coercion happens and every value is passed through as-is.
+func schemaFieldTypes(schema string) (map[string]interface{}, error) {
+	var parsed map[string]interface{}
+	if err := json.Unmarshal([]byte(schema), &parsed); err != nil {
+		return nil, fmt.Errorf("unmarshalling schema failed: %w", err)
+	}
+
+	types := make(map[string]interface{})
+	fields, ok := parsed["fields"].([]interface{})
+	if !ok {
+		return types, nil
+	}
+	for _, f := range fields {
+		field, ok := f.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		name, ok := field["name"].(string)
+		if !ok {
+			continue
+		}
+		types[name] = field["type"]
+	}
+	return types, nil
+}
+
+func init() {
+	serializers.Add("avro",
+		func() telegraf.Serializer {
+			return &Serializer{}
+		},
+	)
+}

--- a/plugins/serializers/avro/avro_test.go
+++ b/plugins/serializers/avro/avro_test.go
@@ -1,0 +1,201 @@
+package avro
+
+import (
+	"testing"
+	"time"
+
+	"github.com/linkedin/goavro/v2"
+	"github.com/stretchr/testify/require"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/metric"
+	"github.com/influxdata/telegraf/plugins/serializers"
+	"github.com/influxdata/telegraf/testutil"
+)
+
+func TestSerialize(t *testing.T) {
+	tests := []struct {
+		name     string
+		schema   string
+		config   Serializer
+		metric   telegraf.Metric
+		expected map[string]interface{}
+	}{
+		{
+			name: "fields and tags",
+			schema: `{
+				"type": "record",
+				"name": "cpu",
+				"fields": [
+					{"name": "host", "type": "string"},
+					{"name": "value", "type": "double"},
+					{"name": "count", "type": "long"}
+				]
+			}`,
+			metric: metric.New(
+				"cpu",
+				map[string]string{"host": "server01"},
+				map[string]interface{}{"value": 42.5, "count": int64(3)},
+				time.Unix(1600000000, 0),
+			),
+			expected: map[string]interface{}{
+				"host":  "server01",
+				"value": 42.5,
+				"count": int64(3),
+			},
+		},
+		{
+			name: "numeric coercion int field into double",
+			schema: `{
+				"type": "record",
+				"name": "cpu",
+				"fields": [{"name": "value", "type": "double"}]
+			}`,
+			metric: metric.New(
+				"cpu",
+				map[string]string{},
+				map[string]interface{}{"value": int64(7)},
+				time.Unix(0, 0),
+			),
+			expected: map[string]interface{}{"value": float64(7)},
+		},
+		{
+			name: "nullable union with a value",
+			schema: `{
+				"type": "record",
+				"name": "cpu",
+				"fields": [{"name": "value", "type": ["null", "long"]}]
+			}`,
+			metric: metric.New(
+				"cpu",
+				map[string]string{},
+				map[string]interface{}{"value": int64(5)},
+				time.Unix(0, 0),
+			),
+			expected: map[string]interface{}{
+				"value": map[string]interface{}{"long": int64(5)},
+			},
+		},
+		{
+			name: "measurement and timestamp fields",
+			schema: `{
+				"type": "record",
+				"name": "cpu",
+				"fields": [
+					{"name": "measurement", "type": "string"},
+					{"name": "time", "type": "long"},
+					{"name": "value", "type": "double"}
+				]
+			}`,
+			config: Serializer{
+				MeasurementField: "measurement",
+				Timestamp:        "time",
+				TimestampFormat:  "unix_ms",
+			},
+			metric: metric.New(
+				"cpu",
+				map[string]string{},
+				map[string]interface{}{"value": 1.0},
+				time.Unix(1600000000, 0),
+			),
+			expected: map[string]interface{}{
+				"measurement": "cpu",
+				"time":        int64(1600000000000),
+				"value":       1.0,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := tt.config
+			s.Schema = tt.schema
+			s.Log = testutil.Logger{}
+			require.NoError(t, s.Init())
+
+			buf, err := s.Serialize(tt.metric)
+			require.NoError(t, err)
+
+			codec, err := goavro.NewCodec(tt.schema)
+			require.NoError(t, err)
+			native, remaining, err := codec.NativeFromBinary(buf)
+			require.NoError(t, err)
+			require.Empty(t, remaining)
+			require.Equal(t, tt.expected, native)
+		})
+	}
+}
+
+func TestSerializeJSONFormat(t *testing.T) {
+	schema := `{
+		"type": "record",
+		"name": "cpu",
+		"fields": [{"name": "value", "type": "long"}]
+	}`
+	s := Serializer{Schema: schema, Format: "json"}
+	require.NoError(t, s.Init())
+
+	buf, err := s.Serialize(metric.New(
+		"cpu",
+		map[string]string{},
+		map[string]interface{}{"value": int64(9)},
+		time.Unix(0, 0),
+	))
+	require.NoError(t, err)
+	require.JSONEq(t, `{"value": 9}`, string(buf))
+}
+
+func TestSerializeBatch(t *testing.T) {
+	schema := `{
+		"type": "record",
+		"name": "cpu",
+		"fields": [{"name": "value", "type": "long"}]
+	}`
+	s := Serializer{Schema: schema}
+	require.NoError(t, s.Init())
+
+	metrics := []telegraf.Metric{
+		metric.New("cpu", map[string]string{}, map[string]interface{}{"value": int64(1)}, time.Unix(0, 0)),
+		metric.New("cpu", map[string]string{}, map[string]interface{}{"value": int64(2)}, time.Unix(0, 0)),
+	}
+
+	buf, err := s.SerializeBatch(metrics)
+	require.NoError(t, err)
+
+	codec, err := goavro.NewCodec(schema)
+	require.NoError(t, err)
+
+	var got []int64
+	remaining := buf
+	for len(remaining) > 0 {
+		var native interface{}
+		native, remaining, err = codec.NativeFromBinary(remaining)
+		require.NoError(t, err)
+		record := native.(map[string]interface{})
+		got = append(got, record["value"].(int64))
+	}
+	require.Equal(t, []int64{1, 2}, got)
+}
+
+func TestInitErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		s    Serializer
+	}{
+		{name: "missing schema", s: Serializer{}},
+		{name: "bad schema", s: Serializer{Schema: "{not valid avro}"}},
+		{name: "bad format", s: Serializer{Schema: `{"type":"record","name":"x","fields":[]}`, Format: "yaml"}},
+		{name: "bad timestamp format", s: Serializer{Schema: `{"type":"record","name":"x","fields":[]}`, TimestampFormat: "rfc3339"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Error(t, tt.s.Init())
+		})
+	}
+}
+
+func TestRegistered(t *testing.T) {
+	creator, ok := serializers.Serializers["avro"]
+	require.True(t, ok)
+	require.NotNil(t, creator())
+}


### PR DESCRIPTION
Resolves #19449. Adds an `avro` serializer so outputs can emit Avro-encoded metrics against a configured schema, which is the piece that was actually missing behind that "Avro for Kafka" request.

It's the mirror image of the existing avro parser and reuses the same `linkedin/goavro` dependency. Each metric becomes one Avro record: tags, fields, and optionally the measurement name and timestamp get matched to the schema's fields by name, and goavro drops anything the schema doesn't ask for. Since Telegraf fields come through as int64/float64/etc, `Init` reads the field types out of the schema once and coerces values to what goavro expects, so an int metric field lands cleanly in a `double` schema field. Nullable `["null", T]` unions are handled (nil for a missing value, the `T` branch otherwise); records/arrays/maps and logical types are passed straight through.

Deliberately kept this to the self-contained static-schema case. It emits bare Avro binary (or Avro JSON via `avro_format = "json"`), not Confluent wire format, so there's no schema registry round-trip and no schema-ID prefix on the output. Schema-registry-backed output could be a follow-up if there's demand, matching the registry support on the parser side.

Registered through `plugins/serializers/all` with the usual build tag, and added to the output data formats list.

Tests are table-driven with inline schemas, nothing hits the network. They round-trip each case back through a goavro codec and assert the decoded record, plus cover the JSON format, batch output, the int-into-double coercion, the nullable union, measurement/timestamp mapping, and the `Init` error paths. `go test ./plugins/serializers/avro/...` passes and `go build ./plugins/serializers/all/...` builds with the new registration.
