### PR TITLE
fix(outputs.parquet): Let a field take precedence over a tag

### DIFF
--- a/plugins/outputs/parquet/parquet.go
+++ b/plugins/outputs/parquet/parquet.go
@@ -414,6 +414,8 @@ func (p *Parquet) createSchema(metrics []telegraf.Metric) (*arrow.Schema, error)
 				rawFields[field.Key] = arrowType
 			}
 		}
+	}
+	for _, metric := range metrics {
 		for _, tag := range metric.TagList() {
 			if _, ok := rawFields[tag.Key]; !ok {
 				rawFields[tag.Key] = arrow.BinaryTypes.String

--- a/plugins/outputs/parquet/parquet_test.go
+++ b/plugins/outputs/parquet/parquet_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/parquet"
 	"github.com/apache/arrow-go/v18/parquet/file"
 	"github.com/stretchr/testify/require"
@@ -555,28 +554,42 @@ func TestFieldTakesPrecedenceOverTagInAnyOrder(t *testing.T) {
 		time.Now(),
 	)
 
-	orders := map[string][]telegraf.Metric{
-		"tag first":   {tagged, fielded},
-		"field first": {fielded, tagged},
+	tests := []struct {
+		name     string
+		metrics  []telegraf.Metric
+		accepted []int
+		rejected []int
+	}{
+		{
+			name:     "tag first",
+			metrics:  []telegraf.Metric{tagged, fielded},
+			accepted: []int{1},
+			rejected: []int{0},
+		},
+		{
+			name:     "field first",
+			metrics:  []telegraf.Metric{fielded, tagged},
+			accepted: []int{0},
+			rejected: []int{1},
+		},
 	}
 
-	for name, metrics := range orders {
-		t.Run(name, func(t *testing.T) {
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
 			plugin := &Parquet{
 				Directory:          t.TempDir(),
 				TimestampFieldName: defaultTimestampFieldName,
 				Log:                testutil.Logger{},
 			}
 			require.NoError(t, plugin.Init())
+			require.NoError(t, plugin.Connect())
 			defer plugin.Close()
 
-			schema, err := plugin.createSchema(metrics)
-			require.NoError(t, err)
-
-			shared, ok := schema.FieldsByName("shared")
-			require.True(t, ok)
-			require.Len(t, shared, 1)
-			require.Equal(t, arrow.PrimitiveTypes.Int64, shared[0].Type)
+			var perr *internal.PartialWriteError
+			require.ErrorAs(t, plugin.Write(tt.metrics), &perr)
+			require.ErrorContains(t, perr.Err, `invalid value from-tag (string) for column "shared" (int64)`)
+			require.ElementsMatch(t, perr.MetricsAccept, tt.accepted)
+			require.ElementsMatch(t, perr.MetricsReject, tt.rejected)
 		})
 	}
 }

--- a/plugins/outputs/parquet/parquet_test.go
+++ b/plugins/outputs/parquet/parquet_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/parquet"
 	"github.com/apache/arrow-go/v18/parquet/file"
 	"github.com/stretchr/testify/require"
@@ -536,6 +537,46 @@ func TestCannotEscapeDirectory(t *testing.T) {
 
 			var perr *os.PathError
 			require.ErrorAs(t, plugin.Write(metrics), &perr)
+		})
+	}
+}
+
+func TestFieldTakesPrecedenceOverTagInAnyOrder(t *testing.T) {
+	tagged := metric.New(
+		"test",
+		map[string]string{"shared": "from-tag"},
+		map[string]interface{}{"other": int64(1)},
+		time.Now(),
+	)
+	fielded := metric.New(
+		"test",
+		map[string]string{},
+		map[string]interface{}{"shared": int64(42)},
+		time.Now(),
+	)
+
+	orders := map[string][]telegraf.Metric{
+		"tag first":   {tagged, fielded},
+		"field first": {fielded, tagged},
+	}
+
+	for name, metrics := range orders {
+		t.Run(name, func(t *testing.T) {
+			plugin := &Parquet{
+				Directory:          t.TempDir(),
+				TimestampFieldName: defaultTimestampFieldName,
+				Log:                testutil.Logger{},
+			}
+			require.NoError(t, plugin.Init())
+			defer plugin.Close()
+
+			schema, err := plugin.createSchema(metrics)
+			require.NoError(t, err)
+
+			shared, ok := schema.FieldsByName("shared")
+			require.True(t, ok)
+			require.Len(t, shared, 1)
+			require.Equal(t, arrow.PrimitiveTypes.Int64, shared[0].Type)
 		})
 	}
 }


### PR DESCRIPTION
The README documents that a field wins over a tag, but column names come from the roder the metric arrived in the batch. A batch that happened to lead with the tag typed the column as a string. Following batches with metric carrying the field was then rejected until the file was rotated with the right schema.

Fields are now collected across the whole batch before tags.

https://github.com/influxdata/telegraf/blob/86435583497fb7f07408b5e95fe8b8b4d1955d99/plugins/outputs/parquet/README.md?plain=1#L53-L54

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [ ] No AI generated code was used in this PR
- [x] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->
