### PR TITLE
feat(outputs.parquet): Introduce partial write errors

### DIFF
--- a/plugins/outputs/parquet/parquet.go
+++ b/plugins/outputs/parquet/parquet.go
@@ -245,63 +245,56 @@ func (p *Parquet) createRecordBatch(metrics []telegraf.Metric, builder *array.Re
 			case int8:
 				if ctype != arrow.PrimitiveTypes.Int8 {
 					err = fmt.Errorf("invalid value %v (%T) for column %q (%s)", value, value, name, ctype.Name())
-					break
 				}
 			case int16:
 				if ctype != arrow.PrimitiveTypes.Int16 {
 					err = fmt.Errorf("invalid value %v (%T) for column %q (%s)", value, value, name, ctype.Name())
-					break
 				}
 			case int32:
 				if ctype != arrow.PrimitiveTypes.Int32 {
 					err = fmt.Errorf("invalid value %v (%T) for column %q (%s)", value, value, name, ctype.Name())
-					break
 				}
 			case int64:
 				if ctype != arrow.PrimitiveTypes.Int64 {
 					err = fmt.Errorf("invalid value %v (%T) for column %q (%s)", value, value, name, ctype.Name())
-					break
 				}
 			case uint8:
 				if ctype != arrow.PrimitiveTypes.Uint8 {
 					err = fmt.Errorf("invalid value %v (%T) for column %q (%s)", value, value, name, ctype.Name())
-					break
 				}
 			case uint16:
 				if ctype != arrow.PrimitiveTypes.Uint16 {
 					err = fmt.Errorf("invalid value %v (%T) for column %q (%s)", value, value, name, ctype.Name())
-					break
 				}
 			case uint32:
 				if ctype != arrow.PrimitiveTypes.Uint32 {
 					err = fmt.Errorf("invalid value %v (%T) for column %q (%s)", value, value, name, ctype.Name())
-					break
 				}
 			case uint64:
 				if ctype != arrow.PrimitiveTypes.Uint64 {
 					err = fmt.Errorf("invalid value %v (%T) for column %q (%s)", value, value, name, ctype.Name())
-					break
 				}
 			case float32:
 				if ctype != arrow.PrimitiveTypes.Float32 {
 					err = fmt.Errorf("invalid value %v (%T) for column %q (%s)", value, value, name, ctype.Name())
-					break
 				}
 			case float64:
 				if ctype != arrow.PrimitiveTypes.Float64 {
 					err = fmt.Errorf("invalid value %v (%T) for column %q (%s)", value, value, name, ctype.Name())
-					break
 				}
 			case string:
 				if ctype != arrow.BinaryTypes.String {
 					err = fmt.Errorf("invalid value %v (%T) for column %q (%s)", value, value, name, ctype.Name())
-					break
 				}
 			case bool:
 				if ctype != arrow.FixedWidthTypes.Boolean {
 					err = fmt.Errorf("invalid value %v (%T) for column %q (%s)", value, value, name, ctype.Name())
-					break
 				}
+			default:
+				err = fmt.Errorf("unknown field value type %T for column %q", value, name)
+			}
+			if err != nil {
+				break
 			}
 		}
 		if err != nil {

--- a/plugins/outputs/parquet/parquet.go
+++ b/plugins/outputs/parquet/parquet.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
+	"github.com/influxdata/telegraf/internal"
 	"github.com/influxdata/telegraf/plugins/outputs"
 )
 
