### PR TITLE
feat(inputs.influxdb_v3_listener): Add listener for the InfluxDB 3 write API

### DIFF
--- a/plugins/inputs/all/influxdb_v3_listener.go
+++ b/plugins/inputs/all/influxdb_v3_listener.go
@@ -1,0 +1,5 @@
+//go:build !custom || inputs || inputs.influxdb_v3_listener
+
+package all
+
+import _ "github.com/influxdata/telegraf/plugins/inputs/influxdb_v3_listener" // register plugin

--- a/plugins/inputs/influxdb_v3_listener/README.md
+++ b/plugins/inputs/influxdb_v3_listener/README.md
@@ -110,6 +110,9 @@ If a `token` is configured, writes have to carry it in the `Authorization`
 header as `Bearer <token>`, `Token <token>` or as the password part of a
 `Basic` credential. The health and ping endpoints are always unauthenticated.
 
+Any other path, and any of the endpoints above requested with a method that is
+not listed for it, is answered with HTTP status 404 as InfluxDB does.
+
 ### Write parameters
 
 The `/api/v3/write_lp` endpoint accepts the query parameters of the InfluxDB 3
@@ -174,8 +177,13 @@ following points:
 - Database names are only required to be non-empty, the character and length
   restrictions of InfluxDB are not enforced.
 - The query, catalog and processing engine endpoints are not served, a request
-  to any of them is answered with HTTP status 404. Requesting a served endpoint
-  with the wrong method gives HTTP status 405 rather than 404.
+  to any of them is answered with HTTP status 404.
+- The health and ping endpoints are unauthenticated, matching the other
+  Telegraf listeners. InfluxDB requires a token for them unless it is started
+  with authorization disabled for those paths.
+- Cross-origin requests are not handled. InfluxDB answers an `OPTIONS`
+  preflight with a permissive set of CORS headers before authenticating, this
+  plugin treats it like any other unknown request.
 - Writes without a timestamp are stamped with the current time in nanosecond
   precision. InfluxDB truncates that time to the requested precision.
 - The health endpoint reports HTTP status 503 once `max_undelivered_metrics`

--- a/plugins/inputs/influxdb_v3_listener/README.md
+++ b/plugins/inputs/influxdb_v3_listener/README.md
@@ -1,0 +1,200 @@
+# InfluxDB V3 Listener Input Plugin
+
+This plugin listens for requests sent according to the [InfluxDB 3 HTTP API][api]
+and allows Telegraf to serve as a proxy or router for the `/api/v3/write_lp`
+endpoint.
+
+Line protocol received on that endpoint is parsed and passed on to the
+configured outputs. Writes to the InfluxDB 1.x `/write` and InfluxDB 2.x
+`/api/v2/write` endpoints are handled by the
+[influxdb_listener][influxdb_listener] and
+[influxdb_v2_listener][influxdb_v2_listener] plugins respectively.
+
+⭐ Telegraf v1.40.0
+🏷️ datastore
+💻 all
+
+[api]: https://docs.influxdata.com/influxdb3/core/api/
+[influxdb_listener]: ../influxdb_listener/README.md
+[influxdb_v2_listener]: ../influxdb_v2_listener/README.md
+
+## Service Input <!-- @/docs/includes/service_input.md -->
+
+This plugin is a service input. Normal plugins gather metrics determined by the
+interval setting. Service plugins start a service to listen and wait for
+metrics or events to occur. Service plugins have two key differences from
+normal plugins:
+
+1. The global or plugin specific `interval` setting may not apply
+2. The CLI options of `--test`, `--test-wait`, and `--once` may not produce
+   output for this plugin
+
+## Tracking metric support <!-- @/docs/includes/plugin_tracking_metrics.md -->
+
+This plugin supports [tracking metrics][METRICS.md], which allows the plugin
+to be notified when metrics have been delivered to all outputs, enabling proper
+acknowledgment back to the source.
+
+[METRICS.md]: ../../../docs/METRICS.md#tracking-metrics
+
+## Global configuration options <!-- @/docs/includes/plugin_config.md -->
+
+Plugins support additional global and plugin configuration settings for tasks
+such as modifying metrics, tags, and fields, creating aliases, and configuring
+plugin ordering. See [CONFIGURATION.md][CONFIGURATION.md] for more details.
+
+[CONFIGURATION.md]: ../../../docs/CONFIGURATION.md#plugins
+
+## Secret store support
+
+This plugin supports secrets from secret stores for the `token` option.
+See the [secret store documentation][SECRETSTORE] for more details on how
+to use them.
+
+[SECRETSTORE]: ../../../docs/CONFIGURATION.md#secret-store-secrets
+
+## Configuration
+
+```toml @sample.conf
+# Accept metrics over the InfluxDB 3 HTTP API
+[[inputs.influxdb_v3_listener]]
+  ## Address and port to host the listener on
+  service_address = ":8181"
+
+  ## Maximum undelivered metrics before rate limit kicks in.
+  ## When the rate limit kicks in, HTTP status 429 will be returned.
+  ## 0 disables rate limiting
+  # max_undelivered_metrics = 0
+
+  ## Maximum duration before timing out read of the request
+  # read_timeout = "10s"
+  ## Maximum duration before timing out write of the response
+  # write_timeout = "10s"
+
+  ## Maximum allowed HTTP request body size in bytes.
+  ## 0 means to use the default of 32MiB.
+  # max_body_size = "32MiB"
+
+  ## Optional tag to store the database of the write in.
+  ## The default of an empty string will not record the database.
+  # database_tag = ""
+
+  ## Set one or more allowed client CA certificate file names to
+  ## enable mutually authenticated TLS connections
+  # tls_allowed_cacerts = ["/etc/telegraf/clientca.pem"]
+
+  ## Add service certificate and key
+  # tls_cert = "/etc/telegraf/cert.pem"
+  # tls_key = "/etc/telegraf/key.pem"
+
+  ## Optional token to accept for HTTP authentication.
+  ## You probably want to make sure you have TLS configured above for this.
+  # token = "some-long-shared-secret-token"
+
+  ## Influx line protocol parser
+  ## 'internal' is the default. 'upstream' is a newer parser that is faster
+  ## and more memory efficient.
+  # parser_type = "internal"
+```
+
+## Endpoints
+
+| endpoint            | method     | description                        |
+|---------------------|------------|------------------------------------|
+| `/api/v3/write_lp`  | POST       | write line protocol                |
+| `/health`           | GET        | health of the listener             |
+| `/api/v1/health`    | GET        | health of the listener             |
+| `/ping`             | GET, POST  | version information                |
+
+If a `token` is configured, writes have to carry it in the `Authorization`
+header as `Bearer <token>`, `Token <token>` or as the password part of a
+`Basic` credential. The health and ping endpoints are always unauthenticated.
+
+### Write parameters
+
+The `/api/v3/write_lp` endpoint accepts the query parameters of the InfluxDB 3
+write API:
+
+| parameter        | default | description                                    |
+|------------------|---------|------------------------------------------------|
+| `db`             |         | database of the write, required                |
+| `precision`      | `auto`  | timestamp precision of the line protocol       |
+| `accept_partial` | `true`  | write the valid lines of a rejected batch      |
+| `no_sync`        | `false` | do not wait for the write-ahead log            |
+
+The `precision` parameter accepts `auto`, `second`, `millisecond`,
+`microsecond` and `nanosecond` as well as the `s`, `ms`, `us`, `u`, `ns` and `n`
+abbreviations. With `auto` the unit of each timestamp is determined by its
+magnitude, the same way InfluxDB does it.
+
+With `accept_partial` enabled, which is the default, the lines that do parse are
+written and the request is answered with HTTP status 400 and the list of the
+lines that did not
+
+```json
+{
+  "error": "partial write of line protocol occurred",
+  "data": [
+    {
+      "original_line": "cpu,host=b value=+Inf",
+      "line_number": 2,
+      "error_message": "metric parse error: expected field at 2:22"
+    }
+  ]
+}
+```
+
+Disabling it rejects the whole batch on the first invalid line, writing nothing
+at all and reporting only that line
+
+```json
+{
+  "error": "line protocol parsing error",
+  "data": {
+    "original_line": "cpu,host=b value=+Inf",
+    "line_number": 2,
+    "error_message": "metric parse error: expected field at 2:22"
+  }
+}
+```
+
+## Deviations from the InfluxDB 3 API
+
+This plugin implements the write API of InfluxDB 3, not InfluxDB 3 itself.
+There is no catalog, no schema and no storage behind it, so it differs in the
+following points:
+
+- The `no_sync` parameter is accepted and ignored, as there is no write-ahead
+  log to acknowledge.
+- Writes are only rejected for line protocol parse errors. InfluxDB also
+  rejects lines on schema conflicts, column limits and retention periods, none
+  of which exist here, so those `error_message` values never occur. The
+  messages of the parse errors are the ones of the Telegraf parser and do not
+  match the InfluxDB wording either.
+- Database names are only required to be non-empty, the character and length
+  restrictions of InfluxDB are not enforced.
+- The query, catalog and processing engine endpoints are not served, a request
+  to any of them is answered with HTTP status 404. Requesting a served endpoint
+  with the wrong method gives HTTP status 405 rather than 404.
+- Writes without a timestamp are stamped with the current time in nanosecond
+  precision. InfluxDB truncates that time to the requested precision.
+- The health endpoint reports HTTP status 503 once `max_undelivered_metrics`
+  pending metrics have not been delivered to the outputs yet.
+
+## Metrics
+
+Metrics are created from InfluxDB Line Protocol in the request body.
+
+## Example Output
+
+Using
+
+```sh
+curl -i -XPOST 'http://localhost:8181/api/v3/write_lp?db=mydb' --data-binary 'cpu_load_short,host=server01,region=us-west value=0.64 1434055562000000000'
+```
+
+will produce the following metric
+
+```text
+cpu_load_short,host=server01,region=us-west value=0.64 1434055562000000000
+```

