### PR TITLE
test(inputs.amqp_consumer): Make sure integration tests are actually executed

### DIFF
--- a/plugins/inputs/amqp_consumer/amqp_consumer_test.go
+++ b/plugins/inputs/amqp_consumer/amqp_consumer_test.go
@@ -148,7 +148,7 @@ func TestIntegration(t *testing.T) {
 	testutil.RequireMetricsEqual(t, expected, acc.GetTelegrafMetrics())
 }
 
-func TestStartupErrorBehaviorError(t *testing.T) {
+func TestStartupErrorBehaviorErrorIntegration(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
@@ -210,7 +210,7 @@ func TestStartupErrorBehaviorError(t *testing.T) {
 	require.ErrorContains(t, model.Start(&acc), "could not connect to any broker")
 }
 
-func TestStartupErrorBehaviorIgnore(t *testing.T) {
+func TestStartupErrorBehaviorIgnoreIntegration(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
@@ -277,7 +277,7 @@ func TestStartupErrorBehaviorIgnore(t *testing.T) {
 	require.ErrorAs(t, err, &fatalErr)
 }
 
-func TestStartupErrorBehaviorRetry(t *testing.T) {
+func TestStartupErrorBehaviorRetryIntegration(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}


### PR DESCRIPTION
## Summary

This PR fixes the integration test naming to actually execute the tests through `make test-integration`.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

related to #19575
