### PR TITLE
fix(inputs.cloudwatch): Avoid caching failed listings

### DIFF
--- a/plugins/inputs/cloudwatch/cloudwatch.go
+++ b/plugins/inputs/cloudwatch/cloudwatch.go
@@ -244,11 +244,11 @@ func (c *CloudWatch) getFilteredMetrics() ([]filteredMetric, error) {
 	} else {
 		for _, ns := range c.Namespaces {
 			m, a, err := c.queryMetrics(&ns)
-			metrics = append(metrics, m...)
-			accounts = append(accounts, a...)
 			if err != nil {
 				return nil, fmt.Errorf("querying metrics for namespace %q failed: %w", ns, err)
 			}
+			metrics = append(metrics, m...)
+			accounts = append(accounts, a...)
 		}
 	}
 
@@ -317,7 +317,7 @@ func (c *CloudWatch) queryMetrics(namespace *string) ([]types.Metric, []string, 
 	for {
 		resp, err := c.client.ListMetrics(context.Background(), params)
 		if err != nil {
-			return metrics, accounts, fmt.Errorf("failed to list metrics: %w", err)
+			return metrics, accounts, err
 		}
 		if namespace == nil {
 			c.Log.Tracef("got %d metrics with %d accounts", len(resp.Metrics), len(resp.OwningAccounts))

--- a/plugins/inputs/cloudwatch/cloudwatch.go
+++ b/plugins/inputs/cloudwatch/cloudwatch.go
@@ -236,12 +236,19 @@ func (c *CloudWatch) getFilteredMetrics() ([]filteredMetric, error) {
 	var metrics []types.Metric
 	var accounts []string
 	if c.wildcardNamespaces {
-		metrics, accounts = c.queryMetrics(nil)
+		var err error
+		metrics, accounts, err = c.queryMetrics(nil)
+		if err != nil {
+			return nil, fmt.Errorf("querying metrics failed: %w", err)
+		}
 	} else {
 		for _, ns := range c.Namespaces {
-			m, a := c.queryMetrics(&ns)
+			m, a, err := c.queryMetrics(&ns)
 			metrics = append(metrics, m...)
 			accounts = append(accounts, a...)
+			if err != nil {
+				return nil, fmt.Errorf("querying metrics for namespace %q failed: %w", ns, err)
+			}
 		}
 	}
 
@@ -293,7 +300,7 @@ func (c *CloudWatch) getFilteredMetrics() ([]filteredMetric, error) {
 	return filtered, nil
 }
 
-func (c *CloudWatch) queryMetrics(namespace *string) ([]types.Metric, []string) {
+func (c *CloudWatch) queryMetrics(namespace *string) ([]types.Metric, []string, error) {
 	// Get all metrics from cloudwatch for filtering
 	params := &cloudwatch.ListMetricsInput{
 		IncludeLinkedAccounts: &c.IncludeLinkedAccounts,
@@ -310,8 +317,7 @@ func (c *CloudWatch) queryMetrics(namespace *string) ([]types.Metric, []string) 
 	for {
 		resp, err := c.client.ListMetrics(context.Background(), params)
 		if err != nil {
-			c.Log.Errorf("failed to list metrics: %v", err)
-			break
+			return metrics, accounts, fmt.Errorf("failed to list metrics: %w", err)
 		}
 		if namespace == nil {
 			c.Log.Tracef("got %d metrics with %d accounts", len(resp.Metrics), len(resp.OwningAccounts))
@@ -356,7 +362,7 @@ func (c *CloudWatch) queryMetrics(namespace *string) ([]types.Metric, []string) 
 		params.NextToken = resp.NextToken
 	}
 
-	return metrics, accounts
+	return metrics, accounts, nil
 }
 
 func (c *CloudWatch) updateWindow(relativeTo time.Time) {

--- a/plugins/inputs/cloudwatch/cloudwatch_test.go
+++ b/plugins/inputs/cloudwatch/cloudwatch_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"net/http"
 	"net/url"
-	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -646,9 +645,7 @@ func TestFailedListDoesntCache(t *testing.T) {
 	plugin.client = client
 
 	// Make the list call fail
-	client.Lock()
 	client.listErr = errors.New("operation error")
-	client.Unlock()
 
 	// Check that we don't have any entry in the cache
 	require.Empty(t, plugin.cache)
@@ -661,9 +658,7 @@ func TestFailedListDoesntCache(t *testing.T) {
 	require.Empty(t, plugin.cache)
 
 	// The next list call should succeed
-	client.Lock()
 	client.listErr = nil
-	client.Unlock()
 
 	// Make sure the listing is called and we get the metrics
 	require.NoError(t, acc.GatherError(plugin.Gather))
@@ -713,7 +708,6 @@ type mockClient struct {
 
 	withNamespace atomic.Bool
 	listCalls     atomic.Uint32
-	sync.Mutex
 }
 
 func defaultMockClient(namespaces ...string) *mockClient {
@@ -795,11 +789,8 @@ func (c *mockClient) ListMetrics(
 ) (*cloudwatch.ListMetricsOutput, error) {
 	c.listCalls.Add(1)
 
-	c.Lock()
-	err := c.listErr
-	c.Unlock()
-	if err != nil {
-		return nil, err
+	if c.listErr != nil {
+		return nil, c.listErr
 	}
 
 	response := &cloudwatch.ListMetricsOutput{

--- a/plugins/inputs/cloudwatch/cloudwatch_test.go
+++ b/plugins/inputs/cloudwatch/cloudwatch_test.go
@@ -2,8 +2,10 @@ package cloudwatch
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/url"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -601,10 +603,117 @@ func TestCombineNamespaces(t *testing.T) {
 	require.Equal(t, []string{"AWS/EC2", "AWS/Billing"}, plugin.Namespaces)
 }
 
+func TestFailedListDoesntCache(t *testing.T) {
+	plugin := &CloudWatch{
+		CredentialConfig: common_aws.CredentialConfig{
+			Region: "us-east-1",
+		},
+		Namespaces: []string{"AWS/ELB"},
+		Delay:      config.Duration(1 * time.Minute),
+		Period:     config.Duration(1 * time.Minute),
+		CacheTTL:   config.Duration(1 * time.Hour),
+		RateLimit:  200,
+		BatchSize:  500,
+		Log:        testutil.Logger{},
+	}
+	require.NoError(t, plugin.Init())
+
+	// Setup the mock client
+	client := &mockClient{
+		metrics: []types.Metric{
+			{
+				Namespace:  aws.String("AWS/ELB"),
+				MetricName: aws.String("Latency"),
+				Dimensions: []types.Dimension{
+					{
+						Name:  aws.String("LoadBalancerName"),
+						Value: aws.String("p-example1"),
+					},
+				},
+			},
+			{
+				Namespace:  aws.String("AWS/ELB"),
+				MetricName: aws.String("Latency"),
+				Dimensions: []types.Dimension{
+					{
+						Name:  aws.String("LoadBalancerName"),
+						Value: aws.String("p-example2"),
+					},
+				},
+			},
+		},
+	}
+	plugin.client = client
+
+	// Make the list call fail
+	client.Lock()
+	client.listErr = errors.New("operation error")
+	client.Unlock()
+
+	// Check that we don't have any entry in the cache
+	require.Empty(t, plugin.cache)
+
+	// Gather and get the error; make sure listing got called and we did not
+	// cache anything
+	var acc testutil.Accumulator
+	require.ErrorContains(t, acc.GatherError(plugin.Gather), "operation error")
+	require.EqualValues(t, 1, client.listCalls.Load())
+	require.Empty(t, plugin.cache)
+
+	// The next list call should succeed
+	client.Lock()
+	client.listErr = nil
+	client.Unlock()
+
+	// Make sure the listing is called and we get the metrics
+	require.NoError(t, acc.GatherError(plugin.Gather))
+	require.EqualValues(t, 2, client.listCalls.Load())
+	require.NotEmpty(t, plugin.cache)
+
+	expected := []telegraf.Metric{
+		metric.New(
+			"cloudwatch_aws_elb",
+			map[string]string{
+				"region":             "us-east-1",
+				"load_balancer_name": "p-example1",
+			},
+			map[string]interface{}{
+				"latency_minimum":      0.1,
+				"latency_maximum":      0.3,
+				"latency_average":      0.2,
+				"latency_sum":          123.0,
+				"latency_sample_count": 100.0,
+			},
+			time.Unix(0, 0),
+		),
+		metric.New(
+			"cloudwatch_aws_elb",
+			map[string]string{
+				"region":             "us-east-1",
+				"load_balancer_name": "p-example2",
+			},
+			map[string]interface{}{
+				"latency_minimum":      0.1,
+				"latency_maximum":      0.3,
+				"latency_average":      0.2,
+				"latency_sum":          124.0,
+				"latency_sample_count": 100.0,
+			},
+			time.Unix(0, 0),
+		),
+	}
+
+	testutil.RequireMetricsEqual(t, expected, acc.GetTelegrafMetrics(), testutil.IgnoreTime())
+}
+
 // INTERNAL mock client implementation
 type mockClient struct {
-	metrics       []types.Metric
+	metrics []types.Metric
+	listErr error
+
 	withNamespace atomic.Bool
+	listCalls     atomic.Uint32
+	sync.Mutex
 }
 
 func defaultMockClient(namespaces ...string) *mockClient {
@@ -684,6 +793,15 @@ func (c *mockClient) ListMetrics(
 	params *cloudwatch.ListMetricsInput,
 	_ ...func(*cloudwatch.Options),
 ) (*cloudwatch.ListMetricsOutput, error) {
+	c.listCalls.Add(1)
+
+	c.Lock()
+	err := c.listErr
+	c.Unlock()
+	if err != nil {
+		return nil, err
+	}
+
 	response := &cloudwatch.ListMetricsOutput{
 		Metrics: c.metrics,
 	}


### PR DESCRIPTION
## Summary

The current code caches listed metrics to avoid too frequent polls of the service running into rate limits. At this, we currently cache the result independent of the success of the list operation, leading to situations where failed listings are cached for the cache-TTL rendering the plugin useless for that time.

This PR returns early if the listing fails and stops caching the result.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

based on #19513 
resolves #19543 
