### PR TITLE
feat(inputs.libvirt): Add energy monitor metrics

### DIFF
--- a/plugins/inputs/libvirt/README.md
+++ b/plugins/inputs/libvirt/README.md
@@ -1,3 +1,6 @@
+<!-- Copyright (C) 2026 Intel Corporation -->
+<!-- SPDX-License-Identifier: MIT -->
+
 # Libvirt Input Plugin
 
 This plugin collects statistics about virtualized guests on a system by using
@@ -141,6 +144,13 @@ More details about metrics can be found at the links below:
 || cpu.cache.monitor.\<num\>.bank.count | bank_count | the number of cache banks in cache monitor \<num\>, not available for kernels from 4.14 upwards |
 || cpu.cache.monitor.\<num\>.bank.\<index\>.id | id|host allocated cache id for bank \<index\> in cache monitor \<num\>, not available for kernels from 4.14 upwards |
 || cpu.cache.monitor.\<num\>.bank.\<index\>.bytes | bytes | the number of bytes of last level cache that the domain is using on cache bank \<index\>, not available for kernels from 4.14 upwards|
+|| cpu.energy.monitor.count | count | the number of resctrl energy monitors for this domain, available with libvirt 12.4.0 or later (exposed as `libvirt_cpu_energy_monitor_total`) |
+|| cpu.energy.monitor.\<num\>.name | name | the name of energy monitor \<num\> (exposed as `libvirt_cpu_energy_monitor`) |
+|| cpu.energy.monitor.\<num\>.vcpus | vcpus | the vCPU list of energy monitor \<num\> |
+|| cpu.energy.monitor.\<num\>.pkg.count | pkg_count | the number of CPU packages reported by energy monitor \<num\> |
+|| cpu.energy.monitor.\<num\>.pkg.\<index\>.id | id | host package ID for package \<index\> in energy monitor \<num\> (exposed as `libvirt_cpu_energy_monitor_pkg`) |
+|| cpu.energy.monitor.\<num\>.pkg.\<index\>.core_energy | core_energy | cumulative core energy in Joules consumed by package \<index\> in energy monitor \<num\> |
+|| cpu.energy.monitor.\<num\>.pkg.\<index\>.activity | activity | cumulative activity counter in Farads for package \<index\> in energy monitor \<num\> |
 | **balloon** | balloon.current | current | the memory in KiB currently used |
 || balloon.maximum | maximum | the maximum memory in KiB allowed |
 || balloon.swap_in | swap_in | the amount of data read from swap space (in KiB) |

