### PR TITLE
feat(outputs.parquet): Start a new file when the column schema changes

### DIFF
--- a/plugins/outputs/parquet/README.md
+++ b/plugins/outputs/parquet/README.md
@@ -4,7 +4,8 @@ This plugin writes metrics to [parquet][parquet] files. By default, metrics are
 grouped by metric name and written all to the same file.
 
 > [!IMPORTANT]
-> If a metric schema does not match the schema in the file it will be dropped.
+> A parquet file fixes its schema when it is created. When new fields or tags
+> appear, the plugin starts a new file so those columns are not dropped.
 
 To lean more about the parquet format, check out the [parquet docs][docs] as
 well as a blog post on [querying parquet][querying].
@@ -35,7 +36,8 @@ plugin ordering. See [CONFIGURATION.md][CONFIGURATION.md] for more details.
   # directory = "."
 
   ## Files are rotated after the time interval specified. When set to 0 no time
-  ## based rotation is performed.
+  ## based rotation is performed. Files also rotate when new fields or tags
+  ## appear so those columns are written instead of dropped.
   # rotation_interval = "0h"
 
   ## Timestamp field name
@@ -59,8 +61,13 @@ metrics to generate the schema. Subsequent flush intervals are significantly
 faster.
 
 When writing to a file, the schema is used to look for each value and if it is
-not present a null value is added. The result is that if additional fields are
-present after the first metric flush those fields are omitted.
+not present a null value is added. If additional fields or tags appear after
+the file is created, the plugin closes that file and starts a new one whose
+schema includes the new columns. Earlier columns are kept so missing values
+are still written as null. Rotation for a schema change is logged.
+
+Because files in the directory can have different columns, readers should join
+by column name (for example DuckDB `union_by_name = true`).
 
 The `timestamp_field_name` column holds the metric time, so a field or tag with
 that same name is dropped and logged. Set `timestamp_field_name` to another name
@@ -90,8 +97,9 @@ If a file with the same target name exists at start, the existing file is
 rotated to avoid over-writing it or conflicting schema.
 
 File rotation is available via a time based interval that a user can optionally
-set. Due to the usage of a buffered writer, a size based rotation is not
-possible as the file may not actually get data at each interval.
+set. Files are also rotated when the column schema grows. Due to the usage of a
+buffered writer, a size based rotation is not possible as the file may not
+actually get data at each interval.
 
 ## Explore Parquet Files
 

--- a/plugins/outputs/parquet/parquet.go
+++ b/plugins/outputs/parquet/parquet.go
@@ -244,7 +244,7 @@ func (p *Parquet) rotateFile(name string) error {
 	return nil
 }
 
