### PR TITLE
feat(inputs.http_response): Add SOCKS5 proxy support

### DIFF
--- a/plugins/common/proxy/socks5.go
+++ b/plugins/common/proxy/socks5.go
@@ -12,11 +12,21 @@ type Socks5ProxyConfig struct {
 }
 
 func (c *Socks5ProxyConfig) GetDialer() (proxy.Dialer, error) {
+	return c.GetDialerWithForward(proxy.Direct)
+}
+
+// GetDialerWithForward creates a SOCKS5 dialer using the given dialer to
+// connect to the proxy server.
+func (c *Socks5ProxyConfig) GetDialerWithForward(forward proxy.Dialer) (*ProxiedDialer, error) {
 	var auth *proxy.Auth
 	if c.Socks5ProxyPassword != "" || c.Socks5ProxyUsername != "" {
 		auth = new(proxy.Auth)
 		auth.User = c.Socks5ProxyUsername
 		auth.Password = c.Socks5ProxyPassword
 	}
-	return proxy.SOCKS5("tcp", c.Socks5ProxyAddress, auth, proxy.Direct)
+	dialer, err := proxy.SOCKS5("tcp", c.Socks5ProxyAddress, auth, forward)
+	if err != nil {
+		return nil, err
+	}
+	return &ProxiedDialer{dialer: dialer}, nil
 }

--- a/plugins/common/proxy/socks5.go
+++ b/plugins/common/proxy/socks5.go
@@ -11,13 +11,9 @@ type Socks5ProxyConfig struct {
 	Socks5ProxyPassword string `toml:"socks5_password"`
 }
 
