### PR TITLE
fix: skip unexpected mntr lines from ZooKeeper 3.6+

### DIFF
--- a/plugins/inputs/zookeeper/zookeeper.go
+++ b/plugins/inputs/zookeeper/zookeeper.go
@@ -105,7 +105,10 @@ func (z *Zookeeper) gatherServer(ctx context.Context, address string, acc telegr
 		parts := zookeeperFormatRE.FindStringSubmatch(line)
 
 		if len(parts) != 3 {
-			return fmt.Errorf("unexpected line in mntr response: %q", line)
+			// ZooKeeper 3.6+ may output Prometheus-style summary metrics
+			// (e.g., zk_om_commit_process_time_ms{quantile="0.5"}\tNaN).
+			// Skip these lines instead of failing the whole plugin.
+			continue
 		}
 
 		measurement := strings.TrimPrefix(parts[1], "zk_")


### PR DESCRIPTION
### Summary

ZooKeeper 3.6+ introduced Prometheus-style summary/histogram metrics in the `mntr` four-letter-word output, such as:

```
zk_om_commit_process_time_ms{quantile="0.5"}	NaN
```

The existing regex (`zookeeperFormatRE` = `^zk_(\w[\w\.\-]*)\s+([\w\.\-]+)`) cannot match lines containing `{quantile=...}` suffixes, causing the plugin to return an error on every poll:

```
Error in plugin: unexpected line in mntr response: "zk_om_commit_process_time_ms{quantile="0.5"}\tNaN"
```

This error makes the entire zookeeper input plugin fail, dropping all metrics from the server.

### Changes

- **Skip** unrecognized lines instead of returning an error. New ZooKeeper versions may add more metrics formats; the plugin should be resilient to output it cannot parse rather than failing completely.

### Impact

- ⚠️ The new metric lines (`zk_om_commit_process_time_ms{quantile=...}`, etc.) are not collected — they are silently skipped. If users need these metrics, they should use a Prometheus-based collector instead.
- All previously working metrics continue to be collected as before.

Fixes: #19488