### PR TITLE
fix(outputs.parquet): Reject metrics that do not fit the column schema

### DIFF
--- a/plugins/outputs/parquet/README.md
+++ b/plugins/outputs/parquet/README.md
@@ -66,6 +66,9 @@ The `timestamp_field_name` column holds the metric time, so a field or tag with
 that same name is dropped and logged. Set `timestamp_field_name` to another name
 or rename the field or tag to keep both.
 
+Since column types are fixed at file creation, when an unknown value is logged
+it will be logged as `null` and once per column.
+
 ### Write
 
 The plugin makes use of the buffered writer. This may buffer some metrics into

--- a/plugins/outputs/parquet/README.md
+++ b/plugins/outputs/parquet/README.md
@@ -66,8 +66,8 @@ The `timestamp_field_name` column holds the metric time, so a field or tag with
 that same name is dropped and logged. Set `timestamp_field_name` to another name
 or rename the field or tag to keep both.
 
-Since column types are fixed at file creation, when an unknown value is logged
-it will be logged as `null` and once per column.
+Since column types are fixed at file creation, an unknown value that doesn't
+match the column cannot be written and is dropped and reported.
 
 ### Write
 

--- a/plugins/outputs/parquet/parquet.go
+++ b/plugins/outputs/parquet/parquet.go
@@ -27,6 +27,7 @@ var defaultTimestampFieldName = "timestamp"
 
 type metricGroup struct {
 	filename string
+	warned   map[string]bool
 	builder  *array.RecordBuilder
 	schema   *arrow.Schema
 	writer   *pqarrow.FileWriter
@@ -106,6 +107,7 @@ func (p *Parquet) Write(metrics []telegraf.Metric) error {
 			p.metricGroups[name] = &metricGroup{
 				builder:  array.NewRecordBuilder(memory.DefaultAllocator, schema),
 				filename: filename,
+				warned:   make(map[string]bool),
 				schema:   schema,
 				writer:   writer,
 			}
@@ -117,14 +119,13 @@ func (p *Parquet) Write(metrics []telegraf.Metric) error {
 			}
 		}
 
-		record, err := p.createRecordBatch(metrics, p.metricGroups[name].builder, p.metricGroups[name].schema)
-		if err != nil {
-			return fmt.Errorf("failed to create record for file %q: %w", p.metricGroups[name].filename, err)
-		}
-		if err = p.metricGroups[name].writer.WriteBuffered(record); err != nil {
-			return fmt.Errorf("failed to write to file %q: %w", p.metricGroups[name].filename, err)
-		}
+		group := p.metricGroups[name]
+		record := p.createRecordBatch(group, metrics)
+		err := group.writer.WriteBuffered(record)
 		record.Release()
+		if err != nil {
+			return fmt.Errorf("failed to write to file %q: %w", group.filename, err)
+		}
 	}
 
 	return nil
@@ -154,89 +155,95 @@ func (p *Parquet) rotateIfNeeded(name string) error {
 	return nil
 }
 
