### PR TITLE
feat(inputs.kube_inventory): Collect metrics for native sidecar containers

### DIFF
--- a/plugins/inputs/kube_inventory/pod.go
+++ b/plugins/inputs/kube_inventory/pod.go
@@ -35,12 +35,23 @@ func (ki *KubernetesInventory) gatherPod(p *corev1.Pod, acc telegraf.Accumulator
 		return
 	}
 
-	containerList := make(map[string]*corev1.ContainerStatus, len(p.Status.ContainerStatuses))
-	for i := range p.Status.ContainerStatuses {
-		containerList[p.Status.ContainerStatuses[i].Name] = &p.Status.ContainerStatuses[i]
+	initContainers := make([]corev1.Container, 0, len(p.Spec.InitContainers))
+	for _, c := range p.Spec.InitContainers {
+		if c.RestartPolicy != nil && *c.RestartPolicy == corev1.ContainerRestartPolicyAlways {
+			initContainers = append(initContainers, c)
+		}
+	}
+	ki.gatherPodContainers(p, initContainers, p.Status.InitContainerStatuses, acc)
+	ki.gatherPodContainers(p, p.Spec.Containers, p.Status.ContainerStatuses, acc)
+}
+
+func (ki *KubernetesInventory) gatherPodContainers(p *corev1.Pod, containers []corev1.Container, statuses []corev1.ContainerStatus, acc telegraf.Accumulator) {
+	containerList := make(map[string]*corev1.ContainerStatus, len(statuses))
+	for i := range statuses {
+		containerList[statuses[i].Name] = &statuses[i]
 	}
 
-	for _, c := range p.Spec.Containers {
+	for _, c := range containers {
 		cs, ok := containerList[c.Name]
 		if !ok {
 			cs = &corev1.ContainerStatus{}

--- a/plugins/inputs/kube_inventory/pod_test.go
+++ b/plugins/inputs/kube_inventory/pod_test.go
@@ -463,6 +463,70 @@ func TestPod(t *testing.T) {
 	}
 }
 
+func TestPodInitContainerResources(t *testing.T) {
+	ki := &KubernetesInventory{}
+	require.NoError(t, ki.createSelectorFilters())
+
+	restartPolicy := corev1.ContainerRestartPolicyAlways
+	acc := new(testutil.Accumulator)
+	ki.gatherPod(&corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			CreationTimestamp: metav1.Now(),
+			Name:              "pod1",
+			Namespace:         "ns1",
+		},
+		Spec: corev1.PodSpec{
+			NodeName: "node1",
+			InitContainers: []corev1.Container{
+				{
+					Name:          "sidecar",
+					Image:         "image1:latest",
+					RestartPolicy: &restartPolicy,
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							"memory": resource.MustParse("256Mi"),
+						},
+					},
+				},
+				{Name: "init", Image: "image2"},
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: "Succeeded",
+			InitContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name: "sidecar",
+					State: corev1.ContainerState{
+						Terminated: &corev1.ContainerStateTerminated{Reason: "Completed"},
+					},
+				},
+				{Name: "init"},
+			},
+		},
+	}, acc)
+
+	require.Len(t, acc.Metrics, 1)
+	acc.AssertContainsTaggedFields(t, podContainerMeasurement,
+		map[string]interface{}{
+			"restarts_total":               int32(0),
+			"state_code":                   1,
+			"state_reason":                 "Completed",
+			"terminated_reason":            "Completed",
+			"resource_limits_memory_bytes": int64(268435456),
+		},
+		map[string]string{
+			"container_name": "sidecar",
+			"image":          "image1",
+			"namespace":      "ns1",
+			"node_name":      "node1",
+			"pod_name":       "pod1",
+			"phase":          "Succeeded",
+			"readiness":      "unready",
+			"state":          "terminated",
+			"version":        "latest",
+		})
+}
+
 func TestPodSelectorFilter(t *testing.T) {
 	cli := &client{}
 	now := time.Now()


### PR DESCRIPTION
## Summary
Collect metrics for sidecar init containers

## Checklist
- [ ] No AI generated code was used in this PR
- [x] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
resolves #19544 
