### PR TITLE
fix(inputs.opcua): Respect the server's MaxNodesPerRead limit

### DIFF
--- a/plugins/inputs/opcua/opcua_test.go
+++ b/plugins/inputs/opcua/opcua_test.go
@@ -237,7 +237,7 @@ func TestReadClientBatchedReads(t *testing.T) {
 	}
 
 	require.NoError(t, srv.Start(t.Context()))
-	t.Cleanup(func() { _ = srv.Close() })
+	defer srv.Close()
 	require.Eventually(t, func() bool {
 		c, err := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", port), 100*time.Millisecond)
 		if err != nil {

--- a/plugins/inputs/opcua/opcua_test.go
+++ b/plugins/inputs/opcua/opcua_test.go
@@ -2,9 +2,13 @@ package opcua
 
 import (
 	"fmt"
+	"net"
+	"strconv"
 	"testing"
 	"time"
 
+	"github.com/gopcua/opcua/server"
+	"github.com/gopcua/opcua/ua"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go/wait"
 
@@ -200,69 +204,77 @@ func TestReadClientIntegration(t *testing.T) {
 	}
 }
 
-func TestReadClientBatchedReadsIntegration(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping integration test in short mode")
+func TestReadClientBatchedReads(t *testing.T) {
+	// Bind a free port up front; close the listener so the server can
+	// claim it.
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := l.Addr().(*net.TCPAddr).Port
+	require.NoError(t, l.Close())
+
+	// The in-process server reports a MaxNodesPerRead limit of 32, so
+	// registering more nodes than that makes the client split the read
+	// according to the limit it discovers on connect.
+	srv := server.New(
+		server.EnableSecurity("None", ua.MessageSecurityModeNone),
+		server.EnableAuthMode(ua.UserTokenTypeAnonymous),
+		server.EndPoint("127.0.0.1", port),
+	)
+	ns := server.NewNodeNameSpace(srv, "telegraf-test")
+	srv.AddNamespace(ns)
+
+	const nodes = 40
+	rootNodes := make([]input.NodeSettings, 0, nodes)
+	for i := range int32(nodes) {
+		name := "node" + strconv.Itoa(int(i))
+		ns.AddNode(server.NewVariableNode(ua.NewStringNodeID(ns.ID(), name), name, i))
+		rootNodes = append(rootNodes, input.NodeSettings{
+			FieldName:      name,
+			Namespace:      strconv.Itoa(int(ns.ID())),
+			IdentifierType: "s",
+			Identifier:     name,
+		})
 	}
 
-	container := testutil.Container{
-		Image:        "open62541/open62541",
-		ExposedPorts: []string{servicePort},
-		WaitingFor: wait.ForAll(
-			wait.ForListeningPort(servicePort),
-			wait.ForLog("TCP network layer listening on opc.tcp://"),
-		),
-	}
-	require.NoError(t, container.Start(), "failed to start container")
-	defer container.Terminate()
-
-	testopctags := []opcTags{
-		{"ProductName", "0", "i", "2261", "open62541 OPC UA Server"},
-		{"ProductUri", "0", "i", "2262", "http://open62541.org"},
-		{"ManufacturerName", "0", "i", "2263", "open62541"},
-		{"badnode", "1", "i", "1337", nil},
-		{"goodnode", "1", "s", "the.answer", int32(42)},
-		{"DateTime", "1", "i", "51037", "0001-01-01T00:00:00Z"},
-	}
+	require.NoError(t, srv.Start(t.Context()))
+	t.Cleanup(func() { _ = srv.Close() })
+	require.Eventually(t, func() bool {
+		c, err := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", port), 100*time.Millisecond)
+		if err != nil {
+			return false
+		}
+		_ = c.Close()
+		return true
+	}, 5*time.Second, 50*time.Millisecond)
 
 	readConfig := readClientConfig{
 		InputClientConfig: input.InputClientConfig{
 			OpcUAClientConfig: opcua.OpcUAClientConfig{
-				Endpoint:       fmt.Sprintf("opc.tcp://%s:%s", container.Address, container.Ports[servicePort]),
+				Endpoint:       fmt.Sprintf("opc.tcp://127.0.0.1:%d", port),
 				SecurityPolicy: "None",
 				SecurityMode:   "None",
 				AuthMethod:     "Anonymous",
 				ConnectTimeout: config.Duration(10 * time.Second),
 				RequestTimeout: config.Duration(1 * time.Second),
-				Workarounds:    opcua.OpcUAWorkarounds{},
 			},
 			MetricName: "testing",
-			RootNodes:  make([]input.NodeSettings, 0),
-			Groups:     make([]input.NodeGroupSettings, 0),
+			RootNodes:  rootNodes,
 		},
 	}
-
-	for _, tags := range testopctags {
-		readConfig.RootNodes = append(readConfig.RootNodes, mapOPCTag(tags))
-	}
-
 	client, err := readConfig.createReadClient(testutil.Logger{})
 	require.NoError(t, err)
 	require.NoError(t, client.connect())
+	defer client.Disconnect(t.Context())
+	require.Equal(t, 32, client.maxNodesPerRead)
 
 	// Clear the values received on connect so the assertions below prove the
 	// batched read actually updated every node
 	for i := range client.LastReceivedData {
 		client.LastReceivedData[i].Value = nil
 	}
-
-	// Force splitting the six nodes into unevenly sized read batches,
-	// regardless of the limit reported by the server
-	client.maxNodesPerRead = 4
 	require.NoError(t, client.read())
-
 	for i, v := range client.LastReceivedData {
-		require.Equal(t, testopctags[i].want, v.Value)
+		require.EqualValues(t, i, v.Value)
 	}
 }
 

--- a/plugins/inputs/opcua/opcua_test.go
+++ b/plugins/inputs/opcua/opcua_test.go
@@ -200,6 +200,72 @@ func TestReadClientIntegration(t *testing.T) {
 	}
 }
 
+func TestReadClientBatchedReadsIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	container := testutil.Container{
+		Image:        "open62541/open62541",
+		ExposedPorts: []string{servicePort},
+		WaitingFor: wait.ForAll(
+			wait.ForListeningPort(servicePort),
+			wait.ForLog("TCP network layer listening on opc.tcp://"),
+		),
+	}
+	require.NoError(t, container.Start(), "failed to start container")
+	defer container.Terminate()
+
+	testopctags := []opcTags{
+		{"ProductName", "0", "i", "2261", "open62541 OPC UA Server"},
+		{"ProductUri", "0", "i", "2262", "http://open62541.org"},
+		{"ManufacturerName", "0", "i", "2263", "open62541"},
+		{"badnode", "1", "i", "1337", nil},
+		{"goodnode", "1", "s", "the.answer", int32(42)},
+		{"DateTime", "1", "i", "51037", "0001-01-01T00:00:00Z"},
+	}
+
+	readConfig := readClientConfig{
+		InputClientConfig: input.InputClientConfig{
+			OpcUAClientConfig: opcua.OpcUAClientConfig{
+				Endpoint:       fmt.Sprintf("opc.tcp://%s:%s", container.Address, container.Ports[servicePort]),
+				SecurityPolicy: "None",
+				SecurityMode:   "None",
+				AuthMethod:     "Anonymous",
+				ConnectTimeout: config.Duration(10 * time.Second),
+				RequestTimeout: config.Duration(1 * time.Second),
+				Workarounds:    opcua.OpcUAWorkarounds{},
+			},
+			MetricName: "testing",
+			RootNodes:  make([]input.NodeSettings, 0),
+			Groups:     make([]input.NodeGroupSettings, 0),
+		},
+	}
+
+	for _, tags := range testopctags {
+		readConfig.RootNodes = append(readConfig.RootNodes, mapOPCTag(tags))
+	}
+
+	client, err := readConfig.createReadClient(testutil.Logger{})
+	require.NoError(t, err)
+	require.NoError(t, client.connect())
+
+	// Clear the values received on connect so the assertions below prove the
+	// batched read actually updated every node
+	for i := range client.LastReceivedData {
+		client.LastReceivedData[i].Value = nil
+	}
+
+	// Force splitting the six nodes into unevenly sized read batches,
+	// regardless of the limit reported by the server
+	client.maxNodesPerRead = 4
+	require.NoError(t, client.read())
+
+	for i, v := range client.LastReceivedData {
+		require.Equal(t, testopctags[i].want, v.Value)
+	}
+}
+
 func TestReadClientIntegrationAdditionalFields(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")

--- a/plugins/inputs/opcua/read_client.go
+++ b/plugins/inputs/opcua/read_client.go
@@ -4,8 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
+	"slices"
 	"time"
 
+	"github.com/gopcua/opcua/id"
 	"github.com/gopcua/opcua/ua"
 
 	"github.com/influxdata/telegraf"
@@ -39,9 +42,10 @@ type readClient struct {
 	Workarounds             readClientWorkarounds
 
 	// Internal flags
-	reqIDs         []*ua.ReadValueID
-	ctx            context.Context
-	forceReconnect bool
+	reqIDs          []*ua.ReadValueID
+	maxNodesPerRead int
+	ctx             context.Context
+	forceReconnect  bool
 }
 
 func (rc *readClientConfig) createReadClient(log telegraf.Logger) (*readClient, error) {
@@ -95,6 +99,28 @@ func (o *readClient) connect() error {
 	if err := o.OpcUAClient.UpdateNamespaceArray(o.ctx); err != nil {
 		o.Log.Warnf("Failed to fetch namespace array: %v", err)
 		// Continue anyway - this is only needed if using namespace URIs
+	}
+
+	// Query the server-imposed limit on nodes per read request so large node
+	// sets can be split accordingly. The property is optional and zero means
+	// "no limit"; in both cases all nodes are sent in a single request.
+	o.maxNodesPerRead = 0
+	limits, err := o.Client.Read(o.ctx, &ua.ReadRequest{
+		NodesToRead: []*ua.ReadValueID{{
+			NodeID: ua.NewNumericNodeID(0, id.Server_ServerCapabilities_OperationLimits_MaxNodesPerRead),
+		}},
+	})
+	switch {
+	case err != nil:
+		o.Log.Debugf("Querying the server's read limit failed: %v", err)
+	case len(limits.Results) == 1 && limits.Results[0].Status == ua.StatusOK && limits.Results[0].Value != nil:
+		if v, ok := limits.Results[0].Value.Value().(uint32); ok && v > 0 {
+			// Clamp to avoid overflowing int on 32-bit platforms
+			o.maxNodesPerRead = int(min(v, math.MaxInt32))
+			o.Log.Debugf("Server limits read requests to %d nodes", v)
+		}
+	default:
+		o.Log.Debug("Server does not report a read limit")
 	}
 
 	// Browse-based discovery runs on every connect so server-side schema
@@ -200,10 +226,15 @@ func (o *readClient) currentValues() ([]telegraf.Metric, error) {
 }
 
 func (o *readClient) read() error {
-	req := &ua.ReadRequest{
-		MaxAge:             2000,
-		TimestampsToReturn: ua.TimestampsToReturnBoth,
-		NodesToRead:        o.reqIDs,
+	// Split the nodes into multiple requests if the server limits the number
+	// of nodes per read; a single request holds everything otherwise.
+	var batches [][]*ua.ReadValueID
+	if o.maxNodesPerRead > 0 {
+		for chunk := range slices.Chunk(o.reqIDs, o.maxNodesPerRead) {
+			batches = append(batches, chunk)
+		}
+	} else {
+		batches = [][]*ua.ReadValueID{o.reqIDs}
 	}
 
 	var count uint64
@@ -212,21 +243,36 @@ func (o *readClient) read() error {
 		count++
 
 		// Try to update the values for all registered nodes
-		o.Log.Tracef("Sending OPC UA read request for %d %s nodes (attempt %d)...",
-			len(o.reqIDs), nodeTypeLabel(o.Workarounds.UseUnregisteredReads), count)
+		o.Log.Tracef("Sending %d OPC UA read request(s) for %d %s nodes (attempt %d)...",
+			len(batches), len(o.reqIDs), nodeTypeLabel(o.Workarounds.UseUnregisteredReads), count)
 		requestStart := time.Now()
-		resp, err := o.Client.Read(o.ctx, req)
+		var err error
+		var updated int
+		for _, batch := range batches {
+			var resp *ua.ReadResponse
+			resp, err = o.Client.Read(o.ctx, &ua.ReadRequest{
+				MaxAge:             2000,
+				TimestampsToReturn: ua.TimestampsToReturnBoth,
+				NodesToRead:        batch,
+			})
+			if err != nil {
+				break
+			}
+			if len(resp.Results) != len(batch) {
+				err = fmt.Errorf("server returned %d results for %d requested nodes", len(resp.Results), len(batch))
+				break
+			}
+			for i, d := range resp.Results {
+				o.UpdateNodeValue(updated+i, d)
+			}
+			updated += len(batch)
+		}
 		plcDuration := time.Since(requestStart)
 		if err == nil {
-			// Success, update the node values and exit
+			// Success, exit with all node values updated
 			o.ReadSuccess.Incr(1)
 			o.forceReconnect = false
-			o.Log.Tracef("OPC UA read response received in %s, updating %d node values...", plcDuration, len(resp.Results))
-			updateStart := time.Now()
-			for i, d := range resp.Results {
-				o.UpdateNodeValue(i, d)
-			}
-			o.Log.Tracef("Node value update took %s", time.Since(updateStart))
+			o.Log.Tracef("OPC UA read completed in %s, updated %d node values", plcDuration, updated)
 			return nil
 		}
 


### PR DESCRIPTION
## Summary

The plugin sends all configured nodes in a single Read request per gather cycle, so any node set larger than the limit a server enforces via its OperationLimits fails entirely (e.g. with BadTooManyOperations). This blocks collecting larger tag counts from a single server.

With this change the plugin queries the spec-defined limit node (Server/ServerCapabilities/OperationLimits/MaxNodesPerRead, ns=0;i=11705) on connect and splits the read into multiple requests of at most that many nodes. The property is optional and zero means "no limit"; in both cases the previous single-request behavior is kept.

## Checklist

- [x] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

resolves #19609