--- a/plugins/inputs/libvirt/libvirt_metric_format.go
+++ b/plugins/inputs/libvirt/libvirt_metric_format.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Intel Corporation
+// SPDX-License-Identifier: MIT
+
 package libvirt
 
 import (
@@ -12,6 +15,8 @@ import (
 var (
 	cpuCacheMonitorRegexp            = regexp.MustCompile(`^cache\.monitor\..+?\.(name|vcpus|bank_count)$`)
 	cpuCacheMonitorBankRegexp        = regexp.MustCompile(`^cache\.monitor\..+?\.bank\..+?\.(id|bytes)$`)
+	cpuEnergyMonitorRegexp           = regexp.MustCompile(`^energy\.monitor\..+?\.(name|vcpus|pkg_count)$`)
+	cpuEnergyMonitorPkgRegexp        = regexp.MustCompile(`^energy\.monitor\..+?\.pkg\..+?\.(id|core_energy|activity)$`)
 	memoryBandwidthMonitorRegexp     = regexp.MustCompile(`^bandwidth\.monitor\..+?\.(name|vcpus|node_count)$`)
 	memoryBandwidthMonitorNodeRegexp = regexp.MustCompile(`^bandwidth\.monitor\..+?\.node\..+?\.(id|bytes_local|bytes_total)$`)
 )
@@ -104,9 +109,12 @@ func addStateMetrics(metrics map[string]golibvirt.TypedParamValue, domainName st
 func addCPUMetrics(metrics map[string]golibvirt.TypedParamValue, domainName string, acc telegraf.Accumulator) {
 	var cpuFields = make(map[string]interface{})
 	var cpuCacheMonitorTotalFields = make(map[string]interface{})
+	var cpuEnergyMonitorTotalFields = make(map[string]interface{})
 
 	var cpuCacheMonitorData = make(map[string]map[string]interface{})
 	var cpuCacheMonitorBankData = make(map[string]map[string]map[string]interface{})
+	var cpuEnergyMonitorData = make(map[string]map[string]interface{})
+	var cpuEnergyMonitorPkgData = make(map[string]map[string]map[string]interface{})
 
 	var cpuTags = map[string]string{
 		"domain_name": domainName,
@@ -120,9 +128,13 @@ func addCPUMetrics(metrics map[string]golibvirt.TypedParamValue, domainName stri
 			cpuFields[strings.ReplaceAll(key, ".", "_")] = metric.I
 		case "cache.monitor.count":
 			cpuCacheMonitorTotalFields["count"] = metric.I
+		case "energy.monitor.count":
+			cpuEnergyMonitorTotalFields["count"] = metric.I
 		default:
 			if strings.Contains(key, "bank.count") {
 				key = strings.ReplaceAll(key, "bank.count", "bank_count")
+			} else if strings.Contains(key, "pkg.count") {
+				key = strings.ReplaceAll(key, "pkg.count", "pkg_count")
 			}
 
 			cpuStat := strings.Split(key, ".")
@@ -152,6 +164,32 @@ func addCPUMetrics(metrics map[string]golibvirt.TypedParamValue, domainName stri
 				}
 
 				bankFields[cpuStat[5]] = metric.I
+			} else if len(cpuStat) == 4 && cpuEnergyMonitorRegexp.MatchString(key) {
+				cpuEnergyMonitorID := cpuStat[2]
+				cpuEnergyMonitorFields, ok := cpuEnergyMonitorData[cpuEnergyMonitorID]
+				if !ok {
+					cpuEnergyMonitorFields = make(map[string]interface{})
+					cpuEnergyMonitorData[cpuEnergyMonitorID] = cpuEnergyMonitorFields
+				}
+
+				cpuEnergyMonitorFields[cpuStat[3]] = metric.I
+			} else if len(cpuStat) == 6 && cpuEnergyMonitorPkgRegexp.MatchString(key) {
+				cpuEnergyMonitorID := cpuStat[2]
+				pkgIndex := cpuStat[4]
+
+				pkgData, ok := cpuEnergyMonitorPkgData[cpuEnergyMonitorID]
+				if !ok {
+					pkgData = make(map[string]map[string]interface{})
+					cpuEnergyMonitorPkgData[cpuEnergyMonitorID] = pkgData
+				}
+
+				pkgFields, ok := pkgData[pkgIndex]
+				if !ok {
+					pkgFields = make(map[string]interface{})
+					pkgData[pkgIndex] = pkgFields
+				}
+
+				pkgFields[cpuStat[5]] = metric.I
 			}
 		}
 	}
@@ -184,6 +222,29 @@ func addCPUMetrics(metrics map[string]golibvirt.TypedParamValue, domainName stri
 				}
 				acc.AddFields("libvirt_cpu_cache_monitor_bank", bankFields, bankTags)
 			}
+		}
+	}
+
+	if len(cpuEnergyMonitorTotalFields) > 0 {
+		acc.AddFields("libvirt_cpu_energy_monitor_total", cpuEnergyMonitorTotalFields, cpuTags)
+	}
+
+	for cpuEnergyMonitorID, fields := range cpuEnergyMonitorData {
+		tags := map[string]string{
+			"domain_name":       domainName,
+			"energy_monitor_id": cpuEnergyMonitorID,
+		}
+		acc.AddFields("libvirt_cpu_energy_monitor", fields, tags)
+	}
+
+	for cpuEnergyMonitorID, pkgData := range cpuEnergyMonitorPkgData {
+		for pkgIndex, fields := range pkgData {
+			tags := map[string]string{
+				"domain_name":       domainName,
+				"energy_monitor_id": cpuEnergyMonitorID,
+				"pkg_index":         pkgIndex,
+			}
+			acc.AddFields("libvirt_cpu_energy_monitor_pkg", fields, tags)
 		}
 	}
 }

