### PR TITLE
fix(inputs.cloudwatch): Restore explicit queries for non-wildcard namespaces

### DIFF
--- a/filter/filter.go
+++ b/filter/filter.go
@@ -1,6 +1,7 @@
 package filter
 
 import (
+	"slices"
 	"strings"
 
 	"github.com/gobwas/glob"
@@ -37,12 +38,9 @@ func Compile(filters []string, separators ...rune) (Filter, error) {
 
 	// check if we can compile a non-glob filter
 	wildcards := len(separators) != 0
-	for _, filter := range filters {
-		if strings.ContainsAny(filter, "*?[") {
-			wildcards = true
-			break
-		}
-	}
+	wildcards = wildcards || slices.ContainsFunc(filters, func(filter string) bool {
+		return strings.ContainsAny(filter, WildcardCharacters)
+	})
 
 	switch {
 	case !wildcards && len(filters) == 1:

--- a/filter/filter.go
+++ b/filter/filter.go
@@ -6,6 +6,8 @@ import (
 	"github.com/gobwas/glob"
 )
 
+const WildcardCharacters = "*?{}[]!"
+
 type Filter interface {
 	Match(string) bool
 }

--- a/plugins/inputs/cloudwatch/cloudwatch.go
+++ b/plugins/inputs/cloudwatch/cloudwatch.go
@@ -51,13 +51,14 @@ type CloudWatch struct {
 	Log                   telegraf.Logger     `toml:"-"`
 	common_aws.CredentialConfig
 
-	client          cloudwatchClient
-	nsFilter        filter.Filter
-	statFilter      filter.Filter
-	cache           *metricCache
-	queryDimensions map[string]*map[string]string
-	windowStart     time.Time
-	windowEnd       time.Time
+	client             cloudwatchClient
+	nsFilter           filter.Filter
+	statFilter         filter.Filter
+	cache              *metricCache
+	queryDimensions    map[string]*map[string]string
+	windowStart        time.Time
+	windowEnd          time.Time
+	wildcardNamespaces bool
 }
 
 type cloudwatchMetric struct {
@@ -161,6 +162,14 @@ func (c *CloudWatch) Init() error {
 		return fmt.Errorf("creating statistics filter failed: %w", err)
 	}
 
+	// Determine if the namespaces contain wildcards
+	for _, ns := range c.Namespaces {
+		if strings.ContainsAny(ns, filter.WildcardCharacters) {
+			c.wildcardNamespaces = true
+			break
+		}
+	}
+
 	// Initialize namespace filter
 	c.nsFilter, err = filter.Compile(c.Namespaces)
 	if err != nil {
@@ -228,61 +237,16 @@ func (c *CloudWatch) getFilteredMetrics() ([]filteredMetric, error) {
 		return c.cache.metrics, nil
 	}
 
-	// Get all metrics from cloudwatch for filtering
-	params := &cloudwatch.ListMetricsInput{
-		IncludeLinkedAccounts: &c.IncludeLinkedAccounts,
-	}
-	if c.RecentlyActive == "PT3H" {
-		params.RecentlyActive = types.RecentlyActivePt3h
-	}
-
-	// Return the subset of metrics matching the namespace and at one of the
-	// metric definitions if any
 	var metrics []types.Metric
 	var accounts []string
-	for {
-		resp, err := c.client.ListMetrics(context.Background(), params)
-		if err != nil {
-			c.Log.Errorf("failed to list metrics: %v", err)
-			break
+	if c.wildcardNamespaces {
+		metrics, accounts = c.queryMetrics(nil)
+	} else {
+		for _, ns := range c.Namespaces {
+			m, a := c.queryMetrics(&ns)
+			metrics = append(metrics, m...)
+			accounts = append(accounts, a...)
 		}
-		c.Log.Tracef("got %d metrics with %d accounts", len(resp.Metrics), len(resp.OwningAccounts))
-		for i, m := range resp.Metrics {
-			if c.Log.Level().Includes(telegraf.Trace) {
-				dims := make([]string, 0, len(m.Dimensions))
-				for _, d := range m.Dimensions {
-					dims = append(dims, *d.Name+"="+*d.Value)
-				}
-				a := "none"
-				if len(resp.OwningAccounts) > 0 {
-					a = resp.OwningAccounts[i]
-				}
-				c.Log.Tracef("  metric %3d: %s (%s): %s [%s]\n", i, *m.MetricName, *m.Namespace, strings.Join(dims, ", "), a)
-			}
-
-			if c.nsFilter != nil && !c.nsFilter.Match(*m.Namespace) {
-				c.Log.Trace("  -> rejected by namespace")
-				continue
-			}
-
-			if len(c.Metrics) > 0 && !slices.ContainsFunc(c.Metrics, func(cm *cloudwatchMetric) bool {
-				return metricMatch(cm, m)
-			}) {
-				c.Log.Trace("  -> rejected by metric mismatch")
-				continue
-			}
-			c.Log.Trace("  -> keeping metric")
-
-			metrics = append(metrics, m)
-			if len(resp.OwningAccounts) > 0 {
-				accounts = append(accounts, resp.OwningAccounts[i])
-			}
-		}
-
-		if resp.NextToken == nil {
-			break
-		}
-		params.NextToken = resp.NextToken
 	}
 
 	var filtered []filteredMetric
@@ -331,6 +295,72 @@ func (c *CloudWatch) getFilteredMetrics() ([]filteredMetric, error) {
 	}
 
 	return filtered, nil
+}
+
+func (c *CloudWatch) queryMetrics(namespace *string) ([]types.Metric, []string) {
+	// Get all metrics from cloudwatch for filtering
+	params := &cloudwatch.ListMetricsInput{
+		IncludeLinkedAccounts: &c.IncludeLinkedAccounts,
+		Namespace:             namespace,
+	}
+	if c.RecentlyActive == "PT3H" {
+		params.RecentlyActive = types.RecentlyActivePt3h
+	}
+
+	// Return the subset of metrics matching the namespace and at one of the
+	// metric definitions if any
+	var metrics []types.Metric
+	var accounts []string
+	for {
+		resp, err := c.client.ListMetrics(context.Background(), params)
+		if err != nil {
+			c.Log.Errorf("failed to list metrics: %v", err)
+			break
+		}
+		if namespace == nil {
+			c.Log.Tracef("got %d metrics with %d accounts", len(resp.Metrics), len(resp.OwningAccounts))
+		} else {
+			c.Log.Tracef("got %d metrics with %d accounts for namespace %q", len(resp.Metrics), len(resp.OwningAccounts), *namespace)
+		}
+		for i, m := range resp.Metrics {
+			if c.Log.Level().Includes(telegraf.Trace) {
+				dims := make([]string, 0, len(m.Dimensions))
+				for _, d := range m.Dimensions {
+					dims = append(dims, *d.Name+"="+*d.Value)
+				}
+				a := "none"
+				if len(resp.OwningAccounts) > 0 {
+					a = resp.OwningAccounts[i]
+				}
+				c.Log.Tracef("  metric %3d: %s (%s): %s [%s]\n", i, *m.MetricName, *m.Namespace, strings.Join(dims, ", "), a)
+			}
+
+			if c.nsFilter != nil && !c.nsFilter.Match(*m.Namespace) {
+				c.Log.Trace("  -> rejected by namespace")
+				continue
+			}
+
+			if len(c.Metrics) > 0 && !slices.ContainsFunc(c.Metrics, func(cm *cloudwatchMetric) bool {
+				return metricMatch(cm, m)
+			}) {
+				c.Log.Trace("  -> rejected by metric mismatch")
+				continue
+			}
+			c.Log.Trace("  -> keeping metric")
+
+			metrics = append(metrics, m)
+			if len(resp.OwningAccounts) > 0 {
+				accounts = append(accounts, resp.OwningAccounts[i])
+			}
+		}
+
+		if resp.NextToken == nil {
+			break
+		}
+		params.NextToken = resp.NextToken
+	}
+
+	return metrics, accounts
 }
 
 func (c *CloudWatch) updateWindow(relativeTo time.Time) {

--- a/plugins/inputs/cloudwatch/cloudwatch.go
+++ b/plugins/inputs/cloudwatch/cloudwatch.go
@@ -163,12 +163,9 @@ func (c *CloudWatch) Init() error {
 	}
 
 	// Determine if the namespaces contain wildcards
-	for _, ns := range c.Namespaces {
-		if strings.ContainsAny(ns, filter.WildcardCharacters) {
-			c.wildcardNamespaces = true
-			break
-		}
-	}
+	c.wildcardNamespaces = len(c.Namespaces) == 0 || slices.ContainsFunc(c.Namespaces, func(ns string) bool {
+		return strings.ContainsAny(ns, filter.WildcardCharacters)
+	})
 
 	// Initialize namespace filter
 	c.nsFilter, err = filter.Compile(c.Namespaces)

--- a/plugins/inputs/cloudwatch/cloudwatch_test.go
+++ b/plugins/inputs/cloudwatch/cloudwatch_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/url"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -195,7 +196,99 @@ func TestMultiAccountGather(t *testing.T) {
 	testutil.RequireMetricsEqual(t, expected, acc.GetTelegrafMetrics(), testutil.IgnoreTime())
 }
 
-func TestGatherMultipleNamespaces(t *testing.T) {
+func TestGatherMultipleNamespacesWildcard(t *testing.T) {
+	plugin := &CloudWatch{
+		CredentialConfig: common_aws.CredentialConfig{
+			Region: "us-east-1",
+		},
+		Namespaces: []string{"AWS/E*"},
+		Delay:      config.Duration(1 * time.Minute),
+		Period:     config.Duration(1 * time.Minute),
+		RateLimit:  200,
+		BatchSize:  500,
+		Log:        testutil.Logger{},
+	}
+	require.NoError(t, plugin.Init())
+	plugin.client = defaultMockClient("AWS/ELB", "AWS/EC2")
+
+	var acc testutil.Accumulator
+	require.NoError(t, acc.GatherError(plugin.Gather))
+
+	expected := []telegraf.Metric{
+		metric.New(
+			"cloudwatch_aws_elb",
+			map[string]string{
+				"region":             "us-east-1",
+				"load_balancer_name": "p-example1",
+			},
+			map[string]interface{}{
+				"latency_minimum":      0.1,
+				"latency_maximum":      0.3,
+				"latency_average":      0.2,
+				"latency_sum":          123.0,
+				"latency_sample_count": 100.0,
+			},
+			time.Unix(0, 0),
+		),
+		metric.New(
+			"cloudwatch_aws_elb",
+			map[string]string{
+				"region":             "us-east-1",
+				"load_balancer_name": "p-example2",
+			},
+			map[string]interface{}{
+				"latency_minimum":      0.1,
+				"latency_maximum":      0.3,
+				"latency_average":      0.2,
+				"latency_sum":          124.0,
+				"latency_sample_count": 100.0,
+			},
+			time.Unix(0, 0),
+		),
+		metric.New(
+			"cloudwatch_aws_ec2",
+			map[string]string{
+				"region":             "us-east-1",
+				"load_balancer_name": "p-example1",
+			},
+			map[string]interface{}{
+				"latency_minimum":      0.1,
+				"latency_maximum":      0.3,
+				"latency_average":      0.2,
+				"latency_sum":          123.0,
+				"latency_sample_count": 100.0,
+			},
+			time.Unix(0, 0),
+		),
+		metric.New(
+			"cloudwatch_aws_ec2",
+			map[string]string{
+				"region":             "us-east-1",
+				"load_balancer_name": "p-example2",
+			},
+			map[string]interface{}{
+				"latency_minimum":      0.1,
+				"latency_maximum":      0.3,
+				"latency_average":      0.2,
+				"latency_sum":          124.0,
+				"latency_sample_count": 100.0,
+			},
+			time.Unix(0, 0),
+		),
+	}
+
+	option := []cmp.Option{
+		testutil.IgnoreTime(),
+		testutil.SortMetrics(),
+	}
+
+	testutil.RequireMetricsEqual(t, expected, acc.GetTelegrafMetrics(), option...)
+
+	// Make sure the query did NOT contain the namespace
+	require.False(t, plugin.client.(*mockClient).withNamespace.Load())
+}
+
+func TestGatherMultipleNamespacesExplicitNamespace(t *testing.T) {
 	plugin := &CloudWatch{
 		CredentialConfig: common_aws.CredentialConfig{
 			Region: "us-east-1",
@@ -282,6 +375,9 @@ func TestGatherMultipleNamespaces(t *testing.T) {
 	}
 
 	testutil.RequireMetricsEqual(t, expected, acc.GetTelegrafMetrics(), option...)
+
+	// Make sure the query contained the namespace
+	require.True(t, plugin.client.(*mockClient).withNamespace.Load())
 }
 
 func TestSelectMetrics(t *testing.T) {
@@ -507,7 +603,8 @@ func TestCombineNamespaces(t *testing.T) {
 
 // INTERNAL mock client implementation
 type mockClient struct {
-	metrics []types.Metric
+	metrics       []types.Metric
+	withNamespace atomic.Bool
 }
 
 func defaultMockClient(namespaces ...string) *mockClient {
@@ -594,6 +691,9 @@ func (c *mockClient) ListMetrics(
 	if params.IncludeLinkedAccounts != nil && *params.IncludeLinkedAccounts {
 		response.OwningAccounts = []string{"123456789012", "923456789017"}
 	}
+
+	c.withNamespace.Store(params.Namespace != nil)
+
 	return response, nil
 }
 


### PR DESCRIPTION
## Summary

This PR restores querying metrics with explicit, server-side namespace filtering if none of the configured namespaces contain a wildcard. This reduces the amount of transferred data and query time if the inventory contains many metrics and only a subset is queried for explicitly specified namespaces.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

resolves #19510 