-func (_ *Parquet) newColumns(schema *arrow.Schema, metrics []telegraf.Metric) ([]arrow.Field, []string, error) {
+func (*Parquet) newColumns(schema *arrow.Schema, metrics []telegraf.Metric) ([]arrow.Field, []string, error) {
 	known := make(map[string]struct{}, len(schema.Fields()))
 	for _, field := range schema.Fields() {
 		known[field.Name] = struct{}{}

--- a/plugins/outputs/parquet/parquet.go
+++ b/plugins/outputs/parquet/parquet.go
@@ -244,7 +244,7 @@ func (p *Parquet) rotateFile(name string) error {
 	return nil
 }
 
-func (p *Parquet) newColumns(schema *arrow.Schema, metrics []telegraf.Metric) ([]arrow.Field, []string, error) {
+func (_ *Parquet) newColumns(schema *arrow.Schema, metrics []telegraf.Metric) ([]arrow.Field, []string, error) {
 	known := make(map[string]struct{}, len(schema.Fields()))
 	for _, field := range schema.Fields() {
 		known[field.Name] = struct{}{}

--- a/plugins/outputs/parquet/parquet.go
+++ b/plugins/outputs/parquet/parquet.go
@@ -7,7 +7,9 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/apache/arrow-go/v18/arrow"
@@ -143,6 +145,11 @@ func (p *Parquet) Write(metrics []telegraf.Metric) error {
 				schema:   schema,
 				writer:   writer,
 			}
+		} else if err := p.rotateIfSchemaChanged(name, metrics); err != nil {
+			perr.MetricsReject = append(perr.MetricsReject, metricIndices[name]...)
+			perr.MetricsRejectErrors = append(perr.MetricsRejectErrors, fmt.Errorf("failed to rotate file %q: %w", p.metricGroups[name].filename, err))
+			perr.Err = fmt.Errorf("failed to rotate file %q: %w", p.metricGroups[name].filename, err)
+			continue
 		}
 
 		if p.RotationInterval != 0 {
@@ -202,6 +209,28 @@ func (p *Parquet) rotateIfNeeded(name string) error {
 		return nil
 	}
 
+	return p.rotateFile(name)
+}
+
+func (p *Parquet) rotateIfSchemaChanged(name string, metrics []telegraf.Metric) error {
+	extra, added, err := p.newColumns(p.metricGroups[name].schema, metrics)
+	if err != nil {
+		return err
+	}
+	if len(extra) == 0 {
+		return nil
+	}
+
+	slices.Sort(added)
+	p.Log.Infof("Starting a new file for %q to add column(s) %s", name, strings.Join(added, ", "))
+
+	p.metricGroups[name].builder.Release()
+	p.metricGroups[name].schema = p.schemaWithNewColumns(p.metricGroups[name].schema, extra)
+	p.metricGroups[name].builder = array.NewRecordBuilder(memory.DefaultAllocator, p.metricGroups[name].schema)
+	return p.rotateFile(name)
+}
+
+func (p *Parquet) rotateFile(name string) error {
 	if err := p.metricGroups[name].writer.Close(); err != nil {
 		return fmt.Errorf("failed to close file for rotation %q: %w", p.metricGroups[name].filename, err)
 	}
@@ -213,6 +242,69 @@ func (p *Parquet) rotateIfNeeded(name string) error {
 	p.metricGroups[name].writer = writer
 
 	return nil
+}
+
+func (p *Parquet) newColumns(schema *arrow.Schema, metrics []telegraf.Metric) ([]arrow.Field, []string, error) {
+	known := make(map[string]struct{}, len(schema.Fields()))
+	for _, field := range schema.Fields() {
+		known[field.Name] = struct{}{}
+	}
+
+	var extra []arrow.Field
+	var added []string
+	for _, metric := range metrics {
+		for _, field := range metric.FieldList() {
+			if _, exists := known[field.Key]; exists {
+				continue
+			}
+			arrowType, err := goToArrowType(field.Value)
+			if err != nil {
+				return nil, nil, fmt.Errorf("error converting '%s=%s' field to arrow type: %w", field.Key, field.Value, err)
+			}
+			known[field.Key] = struct{}{}
+			added = append(added, field.Key)
+			extra = append(extra, arrow.Field{
+				Name:     field.Key,
+				Type:     arrowType,
+				Nullable: true,
+			})
+		}
+		for _, tag := range metric.TagList() {
+			if _, exists := known[tag.Key]; exists {
+				continue
+			}
+			known[tag.Key] = struct{}{}
+			added = append(added, tag.Key)
+			extra = append(extra, arrow.Field{
+				Name:     tag.Key,
+				Type:     arrow.BinaryTypes.String,
+				Nullable: true,
+			})
+		}
+	}
+
+	return extra, added, nil
+}
+
+func (p *Parquet) schemaWithNewColumns(schema *arrow.Schema, extra []arrow.Field) *arrow.Schema {
+	old := schema.Fields()
+	fields := make([]arrow.Field, 0, len(old)+len(extra))
+	var timestamp arrow.Field
+	hasTimestamp := false
+	for _, field := range old {
+		if p.TimestampFieldName != "" && field.Name == p.TimestampFieldName {
+			timestamp = field
+			hasTimestamp = true
+			continue
+		}
+		fields = append(fields, field)
+	}
+	fields = append(fields, extra...)
+	if hasTimestamp {
+		fields = append(fields, timestamp)
+	}
+
+	return arrow.NewSchema(fields, nil)
 }
 
 func (p *Parquet) createRecordBatch(metrics []telegraf.Metric, builder *array.RecordBuilder, schema *arrow.Schema) (arrow.RecordBatch, error) {
@@ -445,11 +537,21 @@ func (p *Parquet) createSchema(metrics []telegraf.Metric) (*arrow.Schema, error)
 	return arrow.NewSchema(fields, nil), nil
 }
 
+func (p *Parquet) unusedFilename(name string) string {
+	now := time.Now()
+	prefix := fmt.Sprintf("%s-%s-%s", name, now.Format("2006-01-02"), strconv.FormatInt(now.Unix(), 10))
+	filename := prefix + ".parquet"
+	for n := 1; ; n++ {
+		if _, err := p.root.Stat(filename); err != nil {
+			return filename
+		}
+		filename = fmt.Sprintf("%s-%d.parquet", prefix, n)
+	}
+}
+
 func (p *Parquet) createWriter(name, filename string, schema *arrow.Schema) (*pqarrow.FileWriter, error) {
 	if _, err := p.root.Stat(filename); err == nil {
-		now := time.Now()
-		rotatedFilename := fmt.Sprintf("%s-%s-%s.parquet", name, now.Format("2006-01-02"), strconv.FormatInt(now.Unix(), 10))
-		if err := p.root.Rename(filename, rotatedFilename); err != nil {
+		if err := p.root.Rename(filename, p.unusedFilename(name)); err != nil {
 			return nil, fmt.Errorf("failed to rename file %q: %w", filename, err)
 		}
 	}

--- a/plugins/outputs/parquet/parquet_test.go
+++ b/plugins/outputs/parquet/parquet_test.go
@@ -539,3 +539,92 @@ func TestCannotEscapeDirectory(t *testing.T) {
 		})
 	}
 }
+
+func columnNames(t *testing.T, path string) []string {
+	t.Helper()
+
+	reader, err := file.OpenParquetFile(path, false)
+	require.NoError(t, err)
+	defer reader.Close()
+
+	schema := reader.MetaData().Schema
+	names := make([]string, 0, schema.NumColumns())
+	for i := 0; i < schema.NumColumns(); i++ {
+		names = append(names, schema.Column(i).Name())
+	}
+
+	return names
+}
+
+func TestNewColumnStartsANewFile(t *testing.T) {
+	dir := t.TempDir()
+	p := &Parquet{Directory: dir, TimestampFieldName: "timestamp", Log: testutil.Logger{}}
+	require.NoError(t, p.Init())
+
+	require.NoError(t, p.Write([]telegraf.Metric{
+		metric.New("demo", nil, map[string]interface{}{"a": int64(1)}, time.Now()),
+	}))
+	require.NoError(t, p.Write([]telegraf.Metric{
+		metric.New("demo", nil, map[string]interface{}{"a": int64(2), "b": int64(3)}, time.Now()),
+	}))
+	require.NoError(t, p.Close())
+
+	written, err := filepath.Glob(filepath.Join(dir, "*.parquet"))
+	require.NoError(t, err)
+	require.Len(t, written, 2)
+
+	schemas := make([][]string, 0, len(written))
+	var rows int64
+	for _, name := range written {
+		schemas = append(schemas, columnNames(t, name))
+		reader, err := file.OpenParquetFile(name, false)
+		require.NoError(t, err)
+		rows += reader.NumRows()
+		require.NoError(t, reader.Close())
+	}
+	require.ElementsMatch(t, [][]string{{"a", "timestamp"}, {"a", "b", "timestamp"}}, schemas)
+	require.Equal(t, int64(2), rows)
+}
+
+func TestNewTagStartsANewFile(t *testing.T) {
+	dir := t.TempDir()
+	p := &Parquet{Directory: dir, TimestampFieldName: "timestamp", Log: testutil.Logger{}}
+	require.NoError(t, p.Init())
+
+	require.NoError(t, p.Write([]telegraf.Metric{
+		metric.New("demo", nil, map[string]interface{}{"a": int64(1)}, time.Now()),
+	}))
+	require.NoError(t, p.Write([]telegraf.Metric{
+		metric.New("demo", map[string]string{"host": "box"}, map[string]interface{}{"a": int64(2)}, time.Now()),
+	}))
+	require.NoError(t, p.Close())
+
+	written, err := filepath.Glob(filepath.Join(dir, "*.parquet"))
+	require.NoError(t, err)
+	require.Len(t, written, 2)
+
+	schemas := make([][]string, 0, len(written))
+	for _, name := range written {
+		schemas = append(schemas, columnNames(t, name))
+	}
+	require.ElementsMatch(t, [][]string{{"a", "timestamp"}, {"a", "host", "timestamp"}}, schemas)
+}
+
+func TestOmittedFieldKeepsTheSameFile(t *testing.T) {
+	dir := t.TempDir()
+	p := &Parquet{Directory: dir, TimestampFieldName: "timestamp", Log: testutil.Logger{}}
+	require.NoError(t, p.Init())
+
+	require.NoError(t, p.Write([]telegraf.Metric{
+		metric.New("demo", nil, map[string]interface{}{"a": int64(1), "b": int64(2)}, time.Now()),
+	}))
+	require.NoError(t, p.Write([]telegraf.Metric{
+		metric.New("demo", nil, map[string]interface{}{"a": int64(3)}, time.Now()),
+	}))
+	require.NoError(t, p.Close())
+
+	written, err := filepath.Glob(filepath.Join(dir, "*.parquet"))
+	require.NoError(t, err)
+	require.Len(t, written, 1)
+	require.ElementsMatch(t, []string{"a", "b", "timestamp"}, columnNames(t, written[0]))
+}

--- a/plugins/outputs/parquet/sample.conf
+++ b/plugins/outputs/parquet/sample.conf
@@ -5,7 +5,8 @@
   # directory = "."
 
   ## Files are rotated after the time interval specified. When set to 0 no time
-  ## based rotation is performed.
+  ## based rotation is performed. Files also rotate when new fields or tags
+  ## appear so those columns are written instead of dropped.
   # rotation_interval = "0h"
 
   ## Timestamp field name


### PR DESCRIPTION
Parquet files freeze their schema on creation, so fields that first appeared after the initial flush were silently dropped with no warning. The plugin now starts a new file with the extra columns, matching existing time-based rotation. Missing values in the new file are still written as null.

## Checklist

- [ ] No AI generated code was used in this PR
- [x] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

resolves #19563