### PR TITLE
fix(inputs.kinesis_consumer): recreate expired iterators from the latest sequence number

### DIFF
--- a/plugins/inputs/kinesis_consumer/consumer.go
+++ b/plugins/inputs/kinesis_consumer/consumer.go
@@ -16,12 +16,20 @@ import (
 
 type recordHandler func(ctx context.Context, shard string, r *types.Record)
 
+// kinesisAPI is the subset of the Kinesis API used by the consumer. It
+// exists so the iterator-expiry handling can be exercised with a fake
+// client in tests; *kinesis.Client satisfies it.
+type kinesisAPI interface {
+	GetRecords(ctx context.Context, params *kinesis.GetRecordsInput, optFns ...func(*kinesis.Options)) (*kinesis.GetRecordsOutput, error)
+	GetShardIterator(ctx context.Context, params *kinesis.GetShardIteratorInput, optFns ...func(*kinesis.Options)) (*kinesis.GetShardIteratorOutput, error)
+}
+
 type shardConsumer struct {
 	seqnr    string
 	interval time.Duration
 	log      telegraf.Logger
 
-	client *kinesis.Client
+	client kinesisAPI
 	params *kinesis.GetShardIteratorInput
 
 	onMessage recordHandler
@@ -55,6 +63,16 @@ func (c *shardConsumer) consume(ctx context.Context, shard string) ([]types.Chil
 				continue
 			case errors.As(err, &expiredIterErr):
 				c.log.Tracef("iterator expired for shard %s...", shard)
+				// Recreate the iterator from the latest consumed sequence
+				// number. The startup sequence number (from the checkpoint
+				// store) can be hours or weeks old; a shard iterator
+				// recreated from it rewinds consumption to that position
+				// and all records in between are delivered again.
+				if c.seqnr != "" {
+					seqnr := c.seqnr
+					c.params.ShardIteratorType = types.ShardIteratorTypeAfterSequenceNumber
+					c.params.StartingSequenceNumber = &seqnr
+				}
 				if iter, err = c.iterator(ctx); err != nil {
 					return nil, fmt.Errorf("getting shard iterator failed: %w", err)
 				}

--- a/plugins/inputs/kinesis_consumer/consumer_test.go
+++ b/plugins/inputs/kinesis_consumer/consumer_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/kinesis"
 	"github.com/aws/aws-sdk-go-v2/service/kinesis/types"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/influxdata/telegraf/testutil"
 )
@@ -51,7 +51,7 @@ func (f *fakeKinesisClient) GetRecords(
 		next = nil
 	}
 	return &kinesis.GetRecordsOutput{
-		Records:          f.recordsPerGet[i],
+		Records:           f.recordsPerGet[i],
 		NextShardIterator: next,
 	}, nil
 }

--- a/plugins/inputs/kinesis_consumer/consumer_test.go
+++ b/plugins/inputs/kinesis_consumer/consumer_test.go
@@ -1,0 +1,110 @@
+package kinesis_consumer
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/kinesis"
+	"github.com/aws/aws-sdk-go-v2/service/kinesis/types"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/influxdata/telegraf/testutil"
+)
+
+// fakeKinesisClient drives the shard consumer through the
+// expired-iterator recovery path and records every iterator request.
+type fakeKinesisClient struct {
+	iterRequests  []kinesis.GetShardIteratorInput
+	getRecordsSeq int
+	recordsPerGet [][]types.Record
+	expireAt      map[int]bool
+}
+
+func (f *fakeKinesisClient) GetShardIterator(
+	_ context.Context,
+	params *kinesis.GetShardIteratorInput,
+	_ ...func(*kinesis.Options),
+) (*kinesis.GetShardIteratorOutput, error) {
+	f.iterRequests = append(f.iterRequests, *params)
+	iter := aws.String("iter-after-" + *params.ShardId)
+	return &kinesis.GetShardIteratorOutput{ShardIterator: iter}, nil
+}
+
+func (f *fakeKinesisClient) GetRecords(
+	_ context.Context,
+	_ *kinesis.GetRecordsInput,
+	_ ...func(*kinesis.Options),
+) (*kinesis.GetRecordsOutput, error) {
+	i := f.getRecordsSeq
+	f.getRecordsSeq++
+
+	if f.expireAt[i] {
+		return nil, &types.ExpiredIteratorException{Message: aws.String("Iterator expired")}
+	}
+
+	next := aws.String("iter-next")
+	if i == len(f.recordsPerGet)-1 {
+		// no next iterator ends the consume loop
+		next = nil
+	}
+	return &kinesis.GetRecordsOutput{
+		Records:          f.recordsPerGet[i],
+		NextShardIterator: next,
+	}, nil
+}
+
+func TestConsumeRecreatesExpiredIteratorFromLatestSequenceNumber(t *testing.T) {
+	shardID := "shard-1"
+	startupSeqnr := "100"
+	latestSeqnr := "999"
+
+	fake := &fakeKinesisClient{
+		// first GetRecords succeeds with a record far newer than the
+		// startup checkpoint, the second one hits an expired iterator,
+		// the third returns no records and no next iterator to end the loop
+		recordsPerGet: [][]types.Record{
+			{{SequenceNumber: aws.String(latestSeqnr), Data: []byte(`{}`)}},
+			{},
+			{},
+		},
+		expireAt: map[int]bool{1: true},
+	}
+
+	var delivered int
+	sc := &shardConsumer{
+		seqnr:    startupSeqnr,
+		interval: time.Millisecond,
+		log:      testutil.Logger{},
+		client:   fake,
+		params: &kinesis.GetShardIteratorInput{
+			ShardId:                &shardID,
+			ShardIteratorType:      types.ShardIteratorTypeAfterSequenceNumber,
+			StartingSequenceNumber: &startupSeqnr,
+			StreamName:             aws.String("stream"),
+		},
+		onMessage: func(_ context.Context, _ string, _ *types.Record) {
+			delivered++
+		},
+	}
+
+	_, err := sc.consume(context.Background(), shardID)
+	require.NoError(t, err)
+
+	// the single record was processed exactly once
+	require.Equal(t, 1, delivered)
+
+	// two iterator requests: the initial one and the recreation after expiry
+	require.Len(t, fake.iterRequests, 2)
+
+	initial, recreated := fake.iterRequests[0], fake.iterRequests[1]
+	assert.Equal(t, types.ShardIteratorTypeAfterSequenceNumber, initial.ShardIteratorType)
+	require.NotNil(t, recreated.StartingSequenceNumber)
+
+	// the recreated iterator must resume from the latest consumed sequence
+	// number, not the (potentially far older) startup one (#19505)
+	assert.Equal(t, types.ShardIteratorTypeAfterSequenceNumber, recreated.ShardIteratorType)
+	assert.Equal(t, latestSeqnr, *recreated.StartingSequenceNumber)
+}


