### PR TITLE
fix: Logparser/tail input on Windows stops sendings logs due to file being lo...

### DIFF
--- a/plugins/inputs/tail/tail.go
+++ b/plugins/inputs/tail/tail.go
@@ -320,7 +320,7 @@ func (t *Tail) tailNewFiles() error {
 					Pipe:      t.Pipe,
 					Logger:    tail.DiscardingLogger,
 					OpenReaderFunc: func(rd io.Reader) io.Reader {
-						r, _ := utfbom.Skip(t.decoder.Reader(rd))
+						r, _ := utfbom.Skip(t.decoder.Reader(newRetryingReader(rd)))
 						return r
 					},
 				})


### PR DESCRIPTION
Fixes #6539

## Root cause

Transient Windows ERROR_LOCK_VIOLATION read kills the tailer permanently

## Changes

- Wrap the tailed file with a retrying reader injected through tail.Config.OpenReaderFunc so transient Windows lock-violation read errors are retried with backoff instead of propagating into the tail library, which would kill the tailer for good. Added platform-specific error classification plus unit tests.