### PR TITLE
chore(linter): Inline types and functions

### DIFF
--- a/models/common.go
+++ b/models/common.go
@@ -18,7 +18,7 @@ func logName(pluginType, name, alias string) string {
 func SetLoggerOnPlugin(i interface{}, logger telegraf.Logger) {
 	valI := reflect.ValueOf(i)
 
-	if valI.Type().Kind() != reflect.Ptr {
+	if valI.Type().Kind() != reflect.Pointer {
 		valI = reflect.New(reflect.TypeOf(i))
 	}
 

--- a/plugins/inputs/aliyuncms/discovery.go
+++ b/plugins/inputs/aliyuncms/discovery.go
@@ -57,7 +57,7 @@ type parsedDResp struct {
 // getRPCReqFromDiscoveryRequest - utility function to map between aliyun request primitives
 // discoveryRequest represents different type of discovery requests
 func getRPCReqFromDiscoveryRequest(req discoveryRequest) (*requests.RpcRequest, error) {
-	if reflect.ValueOf(req).Type().Kind() != reflect.Ptr ||
+	if reflect.ValueOf(req).Type().Kind() != reflect.Pointer ||
 		reflect.ValueOf(req).IsNil() {
 		return nil, fmt.Errorf("unexpected type of the discovery request object: %q, %q", reflect.ValueOf(req).Type(), reflect.ValueOf(req).Kind())
 	}

--- a/plugins/inputs/dpdk/dpdk_utils.go
+++ b/plugins/inputs/dpdk/dpdk_utils.go
@@ -132,5 +132,5 @@ func uniqueValues(values []string) []string {
 }
 
 func isEmpty(value interface{}) bool {
-	return value == nil || (reflect.ValueOf(value).Kind() == reflect.Ptr && reflect.ValueOf(value).IsNil())
+	return value == nil || (reflect.ValueOf(value).Kind() == reflect.Pointer && reflect.ValueOf(value).IsNil())
 }

--- a/plugins/inputs/vsphere/finder.go
+++ b/plugins/inputs/vsphere/finder.go
@@ -193,7 +193,7 @@ func (f *finder) descend(ctx context.Context, root types.ManagedObjectReference,
 
 func objectContentToTypedArray(objs map[string]types.ObjectContent, dst interface{}) error {
 	rt := reflect.TypeOf(dst)
-	if rt == nil || rt.Kind() != reflect.Ptr {
+	if rt == nil || rt.Kind() != reflect.Pointer {
 		panic("need pointer")
 	}
 

--- a/selfstat/collector_test.go
+++ b/selfstat/collector_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestCollectorRegisterIncrSet(t *testing.T) {
-	defer maps.Clear(registry.stats)
+	defer clear(registry.stats)
 
 	// Create a new collector with global tags
 	collector := NewCollector(map[string]string{"global": "zoo"})
@@ -80,7 +80,7 @@ func TestCollectorRegisterIncrSet(t *testing.T) {
 }
 
 func TestCollectorRegisterTimingIncrSet(t *testing.T) {
-	defer maps.Clear(registry.stats)
+	defer clear(registry.stats)
 
 	// Create a new collector with global tags
 	collector := NewCollector(map[string]string{"global": "zoo"})


### PR DESCRIPTION
## Summary

This PR inlines the `maps.Clear` function as well as the `reflect.Ptr` references in preparation of bumping golangci-lint.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
