### PR TITLE
fix: inputs.kinesis_consumer: expired shard iterator unconditionally starts f...

### DIFF
--- a/plugins/inputs/kinesis_consumer/README.md
+++ b/plugins/inputs/kinesis_consumer/README.md
@@ -76,6 +76,15 @@ plugin ordering. See [CONFIGURATION.md][CONFIGURATION.md] for more details.
   ## Available options: 'TRIM_HORIZON' (first in non-expired) and 'LATEST'
   # shard_iterator_type = "TRIM_HORIZON"
 
+  ## Position for recreating an expired shard iterator
+  ## Available options:
+  ##   'checkpoint'          -- sequence number stored in the checkpoint
+  ##                            backend, falls back to 'last_processed' if no
+  ##                            checkpoint is available
+  ##   'last_processed'      -- last sequence number read from the shard
+  ##   'shard_iterator_type' -- position determined by 'shard_iterator_type'
+  # shard_iterator_restart_position = "checkpoint"
+
   ## Interval for checking for new records
   ## Please consider limits for getting records documented here:
   ## https://docs.aws.amazon.com/streams/latest/dev/service-sizes-and-limits.html

--- a/plugins/inputs/kinesis_consumer/consumer.go
+++ b/plugins/inputs/kinesis_consumer/consumer.go
@@ -16,6 +16,12 @@ import (
 
 type recordHandler func(ctx context.Context, shard string, r *types.Record)
 
+const (
+	restartPositionCheckpoint    = "checkpoint"
+	restartPositionLastProcessed = "last_processed"
+	restartPositionIteratorType  = "shard_iterator_type"
+)
+
 type shardConsumer struct {
 	seqnr    string
 	interval time.Duration
@@ -24,6 +30,7 @@ type shardConsumer struct {
 	client   *kinesis.Client
 	params   *kinesis.GetShardIteratorInput
 	position func() string
+	restart  string
 
 	onMessage recordHandler
 }
@@ -96,18 +103,25 @@ func (c *shardConsumer) consume(ctx context.Context, shard string) ([]types.Chil
 }
 
 func (c *shardConsumer) iteratorParams() *kinesis.GetShardIteratorInput {
-	seqnr := c.seqnr
-	if c.position != nil {
-		if checkpoint := c.position(); checkpoint != "" {
-			seqnr = checkpoint
+	var seqnr string
+	switch c.restart {
+	case restartPositionCheckpoint:
+		if c.position != nil {
+			seqnr = c.position()
 		}
+		if seqnr == "" {
+			seqnr = c.seqnr
+		}
+	case restartPositionLastProcessed:
+		seqnr = c.seqnr
+	}
+	if seqnr == "" {
+		return c.params
 	}
 
 	params := *c.params
-	if seqnr != "" {
-		params.ShardIteratorType = types.ShardIteratorTypeAfterSequenceNumber
-		params.StartingSequenceNumber = &seqnr
-	}
+	params.ShardIteratorType = types.ShardIteratorTypeAfterSequenceNumber
+	params.StartingSequenceNumber = &seqnr
 
 	return &params
 }
@@ -137,6 +151,7 @@ type consumer struct {
 	config              aws.Config
 	stream              string
 	iterType            types.ShardIteratorType
+	restart             string
 	pollInterval        time.Duration
 	shardUpdateInterval time.Duration
 	log                 telegraf.Logger
@@ -339,11 +354,16 @@ func (c *consumer) startShardConsumer(ctx context.Context, id, seqnr string) {
 		log:       c.log,
 		onMessage: c.onMessage,
 		client:    c.client,
+		restart:   c.restart,
 		params: &kinesis.GetShardIteratorInput{
 			ShardId:           &id,
 			ShardIteratorType: c.iterType,
 			StreamName:        &c.stream,
 		},
+	}
+	if seqnr != "" {
+		sc.params.ShardIteratorType = types.ShardIteratorTypeAfterSequenceNumber
+		sc.params.StartingSequenceNumber = &seqnr
 	}
 	if c.position != nil {
 		sc.position = func() string { return c.position(id) }

--- a/plugins/inputs/kinesis_consumer/consumer.go
+++ b/plugins/inputs/kinesis_consumer/consumer.go
@@ -94,9 +94,20 @@ func (c *shardConsumer) consume(ctx context.Context, shard string) ([]types.Chil
 	}
 }
 
+func (c *shardConsumer) iteratorParams() *kinesis.GetShardIteratorInput {
+	params := *c.params
+	if c.seqnr != "" {
+		seqnr := c.seqnr
+		params.ShardIteratorType = types.ShardIteratorTypeAfterSequenceNumber
+		params.StartingSequenceNumber = &seqnr
+	}
+
+	return &params
+}
+
 func (c *shardConsumer) iterator(ctx context.Context) (*string, error) {
 	for {
-		resp, err := c.client.GetShardIterator(ctx, c.params)
+		resp, err := c.client.GetShardIterator(ctx, c.iteratorParams())
 		if err != nil {
 			var throughputErr *types.ProvisionedThroughputExceededException
 			if errors.As(err, &throughputErr) {
@@ -325,10 +336,6 @@ func (c *consumer) startShardConsumer(ctx context.Context, id, seqnr string) {
 			ShardIteratorType: c.iterType,
 			StreamName:        &c.stream,
 		},
-	}
-	if seqnr != "" {
-		sc.params.ShardIteratorType = types.ShardIteratorTypeAfterSequenceNumber
-		sc.params.StartingSequenceNumber = &seqnr
 	}
 
 	c.Lock()

--- a/plugins/inputs/kinesis_consumer/consumer.go
+++ b/plugins/inputs/kinesis_consumer/consumer.go
@@ -21,8 +21,9 @@ type shardConsumer struct {
 	interval time.Duration
 	log      telegraf.Logger
 
-	client *kinesis.Client
-	params *kinesis.GetShardIteratorInput
+	client   *kinesis.Client
+	params   *kinesis.GetShardIteratorInput
+	position func() string
 
 	onMessage recordHandler
 }
@@ -95,9 +96,15 @@ func (c *shardConsumer) consume(ctx context.Context, shard string) ([]types.Chil
 }
 
 func (c *shardConsumer) iteratorParams() *kinesis.GetShardIteratorInput {
+	seqnr := c.seqnr
+	if c.position != nil {
+		if checkpoint := c.position(); checkpoint != "" {
+			seqnr = checkpoint
+		}
+	}
+
 	params := *c.params
-	if c.seqnr != "" {
-		seqnr := c.seqnr
+	if seqnr != "" {
 		params.ShardIteratorType = types.ShardIteratorTypeAfterSequenceNumber
 		params.StartingSequenceNumber = &seqnr
 	}
@@ -107,7 +114,8 @@ func (c *shardConsumer) iteratorParams() *kinesis.GetShardIteratorInput {
 
 func (c *shardConsumer) iterator(ctx context.Context) (*string, error) {
 	for {
-		resp, err := c.client.GetShardIterator(ctx, c.iteratorParams())
+		params := c.iteratorParams()
+		resp, err := c.client.GetShardIterator(ctx, params)
 		if err != nil {
 			var throughputErr *types.ProvisionedThroughputExceededException
 			if errors.As(err, &throughputErr) {
@@ -120,7 +128,7 @@ func (c *shardConsumer) iterator(ctx context.Context) (*string, error) {
 
 			return nil, err
 		}
-		c.log.Tracef("successfully updated iterator for shard %s (%s)...", *c.params.ShardId, c.seqnr)
+		c.log.Tracef("successfully updated iterator for shard %s (%s)...", *c.params.ShardId, aws.ToString(params.StartingSequenceNumber))
 		return resp.ShardIterator, nil
 	}
 }
@@ -336,6 +344,9 @@ func (c *consumer) startShardConsumer(ctx context.Context, id, seqnr string) {
 			ShardIteratorType: c.iterType,
 			StreamName:        &c.stream,
 		},
+	}
+	if c.position != nil {
+		sc.position = func() string { return c.position(id) }
 	}
 
 	c.Lock()

--- a/plugins/inputs/kinesis_consumer/kinesis_consumer.go
+++ b/plugins/inputs/kinesis_consumer/kinesis_consumer.go
@@ -27,6 +27,7 @@ var once sync.Once
 type KinesisConsumer struct {
 	StreamName             string          `toml:"streamname"`
 	ShardIteratorType      string          `toml:"shard_iterator_type"`
+	RestartPosition        string          `toml:"shard_iterator_restart_position"`
 	PollInterval           config.Duration `toml:"poll_interval"`
 	ShardUpdateInterval    config.Duration `toml:"shard_update_interval"`
 	DynamoDB               *dynamoDB       `toml:"checkpoint_dynamodb"`
@@ -76,6 +77,9 @@ func (k *KinesisConsumer) Init() error {
 	if k.ShardIteratorType == "" {
 		k.ShardIteratorType = "TRIM_HORIZON"
 	}
+	if k.RestartPosition == "" {
+		k.RestartPosition = restartPositionCheckpoint
+	}
 	if k.ContentEncoding == "" {
 		k.ContentEncoding = "identity"
 	}
@@ -83,6 +87,12 @@ func (k *KinesisConsumer) Init() error {
 	// Check input params
 	if k.StreamName == "" {
 		return errors.New("stream name cannot be empty")
+	}
+
+	switch k.RestartPosition {
+	case restartPositionCheckpoint, restartPositionLastProcessed, restartPositionIteratorType:
+	default:
+		return fmt.Errorf("invalid shard iterator restart position %q", k.RestartPosition)
 	}
 
 	f, err := getDecodingFunc(k.ContentEncoding)
@@ -137,6 +147,7 @@ func (k *KinesisConsumer) Start(acc telegraf.Accumulator) error {
 		config:              k.cfg,
 		stream:              k.StreamName,
 		iterType:            types.ShardIteratorType(k.ShardIteratorType),
+		restart:             k.RestartPosition,
 		pollInterval:        time.Duration(k.PollInterval),
 		shardUpdateInterval: time.Duration(k.ShardUpdateInterval),
 		log:                 k.Log,

--- a/plugins/inputs/kinesis_consumer/kinesis_consumer_test.go
+++ b/plugins/inputs/kinesis_consumer/kinesis_consumer_test.go
@@ -22,8 +22,17 @@ func TestInvalidCoding(t *testing.T) {
 	require.ErrorContains(t, plugin.Init(), "unknown content encoding")
 }
 
+func TestInvalidRestartPosition(t *testing.T) {
+	plugin := &KinesisConsumer{
+		StreamName:      "foo",
+		RestartPosition: "notsupported",
+	}
+	require.ErrorContains(t, plugin.Init(), `invalid shard iterator restart position "notsupported"`)
+}
+
 func TestIteratorParamsFollowConsumedSequenceNumber(t *testing.T) {
 	sc := &shardConsumer{
+		restart: restartPositionLastProcessed,
 		params: &kinesis.GetShardIteratorInput{
 			ShardId:           aws.String("shard-000"),
 			ShardIteratorType: types.ShardIteratorTypeLatest,
@@ -54,6 +63,7 @@ func TestIteratorParamsFollowConsumedSequenceNumber(t *testing.T) {
 func TestIteratorParamsPreferCheckpointedSequenceNumber(t *testing.T) {
 	var checkpoint string
 	sc := &shardConsumer{
+		restart: restartPositionCheckpoint,
 		params: &kinesis.GetShardIteratorInput{
 			ShardId:           aws.String("shard-000"),
 			ShardIteratorType: types.ShardIteratorTypeLatest,
@@ -83,6 +93,25 @@ func TestIteratorParamsPreferCheckpointedSequenceNumber(t *testing.T) {
 	require.Equal(t, types.ShardIteratorTypeAfterSequenceNumber, params.ShardIteratorType)
 	require.NotNil(t, params.StartingSequenceNumber)
 	require.Equal(t, "300", *params.StartingSequenceNumber)
+}
+
+func TestIteratorParamsKeepConfiguredPosition(t *testing.T) {
+	sc := &shardConsumer{
+		seqnr:   "200",
+		restart: restartPositionIteratorType,
+		params: &kinesis.GetShardIteratorInput{
+			ShardId:                aws.String("shard-000"),
+			ShardIteratorType:      types.ShardIteratorTypeAfterSequenceNumber,
+			StartingSequenceNumber: aws.String("100"),
+			StreamName:             aws.String("foo"),
+		},
+		position: func() string { return "300" },
+	}
+
+	params := sc.iteratorParams()
+	require.Equal(t, types.ShardIteratorTypeAfterSequenceNumber, params.ShardIteratorType)
+	require.NotNil(t, params.StartingSequenceNumber)
+	require.Equal(t, "100", *params.StartingSequenceNumber)
 }
 
 func TestOnMessage(t *testing.T) {

--- a/plugins/inputs/kinesis_consumer/kinesis_consumer_test.go
+++ b/plugins/inputs/kinesis_consumer/kinesis_consumer_test.go
@@ -51,6 +51,40 @@ func TestIteratorParamsFollowConsumedSequenceNumber(t *testing.T) {
 	require.Nil(t, sc.params.StartingSequenceNumber)
 }
 
+func TestIteratorParamsPreferCheckpointedSequenceNumber(t *testing.T) {
+	var checkpoint string
+	sc := &shardConsumer{
+		params: &kinesis.GetShardIteratorInput{
+			ShardId:           aws.String("shard-000"),
+			ShardIteratorType: types.ShardIteratorTypeLatest,
+			StreamName:        aws.String("foo"),
+		},
+		position: func() string { return checkpoint },
+	}
+
+	params := sc.iteratorParams()
+	require.Equal(t, types.ShardIteratorTypeLatest, params.ShardIteratorType)
+	require.Nil(t, params.StartingSequenceNumber)
+
+	sc.seqnr = "200"
+	params = sc.iteratorParams()
+	require.Equal(t, types.ShardIteratorTypeAfterSequenceNumber, params.ShardIteratorType)
+	require.NotNil(t, params.StartingSequenceNumber)
+	require.Equal(t, "200", *params.StartingSequenceNumber)
+
+	checkpoint = "100"
+	params = sc.iteratorParams()
+	require.Equal(t, types.ShardIteratorTypeAfterSequenceNumber, params.ShardIteratorType)
+	require.NotNil(t, params.StartingSequenceNumber)
+	require.Equal(t, "100", *params.StartingSequenceNumber)
+
+	checkpoint = "300"
+	params = sc.iteratorParams()
+	require.Equal(t, types.ShardIteratorTypeAfterSequenceNumber, params.ShardIteratorType)
+	require.NotNil(t, params.StartingSequenceNumber)
+	require.Equal(t, "300", *params.StartingSequenceNumber)
+}
+
 func TestOnMessage(t *testing.T) {
 	// Prepare messages
 	zlibBytpes, err := base64.StdEncoding.DecodeString(

--- a/plugins/inputs/kinesis_consumer/kinesis_consumer_test.go
+++ b/plugins/inputs/kinesis_consumer/kinesis_consumer_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/kinesis"
 	"github.com/aws/aws-sdk-go-v2/service/kinesis/types"
 	"github.com/stretchr/testify/require"
 
@@ -19,6 +20,35 @@ func TestInvalidCoding(t *testing.T) {
 		ContentEncoding: "notsupported",
 	}
 	require.ErrorContains(t, plugin.Init(), "unknown content encoding")
+}
+
+func TestIteratorParamsFollowConsumedSequenceNumber(t *testing.T) {
+	sc := &shardConsumer{
+		params: &kinesis.GetShardIteratorInput{
+			ShardId:           aws.String("shard-000"),
+			ShardIteratorType: types.ShardIteratorTypeLatest,
+			StreamName:        aws.String("foo"),
+		},
+	}
+
+	params := sc.iteratorParams()
+	require.Equal(t, types.ShardIteratorTypeLatest, params.ShardIteratorType)
+	require.Nil(t, params.StartingSequenceNumber)
+
+	sc.seqnr = "100"
+	params = sc.iteratorParams()
+	require.Equal(t, types.ShardIteratorTypeAfterSequenceNumber, params.ShardIteratorType)
+	require.NotNil(t, params.StartingSequenceNumber)
+	require.Equal(t, "100", *params.StartingSequenceNumber)
+
+	sc.seqnr = "200"
+	params = sc.iteratorParams()
+	require.Equal(t, types.ShardIteratorTypeAfterSequenceNumber, params.ShardIteratorType)
+	require.NotNil(t, params.StartingSequenceNumber)
+	require.Equal(t, "200", *params.StartingSequenceNumber)
+
+	require.Equal(t, types.ShardIteratorTypeLatest, sc.params.ShardIteratorType)
+	require.Nil(t, sc.params.StartingSequenceNumber)
 }
 
 func TestOnMessage(t *testing.T) {

--- a/plugins/inputs/kinesis_consumer/sample.conf
+++ b/plugins/inputs/kinesis_consumer/sample.conf
@@ -34,6 +34,15 @@
   ## Available options: 'TRIM_HORIZON' (first in non-expired) and 'LATEST'
   # shard_iterator_type = "TRIM_HORIZON"
 
+  ## Position for recreating an expired shard iterator
+  ## Available options:
+  ##   'checkpoint'          -- sequence number stored in the checkpoint
+  ##                            backend, falls back to 'last_processed' if no
+  ##                            checkpoint is available
+  ##   'last_processed'      -- last sequence number read from the shard
+  ##   'shard_iterator_type' -- position determined by 'shard_iterator_type'
+  # shard_iterator_restart_position = "checkpoint"
+
   ## Interval for checking for new records
   ## Please consider limits for getting records documented here:
   ## https://docs.aws.amazon.com/streams/latest/dev/service-sizes-and-limits.html


### PR DESCRIPTION
Fixes #19505

## Root cause

Shard iterator recreated from the startup sequence number, not the last consumed one

## Changes

- Derive the GetShardIterator input from the shard consumer's current sequence number on every iterator request instead of freezing StartingSequenceNumber in the shared params at consumer creation; added a unit test asserting the params follow the last consumed sequence number.