### PR TITLE
fix(outputs.parquet): Mark value columns as nullable 

### DIFF
--- a/plugins/outputs/parquet/parquet.go
+++ b/plugins/outputs/parquet/parquet.go
@@ -261,8 +261,9 @@ func (p *Parquet) createSchema(metrics []telegraf.Metric) (*arrow.Schema, error)
 	fields := make([]arrow.Field, 0)
 	for key, value := range rawFields {
 		fields = append(fields, arrow.Field{
-			Name: key,
-			Type: value,
+			Name:     key,
+			Type:     value,
+			Nullable: true,
 		})
 	}
 

--- a/plugins/outputs/parquet/parquet_test.go
+++ b/plugins/outputs/parquet/parquet_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/metric"
+	"github.com/influxdata/telegraf/testutil"
 )
 
 func TestCases(t *testing.T) {
@@ -244,4 +245,34 @@ func TestTimestampDifferentName(t *testing.T) {
 	metadata := reader.MetaData()
 	require.Equal(t, 1, int(metadata.NumRows))
 	require.Equal(t, 2, metadata.Schema.NumColumns())
+}
+
+func TestMissingValuesReadBackAsNull(t *testing.T) {
+	dir := t.TempDir()
+	p := &Parquet{Directory: dir, TimestampFieldName: "timestamp", Log: testutil.Logger{}}
+	require.NoError(t, p.Init())
+
+	now := time.Now()
+	require.NoError(t, p.Write([]telegraf.Metric{
+		metric.New("demo", nil, map[string]interface{}{"a": int64(1), "b": int64(2)}, now),
+		metric.New("demo", nil, map[string]interface{}{"a": int64(3)}, now),
+	}))
+	require.NoError(t, p.Close())
+
+	written, err := filepath.Glob(filepath.Join(dir, "*.parquet"))
+	require.NoError(t, err)
+	require.Len(t, written, 1)
+
+	reader, err := file.OpenParquetFile(written[0], false)
+	require.NoError(t, err)
+	defer reader.Close()
+
+	schema := reader.MetaData().Schema
+	for i := 0; i < schema.NumColumns(); i++ {
+		column := schema.Column(i)
+		if column.Name() == "timestamp" {
+			continue
+		}
+		require.Equalf(t, int16(1), column.MaxDefinitionLevel(), "column %q is required, nulls would be written as zero", column.Name())
+	}
 }


### PR DESCRIPTION
There is no way to represent a missing value as columns are not marked `Nullable`.

Plugins already append `null` when a metric is missing a field or tag. Putting a `null` into a required column turns missing int64 into `0` and missing bools as `false`.

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [ ] No AI generated code was used in this PR
- [x] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

partially solves #19563 
