### PR TITLE
fix(outputs.parquet): Restrict files to configured directory

### DIFF
--- a/plugins/outputs/parquet/parquet.go
+++ b/plugins/outputs/parquet/parquet.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strconv"
 	"time"
 
@@ -40,6 +41,7 @@ type Parquet struct {
 	Log                telegraf.Logger `toml:"-"`
 
 	metricGroups map[string]*metricGroup
+	root         *os.Root
 }
 
 func (*Parquet) SampleConfig() string {
@@ -51,6 +53,14 @@ func (p *Parquet) Init() error {
 		p.Directory = "."
 	}
 
+	// Get the absolute path of the directory
+	d, err := filepath.Abs(p.Directory)
+	if err != nil {
+		return fmt.Errorf("getting absolute path for directory %q failed: %w", p.Directory, err)
+	}
+	p.Directory = d
+
+	// Create the directory if it doesn't exist and check it actually is a directory
 	stat, err := os.Stat(p.Directory)
 	if os.IsNotExist(err) {
 		if err := os.MkdirAll(p.Directory, 0750); err != nil {
@@ -59,6 +69,13 @@ func (p *Parquet) Init() error {
 	} else if !stat.IsDir() {
 		return fmt.Errorf("provided directory %q is not a directory", p.Directory)
 	}
+
+	// Make sure we cannot leave the given directory
+	root, err := os.OpenRoot(p.Directory)
+	if err != nil {
+		return fmt.Errorf("opening directory %q as root failed: %w", p.Directory, err)
+	}
+	p.root = root
 
 	p.metricGroups = make(map[string]*metricGroup)
 
@@ -83,6 +100,10 @@ func (p *Parquet) Close() error {
 		return errors.New("failed closing one or more parquet files")
 	}
 
+	if p.root != nil {
+		p.root.Close()
+	}
+
 	return nil
 }
 
@@ -99,7 +120,7 @@ func (p *Parquet) Write(metrics []telegraf.Metric) error {
 	now := time.Now()
 	for name, metrics := range groupedMetrics {
 		if _, ok := p.metricGroups[name]; !ok {
-			filename := fmt.Sprintf("%s/%s-%s-%s.parquet", p.Directory, name, now.Format("2006-01-02"), strconv.FormatInt(now.Unix(), 10))
+			filename := fmt.Sprintf("%s-%s-%s.parquet", name, now.Format("2006-01-02"), strconv.FormatInt(now.Unix(), 10))
 			schema, err := p.createSchema(metrics)
 			if err != nil {
 				perr.MetricsReject = append(perr.MetricsReject, metricIndices[name]...)
@@ -165,7 +186,7 @@ func (p *Parquet) Write(metrics []telegraf.Metric) error {
 }
 
 func (p *Parquet) rotateIfNeeded(name string) error {
-	fileInfo, err := os.Stat(p.metricGroups[name].filename)
+	fileInfo, err := p.root.Stat(p.metricGroups[name].filename)
 	if err != nil {
 		return fmt.Errorf("failed to stat file %q: %w", p.metricGroups[name].filename, err)
 	}
@@ -419,14 +440,14 @@ func (p *Parquet) createSchema(metrics []telegraf.Metric) (*arrow.Schema, error)
 }
 
 func (p *Parquet) createWriter(name, filename string, schema *arrow.Schema) (*pqarrow.FileWriter, error) {
-	if _, err := os.Stat(filename); err == nil {
+	if _, err := p.root.Stat(filename); err == nil {
 		now := time.Now()
-		rotatedFilename := fmt.Sprintf("%s/%s-%s-%s.parquet", p.Directory, name, now.Format("2006-01-02"), strconv.FormatInt(now.Unix(), 10))
-		if err := os.Rename(filename, rotatedFilename); err != nil {
+		rotatedFilename := fmt.Sprintf("%s-%s-%s.parquet", name, now.Format("2006-01-02"), strconv.FormatInt(now.Unix(), 10))
+		if err := p.root.Rename(filename, rotatedFilename); err != nil {
 			return nil, fmt.Errorf("failed to rename file %q: %w", filename, err)
 		}
 	}
-	file, err := os.Create(filename)
+	file, err := p.root.Create(filename)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create file %q: %w", filename, err)
 	}

--- a/plugins/outputs/parquet/parquet.go
+++ b/plugins/outputs/parquet/parquet.go
@@ -62,9 +62,13 @@ func (p *Parquet) Init() error {
 
 	// Create the directory if it doesn't exist and check it actually is a directory
 	stat, err := os.Stat(p.Directory)
-	if os.IsNotExist(err) {
-		if err := os.MkdirAll(p.Directory, 0750); err != nil {
-			return fmt.Errorf("failed to create directory %q: %w", p.Directory, err)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			if err := os.MkdirAll(p.Directory, 0750); err != nil {
+				return fmt.Errorf("failed to create directory %q: %w", p.Directory, err)
+			}
+		} else {
+			return fmt.Errorf("failed to stat directory %q: %w", p.Directory, err)
 		}
 	} else if !stat.IsDir() {
 		return fmt.Errorf("provided directory %q is not a directory", p.Directory)
@@ -87,8 +91,11 @@ func (*Parquet) Connect() error {
 }
 
 func (p *Parquet) Close() error {
-	var errorOccurred bool
+	if p.root != nil {
+		p.root.Close()
+	}
 
+	var errorOccurred bool
 	for _, metrics := range p.metricGroups {
 		if err := metrics.writer.Close(); err != nil {
 			p.Log.Errorf("failed to close file %q: %v", metrics.filename, err)
@@ -98,10 +105,6 @@ func (p *Parquet) Close() error {
 
 	if errorOccurred {
 		return errors.New("failed closing one or more parquet files")
-	}
-
-	if p.root != nil {
-		p.root.Close()
 	}
 
 	return nil
@@ -130,8 +133,10 @@ func (p *Parquet) Write(metrics []telegraf.Metric) error {
 			}
 			writer, err := p.createWriter(name, filename, schema)
 			if err != nil {
+				perr.MetricsReject = append(perr.MetricsReject, metricIndices[name]...)
+				perr.MetricsRejectErrors = append(perr.MetricsRejectErrors, fmt.Errorf("failed to create writer for file %q: %w", name, err))
 				perr.Err = fmt.Errorf("failed to create writer for file %q: %w", name, err)
-				return &perr
+				continue
 			}
 			p.metricGroups[name] = &metricGroup{
 				builder:  array.NewRecordBuilder(memory.DefaultAllocator, schema),
@@ -143,8 +148,10 @@ func (p *Parquet) Write(metrics []telegraf.Metric) error {
 
 		if p.RotationInterval != 0 {
 			if err := p.rotateIfNeeded(name); err != nil {
+				perr.MetricsReject = append(perr.MetricsReject, metricIndices[name]...)
+				perr.MetricsRejectErrors = append(perr.MetricsRejectErrors, fmt.Errorf("failed to rotate file %q: %w", p.metricGroups[name].filename, err))
 				perr.Err = fmt.Errorf("failed to rotate file %q: %w", p.metricGroups[name].filename, err)
-				return &perr
+				continue
 			}
 		}
 

--- a/plugins/outputs/parquet/parquet.go
+++ b/plugins/outputs/parquet/parquet.go
@@ -63,12 +63,11 @@ func (p *Parquet) Init() error {
 	// Create the directory if it doesn't exist and check it actually is a directory
 	stat, err := os.Stat(p.Directory)
 	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			if err := os.MkdirAll(p.Directory, 0750); err != nil {
-				return fmt.Errorf("failed to create directory %q: %w", p.Directory, err)
-			}
-		} else {
+		if !errors.Is(err, os.ErrNotExist) {
 			return fmt.Errorf("failed to stat directory %q: %w", p.Directory, err)
+		}
+		if err := os.MkdirAll(p.Directory, 0750); err != nil {
+			return fmt.Errorf("failed to create directory %q: %w", p.Directory, err)
 		}
 	} else if !stat.IsDir() {
 		return fmt.Errorf("provided directory %q is not a directory", p.Directory)

--- a/plugins/outputs/parquet/parquet_test.go
+++ b/plugins/outputs/parquet/parquet_test.go
@@ -422,6 +422,7 @@ func TestInvalidFilename(t *testing.T) {
 		{
 			name:   "dots",
 			metric: "..",
+			os:     []string{"windows"},
 		},
 		{
 			name:   "backslash",
@@ -464,6 +465,55 @@ func TestInvalidFilename(t *testing.T) {
 			require.NoError(t, plugin.Connect())
 			defer plugin.Close()
 			require.ErrorContains(t, plugin.Write(metrics), "failed to create file")
+		})
+	}
+}
+
+func TestCannotEscapeDirectory(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "test")
+	malicious := filepath.Join(tmp, "foo")
+	maliciousAbs, err := filepath.Abs(malicious)
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(path, 0700))
+	require.NoError(t, os.MkdirAll(malicious, 0700))
+
+	tests := []struct {
+		name   string
+		metric string
+	}{
+		{
+			name:   "relative",
+			metric: filepath.Join("..", "foo"),
+		},
+		{
+			name:   "absolute",
+			metric: maliciousAbs,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			metrics := []telegraf.Metric{
+				metric.New(
+					tt.metric,
+					map[string]string{},
+					map[string]interface{}{"value": 1.0},
+					time.Now(),
+				),
+			}
+
+			testDir := t.TempDir()
+			plugin := &Parquet{
+				Directory:          testDir,
+				TimestampFieldName: "time",
+			}
+			require.NoError(t, plugin.Init())
+			require.NoError(t, plugin.Connect())
+			defer plugin.Close()
+
+			var perr *os.PathError
+			require.ErrorAs(t, plugin.Write(metrics), &perr)
 		})
 	}
 }

--- a/plugins/outputs/parquet/parquet_test.go
+++ b/plugins/outputs/parquet/parquet_test.go
@@ -420,11 +420,6 @@ func TestInvalidFilename(t *testing.T) {
 			metric: "nul\x00byte",
 		},
 		{
-			name:   "dots",
-			metric: "..",
-			os:     []string{"windows"},
-		},
-		{
 			name:   "backslash",
 			metric: `a\b`,
 			os:     []string{"windows"},
@@ -432,11 +427,6 @@ func TestInvalidFilename(t *testing.T) {
 		{
 			name:   "tab",
 			metric: "a\tb",
-			os:     []string{"windows"},
-		},
-		{
-			name:   "a<b>c",
-			metric: "brackets",
 			os:     []string{"windows"},
 		},
 	}

--- a/plugins/outputs/parquet/parquet_test.go
+++ b/plugins/outputs/parquet/parquet_test.go
@@ -3,6 +3,9 @@ package parquet
 import (
 	"os"
 	"path/filepath"
+	"runtime"
+	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -400,4 +403,67 @@ func TestTimestampFieldNameCollisionKeepsOneColumn(t *testing.T) {
 	}
 	require.ElementsMatch(t, []string{"value", "timestamp"}, names)
 	require.Equal(t, parquet.Types.Int64, schema.Column(schema.ColumnIndexByName("timestamp")).PhysicalType())
+}
+
+func TestInvalidFilename(t *testing.T) {
+	tests := []struct {
+		name   string
+		metric string
+		os     []string
+	}{
+		{
+			name:   "too long",
+			metric: strings.Repeat("a", 255),
+		},
+		{
+			name:   "null byte",
+			metric: "nul\x00byte",
+		},
+		{
+			name:   "dots",
+			metric: "..",
+		},
+		{
+			name:   "backslash",
+			metric: `a\b`,
+			os:     []string{"windows"},
+		},
+		{
+			name:   "tab",
+			metric: "a\tb",
+			os:     []string{"windows"},
+		},
+		{
+			name:   "a<b>c",
+			metric: "brackets",
+			os:     []string{"windows"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if len(tt.os) != 0 && !slices.Contains(tt.os, runtime.GOOS) {
+				t.Skip("Skipping due to unaffected OS...")
+			}
+
+			metrics := []telegraf.Metric{
+				metric.New(
+					tt.metric,
+					map[string]string{},
+					map[string]interface{}{"value": 1.0},
+					time.Now(),
+				),
+			}
+
+			testDir := t.TempDir()
+			plugin := &Parquet{
+				Directory:          testDir,
+				TimestampFieldName: "time",
+			}
+			require.NoError(t, plugin.Init())
+			require.NoError(t, plugin.Connect())
+			defer plugin.Close()
+			require.ErrorContains(t, plugin.Write(metrics), "failed to create file")
+		})
+	}
 }

--- a/plugins/outputs/parquet/parquet_test.go
+++ b/plugins/outputs/parquet/parquet_test.go
@@ -176,6 +176,41 @@ func TestPartialWrite(t *testing.T) {
 				),
 			},
 			expected: "failed to create writer for file",
+			rejected: []int{0},
+		},
+		{
+			name: "create writer failed in between",
+			metrics: []telegraf.Metric{
+				metric.New(
+					"test",
+					map[string]string{},
+					map[string]interface{}{
+						"value": int8(1),
+					},
+					time.Now(),
+				),
+				metric.New(
+					"test/sub",
+					map[string]string{},
+					map[string]interface{}{
+						"value": int8(2),
+					},
+					time.Now(),
+				),
+				metric.New(
+					"test",
+					map[string]string{},
+					map[string]interface{}{
+						"value": int8(3),
+					},
+					time.Now(),
+				),
+			},
+			numRows:    2,
+			numColumns: 2,
+			expected:   "failed to create writer for file",
+			accepted:   []int{0, 2},
+			rejected:   []int{1},
 		},
 		{
 			name: "schema mismatch",
@@ -463,8 +498,6 @@ func TestCannotEscapeDirectory(t *testing.T) {
 	tmp := t.TempDir()
 	path := filepath.Join(tmp, "test")
 	malicious := filepath.Join(tmp, "foo")
-	maliciousAbs, err := filepath.Abs(malicious)
-	require.NoError(t, err)
 	require.NoError(t, os.MkdirAll(path, 0700))
 	require.NoError(t, os.MkdirAll(malicious, 0700))
 
@@ -478,7 +511,7 @@ func TestCannotEscapeDirectory(t *testing.T) {
 		},
 		{
 			name:   "absolute",
-			metric: maliciousAbs,
+			metric: malicious,
 		},
 	}
 
@@ -493,9 +526,8 @@ func TestCannotEscapeDirectory(t *testing.T) {
 				),
 			}
 
-			testDir := t.TempDir()
 			plugin := &Parquet{
-				Directory:          testDir,
+				Directory:          path,
 				TimestampFieldName: "time",
 			}
 			require.NoError(t, plugin.Init())


### PR DESCRIPTION
## Summary

This PR ensures that parquet files are only written under the configured directory and prevents directory traversal through manipulated metric names.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

inspired by #19552
