### PR TITLE
chore(ci): Disable testcontainers ryuk reaper in integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -181,6 +181,12 @@ jobs:
           no_output_timeout: 30m
           environment:
             AZURE_EVENT_HUBS_EMULATOR_ACCEPT_EULA: yes
+            # The job runs on an ephemeral VM, so ryuk provides no cleanup value.
+            # Disabling it avoids a reaper lifecycle race: all packages of one
+            # "go test ./..." run share a single ryuk container, which exits 10s
+            # after the last test process disconnects; the next package then finds
+            # the dead container and times out waiting for it to become ready.
+            TESTCONTAINERS_RYUK_DISABLED: "true"
   test-go-mac:
     executor: mac
     steps:


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->
The test-integration job fails a few times a week with a single test dying on `reaper: from container "xxxx": wait for reaper xxxx: context deadline exceeded` (recently always `TestIntegrationArtemis` in jolokia2_agent, e.g. jobs 551595, 551618, 551879, 551886, 551994, 552040). All test package processes of one `go test ./...` invocation share a single ryuk container, and ryuk exits 10 seconds after the last test process disconnects. In a full `./...` run there are natural gaps with no active container tests, so ryuk legitimately dies mid-run; the next package that needs a container then finds the dead ryuk container (testcontainers-go looks it up with `All: true` and no running-state filter) and spends 60 seconds waiting for it to become ready before failing. The same package keeps getting hit because package scheduling on the fixed runner is roughly deterministic.

Ryuk only exists to clean up leaked containers, and the job runs on an ephemeral CircleCI machine VM that is destroyed after the job, so it provides no value here. Disabling it removes the whole reaper code path and with it this failure mode.

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #19605