### PR TITLE
fix(outputs.parquet): Reserve the timestamp column for the metric time

### DIFF
--- a/plugins/outputs/parquet/README.md
+++ b/plugins/outputs/parquet/README.md
@@ -62,6 +62,14 @@ When writing to a file, the schema is used to look for each value and if it is
 not present a null value is added. The result is that if additional fields are
 present after the first metric flush those fields are omitted.
 
+Since column types are fixed at file creation, when an unknown value is logged
+it will be logged as `null` and once per column. 
+Inputs that collide with reserved columns like `timestamp_field_name` are
+dropped and logged. Rename `timestamp_field_name` or your field to fix it.
+
+Since parquet column schemas are fixed at file creation, new values that 
+do not fit the column schema are written as `null` and logged once per column.
+
 ### Write
 
 The plugin makes use of the buffered writer. This may buffer some metrics into

--- a/plugins/outputs/parquet/README.md
+++ b/plugins/outputs/parquet/README.md
@@ -62,13 +62,9 @@ When writing to a file, the schema is used to look for each value and if it is
 not present a null value is added. The result is that if additional fields are
 present after the first metric flush those fields are omitted.
 
-Since column types are fixed at file creation, when an unknown value is logged
-it will be logged as `null` and once per column. 
-Inputs that collide with reserved columns like `timestamp_field_name` are
-dropped and logged. Rename `timestamp_field_name` or your field to fix it.
-
-Since parquet column schemas are fixed at file creation, new values that 
-do not fit the column schema are written as `null` and logged once per column.
+The `timestamp_field_name` column holds the metric time, so a field or tag with
+that same name is dropped and logged. Set `timestamp_field_name` to another name
+or rename the field or tag to keep both.
 
 ### Write
 

--- a/plugins/outputs/parquet/parquet.go
+++ b/plugins/outputs/parquet/parquet.go
@@ -258,6 +258,17 @@ func (p *Parquet) createSchema(metrics []telegraf.Metric) (*arrow.Schema, error)
 		}
 	}
 
+	if p.TimestampFieldName != "" {
+		if _, taken := rawFields[p.TimestampFieldName]; taken {
+			delete(rawFields, p.TimestampFieldName)
+			p.Log.Warnf(
+				"Ignoring the %q field or tag as that column holds the metric time; "+
+					"set 'timestamp_field_name' to another name to keep it",
+				p.TimestampFieldName,
+			)
+		}
+	}
+
 	fields := make([]arrow.Field, 0)
 	for key, value := range rawFields {
 		fields = append(fields, arrow.Field{

--- a/plugins/outputs/parquet/parquet.go
+++ b/plugins/outputs/parquet/parquet.go
@@ -258,19 +258,13 @@ func (p *Parquet) createSchema(metrics []telegraf.Metric) (*arrow.Schema, error)
 		}
 	}
 
-	if p.TimestampFieldName != "" {
-		if _, taken := rawFields[p.TimestampFieldName]; taken {
-			delete(rawFields, p.TimestampFieldName)
-			p.Log.Warnf(
-				"Ignoring the %q field or tag as that column holds the metric time; "+
-					"set 'timestamp_field_name' to another name to keep it",
-				p.TimestampFieldName,
-			)
-		}
-	}
-
 	fields := make([]arrow.Field, 0)
 	for key, value := range rawFields {
+		if p.TimestampFieldName != "" && key == p.TimestampFieldName {
+			p.Log.Warnf("Ignoring the %q field or tag as that column holds the metric time; "+
+				"set 'timestamp_field_name' to another name to keep it", key)
+			continue
+		}
 		fields = append(fields, arrow.Field{
 			Name:     key,
 			Type:     value,

--- a/plugins/outputs/parquet/parquet_test.go
+++ b/plugins/outputs/parquet/parquet_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/apache/arrow-go/v18/parquet"
 	"github.com/apache/arrow-go/v18/parquet/file"
 	"github.com/stretchr/testify/require"
 
@@ -275,4 +276,31 @@ func TestMissingValuesReadBackAsNull(t *testing.T) {
 		}
 		require.Equalf(t, int16(1), column.MaxDefinitionLevel(), "column %q is required, nulls would be written as zero", column.Name())
 	}
+}
+
+func TestTimestampFieldNameCollisionKeepsOneColumn(t *testing.T) {
+	dir := t.TempDir()
+	p := &Parquet{Directory: dir, TimestampFieldName: "timestamp", Log: testutil.Logger{}}
+	require.NoError(t, p.Init())
+
+	require.NoError(t, p.Write([]telegraf.Metric{
+		metric.New("demo", nil, map[string]interface{}{"timestamp": "x", "value": int64(1)}, time.Now()),
+	}))
+	require.NoError(t, p.Close())
+
+	written, err := filepath.Glob(filepath.Join(dir, "*.parquet"))
+	require.NoError(t, err)
+	require.Len(t, written, 1)
+
+	reader, err := file.OpenParquetFile(written[0], false)
+	require.NoError(t, err)
+	defer reader.Close()
+
+	schema := reader.MetaData().Schema
+	names := make([]string, 0, schema.NumColumns())
+	for i := 0; i < schema.NumColumns(); i++ {
+		names = append(names, schema.Column(i).Name())
+	}
+	require.ElementsMatch(t, []string{"value", "timestamp"}, names)
+	require.Equal(t, parquet.Types.Int64, schema.Column(schema.ColumnIndexByName("timestamp")).PhysicalType())
 }


### PR DESCRIPTION
Telegraf reserves an int64 `timestamp_field_name` column for the metric time, but gets conflicting names would carry the same name and two different types. A bad input would go to the int64 builder and panic. (eg :: `demo timestamp="x"`)

Now telegraf drops fields or tags that collide with reserved column names and log the exception.

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [ ] No AI generated code was used in this PR
- [x] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

related to #19563
