### PR TITLE
feat(outputs.parquet): Start a new file when the column schema changes

### DIFF
--- a/plugins/outputs/parquet/README.md
+++ b/plugins/outputs/parquet/README.md
@@ -62,6 +62,9 @@ When writing to a file, the schema is used to look for each value and if it is
 not present a null value is added. The result is that if additional fields are
 present after the first metric flush those fields are omitted.
 
+Since column types are fixed at file creation, when an unknown value is logged
+it will be logged as `null` and once per column. 
+
 ### Write
 
 The plugin makes use of the buffered writer. This may buffer some metrics into

--- a/plugins/outputs/parquet/README.md
+++ b/plugins/outputs/parquet/README.md
@@ -82,6 +82,11 @@ of this occurring.
 
 ## File Rotation
 
+Measurement names determine the file name and can be customized with 
+the [rename processor][rename].
+
+[rename]: /plugins/processors/rename/README.md
+
 If a file with the same target name exists at start, the existing file is
 rotated to avoid over-writing it or conflicting schema.
 

--- a/plugins/outputs/parquet/README.md
+++ b/plugins/outputs/parquet/README.md
@@ -64,6 +64,11 @@ present after the first metric flush those fields are omitted.
 
 Since column types are fixed at file creation, when an unknown value is logged
 it will be logged as `null` and once per column. 
+Inputs that collide with reserved columns like `timestamp_field_name` are
+dropped and logged. Rename `timestamp_field_name` or your field to fix it.
+
+Since parquet column schemas are fixed at file creation, new values that 
+do not fit the column schema are written as `null` and logged once per column.
 
 ### Write
 

