### PR TITLE
chore(linter): Remove superfluous DualStack param

### DIFF
--- a/plugins/inputs/burrow/burrow.go
+++ b/plugins/inputs/burrow/burrow.go
@@ -173,7 +173,7 @@ func (b *Burrow) createClient() (*http.Client, error) {
 	}
 
 	timeout := time.Duration(b.ResponseTimeout)
-	dialContext := net.Dialer{Timeout: timeout, DualStack: true}
+	dialContext := net.Dialer{Timeout: timeout}
 	transport := http.Transport{
 		DialContext:     dialContext.DialContext,
 		TLSClientConfig: tlsCfg,

--- a/plugins/inputs/cloudwatch/cloudwatch.go
+++ b/plugins/inputs/cloudwatch/cloudwatch.go
@@ -129,7 +129,6 @@ func (c *CloudWatch) Init() error {
 				DialContext: (&net.Dialer{
 					Timeout:   30 * time.Second,
 					KeepAlive: 30 * time.Second,
-					DualStack: true,
 				}).DialContext,
 				MaxIdleConns:          100,
 				IdleConnTimeout:       90 * time.Second,


### PR DESCRIPTION
## Summary

This PR removes the deprecated `DualStack` setting for `net.Dialer` as fast-fallback support is enabled by default since go 1.12. This is in preparation of bumping golangci-lint.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
