### PR TITLE
chore(inputs.redfish): Migrate to gofish library

### DIFF
--- a/docs/LICENSE_OF_DEPENDENCIES.md
+++ b/docs/LICENSE_OF_DEPENDENCIES.md
@@ -414,6 +414,7 @@ following works:
 - github.com/spiffe/go-spiffe [Apache License 2.0](https://github.com/spiffe/go-spiffe/blob/main/LICENSE)
 - github.com/srebhan/cborquery [MIT License](https://github.com/srebhan/cborquery/blob/main/LICENSE)
 - github.com/srebhan/protobufquery [MIT License](https://github.com/srebhan/protobufquery/blob/master/LICENSE)
+- github.com/stmcginnis/gofish [BSD 3-Clause License](https://github.com/stmcginnis/gofish/blob/main/LICENSE)
 - github.com/tdrn-org/go-hue [MIT License](https://github.com/tdrn-org/go-log/blob/main/LICENSE)
 - github.com/tdrn-org/go-nsdp [MIT License](https://github.com/tdrn-org/go-nsdp/blob/main/LICENSE)
 - github.com/tdrn-org/go-tr064 [Apache License 2.0](https://github.com/tdrn-org/go-tr064/blob/main/LICENSE)

--- a/go.mod
+++ b/go.mod
@@ -206,6 +206,7 @@ require (
 	github.com/snowflakedb/gosnowflake v1.19.1
 	github.com/srebhan/cborquery v1.0.4
 	github.com/srebhan/protobufquery v1.0.4
+	github.com/stmcginnis/gofish v0.23.0
 	github.com/stretchr/testify v1.12.1
 	github.com/tbrandon/mbserver v0.0.0-20170611213546-993e1772cc62
 	github.com/tdrn-org/go-hue v1.2.1
@@ -550,7 +551,6 @@ require (
 	github.com/spf13/cast v1.10.0 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/spiffe/go-spiffe/v2 v2.8.1 // indirect
-	github.com/stmcginnis/gofish v0.23.0 // indirect
 	github.com/stretchr/objx v0.5.3 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -550,6 +550,7 @@ require (
 	github.com/spf13/cast v1.10.0 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/spiffe/go-spiffe/v2 v2.8.1 // indirect
+	github.com/stmcginnis/gofish v0.23.0 // indirect
 	github.com/stretchr/objx v0.5.3 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2357,6 +2357,8 @@ github.com/srebhan/cborquery v1.0.4 h1:R+PZ/ZKpgf2z0d9jkr2aCP53GI0PCC9Ibz8iqX/Pl
 github.com/srebhan/cborquery v1.0.4/go.mod h1:667M4EgeI9mJPFV5Mhyxg8rAuRO0SIIrgGtgZcFLqpE=
 github.com/srebhan/protobufquery v1.0.4 h1:MLMo7nS02HSwux538Id3SCkf/FShA4MK3pppc9U/acY=
 github.com/srebhan/protobufquery v1.0.4/go.mod h1:qMuAoKJAsVFYmyLE4H0dQ8F9+gBBHw+LBMqAZ326uA4=
+github.com/stmcginnis/gofish v0.23.0 h1:OE0Ty+f8xSEmsiPxABcH6JvdAkAwooQhMVuyU0m+pMc=
+github.com/stmcginnis/gofish v0.23.0/go.mod h1:PzF5i8ecRG9A2ol8XT64npKUunyraJ+7t0kYMpQAtqU=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=

--- a/plugins/inputs/redfish/redfish.go
+++ b/plugins/inputs/redfish/redfish.go
@@ -3,6 +3,7 @@ package redfish
 
 import (
 	_ "embed"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
@@ -10,12 +11,13 @@ import (
 	"net/url"
 	"time"
 
+	"github.com/stmcginnis/gofish"
+	"github.com/stmcginnis/gofish/schemas"
+
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/plugins/common/tls"
 	"github.com/influxdata/telegraf/plugins/inputs"
-	"github.com/stmcginnis/gofish"
-	"github.com/stmcginnis/gofish/schemas"
 )
 
 //go:embed sample.conf
@@ -131,14 +133,14 @@ func (r *Redfish) gofishSetup() (*gofish.Service, error) {
 	pass := password.String()
 	password.Destroy()
 
-	config := gofish.ClientConfig{
+	gofishConfig := gofish.ClientConfig{
 		Endpoint:   r.Address,
 		Username:   user,
 		Password:   pass,
 		BasicAuth:  true,
 		HTTPClient: &r.client,
 	}
-	c, err := gofish.Connect(config)
+	c, err := gofish.Connect(gofishConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -148,21 +150,21 @@ func (r *Redfish) gofishSetup() (*gofish.Service, error) {
 }
 
 func (r *Redfish) Gather(acc telegraf.Accumulator) error {
-	redfishUrl, _ := url.Parse(r.Address)
-	address, _, err := net.SplitHostPort(redfishUrl.Host)
+	var address string
+	redfishURL, err := url.Parse(r.Address)
 	if err != nil {
-		address = redfishUrl.Host
+		address = redfishURL.Host
+	} else {
+		address, _, err = net.SplitHostPort(redfishURL.Host)
+	}
+
+	if err != nil {
+		address = redfishURL.Host
 	}
 
 	systems, err := r.gf.Systems()
 	if err != nil {
-		var collectionError *schemas.CollectionError
-		if errors.As(err, &collectionError) {
-			return fmt.Errorf("received status code 401 (Unauthorized) for address %s/redfish/v1/Systems/System.Embedded.1, expected 200", r.Address)
-		} else {
-
-		}
-		return fmt.Errorf("error parsing input from %s: %w", address, err)
+		return r.parseGofishError(err)
 	}
 
 	// Process only the system defined via ComputerSystemID in the config
@@ -170,8 +172,13 @@ func (r *Redfish) Gather(acc telegraf.Accumulator) error {
 	for _, system := range systems {
 		if system.ID == r.ComputerSystemID {
 			chassisList, err := system.Chassis()
-			if err != nil || chassisList == nil {
-				return fmt.Errorf("error parsing input from %s: %w", address, err)
+			if err != nil {
+				return r.parseGofishError(err)
+			}
+
+			if len(chassisList) == 0 {
+				r.Log.Warn("No chassis found, no metric can be produced")
+				return nil
 			}
 
 			for _, chassis := range chassisList {
@@ -194,6 +201,26 @@ func (r *Redfish) Gather(acc telegraf.Accumulator) error {
 		}
 	}
 	return nil
+}
+
+func (r *Redfish) parseGofishError(err error) error {
+	var collectionError *schemas.CollectionError
+	if errors.As(err, &collectionError) {
+		for f, v := range collectionError.Failures {
+			var parseError *json.SyntaxError
+			var queryError *schemas.Error
+			if errors.As(v, &parseError) {
+				return fmt.Errorf("error parsing input from %s: %w", r.Address, err)
+			}
+			if errors.As(v, &queryError) {
+				return fmt.Errorf("received status code %d for address %s%s, expected 200",
+					queryError.HTTPReturnedStatusCode,
+					r.Address,
+					f)
+			}
+		}
+	}
+	return fmt.Errorf("error parsing input from %s: %w", r.Address, err)
 }
 
 func setChassisTags(chassis *schemas.Chassis, tags map[string]string) {

--- a/plugins/inputs/redfish/redfish.go
+++ b/plugins/inputs/redfish/redfish.go
@@ -10,7 +10,6 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"path"
 	"slices"
 	"strings"
 	"time"
@@ -19,6 +18,8 @@ import (
 	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/plugins/common/tls"
 	"github.com/influxdata/telegraf/plugins/inputs"
+	"github.com/stmcginnis/gofish"
+	"github.com/stmcginnis/gofish/schemas"
 )
 
 //go:embed sample.conf
@@ -44,50 +45,7 @@ type Redfish struct {
 	tagSet map[string]bool
 	client http.Client
 	tls.ClientConfig
-	baseURL *url.URL
-}
-
-type system struct {
-	Hostname string `json:"hostname"`
-	Links    struct {
-		Chassis []struct {
-			Ref string `json:"@odata.id"`
-		}
-	}
-}
-
-type chassis struct {
-	ChassisType  string
-	Location     *location
-	Manufacturer string
-	Model        string
-	PartNumber   string
-	Power        struct {
-		Ref string `json:"@odata.id"`
-	}
-	PowerState   string
-	SKU          string
-	SerialNumber string
-	Status       status
-	Thermal      struct {
-		Ref string `json:"@odata.id"`
-	}
-}
-
-type location struct {
-	PostalAddress struct {
-		DataCenter string
-		Room       string
-	}
-	Placement struct {
-		Rack string
-		Row  string
-	}
-}
-
-type status struct {
-	State  string
-	Health string
+	gf *gofish.Service
 }
 
 func (*Redfish) SampleConfig() string {

--- a/plugins/inputs/redfish/redfish.go
+++ b/plugins/inputs/redfish/redfish.go
@@ -49,6 +49,27 @@ func (*Redfish) SampleConfig() string {
 }
 
 func (r *Redfish) Init() error {
+	err := r.checkConfig()
+	if err != nil {
+		return err
+	}
+
+	r.gf, err = r.gofishSetup()
+	if err != nil {
+		return fmt.Errorf("error parsing input from %s. This is likely due to the BMC response being in text/html: %w",
+			r.Address+"/redfish/v1/Systems/"+r.ComputerSystemID,
+			err)
+	}
+
+	r.tagSet = make(map[string]bool, len(r.IncludeTagSets))
+	for _, setLabel := range r.IncludeTagSets {
+		r.tagSet[setLabel] = true
+	}
+
+	return nil
+}
+
+func (r *Redfish) checkConfig() error {
 	if r.Address == "" {
 		return errors.New("did not provide IP")
 	}
@@ -79,22 +100,15 @@ func (r *Redfish) Init() error {
 			return fmt.Errorf("unknown workaround requested: %s", workaround)
 		}
 	}
-	r.tagSet = make(map[string]bool, len(r.IncludeTagSets))
-	for _, setLabel := range r.IncludeTagSets {
-		r.tagSet[setLabel] = true
-	}
 
-	var err error
-	r.baseURL, err = url.Parse(r.Address)
-	if err != nil {
-		return err
-	}
+	return nil
+}
 
+func (r *Redfish) gofishSetup() (*gofish.Service, error) {
 	tlsCfg, err := r.ClientConfig.TLSConfig()
 	if err != nil {
-		return err
+		return nil, err
 	}
-
 	r.client = http.Client{
 		Transport: &http.Transport{
 			TLSClientConfig: tlsCfg,
@@ -103,7 +117,34 @@ func (r *Redfish) Init() error {
 		Timeout: time.Duration(r.Timeout),
 	}
 
-	return nil
+	username, err := r.Username.Get()
+	if err != nil {
+		return nil, fmt.Errorf("getting username failed: %w", err)
+	}
+	user := username.String()
+	username.Destroy()
+
+	password, err := r.Password.Get()
+	if err != nil {
+		return nil, fmt.Errorf("getting password failed: %w", err)
+	}
+	pass := password.String()
+	password.Destroy()
+
+	config := gofish.ClientConfig{
+		Endpoint:   r.Address,
+		Username:   user,
+		Password:   pass,
+		BasicAuth:  true,
+		HTTPClient: &r.client,
+	}
+	c, err := gofish.Connect(config)
+	if err != nil {
+		return nil, err
+	}
+
+	// Retrieve the service root
+	return c.Service, nil
 }
 
 func (r *Redfish) Gather(acc telegraf.Accumulator) error {

--- a/plugins/inputs/redfish/redfish.go
+++ b/plugins/inputs/redfish/redfish.go
@@ -3,15 +3,11 @@ package redfish
 
 import (
 	_ "embed"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net"
 	"net/http"
 	"net/url"
-	"slices"
-	"strings"
 	"time"
 
 	"github.com/influxdata/telegraf"
@@ -158,82 +154,6 @@ func (r *Redfish) Gather(acc telegraf.Accumulator) error {
 		}
 	}
 	return nil
-}
-
-func (r *Redfish) getData(address string, payload interface{}) error {
-	req, err := http.NewRequest("GET", address, nil)
-	if err != nil {
-		return err
-	}
-
-	username, err := r.Username.Get()
-	if err != nil {
-		return fmt.Errorf("getting username failed: %w", err)
-	}
-	user := username.String()
-	username.Destroy()
-
-	password, err := r.Password.Get()
-	if err != nil {
-		return fmt.Errorf("getting password failed: %w", err)
-	}
-	pass := password.String()
-	password.Destroy()
-
-	req.SetBasicAuth(user, pass)
-	req.Header.Set("Accept", "application/json")
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("OData-Version", "4.0")
-
-	// workaround for iLO4 thermal data
-	if slices.Contains(r.Workarounds, "ilo4-thermal") && strings.Contains(address, "/Thermal") {
-		req.Header.Del("OData-Version")
-	}
-
-	resp, err := r.client.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != 200 {
-		return fmt.Errorf("received status code %d (%s) for address %s, expected 200",
-			resp.StatusCode,
-			http.StatusText(resp.StatusCode),
-			address)
-	}
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return err
-	}
-
-	err = json.Unmarshal(body, &payload)
-	if err != nil {
-		return fmt.Errorf("error parsing input from %s (Content-Type %q): %w", address, resp.Header.Get("Content-Type"), err)
-	}
-
-	return nil
-}
-
-func (r *Redfish) getComputerSystem(id string) (*system, error) {
-	loc := r.baseURL.ResolveReference(&url.URL{Path: path.Join("/redfish/v1/Systems/", id)})
-	system := &system{}
-	err := r.getData(loc.String(), system)
-	if err != nil {
-		return nil, err
-	}
-	return system, nil
-}
-
-func (r *Redfish) getChassis(ref string) (*chassis, error) {
-	loc := r.baseURL.ResolveReference(&url.URL{Path: ref})
-	chassis := &chassis{}
-	err := r.getData(loc.String(), chassis)
-	if err != nil {
-		return nil, err
-	}
-	return chassis, nil
 }
 
 func setChassisTags(chassis *chassis, tags map[string]string) {

--- a/plugins/inputs/redfish/redfish.go
+++ b/plugins/inputs/redfish/redfish.go
@@ -148,65 +148,64 @@ func (r *Redfish) gofishSetup() (*gofish.Service, error) {
 }
 
 func (r *Redfish) Gather(acc telegraf.Accumulator) error {
-	address, _, err := net.SplitHostPort(r.baseURL.Host)
+	redfishUrl, _ := url.Parse(r.Address)
+	address, _, err := net.SplitHostPort(redfishUrl.Host)
 	if err != nil {
-		address = r.baseURL.Host
+		address = redfishUrl.Host
 	}
 
-	system, err := r.getComputerSystem(r.ComputerSystemID)
+	systems, err := r.gf.Systems()
 	if err != nil {
-		return err
+		var collectionError *schemas.CollectionError
+		if errors.As(err, &collectionError) {
+			return fmt.Errorf("received status code 401 (Unauthorized) for address %s/redfish/v1/Systems/System.Embedded.1, expected 200", r.Address)
+		} else {
+
+		}
+		return fmt.Errorf("error parsing input from %s: %w", address, err)
 	}
 
-	for _, link := range system.Links.Chassis {
-		// References are resolved against the configured address, so an empty
-		// one would request the device's web root instead of a Redfish resource
-		if link.Ref == "" {
-			r.Log.Warn("Skipping chassis without reference")
-			continue
-		}
-
-		chassis, err := r.getChassis(link.Ref)
-		if err != nil {
-			return err
-		}
-
-		for _, metric := range r.IncludeMetrics {
-			var err error
-			switch metric {
-			case "thermal":
-				if chassis.Thermal.Ref == "" {
-					r.Log.Warnf("Skipping thermal data of chassis %q without reference", link.Ref)
-					continue
-				}
-				err = r.gatherThermal(acc, address, system, chassis)
-			case "power":
-				if chassis.Power.Ref == "" {
-					r.Log.Warnf("Skipping power data of chassis %q without reference", link.Ref)
-					continue
-				}
-				err = r.gatherPower(acc, address, system, chassis)
-			default:
-				return fmt.Errorf("unknown metric requested: %s", metric)
+	// Process only the system defined via ComputerSystemID in the config
+	// Collect configured metrics on every chassis
+	for _, system := range systems {
+		if system.ID == r.ComputerSystemID {
+			chassisList, err := system.Chassis()
+			if err != nil || chassisList == nil {
+				return fmt.Errorf("error parsing input from %s: %w", address, err)
 			}
-			if err != nil {
-				return err
+
+			for _, chassis := range chassisList {
+				for _, metric := range r.IncludeMetrics {
+					var err error
+					switch metric {
+					case "thermal":
+						err = r.gatherThermal(acc, address, system, chassis)
+					case "power":
+						err = r.gatherPower(acc, address, system, chassis)
+					default:
+						return fmt.Errorf("unknown metric requested: %s", metric)
+					}
+					if err != nil {
+						return err
+					}
+				}
 			}
+			break
 		}
 	}
 	return nil
 }
 
-func setChassisTags(chassis *chassis, tags map[string]string) {
-	tags["chassis_chassistype"] = chassis.ChassisType
+func setChassisTags(chassis *schemas.Chassis, tags map[string]string) {
+	tags["chassis_chassistype"] = string(chassis.ChassisType)
 	tags["chassis_manufacturer"] = chassis.Manufacturer
 	tags["chassis_model"] = chassis.Model
 	tags["chassis_partnumber"] = chassis.PartNumber
-	tags["chassis_powerstate"] = chassis.PowerState
+	tags["chassis_powerstate"] = string(chassis.PowerState)
 	tags["chassis_sku"] = chassis.SKU
 	tags["chassis_serialnumber"] = chassis.SerialNumber
-	tags["chassis_state"] = chassis.Status.State
-	tags["chassis_health"] = chassis.Status.Health
+	tags["chassis_state"] = string(chassis.Status.State)
+	tags["chassis_health"] = string(chassis.Status.Health)
 }
 
 func init() {

--- a/plugins/inputs/redfish/redfish_power.go
+++ b/plugins/inputs/redfish/redfish_power.go
@@ -3,8 +3,9 @@ package redfish
 import (
 	"fmt"
 
-	"github.com/influxdata/telegraf"
 	"github.com/stmcginnis/gofish/schemas"
+
+	"github.com/influxdata/telegraf"
 )
 
 func (r *Redfish) gatherPower(acc telegraf.Accumulator, address string, system *schemas.ComputerSystem, chassis *schemas.Chassis) error {
@@ -13,8 +14,13 @@ func (r *Redfish) gatherPower(acc telegraf.Accumulator, address string, system *
 
 func (r *Redfish) gatherPowerMetrics(acc telegraf.Accumulator, address string, system *schemas.ComputerSystem, chassis *schemas.Chassis) error {
 	power, err := chassis.Power()
-	if err != nil || power == nil {
+	if err != nil {
 		return fmt.Errorf("error parsing input from %s: %w", address, err)
+	}
+
+	if power == nil {
+		r.Log.Warnf("Skipping thermal data of chassis %q. Is only the new subsys api available?", chassis.ID)
+		return nil
 	}
 
 	for _, j := range power.PowerControl {
@@ -49,14 +55,14 @@ func (r *Redfish) gatherPowerMetrics(acc telegraf.Accumulator, address string, s
 		acc.AddFields("redfish_power_powercontrol", fields, tags)
 	}
 
-	for _, j := range power.PowerSupplies {
+	for i := range len(power.PowerSupplies) {
 		tags := make(map[string]string, 19)
-		tags["member_id"] = j.MemberID
+		tags["member_id"] = power.PowerSupplies[i].MemberID
 		tags["address"] = address
-		tags["name"] = j.Name
+		tags["name"] = power.PowerSupplies[i].Name
 		tags["source"] = system.HostName
-		tags["state"] = string(j.Status.State)
-		tags["health"] = string(j.Status.Health)
+		tags["state"] = string(power.PowerSupplies[i].Status.State)
+		tags["health"] = string(power.PowerSupplies[i].Status.Health)
 		if _, ok := r.tagSet[tagSetChassisLocation]; ok {
 			tags["datacenter"] = ""
 			tags["room"] = chassis.Location.PostalAddress.Room
@@ -68,11 +74,11 @@ func (r *Redfish) gatherPowerMetrics(acc telegraf.Accumulator, address string, s
 		}
 
 		fields := make(map[string]interface{})
-		fields["power_input_watts"] = j.PowerInputWatts
-		fields["power_output_watts"] = j.PowerOutputWatts
-		fields["line_input_voltage"] = j.LineInputVoltage
-		fields["last_power_output_watts"] = j.LastPowerOutputWatts
-		fields["power_capacity_watts"] = j.PowerCapacityWatts
+		fields["power_input_watts"] = power.PowerSupplies[i].PowerInputWatts
+		fields["power_output_watts"] = power.PowerSupplies[i].PowerOutputWatts
+		fields["line_input_voltage"] = power.PowerSupplies[i].LineInputVoltage
+		fields["last_power_output_watts"] = power.PowerSupplies[i].LastPowerOutputWatts
+		fields["power_capacity_watts"] = power.PowerSupplies[i].PowerCapacityWatts
 		acc.AddFields("redfish_power_powersupplies", fields, tags)
 	}
 

--- a/plugins/inputs/redfish/redfish_power.go
+++ b/plugins/inputs/redfish/redfish_power.go
@@ -1,53 +1,20 @@
 package redfish
 
 import (
-	"net/url"
+	"fmt"
 
 	"github.com/influxdata/telegraf"
+	"github.com/stmcginnis/gofish/schemas"
 )
 
-type power struct {
-	PowerControl []struct {
-		Name                string
-		MemberID            string
-		PowerAllocatedWatts *float64
-		PowerAvailableWatts *float64
-		PowerCapacityWatts  *float64
-		PowerConsumedWatts  *float64
-		PowerRequestedWatts *float64
-		PowerMetrics        struct {
-			AverageConsumedWatts *float64
-			IntervalInMin        int
-			MaxConsumedWatts     *float64
-			MinConsumedWatts     *float64
-		}
-	}
-	PowerSupplies []struct {
-		Name                 string
-		MemberID             string
-		PowerInputWatts      *float64
-		PowerCapacityWatts   *float64
-		PowerOutputWatts     *float64
-		LastPowerOutputWatts *float64
-		Status               status
-		LineInputVoltage     *float64
-	}
-	Voltages []struct {
-		Name                   string
-		MemberID               string
-		ReadingVolts           *float64
-		UpperThresholdCritical *float64
-		UpperThresholdFatal    *float64
-		LowerThresholdCritical *float64
-		LowerThresholdFatal    *float64
-		Status                 status
-	}
+func (r *Redfish) gatherPower(acc telegraf.Accumulator, address string, system *schemas.ComputerSystem, chassis *schemas.Chassis) error {
+	return r.gatherPowerMetrics(acc, address, system, chassis)
 }
 
-func (r *Redfish) gatherPower(acc telegraf.Accumulator, address string, system *system, chassis *chassis) error {
-	power, err := r.getPower(chassis.Power.Ref)
-	if err != nil {
-		return err
+func (r *Redfish) gatherPowerMetrics(acc telegraf.Accumulator, address string, system *schemas.ComputerSystem, chassis *schemas.Chassis) error {
+	power, err := chassis.Power()
+	if err != nil || power == nil {
+		return fmt.Errorf("error parsing input from %s: %w", address, err)
 	}
 
 	for _, j := range power.PowerControl {
@@ -55,10 +22,10 @@ func (r *Redfish) gatherPower(acc telegraf.Accumulator, address string, system *
 			"member_id": j.MemberID,
 			"address":   address,
 			"name":      j.Name,
-			"source":    system.Hostname,
+			"source":    system.HostName,
 		}
-		if _, ok := r.tagSet[tagSetChassisLocation]; ok && chassis.Location != nil {
-			tags["datacenter"] = chassis.Location.PostalAddress.DataCenter
+		if _, ok := r.tagSet[tagSetChassisLocation]; ok {
+			tags["datacenter"] = ""
 			tags["room"] = chassis.Location.PostalAddress.Room
 			tags["rack"] = chassis.Location.Placement.Rack
 			tags["row"] = chassis.Location.Placement.Row
@@ -74,7 +41,7 @@ func (r *Redfish) gatherPower(acc telegraf.Accumulator, address string, system *
 			"power_consumed_watts":   j.PowerConsumedWatts,
 			"power_requested_watts":  j.PowerRequestedWatts,
 			"average_consumed_watts": j.PowerMetrics.AverageConsumedWatts,
-			"interval_in_min":        j.PowerMetrics.IntervalInMin,
+			"interval_in_min":        int64(*j.PowerMetrics.IntervalInMin),
 			"max_consumed_watts":     j.PowerMetrics.MaxConsumedWatts,
 			"min_consumed_watts":     j.PowerMetrics.MinConsumedWatts,
 		}
@@ -87,11 +54,11 @@ func (r *Redfish) gatherPower(acc telegraf.Accumulator, address string, system *
 		tags["member_id"] = j.MemberID
 		tags["address"] = address
 		tags["name"] = j.Name
-		tags["source"] = system.Hostname
-		tags["state"] = j.Status.State
-		tags["health"] = j.Status.Health
-		if _, ok := r.tagSet[tagSetChassisLocation]; ok && chassis.Location != nil {
-			tags["datacenter"] = chassis.Location.PostalAddress.DataCenter
+		tags["source"] = system.HostName
+		tags["state"] = string(j.Status.State)
+		tags["health"] = string(j.Status.Health)
+		if _, ok := r.tagSet[tagSetChassisLocation]; ok {
+			tags["datacenter"] = ""
 			tags["room"] = chassis.Location.PostalAddress.Room
 			tags["rack"] = chassis.Location.Placement.Rack
 			tags["row"] = chassis.Location.Placement.Row
@@ -114,11 +81,11 @@ func (r *Redfish) gatherPower(acc telegraf.Accumulator, address string, system *
 		tags["member_id"] = j.MemberID
 		tags["address"] = address
 		tags["name"] = j.Name
-		tags["source"] = system.Hostname
-		tags["state"] = j.Status.State
-		tags["health"] = j.Status.Health
-		if _, ok := r.tagSet[tagSetChassisLocation]; ok && chassis.Location != nil {
-			tags["datacenter"] = chassis.Location.PostalAddress.DataCenter
+		tags["source"] = system.HostName
+		tags["state"] = string(j.Status.State)
+		tags["health"] = string(j.Status.Health)
+		if _, ok := r.tagSet[tagSetChassisLocation]; ok {
+			tags["datacenter"] = ""
 			tags["room"] = chassis.Location.PostalAddress.Room
 			tags["rack"] = chassis.Location.Placement.Rack
 			tags["row"] = chassis.Location.Placement.Row
@@ -137,14 +104,4 @@ func (r *Redfish) gatherPower(acc telegraf.Accumulator, address string, system *
 	}
 
 	return nil
-}
-
-func (r *Redfish) getPower(ref string) (*power, error) {
-	loc := r.baseURL.ResolveReference(&url.URL{Path: ref})
-	power := &power{}
-	err := r.getData(loc.String(), power)
-	if err != nil {
-		return nil, err
-	}
-	return power, nil
 }

--- a/plugins/inputs/redfish/redfish_test.go
+++ b/plugins/inputs/redfish/redfish_test.go
@@ -997,7 +997,7 @@ func TestParseErrorIncludesContext(t *testing.T) {
 	require.ErrorContains(t, err, "text/html")
 }
 
-func TestSkipChassisWithoutReference(t *testing.T) {
+func TestSkipChassisWithoutThermalAndPowerReference(t *testing.T) {
 	var mu sync.Mutex
 	var requested []string
 
@@ -1017,7 +1017,13 @@ func TestSkipChassisWithoutReference(t *testing.T) {
 		case "/redfish/v1/Systems/":
 			http.ServeFile(w, r, "testdata/hp/hp_available_systems.json")
 		case "/redfish/v1/Systems/1":
-			http.ServeFile(w, r, "testdata/hp/hp_systems_nolink.json")
+			http.ServeFile(w, r, "testdata/hp/hp_systems.json")
+		case "/redfish/v1/Chassis/1/Thermal":
+			w.WriteHeader(http.StatusNotFound)
+		case "/redfish/v1/Chassis/1/Power":
+			w.WriteHeader(http.StatusNotFound)
+		case "/redfish/v1/Chassis/1/":
+			http.ServeFile(w, r, "testdata/hp/hp_chassis_subsys.json")
 		default:
 			w.WriteHeader(http.StatusNotFound)
 		}
@@ -1038,68 +1044,14 @@ func TestSkipChassisWithoutReference(t *testing.T) {
 	require.NoError(t, plugin.Gather(&acc))
 	require.Empty(t, acc.GetTelegrafMetrics())
 
-	// The empty reference must not be requested as it resolves to the web root
-	// There shouldn't be a request to any /redfish/v1/Chassis path
+	// The missing references must not be requested as they cause none/problematic metrics
+	// check that no thermal or power api was requested: /redfish/v1/Chassis/1/Power||Thermal
 	mu.Lock()
 	defer mu.Unlock()
 	for _, path := range requested {
-		require.NotContains(t, path, "/redfish/v1/Chassis")
+		require.NotContains(t, path, "/redfish/v1/Chassis/1/Thermal")
+		require.NotContains(t, path, "/redfish/v1/Chassis/1/Power")
 	}
-}
-
-func TestSkipChassisWithoutThermalAndPowerReference(t *testing.T) {
-	var mu sync.Mutex
-	var requested []string
-
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if !checkAuth(r, "test", "test") {
-			http.Error(w, "Unauthorized.", http.StatusUnauthorized)
-			return
-		}
-
-		mu.Lock()
-		requested = append(requested, r.URL.Path)
-		mu.Unlock()
-
-		w.Header().Set("Content-Type", "application/json")
-
-		var body string
-		switch r.URL.Path {
-		case "/redfish/v1/Systems/1":
-			body = `{"Links": {"Chassis": [{"@odata.id": "/redfish/v1/Chassis/1"}]}}`
-		case "/redfish/v1/Chassis/1":
-			// Firmware exposing the newer ThermalSubsystem and PowerSubsystem
-			// resources does not provide the Thermal and Power ones
-			body = `{"ChassisType": "RackMount", "Model": "AS-1116CS-TN"}`
-		default:
-			t.Errorf("unexpected request for %q", r.URL.Path)
-			return
-		}
-
-		if _, err := w.Write([]byte(body)); err != nil {
-			t.Error(err)
-		}
-	}))
-	defer ts.Close()
-
-	plugin := &Redfish{
-		Address:          ts.URL,
-		Username:         config.NewSecret([]byte("test")),
-		Password:         config.NewSecret([]byte("test")),
-		ComputerSystemID: "1",
-		IncludeMetrics:   []string{"thermal", "power"},
-		Log:              testutil.Logger{},
-	}
-	require.NoError(t, plugin.Init())
-
-	var acc testutil.Accumulator
-	require.NoError(t, plugin.Gather(&acc))
-	require.Empty(t, acc.GetTelegrafMetrics())
-
-	// The missing references must not be requested as they resolve to the web root
-	mu.Lock()
-	defer mu.Unlock()
-	require.Equal(t, []string{"/redfish/v1/Systems/1", "/redfish/v1/Chassis/1"}, requested)
 }
 
 func TestIncludeTagSetsConfiguration(t *testing.T) {

--- a/plugins/inputs/redfish/redfish_test.go
+++ b/plugins/inputs/redfish/redfish_test.go
@@ -991,10 +991,8 @@ func TestParseErrorIncludesContext(t *testing.T) {
 		ComputerSystemID: "System.Embedded.1",
 		IncludeMetrics:   []string{"thermal", "power"},
 	}
-	require.NoError(t, plugin.Init())
+	err := plugin.Init()
 
-	var acc testutil.Accumulator
-	err := plugin.Gather(&acc)
 	require.ErrorContains(t, err, ts.URL+"/redfish/v1/Systems/System.Embedded.1")
 	require.ErrorContains(t, err, "text/html")
 }

--- a/plugins/inputs/redfish/redfish_thermal.go
+++ b/plugins/inputs/redfish/redfish_thermal.go
@@ -4,8 +4,9 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/influxdata/telegraf"
 	"github.com/stmcginnis/gofish/schemas"
+
+	"github.com/influxdata/telegraf"
 )
 
 func (r *Redfish) gatherThermal(acc telegraf.Accumulator, address string, system *schemas.ComputerSystem, chassis *schemas.Chassis) error {
@@ -16,8 +17,13 @@ func (r *Redfish) gatherThermal(acc telegraf.Accumulator, address string, system
 
 func (r *Redfish) gatherThermalMetrics(acc telegraf.Accumulator, address string, system *schemas.ComputerSystem, chassis *schemas.Chassis) error {
 	thermal, err := chassis.Thermal()
-	if err != nil || thermal == nil {
+	if err != nil {
 		return fmt.Errorf("error parsing input from %s: %w", address, err)
+	}
+
+	if thermal == nil {
+		r.Log.Warnf("Skipping thermal data of chassis %q. Is only the new subsys api available?", chassis.ID)
+		return nil
 	}
 
 	for _, j := range thermal.Temperatures {
@@ -47,21 +53,20 @@ func (r *Redfish) gatherThermalMetrics(acc telegraf.Accumulator, address string,
 		acc.AddFields("redfish_thermal_temperatures", fields, tags)
 	}
 
-	for _, j := range thermal.Fans {
+	for i := range thermal.Fans {
 		tags := make(map[string]string, 20)
 		fields := make(map[string]interface{}, 5)
-		tags["member_id"] = j.MemberID
+		tags["member_id"] = thermal.Fans[i].MemberID
 		tags["address"] = address
 
-		// FanName is Deprecated but kept around for ilo4 support
-		if j.Name == "" {
-			tags["name"] = j.FanName
+		if thermal.Fans[i].Name == "" {
+			tags["name"] = thermal.Fans[i].FanName //nolint:staticcheck // FanName is Deprecated but kept around for ilo4 support
 		} else {
-			tags["name"] = j.Name
+			tags["name"] = thermal.Fans[i].Name
 		}
 		tags["source"] = system.HostName
-		tags["state"] = string(j.Status.State)
-		tags["health"] = string(j.Status.Health)
+		tags["state"] = string(thermal.Fans[i].Status.State)
+		tags["health"] = string(thermal.Fans[i].Status.Health)
 		if _, ok := r.tagSet[tagSetChassisLocation]; ok {
 			tags["datacenter"] = "" // Not in the standard, keeping for backward compatibility
 			tags["room"] = chassis.Location.PostalAddress.Room
@@ -76,21 +81,19 @@ func (r *Redfish) gatherThermalMetrics(acc telegraf.Accumulator, address string,
 		var ilo4ReadingPercent struct {
 			CurrentReading *int64
 		}
-		json.Unmarshal(j.RawData, &ilo4ReadingPercent)
+		json.Unmarshal(thermal.Fans[i].RawData, &ilo4ReadingPercent) //nolint:errcheck // Ignore if the marshalling fails as this legacy block should be removed
 
 		if ilo4ReadingPercent.CurrentReading != nil {
 			fields["reading_percent"] = ilo4ReadingPercent.CurrentReading
 		} else {
-			if j.ReadingUnits == "RPM" {
-				fields["upper_threshold_critical"] = j.UpperThresholdCritical
-				fields["upper_threshold_fatal"] = j.UpperThresholdFatal
-				fields["lower_threshold_critical"] = j.LowerThresholdCritical
-				fields["lower_threshold_fatal"] = j.LowerThresholdFatal
-				fields["reading_rpm"] = j.Reading
-			} else if j.Reading != nil {
-				fields["reading_percent"] = j.Reading
+			if thermal.Fans[i].ReadingUnits == "RPM" {
+				fields["upper_threshold_critical"] = thermal.Fans[i].UpperThresholdCritical
+				fields["upper_threshold_fatal"] = thermal.Fans[i].UpperThresholdFatal
+				fields["lower_threshold_critical"] = thermal.Fans[i].LowerThresholdCritical
+				fields["lower_threshold_fatal"] = thermal.Fans[i].LowerThresholdFatal
+				fields["reading_rpm"] = thermal.Fans[i].Reading
 			} else {
-				fields["reading_percent"] = j.Reading
+				fields["reading_percent"] = thermal.Fans[i].Reading
 			}
 		}
 		acc.AddFields("redfish_thermal_fans", fields, tags)

--- a/plugins/inputs/redfish/redfish_thermal.go
+++ b/plugins/inputs/redfish/redfish_thermal.go
@@ -1,41 +1,23 @@
 package redfish
 
 import (
-	"net/url"
+	"encoding/json"
+	"fmt"
 
 	"github.com/influxdata/telegraf"
+	"github.com/stmcginnis/gofish/schemas"
 )
 
-type thermal struct {
-	Fans []struct {
-		Name                   string
-		MemberID               string
-		FanName                string
-		CurrentReading         *int64
-		Reading                *int64
-		ReadingUnits           *string
-		UpperThresholdCritical *int64
-		UpperThresholdFatal    *int64
-		LowerThresholdCritical *int64
-		LowerThresholdFatal    *int64
-		Status                 status
-	}
-	Temperatures []struct {
-		Name                   string
-		MemberID               string
-		ReadingCelsius         *float64
-		UpperThresholdCritical *float64
-		UpperThresholdFatal    *float64
-		LowerThresholdCritical *float64
-		LowerThresholdFatal    *float64
-		Status                 status
-	}
+func (r *Redfish) gatherThermal(acc telegraf.Accumulator, address string, system *schemas.ComputerSystem, chassis *schemas.Chassis) error {
+	// Gather metrics via the legacy api
+	// TODO: Add thermal metric gatering via the new thermalSubsys API
+	return r.gatherThermalMetrics(acc, address, system, chassis)
 }
 
-func (r *Redfish) gatherThermal(acc telegraf.Accumulator, address string, system *system, chassis *chassis) error {
-	thermal, err := r.getThermal(chassis.Thermal.Ref)
-	if err != nil {
-		return err
+func (r *Redfish) gatherThermalMetrics(acc telegraf.Accumulator, address string, system *schemas.ComputerSystem, chassis *schemas.Chassis) error {
+	thermal, err := chassis.Thermal()
+	if err != nil || thermal == nil {
+		return fmt.Errorf("error parsing input from %s: %w", address, err)
 	}
 
 	for _, j := range thermal.Temperatures {
@@ -43,11 +25,11 @@ func (r *Redfish) gatherThermal(acc telegraf.Accumulator, address string, system
 		tags["member_id"] = j.MemberID
 		tags["address"] = address
 		tags["name"] = j.Name
-		tags["source"] = system.Hostname
-		tags["state"] = j.Status.State
-		tags["health"] = j.Status.Health
-		if _, ok := r.tagSet[tagSetChassisLocation]; ok && chassis.Location != nil {
-			tags["datacenter"] = chassis.Location.PostalAddress.DataCenter
+		tags["source"] = system.HostName
+		tags["state"] = string(j.Status.State)
+		tags["health"] = string(j.Status.Health)
+		if _, ok := r.tagSet[tagSetChassisLocation]; ok {
+			tags["datacenter"] = "" // Not in the standard, keeping for backward compatibility
 			tags["room"] = chassis.Location.PostalAddress.Room
 			tags["rack"] = chassis.Location.Placement.Rack
 			tags["row"] = chassis.Location.Placement.Row
@@ -70,15 +52,18 @@ func (r *Redfish) gatherThermal(acc telegraf.Accumulator, address string, system
 		fields := make(map[string]interface{}, 5)
 		tags["member_id"] = j.MemberID
 		tags["address"] = address
-		tags["name"] = j.Name
-		if j.FanName != "" {
+
+		// FanName is Deprecated but kept around for ilo4 support
+		if j.Name == "" {
 			tags["name"] = j.FanName
+		} else {
+			tags["name"] = j.Name
 		}
-		tags["source"] = system.Hostname
-		tags["state"] = j.Status.State
-		tags["health"] = j.Status.Health
-		if _, ok := r.tagSet[tagSetChassisLocation]; ok && chassis.Location != nil {
-			tags["datacenter"] = chassis.Location.PostalAddress.DataCenter
+		tags["source"] = system.HostName
+		tags["state"] = string(j.Status.State)
+		tags["health"] = string(j.Status.Health)
+		if _, ok := r.tagSet[tagSetChassisLocation]; ok {
+			tags["datacenter"] = "" // Not in the standard, keeping for backward compatibility
 			tags["room"] = chassis.Location.PostalAddress.Room
 			tags["rack"] = chassis.Location.Placement.Rack
 			tags["row"] = chassis.Location.Placement.Row
@@ -87,29 +72,29 @@ func (r *Redfish) gatherThermal(acc telegraf.Accumulator, address string, system
 			setChassisTags(chassis, tags)
 		}
 
-		if j.ReadingUnits != nil && *j.ReadingUnits == "RPM" {
-			fields["upper_threshold_critical"] = j.UpperThresholdCritical
-			fields["upper_threshold_fatal"] = j.UpperThresholdFatal
-			fields["lower_threshold_critical"] = j.LowerThresholdCritical
-			fields["lower_threshold_fatal"] = j.LowerThresholdFatal
-			fields["reading_rpm"] = j.Reading
-		} else if j.CurrentReading != nil {
-			fields["reading_percent"] = j.CurrentReading
+		// Due to ILO4 not being fully readfish compatible we have to do this parsing manually
+		var ilo4ReadingPercent struct {
+			CurrentReading *int64
+		}
+		json.Unmarshal(j.RawData, &ilo4ReadingPercent)
+
+		if ilo4ReadingPercent.CurrentReading != nil {
+			fields["reading_percent"] = ilo4ReadingPercent.CurrentReading
 		} else {
-			fields["reading_percent"] = j.Reading
+			if j.ReadingUnits == "RPM" {
+				fields["upper_threshold_critical"] = j.UpperThresholdCritical
+				fields["upper_threshold_fatal"] = j.UpperThresholdFatal
+				fields["lower_threshold_critical"] = j.LowerThresholdCritical
+				fields["lower_threshold_fatal"] = j.LowerThresholdFatal
+				fields["reading_rpm"] = j.Reading
+			} else if j.Reading != nil {
+				fields["reading_percent"] = j.Reading
+			} else {
+				fields["reading_percent"] = j.Reading
+			}
 		}
 		acc.AddFields("redfish_thermal_fans", fields, tags)
 	}
 
 	return nil
-}
-
-func (r *Redfish) getThermal(ref string) (*thermal, error) {
-	loc := r.baseURL.ResolveReference(&url.URL{Path: ref})
-	thermal := &thermal{}
-	err := r.getData(loc.String(), thermal)
-	if err != nil {
-		return nil, err
-	}
-	return thermal, nil
 }


### PR DESCRIPTION
## Summary
This (rather large) PR replaces the handmade types with the auto generated ones from the gofish lib.
As mentioned in #19491 TestSkipChassisWithoutReference can be removed since gf does not have the issue with landing at the http root. TestSkipChassisWithoutThermalAndPowerReference was adjusted because the thermal/power subsys api has not been implemented yet.
TestParseErrorIncludesContext already errors on the init, because some request are made during the setup stage and not like before only in the gather stage.

If any changes should be unclear, feel free to comment about it.


## Checklist
- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy
