### PR TITLE
feat(outputs.parquet)!: Use unique filenames to avoid filename collisions

### DIFF
--- a/plugins/outputs/parquet/README.md
+++ b/plugins/outputs/parquet/README.md
@@ -86,8 +86,8 @@ of this occurring.
 
 ## File Rotation
 
-If a file with the same target name exists at start, the existing file is
-rotated to avoid over-writing it or conflicting schema.
+Existing files are never modified. If the target name is already taken, a
+numeric suffix is appended until an unused name is found.
 
 File rotation is available via a time based interval that a user can optionally
 set. Due to the usage of a buffered writer, a size based rotation is not

--- a/plugins/outputs/parquet/parquet.go
+++ b/plugins/outputs/parquet/parquet.go
@@ -27,6 +27,8 @@ var sampleConfig string
 
 var defaultTimestampFieldName = "timestamp"
 
+const maxFilenameAttempts = 1000
+
 type metricGroup struct {
 	filename string
 	builder  *array.RecordBuilder
@@ -119,10 +121,8 @@ func (p *Parquet) Write(metrics []telegraf.Metric) error {
 	}
 
 	var perr internal.PartialWriteError
-	now := time.Now()
 	for name, metrics := range groupedMetrics {
 		if _, ok := p.metricGroups[name]; !ok {
-			filename := fmt.Sprintf("%s-%s-%s.parquet", name, now.Format("2006-01-02"), strconv.FormatInt(now.Unix(), 10))
 			schema, err := p.createSchema(metrics)
 			if err != nil {
 				perr.MetricsReject = append(perr.MetricsReject, metricIndices[name]...)
@@ -130,7 +130,7 @@ func (p *Parquet) Write(metrics []telegraf.Metric) error {
 				perr.Err = fmt.Errorf("failed to create schema for file %q: %w", name, err)
 				continue
 			}
-			writer, err := p.createWriter(name, filename, schema)
+			writer, filename, err := p.createWriter(name, schema)
 			if err != nil {
 				perr.MetricsReject = append(perr.MetricsReject, metricIndices[name]...)
 				perr.MetricsRejectErrors = append(perr.MetricsRejectErrors, fmt.Errorf("failed to create writer for file %q: %w", name, err))
@@ -206,11 +206,12 @@ func (p *Parquet) rotateIfNeeded(name string) error {
 		return fmt.Errorf("failed to close file for rotation %q: %w", p.metricGroups[name].filename, err)
 	}
 
-	writer, err := p.createWriter(name, p.metricGroups[name].filename, p.metricGroups[name].schema)
+	writer, filename, err := p.createWriter(name, p.metricGroups[name].schema)
 	if err != nil {
 		return fmt.Errorf("failed to create new writer for file %q: %w", p.metricGroups[name].filename, err)
 	}
 	p.metricGroups[name].writer = writer
+	p.metricGroups[name].filename = filename
 
 	return nil
 }
@@ -447,25 +448,34 @@ func (p *Parquet) createSchema(metrics []telegraf.Metric) (*arrow.Schema, error)
 	return arrow.NewSchema(fields, nil), nil
 }
 
-func (p *Parquet) createWriter(name, filename string, schema *arrow.Schema) (*pqarrow.FileWriter, error) {
-	if _, err := p.root.Stat(filename); err == nil {
-		now := time.Now()
-		rotatedFilename := fmt.Sprintf("%s-%s-%s.parquet", name, now.Format("2006-01-02"), strconv.FormatInt(now.Unix(), 10))
-		if err := p.root.Rename(filename, rotatedFilename); err != nil {
-			return nil, fmt.Errorf("failed to rename file %q: %w", filename, err)
+func (p *Parquet) createWriter(name string, schema *arrow.Schema) (*pqarrow.FileWriter, string, error) {
+	now := time.Now()
+	prefix := fmt.Sprintf("%s-%s-%s", name, now.Format("2006-01-02"), strconv.FormatInt(now.Unix(), 10))
+
+	for attempt := 0; attempt < maxFilenameAttempts; attempt++ {
+		filename := prefix + ".parquet"
+		if attempt > 0 {
+			filename = fmt.Sprintf("%s-%d.parquet", prefix, attempt)
 		}
-	}
-	file, err := p.root.Create(filename)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create file %q: %w", filename, err)
+
+		f, err := p.root.OpenFile(filename, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0640)
+		if errors.Is(err, os.ErrExist) {
+			continue
+		}
+		if err != nil {
+			return nil, "", fmt.Errorf("failed to create file %q: %w", filename, err)
+		}
+
+		writer, err := pqarrow.NewFileWriter(schema, f, parquet.NewWriterProperties(), pqarrow.DefaultWriterProps())
+		if err != nil {
+			f.Close()
+			return nil, "", fmt.Errorf("failed to create parquet writer for file %q: %w", filename, err)
+		}
+
+		return writer, filename, nil
 	}
 
-	writer, err := pqarrow.NewFileWriter(schema, file, parquet.NewWriterProperties(), pqarrow.DefaultWriterProps())
-	if err != nil {
-		return nil, fmt.Errorf("failed to create parquet writer for file %q: %w", filename, err)
-	}
-
-	return writer, nil
+	return nil, "", fmt.Errorf("no unused file name available for %q after %d attempts", name, maxFilenameAttempts)
 }
 
 func goToArrowType(value interface{}) (arrow.DataType, error) {

--- a/plugins/outputs/parquet/parquet_test.go
+++ b/plugins/outputs/parquet/parquet_test.go
@@ -593,3 +593,34 @@ func TestFieldTakesPrecedenceOverTagInAnyOrder(t *testing.T) {
 		})
 	}
 }
+
+func TestNeverOverwritesAnExistingFile(t *testing.T) {
+	testDir := t.TempDir()
+	plugin := &Parquet{
+		Directory:          testDir,
+		TimestampFieldName: defaultTimestampFieldName,
+		Log:                testutil.Logger{},
+	}
+	require.NoError(t, plugin.Init())
+	require.NoError(t, plugin.Connect())
+	defer plugin.Close()
+
+	schema, err := plugin.createSchema([]telegraf.Metric{
+		metric.New("test", map[string]string{}, map[string]interface{}{"value": 1.0}, time.Now()),
+	})
+	require.NoError(t, err)
+
+	first, firstName, err := plugin.createWriter("test", schema)
+	require.NoError(t, err)
+	require.NoError(t, first.Close())
+	require.NoError(t, os.WriteFile(filepath.Join(testDir, firstName), []byte("sentinel"), 0640))
+
+	second, secondName, err := plugin.createWriter("test", schema)
+	require.NoError(t, err)
+	require.NoError(t, second.Close())
+
+	require.NotEqual(t, firstName, secondName)
+	preserved, err := os.ReadFile(filepath.Join(testDir, firstName))
+	require.NoError(t, err)
+	require.Equal(t, "sentinel", string(preserved))
+}


### PR DESCRIPTION
The current code creates files with a `<measurement>-<YYYY-MM-DD>-<unix-seconds>.parquet` pattern using the timestamp when `Write` was called. If the file already exists the **existing file** is renamed using a new, current timestamp and the same pattern.

At this, the code assumes only one writer per directory which should minimize the filename collisions to restarts of Telegraf. However, as #19563 describes, having multiple writers, i.e. multiple plugin instances and/or multiple telegraf instances, writing to the same directory will increase the risk of filename collisions and creates the risk of multiple renames target the same filename because they might happen at the same time. This leads to **data loss** as one writer will override the data of other writers on collision.

This PR changes the logic when creating a new writer to create files of the pattern `<measurement>-<YYYYMMDDhhmmss>-<uuid v6>.parquet` where an additional (time-based) UUID is added to the filename to ensure unique filenames. This also prevents the risk of filename collisions for multiple, independent writers.

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [ ] No AI generated code was used in this PR
- [x] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

resolves #19563