-func (p *Parquet) createRecordBatch(metrics []telegraf.Metric, builder *array.RecordBuilder, schema *arrow.Schema) (arrow.RecordBatch, error) {
-	for index, col := range schema.Fields() {
+func (p *Parquet) createRecordBatch(group *metricGroup, metrics []telegraf.Metric) arrow.RecordBatch {
+	for index, column := range group.schema.Fields() {
+		builder := group.builder.Field(index)
+
 		for _, m := range metrics {
-			if p.TimestampFieldName != "" && col.Name == p.TimestampFieldName {
-				builder.Field(index).(*array.Int64Builder).Append(m.Time().UnixNano())
-				continue
-			}
-
-			// Try to get the value from a field first, then from a tag.
-			var value any
-			var ok bool
-			value, ok = m.GetField(col.Name)
-			if !ok {
-				value, ok = m.GetTag(col.Name)
-			}
-
-			// if neither field nor tag exists, append a null value
-			if !ok {
-				switch col.Type {
-				case arrow.PrimitiveTypes.Int8:
-					builder.Field(index).(*array.Int8Builder).AppendNull()
-				case arrow.PrimitiveTypes.Int16:
-					builder.Field(index).(*array.Int16Builder).AppendNull()
-				case arrow.PrimitiveTypes.Int32:
-					builder.Field(index).(*array.Int32Builder).AppendNull()
-				case arrow.PrimitiveTypes.Int64:
-					builder.Field(index).(*array.Int64Builder).AppendNull()
-				case arrow.PrimitiveTypes.Uint8:
-					builder.Field(index).(*array.Uint8Builder).AppendNull()
-				case arrow.PrimitiveTypes.Uint16:
-					builder.Field(index).(*array.Uint16Builder).AppendNull()
-				case arrow.PrimitiveTypes.Uint32:
-					builder.Field(index).(*array.Uint32Builder).AppendNull()
-				case arrow.PrimitiveTypes.Uint64:
-					builder.Field(index).(*array.Uint64Builder).AppendNull()
-				case arrow.PrimitiveTypes.Float32:
-					builder.Field(index).(*array.Float32Builder).AppendNull()
-				case arrow.PrimitiveTypes.Float64:
-					builder.Field(index).(*array.Float64Builder).AppendNull()
-				case arrow.BinaryTypes.String:
-					builder.Field(index).(*array.StringBuilder).AppendNull()
-				case arrow.FixedWidthTypes.Boolean:
-					builder.Field(index).(*array.BooleanBuilder).AppendNull()
-				default:
-					return nil, fmt.Errorf("unsupported type: %T", value)
-				}
-
-				continue
-			}
-
-			switch col.Type {
-			case arrow.PrimitiveTypes.Int8:
-				builder.Field(index).(*array.Int8Builder).Append(value.(int8))
-			case arrow.PrimitiveTypes.Int16:
-				builder.Field(index).(*array.Int16Builder).Append(value.(int16))
-			case arrow.PrimitiveTypes.Int32:
-				builder.Field(index).(*array.Int32Builder).Append(value.(int32))
-			case arrow.PrimitiveTypes.Int64:
-				builder.Field(index).(*array.Int64Builder).Append(value.(int64))
-			case arrow.PrimitiveTypes.Uint8:
-				builder.Field(index).(*array.Uint8Builder).Append(value.(uint8))
-			case arrow.PrimitiveTypes.Uint16:
-				builder.Field(index).(*array.Uint16Builder).Append(value.(uint16))
-			case arrow.PrimitiveTypes.Uint32:
-				builder.Field(index).(*array.Uint32Builder).Append(value.(uint32))
-			case arrow.PrimitiveTypes.Uint64:
-				builder.Field(index).(*array.Uint64Builder).Append(value.(uint64))
-			case arrow.PrimitiveTypes.Float32:
-				builder.Field(index).(*array.Float32Builder).Append(value.(float32))
-			case arrow.PrimitiveTypes.Float64:
-				builder.Field(index).(*array.Float64Builder).Append(value.(float64))
-			case arrow.BinaryTypes.String:
-				builder.Field(index).(*array.StringBuilder).Append(value.(string))
-			case arrow.FixedWidthTypes.Boolean:
-				builder.Field(index).(*array.BooleanBuilder).Append(value.(bool))
-			default:
-				return nil, fmt.Errorf("unsupported type: %T", value)
+			value := p.valueFor(m, column.Name)
+			if !appendValue(builder, value) {
+				p.warnOncef(
+					group, column.Name,
+					"Writing null for column %q of file %q as a %T value does not fit its %s column",
+					column.Name, group.filename, value, column.Type,
+				)
 			}
 		}
 	}
 
-	record := builder.NewRecordBatch()
-	return record, nil
+	return group.builder.NewRecordBatch()
+}
+
+func (p *Parquet) valueFor(m telegraf.Metric, column string) interface{} {
+	if p.TimestampFieldName != "" && column == p.TimestampFieldName {
+		return m.Time().UnixNano()
+	}
+	if value, found := m.GetField(column); found {
+		return value
+	}
+	if value, found := m.GetTag(column); found {
+		return value
+	}
+
+	return nil
+}
+
+func (p *Parquet) warnOncef(group *metricGroup, column, format string, args ...interface{}) {
+	if group.warned[column] {
+		return
+	}
+	group.warned[column] = true
+	p.Log.Warnf(format, args...)
+}
+
+func appendValue(builder array.Builder, value interface{}) bool {
+	switch v := value.(type) {
+	case nil:
+		builder.AppendNull()
+		return true
+	case int8:
+		return appendTyped(builder, v)
+	case int16:
+		return appendTyped(builder, v)
+	case int32:
+		return appendTyped(builder, v)
+	case int64:
+		return appendTyped(builder, v)
+	case int:
+		return appendTyped(builder, int64(v))
+	case uint8:
+		return appendTyped(builder, v)
+	case uint16:
+		return appendTyped(builder, v)
+	case uint32:
+		return appendTyped(builder, v)
+	case uint64:
+		return appendTyped(builder, v)
+	case uint:
+		return appendTyped(builder, uint64(v))
+	case float32:
+		return appendTyped(builder, v)
+	case float64:
+		return appendTyped(builder, v)
+	case string:
+		return appendTyped(builder, v)
+	case bool:
+		return appendTyped(builder, v)
+	default:
+		builder.AppendNull()
+		return false
+	}
+}
+
+func appendTyped[T any](builder array.Builder, value T) bool {
+	column, ok := builder.(interface{ Append(T) })
+	if !ok {
+		builder.AppendNull()
+		return false
+	}
+	column.Append(value)
+
+	return true
 }
 
 func (p *Parquet) createSchema(metrics []telegraf.Metric) (*arrow.Schema, error) {

--- a/plugins/outputs/parquet/parquet.go
+++ b/plugins/outputs/parquet/parquet.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
+	"github.com/influxdata/telegraf/internal"
 	"github.com/influxdata/telegraf/plugins/outputs"
 )
 
@@ -27,7 +28,6 @@ var defaultTimestampFieldName = "timestamp"
 
 type metricGroup struct {
 	filename string
-	warned   map[string]bool
 	builder  *array.RecordBuilder
 	schema   *arrow.Schema
 	writer   *pqarrow.FileWriter
@@ -87,16 +87,24 @@ func (p *Parquet) Close() error {
 }
 
 func (p *Parquet) Write(metrics []telegraf.Metric) error {
-	groupedMetrics := make(map[string][]telegraf.Metric)
-	for _, metric := range metrics {
-		groupedMetrics[metric.Name()] = append(groupedMetrics[metric.Name()], metric)
+	grouped := make(map[string][]int)
+	for i, m := range metrics {
+		grouped[m.Name()] = append(grouped[m.Name()], i)
 	}
 
+	var writeErr internal.PartialWriteError
+
 	now := time.Now()
-	for name, metrics := range groupedMetrics {
-		if _, ok := p.metricGroups[name]; !ok {
+	for name, indices := range grouped {
+		group, found := p.metricGroups[name]
+		if !found {
+			batch := make([]telegraf.Metric, 0, len(indices))
+			for _, i := range indices {
+				batch = append(batch, metrics[i])
+			}
+
 			filename := fmt.Sprintf("%s/%s-%s-%s.parquet", p.Directory, name, now.Format("2006-01-02"), strconv.FormatInt(now.Unix(), 10))
-			schema, err := p.createSchema(metrics)
+			schema, err := p.createSchema(batch)
 			if err != nil {
 				return fmt.Errorf("failed to create schema for file %q: %w", name, err)
 			}
@@ -104,27 +112,62 @@ func (p *Parquet) Write(metrics []telegraf.Metric) error {
 			if err != nil {
 				return fmt.Errorf("failed to create writer for file %q: %w", name, err)
 			}
-			p.metricGroups[name] = &metricGroup{
+
+			group = &metricGroup{
 				builder:  array.NewRecordBuilder(memory.DefaultAllocator, schema),
 				filename: filename,
-				warned:   make(map[string]bool),
 				schema:   schema,
 				writer:   writer,
 			}
+			p.metricGroups[name] = group
 		}
 
 		if p.RotationInterval != 0 {
 			if err := p.rotateIfNeeded(name); err != nil {
-				return fmt.Errorf("failed to rotate file %q: %w", p.metricGroups[name].filename, err)
+				return fmt.Errorf("failed to rotate file %q: %w", group.filename, err)
 			}
 		}
 
-		group := p.metricGroups[name]
-		record := p.createRecordBatch(group, metrics)
+		accepted := make([]telegraf.Metric, 0, len(indices))
+		for _, i := range indices {
+			if err := p.checkSchema(group, metrics[i]); err != nil {
+				writeErr.MetricsReject = append(writeErr.MetricsReject, i)
+				writeErr.MetricsRejectErrors = append(writeErr.MetricsRejectErrors, err)
+				continue
+			}
+			accepted = append(accepted, metrics[i])
+			writeErr.MetricsAccept = append(writeErr.MetricsAccept, i)
+		}
+
+		record := p.createRecordBatch(group, accepted)
 		err := group.writer.WriteBuffered(record)
 		record.Release()
 		if err != nil {
 			return fmt.Errorf("failed to write to file %q: %w", group.filename, err)
+		}
+	}
+
+	if len(writeErr.MetricsReject) == 0 {
+		return nil
+	}
+	writeErr.Err = fmt.Errorf("rejected %d metric(s): %w", len(writeErr.MetricsReject), errors.Join(writeErr.MetricsRejectErrors...))
+
+	return &writeErr
+}
+
+func (p *Parquet) checkSchema(group *metricGroup, m telegraf.Metric) error {
+	for _, column := range group.schema.Fields() {
+		value := p.valueFor(m, column.Name)
+		if value == nil {
+			continue
+		}
+
+		datatype, err := goToArrowType(value)
+		if err != nil {
+			return fmt.Errorf("column %q of file %q: %w", column.Name, group.filename, err)
+		}
+		if !arrow.TypeEqual(datatype, column.Type) {
+			return fmt.Errorf("column %q of file %q holds %s but the metric has a %s value", column.Name, group.filename, column.Type, datatype)
 		}
 	}
 
@@ -160,14 +203,7 @@ func (p *Parquet) createRecordBatch(group *metricGroup, metrics []telegraf.Metri
 		builder := group.builder.Field(index)
 
 		for _, m := range metrics {
-			value := p.valueFor(m, column.Name)
-			if !appendValue(builder, value) {
-				p.warnOncef(
-					group, column.Name,
-					"Writing null for column %q of file %q as a %T value does not fit its %s column",
-					column.Name, group.filename, value, column.Type,
-				)
-			}
+			appendValue(builder, p.valueFor(m, column.Name))
 		}
 	}
 
@@ -188,62 +224,50 @@ func (p *Parquet) valueFor(m telegraf.Metric, column string) interface{} {
 	return nil
 }
 
-func (p *Parquet) warnOncef(group *metricGroup, column, format string, args ...interface{}) {
-	if group.warned[column] {
-		return
-	}
-	group.warned[column] = true
-	p.Log.Warnf(format, args...)
-}
-
-func appendValue(builder array.Builder, value interface{}) bool {
+func appendValue(builder array.Builder, value interface{}) {
 	switch v := value.(type) {
 	case nil:
 		builder.AppendNull()
-		return true
 	case int8:
-		return appendTyped(builder, v)
+		appendTyped(builder, v)
 	case int16:
-		return appendTyped(builder, v)
+		appendTyped(builder, v)
 	case int32:
-		return appendTyped(builder, v)
+		appendTyped(builder, v)
 	case int64:
-		return appendTyped(builder, v)
+		appendTyped(builder, v)
 	case int:
-		return appendTyped(builder, int64(v))
+		appendTyped(builder, int64(v))
 	case uint8:
-		return appendTyped(builder, v)
+		appendTyped(builder, v)
 	case uint16:
-		return appendTyped(builder, v)
+		appendTyped(builder, v)
 	case uint32:
-		return appendTyped(builder, v)
+		appendTyped(builder, v)
 	case uint64:
-		return appendTyped(builder, v)
+		appendTyped(builder, v)
 	case uint:
-		return appendTyped(builder, uint64(v))
+		appendTyped(builder, uint64(v))
 	case float32:
-		return appendTyped(builder, v)
+		appendTyped(builder, v)
 	case float64:
-		return appendTyped(builder, v)
+		appendTyped(builder, v)
 	case string:
-		return appendTyped(builder, v)
+		appendTyped(builder, v)
 	case bool:
-		return appendTyped(builder, v)
+		appendTyped(builder, v)
 	default:
 		builder.AppendNull()
-		return false
 	}
 }
 
-func appendTyped[T any](builder array.Builder, value T) bool {
+func appendTyped[T any](builder array.Builder, value T) {
 	column, ok := builder.(interface{ Append(T) })
 	if !ok {
 		builder.AppendNull()
-		return false
+		return
 	}
 	column.Append(value)
-
-	return true
 }
 
 func (p *Parquet) createSchema(metrics []telegraf.Metric) (*arrow.Schema, error) {

--- a/plugins/outputs/parquet/parquet_test.go
+++ b/plugins/outputs/parquet/parquet_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
+	"github.com/influxdata/telegraf/internal"
 	"github.com/influxdata/telegraf/metric"
 	"github.com/influxdata/telegraf/testutil"
 )
@@ -308,7 +309,7 @@ func TestTimestampFieldNameCollisionKeepsOneColumn(t *testing.T) {
 	require.Equal(t, parquet.Types.Int64, schema.Column(schema.ColumnIndexByName("timestamp")).PhysicalType())
 }
 
-func TestConflictingValueTypesDoNotPanic(t *testing.T) {
+func TestConflictingValueTypesAreRejected(t *testing.T) {
 	dir := t.TempDir()
 	p := &Parquet{Directory: dir, TimestampFieldName: "timestamp", Log: testutil.Logger{}}
 	require.NoError(t, p.Init())
@@ -316,8 +317,16 @@ func TestConflictingValueTypesDoNotPanic(t *testing.T) {
 	require.NoError(t, p.Write([]telegraf.Metric{
 		metric.New("demo", nil, map[string]interface{}{"k": int64(1)}, time.Now()),
 	}))
-	require.NoError(t, p.Write([]telegraf.Metric{
+
+	var writeErr *internal.PartialWriteError
+	require.ErrorAs(t, p.Write([]telegraf.Metric{
 		metric.New("demo", map[string]string{"k": "v"}, map[string]interface{}{"other": int64(2)}, time.Now()),
+	}), &writeErr)
+	require.Equal(t, []int{0}, writeErr.MetricsReject)
+	require.Empty(t, writeErr.MetricsAccept)
+
+	require.NoError(t, p.Write([]telegraf.Metric{
+		metric.New("demo", nil, map[string]interface{}{"k": int64(3)}, time.Now()),
 	}))
 	require.NoError(t, p.Close())
 
@@ -329,6 +338,31 @@ func TestConflictingValueTypesDoNotPanic(t *testing.T) {
 	require.NoError(t, err)
 	defer reader.Close()
 	require.Equal(t, int64(2), reader.NumRows())
+}
+
+func TestFieldTakesPrecedenceOverTag(t *testing.T) {
+	p := &Parquet{TimestampFieldName: "timestamp", Log: testutil.Logger{}}
+	m := metric.New("demo", map[string]string{"k": "tag"}, map[string]interface{}{"k": int64(1)}, time.Now())
+
+	require.Equal(t, int64(1), p.valueFor(m, "k"))
+}
+
+func TestRejectedMetricsReportEveryIndexExactlyOnce(t *testing.T) {
+	dir := t.TempDir()
+	p := &Parquet{Directory: dir, TimestampFieldName: "timestamp", Log: testutil.Logger{}}
+	require.NoError(t, p.Init())
+
+	var writeErr *internal.PartialWriteError
+	require.ErrorAs(t, p.Write([]telegraf.Metric{
+		metric.New("demo", nil, map[string]interface{}{"k": int64(1)}, time.Now()),
+		metric.New("demo", map[string]string{"k": "v"}, map[string]interface{}{"other": int64(2)}, time.Now()),
+		metric.New("other", nil, map[string]interface{}{"v": int64(3)}, time.Now()),
+	}), &writeErr)
+	require.NoError(t, p.Close())
+
+	require.ElementsMatch(t, []int{1}, writeErr.MetricsReject)
+	require.ElementsMatch(t, []int{0, 2}, writeErr.MetricsAccept)
+	require.Len(t, writeErr.MetricsRejectErrors, 1)
 }
 
 func TestEveryConvertibleTypeRoundTrips(t *testing.T) {
@@ -347,7 +381,7 @@ func TestEveryConvertibleTypeRoundTrips(t *testing.T) {
 			builder := array.NewBuilder(memory.DefaultAllocator, datatype)
 			defer builder.Release()
 
-			require.True(t, appendValue(builder, value))
+			appendValue(builder, value)
 			require.Equal(t, 0, builder.NullN())
 		})
 	}
@@ -357,8 +391,8 @@ func TestAppendValueNullsWhatItCannotWrite(t *testing.T) {
 	builder := array.NewBuilder(memory.DefaultAllocator, arrow.PrimitiveTypes.Int64)
 	defer builder.Release()
 
-	require.False(t, appendValue(builder, "not an int"))
-	require.False(t, appendValue(builder, []string{"unsupported"}))
-	require.True(t, appendValue(builder, nil))
+	appendValue(builder, "not an int")
+	appendValue(builder, []string{"unsupported"})
+	appendValue(builder, nil)
 	require.Equal(t, 3, builder.NullN())
 }

--- a/plugins/outputs/parquet/parquet_test.go
+++ b/plugins/outputs/parquet/parquet_test.go
@@ -6,6 +6,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/apache/arrow-go/v18/parquet"
 	"github.com/apache/arrow-go/v18/parquet/file"
 	"github.com/stretchr/testify/require"
@@ -303,4 +306,59 @@ func TestTimestampFieldNameCollisionKeepsOneColumn(t *testing.T) {
 	}
 	require.ElementsMatch(t, []string{"value", "timestamp"}, names)
 	require.Equal(t, parquet.Types.Int64, schema.Column(schema.ColumnIndexByName("timestamp")).PhysicalType())
+}
+
+func TestConflictingValueTypesDoNotPanic(t *testing.T) {
+	dir := t.TempDir()
+	p := &Parquet{Directory: dir, TimestampFieldName: "timestamp", Log: testutil.Logger{}}
+	require.NoError(t, p.Init())
+
+	require.NoError(t, p.Write([]telegraf.Metric{
+		metric.New("demo", nil, map[string]interface{}{"k": int64(1)}, time.Now()),
+	}))
+	require.NoError(t, p.Write([]telegraf.Metric{
+		metric.New("demo", map[string]string{"k": "v"}, map[string]interface{}{"other": int64(2)}, time.Now()),
+	}))
+	require.NoError(t, p.Close())
+
+	written, err := filepath.Glob(filepath.Join(dir, "*.parquet"))
+	require.NoError(t, err)
+	require.Len(t, written, 1)
+
+	reader, err := file.OpenParquetFile(written[0], false)
+	require.NoError(t, err)
+	defer reader.Close()
+	require.Equal(t, int64(2), reader.NumRows())
+}
+
+func TestEveryConvertibleTypeRoundTrips(t *testing.T) {
+	values := map[string]interface{}{
+		"int8": int8(1), "int16": int16(2), "int32": int32(3), "int64": int64(4), "int": 5,
+		"uint8": uint8(6), "uint16": uint16(7), "uint32": uint32(8), "uint64": uint64(9), "uint": uint(10),
+		"float32": float32(11), "float64": float64(12),
+		"string": "thirteen", "bool": true,
+	}
+
+	for name, value := range values {
+		t.Run(name, func(t *testing.T) {
+			datatype, err := goToArrowType(value)
+			require.NoError(t, err)
+
+			builder := array.NewBuilder(memory.DefaultAllocator, datatype)
+			defer builder.Release()
+
+			require.True(t, appendValue(builder, value))
+			require.Equal(t, 0, builder.NullN())
+		})
+	}
+}
+
+func TestAppendValueNullsWhatItCannotWrite(t *testing.T) {
+	builder := array.NewBuilder(memory.DefaultAllocator, arrow.PrimitiveTypes.Int64)
+	defer builder.Release()
+
+	require.False(t, appendValue(builder, "not an int"))
+	require.False(t, appendValue(builder, []string{"unsupported"}))
+	require.True(t, appendValue(builder, nil))
+	require.Equal(t, 3, builder.NullN())
 }


### PR DESCRIPTION
Since parquet files have immutable schemas after creation, a value that did not match its column panicked (eg :: (1) `demo k=1i` (2) `demo,k=v other=2i`). Since this is uncaught, it crashed Telegraf.

Values are now appended through a checked type assertion that rejects bad metrics with a PartialWriteError. This drops the bad metric and reports why, rather than failing the whole batch and requeueing it forever.

Starting a new file when the schema changes is left to https://github.com/influxdata/telegraf/pull/19561.

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [ ] No AI generated code was used in this PR
- [x] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves # security issue + #19563