-func (c *Socks5ProxyConfig) GetDialer() (proxy.Dialer, error) {
-	return c.GetDialerWithForward(proxy.Direct)
-}
-
-// GetDialerWithForward creates a SOCKS5 dialer using the given dialer to
-// connect to the proxy server.
-func (c *Socks5ProxyConfig) GetDialerWithForward(forward proxy.Dialer) (*ProxiedDialer, error) {
+// GetDialer creates a SOCKS5 dialer using the given dialer to connect to the
+// proxy server. If forward is nil, a default net.Dialer is used.
+func (c *Socks5ProxyConfig) GetDialer(forward proxy.Dialer) (*ProxiedDialer, error) {
 	var auth *proxy.Auth
 	if c.Socks5ProxyPassword != "" || c.Socks5ProxyUsername != "" {
 		auth = new(proxy.Auth)

--- a/plugins/common/proxy/socks5_test.go
+++ b/plugins/common/proxy/socks5_test.go
@@ -44,7 +44,7 @@ func TestSocks5ProxyConfigIntegration(t *testing.T) {
 		Socks5ProxyUsername: proxyUsername,
 		Socks5ProxyPassword: proxyPassword,
 	}
-	dialer, err := conf.GetDialer()
+	dialer, err := conf.GetDialer(nil)
 	require.NoError(t, err)
 
 	var proxyConn net.Conn

--- a/plugins/inputs/http_response/README.md
+++ b/plugins/inputs/http_response/README.md
@@ -36,6 +36,12 @@ to use them.
   ## Telegraf uses the system wide proxy settings if it's is not set.
   # http_proxy = "http://localhost:8888"
 
+  ## Optional SOCKS5 proxy to use when connecting to the server
+  # socks5_enabled = true
+  # socks5_address = "127.0.0.1:1080"
+  # socks5_username = "alice"
+  # socks5_password = "pass123"
+
   ## Set response_timeout (default 5 seconds)
   # response_timeout = "5s"
 

--- a/plugins/inputs/http_response/http_response.go
+++ b/plugins/inputs/http_response/http_response.go
@@ -23,6 +23,7 @@ import (
 	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/internal"
 	"github.com/influxdata/telegraf/plugins/common/cookie"
+	"github.com/influxdata/telegraf/plugins/common/proxy"
 	"github.com/influxdata/telegraf/plugins/common/tls"
 	"github.com/influxdata/telegraf/plugins/inputs"
 )
@@ -57,6 +58,7 @@ type HTTPResponse struct {
 	// HTTP Basic Auth Credentials
 	Username config.Secret `toml:"username"`
 	Password config.Secret `toml:"password"`
+	proxy.Socks5ProxyConfig
 	tls.ClientConfig
 	cookie.CookieAuthConfig
 
@@ -180,11 +182,19 @@ func (h *HTTPResponse) createHTTPClient(address url.URL) (*http.Client, error) {
 			return nil, err
 		}
 	}
+	dialContext := dialer.DialContext
+	if h.Socks5ProxyEnabled {
+		proxyDialer, err := h.Socks5ProxyConfig.GetDialerWithForward(dialer)
+		if err != nil {
+			return nil, fmt.Errorf("creating SOCKS5 proxy dialer failed: %w", err)
+		}
+		dialContext = proxyDialer.DialContext
+	}
 
 	client := &http.Client{
 		Transport: &http.Transport{
 			Proxy:             getProxyFunc(h.HTTPProxy),
-			DialContext:       dialer.DialContext,
+			DialContext:       dialContext,
 			DisableKeepAlives: true,
 			TLSClientConfig:   tlsCfg,
 		},

--- a/plugins/inputs/http_response/http_response.go
+++ b/plugins/inputs/http_response/http_response.go
@@ -184,7 +184,7 @@ func (h *HTTPResponse) createHTTPClient(address url.URL) (*http.Client, error) {
 	}
 	dialContext := dialer.DialContext
 	if h.Socks5ProxyEnabled {
-		proxyDialer, err := h.Socks5ProxyConfig.GetDialerWithForward(dialer)
+		proxyDialer, err := h.Socks5ProxyConfig.GetDialer(dialer)
 		if err != nil {
 			return nil, fmt.Errorf("creating SOCKS5 proxy dialer failed: %w", err)
 		}

--- a/plugins/inputs/http_response/http_response_test.go
+++ b/plugins/inputs/http_response/http_response_test.go
@@ -11,12 +11,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/armon/go-socks5"
 	"github.com/stretchr/testify/require"
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/internal"
 	"github.com/influxdata/telegraf/metric"
+	commonproxy "github.com/influxdata/telegraf/plugins/common/proxy"
 	"github.com/influxdata/telegraf/plugins/common/tls"
 	"github.com/influxdata/telegraf/testutil"
 )
@@ -560,6 +562,65 @@ func TestInterface(t *testing.T) {
 	}
 	absentFields := []string{"response_string_match"}
 	checkOutput(t, &acc, expectedFields, expectedTags, absentFields, nil)
+}
+
+func TestSocks5Proxy(t *testing.T) {
+	const (
+		proxyUsername = "user"
+		proxyPassword = "password"
+	)
+
+	mux := setUpTestMux()
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	proxyListener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer proxyListener.Close()
+
+	proxyServer, err := socks5.New(&socks5.Config{
+		AuthMethods: []socks5.Authenticator{socks5.UserPassAuthenticator{
+			Credentials: socks5.StaticCredentials{proxyUsername: proxyPassword},
+		}},
+	})
+	require.NoError(t, err)
+	go func() {
+		if err := proxyServer.Serve(proxyListener); err != nil && !errors.Is(err, net.ErrClosed) {
+			t.Error(err)
+		}
+	}()
+
+	h := &HTTPResponse{
+		Log:             testutil.Logger{},
+		URLs:            []string{ts.URL + "/good"},
+		Method:          "GET",
+		ResponseTimeout: config.Duration(time.Second * 20),
+		Socks5ProxyConfig: commonproxy.Socks5ProxyConfig{
+			Socks5ProxyEnabled:  true,
+			Socks5ProxyAddress:  proxyListener.Addr().String(),
+			Socks5ProxyUsername: proxyUsername,
+			Socks5ProxyPassword: proxyPassword,
+		},
+	}
+
+	var acc testutil.Accumulator
+	require.NoError(t, h.Init())
+	require.NoError(t, h.Gather(&acc))
+
+	expectedFields := map[string]interface{}{
+		"http_response_code": http.StatusOK,
+		"result_type":        "success",
+		"result_code":        0,
+		"response_time":      nil,
+		"content_length":     nil,
+	}
+	expectedTags := map[string]interface{}{
+		"server":      nil,
+		"method":      "GET",
+		"status_code": "200",
+		"result":      "success",
+	}
+	checkOutput(t, &acc, expectedFields, expectedTags, []string{"response_string_match"}, nil)
 }
 
 func TestRedirects(t *testing.T) {

--- a/plugins/inputs/http_response/sample.conf
+++ b/plugins/inputs/http_response/sample.conf
@@ -7,6 +7,12 @@
   ## Telegraf uses the system wide proxy settings if it's is not set.
   # http_proxy = "http://localhost:8888"
 
+  ## Optional SOCKS5 proxy to use when connecting to the server
+  # socks5_enabled = true
+  # socks5_address = "127.0.0.1:1080"
+  # socks5_username = "alice"
+  # socks5_password = "pass123"
+
   ## Set response_timeout (default 5 seconds)
   # response_timeout = "5s"
 

--- a/plugins/outputs/kafka/kafka.go
+++ b/plugins/outputs/kafka/kafka.go
@@ -91,7 +91,7 @@ func (k *Kafka) Init() error {
 	if k.Socks5ProxyEnabled {
 		config.Net.Proxy.Enable = true
 
-		dialer, err := k.Socks5ProxyConfig.GetDialer()
+		dialer, err := k.Socks5ProxyConfig.GetDialer(nil)
 		if err != nil {
 			return fmt.Errorf("connecting to proxy server failed: %w", err)
 		}

--- a/plugins/outputs/websocket/websocket.go
+++ b/plugins/outputs/websocket/websocket.go
@@ -82,7 +82,7 @@ func (w *WebSocket) Connect() error {
 	}
 
 	if w.Socks5ProxyEnabled {
-		netDialer, err := w.Socks5ProxyConfig.GetDialer()
+		netDialer, err := w.Socks5ProxyConfig.GetDialer(nil)
 		if err != nil {
 			return fmt.Errorf("error connecting to socks5 proxy: %w", err)
 		}


### PR DESCRIPTION
 ## Summary

  Add optional SOCKS5 proxy support to the `inputs.http_response` plugin so Telegraf can monitor HTTP endpoints that are only reachable through a SOCKS5 proxy.

  The implementation reuses the common SOCKS5 proxy configuration, supports optional username/password authentication, and preserves the configured network interface by using the existing network dialer for the
  connection to the proxy.

  The sample configuration and README are updated, and an integration test covers an authenticated SOCKS5 connection to an HTTP endpoint.

  Validated with:

  - package tests for `plugins/common/proxy` and `plugins/inputs/http_response`
  - race detector
  - `go vet`
  - README generator and linter
  - repeated SOCKS5 integration-test runs

  ## Checklist

  - [ ] No AI generated code was used in this PR
  - [x] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

  [policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

  ## Related issues

  resolves #11804
