### PR TITLE
feat(inputs.prometheus): Allow configuring the pod name tag name

### DIFF
--- a/plugins/inputs/prometheus/README.md
+++ b/plugins/inputs/prometheus/README.md
@@ -116,6 +116,9 @@ and `bearer_token_string` option. See the
   ## The name of the label for the pod that is being scraped.
   ## Default is 'namespace' but this can conflict with metrics that have the label 'namespace'
   # pod_namespace_label_name = "namespace"
+  ## The name of the tag carrying the name of the pod that is being scraped.
+  ## Default is 'pod_name' but this can conflict with metrics that have the label 'pod_name'
+  # pod_name_label_name = "pod_name"
   # label selector to target pods which have the label
   # kubernetes_label_selector = "env=dev,app=nginx"
   # field selector to target pods
@@ -274,6 +277,12 @@ pods you are scraping.
 The setting `pod_namespace_label_name` allows you to change the label name for
 the namespace of the pod you are scraping. The default is `namespace`, but this
 will overwrite a label with the name `namespace` from a metric scraped.
+
+Metrics scraped from a discovered pod are always tagged with the name of that
+pod, which allows distinguishing metrics originating from different replicas of
+the same workload. The setting `pod_name_label_name` allows you to change the
+label name used for it. The default is `pod_name`, but this will overwrite a
+label with the name `pod_name` from a metric scraped.
 
 Using `pod_scrape_scope = "node"` allows more scalable scraping for pods which
 will scrape pods only in the node that telegraf is running. It will fetch the

--- a/plugins/inputs/prometheus/kubernetes.go
+++ b/plugins/inputs/prometheus/kubernetes.go
@@ -417,12 +417,8 @@ func registerPod(pod *corev1.Pod, p *Prometheus) {
 		}
 	}
 
