### PR TITLE
fix(outputs.postgresql): report a missing table instead of panicking

### DIFF
--- a/plugins/outputs/postgresql/sqltemplate/template.go
+++ b/plugins/outputs/postgresql/sqltemplate/template.go
@@ -115,6 +115,7 @@ package sqltemplate
 import (
 	"bytes"
 	"encoding/base32"
+	"errors"
 	"fmt"
 	"hash/fnv"
 	"strings"
@@ -390,6 +391,13 @@ func (t *Template) UnmarshalText(text []byte) error {
 }
 
 func (t *Template) Render(table *Table, newColumns []utils.Column, metricTable, tagTable *Table) ([]byte, error) {
+	// NewTable returns nil for an empty table name, and every template needs a
+	// table to render against, so report that instead of dereferencing it and
+	// taking the agent down with a segfault.
+	if table == nil {
+		return nil, errors.New("cannot render template without a table")
+	}
+
 	tcs := NewColumns(newColumns).Sorted()
 	data := map[string]interface{}{
 		"table":       table,

--- a/plugins/outputs/postgresql/sqltemplate/template_test.go
+++ b/plugins/outputs/postgresql/sqltemplate/template_test.go
@@ -1,0 +1,27 @@
+package sqltemplate
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/influxdata/telegraf/plugins/outputs/postgresql/utils"
+)
+
+func TestRenderWithoutTable(t *testing.T) {
+	// NewTable returns nil when the table name is empty, and Render used to
+	// dereference it while building "allColumns", taking the agent down with
+	// a segfault instead of reporting the problem.
+	tmpl := &Template{}
+	require.NoError(t, tmpl.UnmarshalText([]byte(`CREATE TABLE {{ .table }} ({{ .columns }})`)))
+
+	columns := []utils.Column{{Name: "time", Type: "timestamptz", Role: utils.TimeColType}}
+	metricTable := NewTable("public", "metrics", columns)
+
+	_, err := tmpl.Render(NewTable("", "", nil), columns, metricTable, nil)
+	require.ErrorContains(t, err, "cannot render template without a table")
+
+	sql, err := tmpl.Render(metricTable, columns, metricTable, nil)
+	require.NoError(t, err)
+	require.Equal(t, `CREATE TABLE "public"."metrics" ("time" timestamptz)`, string(sql))
+}


### PR DESCRIPTION
Fixes #19501.

`Render` builds `allColumns` with `tcs.Concat(table.Columns)` without checking `table`, and `NewTable` returns nil whenever the table name is empty. A nil table therefore segfaults inside the template render and takes the agent down, which is the crash in the report:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x6b5f965]
sqltemplate.(*Template).Render(...)
        plugins/outputs/postgresql/sqltemplate/template.go:397
```

I reproduced that exact frame from a unit test by handing `Render` the nil that `NewTable("", "", nil)` returns, so it is reachable from any caller that ends up with an empty table name, not only through the reported configuration.

`Render` now returns `cannot render template without a table` instead. The write then fails the way any other schema error does, gets logged by the table manager, and the agent keeps running.

To be clear about the scope: this stops the crash and turns it into a reportable error, but it does not explain how the table state reaches `update` with an empty name in the reporter's setup. That is worth chasing separately, and this change makes it visible in the logs instead of a stack trace.

`TestRenderWithoutTable` covers both directions, the nil table erroring and an ordinary table still rendering. It panics on master rather than failing.

`go test ./plugins/outputs/postgresql/...` passes.
