### PR TITLE
fix(outputs.parquet): Rotate on the age of the open file

### DIFF
--- a/plugins/outputs/parquet/README.md
+++ b/plugins/outputs/parquet/README.md
@@ -90,8 +90,14 @@ If a file with the same target name exists at start, the existing file is
 rotated to avoid over-writing it or conflicting schema.
 
 File rotation is available via a time based interval that a user can optionally
-set. Due to the usage of a buffered writer, a size based rotation is not
-possible as the file may not actually get data at each interval.
+set, measured from the time the current file was created. Due to the usage of a
+buffered writer, a size based rotation is not possible as the file may not
+actually get data at each interval.
+
+The file is not inspected between rotations, so a file removed or replaced
+underneath the agent goes unnoticed and everything written to it is lost until
+the next rotation opens a new file. With `rotation_interval` unset there is no
+next rotation, so those metrics are lost for the lifetime of the agent.
 
 ## Explore Parquet Files
 

--- a/plugins/outputs/parquet/parquet.go
+++ b/plugins/outputs/parquet/parquet.go
@@ -29,6 +29,7 @@ var defaultTimestampFieldName = "timestamp"
 
 type metricGroup struct {
 	filename string
+	created  time.Time
 	builder  *array.RecordBuilder
 	schema   *arrow.Schema
 	writer   *pqarrow.FileWriter
@@ -140,18 +141,17 @@ func (p *Parquet) Write(metrics []telegraf.Metric) error {
 			p.metricGroups[name] = &metricGroup{
 				builder:  array.NewRecordBuilder(memory.DefaultAllocator, schema),
 				filename: filename,
+				created:  now,
 				schema:   schema,
 				writer:   writer,
 			}
 		}
 
-		if p.RotationInterval != 0 {
-			if err := p.rotateIfNeeded(name); err != nil {
-				perr.MetricsReject = append(perr.MetricsReject, metricIndices[name]...)
-				perr.MetricsRejectErrors = append(perr.MetricsRejectErrors, fmt.Errorf("failed to rotate file %q: %w", p.metricGroups[name].filename, err))
-				perr.Err = fmt.Errorf("failed to rotate file %q: %w", p.metricGroups[name].filename, err)
-				continue
-			}
+		if err := p.rotateIfNeeded(name); err != nil {
+			perr.MetricsReject = append(perr.MetricsReject, metricIndices[name]...)
+			perr.MetricsRejectErrors = append(perr.MetricsRejectErrors, fmt.Errorf("failed to rotate file %q: %w", p.metricGroups[name].filename, err))
+			perr.Err = fmt.Errorf("failed to rotate file %q: %w", p.metricGroups[name].filename, err)
+			continue
 		}
 
 		record, err := p.createRecordBatch(metrics, p.metricGroups[name].builder, p.metricGroups[name].schema)
@@ -192,25 +192,22 @@ func (p *Parquet) Write(metrics []telegraf.Metric) error {
 }
 
 func (p *Parquet) rotateIfNeeded(name string) error {
-	fileInfo, err := p.root.Stat(p.metricGroups[name].filename)
-	if err != nil {
-		return fmt.Errorf("failed to stat file %q: %w", p.metricGroups[name].filename, err)
-	}
-
-	expireTime := fileInfo.ModTime().Add(time.Duration(p.RotationInterval))
-	if time.Now().Before(expireTime) {
+	group := p.metricGroups[name]
+	interval := time.Duration(p.RotationInterval)
+	if interval == 0 || time.Since(group.created) < interval {
 		return nil
 	}
 
-	if err := p.metricGroups[name].writer.Close(); err != nil {
-		return fmt.Errorf("failed to close file for rotation %q: %w", p.metricGroups[name].filename, err)
+	if err := group.writer.Close(); err != nil {
+		return fmt.Errorf("failed to close file for rotation %q: %w", group.filename, err)
 	}
 
-	writer, err := p.createWriter(name, p.metricGroups[name].filename, p.metricGroups[name].schema)
+	writer, err := p.createWriter(name, group.filename, group.schema)
 	if err != nil {
-		return fmt.Errorf("failed to create new writer for file %q: %w", p.metricGroups[name].filename, err)
+		return fmt.Errorf("failed to create new writer for file %q: %w", group.filename, err)
 	}
-	p.metricGroups[name].writer = writer
+	group.writer = writer
+	group.created = time.Now()
 
 	return nil
 }

--- a/plugins/outputs/parquet/parquet_test.go
+++ b/plugins/outputs/parquet/parquet_test.go
@@ -593,3 +593,74 @@ func TestFieldTakesPrecedenceOverTagInAnyOrder(t *testing.T) {
 		})
 	}
 }
+
+func TestRotationIgnoresExternalModifications(t *testing.T) {
+	testDir := t.TempDir()
+	plugin := &Parquet{
+		Directory:          testDir,
+		RotationInterval:   config.Duration(time.Second),
+		TimestampFieldName: defaultTimestampFieldName,
+		Log:                testutil.Logger{},
+	}
+	require.NoError(t, plugin.Init())
+	require.NoError(t, plugin.Connect())
+
+	write := func(value float64) {
+		require.NoError(t, plugin.Write([]telegraf.Metric{
+			metric.New("test", map[string]string{}, map[string]interface{}{"value": value}, time.Now()),
+		}))
+	}
+
+	write(1.0)
+
+	stale := time.Now().Add(-time.Hour)
+	require.NoError(t, os.Chtimes(filepath.Join(testDir, plugin.metricGroups["test"].filename), stale, stale))
+
+	write(2.0)
+	require.NoError(t, plugin.Close())
+
+	files, err := os.ReadDir(testDir)
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+
+	reader, err := file.OpenParquetFile(filepath.Join(testDir, files[0].Name()), false)
+	require.NoError(t, err)
+	defer reader.Close()
+	require.Equal(t, 2, int(reader.MetaData().NumRows))
+}
+
+func TestDeletedFileReappearsOnlyOnRotation(t *testing.T) {
+	testDir := t.TempDir()
+	plugin := &Parquet{
+		Directory:          testDir,
+		RotationInterval:   config.Duration(time.Hour),
+		TimestampFieldName: defaultTimestampFieldName,
+		Log:                testutil.Logger{},
+	}
+	require.NoError(t, plugin.Init())
+	require.NoError(t, plugin.Connect())
+	defer plugin.Close()
+
+	write := func(value float64) {
+		require.NoError(t, plugin.Write([]telegraf.Metric{
+			metric.New("test", map[string]string{}, map[string]interface{}{"value": value}, time.Now()),
+		}))
+	}
+
+	write(1.0)
+
+	group := plugin.metricGroups["test"]
+	require.NoError(t, os.Remove(filepath.Join(testDir, group.filename)))
+
+	write(2.0)
+	files, err := os.ReadDir(testDir)
+	require.NoError(t, err)
+	require.Empty(t, files, "the delete goes unnoticed, so the write lands in the removed file")
+
+	group.created = group.created.Add(-2 * time.Hour)
+	write(3.0)
+
+	files, err = os.ReadDir(testDir)
+	require.NoError(t, err)
+	require.Len(t, files, 1, "the rotation opens a new file")
+}


### PR DESCRIPTION
## Summary

Rotation compared against the file's modification time via `os.Stat` on every flush. Since the plugin writes through a buffered writer, the modification time only moves when the writer actually flushes to disk, so on a quiet stream it can sit unchanged until `Close` and push the rotation out.

If the file was removed underneath the agent, the stat failed and the metrics of that flush were rejected.

Now Telegraf records when the file was opened and rotates on that.

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [ ] No AI generated code was used in this PR
- [x] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->