-	tags["pod_name"] = pod.Name
-	podNamespace := "namespace"
-	if p.PodNamespaceLabelName != "" {
-		podNamespace = p.PodNamespaceLabelName
-	}
-	tags[podNamespace] = pod.Namespace
+	tags[p.PodNameLabelName] = pod.Name
+	tags[p.PodNamespaceLabelName] = pod.Namespace
 
 	// add labels as metrics tags, subject to include/exclude filters
 	for k, v := range pod.Labels {

--- a/plugins/inputs/prometheus/kubernetes_test.go
+++ b/plugins/inputs/prometheus/kubernetes_test.go
@@ -192,6 +192,7 @@ func TestDeletePods(t *testing.T) {
 
 func TestKeepDefaultNamespaceLabelName(t *testing.T) {
 	prom := &Prometheus{Log: testutil.Logger{}, kubernetesPods: map[podID]urlAndAddress{}}
+	require.NoError(t, prom.Init())
 
 	p := pod()
 	p.Annotations = map[string]string{"prometheus.io/scrape": "true"}
@@ -205,6 +206,7 @@ func TestKeepDefaultNamespaceLabelName(t *testing.T) {
 
 func TestChangeNamespaceLabelName(t *testing.T) {
 	prom := &Prometheus{Log: testutil.Logger{}, PodNamespaceLabelName: "pod_namespace", kubernetesPods: map[podID]urlAndAddress{}}
+	require.NoError(t, prom.Init())
 
 	p := pod()
 	p.Annotations = map[string]string{"prometheus.io/scrape": "true"}
@@ -215,6 +217,35 @@ func TestChangeNamespaceLabelName(t *testing.T) {
 	tags := prom.kubernetesPods[podID(id)].tags
 	require.Equal(t, "default", tags["pod_namespace"])
 	require.Empty(t, tags["namespace"])
+}
+
+func TestKeepDefaultPodNameLabelName(t *testing.T) {
+	prom := &Prometheus{Log: testutil.Logger{}, kubernetesPods: map[podID]urlAndAddress{}}
+	require.NoError(t, prom.Init())
+
+	p := pod()
+	p.Annotations = map[string]string{"prometheus.io/scrape": "true"}
+	registerPod(p, prom)
+
+	id, err := cache.MetaNamespaceKeyFunc(p)
+	require.NoError(t, err)
+	tags := prom.kubernetesPods[podID(id)].tags
+	require.Equal(t, "myPod", tags["pod_name"])
+}
+
+func TestChangePodNameLabelName(t *testing.T) {
+	prom := &Prometheus{Log: testutil.Logger{}, PodNameLabelName: "source_pod_name", kubernetesPods: map[podID]urlAndAddress{}}
+	require.NoError(t, prom.Init())
+
+	p := pod()
+	p.Annotations = map[string]string{"prometheus.io/scrape": "true"}
+	registerPod(p, prom)
+
+	id, err := cache.MetaNamespaceKeyFunc(p)
+	require.NoError(t, err)
+	tags := prom.kubernetesPods[podID(id)].tags
+	require.Equal(t, "myPod", tags["source_pod_name"])
+	require.Empty(t, tags["pod_name"])
 }
 
 func TestPodHasMatchingNamespace(t *testing.T) {

--- a/plugins/inputs/prometheus/prometheus.go
+++ b/plugins/inputs/prometheus/prometheus.go
@@ -66,6 +66,7 @@ type Prometheus struct {
 	PodScrapeInterval           int                 `toml:"pod_scrape_interval"`
 	PodNamespace                string              `toml:"monitor_kubernetes_pods_namespace"`
 	PodNamespaceLabelName       string              `toml:"pod_namespace_label_name"`
+	PodNameLabelName            string              `toml:"pod_name_label_name"`
 	KubernetesServices          []string            `toml:"kubernetes_services"`
 	KubeConfig                  string              `toml:"kube_config"`
 	KubernetesLabelSelector     string              `toml:"kubernetes_label_selector"`
@@ -187,6 +188,14 @@ func (p *Prometheus) Init() error {
 
 	if p.MonitorKubernetesPodsMethod == monitorMethodNone {
 		p.MonitorKubernetesPodsMethod = monitorMethodAnnotations
+	}
+
+	if p.PodNamespaceLabelName == "" {
+		p.PodNamespaceLabelName = "namespace"
+	}
+
+	if p.PodNameLabelName == "" {
+		p.PodNameLabelName = "pod_name"
 	}
 
 	// Parse label and field selectors - will be used to filter pods after cAdvisor call

--- a/plugins/inputs/prometheus/sample.conf
+++ b/plugins/inputs/prometheus/sample.conf
@@ -85,6 +85,9 @@
   ## The name of the label for the pod that is being scraped.
   ## Default is 'namespace' but this can conflict with metrics that have the label 'namespace'
   # pod_namespace_label_name = "namespace"
+  ## The name of the tag carrying the name of the pod that is being scraped.
+  ## Default is 'pod_name' but this can conflict with metrics that have the label 'pod_name'
+  # pod_name_label_name = "pod_name"
   # label selector to target pods which have the label
   # kubernetes_label_selector = "env=dev,app=nginx"
   # field selector to target pods


### PR DESCRIPTION
## Summary

Metrics scraped from pods discovered by the Kubernetes service discovery are already tagged with the name of the source pod — `registerPod()` sets `tags["pod_name"] = pod.Name` unconditionally, and has done so since #4920. There is only one pod registration path, so this applies to every `monitor_kubernetes_pods_method`.

Two things are missing, and this PR addresses both:

**The tag name is hard-coded.** `pod_namespace_label_name` exists so the namespace tag can be moved out of the way when a scraped metric carries its own `namespace` label. A scraped metric can carry its own `pod_name` label just as easily, but there is no equivalent option — the tag silently overwrites it. The request in #16192 was for a custom name (`source_pod_name`) for exactly this kind of reason.

This adds the symmetric `pod_name_label_name` option, following the same idiom as the existing namespace handling. It defaults to `pod_name`, so existing behavior is unchanged.

**The tag is undocumented.** The README never mentioned that `pod_name` is added at all, which is likely why the reporter concluded the feature did not exist. Added a short paragraph next to the existing `pod_namespace_label_name` docs.

Tests mirror the existing `TestKeepDefaultNamespaceLabelName` / `TestChangeNamespaceLabelName` pair.

## Checklist

- [ ] No AI generated code was used in this PR
- [x] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

resolves #16192