### PR DESCRIPTION
## Description

Fixes #19505.

When a shard iterator expires (Kinesis iterators live 5 minutes; the reporter hit this via a network partition in ECS), `consume()` recreates it through `c.iterator(ctx)` — which sends the *startup* `GetShardIteratorInput`, whose `StartingSequenceNumber` is the position read from the checkpoint store when the consumer launched. On a consumer that has been running for hours or weeks, that position is far behind the stream tip, so Kinesis returns an iterator at the stale position (or, once it falls behind the trim horizon, at the head of the stream) and **every record in between is delivered again**.

The consumer already tracks the last consumed sequence number in `c.seqnr` — the comment above the record loop says it is kept "for recreating the iterator" — but nothing ever fed it back into the iterator request. This PR updates `c.params` from `c.seqnr` immediately before recreating the iterator in the `ExpiredIteratorException` branch.

The `shardConsumer` client dependency is narrowed to a `kinesisAPI` interface (satisfied by `*kinesis.Client`, no behavior change) so the expiry path can be exercised by a unit test with a fake client.

## Testing

- New `TestConsumeRecreatesExpiredIteratorFromLatestSequenceNumber` drives a shard consumer through: initial iterator from checkpoint `100` → a record at `999` → `ExpiredIteratorException` → iterator recreation → end of shard. It asserts the recreated iterator request carries `AFTER_SEQUENCE_NUMBER` with sequence number `999` (the latest consumed), not `100`.
- Differential: with only the interface refactor and without the fix, the test fails with `actual: "100"`; with the fix it passes (`go test -count=1 ./plugins/inputs/kinesis_consumer/...` → ok).
- `go vet` clean, `gofmt` clean.
