### PR TITLE
test(inputs.amqp_consumer): Unparameterize test functions

### DIFF
--- a/plugins/inputs/amqp_consumer/amqp_consumer_test.go
+++ b/plugins/inputs/amqp_consumer/amqp_consumer_test.go
@@ -73,11 +73,6 @@ func TestIntegration(t *testing.T) {
 
 	// Define common properties
 	servicePort := "5672"
-	vhost := "/"
-	exchange := "telegraf"
-	exchangeType := "direct"
-	queueName := "test"
-	bindingKey := "test"
 
 	// Setup the container
 	container := testutil.Container{
@@ -90,10 +85,10 @@ func TestIntegration(t *testing.T) {
 	}
 	require.NoError(t, container.Start(), "failed to start container")
 	defer container.Terminate()
-	url := fmt.Sprintf("amqp://%s:%s%s", container.Address, container.Ports[servicePort], vhost)
+	url := fmt.Sprintf("amqp://%s:%s/", container.Address, container.Ports[servicePort])
 
 	// Setup a AMQP producer to send messages
-	client, err := newProducer(url, vhost, exchange, exchangeType, queueName, bindingKey)
+	client, err := newProducer(url)
 	require.NoError(t, err)
 	defer client.close()
 
@@ -103,10 +98,10 @@ func TestIntegration(t *testing.T) {
 		Username:     config.NewSecret([]byte("guest")),
 		Password:     config.NewSecret([]byte("guest")),
 		Timeout:      config.Duration(3 * time.Second),
-		Exchange:     exchange,
-		ExchangeType: exchangeType,
-		Queue:        queueName,
-		BindingKey:   bindingKey,
+		Exchange:     "telegraf",
+		ExchangeType: "direct",
+		Queue:        "test",
+		BindingKey:   "test",
 		Log:          testutil.Logger{},
 	}
 
@@ -135,7 +130,7 @@ func TestIntegration(t *testing.T) {
 
 	// Write metrics
 	for _, x := range metrics {
-		require.NoError(t, client.write(t.Context(), exchange, queueName, []byte(x)))
+		require.NoError(t, client.write(t.Context(), []byte(x)))
 	}
 
 	// Verify that the metrics were actually written
@@ -155,11 +150,6 @@ func TestStartupErrorBehaviorErrorIntegration(t *testing.T) {
 
 	// Define common properties
 	servicePort := "5672"
-	vhost := "/"
-	exchange := "telegraf"
-	exchangeType := "direct"
-	queueName := "test"
-	bindingKey := "test"
 
 	// Setup the container
 	container := testutil.Container{
@@ -172,7 +162,7 @@ func TestStartupErrorBehaviorErrorIntegration(t *testing.T) {
 	}
 	require.NoError(t, container.Start(), "failed to start container")
 	defer container.Terminate()
-	url := fmt.Sprintf("amqp://%s:%s%s", container.Address, container.Ports[servicePort], vhost)
+	url := fmt.Sprintf("amqp://%s:%s/", container.Address, container.Ports[servicePort])
 
 	// Pause the container for simulating connectivity issues
 	require.NoError(t, container.Pause())
@@ -184,10 +174,10 @@ func TestStartupErrorBehaviorErrorIntegration(t *testing.T) {
 		Username:     config.NewSecret([]byte("guest")),
 		Password:     config.NewSecret([]byte("guest")),
 		Timeout:      config.Duration(1 * time.Second),
-		Exchange:     exchange,
-		ExchangeType: exchangeType,
-		Queue:        queueName,
-		BindingKey:   bindingKey,
+		Exchange:     "telegraf",
+		ExchangeType: "direct",
+		Queue:        "test",
+		BindingKey:   "test",
 		Log:          testutil.Logger{},
 	}
 
@@ -217,11 +207,6 @@ func TestStartupErrorBehaviorIgnoreIntegration(t *testing.T) {
 
 	// Define common properties
 	servicePort := "5672"
-	vhost := "/"
-	exchange := "telegraf"
-	exchangeType := "direct"
-	queueName := "test"
-	bindingKey := "test"
 
 	// Setup the container
 	container := testutil.Container{
@@ -234,7 +219,7 @@ func TestStartupErrorBehaviorIgnoreIntegration(t *testing.T) {
 	}
 	require.NoError(t, container.Start(), "failed to start container")
 	defer container.Terminate()
-	url := fmt.Sprintf("amqp://%s:%s%s", container.Address, container.Ports[servicePort], vhost)
+	url := fmt.Sprintf("amqp://%s:%s/", container.Address, container.Ports[servicePort])
 
 	// Pause the container for simulating connectivity issues
 	require.NoError(t, container.Pause())
@@ -246,10 +231,10 @@ func TestStartupErrorBehaviorIgnoreIntegration(t *testing.T) {
 		Username:     config.NewSecret([]byte("guest")),
 		Password:     config.NewSecret([]byte("guest")),
 		Timeout:      config.Duration(1 * time.Second),
-		Exchange:     exchange,
-		ExchangeType: exchangeType,
-		Queue:        queueName,
-		BindingKey:   bindingKey,
+		Exchange:     "telegraf",
+		ExchangeType: "direct",
+		Queue:        "test",
+		BindingKey:   "test",
 		Log:          testutil.Logger{},
 	}
 
@@ -284,11 +269,6 @@ func TestStartupErrorBehaviorRetryIntegration(t *testing.T) {
 
 	// Define common properties
 	servicePort := "5672"
-	vhost := "/"
-	exchange := "telegraf"
-	exchangeType := "direct"
-	queueName := "test"
-	bindingKey := "test"
 
 	// Setup the container
 	container := testutil.Container{
@@ -301,7 +281,7 @@ func TestStartupErrorBehaviorRetryIntegration(t *testing.T) {
 	}
 	require.NoError(t, container.Start(), "failed to start container")
 	defer container.Terminate()
-	url := fmt.Sprintf("amqp://%s:%s%s", container.Address, container.Ports[servicePort], vhost)
+	url := fmt.Sprintf("amqp://%s:%s/", container.Address, container.Ports[servicePort])
 
 	// Pause the container for simulating connectivity issues
 	require.NoError(t, container.Pause())
@@ -313,10 +293,10 @@ func TestStartupErrorBehaviorRetryIntegration(t *testing.T) {
 		Username:     config.NewSecret([]byte("guest")),
 		Password:     config.NewSecret([]byte("guest")),
 		Timeout:      config.Duration(1 * time.Second),
-		Exchange:     exchange,
-		ExchangeType: exchangeType,
-		Queue:        queueName,
-		BindingKey:   bindingKey,
+		Exchange:     "telegraf",
+		ExchangeType: "direct",
+		Queue:        "test",
+		BindingKey:   "test",
 		Log:          testutil.Logger{},
 	}
 
@@ -363,13 +343,13 @@ func TestStartupErrorBehaviorRetryIntegration(t *testing.T) {
 	require.NoError(t, model.Gather(&acc))
 
 	// Setup a AMQP producer and send messages
-	client, err := newProducer(url, vhost, exchange, exchangeType, queueName, bindingKey)
+	client, err := newProducer(url)
 	require.NoError(t, err)
 	defer client.close()
 
 	// Write metrics
 	for _, x := range metrics {
-		require.NoError(t, client.write(t.Context(), exchange, queueName, []byte(x)))
+		require.NoError(t, client.write(t.Context(), []byte(x)))
 	}
 
 	// Verify that the metrics were actually collected
@@ -388,9 +368,9 @@ type producer struct {
 	queue   amqp091.Queue
 }
 
-func newProducer(url, vhost, exchange, exchangeType, queueName, key string) (*producer, error) {
+func newProducer(url string) (*producer, error) {
 	cfg := amqp091.Config{
-		Vhost:      vhost,
+		Vhost:      "/",
 		Properties: amqp091.NewConnectionProperties(),
 	}
 	cfg.Properties.SetClientConnectionName("test-producer")
@@ -404,16 +384,16 @@ func newProducer(url, vhost, exchange, exchangeType, queueName, key string) (*pr
 		return nil, err
 	}
 
-	if err := channel.ExchangeDeclare(exchange, exchangeType, true, false, false, false, nil); err != nil {
+	if err := channel.ExchangeDeclare("telegraf", "direct", true, false, false, false, nil); err != nil {
 		return nil, err
 	}
 
-	queue, err := channel.QueueDeclare(queueName, true, false, false, false, nil)
+	queue, err := channel.QueueDeclare("test", true, false, false, false, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := channel.QueueBind(queue.Name, key, exchange, false, nil); err != nil {
+	if err := channel.QueueBind(queue.Name, "test", "telegraf", false, nil); err != nil {
 		return nil, err
 	}
 
@@ -429,7 +409,7 @@ func (p *producer) close() {
 	p.conn.Close()
 }
 
-func (p *producer) write(testContext context.Context, exchange, key string, payload []byte) error {
+func (p *producer) write(testContext context.Context, payload []byte) error {
 	msg := amqp091.Publishing{
 		DeliveryMode: amqp091.Persistent,
 		Timestamp:    time.Now(),
@@ -440,5 +420,5 @@ func (p *producer) write(testContext context.Context, exchange, key string, payl
 	ctx, cancel := context.WithTimeout(testContext, 3*time.Second)
 	defer cancel()
 
-	return p.channel.PublishWithContext(ctx, exchange, key, true, false, msg)
+	return p.channel.PublishWithContext(ctx, "telegraf", "test", true, false, msg)
 }

--- a/plugins/inputs/amqp_consumer/amqp_consumer_test.go
+++ b/plugins/inputs/amqp_consumer/amqp_consumer_test.go
@@ -365,7 +365,6 @@ func TestStartupErrorBehaviorRetryIntegration(t *testing.T) {
 type producer struct {
 	conn    *amqp091.Connection
 	channel *amqp091.Channel
-	queue   amqp091.Queue
 }
 
 func newProducer(url string) (*producer, error) {
@@ -400,7 +399,6 @@ func newProducer(url string) (*producer, error) {
 	return &producer{
 		conn:    conn,
 		channel: channel,
-		queue:   queue,
 	}, nil
 }
 

--- a/plugins/inputs/amqp_consumer/amqp_consumer_test.go
+++ b/plugins/inputs/amqp_consumer/amqp_consumer_test.go
@@ -368,10 +368,7 @@ type producer struct {
 }
 
 func newProducer(url string) (*producer, error) {
-	cfg := amqp091.Config{
-		Vhost:      "/",
-		Properties: amqp091.NewConnectionProperties(),
-	}
+	cfg := amqp091.Config{Properties: amqp091.NewConnectionProperties()}
 	cfg.Properties.SetClientConnectionName("test-producer")
 	conn, err := amqp091.DialConfig(url, cfg)
 	if err != nil {


### PR DESCRIPTION
## Summary

This PR moves non varying parameters into the function to please the `unparam` linter which would trigger with any additional test.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

related to #19575