--- a/plugins/inputs/libvirt/libvirt_test.go
+++ b/plugins/inputs/libvirt/libvirt_test.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Intel Corporation
+// SPDX-License-Identifier: MIT
+
 package libvirt
 
 import (
@@ -388,6 +391,16 @@ var (
 				{Field: "cpu.cache.monitor.1.bank.0.bytes", Value: *golibvirt.NewTypedParamValueLlong(720896)},
 				{Field: "cpu.cache.monitor.1.bank.1.id", Value: *golibvirt.NewTypedParamValueLlong(1)},
 				{Field: "cpu.cache.monitor.1.bank.1.bytes", Value: *golibvirt.NewTypedParamValueLlong(8200192)},
+				{Field: "cpu.energy.monitor.count", Value: *golibvirt.NewTypedParamValueUint(1)},
+				{Field: "cpu.energy.monitor.0.name", Value: *golibvirt.NewTypedParamValueString("all_vcpus")},
+				{Field: "cpu.energy.monitor.0.vcpus", Value: *golibvirt.NewTypedParamValueString("0-9")},
+				{Field: "cpu.energy.monitor.0.pkg.count", Value: *golibvirt.NewTypedParamValueUint(2)},
+				{Field: "cpu.energy.monitor.0.pkg.0.id", Value: *golibvirt.NewTypedParamValueUint(0)},
+				{Field: "cpu.energy.monitor.0.pkg.0.core_energy", Value: *golibvirt.NewTypedParamValueDouble(1234.5)},
+				{Field: "cpu.energy.monitor.0.pkg.0.activity", Value: *golibvirt.NewTypedParamValueDouble(5678.25)},
+				{Field: "cpu.energy.monitor.0.pkg.1.id", Value: *golibvirt.NewTypedParamValueUint(1)},
+				{Field: "cpu.energy.monitor.0.pkg.1.core_energy", Value: *golibvirt.NewTypedParamValueDouble(9012.75)},
+				{Field: "cpu.energy.monitor.0.pkg.1.activity", Value: *golibvirt.NewTypedParamValueDouble(3456.5)},
 			},
 		},
 	}
@@ -695,6 +708,36 @@ var (
 			map[string]interface{}{
 				"id":    1,
 				"bytes": 8200192,
+			},
+			time.Now()),
+		metric.New("libvirt_cpu_energy_monitor_total",
+			map[string]string{"domain_name": "Droplet-844329"},
+			map[string]interface{}{
+				"count": uint64(1),
+			},
+			time.Now()),
+		metric.New("libvirt_cpu_energy_monitor",
+			map[string]string{"domain_name": "Droplet-844329", "energy_monitor_id": "0"},
+			map[string]interface{}{
+				"name":      "all_vcpus",
+				"vcpus":     "0-9",
+				"pkg_count": uint64(2),
+			},
+			time.Now()),
+		metric.New("libvirt_cpu_energy_monitor_pkg",
+			map[string]string{"domain_name": "Droplet-844329", "energy_monitor_id": "0", "pkg_index": "0"},
+			map[string]interface{}{
+				"id":          uint64(0),
+				"core_energy": 1234.5,
+				"activity":    5678.25,
+			},
+			time.Now()),
+		metric.New("libvirt_cpu_energy_monitor_pkg",
+			map[string]string{"domain_name": "Droplet-844329", "energy_monitor_id": "0", "pkg_index": "1"},
+			map[string]interface{}{
+				"id":          uint64(1),
+				"core_energy": 9012.75,
+				"activity":    3456.5,
 			},
 			time.Now()),
 	}


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
Add support for energy monitor stats introduced in libvirt 12.4.0.

Expose energy monitor metadata and per-package `core_energy` in Joules and `activity` in Farads
counters reported under `cpu.energy.monitor.*` for per-domain energy observability.

My CCLA request has been waiting for approval for almost 2 months now with no response from Influx legal team. Could someone ping them internally please?
Let me know how you feel about copyright notice, Intel's legal team asked me to put those. I didnt find any relevant info about it in the legal docs.

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [ ] No AI generated code was used in this PR
- [X] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #19512 
