### PR TITLE
feat(packaging): Use signed binary in MacOS tar archives

### DIFF
--- a/scripts/mac-signing.sh
+++ b/scripts/mac-signing.sh
@@ -82,8 +82,8 @@ sudo security import MacCertificate.p12 -k /Library/Keychains/System.keychain -P
 base64 -D -o AppleSigningAuthorityCertificate.cer <<< "$AppleSigningAuthorityCertificate"
 sudo security import AppleSigningAuthorityCertificate.cer -k '/Library/Keychains/System.keychain' -A
 
-amdFile=$(find "$HOME/project/dist" -name "*darwin_amd64.tar*")
-armFile=$(find "$HOME/project/dist" -name "*darwin_arm64.tar*")
+amdFile=$(find "$HOME/project/dist" -name "telegraf-*darwin_amd64.tar.gz")
+armFile=$(find "$HOME/project/dist" -name "telegraf-*darwin_arm64.tar.gz")
 macFiles=("${amdFile}" "${armFile}")
 
 version=$(make version)
@@ -136,4 +136,15 @@ do
   mv "$baseName".dmg ~/project/build/dist
 
   echo "$baseName.dmg signed and notarized!"
+
+  # Replace the telegraf binary with the signed version in the tar archive
+  versionDir=$(basename "${tarFile}")
+  versionDir=${versionDir/_*}
+  mkdir -p "$RootAppDir/Extracted"
+  tar -xzvf "$tarFile" -C "$RootAppDir/Extracted"
+  cp "${TelegrafBinPath}" "$RootAppDir/Extracted/${versionDir}/usr/bin/telegraf"
+  tar -czvf "$tarFile" -C "$RootAppDir/Extracted" ${versionDir}
+
+  echo "Replaced tar binary with signed version!"
+
 done

--- a/scripts/mac-signing.sh
+++ b/scripts/mac-signing.sh
@@ -113,6 +113,18 @@ do
 
   printf "\n"
 
+  # Replace the telegraf binary with the signed version in the tar archive
+  versionDir=$(basename "${tarFile}")
+  versionDir=${versionDir/_*}
+  mkdir -p "TarRepackage"
+  tar -xzvf "${tarFile}" -C "TarRepackage"
+  cp "${TelegrafBinPath}" "TarRepackage/${versionDir}/usr/bin/telegraf"
+  tar  --owner 0 --group 0 -czvf "${tarFile}" -C "TarRepackage" "${versionDir}"
+  mkdir -p ~/project/build/dist
+  cp "${tarFile}" "~/project/build/dist"
+
+  echo "Replaced tar binary with signed version!"
+
   cp ~/project/scripts/telegraf_entry_mac "$RootAppDir"/MacOS
   cp ~/project/Info.plist "$RootAppDir"
   cp  ~/project/assets/windows/icon.icns "$RootAppDir/Resources"
@@ -136,15 +148,4 @@ do
   mv "$baseName".dmg ~/project/build/dist
 
   echo "$baseName.dmg signed and notarized!"
-
-  # Replace the telegraf binary with the signed version in the tar archive
-  versionDir=$(basename "${tarFile}")
-  versionDir=${versionDir/_*}
-  mkdir -p "$RootAppDir/Extracted"
-  tar -xzvf "${tarFile}" -C "$RootAppDir/Extracted"
-  cp "${TelegrafBinPath}" "$RootAppDir/Extracted/${versionDir}/usr/bin/telegraf"
-  tar -czvf "${tarFile}" -C "$RootAppDir/Extracted" "${versionDir}"
-
-  echo "Replaced tar binary with signed version!"
-
 done

--- a/scripts/mac-signing.sh
+++ b/scripts/mac-signing.sh
@@ -120,8 +120,8 @@ do
   tar -xzvf "${tarFile}" -C "TarRepackage"
   cp "${TelegrafBinPath}" "TarRepackage/${versionDir}/usr/bin/telegraf"
   tar  --owner 0 --group 0 -czvf "${tarFile}" -C "TarRepackage" "${versionDir}"
-  mkdir -p ~/project/build/dist
-  cp "${tarFile}" "~/project/build/dist"
+  mkdir -p "${HOME}/project/build/dist"
+  cp "${tarFile}" "${HOME}/project/build/dist"
 
   echo "Replaced tar binary with signed version!"
 

--- a/scripts/mac-signing.sh
+++ b/scripts/mac-signing.sh
@@ -141,9 +141,9 @@ do
   versionDir=$(basename "${tarFile}")
   versionDir=${versionDir/_*}
   mkdir -p "$RootAppDir/Extracted"
-  tar -xzvf "$tarFile" -C "$RootAppDir/Extracted"
+  tar -xzvf "${tarFile}" -C "$RootAppDir/Extracted"
   cp "${TelegrafBinPath}" "$RootAppDir/Extracted/${versionDir}/usr/bin/telegraf"
-  tar -czvf "$tarFile" -C "$RootAppDir/Extracted" ${versionDir}
+  tar -czvf "${tarFile}" -C "$RootAppDir/Extracted" "${versionDir}"
 
   echo "Replaced tar binary with signed version!"
 


### PR DESCRIPTION
## Summary

This PR replaces the telegraf binary in the tar archives of MacOS with the signed version.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

resolves #19490 
