### PR TITLE
fix(inputs.cloudwatch_metric_streams): Initialize close channel

### DIFF
--- a/plugins/inputs/cloudwatch_metric_streams/cloudwatch_metric_streams.go
+++ b/plugins/inputs/cloudwatch_metric_streams/cloudwatch_metric_streams.go
@@ -111,6 +111,8 @@ func (cms *CloudWatchMetricStreams) Init() error {
 		cms.WriteTimeout = config.Duration(time.Second * 10)
 	}
 
+	cms.close = make(chan struct{})
+
 	return nil
 }
 


### PR DESCRIPTION
## Summary

This PR initializes the otherwise uninitialized `close` channel to prevent writing to a closed channel during shutdown.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
