### PR TITLE
fix(migrations.inputs_sflow): Set protocol on migrated config

### DIFF
--- a/migrations/inputs_sflow/migration.go
+++ b/migrations/inputs_sflow/migration.go
@@ -43,6 +43,7 @@ func migrate(tbl *ast.Table) ([]byte, string, error) {
 
 	// Use a map for the new plugin and fill in the data
 	plugin["service_address"] = old.ServiceAddress
+	plugin["protocol"] = "sflow v5"
 	if old.ReadBufferSize != "" {
 		plugin["read_buffer_size"] = old.ReadBufferSize
 	}

--- a/migrations/inputs_sflow/testcases/filters/expected.conf
+++ b/migrations/inputs_sflow/testcases/filters/expected.conf
@@ -1,5 +1,6 @@
 [[inputs.netflow]]
 service_address = "udp://:6343"
+protocol = "sflow v5"
 read_buffer_size = "32KiB"
 fieldinclude = ["a"]
 name_override = "foo"

--- a/migrations/inputs_sflow/testcases/minimal/expected.conf
+++ b/migrations/inputs_sflow/testcases/minimal/expected.conf
@@ -1,2 +1,3 @@
 [[inputs.netflow]]
 service_address = "udp://:6343"
+protocol = "sflow v5"

--- a/migrations/inputs_sflow/testcases/read_buffer_size/expected.conf
+++ b/migrations/inputs_sflow/testcases/read_buffer_size/expected.conf
@@ -1,3 +1,4 @@
 [[inputs.netflow]]
 service_address = "udp://:6343"
+protocol = "sflow v5"
 read_buffer_size = "32KiB"


### PR DESCRIPTION
## Summary

Make sure the new configuration has the correct protocol set.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
