### PR TITLE
fix(config): Handle quotes at end of file without a trailing newline

### DIFF
--- a/config/envvar.go
+++ b/config/envvar.go
@@ -78,21 +78,21 @@ func (t *trimmer) process() error {
 }
 
 func (t *trimmer) hasNQuotes(ref byte, limit int64) bool {
-	var count int64
+	var count, unmatched int64
 	// Look ahead check if the next characters are what we expect
 	for count = 0; count < limit; count++ {
 		c, err := t.input.ReadByte()
-		if err != nil || c != ref {
+		if err != nil {
+			break
+		}
+		if c != ref {
+			// We also need to unread the non-matching character
+			unmatched = 1
 			break
 		}
 	}
-	// We also need to unread the non-matching character
-	offset := -count
-	if count < limit {
-		offset--
-	}
 	//nolint:errcheck // Unread the already matched characters
-	t.input.Seek(offset, io.SeekCurrent)
+	t.input.Seek(-(count + unmatched), io.SeekCurrent)
 	return count >= limit
 }
 

--- a/config/internal_test.go
+++ b/config/internal_test.go
@@ -374,6 +374,31 @@ func TestRemoveComments(t *testing.T) {
 	require.Equal(t, string(expected), string(actual))
 }
 
+func TestRemoveCommentsQuotesAtEOF(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{"empty basic string", `[agent]` + "\n" + `  hostname = ""`},
+		{"empty literal string", `[agent]` + "\n" + `  hostname = ''`},
+		{"non-empty basic string", `[agent]` + "\n" + `  hostname = "a"`},
+		{"four double quotes", `[agent]` + "\n" + `  hostname = """"`},
+		{"four single quotes", `[agent]` + "\n" + `  hostname = ''''`},
+		{"five double quotes", `[agent]` + "\n" + `  hostname = """""`},
+		{"empty multi-line basic string", `[agent]` + "\n" + `  hostname = """"""`},
+		{"empty multi-line literal string", `[agent]` + "\n" + `  hostname = ''''''`},
+		{"trailing newline", `[agent]` + "\n" + `  hostname = ""` + "\n"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual, err := removeComments([]byte(tt.input))
+			require.NoError(t, err)
+			require.Equal(t, tt.input, string(actual))
+		})
+	}
+}
+
 func TestURLRetries3Fails(t *testing.T) {
 	httpLoadConfigRetryInterval = 0 * time.Second
 	responseCounter := 0


### PR DESCRIPTION
## Summary

`hasNQuotes` in `config/envvar.go` broke out of its look-ahead loop on both a non-matching byte and a read error, but unread an extra byte in either case. On EOF the failed `ReadByte` consumes nothing, so the reader was rewound one byte too far and input that had already been written to the output got emitted a second time.

A config file ending in `hostname = ""` with no trailing newline was therefore handed to the TOML parser as `hostname =  """` — an unterminated multi-line basic string — and rejected as invalid syntax. Ending in four or more quotes was worse: `tripleDoubleQuote` / `tripleSingleQuote` call `hasNQuotes(ref, 2)` at EOF, get a one-byte over-rewind, and re-read the same byte on every iteration while appending to the output, hanging the process until it runs out of memory.

The fix only unreads the extra byte when the loop actually consumed a non-matching one. Full credit for the diagnosis goes to @chris3713, who tracked this down in the issue.

### Verification

Before, on `main`:

```
in : "[agent]\n  hostname = \"\""
out: "[agent]\n  hostname =  \"\"\""
```

and `hostname = """"` never returns.

After, with the built binary:

- `printf '[agent]\n  hostname = ""'` → gets past the parser to `Error running agent: no inputs found`, which is the same place the file reaches when it has a trailing newline.
- `printf '[agent]\n  hostname = """"'` → terminates immediately with `invalid TOML syntax`. That input really is invalid TOML, so an error is the right outcome; the hang was not.

`TestRemoveComments` reads a `testdata` fixture that ends with a newline, so this path had no coverage. Added `TestRemoveCommentsQuotesAtEOF`, a table test over in-memory inputs that end on a quote, asserting the trimmer passes comment-free input through unchanged. It fails on `main` — the quote cases produce corrupted output and the four-or-more-quote cases hang until the test timeout.

### Regression range

Introduced by the rewritten comment trimmer in 1887d2983 (#14240). `config/envvar.go` does not exist before v1.28.4.

## Checklist

- [ ] No AI generated code was used in this PR
- [x] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

resolves #19569