--- a/plugins/outputs/parquet/README.md
+++ b/plugins/outputs/parquet/README.md
@@ -30,8 +30,8 @@ plugin ordering. See [CONFIGURATION.md][CONFIGURATION.md] for more details.
 ```toml @sample.conf
 # A plugin that writes metrics to parquet files
 [[outputs.parquet]]
-  ## Directory to write parquet files in. If a file already exists the output
-  ## will attempt to continue using the existing file.
+  ## Directory to write parquet files in. Existing files are never modified.
+  ## A new file is created at startup and on rotation.
   # directory = "."
 
   ## Files are rotated after the time interval specified. When set to 0 no time
@@ -96,8 +96,8 @@ the [rename processor][rename].
 
 [rename]: /plugins/processors/rename/README.md
 
-If a file with the same target name exists at start, the existing file is
-rotated to avoid over-writing it or conflicting schema.
+File names carry the time the file was created with a counter if two files
+are created in the same timestamp to avoid loss of data. 
 
 File rotation is available via a time based interval that a user can optionally
 set. Due to the usage of a buffered writer, a size based rotation is not

--- a/plugins/outputs/parquet/README.md
+++ b/plugins/outputs/parquet/README.md
@@ -4,7 +4,8 @@ This plugin writes metrics to [parquet][parquet] files. By default, metrics are
 grouped by metric name and written all to the same file.
 
 > [!IMPORTANT]
-> If a metric schema does not match the schema in the file it will be dropped.
+> A parquet file fixes its schema when it is created. When the column schema
+> changes, the plugin starts a new file. See [schema changes](#schema-changes).
 
 To lean more about the parquet format, check out the [parquet docs][docs] as
 well as a blog post on [querying parquet][querying].
@@ -31,7 +32,7 @@ plugin ordering. See [CONFIGURATION.md][CONFIGURATION.md] for more details.
 # A plugin that writes metrics to parquet files
 [[outputs.parquet]]
   ## Directory to write parquet files in. Existing files are never modified.
-  ## A new file is created at startup and on rotation.
+  ## A new file is created at startup, on rotation, and on schema change.
   # directory = "."
 
   ## Files are rotated after the time interval specified. When set to 0 no time
@@ -54,22 +55,31 @@ based on the union of all fields and tags. If a field and tag have the same name
 then the field takes precedence. Columns are ordered by name with
 the timestamp column last.
 
-The consequence of schema generation is that the very first flush sequence a
-metric is seen takes much longer due to the additional looping through the
-metrics to generate the schema. Subsequent flush intervals are significantly
-faster.
+Every flush walks its metrics to pick up columns the current file does not have
+yet, so the cost of schema generation is spread across flushes rather than paid
+entirely on the first one.
 
 When writing to a file, the schema is used to look for each value and if it is
-not present a null value is added. The result is that if additional fields are
-present after the first metric flush those fields are omitted.
+not present a null value is written.
 
-Since column types are fixed at file creation, when an unknown value is logged
-it will be logged as `null` and once per column. 
+Since parquet column schemas are fixed at file creation, new values that do 
+not fit the column schema are written as `null` and logged once per column.
+
 Inputs that collide with reserved columns like `timestamp_field_name` are
 dropped and logged. Rename `timestamp_field_name` or your field to fix it.
 
-Since parquet column schemas are fixed at file creation, new values that 
-do not fit the column schema are written as `null` and logged once per column.
+### Schema changes
+
+Since parquet column schemas are set at file creation, schema changes have to
+rotate to a new file with the extra column. Rotation events are logged. 
+
+Columns are only added, never dropped so a missing metric writes out as 
+`null`. Column types are fixed. Values that don't fit the fype are written 
+as `null` and logged once per column. 
+
+Since output files can have different schemas, a reader can take the first 
+file's schema and ignore columns that appear in later ones. Or if you use 
+DuckDB, use `union_by_name = true` to avoid this.
 
 ### Write
 
@@ -91,13 +101,13 @@ of this occurring.
 
 ## File Rotation
 
-Measurement names determine the file name and can be customized with 
+Measurement names determine the file name and can be customized with
 the [rename processor][rename].
 
 [rename]: /plugins/processors/rename/README.md
 
 File names carry the time the file was created with a counter if two files
-are created in the same timestamp to avoid loss of data. 
+are created in the same timestamp to avoid loss of data.
 
 File rotation is available via a time based interval that a user can optionally
 set, measured from the time the current file was created. Due to the usage

--- a/plugins/outputs/parquet/README.md
+++ b/plugins/outputs/parquet/README.md
@@ -51,7 +51,8 @@ plugin ordering. See [CONFIGURATION.md][CONFIGURATION.md] for more details.
 Parquet files require a schema when writing files. To generate a schema,
 Telegraf will go through all grouped metrics and generate an Apache Arrow schema
 based on the union of all fields and tags. If a field and tag have the same name
-then the field takes precedence.
+then the field takes precedence. Columns are ordered by name with
+the timestamp column last.
 
 The consequence of schema generation is that the very first flush sequence a
 metric is seen takes much longer due to the additional looping through the

--- a/plugins/outputs/parquet/README.md
+++ b/plugins/outputs/parquet/README.md
@@ -100,8 +100,9 @@ File names carry the time the file was created with a counter if two files
 are created in the same timestamp to avoid loss of data. 
 
 File rotation is available via a time based interval that a user can optionally
-set. Due to the usage of a buffered writer, a size based rotation is not
-possible as the file may not actually get data at each interval.
+set, measured from the time the current file was created. Due to the usage
+of a buffered writer, a size based rotation is not possible as the file may
+not actually get data at each interval.
 
 ## Explore Parquet Files
 

--- a/plugins/outputs/parquet/parquet.go
+++ b/plugins/outputs/parquet/parquet.go
@@ -33,6 +33,7 @@ type metricGroup struct {
 	name     string
 	filename string
 	created  time.Time
+	columns  map[string]arrow.DataType
 	warned   map[string]bool
 	builder  *array.RecordBuilder
 	schema   *arrow.Schema
@@ -101,19 +102,13 @@ func (p *Parquet) Write(metrics []telegraf.Metric) error {
 	}
 
 	for name, metrics := range groupedMetrics {
-		group, found := p.metricGroups[name]
-		if !found {
-			group = &metricGroup{name: name, warned: make(map[string]bool)}
-			if err := p.openFile(group, p.createSchema(metrics)); err != nil {
-				return err
-			}
-			p.metricGroups[name] = group
-		} else if err := p.rotateIfNeeded(group); err != nil {
+		group, err := p.groupFor(name, metrics)
+		if err != nil {
 			return err
 		}
 
 		record := p.createRecordBatch(group, metrics)
-		err := group.writer.WriteBuffered(record)
+		err = group.writer.WriteBuffered(record)
 		record.Release()
 		if err != nil {
 			return fmt.Errorf("failed to write to file %q: %w", group.filename, err)
@@ -121,6 +116,46 @@ func (p *Parquet) Write(metrics []telegraf.Metric) error {
 	}
 
 	return nil
+}
+
+func (p *Parquet) groupFor(name string, metrics []telegraf.Metric) (*metricGroup, error) {
+	columns := p.collectColumns(metrics)
+
+	group, found := p.metricGroups[name]
+	if !found {
+		group = &metricGroup{name: name, columns: columns, warned: make(map[string]bool)}
+		if err := p.openFile(group); err != nil {
+			return nil, err
+		}
+		p.metricGroups[name] = group
+
+		return group, nil
+	}
+
+	added := group.addColumns(columns)
+	if len(added) == 0 {
+		return group, p.rotateIfNeeded(group)
+	}
+
+	p.Log.Infof("Starting a new file for %q to add column(s) %s", name, strings.Join(added, ", "))
+	if err := p.reopen(group); err != nil {
+		return nil, err
+	}
+
+	return group, nil
+}
+
+func (g *metricGroup) addColumns(columns map[string]arrow.DataType) []string {
+	added := make([]string, 0, len(columns))
+	for column, datatype := range columns {
+		if _, known := g.columns[column]; !known {
+			g.columns[column] = datatype
+			added = append(added, column)
+		}
+	}
+	slices.Sort(added)
+
+	return added
 }
 
 const maxMeasurementLen = 255 - len("-2006-01-02-1234567890-999.parquet")
@@ -162,13 +197,12 @@ func (p *Parquet) rotateIfNeeded(group *metricGroup) error {
 }
 
 func (p *Parquet) reopen(group *metricGroup) error {
-	schema := group.schema
 	if err := group.close(); err != nil {
 		delete(p.metricGroups, group.name)
 		return fmt.Errorf("failed to close file %q: %w", group.filename, err)
 	}
 
-	if err := p.openFile(group, schema); err != nil {
+	if err := p.openFile(group); err != nil {
 		delete(p.metricGroups, group.name)
 		return err
 	}
@@ -183,9 +217,9 @@ func (g *metricGroup) close() error {
 	return err
 }
 
-func (p *Parquet) openFile(group *metricGroup, schema *arrow.Schema) error {
-	group.schema = schema
-	group.builder = array.NewRecordBuilder(memory.DefaultAllocator, schema)
+func (p *Parquet) openFile(group *metricGroup) error {
+	group.schema = p.createSchema(group.columns)
+	group.builder = array.NewRecordBuilder(memory.DefaultAllocator, group.schema)
 	group.filename = p.unusedFilename(group.name)
 	group.created = time.Now()
 
@@ -194,7 +228,7 @@ func (p *Parquet) openFile(group *metricGroup, schema *arrow.Schema) error {
 		return fmt.Errorf("failed to create file %q: %w", group.filename, err)
 	}
 
-	writer, err := pqarrow.NewFileWriter(schema, f, parquet.NewWriterProperties(), pqarrow.DefaultWriterProps())
+	writer, err := pqarrow.NewFileWriter(group.schema, f, parquet.NewWriterProperties(), pqarrow.DefaultWriterProps())
 	if err != nil {
 		f.Close()
 		return fmt.Errorf("failed to create parquet writer for file %q: %w", group.filename, err)
@@ -308,33 +342,33 @@ func appendTyped[T any](builder array.Builder, value T) bool {
 	return true
 }
 
-func (p *Parquet) createSchema(metrics []telegraf.Metric) *arrow.Schema {
-	rawFields := make(map[string]arrow.DataType)
+func (p *Parquet) collectColumns(metrics []telegraf.Metric) map[string]arrow.DataType {
+	columns := make(map[string]arrow.DataType)
 	for _, metric := range metrics {
 		for _, field := range metric.FieldList() {
-			if _, known := rawFields[field.Key]; known {
+			if _, known := columns[field.Key]; known {
 				continue
 			}
-			arrowType, err := goToArrowType(field.Value)
+			datatype, err := goToArrowType(field.Value)
 			if err != nil {
 				p.Log.Warnf("Skipping field %q of metric %q: %v", field.Key, metric.Name(), err)
 				continue
 			}
-			rawFields[field.Key] = arrowType
+			columns[field.Key] = datatype
 		}
 	}
 
 	for _, metric := range metrics {
 		for _, tag := range metric.TagList() {
-			if _, known := rawFields[tag.Key]; !known {
-				rawFields[tag.Key] = arrow.BinaryTypes.String
+			if _, known := columns[tag.Key]; !known {
+				columns[tag.Key] = arrow.BinaryTypes.String
 			}
 		}
 	}
 
 	if p.TimestampFieldName != "" {
-		if _, taken := rawFields[p.TimestampFieldName]; taken {
-			delete(rawFields, p.TimestampFieldName)
+		if _, taken := columns[p.TimestampFieldName]; taken {
+			delete(columns, p.TimestampFieldName)
 			p.Log.Warnf(
 				"Ignoring the %q field or tag as that column holds the metric time; "+
 					"set 'timestamp_field_name' to another name to keep it",
@@ -343,8 +377,12 @@ func (p *Parquet) createSchema(metrics []telegraf.Metric) *arrow.Schema {
 		}
 	}
 
-	names := make([]string, 0, len(rawFields))
-	for name := range rawFields {
+	return columns
+}
+
+func (p *Parquet) createSchema(columns map[string]arrow.DataType) *arrow.Schema {
+	names := make([]string, 0, len(columns))
+	for name := range columns {
 		names = append(names, name)
 	}
 	slices.Sort(names)
@@ -353,7 +391,7 @@ func (p *Parquet) createSchema(metrics []telegraf.Metric) *arrow.Schema {
 	for _, name := range names {
 		fields = append(fields, arrow.Field{
 			Name:     name,
-			Type:     rawFields[name],
+			Type:     columns[name],
 			Nullable: true,
 		})
 	}

--- a/plugins/outputs/parquet/parquet.go
+++ b/plugins/outputs/parquet/parquet.go
@@ -30,6 +30,7 @@ var defaultTimestampFieldName = "timestamp"
 
 type metricGroup struct {
 	filename string
+	warned   map[string]bool
 	builder  *array.RecordBuilder
 	schema   *arrow.Schema
 	writer   *pqarrow.FileWriter
@@ -111,6 +112,7 @@ func (p *Parquet) Write(metrics []telegraf.Metric) error {
 			p.metricGroups[name] = &metricGroup{
 				builder:  array.NewRecordBuilder(memory.DefaultAllocator, schema),
 				filename: filename,
+				warned:   make(map[string]bool),
 				schema:   schema,
 				writer:   writer,
 			}
@@ -122,14 +124,13 @@ func (p *Parquet) Write(metrics []telegraf.Metric) error {
 			}
 		}
 
-		record, err := p.createRecordBatch(metrics, p.metricGroups[name].builder, p.metricGroups[name].schema)
-		if err != nil {
-			return fmt.Errorf("failed to create record for file %q: %w", p.metricGroups[name].filename, err)
-		}
-		if err = p.metricGroups[name].writer.WriteBuffered(record); err != nil {
-			return fmt.Errorf("failed to write to file %q: %w", p.metricGroups[name].filename, err)
-		}
+		group := p.metricGroups[name]
+		record := p.createRecordBatch(group, metrics)
+		err := group.writer.WriteBuffered(record)
 		record.Release()
+		if err != nil {
+			return fmt.Errorf("failed to write to file %q: %w", group.filename, err)
+		}
 	}
 
 	return nil
@@ -189,89 +190,95 @@ func (p *Parquet) rotateIfNeeded(name string) error {
 	return nil
 }
 
-func (p *Parquet) createRecordBatch(metrics []telegraf.Metric, builder *array.RecordBuilder, schema *arrow.Schema) (arrow.RecordBatch, error) {
-	for index, col := range schema.Fields() {
+func (p *Parquet) createRecordBatch(group *metricGroup, metrics []telegraf.Metric) arrow.RecordBatch {
+	for index, column := range group.schema.Fields() {
+		builder := group.builder.Field(index)
+
 		for _, m := range metrics {
-			if p.TimestampFieldName != "" && col.Name == p.TimestampFieldName {
-				builder.Field(index).(*array.Int64Builder).Append(m.Time().UnixNano())
-				continue
-			}
-
-			// Try to get the value from a field first, then from a tag.
-			var value any
-			var ok bool
-			value, ok = m.GetField(col.Name)
-			if !ok {
-				value, ok = m.GetTag(col.Name)
-			}
-
-			// if neither field nor tag exists, append a null value
-			if !ok {
-				switch col.Type {
-				case arrow.PrimitiveTypes.Int8:
-					builder.Field(index).(*array.Int8Builder).AppendNull()
-				case arrow.PrimitiveTypes.Int16:
-					builder.Field(index).(*array.Int16Builder).AppendNull()
-				case arrow.PrimitiveTypes.Int32:
-					builder.Field(index).(*array.Int32Builder).AppendNull()
-				case arrow.PrimitiveTypes.Int64:
-					builder.Field(index).(*array.Int64Builder).AppendNull()
-				case arrow.PrimitiveTypes.Uint8:
-					builder.Field(index).(*array.Uint8Builder).AppendNull()
-				case arrow.PrimitiveTypes.Uint16:
-					builder.Field(index).(*array.Uint16Builder).AppendNull()
-				case arrow.PrimitiveTypes.Uint32:
-					builder.Field(index).(*array.Uint32Builder).AppendNull()
-				case arrow.PrimitiveTypes.Uint64:
-					builder.Field(index).(*array.Uint64Builder).AppendNull()
-				case arrow.PrimitiveTypes.Float32:
-					builder.Field(index).(*array.Float32Builder).AppendNull()
-				case arrow.PrimitiveTypes.Float64:
-					builder.Field(index).(*array.Float64Builder).AppendNull()
-				case arrow.BinaryTypes.String:
-					builder.Field(index).(*array.StringBuilder).AppendNull()
-				case arrow.FixedWidthTypes.Boolean:
-					builder.Field(index).(*array.BooleanBuilder).AppendNull()
-				default:
-					return nil, fmt.Errorf("unsupported type: %T", value)
-				}
-
-				continue
-			}
-
-			switch col.Type {
-			case arrow.PrimitiveTypes.Int8:
-				builder.Field(index).(*array.Int8Builder).Append(value.(int8))
-			case arrow.PrimitiveTypes.Int16:
-				builder.Field(index).(*array.Int16Builder).Append(value.(int16))
-			case arrow.PrimitiveTypes.Int32:
-				builder.Field(index).(*array.Int32Builder).Append(value.(int32))
-			case arrow.PrimitiveTypes.Int64:
-				builder.Field(index).(*array.Int64Builder).Append(value.(int64))
-			case arrow.PrimitiveTypes.Uint8:
-				builder.Field(index).(*array.Uint8Builder).Append(value.(uint8))
-			case arrow.PrimitiveTypes.Uint16:
-				builder.Field(index).(*array.Uint16Builder).Append(value.(uint16))
-			case arrow.PrimitiveTypes.Uint32:
-				builder.Field(index).(*array.Uint32Builder).Append(value.(uint32))
-			case arrow.PrimitiveTypes.Uint64:
-				builder.Field(index).(*array.Uint64Builder).Append(value.(uint64))
-			case arrow.PrimitiveTypes.Float32:
-				builder.Field(index).(*array.Float32Builder).Append(value.(float32))
-			case arrow.PrimitiveTypes.Float64:
-				builder.Field(index).(*array.Float64Builder).Append(value.(float64))
-			case arrow.BinaryTypes.String:
-				builder.Field(index).(*array.StringBuilder).Append(value.(string))
-			case arrow.FixedWidthTypes.Boolean:
-				builder.Field(index).(*array.BooleanBuilder).Append(value.(bool))
-			default:
-				return nil, fmt.Errorf("unsupported type: %T", value)
+			value := p.valueFor(m, column.Name)
+			if !appendValue(builder, value) {
+				p.warnOncef(
+					group, column.Name,
+					"Writing null for column %q of file %q as a %T value does not fit its %s column",
+					column.Name, group.filename, value, column.Type,
+				)
 			}
 		}
 	}
 
-	record := builder.NewRecordBatch()
-	return record, nil
+	return group.builder.NewRecordBatch()
+}
+
+func (p *Parquet) valueFor(m telegraf.Metric, column string) interface{} {
+	if p.TimestampFieldName != "" && column == p.TimestampFieldName {
+		return m.Time().UnixNano()
+	}
+	if value, found := m.GetField(column); found {
+		return value
+	}
+	if value, found := m.GetTag(column); found {
+		return value
+	}
+
+	return nil
+}
+
+func (p *Parquet) warnOncef(group *metricGroup, column, format string, args ...interface{}) {
+	if group.warned[column] {
+		return
+	}
+	group.warned[column] = true
+	p.Log.Warnf(format, args...)
+}
+
+func appendValue(builder array.Builder, value interface{}) bool {
+	switch v := value.(type) {
+	case nil:
+		builder.AppendNull()
+		return true
+	case int8:
+		return appendTyped(builder, v)
+	case int16:
+		return appendTyped(builder, v)
+	case int32:
+		return appendTyped(builder, v)
+	case int64:
+		return appendTyped(builder, v)
+	case int:
+		return appendTyped(builder, int64(v))
+	case uint8:
+		return appendTyped(builder, v)
+	case uint16:
+		return appendTyped(builder, v)
+	case uint32:
+		return appendTyped(builder, v)
+	case uint64:
+		return appendTyped(builder, v)
+	case uint:
+		return appendTyped(builder, uint64(v))
+	case float32:
+		return appendTyped(builder, v)
+	case float64:
+		return appendTyped(builder, v)
+	case string:
+		return appendTyped(builder, v)
+	case bool:
+		return appendTyped(builder, v)
+	default:
+		builder.AppendNull()
+		return false
+	}
+}
+
+func appendTyped[T any](builder array.Builder, value T) bool {
+	column, ok := builder.(interface{ Append(T) })
+	if !ok {
+		builder.AppendNull()
+		return false
+	}
+	column.Append(value)
+
+	return true
 }
 
 func (p *Parquet) createSchema(metrics []telegraf.Metric) (*arrow.Schema, error) {

--- a/plugins/outputs/parquet/parquet.go
+++ b/plugins/outputs/parquet/parquet.go
@@ -300,6 +300,17 @@ func (p *Parquet) createSchema(metrics []telegraf.Metric) (*arrow.Schema, error)
 		}
 	}
 
+	if p.TimestampFieldName != "" {
+		if _, taken := rawFields[p.TimestampFieldName]; taken {
+			delete(rawFields, p.TimestampFieldName)
+			p.Log.Warnf(
+				"Ignoring the %q field or tag as that column holds the metric time; "+
+					"set 'timestamp_field_name' to another name to keep it",
+				p.TimestampFieldName,
+			)
+		}
+	}
+
 	fields := make([]arrow.Field, 0)
 	for key, value := range rawFields {
 		fields = append(fields, arrow.Field{

--- a/plugins/outputs/parquet/parquet.go
+++ b/plugins/outputs/parquet/parquet.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -311,11 +312,17 @@ func (p *Parquet) createSchema(metrics []telegraf.Metric) (*arrow.Schema, error)
 		}
 	}
 
-	fields := make([]arrow.Field, 0)
-	for key, value := range rawFields {
+	names := make([]string, 0, len(rawFields))
+	for name := range rawFields {
+		names = append(names, name)
+	}
+	slices.Sort(names)
+
+	fields := make([]arrow.Field, 0, len(names)+1)
+	for _, name := range names {
 		fields = append(fields, arrow.Field{
-			Name:     key,
-			Type:     value,
+			Name:     name,
+			Type:     rawFields[name],
 			Nullable: true,
 		})
 	}

--- a/plugins/outputs/parquet/parquet.go
+++ b/plugins/outputs/parquet/parquet.go
@@ -32,6 +32,7 @@ var defaultTimestampFieldName = "timestamp"
 type metricGroup struct {
 	name     string
 	filename string
+	created  time.Time
 	warned   map[string]bool
 	builder  *array.RecordBuilder
 	schema   *arrow.Schema
@@ -107,9 +108,7 @@ func (p *Parquet) Write(metrics []telegraf.Metric) error {
 				return err
 			}
 			p.metricGroups[name] = group
-		}
-
-		if err := p.rotateIfNeeded(group); err != nil {
+		} else if err := p.rotateIfNeeded(group); err != nil {
 			return err
 		}
 
@@ -155,15 +154,7 @@ func reservedInFilename(r rune) bool {
 }
 
 func (p *Parquet) rotateIfNeeded(group *metricGroup) error {
-	if p.RotationInterval == 0 {
-		return nil
-	}
-
-	fileInfo, err := os.Stat(group.filename)
-	if err != nil {
-		return fmt.Errorf("failed to stat file %q: %w", group.filename, err)
-	}
-	if time.Now().Before(fileInfo.ModTime().Add(time.Duration(p.RotationInterval))) {
+	if p.RotationInterval == 0 || time.Since(group.created) < time.Duration(p.RotationInterval) {
 		return nil
 	}
 
@@ -196,6 +187,7 @@ func (p *Parquet) openFile(group *metricGroup, schema *arrow.Schema) error {
 	group.schema = schema
 	group.builder = array.NewRecordBuilder(memory.DefaultAllocator, schema)
 	group.filename = p.unusedFilename(group.name)
+	group.created = time.Now()
 
 	f, err := os.Create(group.filename)
 	if err != nil {

--- a/plugins/outputs/parquet/parquet.go
+++ b/plugins/outputs/parquet/parquet.go
@@ -6,8 +6,11 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"runtime"
 	"strconv"
+	"strings"
 	"time"
+	"unicode"
 
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
@@ -38,7 +41,8 @@ type Parquet struct {
 	TimestampFieldName string          `toml:"timestamp_field_name"`
 	Log                telegraf.Logger `toml:"-"`
 
-	metricGroups map[string]*metricGroup
+	metricGroups     map[string]*metricGroup
+	warnedOnFilename bool
 }
 
 func (*Parquet) SampleConfig() string {
@@ -88,7 +92,8 @@ func (p *Parquet) Close() error {
 func (p *Parquet) Write(metrics []telegraf.Metric) error {
 	groupedMetrics := make(map[string][]telegraf.Metric)
 	for _, metric := range metrics {
-		groupedMetrics[metric.Name()] = append(groupedMetrics[metric.Name()], metric)
+		name := p.metricToFile(metric.Name())
+		groupedMetrics[name] = append(groupedMetrics[name], metric)
 	}
 
 	now := time.Now()
@@ -128,6 +133,36 @@ func (p *Parquet) Write(metrics []telegraf.Metric) error {
 	}
 
 	return nil
+}
+
+const maxMeasurementLen = 255 - len("-2006-01-02-1234567890.parquet")
+
+func (p *Parquet) metricToFile(name string) string {
+	safe := strings.Map(func(r rune) rune {
+		if reservedInFilename(r) {
+			return '_'
+		}
+		return r
+	}, name)
+
+	if len(safe) > maxMeasurementLen {
+		safe = strings.ToValidUTF8(safe[:maxMeasurementLen], "")
+	}
+
+	if safe != name && !p.warnedOnFilename {
+		p.warnedOnFilename = true
+		p.Log.Warnf("Metric %q is not usable as a file name, writing to %q instead; use the rename processor to choose the name", name, safe)
+	}
+
+	return safe
+}
+
+func reservedInFilename(r rune) bool {
+	if r == '/' || r == '\\' || unicode.IsControl(r) {
+		return true
+	}
+
+	return runtime.GOOS == "windows" && strings.ContainsRune(`<>:"|?*`, r)
 }
 
 func (p *Parquet) rotateIfNeeded(name string) error {

--- a/plugins/outputs/parquet/parquet.go
+++ b/plugins/outputs/parquet/parquet.go
@@ -309,7 +309,7 @@ func appendTyped[T any](builder array.Builder, value T) bool {
 }
 
 func (p *Parquet) createSchema(metrics []telegraf.Metric) *arrow.Schema {
-	rawFields := make(map[string]arrow.DataType, 0)
+	rawFields := make(map[string]arrow.DataType)
 	for _, metric := range metrics {
 		for _, field := range metric.FieldList() {
 			if _, known := rawFields[field.Key]; known {
@@ -322,8 +322,11 @@ func (p *Parquet) createSchema(metrics []telegraf.Metric) *arrow.Schema {
 			}
 			rawFields[field.Key] = arrowType
 		}
+	}
+
+	for _, metric := range metrics {
 		for _, tag := range metric.TagList() {
-			if _, ok := rawFields[tag.Key]; !ok {
+			if _, known := rawFields[tag.Key]; !known {
 				rawFields[tag.Key] = arrow.BinaryTypes.String
 			}
 		}

--- a/plugins/outputs/parquet/parquet.go
+++ b/plugins/outputs/parquet/parquet.go
@@ -6,9 +6,9 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"runtime"
 	"slices"
-	"strconv"
 	"strings"
 	"time"
 	"unicode"
@@ -30,6 +30,7 @@ var sampleConfig string
 var defaultTimestampFieldName = "timestamp"
 
 type metricGroup struct {
+	name     string
 	filename string
 	warned   map[string]bool
 	builder  *array.RecordBuilder
@@ -77,9 +78,9 @@ func (*Parquet) Connect() error {
 func (p *Parquet) Close() error {
 	var errorOccurred bool
 
-	for _, metrics := range p.metricGroups {
-		if err := metrics.writer.Close(); err != nil {
-			p.Log.Errorf("failed to close file %q: %v", metrics.filename, err)
+	for _, group := range p.metricGroups {
+		if err := group.close(); err != nil {
+			p.Log.Errorf("Failed to close file %q: %v", group.filename, err)
 			errorOccurred = true
 		}
 	}
@@ -98,31 +99,20 @@ func (p *Parquet) Write(metrics []telegraf.Metric) error {
 		groupedMetrics[name] = append(groupedMetrics[name], metric)
 	}
 
-	now := time.Now()
 	for name, metrics := range groupedMetrics {
-		if _, ok := p.metricGroups[name]; !ok {
-			filename := fmt.Sprintf("%s/%s-%s-%s.parquet", p.Directory, name, now.Format("2006-01-02"), strconv.FormatInt(now.Unix(), 10))
-			schema := p.createSchema(metrics)
-			writer, err := p.createWriter(name, filename, schema)
-			if err != nil {
-				return fmt.Errorf("failed to create writer for file %q: %w", name, err)
+		group, found := p.metricGroups[name]
+		if !found {
+			group = &metricGroup{name: name, warned: make(map[string]bool)}
+			if err := p.openFile(group, p.createSchema(metrics)); err != nil {
+				return err
 			}
-			p.metricGroups[name] = &metricGroup{
-				builder:  array.NewRecordBuilder(memory.DefaultAllocator, schema),
-				filename: filename,
-				warned:   make(map[string]bool),
-				schema:   schema,
-				writer:   writer,
-			}
+			p.metricGroups[name] = group
 		}
 
-		if p.RotationInterval != 0 {
-			if err := p.rotateIfNeeded(name); err != nil {
-				return fmt.Errorf("failed to rotate file %q: %w", p.metricGroups[name].filename, err)
-			}
+		if err := p.rotateIfNeeded(group); err != nil {
+			return err
 		}
 
-		group := p.metricGroups[name]
 		record := p.createRecordBatch(group, metrics)
 		err := group.writer.WriteBuffered(record)
 		record.Release()
@@ -134,7 +124,7 @@ func (p *Parquet) Write(metrics []telegraf.Metric) error {
 	return nil
 }
 
-const maxMeasurementLen = 255 - len("-2006-01-02-1234567890.parquet")
+const maxMeasurementLen = 255 - len("-2006-01-02-1234567890-999.parquet")
 
 func (p *Parquet) metricToFile(name string) string {
 	safe := strings.Map(func(r rune) rune {
@@ -164,28 +154,75 @@ func reservedInFilename(r rune) bool {
 	return runtime.GOOS == "windows" && strings.ContainsRune(`<>:"|?*`, r)
 }
 
-func (p *Parquet) rotateIfNeeded(name string) error {
-	fileInfo, err := os.Stat(p.metricGroups[name].filename)
-	if err != nil {
-		return fmt.Errorf("failed to stat file %q: %w", p.metricGroups[name].filename, err)
-	}
-
-	expireTime := fileInfo.ModTime().Add(time.Duration(p.RotationInterval))
-	if time.Now().Before(expireTime) {
+func (p *Parquet) rotateIfNeeded(group *metricGroup) error {
+	if p.RotationInterval == 0 {
 		return nil
 	}
 
-	if err := p.metricGroups[name].writer.Close(); err != nil {
-		return fmt.Errorf("failed to close file for rotation %q: %w", p.metricGroups[name].filename, err)
+	fileInfo, err := os.Stat(group.filename)
+	if err != nil {
+		return fmt.Errorf("failed to stat file %q: %w", group.filename, err)
+	}
+	if time.Now().Before(fileInfo.ModTime().Add(time.Duration(p.RotationInterval))) {
+		return nil
 	}
 
-	writer, err := p.createWriter(name, p.metricGroups[name].filename, p.metricGroups[name].schema)
-	if err != nil {
-		return fmt.Errorf("failed to create new writer for file %q: %w", p.metricGroups[name].filename, err)
+	return p.reopen(group)
+}
+
+func (p *Parquet) reopen(group *metricGroup) error {
+	schema := group.schema
+	if err := group.close(); err != nil {
+		delete(p.metricGroups, group.name)
+		return fmt.Errorf("failed to close file %q: %w", group.filename, err)
 	}
-	p.metricGroups[name].writer = writer
+
+	if err := p.openFile(group, schema); err != nil {
+		delete(p.metricGroups, group.name)
+		return err
+	}
 
 	return nil
+}
+
+func (g *metricGroup) close() error {
+	err := g.writer.Close()
+	g.builder.Release()
+
+	return err
+}
+
+func (p *Parquet) openFile(group *metricGroup, schema *arrow.Schema) error {
+	group.schema = schema
+	group.builder = array.NewRecordBuilder(memory.DefaultAllocator, schema)
+	group.filename = p.unusedFilename(group.name)
+
+	f, err := os.Create(group.filename)
+	if err != nil {
+		return fmt.Errorf("failed to create file %q: %w", group.filename, err)
+	}
+
+	writer, err := pqarrow.NewFileWriter(schema, f, parquet.NewWriterProperties(), pqarrow.DefaultWriterProps())
+	if err != nil {
+		f.Close()
+		return fmt.Errorf("failed to create parquet writer for file %q: %w", group.filename, err)
+	}
+	group.writer = writer
+
+	return nil
+}
+
+func (p *Parquet) unusedFilename(name string) string {
+	now := time.Now()
+	prefix := filepath.Join(p.Directory, fmt.Sprintf("%s-%s-%d", name, now.Format("2006-01-02"), now.Unix()))
+
+	filename := prefix + ".parquet"
+	for suffix := 1; ; suffix++ {
+		if _, err := os.Stat(filename); err != nil {
+			return filename
+		}
+		filename = fmt.Sprintf("%s-%d.parquet", prefix, suffix)
+	}
 }
 
 func (p *Parquet) createRecordBatch(group *metricGroup, metrics []telegraf.Metric) arrow.RecordBatch {
@@ -334,27 +371,6 @@ func (p *Parquet) createSchema(metrics []telegraf.Metric) *arrow.Schema {
 	}
 
 	return arrow.NewSchema(fields, nil)
-}
-
-func (p *Parquet) createWriter(name, filename string, schema *arrow.Schema) (*pqarrow.FileWriter, error) {
-	if _, err := os.Stat(filename); err == nil {
-		now := time.Now()
-		rotatedFilename := fmt.Sprintf("%s/%s-%s-%s.parquet", p.Directory, name, now.Format("2006-01-02"), strconv.FormatInt(now.Unix(), 10))
-		if err := os.Rename(filename, rotatedFilename); err != nil {
-			return nil, fmt.Errorf("failed to rename file %q: %w", filename, err)
-		}
-	}
-	file, err := os.Create(filename)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create file %q: %w", filename, err)
-	}
-
-	writer, err := pqarrow.NewFileWriter(schema, file, parquet.NewWriterProperties(), pqarrow.DefaultWriterProps())
-	if err != nil {
-		return nil, fmt.Errorf("failed to create parquet writer for file %q: %w", filename, err)
-	}
-
-	return writer, nil
 }
 
 func goToArrowType(value interface{}) (arrow.DataType, error) {

--- a/plugins/outputs/parquet/parquet.go
+++ b/plugins/outputs/parquet/parquet.go
@@ -102,10 +102,7 @@ func (p *Parquet) Write(metrics []telegraf.Metric) error {
 	for name, metrics := range groupedMetrics {
 		if _, ok := p.metricGroups[name]; !ok {
 			filename := fmt.Sprintf("%s/%s-%s-%s.parquet", p.Directory, name, now.Format("2006-01-02"), strconv.FormatInt(now.Unix(), 10))
-			schema, err := p.createSchema(metrics)
-			if err != nil {
-				return fmt.Errorf("failed to create schema for file %q: %w", name, err)
-			}
+			schema := p.createSchema(metrics)
 			writer, err := p.createWriter(name, filename, schema)
 			if err != nil {
 				return fmt.Errorf("failed to create writer for file %q: %w", name, err)
@@ -282,17 +279,19 @@ func appendTyped[T any](builder array.Builder, value T) bool {
 	return true
 }
 
-func (p *Parquet) createSchema(metrics []telegraf.Metric) (*arrow.Schema, error) {
+func (p *Parquet) createSchema(metrics []telegraf.Metric) *arrow.Schema {
 	rawFields := make(map[string]arrow.DataType, 0)
 	for _, metric := range metrics {
 		for _, field := range metric.FieldList() {
-			if _, ok := rawFields[field.Key]; !ok {
-				arrowType, err := goToArrowType(field.Value)
-				if err != nil {
-					return nil, fmt.Errorf("error converting '%s=%s' field to arrow type: %w", field.Key, field.Value, err)
-				}
-				rawFields[field.Key] = arrowType
+			if _, known := rawFields[field.Key]; known {
+				continue
 			}
+			arrowType, err := goToArrowType(field.Value)
+			if err != nil {
+				p.Log.Warnf("Skipping field %q of metric %q: %v", field.Key, metric.Name(), err)
+				continue
+			}
+			rawFields[field.Key] = arrowType
 		}
 		for _, tag := range metric.TagList() {
 			if _, ok := rawFields[tag.Key]; !ok {
@@ -334,7 +333,7 @@ func (p *Parquet) createSchema(metrics []telegraf.Metric) (*arrow.Schema, error)
 		})
 	}
 
-	return arrow.NewSchema(fields, nil), nil
+	return arrow.NewSchema(fields, nil)
 }
 
 func (p *Parquet) createWriter(name, filename string, schema *arrow.Schema) (*pqarrow.FileWriter, error) {

--- a/plugins/outputs/parquet/parquet.go
+++ b/plugins/outputs/parquet/parquet.go
@@ -296,8 +296,9 @@ func (p *Parquet) createSchema(metrics []telegraf.Metric) (*arrow.Schema, error)
 	fields := make([]arrow.Field, 0)
 	for key, value := range rawFields {
 		fields = append(fields, arrow.Field{
-			Name: key,
-			Type: value,
+			Name:     key,
+			Type:     value,
+			Nullable: true,
 		})
 	}
 

--- a/plugins/outputs/parquet/parquet_test.go
+++ b/plugins/outputs/parquet/parquet_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/apache/arrow-go/v18/arrow"
 	"github.com/apache/arrow-go/v18/arrow/array"
 	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/apache/arrow-go/v18/parquet"
 	"github.com/apache/arrow-go/v18/parquet/file"
 	"github.com/stretchr/testify/require"
 
@@ -410,4 +411,31 @@ func TestAppendValueNullsWhatItCannotWrite(t *testing.T) {
 	require.False(t, appendValue(builder, []string{"unsupported"}))
 	require.True(t, appendValue(builder, nil))
 	require.Equal(t, 3, builder.NullN())
+}
+
+func TestTimestampFieldNameCollisionKeepsOneColumn(t *testing.T) {
+	dir := t.TempDir()
+	p := &Parquet{Directory: dir, TimestampFieldName: "timestamp", Log: testutil.Logger{}}
+	require.NoError(t, p.Init())
+
+	require.NoError(t, p.Write([]telegraf.Metric{
+		metric.New("demo", nil, map[string]interface{}{"timestamp": "x", "value": int64(1)}, time.Now()),
+	}))
+	require.NoError(t, p.Close())
+
+	written, err := filepath.Glob(filepath.Join(dir, "*.parquet"))
+	require.NoError(t, err)
+	require.Len(t, written, 1)
+
+	reader, err := file.OpenParquetFile(written[0], false)
+	require.NoError(t, err)
+	defer reader.Close()
+
+	schema := reader.MetaData().Schema
+	names := make([]string, 0, schema.NumColumns())
+	for i := 0; i < schema.NumColumns(); i++ {
+		names = append(names, schema.Column(i).Name())
+	}
+	require.ElementsMatch(t, []string{"value", "timestamp"}, names)
+	require.Equal(t, parquet.Types.Int64, schema.Column(schema.ColumnIndexByName("timestamp")).PhysicalType())
 }

--- a/plugins/outputs/parquet/parquet_test.go
+++ b/plugins/outputs/parquet/parquet_test.go
@@ -470,3 +470,34 @@ func TestColumnOrderIsDeterministic(t *testing.T) {
 	}
 	require.Equal(t, []string{"alpha", "charlie", "delta", "zone", "timestamp"}, names)
 }
+
+func TestUnsupportedFieldTypeDoesNotStallOutput(t *testing.T) {
+	dir := t.TempDir()
+	p := &Parquet{Directory: dir, TimestampFieldName: "timestamp", Log: testutil.Logger{}}
+	require.NoError(t, p.Init())
+
+	poisoned := metric.New("demo", nil, map[string]interface{}{"value": int64(1)}, time.Now())
+	poisoned.AddField("unsupported", struct{ x int }{1})
+	require.NoError(t, p.Write([]telegraf.Metric{poisoned}))
+
+	require.NoError(t, p.Write([]telegraf.Metric{
+		metric.New("demo", nil, map[string]interface{}{"value": int64(2)}, time.Now()),
+	}))
+	require.NoError(t, p.Close())
+
+	written, err := filepath.Glob(filepath.Join(dir, "*.parquet"))
+	require.NoError(t, err)
+	require.Len(t, written, 1)
+
+	reader, err := file.OpenParquetFile(written[0], false)
+	require.NoError(t, err)
+	defer reader.Close()
+	require.Equal(t, int64(2), reader.NumRows())
+
+	schema := reader.MetaData().Schema
+	names := make([]string, 0, schema.NumColumns())
+	for i := 0; i < schema.NumColumns(); i++ {
+		names = append(names, schema.Column(i).Name())
+	}
+	require.Equal(t, []string{"value", "timestamp"}, names)
+}

--- a/plugins/outputs/parquet/parquet_test.go
+++ b/plugins/outputs/parquet/parquet_test.go
@@ -373,12 +373,15 @@ func TestConflictingValueTypesDoNotPanic(t *testing.T) {
 
 	written, err := filepath.Glob(filepath.Join(dir, "*.parquet"))
 	require.NoError(t, err)
-	require.Len(t, written, 1)
 
-	reader, err := file.OpenParquetFile(written[0], false)
-	require.NoError(t, err)
-	defer reader.Close()
-	require.Equal(t, int64(2), reader.NumRows())
+	var total int64
+	for _, name := range written {
+		reader, err := file.OpenParquetFile(name, false)
+		require.NoError(t, err)
+		total += reader.NumRows()
+		require.NoError(t, reader.Close())
+	}
+	require.Equal(t, int64(2), total)
 }
 
 func TestEveryConvertibleTypeRoundTrips(t *testing.T) {
@@ -459,16 +462,7 @@ func TestColumnOrderIsDeterministic(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, written, 1)
 
-	reader, err := file.OpenParquetFile(written[0], false)
-	require.NoError(t, err)
-	defer reader.Close()
-
-	schema := reader.MetaData().Schema
-	names := make([]string, 0, schema.NumColumns())
-	for i := 0; i < schema.NumColumns(); i++ {
-		names = append(names, schema.Column(i).Name())
-	}
-	require.Equal(t, []string{"alpha", "charlie", "delta", "zone", "timestamp"}, names)
+	require.Equal(t, []string{"alpha", "charlie", "delta", "zone", "timestamp"}, columnNames(t, written[0]))
 }
 
 func TestUnsupportedFieldTypeDoesNotStallOutput(t *testing.T) {
@@ -574,4 +568,63 @@ func TestFieldTakesPrecedenceOverTagOfTheSameName(t *testing.T) {
 
 	schema := reader.MetaData().Schema
 	require.Equal(t, parquet.Types.Int64, schema.Column(schema.ColumnIndexByName("k")).PhysicalType())
+}
+
+func columnNames(t *testing.T, path string) []string {
+	t.Helper()
+
+	reader, err := file.OpenParquetFile(path, false)
+	require.NoError(t, err)
+	defer reader.Close()
+
+	schema := reader.MetaData().Schema
+	names := make([]string, 0, schema.NumColumns())
+	for i := 0; i < schema.NumColumns(); i++ {
+		names = append(names, schema.Column(i).Name())
+	}
+
+	return names
+}
+
+func TestNewColumnStartsANewFile(t *testing.T) {
+	dir := t.TempDir()
+	p := &Parquet{Directory: dir, TimestampFieldName: "timestamp", Log: testutil.Logger{}}
+	require.NoError(t, p.Init())
+
+	require.NoError(t, p.Write([]telegraf.Metric{
+		metric.New("demo", nil, map[string]interface{}{"a": int64(1)}, time.Now()),
+	}))
+	require.NoError(t, p.Write([]telegraf.Metric{
+		metric.New("demo", nil, map[string]interface{}{"a": int64(2), "b": int64(3)}, time.Now()),
+	}))
+	require.NoError(t, p.Close())
+
+	written, err := filepath.Glob(filepath.Join(dir, "*.parquet"))
+	require.NoError(t, err)
+	require.Len(t, written, 2)
+
+	schemas := make([][]string, 0, len(written))
+	for _, name := range written {
+		schemas = append(schemas, columnNames(t, name))
+	}
+	require.ElementsMatch(t, [][]string{{"a", "timestamp"}, {"a", "b", "timestamp"}}, schemas)
+}
+
+func TestOmittedFieldKeepsTheSameFile(t *testing.T) {
+	dir := t.TempDir()
+	p := &Parquet{Directory: dir, TimestampFieldName: "timestamp", Log: testutil.Logger{}}
+	require.NoError(t, p.Init())
+
+	require.NoError(t, p.Write([]telegraf.Metric{
+		metric.New("demo", nil, map[string]interface{}{"a": int64(1), "b": int64(2)}, time.Now()),
+	}))
+	require.NoError(t, p.Write([]telegraf.Metric{
+		metric.New("demo", nil, map[string]interface{}{"a": int64(3)}, time.Now()),
+	}))
+	require.NoError(t, p.Close())
+
+	written, err := filepath.Glob(filepath.Join(dir, "*.parquet"))
+	require.NoError(t, err)
+	require.Len(t, written, 1)
+	require.Equal(t, []string{"a", "b", "timestamp"}, columnNames(t, written[0]))
 }

--- a/plugins/outputs/parquet/parquet_test.go
+++ b/plugins/outputs/parquet/parquet_test.go
@@ -552,3 +552,26 @@ func TestRotationSurvivesAMissingFile(t *testing.T) {
 	}))
 	require.NoError(t, p.Close())
 }
+
+func TestFieldTakesPrecedenceOverTagOfTheSameName(t *testing.T) {
+	dir := t.TempDir()
+	p := &Parquet{Directory: dir, TimestampFieldName: "timestamp", Log: testutil.Logger{}}
+	require.NoError(t, p.Init())
+
+	require.NoError(t, p.Write([]telegraf.Metric{
+		metric.New("demo", map[string]string{"k": "from tag"}, map[string]interface{}{"other": int64(0)}, time.Now()),
+		metric.New("demo", nil, map[string]interface{}{"k": int64(1)}, time.Now()),
+	}))
+	require.NoError(t, p.Close())
+
+	written, err := filepath.Glob(filepath.Join(dir, "*.parquet"))
+	require.NoError(t, err)
+	require.Len(t, written, 1)
+
+	reader, err := file.OpenParquetFile(written[0], false)
+	require.NoError(t, err)
+	defer reader.Close()
+
+	schema := reader.MetaData().Schema
+	require.Equal(t, parquet.Types.Int64, schema.Column(schema.ColumnIndexByName("k")).PhysicalType())
+}

--- a/plugins/outputs/parquet/parquet_test.go
+++ b/plugins/outputs/parquet/parquet_test.go
@@ -439,3 +439,34 @@ func TestTimestampFieldNameCollisionKeepsOneColumn(t *testing.T) {
 	require.ElementsMatch(t, []string{"value", "timestamp"}, names)
 	require.Equal(t, parquet.Types.Int64, schema.Column(schema.ColumnIndexByName("timestamp")).PhysicalType())
 }
+
+func TestColumnOrderIsDeterministic(t *testing.T) {
+	dir := t.TempDir()
+	p := &Parquet{Directory: dir, TimestampFieldName: "timestamp", Log: testutil.Logger{}}
+	require.NoError(t, p.Init())
+
+	require.NoError(t, p.Write([]telegraf.Metric{
+		metric.New(
+			"demo",
+			map[string]string{"zone": "a"},
+			map[string]interface{}{"delta": int64(1), "alpha": int64(2), "charlie": int64(3)},
+			time.Now(),
+		),
+	}))
+	require.NoError(t, p.Close())
+
+	written, err := filepath.Glob(filepath.Join(dir, "*.parquet"))
+	require.NoError(t, err)
+	require.Len(t, written, 1)
+
+	reader, err := file.OpenParquetFile(written[0], false)
+	require.NoError(t, err)
+	defer reader.Close()
+
+	schema := reader.MetaData().Schema
+	names := make([]string, 0, schema.NumColumns())
+	for i := 0; i < schema.NumColumns(); i++ {
+		names = append(names, schema.Column(i).Name())
+	}
+	require.Equal(t, []string{"alpha", "charlie", "delta", "zone", "timestamp"}, names)
+}

--- a/plugins/outputs/parquet/parquet_test.go
+++ b/plugins/outputs/parquet/parquet_test.go
@@ -8,6 +8,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/apache/arrow-go/v18/parquet/file"
 	"github.com/stretchr/testify/require"
 
@@ -352,4 +355,59 @@ func TestMissingValuesReadBackAsNull(t *testing.T) {
 		}
 		require.Equalf(t, int16(1), column.MaxDefinitionLevel(), "column %q is required, nulls would be written as zero", column.Name())
 	}
+}
+
+func TestConflictingValueTypesDoNotPanic(t *testing.T) {
+	dir := t.TempDir()
+	p := &Parquet{Directory: dir, TimestampFieldName: "timestamp", Log: testutil.Logger{}}
+	require.NoError(t, p.Init())
+
+	require.NoError(t, p.Write([]telegraf.Metric{
+		metric.New("demo", nil, map[string]interface{}{"k": int64(1)}, time.Now()),
+	}))
+	require.NoError(t, p.Write([]telegraf.Metric{
+		metric.New("demo", map[string]string{"k": "v"}, map[string]interface{}{"other": int64(2)}, time.Now()),
+	}))
+	require.NoError(t, p.Close())
+
+	written, err := filepath.Glob(filepath.Join(dir, "*.parquet"))
+	require.NoError(t, err)
+	require.Len(t, written, 1)
+
+	reader, err := file.OpenParquetFile(written[0], false)
+	require.NoError(t, err)
+	defer reader.Close()
+	require.Equal(t, int64(2), reader.NumRows())
+}
+
+func TestEveryConvertibleTypeRoundTrips(t *testing.T) {
+	values := map[string]interface{}{
+		"int8": int8(1), "int16": int16(2), "int32": int32(3), "int64": int64(4), "int": 5,
+		"uint8": uint8(6), "uint16": uint16(7), "uint32": uint32(8), "uint64": uint64(9), "uint": uint(10),
+		"float32": float32(11), "float64": float64(12),
+		"string": "thirteen", "bool": true,
+	}
+
+	for name, value := range values {
+		t.Run(name, func(t *testing.T) {
+			datatype, err := goToArrowType(value)
+			require.NoError(t, err)
+
+			builder := array.NewBuilder(memory.DefaultAllocator, datatype)
+			defer builder.Release()
+
+			require.True(t, appendValue(builder, value))
+			require.Equal(t, 0, builder.NullN())
+		})
+	}
+}
+
+func TestAppendValueNullsWhatItCannotWrite(t *testing.T) {
+	builder := array.NewBuilder(memory.DefaultAllocator, arrow.PrimitiveTypes.Int64)
+	defer builder.Release()
+
+	require.False(t, appendValue(builder, "not an int"))
+	require.False(t, appendValue(builder, []string{"unsupported"}))
+	require.True(t, appendValue(builder, nil))
+	require.Equal(t, 3, builder.NullN())
 }

--- a/plugins/outputs/parquet/parquet_test.go
+++ b/plugins/outputs/parquet/parquet_test.go
@@ -323,3 +323,33 @@ func TestLongMeasurementNameKeepsOutputWriting(t *testing.T) {
 		require.LessOrEqual(t, len(filepath.Base(name)), 255)
 	}
 }
+
+func TestMissingValuesReadBackAsNull(t *testing.T) {
+	dir := t.TempDir()
+	p := &Parquet{Directory: dir, TimestampFieldName: "timestamp", Log: testutil.Logger{}}
+	require.NoError(t, p.Init())
+
+	now := time.Now()
+	require.NoError(t, p.Write([]telegraf.Metric{
+		metric.New("demo", nil, map[string]interface{}{"a": int64(1), "b": int64(2)}, now),
+		metric.New("demo", nil, map[string]interface{}{"a": int64(3)}, now),
+	}))
+	require.NoError(t, p.Close())
+
+	written, err := filepath.Glob(filepath.Join(dir, "*.parquet"))
+	require.NoError(t, err)
+	require.Len(t, written, 1)
+
+	reader, err := file.OpenParquetFile(written[0], false)
+	require.NoError(t, err)
+	defer reader.Close()
+
+	schema := reader.MetaData().Schema
+	for i := 0; i < schema.NumColumns(); i++ {
+		column := schema.Column(i)
+		if column.Name() == "timestamp" {
+			continue
+		}
+		require.Equalf(t, int16(1), column.MaxDefinitionLevel(), "column %q is required, nulls would be written as zero", column.Name())
+	}
+}

--- a/plugins/outputs/parquet/parquet_test.go
+++ b/plugins/outputs/parquet/parquet_test.go
@@ -3,6 +3,8 @@ package parquet
 import (
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -12,6 +14,7 @@ import (
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/metric"
+	"github.com/influxdata/telegraf/testutil"
 )
 
 func TestCases(t *testing.T) {
@@ -244,4 +247,79 @@ func TestTimestampDifferentName(t *testing.T) {
 	metadata := reader.MetaData()
 	require.Equal(t, 1, int(metadata.NumRows))
 	require.Equal(t, 2, metadata.Schema.NumColumns())
+}
+
+func TestMetricToFile(t *testing.T) {
+	tests := []struct {
+		name     string
+		expected string
+	}{
+		{"cpu", "cpu"},
+		{"../../etc/passwd", ".._.._etc_passwd"},
+		{`a/b\c`, "a_b_c"},
+		{"nul\x00byte", "nul_byte"},
+		{"tab\tnewline\n", "tab_newline_"},
+		{strings.Repeat("a", 300), strings.Repeat("a", maxMeasurementLen)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &Parquet{Log: testutil.Logger{}}
+			require.Equal(t, tt.expected, p.metricToFile(tt.name))
+		})
+	}
+}
+
+func TestWindowsReservedCharacters(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("windows only")
+	}
+
+	p := &Parquet{Log: testutil.Logger{}}
+	require.Equal(t, "a_b_c", p.metricToFile(`a<b>c`))
+}
+
+func TestMeasurementNamesCannotEscapeDirectory(t *testing.T) {
+	dir := t.TempDir()
+	outside := filepath.Dir(dir)
+	before, err := filepath.Glob(filepath.Join(outside, "*.parquet"))
+	require.NoError(t, err)
+
+	p := &Parquet{Directory: dir, TimestampFieldName: "timestamp", Log: testutil.Logger{}}
+	require.NoError(t, p.Init())
+
+	for _, name := range []string{"../../../../tmp/evil", "..", "../evil", `a\..\..\b`} {
+		m := metric.New(name, nil, map[string]interface{}{"value": int64(1)}, time.Now())
+		require.NoError(t, p.Write([]telegraf.Metric{m}))
+	}
+	require.NoError(t, p.Close())
+
+	after, err := filepath.Glob(filepath.Join(outside, "*.parquet"))
+	require.NoError(t, err)
+	require.Equal(t, before, after)
+
+	written, err := filepath.Glob(filepath.Join(dir, "*.parquet"))
+	require.NoError(t, err)
+	require.Len(t, written, 4)
+}
+
+func TestLongMeasurementNameKeepsOutputWriting(t *testing.T) {
+	dir := t.TempDir()
+	p := &Parquet{Directory: dir, TimestampFieldName: "timestamp", Log: testutil.Logger{}}
+	require.NoError(t, p.Init())
+
+	require.NoError(t, p.Write([]telegraf.Metric{
+		metric.New(strings.Repeat("a", 300), nil, map[string]interface{}{"value": int64(1)}, time.Now()),
+	}))
+	require.NoError(t, p.Write([]telegraf.Metric{
+		metric.New("good", nil, map[string]interface{}{"value": int64(2)}, time.Now()),
+	}))
+	require.NoError(t, p.Close())
+
+	written, err := filepath.Glob(filepath.Join(dir, "*.parquet"))
+	require.NoError(t, err)
+	require.Len(t, written, 2)
+	for _, name := range written {
+		require.LessOrEqual(t, len(filepath.Base(name)), 255)
+	}
 }

--- a/plugins/outputs/parquet/parquet_test.go
+++ b/plugins/outputs/parquet/parquet_test.go
@@ -501,3 +501,29 @@ func TestUnsupportedFieldTypeDoesNotStallOutput(t *testing.T) {
 	}
 	require.Equal(t, []string{"value", "timestamp"}, names)
 }
+
+func TestExistingFilesAreNeverOverwritten(t *testing.T) {
+	dir := t.TempDir()
+
+	for i := 1; i <= 3; i++ {
+		p := &Parquet{Directory: dir, TimestampFieldName: "timestamp", Log: testutil.Logger{}}
+		require.NoError(t, p.Init())
+		require.NoError(t, p.Write([]telegraf.Metric{
+			metric.New("demo", nil, map[string]interface{}{"value": int64(i)}, time.Now()),
+		}))
+		require.NoError(t, p.Close())
+	}
+
+	written, err := filepath.Glob(filepath.Join(dir, "*.parquet"))
+	require.NoError(t, err)
+	require.Len(t, written, 3)
+
+	var total int64
+	for _, name := range written {
+		reader, err := file.OpenParquetFile(name, false)
+		require.NoError(t, err)
+		total += reader.NumRows()
+		require.NoError(t, reader.Close())
+	}
+	require.Equal(t, int64(3), total)
+}

--- a/plugins/outputs/parquet/parquet_test.go
+++ b/plugins/outputs/parquet/parquet_test.go
@@ -527,3 +527,28 @@ func TestExistingFilesAreNeverOverwritten(t *testing.T) {
 	}
 	require.Equal(t, int64(3), total)
 }
+
+func TestRotationSurvivesAMissingFile(t *testing.T) {
+	dir := t.TempDir()
+	p := &Parquet{
+		Directory:          dir,
+		RotationInterval:   config.Duration(time.Nanosecond),
+		TimestampFieldName: "timestamp",
+		Log:                testutil.Logger{},
+	}
+	require.NoError(t, p.Init())
+
+	require.NoError(t, p.Write([]telegraf.Metric{
+		metric.New("demo", nil, map[string]interface{}{"value": int64(1)}, time.Now()),
+	}))
+
+	written, err := filepath.Glob(filepath.Join(dir, "*.parquet"))
+	require.NoError(t, err)
+	require.Len(t, written, 1)
+	require.NoError(t, os.Remove(written[0]))
+
+	require.NoError(t, p.Write([]telegraf.Metric{
+		metric.New("demo", nil, map[string]interface{}{"value": int64(2)}, time.Now()),
+	}))
+	require.NoError(t, p.Close())
+}

--- a/plugins/outputs/parquet/sample.conf
+++ b/plugins/outputs/parquet/sample.conf
@@ -1,7 +1,7 @@
 # A plugin that writes metrics to parquet files
 [[outputs.parquet]]
   ## Directory to write parquet files in. Existing files are never modified.
-  ## A new file is created at startup and on rotation.
+  ## A new file is created at startup, on rotation, and on schema change.
   # directory = "."
 
   ## Files are rotated after the time interval specified. When set to 0 no time

--- a/plugins/outputs/parquet/sample.conf
+++ b/plugins/outputs/parquet/sample.conf
@@ -1,7 +1,7 @@
 # A plugin that writes metrics to parquet files
 [[outputs.parquet]]
-  ## Directory to write parquet files in. If a file already exists the output
-  ## will attempt to continue using the existing file.
+  ## Directory to write parquet files in. Existing files are never modified.
+  ## A new file is created at startup and on rotation.
   # directory = "."
 
   ## Files are rotated after the time interval specified. When set to 0 no time


### PR DESCRIPTION
Since a parquet column schema is set on file creation, any schema changes were silently dropped until the file was rotated. For example a metric that reports an optional field only on error, an input that gains a field after an upgrade, or simply a host that joins later with an extra tag.

Now telegraf rotates the file. Columns schemas are additive, so a missing metric still writes `null`. Files in a directory can now have different columns so readers have to join files by column name.

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [ ] No AI generated code was used in this PR
- [x] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves # #19563
