### PR TITLE
fix(outputs.parquet): Order columns deterministically

### DIFF
--- a/plugins/outputs/parquet/README.md
+++ b/plugins/outputs/parquet/README.md
@@ -51,7 +51,8 @@ plugin ordering. See [CONFIGURATION.md][CONFIGURATION.md] for more details.
 Parquet files require a schema when writing files. To generate a schema,
 Telegraf will go through all grouped metrics and generate an Apache Arrow schema
 based on the union of all fields and tags. If a field and tag have the same name
-then the field takes precedence.
+then the field takes precedence. Columns are ordered by name, with the
+timestamp column last.
 
 The consequence of schema generation is that the very first flush sequence a
 metric is seen takes much longer due to the additional looping through the

--- a/plugins/outputs/parquet/parquet.go
+++ b/plugins/outputs/parquet/parquet.go
@@ -5,8 +5,10 @@ import (
 	_ "embed"
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"time"
 
@@ -423,8 +425,9 @@ func (p *Parquet) createSchema(metrics []telegraf.Metric) (*arrow.Schema, error)
 		}
 	}
 
-	fields := make([]arrow.Field, 0)
-	for key, value := range rawFields {
+	fields := make([]arrow.Field, 0, len(rawFields)+1)
+	for _, key := range slices.Sorted(maps.Keys(rawFields)) {
+		value := rawFields[key]
 		if p.TimestampFieldName != "" && key == p.TimestampFieldName {
 			p.Log.Warnf("Ignoring the %q field or tag as that column holds the metric time; "+
 				"set 'timestamp_field_name' to another name to keep it", key)

--- a/plugins/outputs/parquet/parquet_test.go
+++ b/plugins/outputs/parquet/parquet_test.go
@@ -593,3 +593,41 @@ func TestFieldTakesPrecedenceOverTagInAnyOrder(t *testing.T) {
 		})
 	}
 }
+
+func TestColumnsSortedByNameWithTimestampLast(t *testing.T) {
+	dir := t.TempDir()
+	p := &Parquet{Directory: dir, TimestampFieldName: "timestamp", Log: testutil.Logger{}}
+	require.NoError(t, p.Init())
+
+	require.NoError(t, p.Write([]telegraf.Metric{
+		metric.New("cpu",
+			map[string]string{"region": "eu-west", "host": "web-01"},
+			map[string]interface{}{
+				"usage_user":   6.0,
+				"usage_system": 4.0,
+				"usage_idle":   90.0,
+				"usage_iowait": 0.5,
+				"usage_steal":  0.25,
+			},
+			time.Now(),
+		),
+	}))
+	require.NoError(t, p.Close())
+
+	written, err := filepath.Glob(filepath.Join(dir, "*.parquet"))
+	require.NoError(t, err)
+	require.Len(t, written, 1)
+
+	reader, err := file.OpenParquetFile(written[0], false)
+	require.NoError(t, err)
+	defer reader.Close()
+
+	schema := reader.MetaData().Schema
+	names := make([]string, 0, schema.NumColumns())
+	for i := 0; i < schema.NumColumns(); i++ {
+		names = append(names, schema.Column(i).Name())
+	}
+	require.Equal(t, []string{
+		"host", "region", "usage_idle", "usage_iowait", "usage_steal", "usage_system", "usage_user", "timestamp",
+	}, names)
+}


### PR DESCRIPTION
The schema is built by ranging over a map, which is randomly ordered on Go.

Readers can get around this by matching columns by name, but now they can also match columns by position which should be faster.

Columns are now sorted by name, with the timestamp column last.

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [ ] No AI generated code was used in this PR
- [x] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves # security issue + #19563