--- a/plugins/inputs/influxdb_v3_listener/influxdb_v3_listener.go
+++ b/plugins/inputs/influxdb_v3_listener/influxdb_v3_listener.go
@@ -425,25 +425,27 @@ func (h *InfluxDBV3Listener) handleWrite() http.HandlerFunc {
 }
 
 // readBody returns the request body, limited to the maximum body size and
-// decompressed if the client sent it compressed. The limit is applied to the
-// decompressed data, as a compressed body of a few megabytes can otherwise
-// expand to an arbitrary amount of memory.
+// decompressed if the client sent it compressed. A compressed body is limited
+// on both ends, as InfluxDB does: the compressed size bounds how much of an
+// endless stream is read, the decompressed size keeps a small body from
+// expanding to an arbitrary amount of memory.
 func (h *InfluxDBV3Listener) readBody(res http.ResponseWriter, req *http.Request) ([]byte, error) {
+	body := http.MaxBytesReader(res, req.Body, int64(h.MaxBodySize))
 	if req.Header.Get("Content-Encoding") == "gzip" {
-		reader, err := gzip.NewReader(req.Body)
+		reader, err := gzip.NewReader(body)
 		if err != nil {
 			return nil, fmt.Errorf("decompressing request body failed: %w", err)
 		}
 		defer reader.Close()
 
-		body, err := io.ReadAll(http.MaxBytesReader(res, reader, int64(h.MaxBodySize)))
+		decompressed, err := io.ReadAll(http.MaxBytesReader(res, reader, int64(h.MaxBodySize)))
 		if err != nil {
 			return nil, fmt.Errorf("reading decompressed request body failed: %w", err)
 		}
-		return body, nil
+		return decompressed, nil
 	}
 
-	return io.ReadAll(http.MaxBytesReader(res, req.Body, int64(h.MaxBodySize)))
+	return io.ReadAll(body)
 }
 
 func (h *InfluxDBV3Listener) newParser(r io.Reader, precision time.Duration) (streamParser, error) {

--- a/plugins/inputs/influxdb_v3_listener/influxdb_v3_listener.go
+++ b/plugins/inputs/influxdb_v3_listener/influxdb_v3_listener.go
@@ -68,6 +68,7 @@ type InfluxDBV3Listener struct {
 	countLock               sync.Mutex
 	totalUndeliveredMetrics atomic.Int64
 
+	tlsConf   *tls.Config
 	listener  net.Listener
 	server    http.Server
 	mux       http.ServeMux
@@ -94,6 +95,12 @@ func (h *InfluxDBV3Listener) Init() error {
 	default:
 		return fmt.Errorf("invalid parser type %q", h.ParserType)
 	}
+
+	tlsConf, err := h.ServerConfig.TLSConfig()
+	if err != nil {
+		return fmt.Errorf("creating TLS config failed: %w", err)
+	}
+	h.tlsConf = tlsConf
 
 	tags := map[string]string{"address": h.ServiceAddress}
 	h.bytesRecv = h.Statistics.Register("influxdb_v3_listener", "bytes_received", tags)
@@ -151,21 +158,17 @@ func (h *InfluxDBV3Listener) Start(acc telegraf.Accumulator) error {
 		}()
 	}
 
-	tlsConf, err := h.ServerConfig.TLSConfig()
-	if err != nil {
-		return err
-	}
-
 	h.server = http.Server{
 		Addr:         h.ServiceAddress,
 		Handler:      h,
-		TLSConfig:    tlsConf,
+		TLSConfig:    h.tlsConf,
 		ReadTimeout:  time.Duration(h.ReadTimeout),
 		WriteTimeout: time.Duration(h.WriteTimeout),
 	}
 
-	if tlsConf != nil {
-		h.listener, err = tls.Listen("tcp", h.ServiceAddress, tlsConf)
+	var err error
+	if h.tlsConf != nil {
+		h.listener, err = tls.Listen("tcp", h.ServiceAddress, h.tlsConf)
 	} else {
 		h.listener, err = net.Listen("tcp", h.ServiceAddress)
 	}
@@ -422,20 +425,25 @@ func (h *InfluxDBV3Listener) handleWrite() http.HandlerFunc {
 }
 
 // readBody returns the request body, limited to the maximum body size and
-// decompressed if the client sent it compressed.
+// decompressed if the client sent it compressed. The limit is applied to the
+// decompressed data, as a compressed body of a few megabytes can otherwise
+// expand to an arbitrary amount of memory.
 func (h *InfluxDBV3Listener) readBody(res http.ResponseWriter, req *http.Request) ([]byte, error) {
-	body := http.MaxBytesReader(res, req.Body, int64(h.MaxBodySize))
 	if req.Header.Get("Content-Encoding") == "gzip" {
-		reader, err := gzip.NewReader(body)
+		reader, err := gzip.NewReader(req.Body)
 		if err != nil {
 			return nil, fmt.Errorf("decompressing request body failed: %w", err)
 		}
 		defer reader.Close()
 
-		return io.ReadAll(reader)
+		body, err := io.ReadAll(http.MaxBytesReader(res, reader, int64(h.MaxBodySize)))
+		if err != nil {
+			return nil, fmt.Errorf("reading decompressed request body failed: %w", err)
+		}
+		return body, nil
 	}
 
-	return io.ReadAll(body)
+	return io.ReadAll(http.MaxBytesReader(res, req.Body, int64(h.MaxBodySize)))
 }
 
 func (h *InfluxDBV3Listener) newParser(r io.Reader, precision time.Duration) (streamParser, error) {
@@ -547,6 +555,7 @@ type lineError struct {
 // requestToken extracts the token from an authorization header using one of the
 // schemes InfluxDB 3 supports.
 func requestToken(header string) ([]byte, error) {
+	// InfluxDB splits the header on spaces and requires exactly two parts
 	scheme, credentials, found := strings.Cut(header, " ")
 	if !found || strings.Contains(credentials, " ") {
 		return nil, errors.New("authorization header is not in the form of 'Authorization: <auth-scheme> <token>'")
@@ -560,7 +569,9 @@ func requestToken(header string) ([]byte, error) {
 		if err != nil {
 			return nil, fmt.Errorf("decoding basic credentials failed: %w", err)
 		}
-		// The token is the password part, the username is ignored
+		// The token is the password part, the username is ignored. InfluxDB
+		// splits at the last colon and rejects a username containing one, so
+		// credentials with more than one colon are rejected either way.
 		_, token, found := strings.Cut(string(decoded), ":")
 		if !found || strings.Contains(token, ":") {
 			return nil, errors.New("basic credentials are not in the form of '<username>:<token>'")

--- a/plugins/inputs/influxdb_v3_listener/influxdb_v3_listener.go
+++ b/plugins/inputs/influxdb_v3_listener/influxdb_v3_listener.go
@@ -1,0 +1,664 @@
+//go:generate ../../../tools/readme_config_includer/generator
+package influxdb_v3_listener
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/subtle"
+	"crypto/tls"
+	_ "embed"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/gofrs/uuid/v5"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/config"
+	"github.com/influxdata/telegraf/internal"
+	common_tls "github.com/influxdata/telegraf/plugins/common/tls"
+	"github.com/influxdata/telegraf/plugins/inputs"
+	"github.com/influxdata/telegraf/plugins/parsers/influx"
+	"github.com/influxdata/telegraf/plugins/parsers/influx/influx_upstream"
+	"github.com/influxdata/telegraf/selfstat"
+)
+
+//go:embed sample.conf
+var sampleConfig string
+
+const (
+	// defaultMaxBodySize is the default maximum request body size, in bytes.
+	// If the request body is over this size, we will return an HTTP 413 error.
+	defaultMaxBodySize  = 32 * 1024 * 1024
+	defaultReadTimeout  = 10 * time.Second
+	defaultWriteTimeout = 10 * time.Second
+)
+
+type InfluxDBV3Listener struct {
+	ServiceAddress        string          `toml:"service_address"`
+	MaxUndeliveredMetrics int             `toml:"max_undelivered_metrics"`
+	ReadTimeout           config.Duration `toml:"read_timeout"`
+	WriteTimeout          config.Duration `toml:"write_timeout"`
+	MaxBodySize           config.Size     `toml:"max_body_size"`
+	Token                 config.Secret   `toml:"token"`
+	DatabaseTag           string          `toml:"database_tag"`
+	ParserType            string          `toml:"parser_type"`
+	common_tls.ServerConfig
+
+	Statistics *selfstat.Collector `toml:"-"`
+	Log        telegraf.Logger     `toml:"-"`
+
+	acc         telegraf.Accumulator
+	trackingAcc telegraf.TrackingAccumulator
+
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	trackingMetricCount     map[telegraf.TrackingID]int64
+	countLock               sync.Mutex
+	totalUndeliveredMetrics atomic.Int64
+
+	listener  net.Listener
+	server    http.Server
+	mux       http.ServeMux
+	processID string
+	timeFunc  func() time.Time
+
+	bytesRecv       selfstat.Stat
+	requestsRecv    selfstat.Stat
+	requestsServed  selfstat.Stat
+	writesServed    selfstat.Stat
+	healthsServed   selfstat.Stat
+	pingsServed     selfstat.Stat
+	notFoundsServed selfstat.Stat
+	authFailures    selfstat.Stat
+}
+
+func (*InfluxDBV3Listener) SampleConfig() string {
+	return sampleConfig
+}
+
+func (h *InfluxDBV3Listener) Init() error {
+	switch h.ParserType {
+	case "", "internal", "upstream":
+	default:
+		return fmt.Errorf("invalid parser type %q", h.ParserType)
+	}
+
+	tags := map[string]string{"address": h.ServiceAddress}
+	h.bytesRecv = h.Statistics.Register("influxdb_v3_listener", "bytes_received", tags)
+	h.requestsRecv = h.Statistics.Register("influxdb_v3_listener", "requests_received", tags)
+	h.requestsServed = h.Statistics.Register("influxdb_v3_listener", "requests_served", tags)
+	h.writesServed = h.Statistics.Register("influxdb_v3_listener", "writes_served", tags)
+	h.healthsServed = h.Statistics.Register("influxdb_v3_listener", "healths_served", tags)
+	h.pingsServed = h.Statistics.Register("influxdb_v3_listener", "pings_served", tags)
+	h.notFoundsServed = h.Statistics.Register("influxdb_v3_listener", "not_founds_served", tags)
+	h.authFailures = h.Statistics.Register("influxdb_v3_listener", "auth_failures", tags)
+
+	if h.MaxBodySize == 0 {
+		h.MaxBodySize = config.Size(defaultMaxBodySize)
+	}
+	if h.ReadTimeout < config.Duration(time.Second) {
+		h.ReadTimeout = config.Duration(defaultReadTimeout)
+	}
+	if h.WriteTimeout < config.Duration(time.Second) {
+		h.WriteTimeout = config.Duration(defaultWriteTimeout)
+	}
+
+	processID, err := uuid.NewV4()
+	if err != nil {
+		return fmt.Errorf("generating process identifier failed: %w", err)
+	}
+	h.processID = processID.String()
+
+	return h.routes()
+}
+
+func (*InfluxDBV3Listener) Gather(telegraf.Accumulator) error {
+	return nil
+}
+
+func (h *InfluxDBV3Listener) Start(acc telegraf.Accumulator) error {
+	h.acc = acc
+	h.ctx, h.cancel = context.WithCancel(context.Background())
+	if h.MaxUndeliveredMetrics > 0 {
+		h.trackingAcc = h.acc.WithTracking(h.MaxUndeliveredMetrics)
+		h.trackingMetricCount = make(map[telegraf.TrackingID]int64, h.MaxUndeliveredMetrics)
+		go func() {
+			for {
+				select {
+				case <-h.ctx.Done():
+					return
+				case info := <-h.trackingAcc.Delivered():
+					h.countLock.Lock()
+					if count, ok := h.trackingMetricCount[info.ID()]; ok {
+						h.totalUndeliveredMetrics.Add(-count)
+						delete(h.trackingMetricCount, info.ID())
+					}
+					h.countLock.Unlock()
+				}
+			}
+		}()
+	}
+
+	tlsConf, err := h.ServerConfig.TLSConfig()
+	if err != nil {
+		return err
+	}
+
+	h.server = http.Server{
+		Addr:         h.ServiceAddress,
+		Handler:      h,
+		TLSConfig:    tlsConf,
+		ReadTimeout:  time.Duration(h.ReadTimeout),
+		WriteTimeout: time.Duration(h.WriteTimeout),
+	}
+
+	if tlsConf != nil {
+		h.listener, err = tls.Listen("tcp", h.ServiceAddress, tlsConf)
+	} else {
+		h.listener, err = net.Listen("tcp", h.ServiceAddress)
+	}
+	if err != nil {
+		h.Stop()
+		return err
+	}
+
+	go func() {
+		if err := h.server.Serve(h.listener); !errors.Is(err, http.ErrServerClosed) {
+			h.Log.Errorf("Serving HTTP on %s failed: %v", h.ServiceAddress, err)
+		}
+	}()
+
+	h.Log.Infof("Started HTTP listener service on %s", h.ServiceAddress)
+
+	return nil
+}
+
+func (h *InfluxDBV3Listener) Stop() {
+	h.cancel()
+	if err := h.server.Shutdown(context.Background()); err != nil {
+		h.Log.Infof("Error shutting down HTTP server: %v", err)
+	}
+}
+
+func (h *InfluxDBV3Listener) ServeHTTP(res http.ResponseWriter, req *http.Request) {
+	h.requestsRecv.Incr(1)
+	h.mux.ServeHTTP(res, req)
+	h.requestsServed.Incr(1)
+}
+
+func (h *InfluxDBV3Listener) routes() error {
+	var token []byte
+	if !h.Token.Empty() {
+		secret, err := h.Token.Get()
+		if err != nil {
+			return fmt.Errorf("getting token failed: %w", err)
+		}
+		token = bytes.Clone(secret.Bytes())
+		secret.Destroy()
+	}
+	auth := h.authenticate(token)
+
+	h.mux.Handle("POST /api/v3/write_lp", auth(h.handleWrite()))
+	h.mux.Handle("GET /health", h.handleHealth())
+	h.mux.Handle("GET /api/v1/health", h.handleHealth())
+	h.mux.Handle("GET /ping", h.handlePing())
+	h.mux.Handle("POST /ping", h.handlePing())
+	h.mux.Handle("/", auth(h.handleDefault()))
+
+	return nil
+}
+
+// authenticate requires the configured token to be sent as one of the schemes
+// InfluxDB 3 accepts, i.e. "Bearer <token>", "Token <token>" or as the password
+// part of a "Basic" credential. It is a no-op if no token is configured.
+func (h *InfluxDBV3Listener) authenticate(token []byte) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+			if len(token) > 0 {
+				provided, err := requestToken(req.Header.Get("Authorization"))
+				if err != nil || subtle.ConstantTimeCompare(provided, token) != 1 {
+					h.authFailures.Incr(1)
+					http.Error(res, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
+					return
+				}
+			}
+			next.ServeHTTP(res, req)
+		})
+	}
+}
+
+func (h *InfluxDBV3Listener) handleHealth() http.HandlerFunc {
+	return func(res http.ResponseWriter, _ *http.Request) {
+		defer h.healthsServed.Incr(1)
+
+		res.Header().Set("Content-Type", "text/plain; charset=utf-8")
+
+		pending := h.totalUndeliveredMetrics.Load()
+		if h.MaxUndeliveredMetrics > 0 && pending >= int64(h.MaxUndeliveredMetrics) {
+			res.WriteHeader(http.StatusServiceUnavailable)
+			msg := fmt.Sprintf("pending undelivered metrics (%d) is above limit", pending)
+			if _, err := res.Write([]byte(msg)); err != nil {
+				h.Log.Debugf("Writing health response failed: %v", err)
+			}
+			return
+		}
+
+		res.WriteHeader(http.StatusOK)
+		if _, err := res.Write([]byte("OK")); err != nil {
+			h.Log.Debugf("Writing health response failed: %v", err)
+		}
+	}
+}
+
+func (h *InfluxDBV3Listener) handlePing() http.HandlerFunc {
+	return func(res http.ResponseWriter, _ *http.Request) {
+		defer h.pingsServed.Incr(1)
+
+		res.Header().Set("Content-Type", "application/json")
+		res.Header().Set("X-Influxdb-Build", "telegraf")
+		res.Header().Set("X-Influxdb-Version", internal.Version)
+		res.WriteHeader(http.StatusOK)
+
+		b, err := json.Marshal(map[string]string{
+			"product_name": "telegraf",
+			"version":      internal.Version,
+			"revision":     internal.Commit,
+			"process_id":   h.processID,
+		})
+		if err != nil {
+			h.Log.Debugf("Marshalling ping response failed: %v", err)
+			return
+		}
+		if _, err := res.Write(b); err != nil {
+			h.Log.Debugf("Writing ping response failed: %v", err)
+		}
+	}
+}
+
+func (h *InfluxDBV3Listener) handleDefault() http.HandlerFunc {
+	return func(res http.ResponseWriter, req *http.Request) {
+		defer h.notFoundsServed.Incr(1)
+		http.NotFound(res, req)
+	}
+}
+
+func (h *InfluxDBV3Listener) handleWrite() http.HandlerFunc {
+	return func(res http.ResponseWriter, req *http.Request) {
+		defer h.writesServed.Incr(1)
+
+		// Check that the content length is not too large for us to handle
+		if req.ContentLength > int64(h.MaxBodySize) {
+			h.tooLarge(res)
+			return
+		}
+
+		// InfluxDB requires the database, the remaining parameters are optional
+		if req.URL.RawQuery == "" {
+			h.badRequest(res, "missing query parameter 'db'")
+			return
+		}
+		query := req.URL.Query()
+		database := query.Get("db")
+		if database == "" {
+			h.badRequest(res, "db name cannot be empty")
+			return
+		}
+		precision, err := parsePrecision(query.Get("precision"))
+		if err != nil {
+			h.badRequest(res, err.Error())
+			return
+		}
+		acceptPartial, err := parseBool(query.Get("accept_partial"), true)
+		if err != nil {
+			h.badRequest(res, err.Error())
+			return
+		}
+		// The 'no_sync' parameter controls acknowledgement of the write-ahead
+		// log which does not exist here, so it is only validated
+		if _, err := parseBool(query.Get("no_sync"), false); err != nil {
+			h.badRequest(res, err.Error())
+			return
+		}
+
+		body, err := h.readBody(res, req)
+		if err != nil {
+			// Bodies sent without a content-length only exceed the limit while reading them
+			if maxBytes, ok := errors.AsType[*http.MaxBytesError](err); ok {
+				h.Log.Debugf("Rejecting write request: body exceeds the limit of %d bytes", maxBytes.Limit)
+				h.tooLarge(res)
+				return
+			}
+			h.badRequest(res, err.Error())
+			return
+		}
+		h.bytesRecv.Incr(int64(len(body)))
+
+		parser, err := h.newParser(bytes.NewReader(body), precision)
+		if err != nil {
+			h.Log.Errorf("Creating parser failed: %v", err)
+			http.Error(res, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
+		}
+
+		// Parse the body line by line, keeping the valid metrics and collecting
+		// the errors of the invalid lines. The original lines are only needed
+		// for reporting, so they are split off the body on the first error.
+		var metrics []telegraf.Metric
+		var invalid []lineError
+		var lines []string
+		for {
+			select {
+			case <-req.Context().Done():
+				// Shutting down before parsing is finished
+				res.WriteHeader(http.StatusServiceUnavailable)
+				return
+			default:
+			}
+
+			m, err := parser.Next()
+			if err != nil {
+				lineNumber, ok := parseErrorLine(err)
+				if !ok {
+					if !errors.Is(err, influx.EOF) && !errors.Is(err, io.EOF) {
+						h.badRequest(res, err.Error())
+						return
+					}
+					break
+				}
+
+				if lines == nil {
+					lines = strings.Split(string(body), "\n")
+				}
+				e := lineError{
+					OriginalLine: originalLine(lines, lineNumber),
+					LineNumber:   lineNumber,
+					ErrorMessage: err.Error(),
+				}
+				if !acceptPartial {
+					h.rejectedWrite(res, e)
+					return
+				}
+				invalid = append(invalid, e)
+				continue
+			}
+
+			if h.DatabaseTag != "" {
+				m.AddTag(h.DatabaseTag, database)
+			}
+			if precision == 0 {
+				m.SetTime(guessPrecision(m.Time()))
+			}
+			metrics = append(metrics, m)
+		}
+
+		if h.MaxUndeliveredMetrics > 0 {
+			if !h.writeWithTracking(res, metrics) {
+				return
+			}
+		} else {
+			for _, m := range metrics {
+				h.acc.AddMetric(m)
+			}
+		}
+
+		if len(invalid) > 0 {
+			h.partialWrite(res, invalid)
+			return
+		}
+		res.WriteHeader(http.StatusNoContent)
+	}
+}
+
+// readBody returns the request body, limited to the maximum body size and
+// decompressed if the client sent it compressed.
+func (h *InfluxDBV3Listener) readBody(res http.ResponseWriter, req *http.Request) ([]byte, error) {
+	body := http.MaxBytesReader(res, req.Body, int64(h.MaxBodySize))
+	if req.Header.Get("Content-Encoding") == "gzip" {
+		reader, err := gzip.NewReader(body)
+		if err != nil {
+			return nil, fmt.Errorf("decompressing request body failed: %w", err)
+		}
+		defer reader.Close()
+
+		return io.ReadAll(reader)
+	}
+
+	return io.ReadAll(body)
+}
+
+func (h *InfluxDBV3Listener) newParser(r io.Reader, precision time.Duration) (streamParser, error) {
+	if h.ParserType == "upstream" {
+		parser := influx_upstream.NewStreamParser(r)
+		parser.SetTimeFunc(influx_upstream.TimeFunc(h.timeFunc))
+		if precision > 0 {
+			if err := parser.SetTimePrecision(precision); err != nil {
+				return nil, fmt.Errorf("setting time precision failed: %w", err)
+			}
+		}
+		return parser, nil
+	}
+
+	parser := influx.NewStreamParser(r)
+	parser.SetTimeFunc(h.timeFunc)
+	if precision > 0 {
+		parser.SetTimePrecision(precision)
+	}
+	return parser, nil
+}
+
+// writeWithTracking delivers the metrics through the tracking accumulator and
+// reports whether they were accepted. The response is written by the caller if
+// and only if they were.
+func (h *InfluxDBV3Listener) writeWithTracking(res http.ResponseWriter, metrics []telegraf.Metric) bool {
+	if len(metrics) == 0 {
+		return true
+	}
+
+	if len(metrics) > h.MaxUndeliveredMetrics {
+		res.WriteHeader(http.StatusRequestEntityTooLarge)
+		h.Log.Debugf("status %d, always rejecting batch of %d metrics: larger than max_undelivered_metrics %d",
+			http.StatusRequestEntityTooLarge, len(metrics), h.MaxUndeliveredMetrics)
+		return false
+	}
+
+	remaining := int64(h.MaxUndeliveredMetrics) - h.totalUndeliveredMetrics.Load()
+	if int64(len(metrics)) > remaining {
+		res.WriteHeader(http.StatusTooManyRequests)
+		h.Log.Debugf("status %d, rejecting batch of %d metrics: larger than remaining undelivered metrics %d",
+			http.StatusTooManyRequests, len(metrics), remaining)
+		return false
+	}
+
+	h.countLock.Lock()
+	trackingID := h.trackingAcc.AddTrackingMetricGroup(metrics)
+	h.trackingMetricCount[trackingID] = int64(len(metrics))
+	h.totalUndeliveredMetrics.Add(int64(len(metrics)))
+	h.countLock.Unlock()
+
+	return true
+}
+
+func (h *InfluxDBV3Listener) partialWrite(res http.ResponseWriter, invalid []lineError) {
+	h.writeError(res, http.StatusBadRequest, "partial write of line protocol occurred", invalid)
+}
+
+func (h *InfluxDBV3Listener) rejectedWrite(res http.ResponseWriter, invalid lineError) {
+	h.writeError(res, http.StatusBadRequest, "line protocol parsing error", invalid)
+}
+
+func (h *InfluxDBV3Listener) writeError(res http.ResponseWriter, code int, msg string, data any) {
+	res.Header().Set("Content-Type", "application/json")
+	res.WriteHeader(code)
+
+	b, err := json.Marshal(errorMessage{Error: msg, Data: data})
+	if err != nil {
+		h.Log.Debugf("Marshalling error response failed: %v", err)
+		return
+	}
+	if _, err := res.Write(b); err != nil {
+		h.Log.Debugf("Writing error response failed: %v", err)
+	}
+}
+
+// badRequest reports a request that was rejected before any line protocol was
+// parsed. Those errors are plain text in InfluxDB, only write failures use JSON.
+func (h *InfluxDBV3Listener) badRequest(res http.ResponseWriter, msg string) {
+	h.Log.Debugf("Rejecting write request: %s", msg)
+	http.Error(res, msg, http.StatusBadRequest)
+}
+
+func (h *InfluxDBV3Listener) tooLarge(res http.ResponseWriter) {
+	res.Header().Set("X-Influxdb-Error", "http: request body too large")
+	msg := "the request body exceeded the maximum size of " + strconv.FormatInt(int64(h.MaxBodySize), 10) + " bytes"
+	http.Error(res, msg, http.StatusRequestEntityTooLarge)
+}
+
+// streamParser is the common part of the two line protocol stream parsers, both
+// of which can resume after a parse error to report the next line.
+type streamParser interface {
+	Next() (telegraf.Metric, error)
+}
+
+// errorMessage is the InfluxDB 3 error response. The data is a list of line
+// errors for a partial write and a single line error for a rejected one.
+type errorMessage struct {
+	Error string `json:"error"`
+	Data  any    `json:"data,omitempty"`
+}
+
+type lineError struct {
+	OriginalLine string `json:"original_line"`
+	LineNumber   int    `json:"line_number"`
+	ErrorMessage string `json:"error_message"`
+}
+
+// requestToken extracts the token from an authorization header using one of the
+// schemes InfluxDB 3 supports.
+func requestToken(header string) ([]byte, error) {
+	scheme, credentials, found := strings.Cut(header, " ")
+	if !found || strings.Contains(credentials, " ") {
+		return nil, errors.New("authorization header is not in the form of 'Authorization: <auth-scheme> <token>'")
+	}
+
+	switch scheme {
+	case "Bearer", "Token":
+		return []byte(credentials), nil
+	case "Basic":
+		decoded, err := base64.StdEncoding.DecodeString(credentials)
+		if err != nil {
+			return nil, fmt.Errorf("decoding basic credentials failed: %w", err)
+		}
+		// The token is the password part, the username is ignored
+		_, token, found := strings.Cut(string(decoded), ":")
+		if !found || strings.Contains(token, ":") {
+			return nil, errors.New("basic credentials are not in the form of '<username>:<token>'")
+		}
+		return []byte(token), nil
+	}
+
+	return nil, fmt.Errorf("unsupported auth-scheme %q, supported auth-schemes are Bearer, Token and Basic", scheme)
+}
+
+// parsePrecision maps the precision parameter to the multiplier of the
+// timestamps in the body. A zero duration denotes the "auto" precision which
+// has to be determined per timestamp.
+func parsePrecision(precision string) (time.Duration, error) {
+	switch precision {
+	case "", "auto":
+		return 0, nil
+	case "s", "second":
+		return time.Second, nil
+	case "ms", "millisecond":
+		return time.Millisecond, nil
+	case "u", "us", "microsecond":
+		return time.Microsecond, nil
+	case "n", "ns", "nanosecond":
+		return time.Nanosecond, nil
+	}
+
+	return 0, fmt.Errorf("unknown precision %q, expected one of auto, second, millisecond, microsecond or nanosecond", precision)
+}
+
+func parseBool(value string, defaultValue bool) (bool, error) {
+	if value == "" {
+		return defaultValue, nil
+	}
+
+	// InfluxDB only accepts the lower-case spelling of the boolean values
+	switch value {
+	case "true":
+		return true, nil
+	case "false":
+		return false, nil
+	}
+
+	return false, fmt.Errorf("provided string was not `true` or `false`, got %q", value)
+}
+
+// guessPrecision determines the unit of a timestamp parsed at nanosecond
+// precision by its magnitude, the way InfluxDB does for the "auto" precision.
+// Timestamps without a unit reaching into the nanosecond range, which includes
+// the server time filled in for lines without a timestamp, are left untouched.
+func guessPrecision(t time.Time) time.Time {
+	raw := t.UnixNano()
+
+	magnitude := raw / int64(time.Second)
+	if magnitude < 0 {
+		magnitude = -magnitude
+	}
+
+	switch {
+	case magnitude < 5:
+		return time.Unix(raw, 0)
+	case magnitude < 5_000:
+		return time.Unix(0, raw*int64(time.Millisecond))
+	case magnitude < 5_000_000:
+		return time.Unix(0, raw*int64(time.Microsecond))
+	}
+
+	return t
+}
+
+// parseErrorLine reports the one-based number of the line that failed to parse.
+func parseErrorLine(err error) (int, bool) {
+	if internalErr, ok := errors.AsType[*influx.ParseError](err); ok {
+		return internalErr.LineNumber, true
+	}
+
+	if upstreamErr, ok := errors.AsType[*influx_upstream.ParseError](err); ok {
+		return int(upstreamErr.Line), true
+	}
+
+	return 0, false
+}
+
+// originalLine returns the line the parser reported an error for. The parsers
+// truncate the line at the error column, so it is taken from the body instead.
+func originalLine(lines []string, lineNumber int) string {
+	if lineNumber < 1 || lineNumber > len(lines) {
+		return ""
+	}
+
+	return strings.TrimSuffix(lines[lineNumber-1], "\r")
+}
+
+func init() {
+	inputs.Add("influxdb_v3_listener", func() telegraf.Input {
+		return &InfluxDBV3Listener{
+			ServiceAddress: ":8181",
+			timeFunc:       time.Now,
+		}
+	})
+}

--- a/plugins/inputs/influxdb_v3_listener/influxdb_v3_listener_test.go
+++ b/plugins/inputs/influxdb_v3_listener/influxdb_v3_listener_test.go
@@ -528,6 +528,32 @@ func TestWriteGzippedBody(t *testing.T) {
 	require.Len(t, acc.GetTelegrafMetrics(), 1)
 }
 
+func TestWriteGzippedBodyTooLarge(t *testing.T) {
+	var buf bytes.Buffer
+	writer := gzip.NewWriter(&buf)
+	_, err := writer.Write([]byte(strings.Repeat(testMsg, 10000)))
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	listener := newTestListener()
+	listener.MaxBodySize = config.Size(4096)
+
+	var acc testutil.Accumulator
+	startListener(t, listener, &acc)
+
+	// The compressed body is well below the limit, only the decompressed one
+	// is above it
+	require.Less(t, int64(buf.Len()), int64(listener.MaxBodySize))
+
+	req, err := http.NewRequest("POST", listenerURL(listener, "http", "/api/v3/write_lp", "db=mydb"), &buf)
+	require.NoError(t, err)
+	req.Header.Set("Content-Encoding", "gzip")
+
+	resp := do(t, http.DefaultClient, req)
+	require.Equal(t, http.StatusRequestEntityTooLarge, resp.status)
+	require.Empty(t, acc.GetTelegrafMetrics())
+}
+
 func TestWriteBodyTooLarge(t *testing.T) {
 	listener := newTestListener()
 	listener.MaxBodySize = config.Size(len(testMsg) - 1)
@@ -716,6 +742,34 @@ func TestUnknownPath(t *testing.T) {
 
 	resp := getFrom(t, listenerURL(listener, "http", "/api/v2/write", "bucket=mybucket"))
 	require.Equal(t, http.StatusNotFound, resp.status)
+}
+
+func TestUnsupportedMethod(t *testing.T) {
+	tests := []struct {
+		method string
+		path   string
+	}{
+		{method: "GET", path: "/api/v3/write_lp"},
+		{method: "PUT", path: "/api/v3/write_lp"},
+		{method: "POST", path: "/health"},
+		{method: "POST", path: "/api/v1/health"},
+		{method: "PUT", path: "/ping"},
+	}
+
+	listener := newTestListener()
+
+	var acc testutil.Accumulator
+	startListener(t, listener, &acc)
+
+	for _, tt := range tests {
+		t.Run(tt.method+" "+tt.path, func(t *testing.T) {
+			req, err := http.NewRequest(tt.method, listenerURL(listener, "http", tt.path, ""), nil)
+			require.NoError(t, err)
+
+			resp := do(t, http.DefaultClient, req)
+			require.Equal(t, http.StatusNotFound, resp.status)
+		})
+	}
 }
 
 func TestUnknownPathRequiresAuth(t *testing.T) {

--- a/plugins/inputs/influxdb_v3_listener/influxdb_v3_listener_test.go
+++ b/plugins/inputs/influxdb_v3_listener/influxdb_v3_listener_test.go
@@ -1,0 +1,775 @@
+package influxdb_v3_listener
+
+import (
+	"bytes"
+	"compress/gzip"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/config"
+	"github.com/influxdata/telegraf/metric"
+	"github.com/influxdata/telegraf/selfstat"
+	"github.com/influxdata/telegraf/testutil"
+)
+
+const (
+	testMsg = "cpu_load_short,host=server01 value=12.0 1422568543702900257\n"
+
+	testMsgs = `cpu_load_short,host=server02 value=12.0 1422568543702900257
+cpu_load_short,host=server03 value=12.0 1422568543702900257
+cpu_load_short,host=server04 value=12.0 1422568543702900257
+`
+
+	// The second line is invalid, the first and the last one are valid
+	testPartial = `cpu,host=a value=1 1422568543702900257
+cpu,host=b value=1,value2=+Inf,value3=3 1422568543702900257
+cpu,host=c value=1 1422568543702900257`
+
+	token = "test-token-please-ignore"
+)
+
+var (
+	pki = testutil.NewPKI("../../../testutil/pki")
+
+	parserTypes = []string{"internal", "upstream"}
+)
+
+// response is the fully read answer of the listener
+type response struct {
+	status int
+	header http.Header
+	body   string
+}
+
+func newTestListener() *InfluxDBV3Listener {
+	return &InfluxDBV3Listener{
+		ServiceAddress: "localhost:0",
+		Statistics:     selfstat.NewCollector(nil),
+		Log:            testutil.Logger{},
+		timeFunc:       time.Now,
+	}
+}
+
+func startListener(t *testing.T, listener *InfluxDBV3Listener, acc telegraf.Accumulator) {
+	t.Helper()
+
+	require.NoError(t, listener.Init())
+	t.Cleanup(listener.Statistics.UnregisterAll)
+	require.NoError(t, listener.Start(acc))
+	t.Cleanup(listener.Stop)
+}
+
+func listenerURL(listener *InfluxDBV3Listener, scheme, path, rawQuery string) string {
+	u := url.URL{
+		Scheme:   scheme,
+		Host:     listener.listener.Addr().String(),
+		Path:     path,
+		RawQuery: rawQuery,
+	}
+	return u.String()
+}
+
+func do(t *testing.T, client *http.Client, req *http.Request) response {
+	t.Helper()
+
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	return response{status: resp.StatusCode, header: resp.Header, body: string(body)}
+}
+
+func getFrom(t *testing.T, address string) response {
+	t.Helper()
+
+	req, err := http.NewRequest("GET", address, nil)
+	require.NoError(t, err)
+
+	return do(t, http.DefaultClient, req)
+}
+
+func writeTo(t *testing.T, listener *InfluxDBV3Listener, rawQuery, body string) response {
+	t.Helper()
+
+	address := listenerURL(listener, "http", "/api/v3/write_lp", rawQuery)
+	req, err := http.NewRequest("POST", address, strings.NewReader(body))
+	require.NoError(t, err)
+
+	return do(t, http.DefaultClient, req)
+}
+
+func TestInitInvalidParserType(t *testing.T) {
+	listener := newTestListener()
+	listener.ParserType = "unknown"
+
+	require.ErrorContains(t, listener.Init(), `invalid parser type "unknown"`)
+}
+
+func TestWrite(t *testing.T) {
+	expected := []telegraf.Metric{
+		metric.New(
+			"cpu_load_short",
+			map[string]string{"host": "server01"},
+			map[string]any{"value": 12.0},
+			time.Unix(0, 1422568543702900257),
+		),
+	}
+
+	for _, parserType := range parserTypes {
+		t.Run(parserType, func(t *testing.T) {
+			listener := newTestListener()
+			listener.ParserType = parserType
+
+			var acc testutil.Accumulator
+			startListener(t, listener, &acc)
+
+			resp := writeTo(t, listener, "db=mydb", testMsg)
+			require.Equal(t, http.StatusNoContent, resp.status)
+
+			acc.Wait(1)
+			testutil.RequireMetricsEqual(t, expected, acc.GetTelegrafMetrics())
+		})
+	}
+}
+
+func TestWriteMultipleMetrics(t *testing.T) {
+	for _, parserType := range parserTypes {
+		t.Run(parserType, func(t *testing.T) {
+			listener := newTestListener()
+			listener.ParserType = parserType
+
+			var acc testutil.Accumulator
+			startListener(t, listener, &acc)
+
+			resp := writeTo(t, listener, "db=mydb", testMsgs)
+			require.Equal(t, http.StatusNoContent, resp.status)
+
+			acc.Wait(3)
+			require.Len(t, acc.GetTelegrafMetrics(), 3)
+		})
+	}
+}
+
+func TestWriteEmptyBody(t *testing.T) {
+	listener := newTestListener()
+
+	var acc testutil.Accumulator
+	startListener(t, listener, &acc)
+
+	resp := writeTo(t, listener, "db=mydb", "")
+	require.Equal(t, http.StatusNoContent, resp.status)
+	require.Empty(t, acc.GetTelegrafMetrics())
+}
+
+func TestWriteDatabaseTag(t *testing.T) {
+	expected := []telegraf.Metric{
+		metric.New(
+			"cpu_load_short",
+			map[string]string{"host": "server01", "database": "mydb"},
+			map[string]any{"value": 12.0},
+			time.Unix(0, 1422568543702900257),
+		),
+	}
+
+	listener := newTestListener()
+	listener.DatabaseTag = "database"
+
+	var acc testutil.Accumulator
+	startListener(t, listener, &acc)
+
+	resp := writeTo(t, listener, "db=mydb", testMsg)
+	require.Equal(t, http.StatusNoContent, resp.status)
+
+	acc.Wait(1)
+	testutil.RequireMetricsEqual(t, expected, acc.GetTelegrafMetrics())
+}
+
+func TestWriteDatabaseTagOverridesLine(t *testing.T) {
+	expected := []telegraf.Metric{
+		metric.New(
+			"cpu_load_short",
+			map[string]string{"host": "server01", "database": "mydb"},
+			map[string]any{"value": 12.0},
+			time.Unix(0, 1422568543702900257),
+		),
+	}
+
+	listener := newTestListener()
+	listener.DatabaseTag = "database"
+
+	var acc testutil.Accumulator
+	startListener(t, listener, &acc)
+
+	msg := "cpu_load_short,host=server01,database=wrongdb value=12.0 1422568543702900257\n"
+	resp := writeTo(t, listener, "db=mydb", msg)
+	require.Equal(t, http.StatusNoContent, resp.status)
+
+	acc.Wait(1)
+	testutil.RequireMetricsEqual(t, expected, acc.GetTelegrafMetrics())
+}
+
+func TestWriteInvalidQueryParameters(t *testing.T) {
+	tests := []struct {
+		name     string
+		rawQuery string
+		expected string
+	}{
+		{
+			name:     "no parameters at all",
+			rawQuery: "",
+			expected: "missing query parameter 'db'",
+		},
+		{
+			name:     "missing database",
+			rawQuery: "precision=auto",
+			expected: "db name cannot be empty",
+		},
+		{
+			name:     "empty database",
+			rawQuery: "db=",
+			expected: "db name cannot be empty",
+		},
+		{
+			name:     "unknown precision",
+			rawQuery: "db=mydb&precision=fortnight",
+			expected: `unknown precision "fortnight"`,
+		},
+		{
+			name:     "non-boolean accept_partial",
+			rawQuery: "db=mydb&accept_partial=yes",
+			expected: "provided string was not `true` or `false`, got \"yes\"",
+		},
+		{
+			name:     "non-boolean no_sync",
+			rawQuery: "db=mydb&no_sync=1",
+			expected: "provided string was not `true` or `false`, got \"1\"",
+		},
+	}
+
+	listener := newTestListener()
+
+	var acc testutil.Accumulator
+	startListener(t, listener, &acc)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := writeTo(t, listener, tt.rawQuery, testMsg)
+			require.Equal(t, http.StatusBadRequest, resp.status)
+			require.Contains(t, resp.body, tt.expected)
+			require.Empty(t, acc.GetTelegrafMetrics())
+		})
+	}
+}
+
+func TestWriteNoSyncAccepted(t *testing.T) {
+	listener := newTestListener()
+
+	var acc testutil.Accumulator
+	startListener(t, listener, &acc)
+
+	resp := writeTo(t, listener, "db=mydb&no_sync=true", testMsg)
+	require.Equal(t, http.StatusNoContent, resp.status)
+
+	acc.Wait(1)
+	require.Len(t, acc.GetTelegrafMetrics(), 1)
+}
+
+func TestWritePartial(t *testing.T) {
+	tests := []struct {
+		name     string
+		rawQuery string
+	}{
+		{
+			name:     "accept_partial defaults to true",
+			rawQuery: "db=mydb",
+		},
+		{
+			name:     "accept_partial set to true",
+			rawQuery: "db=mydb&accept_partial=true",
+		},
+	}
+
+	for _, parserType := range parserTypes {
+		for _, tt := range tests {
+			t.Run(parserType+"/"+tt.name, func(t *testing.T) {
+				listener := newTestListener()
+				listener.ParserType = parserType
+
+				var acc testutil.Accumulator
+				startListener(t, listener, &acc)
+
+				resp := writeTo(t, listener, tt.rawQuery, testPartial)
+				require.Equal(t, http.StatusBadRequest, resp.status)
+				require.Equal(t, "application/json", resp.header.Get("Content-Type"))
+
+				var body struct {
+					Error string      `json:"error"`
+					Data  []lineError `json:"data"`
+				}
+				require.NoError(t, json.Unmarshal([]byte(resp.body), &body))
+				require.Equal(t, "partial write of line protocol occurred", body.Error)
+				require.Len(t, body.Data, 1)
+				require.Equal(t, 2, body.Data[0].LineNumber)
+				require.Equal(t, "cpu,host=b value=1,value2=+Inf,value3=3 1422568543702900257", body.Data[0].OriginalLine)
+				require.NotEmpty(t, body.Data[0].ErrorMessage)
+
+				// The valid lines around the invalid one are still delivered
+				acc.Wait(2)
+				metrics := acc.GetTelegrafMetrics()
+				require.Len(t, metrics, 2)
+				require.Equal(t, "a", metrics[0].Tags()["host"])
+				require.Equal(t, "c", metrics[1].Tags()["host"])
+			})
+		}
+	}
+}
+
+func TestWritePartialRejected(t *testing.T) {
+	for _, parserType := range parserTypes {
+		t.Run(parserType, func(t *testing.T) {
+			listener := newTestListener()
+			listener.ParserType = parserType
+
+			var acc testutil.Accumulator
+			startListener(t, listener, &acc)
+
+			resp := writeTo(t, listener, "db=mydb&accept_partial=false", testPartial)
+			require.Equal(t, http.StatusBadRequest, resp.status)
+
+			var body struct {
+				Error string    `json:"error"`
+				Data  lineError `json:"data"`
+			}
+			require.NoError(t, json.Unmarshal([]byte(resp.body), &body))
+			require.Equal(t, "line protocol parsing error", body.Error)
+			require.Equal(t, 2, body.Data.LineNumber)
+			require.Equal(t, "cpu,host=b value=1,value2=+Inf,value3=3 1422568543702900257", body.Data.OriginalLine)
+
+			// Nothing at all is delivered, not even the valid first line
+			require.Empty(t, acc.GetTelegrafMetrics())
+		})
+	}
+}
+
+func TestWritePartialLineNumbers(t *testing.T) {
+	tests := []struct {
+		name          string
+		body          string
+		expectedLines []int
+		expectedText  []string
+	}{
+		{
+			name:          "first line invalid",
+			body:          "invalid line\ncpu,host=a value=1 1\n",
+			expectedLines: []int{1},
+			expectedText:  []string{"invalid line"},
+		},
+		{
+			name:          "last line invalid without trailing newline",
+			body:          "cpu,host=a value=1 1\ninvalid line",
+			expectedLines: []int{2},
+			expectedText:  []string{"invalid line"},
+		},
+		{
+			name:          "carriage returns are trimmed",
+			body:          "cpu,host=a value=1 1\r\ninvalid line\r\n",
+			expectedLines: []int{2},
+			expectedText:  []string{"invalid line"},
+		},
+		{
+			name:          "multiple invalid lines",
+			body:          "invalid one\ncpu,host=a value=1 1\ninvalid two\n",
+			expectedLines: []int{1, 3},
+			expectedText:  []string{"invalid one", "invalid two"},
+		},
+		{
+			name:          "newline inside a quoted field does not shift the count",
+			body:          "cpu,host=a msg=\"first\nsecond\" 1\ninvalid line\n",
+			expectedLines: []int{3},
+			expectedText:  []string{"invalid line"},
+		},
+	}
+
+	listener := newTestListener()
+
+	var acc testutil.Accumulator
+	startListener(t, listener, &acc)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := writeTo(t, listener, "db=mydb", tt.body)
+			require.Equal(t, http.StatusBadRequest, resp.status)
+
+			var body struct {
+				Data []lineError `json:"data"`
+			}
+			require.NoError(t, json.Unmarshal([]byte(resp.body), &body))
+
+			lines := make([]int, 0, len(body.Data))
+			text := make([]string, 0, len(body.Data))
+			for _, e := range body.Data {
+				lines = append(lines, e.LineNumber)
+				text = append(text, e.OriginalLine)
+			}
+			require.Equal(t, tt.expectedLines, lines)
+			require.Equal(t, tt.expectedText, text)
+		})
+	}
+}
+
+func TestWritePrecision(t *testing.T) {
+	tests := []struct {
+		name      string
+		precision string
+		timestamp string
+		expected  time.Time
+	}{
+		{"second", "second", "1422568543", time.Unix(1422568543, 0)},
+		{"second abbreviated", "s", "1422568543", time.Unix(1422568543, 0)},
+		{"millisecond", "millisecond", "1422568543702", time.Unix(0, 1422568543702000000)},
+		{"millisecond abbreviated", "ms", "1422568543702", time.Unix(0, 1422568543702000000)},
+		{"microsecond", "microsecond", "1422568543702900", time.Unix(0, 1422568543702900000)},
+		{"microsecond abbreviated", "us", "1422568543702900", time.Unix(0, 1422568543702900000)},
+		{"microsecond single letter", "u", "1422568543702900", time.Unix(0, 1422568543702900000)},
+		{"nanosecond", "nanosecond", "1422568543702900257", time.Unix(0, 1422568543702900257)},
+		{"nanosecond abbreviated", "ns", "1422568543702900257", time.Unix(0, 1422568543702900257)},
+		{"nanosecond single letter", "n", "1422568543702900257", time.Unix(0, 1422568543702900257)},
+		{"auto detects seconds", "auto", "1422568543", time.Unix(1422568543, 0)},
+		{"auto detects milliseconds", "auto", "1422568543702", time.Unix(0, 1422568543702000000)},
+		{"auto detects microseconds", "auto", "1422568543702900", time.Unix(0, 1422568543702900000)},
+		{"auto detects nanoseconds", "auto", "1422568543702900257", time.Unix(0, 1422568543702900257)},
+		{"auto handles negative timestamps", "auto", "-1422568543", time.Unix(-1422568543, 0)},
+		{"auto is the default", "", "1422568543", time.Unix(1422568543, 0)},
+	}
+
+	for _, parserType := range parserTypes {
+		for _, tt := range tests {
+			t.Run(parserType+"/"+tt.name, func(t *testing.T) {
+				listener := newTestListener()
+				listener.ParserType = parserType
+
+				var acc testutil.Accumulator
+				startListener(t, listener, &acc)
+
+				rawQuery := "db=mydb"
+				if tt.precision != "" {
+					rawQuery += "&precision=" + tt.precision
+				}
+				resp := writeTo(t, listener, rawQuery, "cpu,host=a value=1 "+tt.timestamp+"\n")
+				require.Equal(t, http.StatusNoContent, resp.status)
+
+				acc.Wait(1)
+				metrics := acc.GetTelegrafMetrics()
+				require.Len(t, metrics, 1)
+				require.Equal(t, tt.expected.UTC(), metrics[0].Time().UTC())
+			})
+		}
+	}
+}
+
+func TestWritePrecisionAutoWithoutTimestamp(t *testing.T) {
+	now := time.Unix(0, 1422568543702900257)
+
+	for _, parserType := range parserTypes {
+		t.Run(parserType, func(t *testing.T) {
+			listener := newTestListener()
+			listener.ParserType = parserType
+			listener.timeFunc = func() time.Time { return now }
+
+			var acc testutil.Accumulator
+			startListener(t, listener, &acc)
+
+			resp := writeTo(t, listener, "db=mydb&precision=auto", "cpu,host=a value=1\n")
+			require.Equal(t, http.StatusNoContent, resp.status)
+
+			acc.Wait(1)
+			metrics := acc.GetTelegrafMetrics()
+			require.Len(t, metrics, 1)
+			require.Equal(t, now.UTC(), metrics[0].Time().UTC())
+		})
+	}
+}
+
+func TestWriteGzippedBody(t *testing.T) {
+	var buf bytes.Buffer
+	writer := gzip.NewWriter(&buf)
+	_, err := writer.Write([]byte(testMsg))
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	listener := newTestListener()
+
+	var acc testutil.Accumulator
+	startListener(t, listener, &acc)
+
+	req, err := http.NewRequest("POST", listenerURL(listener, "http", "/api/v3/write_lp", "db=mydb"), &buf)
+	require.NoError(t, err)
+	req.Header.Set("Content-Encoding", "gzip")
+
+	resp := do(t, http.DefaultClient, req)
+	require.Equal(t, http.StatusNoContent, resp.status)
+
+	acc.Wait(1)
+	require.Len(t, acc.GetTelegrafMetrics(), 1)
+}
+
+func TestWriteBodyTooLarge(t *testing.T) {
+	listener := newTestListener()
+	listener.MaxBodySize = config.Size(len(testMsg) - 1)
+
+	var acc testutil.Accumulator
+	startListener(t, listener, &acc)
+
+	resp := writeTo(t, listener, "db=mydb", testMsg)
+	require.Equal(t, http.StatusRequestEntityTooLarge, resp.status)
+	require.Equal(t, "http: request body too large", resp.header.Get("X-Influxdb-Error"))
+	require.Empty(t, acc.GetTelegrafMetrics())
+}
+
+func TestWriteBodyTooLargeWithoutContentLength(t *testing.T) {
+	listener := newTestListener()
+	listener.MaxBodySize = config.Size(len(testMsg) - 1)
+
+	var acc testutil.Accumulator
+	startListener(t, listener, &acc)
+
+	// Sending the body from a reader of unknown length makes the client use
+	// chunked transfer encoding, so the size is only known while reading it
+	address := listenerURL(listener, "http", "/api/v3/write_lp", "db=mydb")
+	req, err := http.NewRequest("POST", address, io.NopCloser(strings.NewReader(testMsg)))
+	require.NoError(t, err)
+
+	resp := do(t, http.DefaultClient, req)
+	require.Equal(t, http.StatusRequestEntityTooLarge, resp.status)
+	require.Empty(t, acc.GetTelegrafMetrics())
+}
+
+func TestWriteUndeliveredMetricsRateLimit(t *testing.T) {
+	listener := newTestListener()
+	listener.MaxUndeliveredMetrics = 2
+
+	var acc testutil.Accumulator
+	startListener(t, listener, &acc)
+
+	// A batch larger than the limit can never be delivered
+	resp := writeTo(t, listener, "db=mydb", testMsgs)
+	require.Equal(t, http.StatusRequestEntityTooLarge, resp.status)
+
+	// Filling up the limit works, exceeding what is left is rate limited
+	resp = writeTo(t, listener, "db=mydb", testMsg+testMsg)
+	require.Equal(t, http.StatusNoContent, resp.status)
+
+	resp = writeTo(t, listener, "db=mydb", testMsg)
+	require.Equal(t, http.StatusTooManyRequests, resp.status)
+}
+
+func TestWriteAuth(t *testing.T) {
+	tests := []struct {
+		name     string
+		header   string
+		expected int
+	}{
+		{"bearer scheme", "Bearer " + token, http.StatusNoContent},
+		{"token scheme", "Token " + token, http.StatusNoContent},
+		{"basic scheme", "Basic " + base64.StdEncoding.EncodeToString([]byte("user:"+token)), http.StatusNoContent},
+		{"wrong token", "Bearer nope", http.StatusUnauthorized},
+		{"wrong scheme", "Digest " + token, http.StatusUnauthorized},
+		{"token without scheme", token, http.StatusUnauthorized},
+		{"no authorization at all", "", http.StatusUnauthorized},
+	}
+
+	listener := newTestListener()
+	listener.Token = config.NewSecret([]byte(token))
+
+	var acc testutil.Accumulator
+	startListener(t, listener, &acc)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			address := listenerURL(listener, "http", "/api/v3/write_lp", "db=mydb")
+			req, err := http.NewRequest("POST", address, strings.NewReader(testMsg))
+			require.NoError(t, err)
+			if tt.header != "" {
+				req.Header.Set("Authorization", tt.header)
+			}
+
+			require.Equal(t, tt.expected, do(t, http.DefaultClient, req).status)
+		})
+	}
+}
+
+func TestWriteWithoutTokenConfigured(t *testing.T) {
+	listener := newTestListener()
+
+	var acc testutil.Accumulator
+	startListener(t, listener, &acc)
+
+	resp := writeTo(t, listener, "db=mydb", testMsg)
+	require.Equal(t, http.StatusNoContent, resp.status)
+}
+
+func TestWriteSecureWithClientAuth(t *testing.T) {
+	listener := newTestListener()
+	listener.ServerConfig = *pki.TLSServerConfig()
+
+	var acc testutil.Accumulator
+	startListener(t, listener, &acc)
+
+	tlsConfig, err := pki.TLSClientConfig().TLSConfig()
+	require.NoError(t, err)
+	client := &http.Client{Transport: &http.Transport{TLSClientConfig: tlsConfig}}
+
+	address := listenerURL(listener, "https", "/api/v3/write_lp", "db=mydb")
+	req, err := http.NewRequest("POST", address, strings.NewReader(testMsg))
+	require.NoError(t, err)
+
+	require.Equal(t, http.StatusNoContent, do(t, client, req).status)
+
+	acc.Wait(1)
+	require.Len(t, acc.GetTelegrafMetrics(), 1)
+}
+
+func TestWriteSecureNoClientAuth(t *testing.T) {
+	listener := newTestListener()
+	listener.ServerConfig = *pki.TLSServerConfig()
+	listener.TLSAllowedCACerts = nil
+
+	var acc testutil.Accumulator
+	startListener(t, listener, &acc)
+
+	cas := x509.NewCertPool()
+	require.True(t, cas.AppendCertsFromPEM([]byte(pki.ReadServerCert())))
+	client := &http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{RootCAs: cas}}}
+
+	address := listenerURL(listener, "https", "/api/v3/write_lp", "db=mydb")
+	req, err := http.NewRequest("POST", address, strings.NewReader(testMsg))
+	require.NoError(t, err)
+
+	require.Equal(t, http.StatusNoContent, do(t, client, req).status)
+}
+
+func TestHealth(t *testing.T) {
+	for _, path := range []string{"/health", "/api/v1/health"} {
+		t.Run(path, func(t *testing.T) {
+			listener := newTestListener()
+
+			var acc testutil.Accumulator
+			startListener(t, listener, &acc)
+
+			resp := getFrom(t, listenerURL(listener, "http", path, ""))
+			require.Equal(t, http.StatusOK, resp.status)
+			require.Equal(t, "OK", resp.body)
+		})
+	}
+}
+
+func TestHealthUndeliveredMetricsAboveLimit(t *testing.T) {
+	listener := newTestListener()
+	listener.MaxUndeliveredMetrics = 1
+
+	var acc testutil.Accumulator
+	startListener(t, listener, &acc)
+
+	require.Equal(t, http.StatusNoContent, writeTo(t, listener, "db=mydb", testMsg).status)
+
+	resp := getFrom(t, listenerURL(listener, "http", "/health", ""))
+	require.Equal(t, http.StatusServiceUnavailable, resp.status)
+	require.Contains(t, resp.body, "pending undelivered metrics (1) is above limit")
+}
+
+func TestPing(t *testing.T) {
+	listener := newTestListener()
+
+	var acc testutil.Accumulator
+	startListener(t, listener, &acc)
+
+	resp := getFrom(t, listenerURL(listener, "http", "/ping", ""))
+	require.Equal(t, http.StatusOK, resp.status)
+	require.Equal(t, "telegraf", resp.header.Get("X-Influxdb-Build"))
+
+	var body map[string]string
+	require.NoError(t, json.Unmarshal([]byte(resp.body), &body))
+	require.Equal(t, "telegraf", body["product_name"])
+	require.NotEmpty(t, body["process_id"])
+}
+
+func TestUnknownPath(t *testing.T) {
+	listener := newTestListener()
+
+	var acc testutil.Accumulator
+	startListener(t, listener, &acc)
+
+	resp := getFrom(t, listenerURL(listener, "http", "/api/v2/write", "bucket=mybucket"))
+	require.Equal(t, http.StatusNotFound, resp.status)
+}
+
+func TestUnknownPathRequiresAuth(t *testing.T) {
+	listener := newTestListener()
+	listener.Token = config.NewSecret([]byte(token))
+
+	var acc testutil.Accumulator
+	startListener(t, listener, &acc)
+
+	resp := getFrom(t, listenerURL(listener, "http", "/api/v2/write", "bucket=mybucket"))
+	require.Equal(t, http.StatusUnauthorized, resp.status)
+}
+
+func TestWriteConcurrentRequests(t *testing.T) {
+	const requests = 50
+
+	listener := newTestListener()
+
+	var acc testutil.Accumulator
+	startListener(t, listener, &acc)
+
+	type result struct {
+		status int
+		err    error
+	}
+
+	address := listenerURL(listener, "http", "/api/v3/write_lp", "db=mydb")
+	results := make(chan result, requests)
+	for i := range requests {
+		go func() {
+			body := "cpu,host=server" + strconv.Itoa(i) + " value=12.0 1422568543702900257\n"
+			req, err := http.NewRequest("POST", address, strings.NewReader(body))
+			if err != nil {
+				results <- result{err: err}
+				return
+			}
+
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				results <- result{err: err}
+				return
+			}
+			defer resp.Body.Close()
+
+			results <- result{status: resp.StatusCode}
+		}()
+	}
+
+	for range requests {
+		r := <-results
+		require.NoError(t, r.err)
+		require.Equal(t, http.StatusNoContent, r.status)
+	}
+
+	acc.Wait(requests)
+	require.Len(t, acc.GetTelegrafMetrics(), requests)
+}

