### PR TITLE
fix(inputs.amqp_consumer): Restore configuration to successfully reconnect

### DIFF
--- a/plugins/inputs/amqp_consumer/README.md
+++ b/plugins/inputs/amqp_consumer/README.md
@@ -141,6 +141,9 @@ to use them.
   ## Timeout for establishing the connection to a broker
   # timeout = "30s"
 
+  ## Heartbeat interval; uses the server configured value if less than a second
+  # heartbeat = "0s"
+
   ## Auth method. PLAIN and EXTERNAL are supported
   ## Using EXTERNAL requires enabling the rabbitmq_auth_mechanism_ssl plugin as
   ## described here: https://www.rabbitmq.com/plugins.html

--- a/plugins/inputs/amqp_consumer/amqp_consumer.go
+++ b/plugins/inputs/amqp_consumer/amqp_consumer.go
@@ -61,6 +61,10 @@ type AMQPConsumer struct {
 	wg      *sync.WaitGroup
 	cancel  context.CancelFunc
 	decoder internal.ContentDecoder
+
+	// This lock is only required for testing to prevent a race for the
+	// connection `conn` during reconnect.
+	sync.Mutex
 }
 
 // Mechanism represents the authentication mechanism used for AMQP connections.
@@ -245,7 +249,9 @@ func (a *AMQPConsumer) connect() (<-chan amqp.Delivery, error) {
 		a.Log.Debugf("Connecting to %q", broker)
 		conn, err := amqp.DialConfig(broker, *cfg)
 		if err == nil {
+			a.Lock()
 			a.conn = conn
+			a.Unlock()
 			a.Log.Debugf("Connected to %q", broker)
 			break
 		}

--- a/plugins/inputs/amqp_consumer/amqp_consumer.go
+++ b/plugins/inputs/amqp_consumer/amqp_consumer.go
@@ -51,6 +51,7 @@ type AMQPConsumer struct {
 	ContentEncoding        string                 `toml:"content_encoding"`
 	MaxDecompressionSize   config.Size            `toml:"max_decompression_size"`
 	Timeout                config.Duration        `toml:"timeout"`
+	Heartbeat              config.Duration        `toml:"heartbeat"`
 	Log                    telegraf.Logger        `toml:"-"`
 	tls.ClientConfig
 
@@ -58,13 +59,9 @@ type AMQPConsumer struct {
 
 	parser  telegraf.Parser
 	conn    *amqp.Connection
-	wg      *sync.WaitGroup
+	wg      sync.WaitGroup
 	cancel  context.CancelFunc
 	decoder internal.ContentDecoder
-
-	// This lock is only required for testing to prevent a race for the
-	// connection `conn` during reconnect.
-	sync.Mutex
 }
 
 // Mechanism represents the authentication mechanism used for AMQP connections.
@@ -111,6 +108,8 @@ func (a *AMQPConsumer) Init() error {
 		a.MaxUndeliveredMessages = 1000
 	}
 
+	a.deliveries = make(map[telegraf.TrackingID]amqp.Delivery)
+
 	return nil
 }
 
@@ -137,12 +136,34 @@ func (a *AMQPConsumer) Start(acc telegraf.Accumulator) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	a.cancel = cancel
 
-	a.wg = &sync.WaitGroup{}
+	processingCtx, processingCancel := context.WithCancel(ctx)
+	var processingWg sync.WaitGroup
 	a.wg.Add(1)
+	processingWg.Add(1)
 	go func() {
 		defer a.wg.Done()
-		a.process(ctx, msgs, acc)
+		defer processingWg.Done()
+		a.process(processingCtx, msgs, acc)
 	}()
+
+	if a.Log.Level().Includes(telegraf.Trace) {
+		a.wg.Add(1)
+		go func() {
+			defer a.wg.Done()
+			notifications := make(chan *amqp.StateChanged, 10)
+			a.conn.NotifyStateChange(notifications)
+			select {
+			case <-ctx.Done():
+				return
+			case n := <-notifications:
+				var reason string
+				if n.Err != nil {
+					reason = " (" + n.Err.Error() + ")"
+				}
+				a.Log.Tracef("Connection state changed for %q to %q%s", n.From, n.To, reason)
+			}
+		}()
+	}
 
 	go func() {
 		for {
@@ -151,22 +172,27 @@ func (a *AMQPConsumer) Start(acc telegraf.Accumulator) error {
 				break
 			}
 
-			a.Log.Infof("Connection closed: %s; trying to reconnect", err)
+			a.Log.Infof("Connection closed: %s; trying to reconnect...", err)
+			processingCancel()
+			processingWg.Wait()
 			for {
 				msgs, err := a.connect()
 				if err != nil {
-					a.Log.Errorf("AMQP connection failed: %s", err)
-					time.Sleep(10 * time.Second)
+					a.Log.Errorf("AMQP reconnection failed: %s; retrying...", err)
 					continue
 				}
 
+				processingCtx, processingCancel = context.WithCancel(ctx)
 				a.wg.Add(1)
+				processingWg.Add(1)
 				go func() {
 					defer a.wg.Done()
-					a.process(ctx, msgs, acc)
+					defer processingWg.Done()
+					a.process(processingCtx, msgs, acc)
 				}()
 				break
 			}
+			a.Log.Info("Successfully reconnected")
 		}
 	}()
 
@@ -182,8 +208,12 @@ func (a *AMQPConsumer) Stop() {
 	if a.conn == nil || a.conn.IsClosed() {
 		return
 	}
+	if a.cancel != nil {
+		a.cancel()
+	}
 	a.cancel()
 	a.wg.Wait()
+
 	err := a.conn.Close()
 	if err != nil && !errors.Is(err, amqp.ErrClosed) {
 		a.Log.Errorf("Error closing AMQP connection: %s", err)
@@ -227,31 +257,28 @@ func (a *AMQPConsumer) createConfig() (*amqp.Config, error) {
 		SASL:            auth, // if nil, it will be PLAIN
 		Dial:            amqp.DefaultDial(time.Duration(a.Timeout)),
 	}
+	if a.Heartbeat > 0 {
+		amqpConfig.Heartbeat = time.Duration(a.Heartbeat)
+	}
 	return &amqpConfig, nil
 }
 
 func (a *AMQPConsumer) connect() (<-chan amqp.Delivery, error) {
-	if a.conn != nil {
-		a.conn.Close()
-	}
-
-	cfg, err := a.createConfig()
-	if err != nil {
-		return nil, fmt.Errorf("creating configuration failed: %w", err)
-	}
-
 	brokers := a.Brokers
+
+	amqpConf, err := a.createConfig()
+	if err != nil {
+		return nil, fmt.Errorf("creating config failed: %w", err)
+	}
 
 	//nolint:gosec // False-positive for G404 as we don't need strong random numbers
 	p := rand.Perm(len(brokers))
 	for _, n := range p {
 		broker := brokers[n]
 		a.Log.Debugf("Connecting to %q", broker)
-		conn, err := amqp.DialConfig(broker, *cfg)
+		conn, err := amqp.DialConfig(broker, *amqpConf)
 		if err == nil {
-			a.Lock()
 			a.conn = conn
-			a.Unlock()
 			a.Log.Debugf("Connected to %q", broker)
 			break
 		}
@@ -412,11 +439,10 @@ func (a *AMQPConsumer) declareQueue(channel *amqp.Channel) (*amqp.Queue, error) 
 
 // Read messages from queue and add them to the Accumulator
 func (a *AMQPConsumer) process(ctx context.Context, msgs <-chan amqp.Delivery, ac telegraf.Accumulator) {
-	a.deliveries = make(map[telegraf.TrackingID]amqp.Delivery)
+	clear(a.deliveries)
 
 	acc := ac.WithTracking(a.MaxUndeliveredMessages)
 	sem := make(semaphore, a.MaxUndeliveredMessages)
-
 	for {
 		select {
 		case <-ctx.Done():

--- a/plugins/inputs/amqp_consumer/amqp_consumer.go
+++ b/plugins/inputs/amqp_consumer/amqp_consumer.go
@@ -115,21 +115,17 @@ func (a *AMQPConsumer) SetParser(parser telegraf.Parser) {
 }
 
 func (a *AMQPConsumer) Start(acc telegraf.Accumulator) error {
-	amqpConf, err := a.createConfig()
-	if err != nil {
-		return err
-	}
-
 	var options []internal.DecodingOption
 	if a.MaxDecompressionSize > 0 {
 		options = append(options, internal.WithMaxDecompressionSize(int64(a.MaxDecompressionSize)))
 	}
-	a.decoder, err = internal.NewContentDecoder(a.ContentEncoding, options...)
+	dec, err := internal.NewContentDecoder(a.ContentEncoding, options...)
 	if err != nil {
 		return err
 	}
+	a.decoder = dec
 
-	msgs, err := a.connect(amqpConf)
+	msgs, err := a.connect()
 	if err != nil {
 		return err
 	}
@@ -153,7 +149,7 @@ func (a *AMQPConsumer) Start(acc telegraf.Accumulator) error {
 
 			a.Log.Infof("Connection closed: %s; trying to reconnect", err)
 			for {
-				msgs, err := a.connect(amqpConf)
+				msgs, err := a.connect()
 				if err != nil {
 					a.Log.Errorf("AMQP connection failed: %s", err)
 					time.Sleep(10 * time.Second)
@@ -230,7 +226,16 @@ func (a *AMQPConsumer) createConfig() (*amqp.Config, error) {
 	return &amqpConfig, nil
 }
 
-func (a *AMQPConsumer) connect(amqpConf *amqp.Config) (<-chan amqp.Delivery, error) {
+func (a *AMQPConsumer) connect() (<-chan amqp.Delivery, error) {
+	if a.conn != nil {
+		a.conn.Close()
+	}
+
+	cfg, err := a.createConfig()
+	if err != nil {
+		return nil, fmt.Errorf("creating configuration failed: %w", err)
+	}
+
 	brokers := a.Brokers
 
 	//nolint:gosec // False-positive for G404 as we don't need strong random numbers
@@ -238,7 +243,7 @@ func (a *AMQPConsumer) connect(amqpConf *amqp.Config) (<-chan amqp.Delivery, err
 	for _, n := range p {
 		broker := brokers[n]
 		a.Log.Debugf("Connecting to %q", broker)
-		conn, err := amqp.DialConfig(broker, *amqpConf)
+		conn, err := amqp.DialConfig(broker, *cfg)
 		if err == nil {
 			a.conn = conn
 			a.Log.Debugf("Connected to %q", broker)

--- a/plugins/inputs/amqp_consumer/amqp_consumer.go
+++ b/plugins/inputs/amqp_consumer/amqp_consumer.go
@@ -136,35 +136,52 @@ func (a *AMQPConsumer) Start(acc telegraf.Accumulator) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	a.cancel = cancel
 
+	var processingWg sync.WaitGroup
 	processingCtx, processingCancel := context.WithCancel(ctx)
 	a.wg.Add(1)
+	processingWg.Add(1)
 	go func() {
 		defer a.wg.Done()
+		defer processingWg.Done()
 		a.process(processingCtx, msgs, acc)
 	}()
 
+	a.wg.Add(1)
 	go func() {
+		defer a.wg.Done()
 		for {
-			err := <-a.conn.NotifyClose(make(chan *amqp.Error))
-			if err == nil {
-				break
+			select {
+			case <-ctx.Done():
+				a.close()
+				return
+			case err := <-a.conn.NotifyClose(make(chan *amqp.Error)):
+				if err == nil {
+					return
+				}
 			}
 
 			a.Log.Infof("Connection closed: %s; trying to reconnect...", err)
 			processingCancel()
-			a.wg.Wait()
+			processingWg.Wait()
 			for {
 				msgs, err := a.connect()
 				if err != nil {
 					a.Log.Errorf("AMQP reconnection failed: %s; retrying...", err)
-					time.Sleep(10 * time.Second)
-					continue
+					select {
+					case <-ctx.Done():
+						a.close()
+						return
+					case <-time.After(10 * time.Second):
+						continue
+					}
 				}
 
 				processingCtx, processingCancel = context.WithCancel(ctx)
 				a.wg.Add(1)
+				processingWg.Add(1)
 				go func() {
 					defer a.wg.Done()
+					defer processingWg.Done()
 					a.process(processingCtx, msgs, acc)
 				}()
 				break
@@ -176,7 +193,7 @@ func (a *AMQPConsumer) Start(acc telegraf.Accumulator) error {
 	return nil
 }
 
-func (*AMQPConsumer) Gather(_ telegraf.Accumulator) error {
+func (*AMQPConsumer) Gather(telegraf.Accumulator) error {
 	return nil
 }
 
@@ -186,11 +203,7 @@ func (a *AMQPConsumer) Stop() {
 	}
 	a.wg.Wait()
 
-	if a.conn != nil && !a.conn.IsClosed() {
-		if err := a.conn.Close(); err != nil && !errors.Is(err, amqp.ErrClosed) {
-			a.Log.Errorf("Error closing AMQP connection: %s", err)
-		}
-	}
+	a.close()
 }
 
 func (a *AMQPConsumer) createConfig() (*amqp.Config, error) {
@@ -335,6 +348,13 @@ func (a *AMQPConsumer) connect() (<-chan amqp.Delivery, error) {
 	}
 
 	return msgs, err
+}
+func (a *AMQPConsumer) close() {
+	if a.conn != nil && !a.conn.IsClosed() {
+		if err := a.conn.Close(); err != nil && !errors.Is(err, amqp.ErrClosed) {
+			a.Log.Errorf("Error closing AMQP connection: %s", err)
+		}
+	}
 }
 
 func (a *AMQPConsumer) declareExchange(

--- a/plugins/inputs/amqp_consumer/amqp_consumer.go
+++ b/plugins/inputs/amqp_consumer/amqp_consumer.go
@@ -137,33 +137,11 @@ func (a *AMQPConsumer) Start(acc telegraf.Accumulator) error {
 	a.cancel = cancel
 
 	processingCtx, processingCancel := context.WithCancel(ctx)
-	var processingWg sync.WaitGroup
 	a.wg.Add(1)
-	processingWg.Add(1)
 	go func() {
 		defer a.wg.Done()
-		defer processingWg.Done()
 		a.process(processingCtx, msgs, acc)
 	}()
-
-	if a.Log.Level().Includes(telegraf.Trace) {
-		a.wg.Add(1)
-		go func() {
-			defer a.wg.Done()
-			notifications := make(chan *amqp.StateChanged, 10)
-			a.conn.NotifyStateChange(notifications)
-			select {
-			case <-ctx.Done():
-				return
-			case n := <-notifications:
-				var reason string
-				if n.Err != nil {
-					reason = " (" + n.Err.Error() + ")"
-				}
-				a.Log.Tracef("Connection state changed for %q to %q%s", n.From, n.To, reason)
-			}
-		}()
-	}
 
 	go func() {
 		for {
@@ -174,20 +152,19 @@ func (a *AMQPConsumer) Start(acc telegraf.Accumulator) error {
 
 			a.Log.Infof("Connection closed: %s; trying to reconnect...", err)
 			processingCancel()
-			processingWg.Wait()
+			a.wg.Wait()
 			for {
 				msgs, err := a.connect()
 				if err != nil {
 					a.Log.Errorf("AMQP reconnection failed: %s; retrying...", err)
+					time.Sleep(10 * time.Second)
 					continue
 				}
 
 				processingCtx, processingCancel = context.WithCancel(ctx)
 				a.wg.Add(1)
-				processingWg.Add(1)
 				go func() {
 					defer a.wg.Done()
-					defer processingWg.Done()
 					a.process(processingCtx, msgs, acc)
 				}()
 				break
@@ -204,20 +181,15 @@ func (*AMQPConsumer) Gather(_ telegraf.Accumulator) error {
 }
 
 func (a *AMQPConsumer) Stop() {
-	// We did not connect successfully so there is nothing to do here.
-	if a.conn == nil || a.conn.IsClosed() {
-		return
-	}
 	if a.cancel != nil {
 		a.cancel()
 	}
-	a.cancel()
 	a.wg.Wait()
 
-	err := a.conn.Close()
-	if err != nil && !errors.Is(err, amqp.ErrClosed) {
-		a.Log.Errorf("Error closing AMQP connection: %s", err)
-		return
+	if a.conn != nil && !a.conn.IsClosed() {
+		if err := a.conn.Close(); err != nil && !errors.Is(err, amqp.ErrClosed) {
+			a.Log.Errorf("Error closing AMQP connection: %s", err)
+		}
 	}
 }
 

--- a/plugins/inputs/amqp_consumer/amqp_consumer_test.go
+++ b/plugins/inputs/amqp_consumer/amqp_consumer_test.go
@@ -76,7 +76,7 @@ func TestIntegration(t *testing.T) {
 	servicePort := "5672"
 
 	// Setup the container
-	container := testutil.Container{
+	container := &testutil.Container{
 		Image:        "rabbitmq",
 		ExposedPorts: []string{servicePort},
 		WaitingFor: wait.ForAll(
@@ -153,7 +153,7 @@ func TestReconnectIntegration(t *testing.T) {
 	servicePort := "5672"
 
 	// Setup the container
-	container := testutil.Container{
+	container := &testutil.Container{
 		Image:        "rabbitmq",
 		ExposedPorts: []string{servicePort},
 		WaitingFor: wait.ForAll(
@@ -163,6 +163,7 @@ func TestReconnectIntegration(t *testing.T) {
 	}
 	require.NoError(t, container.Start(), "failed to start container")
 	defer container.Terminate()
+
 	url := fmt.Sprintf("amqp://%s:%s/", container.Address, container.Ports[servicePort])
 
 	// Setup a AMQP producer to send messages
@@ -176,11 +177,12 @@ func TestReconnectIntegration(t *testing.T) {
 		Brokers:      []string{url},
 		Username:     config.NewSecret([]byte("guest")),
 		Password:     config.NewSecret([]byte("guest")),
-		Timeout:      config.Duration(500 * time.Millisecond),
 		Exchange:     "telegraf",
 		ExchangeType: "direct",
 		Queue:        "test",
 		BindingKey:   "test",
+		Timeout:      config.Duration(500 * time.Millisecond),
+		Heartbeat:    config.Duration(time.Second),
 		Log:          logger,
 	}
 
@@ -229,12 +231,7 @@ func TestReconnectIntegration(t *testing.T) {
 
 	// Stop the container to force the plugin to disconnect and wait for the
 	// corresponding message
-	require.NoError(t, container.Stop())
-	require.Eventually(t, func() bool {
-		plugin.Lock()
-		defer plugin.Unlock()
-		return plugin.conn.IsClosed()
-	}, 30*time.Second, 100*time.Millisecond, "plugin never lost connection")
+	require.NoError(t, container.Pause())
 	require.Eventually(t, func() bool {
 		var disconnected, firstAttempt bool
 		for _, msg := range logger.Messages() {
@@ -243,29 +240,30 @@ func TestReconnectIntegration(t *testing.T) {
 				strings.Contains(msg.Text, "Connection closed") &&
 				strings.Contains(msg.Text, "trying to reconnect") {
 				disconnected = true
-				continue
 			}
 
 			// Check for the first attempt to reconnect
-			if msg.Level == testutil.LevelError && strings.Contains(msg.Text, "AMQP connection failed") {
+			if msg.Level == testutil.LevelError && strings.Contains(msg.Text, "AMQP reconnection failed") {
 				firstAttempt = true
 			}
 		}
 		return disconnected && firstAttempt
-	}, 3*time.Second, 100*time.Millisecond)
+	}, 15*time.Second, 1*time.Second, "plugin never disconnected")
 
 	// Restart the container and wait for the plugin to reconnect with a long
 	// timeout. This is necessary because the plugin has a fixed reconnect
 	// interval of 10 seconds so give it some tries.
-	require.NoError(t, container.Start())
-	url = fmt.Sprintf("amqp://%s:%s/", container.Address, container.Ports[servicePort])
-	plugin.Brokers = []string{url}
+	require.NoError(t, container.Resume())
 
 	require.Eventually(t, func() bool {
-		plugin.Lock()
-		defer plugin.Unlock()
-		return !plugin.conn.IsClosed()
-	}, 15*time.Second, 100*time.Millisecond, "plugin never reconnected")
+		for _, msg := range logger.Messages() {
+			// Check for the reconnect message
+			if msg.Level == testutil.LevelInfo && strings.Contains(msg.Text, "Successfully reconnected") {
+				return true
+			}
+		}
+		return false
+	}, 15*time.Second, 1*time.Second, "plugin never reconnected")
 
 	// Setup another AMQP producer to send messages
 	client2, err := newProducer(url)
@@ -281,7 +279,6 @@ func TestReconnectIntegration(t *testing.T) {
 	require.Eventually(t, func() bool {
 		return acc.NMetrics() >= uint64(len(expected))
 	}, 3*time.Second, 100*time.Millisecond)
-	client2.close()
 	testutil.RequireMetricsEqual(t, expected, acc.GetTelegrafMetrics())
 }
 
@@ -294,7 +291,7 @@ func TestStartupErrorBehaviorErrorIntegration(t *testing.T) {
 	servicePort := "5672"
 
 	// Setup the container
-	container := testutil.Container{
+	container := &testutil.Container{
 		Image:        "rabbitmq",
 		ExposedPorts: []string{servicePort},
 		WaitingFor: wait.ForAll(
@@ -351,7 +348,7 @@ func TestStartupErrorBehaviorIgnoreIntegration(t *testing.T) {
 	servicePort := "5672"
 
 	// Setup the container
-	container := testutil.Container{
+	container := &testutil.Container{
 		Image:        "rabbitmq",
 		ExposedPorts: []string{servicePort},
 		WaitingFor: wait.ForAll(
@@ -413,7 +410,7 @@ func TestStartupErrorBehaviorRetryIntegration(t *testing.T) {
 	servicePort := "5672"
 
 	// Setup the container
-	container := testutil.Container{
+	container := &testutil.Container{
 		Image:        "rabbitmq",
 		ExposedPorts: []string{servicePort},
 		WaitingFor: wait.ForAll(

--- a/plugins/inputs/amqp_consumer/amqp_consumer_test.go
+++ b/plugins/inputs/amqp_consumer/amqp_consumer_test.go
@@ -227,6 +227,8 @@ func TestReconnectIntegration(t *testing.T) {
 	// corresponding message
 	require.NoError(t, container.Stop())
 	require.Eventually(t, func() bool {
+		plugin.Lock()
+		defer plugin.Unlock()
 		return plugin.conn.IsClosed()
 	}, 30*time.Second, 100*time.Millisecond, "plugin never lost connection")
 	require.Eventually(t, func() bool {
@@ -256,6 +258,8 @@ func TestReconnectIntegration(t *testing.T) {
 	plugin.Brokers = []string{url}
 
 	require.Eventually(t, func() bool {
+		plugin.Lock()
+		defer plugin.Unlock()
 		return !plugin.conn.IsClosed()
 	}, 15*time.Second, 100*time.Millisecond, "plugin never reconnected")
 

--- a/plugins/inputs/amqp_consumer/amqp_consumer_test.go
+++ b/plugins/inputs/amqp_consumer/amqp_consumer_test.go
@@ -217,7 +217,11 @@ func TestReconnectIntegration(t *testing.T) {
 		return acc.NMetrics() >= uint64(len(expected))
 	}, 3*time.Second, 100*time.Millisecond)
 	client.close()
-	testutil.RequireMetricsEqual(t, expected, acc.GetTelegrafMetrics())
+	actual := acc.GetTelegrafMetrics()
+	testutil.RequireMetricsEqual(t, expected, actual)
+	for _, m := range actual {
+		m.Accept()
+	}
 
 	// Remove the metrics to make sure we can receive after reconnecting
 	acc.ClearMetrics()

--- a/plugins/inputs/amqp_consumer/amqp_consumer_test.go
+++ b/plugins/inputs/amqp_consumer/amqp_consumer_test.go
@@ -3,6 +3,7 @@ package amqp_consumer
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -140,6 +141,139 @@ func TestIntegration(t *testing.T) {
 
 	client.close()
 	plugin.Stop()
+	testutil.RequireMetricsEqual(t, expected, acc.GetTelegrafMetrics())
+}
+
+func TestReconnectIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	// Define common properties
+	servicePort := "5672"
+
+	// Setup the container
+	container := testutil.Container{
+		Image:        "rabbitmq",
+		ExposedPorts: []string{servicePort},
+		WaitingFor: wait.ForAll(
+			wait.ForListeningPort(servicePort),
+			wait.ForLog("Server startup complete"),
+		),
+	}
+	require.NoError(t, container.Start(), "failed to start container")
+	defer container.Terminate()
+	url := fmt.Sprintf("amqp://%s:%s/", container.Address, container.Ports[servicePort])
+
+	// Setup a AMQP producer to send messages
+	client, err := newProducer(url)
+	require.NoError(t, err)
+	defer client.close()
+
+	// Setup the plugin with an Influx line-protocol parser
+	logger := &testutil.CaptureLogger{}
+	plugin := &AMQPConsumer{
+		Brokers:      []string{url},
+		Username:     config.NewSecret([]byte("guest")),
+		Password:     config.NewSecret([]byte("guest")),
+		Timeout:      config.Duration(500 * time.Millisecond),
+		Exchange:     "telegraf",
+		ExchangeType: "direct",
+		Queue:        "test",
+		BindingKey:   "test",
+		Log:          logger,
+	}
+
+	parser := &influx.Parser{}
+	require.NoError(t, parser.Init())
+	plugin.SetParser(parser)
+	require.NoError(t, plugin.Init())
+
+	// Setup the metrics
+	metrics := []string{
+		"test,source=A value=0i 1712780301000000000",
+		"test,source=B value=1i 1712780301000000100",
+		"test,source=C value=2i 1712780301000000200",
+	}
+	expected := make([]telegraf.Metric, 0, len(metrics))
+	for _, x := range metrics {
+		m, err := parser.Parse([]byte(x))
+		require.NoError(t, err)
+		expected = append(expected, m...)
+	}
+
+	// Start the plugin
+	var acc testutil.Accumulator
+	require.NoError(t, plugin.Start(&acc))
+	defer plugin.Stop()
+
+	// Write metrics
+	for _, x := range metrics {
+		require.NoError(t, client.write(t.Context(), []byte(x)))
+	}
+
+	// Verify that the metrics were actually written
+	require.Eventually(t, func() bool {
+		return acc.NMetrics() >= uint64(len(expected))
+	}, 3*time.Second, 100*time.Millisecond)
+	client.close()
+	testutil.RequireMetricsEqual(t, expected, acc.GetTelegrafMetrics())
+
+	// Remove the metrics to make sure we can receive after reconnecting
+	acc.ClearMetrics()
+	require.Empty(t, acc.GetTelegrafMetrics())
+
+	// Stop the container to force the plugin to disconnect and wait for the
+	// corresponding message
+	require.NoError(t, container.Stop())
+	require.Eventually(t, func() bool {
+		return plugin.conn.IsClosed()
+	}, 30*time.Second, 100*time.Millisecond, "plugin never lost connection")
+	require.Eventually(t, func() bool {
+		var disconnected, firstAttempt bool
+		for _, msg := range logger.Messages() {
+			// Check for the disconnect message
+			if msg.Level == testutil.LevelInfo &&
+				strings.Contains(msg.Text, "Connection closed") &&
+				strings.Contains(msg.Text, "trying to reconnect") {
+				disconnected = true
+				continue
+			}
+
+			// Check for the first attempt to reconnect
+			if msg.Level == testutil.LevelError && strings.Contains(msg.Text, "AMQP connection failed") {
+				firstAttempt = true
+			}
+		}
+		return disconnected && firstAttempt
+	}, 3*time.Second, 100*time.Millisecond)
+
+	// Restart the container and wait for the plugin to reconnect with a long
+	// timeout. This is necessary because the plugin has a fixed reconnect
+	// interval of 10 seconds so give it some tries.
+	require.NoError(t, container.Start())
+	url = fmt.Sprintf("amqp://%s:%s/", container.Address, container.Ports[servicePort])
+	plugin.Brokers = []string{url}
+
+	require.Eventually(t, func() bool {
+		return !plugin.conn.IsClosed()
+	}, 15*time.Second, 100*time.Millisecond, "plugin never reconnected")
+
+	// Setup another AMQP producer to send messages
+	client2, err := newProducer(url)
+	require.NoError(t, err)
+	defer client2.close()
+
+	// Write metrics
+	for _, x := range metrics {
+		require.NoError(t, client2.write(t.Context(), []byte(x)))
+	}
+
+	// Verify that the metrics were actually written
+	require.Eventually(t, func() bool {
+		return acc.NMetrics() >= uint64(len(expected))
+	}, 3*time.Second, 100*time.Millisecond)
+	client2.close()
 	testutil.RequireMetricsEqual(t, expected, acc.GetTelegrafMetrics())
 }
 

--- a/plugins/inputs/amqp_consumer/sample.conf
+++ b/plugins/inputs/amqp_consumer/sample.conf
@@ -64,6 +64,9 @@
   ## Timeout for establishing the connection to a broker
   # timeout = "30s"
 
+  ## Heartbeat interval; uses the server configured value if less than a second
+  # heartbeat = "0s"
+
   ## Auth method. PLAIN and EXTERNAL are supported
   ## Using EXTERNAL requires enabling the rabbitmq_auth_mechanism_ssl plugin as
   ## described here: https://www.rabbitmq.com/plugins.html

--- a/testutil/container.go
+++ b/testutil/container.go
@@ -39,7 +39,7 @@ type Container struct {
 
 	Address string
 	Ports   map[string]string
-	Logs    *TestLogConsumer
+	Logs    TestLogConsumer
 	Quiet   bool
 
 	container testcontainers.Container
@@ -47,25 +47,19 @@ type Container struct {
 }
 
 func (c *Container) Start() error {
-	if c.ctx == nil {
-		c.ctx = context.Background()
+	c.ctx = context.Background()
+
+	files := make([]testcontainers.ContainerFile, 0, len(c.Files))
+	for k, v := range c.Files {
+		files = append(files, testcontainers.ContainerFile{
+			ContainerFilePath: k,
+			HostFilePath:      v,
+			FileMode:          0o755,
+		})
 	}
 
-	if c.Logs == nil {
-		c.Logs = &TestLogConsumer{}
-	}
-
-	if c.container == nil {
-		files := make([]testcontainers.ContainerFile, 0, len(c.Files))
-		for k, v := range c.Files {
-			files = append(files, testcontainers.ContainerFile{
-				ContainerFilePath: k,
-				HostFilePath:      v,
-				FileMode:          0o755,
-			})
-		}
-
-		req := testcontainers.GenericContainerRequest{
+	req := testcontainers.GenericContainerRequest{
+		ContainerRequest: testcontainers.ContainerRequest{
 			Entrypoint:         c.Entrypoint,
 			Env:                c.Env,
 			ExposedPorts:       c.ExposedPorts,
@@ -78,24 +72,23 @@ func (c *Container) Start() error {
 			Hostname:           c.Hostname,
 			Networks:           c.Networks,
 			WaitingFor:         c.WaitingFor,
-			LogConsumerCfg: &testcontainers.LogConsumerConfig{
-				Consumers: []testcontainers.LogConsumer{c.Logs},
-			},
-			Started: true,
-		}
-
-		cntnr, err := testcontainers.GenericContainer(c.ctx, req)
-		if err != nil {
-			return fmt.Errorf("container failed to start: %w", err)
-		}
-		c.container = cntnr
-		c.Address = "localhost"
-	} else {
-		c.Ports = make(map[string]string)
-		if err := c.container.Start(c.ctx); err != nil {
-			return fmt.Errorf("container failed to restart: %w", err)
-		}
+		},
+		Started: true,
 	}
+
+	cntnr, err := testcontainers.GenericContainer(c.ctx, req)
+	if err != nil {
+		return fmt.Errorf("container failed to start: %w", err)
+	}
+	c.container = cntnr
+
+	c.Logs = TestLogConsumer{}
+	c.container.FollowOutput(&c.Logs)
+	if err := c.container.StartLogProducer(c.ctx); err != nil {
+		return fmt.Errorf("log producer failed: %w", err)
+	}
+
+	c.Address = "localhost"
 
 	info, err := c.GetInfo()
 	if err != nil {
@@ -109,10 +102,6 @@ func (c *Container) Start() error {
 	}
 
 	return nil
-}
-
-func (c *Container) Stop() error {
-	return c.container.Stop(c.ctx, nil)
 }
 
 // LookupMappedPorts creates a lookup table of exposed ports to mapped ports

--- a/testutil/container.go
+++ b/testutil/container.go
@@ -104,6 +104,10 @@ func (c *Container) Start() error {
 	return nil
 }
 
+func (c *Container) Stop() error {
+	return c.container.Stop(c.ctx, nil)
+}
+
 // LookupMappedPorts creates a lookup table of exposed ports to mapped ports
 func (c *Container) LookupMappedPorts() error {
 	if len(c.ExposedPorts) == 0 {

--- a/testutil/container.go
+++ b/testutil/container.go
@@ -39,7 +39,7 @@ type Container struct {
 
 	Address string
 	Ports   map[string]string
-	Logs    TestLogConsumer
+	Logs    *TestLogConsumer
 	Quiet   bool
 
 	container testcontainers.Container
@@ -47,19 +47,25 @@ type Container struct {
 }
 
 func (c *Container) Start() error {
-	c.ctx = context.Background()
-
-	files := make([]testcontainers.ContainerFile, 0, len(c.Files))
-	for k, v := range c.Files {
-		files = append(files, testcontainers.ContainerFile{
-			ContainerFilePath: k,
-			HostFilePath:      v,
-			FileMode:          0o755,
-		})
+	if c.ctx == nil {
+		c.ctx = context.Background()
 	}
 
-	req := testcontainers.GenericContainerRequest{
-		ContainerRequest: testcontainers.ContainerRequest{
+	if c.Logs == nil {
+		c.Logs = &TestLogConsumer{}
+	}
+
+	if c.container == nil {
+		files := make([]testcontainers.ContainerFile, 0, len(c.Files))
+		for k, v := range c.Files {
+			files = append(files, testcontainers.ContainerFile{
+				ContainerFilePath: k,
+				HostFilePath:      v,
+				FileMode:          0o755,
+			})
+		}
+
+		req := testcontainers.GenericContainerRequest{
 			Entrypoint:         c.Entrypoint,
 			Env:                c.Env,
 			ExposedPorts:       c.ExposedPorts,
@@ -72,23 +78,24 @@ func (c *Container) Start() error {
 			Hostname:           c.Hostname,
 			Networks:           c.Networks,
 			WaitingFor:         c.WaitingFor,
-		},
-		Started: true,
-	}
+			LogConsumerCfg: &testcontainers.LogConsumerConfig{
+				Consumers: []testcontainers.LogConsumer{c.Logs},
+			},
+			Started: true,
+		}
 
-	cntnr, err := testcontainers.GenericContainer(c.ctx, req)
-	if err != nil {
-		return fmt.Errorf("container failed to start: %w", err)
+		cntnr, err := testcontainers.GenericContainer(c.ctx, req)
+		if err != nil {
+			return fmt.Errorf("container failed to start: %w", err)
+		}
+		c.container = cntnr
+		c.Address = "localhost"
+	} else {
+		c.Ports = make(map[string]string)
+		if err := c.container.Start(c.ctx); err != nil {
+			return fmt.Errorf("container failed to restart: %w", err)
+		}
 	}
-	c.container = cntnr
-
-	c.Logs = TestLogConsumer{}
-	c.container.FollowOutput(&c.Logs)
-	if err := c.container.StartLogProducer(c.ctx); err != nil {
-		return fmt.Errorf("log producer failed: %w", err)
-	}
-
-	c.Address = "localhost"
 
 	info, err := c.GetInfo()
 	if err != nil {


### PR DESCRIPTION
## Summary

The AMPQ consumer wipes credentials in its configuration after the first successful connect. This leads to issues during reconnect if the configuration is reused as now the credentials is empty.

This PR recreated the configuration on every connection attempt to fix the issue.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

resolves #19571 
based on #19576
based on #19580
