### PR TITLE
fix(inputs.cloudwatch): Restore empty value to match all dimensions

### DIFF
--- a/plugins/inputs/cloudwatch/cloudwatch.go
+++ b/plugins/inputs/cloudwatch/cloudwatch.go
@@ -147,6 +147,11 @@ func (c *CloudWatch) Init() error {
 		})
 		// Initialize filter for metric dimensions to include
 		for _, dimension := range m.Dimensions {
+			// If no value is given, match all by not assigning a filter
+			if dimension.Value == "" {
+				continue
+			}
+
 			matcher, err := filter.NewIncludeExcludeFilter([]string{dimension.Value}, nil)
 			if err != nil {
 				return fmt.Errorf("creating dimension filter for dimension %q failed: %w", dimension, err)

--- a/plugins/inputs/cloudwatch/cloudwatch_test.go
+++ b/plugins/inputs/cloudwatch/cloudwatch_test.go
@@ -451,6 +451,34 @@ func TestSelectMetricsSummaryOnly(t *testing.T) {
 	require.Len(t, filtered[0].metrics, 6)
 }
 
+func TestSelectMetricsNoValueMatchesAll(t *testing.T) {
+	plugin := &CloudWatch{
+		CredentialConfig: common_aws.CredentialConfig{
+			Region: "us-east-1",
+		},
+		Namespaces: []string{"AWS/ELB"},
+		Delay:      config.Duration(1 * time.Minute),
+		Period:     config.Duration(1 * time.Minute),
+		RateLimit:  200,
+		BatchSize:  500,
+		Metrics: []*cloudwatchMetric{
+			{
+				MetricNames: []string{"Latency", "RequestCount"},
+				Dimensions:  []*dimension{{Name: "LoadBalancerName"}},
+			},
+		},
+		Log: testutil.Logger{},
+	}
+	require.NoError(t, plugin.Init())
+	plugin.client = selectedMockClient()
+	filtered, err := plugin.getFilteredMetrics()
+	require.NoError(t, err)
+
+	// Without a value we should match all metrics with the corresponding metric
+	// names so 2 (out of 4) metrics for all 3 load balancers
+	require.Len(t, filtered[0].metrics, 6)
+}
+
 func TestGenerateStatisticsInputParams(t *testing.T) {
 	d := types.Dimension{
 		Name:  aws.String("LoadBalancerName"),


### PR DESCRIPTION
## Summary

Previously (before v1.33.2) we matched all dimensions if the `value` setting of a `metric` `dimension` was omitted. This unintentionally changed with PR #16337.

This PR restores the behavior before PR #16337 and matches all dimensions if `value` is omitted.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
based on #19513
based on #19547
resolves #19542 