--- a/plugins/inputs/influxdb_v3_listener/sample.conf
+++ b/plugins/inputs/influxdb_v3_listener/sample.conf
@@ -1,0 +1,39 @@
+# Accept metrics over the InfluxDB 3 HTTP API
+[[inputs.influxdb_v3_listener]]
+  ## Address and port to host the listener on
+  service_address = ":8181"
+
+  ## Maximum undelivered metrics before rate limit kicks in.
+  ## When the rate limit kicks in, HTTP status 429 will be returned.
+  ## 0 disables rate limiting
+  # max_undelivered_metrics = 0
+
+  ## Maximum duration before timing out read of the request
+  # read_timeout = "10s"
+  ## Maximum duration before timing out write of the response
+  # write_timeout = "10s"
+
+  ## Maximum allowed HTTP request body size in bytes.
+  ## 0 means to use the default of 32MiB.
+  # max_body_size = "32MiB"
+
+  ## Optional tag to store the database of the write in.
+  ## The default of an empty string will not record the database.
+  # database_tag = ""
+
+  ## Set one or more allowed client CA certificate file names to
+  ## enable mutually authenticated TLS connections
+  # tls_allowed_cacerts = ["/etc/telegraf/clientca.pem"]
+
+  ## Add service certificate and key
+  # tls_cert = "/etc/telegraf/cert.pem"
+  # tls_key = "/etc/telegraf/key.pem"
+
+  ## Optional token to accept for HTTP authentication.
+  ## You probably want to make sure you have TLS configured above for this.
+  # token = "some-long-shared-secret-token"
+
+  ## Influx line protocol parser
+  ## 'internal' is the default. 'upstream' is a newer parser that is faster
+  ## and more memory efficient.
+  # parser_type = "internal"


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Adds a new `inputs.influxdb_v3_listener` serving `POST /api/v3/write_lp`, so Telegraf can sit in front of InfluxDB 3 the way `influxdb_listener` and `influxdb_v2_listener` do for v1 and v2. It implements the v3 write API rather than InfluxDB 3 itself: partial writes with the per-line error body, the `auto` precision, and the health and ping endpoints. Every difference from the write API is listed under "Deviations from the InfluxDB 3 API" in the README. Most are things a listener structurally cannot do, mainly `no_sync` and the schema-level rejections; a couple are deliberate, such as leaving health and ping unauthenticated the way the v1 and v2 listeners do.

The behaviour was taken from the InfluxDB 3 source rather than the docs, which are wrong on two points: the `accept_partial=false` error is `line protocol parsing error`, and there is no 100-entry cap on the reported lines.

One thing worth a look in review: the write API accepts the token as `Bearer`, `Token` or `Basic`, so the plugin does too, which is wider than the Bearer-only we had discussed.

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