@@ -87,21 +88,29 @@ func (p *Parquet) Close() error {
 
 func (p *Parquet) Write(metrics []telegraf.Metric) error {
 	groupedMetrics := make(map[string][]telegraf.Metric)
-	for _, metric := range metrics {
-		groupedMetrics[metric.Name()] = append(groupedMetrics[metric.Name()], metric)
+	metricIndices := make(map[string][]int)
+	for i, metric := range metrics {
+		name := metric.Name()
+		groupedMetrics[name] = append(groupedMetrics[name], metric)
+		metricIndices[name] = append(metricIndices[name], i)
 	}
 
+	var perr internal.PartialWriteError
 	now := time.Now()
 	for name, metrics := range groupedMetrics {
 		if _, ok := p.metricGroups[name]; !ok {
 			filename := fmt.Sprintf("%s/%s-%s-%s.parquet", p.Directory, name, now.Format("2006-01-02"), strconv.FormatInt(now.Unix(), 10))
 			schema, err := p.createSchema(metrics)
 			if err != nil {
-				return fmt.Errorf("failed to create schema for file %q: %w", name, err)
+				perr.MetricsReject = append(perr.MetricsReject, metricIndices[name]...)
+				perr.MetricsRejectErrors = append(perr.MetricsRejectErrors, fmt.Errorf("failed to create schema for file %q: %w", name, err))
+				perr.Err = fmt.Errorf("failed to create schema for file %q: %w", name, err)
+				continue
 			}
 			writer, err := p.createWriter(name, filename, schema)
 			if err != nil {
-				return fmt.Errorf("failed to create writer for file %q: %w", name, err)
+				perr.Err = fmt.Errorf("failed to create writer for file %q: %w", name, err)
+				return &perr
 			}
 			p.metricGroups[name] = &metricGroup{
 				builder:  array.NewRecordBuilder(memory.DefaultAllocator, schema),
@@ -113,18 +122,43 @@ func (p *Parquet) Write(metrics []telegraf.Metric) error {
 
 		if p.RotationInterval != 0 {
 			if err := p.rotateIfNeeded(name); err != nil {
-				return fmt.Errorf("failed to rotate file %q: %w", p.metricGroups[name].filename, err)
+				perr.Err = fmt.Errorf("failed to rotate file %q: %w", p.metricGroups[name].filename, err)
+				return &perr
 			}
 		}
 
 		record, err := p.createRecordBatch(metrics, p.metricGroups[name].builder, p.metricGroups[name].schema)
+		accepted := metricIndices[name]
 		if err != nil {
-			return fmt.Errorf("failed to create record for file %q: %w", p.metricGroups[name].filename, err)
+			var crbErr *internal.PartialWriteError
+			if errors.As(err, &crbErr) {
+				accepted = make([]int, 0, len(perr.MetricsAccept))
+				for _, idx := range crbErr.MetricsAccept {
+					perr.MetricsAccept = append(perr.MetricsAccept, metricIndices[name][idx])
+				}
+				for _, idx := range crbErr.MetricsReject {
+					perr.MetricsReject = append(perr.MetricsReject, metricIndices[name][idx])
+					perr.MetricsRejectErrors = append(perr.MetricsRejectErrors, crbErr.MetricsRejectErrors...)
+				}
+			} else {
+				accepted = make([]int, 0)
+				perr.MetricsReject = append(perr.MetricsReject, metricIndices[name]...)
+				perr.MetricsRejectErrors = append(perr.MetricsRejectErrors, fmt.Errorf("failed to create record for file %q: %w", name, err))
+			}
+			perr.Err = fmt.Errorf("failed to create record for file %q: %w", p.metricGroups[name].filename, err)
+			if len(accepted) > 0 {
+				continue
+			}
 		}
-		if err = p.metricGroups[name].writer.WriteBuffered(record); err != nil {
-			return fmt.Errorf("failed to write to file %q: %w", p.metricGroups[name].filename, err)
+		if err := p.metricGroups[name].writer.WriteBuffered(record); err != nil {
+			perr.Err = fmt.Errorf("failed to write to file %q: %w", p.metricGroups[name].filename, err)
+			return &perr
 		}
+		perr.MetricsAccept = append(perr.MetricsAccept, accepted...)
 		record.Release()
+	}
+	if perr.Err != nil {
+		return &perr
 	}
 
 	return nil
@@ -155,23 +189,133 @@ func (p *Parquet) rotateIfNeeded(name string) error {
 }
 
 func (p *Parquet) createRecordBatch(metrics []telegraf.Metric, builder *array.RecordBuilder, schema *arrow.Schema) (arrow.RecordBatch, error) {
-	for index, col := range schema.Fields() {
-		for _, m := range metrics {
-			if p.TimestampFieldName != "" && col.Name == p.TimestampFieldName {
-				builder.Field(index).(*array.Int64Builder).Append(m.Time().UnixNano())
+	// Create a lookup table for the schema columns
+	columnTypes := make(map[string]arrow.DataType, len(schema.Fields()))
+	for _, col := range schema.Fields() {
+		switch col.Type {
+		case arrow.PrimitiveTypes.Int8,
+			arrow.PrimitiveTypes.Int16,
+			arrow.PrimitiveTypes.Int32,
+			arrow.PrimitiveTypes.Int64,
+			arrow.PrimitiveTypes.Uint8,
+			arrow.PrimitiveTypes.Uint16,
+			arrow.PrimitiveTypes.Uint32,
+			arrow.PrimitiveTypes.Uint64,
+			arrow.PrimitiveTypes.Float32,
+			arrow.PrimitiveTypes.Float64,
+			arrow.BinaryTypes.String,
+			arrow.FixedWidthTypes.Boolean:
+		default:
+			// Return the error directly as all metrics will fail here
+			return nil, fmt.Errorf("unsupported column type %q for column %q", col.Type.Name(), col.Name)
+		}
+		columnTypes[col.Name] = col.Type
+	}
+
+	var perr internal.PartialWriteError
+	for i, m := range metrics {
+		// Collect the row values in order of reverse precedence to add them to
+		// the columns. We need to do this intermediate step to remove metric
+		// rows with invalid types.
+		row := make(map[string]any, len(columnTypes))
+		for _, tag := range m.TagList() {
+			if _, found := columnTypes[tag.Key]; !found {
 				continue
 			}
-
-			// Try to get the value from a field first, then from a tag.
-			var value any
-			var ok bool
-			value, ok = m.GetField(col.Name)
-			if !ok {
-				value, ok = m.GetTag(col.Name)
+			row[tag.Key] = tag.Value
+		}
+		for _, field := range m.FieldList() {
+			if _, found := columnTypes[field.Key]; !found {
+				continue
 			}
+			row[field.Key] = field.Value
+		}
 
-			// if neither field nor tag exists, append a null value
-			if !ok {
+		if p.TimestampFieldName != "" {
+			row[p.TimestampFieldName] = m.Time().UnixNano()
+		}
+
+		// Check if the row values do match the corresponding schema column type
+		var err error
+		for name, value := range row {
+			ctype := columnTypes[name]
+
+			// Check if the value matches the schema type
+			switch value.(type) {
+			case int8:
+				if ctype != arrow.PrimitiveTypes.Int8 {
+					err = fmt.Errorf("invalid value %v (%T) for column %q (%s)", value, value, name, ctype.Name())
+					break
+				}
+			case int16:
+				if ctype != arrow.PrimitiveTypes.Int16 {
+					err = fmt.Errorf("invalid value %v (%T) for column %q (%s)", value, value, name, ctype.Name())
+					break
+				}
+			case int32:
+				if ctype != arrow.PrimitiveTypes.Int32 {
+					err = fmt.Errorf("invalid value %v (%T) for column %q (%s)", value, value, name, ctype.Name())
+					break
+				}
+			case int64:
+				if ctype != arrow.PrimitiveTypes.Int64 {
+					err = fmt.Errorf("invalid value %v (%T) for column %q (%s)", value, value, name, ctype.Name())
+					break
+				}
+			case uint8:
+				if ctype != arrow.PrimitiveTypes.Uint8 {
+					err = fmt.Errorf("invalid value %v (%T) for column %q (%s)", value, value, name, ctype.Name())
+					break
+				}
+			case uint16:
+				if ctype != arrow.PrimitiveTypes.Uint16 {
+					err = fmt.Errorf("invalid value %v (%T) for column %q (%s)", value, value, name, ctype.Name())
+					break
+				}
+			case uint32:
+				if ctype != arrow.PrimitiveTypes.Uint32 {
+					err = fmt.Errorf("invalid value %v (%T) for column %q (%s)", value, value, name, ctype.Name())
+					break
+				}
+			case uint64:
+				if ctype != arrow.PrimitiveTypes.Uint64 {
+					err = fmt.Errorf("invalid value %v (%T) for column %q (%s)", value, value, name, ctype.Name())
+					break
+				}
+			case float32:
+				if ctype != arrow.PrimitiveTypes.Float32 {
+					err = fmt.Errorf("invalid value %v (%T) for column %q (%s)", value, value, name, ctype.Name())
+					break
+				}
+			case float64:
+				if ctype != arrow.PrimitiveTypes.Float64 {
+					err = fmt.Errorf("invalid value %v (%T) for column %q (%s)", value, value, name, ctype.Name())
+					break
+				}
+			case string:
+				if ctype != arrow.BinaryTypes.String {
+					err = fmt.Errorf("invalid value %v (%T) for column %q (%s)", value, value, name, ctype.Name())
+					break
+				}
+			case bool:
+				if ctype != arrow.FixedWidthTypes.Boolean {
+					err = fmt.Errorf("invalid value %v (%T) for column %q (%s)", value, value, name, ctype.Name())
+					break
+				}
+			}
+		}
+		if err != nil {
+			perr.Err = err
+			perr.MetricsRejectErrors = append(perr.MetricsRejectErrors, err)
+			perr.MetricsReject = append(perr.MetricsReject, i)
+			continue
+		}
+
+		for index, col := range schema.Fields() {
+			value, found := row[col.Name]
+
+			// If no value exists for the column we append a null value
+			if !found {
 				switch col.Type {
 				case arrow.PrimitiveTypes.Int8:
 					builder.Field(index).(*array.Int8Builder).AppendNull()
@@ -197,10 +341,7 @@ func (p *Parquet) createRecordBatch(metrics []telegraf.Metric, builder *array.Re
 					builder.Field(index).(*array.StringBuilder).AppendNull()
 				case arrow.FixedWidthTypes.Boolean:
 					builder.Field(index).(*array.BooleanBuilder).AppendNull()
-				default:
-					return nil, fmt.Errorf("unsupported type: %T", value)
 				}
-
 				continue
 			}
 
@@ -229,13 +370,15 @@ func (p *Parquet) createRecordBatch(metrics []telegraf.Metric, builder *array.Re
 				builder.Field(index).(*array.StringBuilder).Append(value.(string))
 			case arrow.FixedWidthTypes.Boolean:
 				builder.Field(index).(*array.BooleanBuilder).Append(value.(bool))
-			default:
-				return nil, fmt.Errorf("unsupported type: %T", value)
 			}
 		}
+		perr.MetricsAccept = append(perr.MetricsAccept, i)
 	}
 
 	record := builder.NewRecordBatch()
+	if len(perr.MetricsReject) > 0 {
+		return record, &perr
+	}
 	return record, nil
 }
 

--- a/plugins/outputs/parquet/parquet.go
+++ b/plugins/outputs/parquet/parquet.go
@@ -134,7 +134,7 @@ func (p *Parquet) Write(metrics []telegraf.Metric) error {
 			if errors.As(err, &crbErr) {
 				accepted = make([]int, 0, len(perr.MetricsAccept))
 				for _, idx := range crbErr.MetricsAccept {
-					perr.MetricsAccept = append(perr.MetricsAccept, metricIndices[name][idx])
+					accepted = append(accepted, metricIndices[name][idx])
 				}
 				for _, idx := range crbErr.MetricsReject {
 					perr.MetricsReject = append(perr.MetricsReject, metricIndices[name][idx])
@@ -146,9 +146,9 @@ func (p *Parquet) Write(metrics []telegraf.Metric) error {
 				perr.MetricsRejectErrors = append(perr.MetricsRejectErrors, fmt.Errorf("failed to create record for file %q: %w", name, err))
 			}
 			perr.Err = fmt.Errorf("failed to create record for file %q: %w", p.metricGroups[name].filename, err)
-			if len(accepted) > 0 {
-				continue
-			}
+		}
+		if len(accepted) == 0 || record == nil {
+			continue
 		}
 		if err := p.metricGroups[name].writer.WriteBuffered(record); err != nil {
 			perr.Err = fmt.Errorf("failed to write to file %q: %w", p.metricGroups[name].filename, err)

--- a/plugins/outputs/parquet/parquet_test.go
+++ b/plugins/outputs/parquet/parquet_test.go
@@ -12,19 +12,18 @@ import (
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
+	"github.com/influxdata/telegraf/internal"
 	"github.com/influxdata/telegraf/metric"
 	"github.com/influxdata/telegraf/testutil"
 )
 
-func TestCases(t *testing.T) {
-	type testcase struct {
+func TestGather(t *testing.T) {
+	tests := []struct {
 		name       string
 		metrics    []telegraf.Metric
 		numRows    int
 		numColumns int
-	}
-
-	var testcases = []testcase{
+	}{
 		{
 			name: "basic single metric",
 			metrics: []telegraf.Metric{
@@ -124,8 +123,8 @@ func TestCases(t *testing.T) {
 		},
 	}
 
-	for _, tc := range testcases {
-		t.Run(tc.name, func(t *testing.T) {
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
 			testDir := t.TempDir()
 			plugin := &Parquet{
 				Directory:          testDir,
@@ -133,7 +132,7 @@ func TestCases(t *testing.T) {
 			}
 			require.NoError(t, plugin.Init())
 			require.NoError(t, plugin.Connect())
-			require.NoError(t, plugin.Write(tc.metrics))
+			require.NoError(t, plugin.Write(tt.metrics))
 			require.NoError(t, plugin.Close())
 
 			// Read metrics from parquet file
@@ -145,8 +144,113 @@ func TestCases(t *testing.T) {
 			defer reader.Close()
 
 			metadata := reader.MetaData()
-			require.Equal(t, tc.numRows, int(metadata.NumRows))
-			require.Equal(t, tc.numColumns, metadata.Schema.NumColumns())
+			require.Equal(t, tt.numRows, int(metadata.NumRows))
+			require.Equal(t, tt.numColumns, metadata.Schema.NumColumns())
+		})
+	}
+}
+
+func TestPartialWrite(t *testing.T) {
+	tests := []struct {
+		name          string
+		noPermissions bool
+		metrics       []telegraf.Metric
+		numRows       int
+		numColumns    int
+		expected      string
+		accepted      []int
+		rejected      []int
+	}{
+		{
+			name:          "create writer failed",
+			noPermissions: true,
+			metrics: []telegraf.Metric{
+				metric.New(
+					"test",
+					map[string]string{},
+					map[string]interface{}{
+						"value": 1.0,
+					},
+					time.Now(),
+				),
+			},
+			expected: "failed to create writer for file",
+		},
+		{
+			name: "schema mismatch",
+			metrics: []telegraf.Metric{
+				metric.New(
+					"test",
+					map[string]string{},
+					map[string]interface{}{
+						"value": int8(1),
+					},
+					time.Now(),
+				),
+				metric.New(
+					"test",
+					map[string]string{},
+					map[string]interface{}{
+						"value": "2",
+					},
+					time.Now(),
+				),
+				metric.New(
+					"test",
+					map[string]string{},
+					map[string]interface{}{
+						"value": int8(3),
+					},
+					time.Now(),
+				),
+			},
+			numRows:    2,
+			numColumns: 2,
+			expected:   "invalid value 2 (string) for column \"value\" (int64)",
+			accepted:   []int{0, 2},
+			rejected:   []int{1},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			path := tmpDir
+			if tt.noPermissions {
+				path = filepath.Join(tmpDir, "no_permissions")
+				require.NoError(t, os.MkdirAll(path, 0500))
+			}
+
+			plugin := &Parquet{
+				Directory:          path,
+				TimestampFieldName: defaultTimestampFieldName,
+			}
+			require.NoError(t, plugin.Init())
+			require.NoError(t, plugin.Connect())
+			defer plugin.Close()
+			var perr *internal.PartialWriteError
+			require.ErrorAs(t, plugin.Write(tt.metrics), &perr)
+			require.NoError(t, plugin.Close())
+			require.ErrorContains(t, perr.Err, tt.expected)
+			require.ElementsMatch(t, perr.MetricsAccept, tt.accepted)
+			require.ElementsMatch(t, perr.MetricsReject, tt.rejected)
+
+			// Read metrics from parquet file
+			files, err := os.ReadDir(path)
+			require.NoError(t, err)
+			if tt.numRows == 0 {
+				require.Empty(t, files)
+				return
+			}
+			require.Len(t, files, 1)
+
+			reader, err := file.OpenParquetFile(filepath.Join(path, files[0].Name()), false)
+			require.NoError(t, err)
+			defer reader.Close()
+
+			metadata := reader.MetaData()
+			require.Equal(t, tt.numRows, int(metadata.NumRows), "wrong number of rows")
+			require.Equal(t, tt.numColumns, metadata.Schema.NumColumns(), "wrong number of columns")
 		})
 	}
 }

--- a/plugins/outputs/parquet/parquet_test.go
+++ b/plugins/outputs/parquet/parquet_test.go
@@ -166,7 +166,7 @@ func TestPartialWrite(t *testing.T) {
 			noPermissions: true,
 			metrics: []telegraf.Metric{
 				metric.New(
-					"test",
+					"test/sub",
 					map[string]string{},
 					map[string]interface{}{
 						"value": 1.0,
@@ -214,12 +214,7 @@ func TestPartialWrite(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tmpDir := t.TempDir()
-			path := tmpDir
-			if tt.noPermissions {
-				path = filepath.Join(tmpDir, "no_permissions")
-				require.NoError(t, os.MkdirAll(path, 0500))
-			}
+			path := t.TempDir()
 
 			plugin := &Parquet{
 				Directory:          path,

--- a/plugins/outputs/parquet/parquet_test.go
+++ b/plugins/outputs/parquet/parquet_test.go
@@ -152,18 +152,16 @@ func TestGather(t *testing.T) {
 
 func TestPartialWrite(t *testing.T) {
 	tests := []struct {
-		name          string
-		noPermissions bool
-		metrics       []telegraf.Metric
-		numRows       int
-		numColumns    int
-		expected      string
-		accepted      []int
-		rejected      []int
+		name       string
+		metrics    []telegraf.Metric
+		numRows    int
+		numColumns int
+		expected   string
+		accepted   []int
+		rejected   []int
 	}{
 		{
-			name:          "create writer failed",
-			noPermissions: true,
+			name: "create writer failed",
 			metrics: []telegraf.Metric{
 				metric.New(
 					"test/sub",


### PR DESCRIPTION
## Summary

This PR introduces partial write errors for the parquet output as a prerequisite for PR #19573. As a side effect, metrics not following the file schema will be rejected and are not causing panic.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

related to #19573 
superseeds #19560
superseeds #19554