### PR TITLE
chore(linter): Remove deprecated functions

### DIFF
--- a/plugins/inputs/gnmi/gnmi_test.go
+++ b/plugins/inputs/gnmi/gnmi_test.go
@@ -661,7 +661,7 @@ func TestNotification(t *testing.T) {
 												{Name: "low-threshold"},
 											}},
 										Val: &gnmi.TypedValue{
-											Value: &gnmi.TypedValue_FloatVal{FloatVal: 0},
+											Value: &gnmi.TypedValue_DoubleVal{DoubleVal: 0},
 										},
 									},
 									{
@@ -700,7 +700,7 @@ func TestNotification(t *testing.T) {
 												{Name: "critical-high-threshold"},
 											}},
 										Val: &gnmi.TypedValue{
-											Value: &gnmi.TypedValue_FloatVal{FloatVal: 94},
+											Value: &gnmi.TypedValue_DoubleVal{DoubleVal: 94},
 										},
 									},
 									{
@@ -710,7 +710,7 @@ func TestNotification(t *testing.T) {
 												{Name: "current"},
 											}},
 										Val: &gnmi.TypedValue{
-											Value: &gnmi.TypedValue_FloatVal{FloatVal: 29},
+											Value: &gnmi.TypedValue_DoubleVal{DoubleVal: 29},
 										},
 									},
 									{
@@ -720,7 +720,7 @@ func TestNotification(t *testing.T) {
 												{Name: "high-threshold"},
 											}},
 										Val: &gnmi.TypedValue{
-											Value: &gnmi.TypedValue_FloatVal{FloatVal: 90},
+											Value: &gnmi.TypedValue_DoubleVal{DoubleVal: 90},
 										},
 									},
 								},

--- a/plugins/inputs/kube_inventory/node_test.go
+++ b/plugins/inputs/kube_inventory/node_test.go
@@ -56,7 +56,6 @@ func TestNode(t *testing.T) {
 										OSImage:                 "Container Linux by CoreOS 1745.7.0 (Rhyolite)",
 										ContainerRuntimeVersion: "docker://18.3.1",
 										KubeletVersion:          "v1.10.3",
-										KubeProxyVersion:        "v1.10.3",
 									},
 									Phase: "Running",
 									Capacity: corev1.ResourceList{

--- a/plugins/inputs/prometheus/prometheus.go
+++ b/plugins/inputs/prometheus/prometheus.go
@@ -518,7 +518,7 @@ func (p *Prometheus) gatherURL(u urlAndAddress, acc telegraf.Accumulator) (map[s
 			Transport: &http.Transport{
 				TLSClientConfig:   tlsCfg,
 				DisableKeepAlives: true,
-				Dial: func(string, string) (net.Conn, error) {
+				DialContext: func(context.Context, string, string) (net.Conn, error) {
 					c, err := net.Dial("unix", u.url.Path)
 					return c, err
 				},

--- a/plugins/outputs/influxdb/http.go
+++ b/plugins/outputs/influxdb/http.go
@@ -181,7 +181,7 @@ func NewHTTPClient(cfg HTTPConfig) (*httpClient, error) {
 		}
 	case "unix":
 		transport = &http.Transport{
-			Dial: func(_, _ string) (net.Conn, error) {
+			DialContext: func(context.Context, string, string) (net.Conn, error) {
 				return net.DialTimeout(
 					cfg.URL.Scheme,
 					cfg.URL.Path,


### PR DESCRIPTION
## Summary
This PR removes deprecated function in preparation of bumping golangci-lint.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
