### PR TITLE
test(inputs.redfish): Prepare redfish refactoring

### DIFF
--- a/plugins/inputs/redfish/redfish_test.go
+++ b/plugins/inputs/redfish/redfish_test.go
@@ -927,6 +927,10 @@ func TestInvalidHPJSON(t *testing.T) {
 				}
 
 				switch r.URL.Path {
+				case "/redfish/v1/":
+					http.ServeFile(w, r, "testdata/base.json")
+				case "/redfish/v1/Systems/":
+					http.ServeFile(w, r, "testdata/hp/hp_available_systems.json")
 				case "/redfish/v1/Chassis/1/Thermal":
 					http.ServeFile(w, r, tt.thermalfilename)
 				case "/redfish/v1/Chassis/1/Power":

--- a/plugins/inputs/redfish/redfish_test.go
+++ b/plugins/inputs/redfish/redfish_test.go
@@ -777,7 +777,8 @@ func TestInvalidUsernameorPassword(t *testing.T) {
 	u, err := url.Parse(ts.URL)
 	require.NoError(t, err)
 	err = r.Gather(&acc)
-	require.EqualError(t, err, "received status code 401 (Unauthorized) for address http://"+u.Host+"/redfish/v1/Systems/System.Embedded.1, expected 200")
+	require.ErrorContains(t, err, "401")
+	require.ErrorContains(t, err, "http://"+u.Host+"/redfish/v1/Systems/")
 }
 func TestNoUsernameorPasswordConfiguration(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/plugins/inputs/redfish/redfish_test.go
+++ b/plugins/inputs/redfish/redfish_test.go
@@ -729,6 +729,11 @@ func TestHPilo4Apis(t *testing.T) {
 }
 
 func checkAuth(r *http.Request, username, password string) bool {
+	// The base path requires no auth
+	if r.URL.Path == "/redfish/v1/" {
+		return true
+	}
+
 	user, pass, ok := r.BasicAuth()
 	if !ok {
 		return false

--- a/plugins/inputs/redfish/redfish_test.go
+++ b/plugins/inputs/redfish/redfish_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"slices"
 	"sync"
 	"testing"
 	"time"
@@ -1012,9 +1013,15 @@ func TestSkipChassisWithoutReference(t *testing.T) {
 		requested = append(requested, r.URL.Path)
 		mu.Unlock()
 
-		w.Header().Set("Content-Type", "application/json")
-		if _, err := w.Write([]byte(`{"Links": {"Chassis": [{"@odata.id": ""}]}}`)); err != nil {
-			t.Error(err)
+		switch r.URL.Path {
+		case "/redfish/v1/":
+			http.ServeFile(w, r, "testdata/base.json")
+		case "/redfish/v1/Systems/":
+			http.ServeFile(w, r, "testdata/hp/hp_available_systems.json")
+		case "/redfish/v1/Systems/1":
+			http.ServeFile(w, r, "testdata/hp/hp_systems_nolink.json")
+		default:
+			w.WriteHeader(http.StatusNotFound)
 		}
 	}))
 	defer ts.Close()
@@ -1034,9 +1041,10 @@ func TestSkipChassisWithoutReference(t *testing.T) {
 	require.Empty(t, acc.GetTelegrafMetrics())
 
 	// The empty reference must not be requested as it resolves to the web root
+	// There shouldn't be a request to any /redfish/v1/Chassis path
 	mu.Lock()
 	defer mu.Unlock()
-	require.Equal(t, []string{"/redfish/v1/Systems/1"}, requested)
+	require.False(t, slices.Contains(requested, "/redfish/v1/Chassis"))
 }
 
 func TestSkipChassisWithoutThermalAndPowerReference(t *testing.T) {

--- a/plugins/inputs/redfish/redfish_test.go
+++ b/plugins/inputs/redfish/redfish_test.go
@@ -944,7 +944,7 @@ func TestInvalidHPJSON(t *testing.T) {
 					http.ServeFile(w, r, tt.powerfilename)
 				case "/redfish/v1/Chassis/1/":
 					http.ServeFile(w, r, tt.chassisfilename)
-				case "/redfish/v1/Systems/System.Embedded.2":
+				case "/redfish/v1/Systems/1":
 					http.ServeFile(w, r, tt.hostnamefilename)
 				default:
 					w.WriteHeader(http.StatusNotFound)
@@ -956,7 +956,7 @@ func TestInvalidHPJSON(t *testing.T) {
 				Address:          ts.URL,
 				Username:         config.NewSecret([]byte("test")),
 				Password:         config.NewSecret([]byte("test")),
-				ComputerSystemID: "System.Embedded.2",
+				ComputerSystemID: "1",
 				IncludeMetrics:   []string{"thermal", "power"},
 			}
 

--- a/plugins/inputs/redfish/redfish_test.go
+++ b/plugins/inputs/redfish/redfish_test.go
@@ -1044,7 +1044,9 @@ func TestSkipChassisWithoutReference(t *testing.T) {
 	// There shouldn't be a request to any /redfish/v1/Chassis path
 	mu.Lock()
 	defer mu.Unlock()
-	require.NotContains(t, requested, "/redfish/v1/Chassis")
+	for _, path := range requested {
+		require.NotContains(t, path, "/redfish/v1/Chassis")
+	}
 }
 
 func TestSkipChassisWithoutThermalAndPowerReference(t *testing.T) {

--- a/plugins/inputs/redfish/redfish_test.go
+++ b/plugins/inputs/redfish/redfish_test.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"slices"
 	"sync"
 	"testing"
 	"time"
@@ -1045,7 +1044,7 @@ func TestSkipChassisWithoutReference(t *testing.T) {
 	// There shouldn't be a request to any /redfish/v1/Chassis path
 	mu.Lock()
 	defer mu.Unlock()
-	require.False(t, slices.Contains(requested, "/redfish/v1/Chassis"))
+	require.NotContains(t, requested, "/redfish/v1/Chassis")
 }
 
 func TestSkipChassisWithoutThermalAndPowerReference(t *testing.T) {

--- a/plugins/inputs/redfish/redfish_test.go
+++ b/plugins/inputs/redfish/redfish_test.go
@@ -776,7 +776,7 @@ func TestInvalidUsernameorPassword(t *testing.T) {
 	u, err := url.Parse(ts.URL)
 	require.NoError(t, err)
 	err = r.Gather(&acc)
-	require.ErrorContains(t, err, "401")
+	require.ErrorContains(t, err, "received status code 401")
 	require.ErrorContains(t, err, "http://"+u.Host+"/redfish/v1/Systems/")
 }
 func TestNoUsernameorPasswordConfiguration(t *testing.T) {

--- a/plugins/inputs/redfish/testdata/dell/dell_chassisinvalid.json
+++ b/plugins/inputs/redfish/testdata/dell/dell_chassisinvalid.json
@@ -1,3 +1,4 @@
+}
 {
   "@odata.context": "/redfish/v1/$metadata#Chassis.Chassis",
   "@odata.id": "/redfish/v1/Chassis/System.Embedded.1",
@@ -185,4 +186,3 @@
     "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Thermal"
   }
 }
-{

--- a/plugins/inputs/redfish/testdata/hp/hp_systems_nolink.json
+++ b/plugins/inputs/redfish/testdata/hp/hp_systems_nolink.json
@@ -1,0 +1,307 @@
+{
+  "@odata.context": "/redfish/v1/$metadata#ComputerSystem.ComputerSystem",
+  "@odata.etag": "W/\"43E302D1\"",
+  "@odata.id": "/redfish/v1/Systems/1/",
+  "@odata.type": "#ComputerSystem.v1_4_0.ComputerSystem",
+  "Id": "1",
+  "Actions": {
+    "#ComputerSystem.Reset": {
+      "ResetType@Redfish.AllowableValues": [
+        "On",
+        "ForceOff",
+        "ForceRestart",
+        "Nmi",
+        "PushPowerButton"
+      ],
+      "target": "/redfish/v1/Systems/1/Actions/ComputerSystem.Reset/"
+    }
+  },
+  "AssetTag": "",
+  "Bios": {
+    "@odata.id": "/redfish/v1/systems/1/bios/"
+  },
+  "BiosVersion": "U32 v2.10 (05/21/2019)",
+  "Boot": {
+    "BootSourceOverrideEnabled": "Disabled",
+    "BootSourceOverrideMode": "UEFI",
+    "BootSourceOverrideTarget": "None",
+    "BootSourceOverrideTarget@Redfish.AllowableValues": [
+      "None",
+      "Cd",
+      "Hdd",
+      "Usb",
+      "SDCard",
+      "Utilities",
+      "Diags",
+      "BiosSetup",
+      "Pxe",
+      "UefiShell",
+      "UefiHttp",
+      "UefiTarget"
+    ],
+    "UefiTargetBootSourceOverride": "None",
+    "UefiTargetBootSourceOverride@Redfish.AllowableValues": [
+      "HD(1,GPT,0E3A0969-7AFC-4B55-8B24-AEFA09F33D2D,0x800,0x12C000)/\\EFI\\redhat\\shimx64.efi",
+      "UsbClass(0xFFFF,0xFFFF,0xFF,0xFF,0xFF)",
+      "PciRoot(0x0)/Pci(0x1C,0x0)/Pci(0x0,0x0)/MAC(8030E0421B1C,0x1)/IPv4(0.0.0.0)/Uri()",
+      "PciRoot(0x0)/Pci(0x1C,0x0)/Pci(0x0,0x0)/MAC(8030E0421B1C,0x1)/IPv4(0.0.0.0)",
+      "PciRoot(0x3)/Pci(0x2,0x0)/Pci(0x0,0x0)/MAC(48DF37959430,0x1)/IPv4(0.0.0.0)/Uri()",
+      "PciRoot(0x3)/Pci(0x2,0x0)/Pci(0x0,0x0)/MAC(48DF37959430,0x1)/IPv4(0.0.0.0)",
+      "PciRoot(0x0)/Pci(0x1C,0x0)/Pci(0x0,0x0)/MAC(8030E0421B1C,0x1)/IPv6(0000:0000:0000:0000:0000:0000:0000:0000)/Uri()",
+      "PciRoot(0x3)/Pci(0x2,0x0)/Pci(0x0,0x0)/MAC(48DF37959430,0x1)/IPv6(0000:0000:0000:0000:0000:0000:0000:0000)/Uri()",
+      "PciRoot(0x3)/Pci(0x2,0x0)/Pci(0x0,0x0)/MAC(48DF37959430,0x1)/IPv6(0000:0000:0000:0000:0000:0000:0000:0000)",
+      "PciRoot(0x0)/Pci(0x1C,0x0)/Pci(0x0,0x0)/MAC(8030E0421B1C,0x1)/IPv6(0000:0000:0000:0000:0000:0000:0000:0000)",
+      "PciRoot(0x9)/Pci(0x0,0x0)/Pci(0x0,0x0)/MAC(B88303866AE8,0x1)/IPv4(0.0.0.0)/Uri()",
+      "PciRoot(0x9)/Pci(0x0,0x0)/Pci(0x0,0x0)/MAC(B88303866AE8,0x1)/IPv4(0.0.0.0)",
+      "PciRoot(0x9)/Pci(0x0,0x0)/Pci(0x0,0x0)/MAC(B88303866AE8,0x1)/IPv6(0000:0000:0000:0000:0000:0000:0000:0000)/Uri()",
+      "PciRoot(0x9)/Pci(0x0,0x0)/Pci(0x0,0x0)/MAC(B88303866AE8,0x1)/IPv6(0000:0000:0000:0000:0000:0000:0000:0000)",
+      "PciRoot(0x0)/Pci(0x14,0x0)/USB(0x13,0x0)",
+      "PciRoot(0x3)/Pci(0x0,0x0)/Pci(0x0,0x0)/Scsi(0x0,0x0)"
+    ]
+  },
+  "EthernetInterfaces": {
+    "@odata.id": "/redfish/v1/Systems/1/EthernetInterfaces/"
+  },
+  "HostName": "tpa-hostname",
+  "IndicatorLED": "Off",
+  "LogServices": {
+    "@odata.id": "/redfish/v1/Systems/1/LogServices/"
+  },
+  "Manufacturer": "HPE",
+  "Memory": {
+    "@odata.id": "/redfish/v1/Systems/1/Memory/"
+  },
+  "MemoryDomains": {
+    "@odata.id": "/redfish/v1/Systems/1/MemoryDomains/"
+  },
+  "MemorySummary": {
+    "Status": {
+      "HealthRollup": "OK"
+    },
+    "TotalSystemMemoryGiB": 384,
+    "TotalSystemPersistentMemoryGiB": 0
+  },
+  "Model": "ProLiant DL360 Gen10",
+  "Name": "Computer System",
+  "NetworkInterfaces": {
+    "@odata.id": "/redfish/v1/Systems/1/NetworkInterfaces/"
+  },
+  "Oem": {
+    "Hpe": {
+      "@odata.context": "/redfish/v1/$metadata#HpeComputerSystemExt.HpeComputerSystemExt",
+      "@odata.type": "#HpeComputerSystemExt.v2_6_1.HpeComputerSystemExt",
+      "Actions": {
+        "#HpeComputerSystemExt.PowerButton": {
+          "PushType@Redfish.AllowableValues": [
+            "Press",
+            "PressAndHold"
+          ],
+          "target": "/redfish/v1/Systems/1/Actions/Oem/Hpe/HpeComputerSystemExt.PowerButton/"
+        },
+        "#HpeComputerSystemExt.SecureSystemErase": {
+          "target": "/redfish/v1/Systems/1/Actions/Oem/Hpe/HpeComputerSystemExt.SecureSystemErase/"
+        },
+        "#HpeComputerSystemExt.SystemReset": {
+          "ResetType@Redfish.AllowableValues": [
+            "ColdBoot",
+            "AuxCycle"
+          ],
+          "target": "/redfish/v1/Systems/1/Actions/Oem/Hpe/HpeComputerSystemExt.SystemReset/"
+        }
+      },
+      "AggregateHealthStatus": {
+        "AgentlessManagementService": "Unavailable",
+        "BiosOrHardwareHealth": {
+          "Status": {
+            "Health": "OK"
+          }
+        },
+        "FanRedundancy": "Redundant",
+        "Fans": {
+          "Status": {
+            "Health": "OK"
+          }
+        },
+        "Memory": {
+          "Status": {
+            "Health": "OK"
+          }
+        },
+        "Network": {
+          "Status": {
+            "Health": "OK"
+          }
+        },
+        "PowerSupplies": {
+          "PowerSuppliesMismatch": false,
+          "Status": {
+            "Health": "OK"
+          }
+        },
+        "PowerSupplyRedundancy": "Redundant",
+        "Processors": {
+          "Status": {
+            "Health": "OK"
+          }
+        },
+        "SmartStorageBattery": {
+          "Status": {
+            "Health": "OK"
+          }
+        },
+        "Storage": {
+          "Status": {
+            "Health": "OK"
+          }
+        },
+        "Temperatures": {
+          "Status": {
+            "Health": "OK"
+          }
+        }
+      },
+      "Bios": {
+        "Backup": {
+          "Date": "05/21/2019",
+          "Family": "U32",
+          "VersionString": "U32 v2.10 (05/21/2019)"
+        },
+        "Current": {
+          "Date": "05/21/2019",
+          "Family": "U32",
+          "VersionString": "U32 v2.10 (05/21/2019)"
+        },
+        "UefiClass": 2
+      },
+      "CurrentPowerOnTimeSeconds": 29290,
+      "DeviceDiscoveryComplete": {
+        "AMSDeviceDiscovery": "NoAMS",
+        "DeviceDiscovery": "vMainDeviceDiscoveryComplete",
+        "SmartArrayDiscovery": "Complete"
+      },
+      "ElapsedEraseTimeInMinutes": 0,
+      "EndOfPostDelaySeconds": null,
+      "EstimatedEraseTimeInMinutes": 0,
+      "IntelligentProvisioningAlwaysOn": true,
+      "IntelligentProvisioningIndex": 9,
+      "IntelligentProvisioningLocation": "System Board",
+      "IntelligentProvisioningVersion": "3.30.213",
+      "IsColdBooting": false,
+      "Links": {
+        "PCIDevices": {
+          "@odata.id": "/redfish/v1/Systems/1/PCIDevices/"
+        },
+        "PCISlots": {
+          "@odata.id": "/redfish/v1/Systems/1/PCISlots/"
+        },
+        "NetworkAdapters": {
+          "@odata.id": "/redfish/v1/Systems/1/BaseNetworkAdapters/"
+        },
+        "SmartStorage": {
+          "@odata.id": "/redfish/v1/Systems/1/SmartStorage/"
+        },
+        "USBPorts": {
+          "@odata.id": "/redfish/v1/Systems/1/USBPorts/"
+        },
+        "USBDevices": {
+          "@odata.id": "/redfish/v1/Systems/1/USBDevices/"
+        },
+        "EthernetInterfaces": {
+          "@odata.id": "/redfish/v1/Systems/1/EthernetInterfaces/"
+        },
+        "WorkloadPerformanceAdvisor": {
+          "@odata.id": "/redfish/v1/Systems/1/WorkloadPerformanceAdvisor/"
+        }
+      },
+      "PCAPartNumber": "847479-002",
+      "PCASerialNumber": "PWUFL0ARHCF3KR",
+      "PostDiscoveryCompleteTimeStamp": "2020-02-24T02:43:43Z",
+      "PostDiscoveryMode": null,
+      "PostMode": null,
+      "PostState": "FinishedPost",
+      "PowerAllocationLimit": 1600,
+      "PowerAutoOn": "Restore",
+      "PowerOnDelay": "Minimum",
+      "PowerOnMinutes": 95715,
+      "PowerRegulatorMode": "Max",
+      "PowerRegulatorModesSupported": [
+        "OSControl",
+        "Dynamic",
+        "Max",
+        "Min"
+      ],
+      "ProcessorJitterControl": {
+        "ConfiguredFrequencyLimitMHz": 0,
+        "Mode": "Disabled"
+      },
+      "SMBIOS": {
+        "extref": "/smbios"
+      },
+      "ServerFQDN": "TPAVCPAR088S4.vici.verizon.com",
+      "SmartStorageConfig": [
+        {
+          "@odata.id": "/redfish/v1/systems/1/smartstorageconfig/"
+        }
+      ],
+      "SystemROMAndiLOEraseComponentStatus": {
+        "BIOSSettingsEraseStatus": "Idle",
+        "iLOSettingsEraseStatus": "Idle"
+      },
+      "SystemROMAndiLOEraseStatus": "Idle",
+      "SystemUsage": {
+        "AvgCPU0Freq": 0,
+        "AvgCPU1Freq": 6,
+        "CPU0Power": 50,
+        "CPU1Power": 51,
+        "CPUICUtil": 0,
+        "CPUUtil": 0,
+        "IOBusUtil": 0,
+        "JitterCount": 35,
+        "MemoryBusUtil": 0
+      },
+      "UserDataEraseComponentStatus": {},
+      "UserDataEraseStatus": "Idle",
+      "VirtualProfile": "Inactive"
+    }
+  },
+  "PowerState": "On",
+  "ProcessorSummary": {
+    "Count": 2,
+    "Model": "Intel(R) Xeon(R) Gold 6148 CPU @ 2.40GHz",
+    "Status": {
+      "HealthRollup": "OK"
+    }
+  },
+  "Processors": {
+    "@odata.id": "/redfish/v1/Systems/1/Processors/"
+  },
+  "SKU": "867959-B21",
+  "SecureBoot": {
+    "@odata.id": "/redfish/v1/Systems/1/SecureBoot/"
+  },
+  "SerialNumber": "MXQ93003RB",
+  "Status": {
+    "Health": "OK",
+    "State": "Enabled"
+  },
+  "Storage": {
+    "@odata.id": "/redfish/v1/Systems/1/Storage/"
+  },
+  "SystemType": "Physical",
+  "TrustedModules": [
+    {
+      "FirmwareVersion": "73.0",
+      "InterfaceType": "TPM1_2",
+      "Oem": {
+        "Hpe": {
+          "@odata.context": "/redfish/v1/$metadata#HpeTrustedModuleExt.HpeTrustedModuleExt",
+          "@odata.type": "#HpeTrustedModuleExt.v2_0_0.HpeTrustedModuleExt",
+          "VendorName": "STMicro"
+        }
+      },
+      "Status": {
+        "State": "Disabled"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
In preparation of the upcoming refactor there are some more test cases that require adaption.

1. 1664a04: dell_chassisinvalid.json has the trailing bracket moved to the front. This was missed in #19163
2. edad556: TestInvalidHPJSON requires data at _/redfish/v1/_ and _/redfish/v1/Systems_
3. 22edafb: The _/redfish/v1/_ endpoint requires no auth
4. b6323de: Extend the test from @skartikey in #19333 with testdata and a negative test. As gofish has a different path traversal.
This will also be relevant for _TestSkipChassisWithoutThermalAndPowerReference_ but requires a bigger change of the test. I'll spin up a quick separate PR when i get around to it.
5. 4088468: To make testing for unauthenticated more flexible we shouldn't test the entire error message but just the path and the status code. As the same error path could be used for other errors too like 404 not found.
6. e8fa59a4: _getComputerSystem()_ resolves to "/redfish/v1/Systems/_SystemID_. The SystemID is from the configuration. Since gofish does link traversal down from /redfish/v1/ -> /redfish/v1/Systems/ -> /redfish/v1/Systems/SomeSystemID we can only filter out if a system present matches the configured ID. So __gofish forces a consistent ID over every path it query's.__ _TestInvalidHPJSON_ uses an inconsistent ID over its Tests.

## Checklist
- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy