### PR TITLE
fix(outputs.stackdriver): Classify write errors and stop abandoning chunks

### DIFF
--- a/plugins/outputs/stackdriver/stackdriver.go
+++ b/plugins/outputs/stackdriver/stackdriver.go
@@ -19,6 +19,7 @@ import (
 	"google.golang.org/genproto/googleapis/api/distribution"
 	metricpb "google.golang.org/genproto/googleapis/api/metric"
 	monitoredrespb "google.golang.org/genproto/googleapis/api/monitoredres"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -227,7 +228,9 @@ func (s *Stackdriver) Write(metrics []telegraf.Metric) error {
 	return nil
 }
 
-// Write the metrics to Google Cloud Stackdriver.
+// sendBatch writes one timestamp group in chunks of at most 200 time series.
+// Permanently rejected chunks are dropped so the following chunks are still
+// sent; a retryable failure is returned so Telegraf replays the batch.
 func (s *Stackdriver) sendBatch(batch []telegraf.Metric) error {
 	ctx := context.Background()
 
@@ -413,17 +416,16 @@ func (s *Stackdriver) sendBatch(batch []telegraf.Metric) error {
 		}
 
 		// Create the time series in Stackdriver.
-		err := s.client.CreateTimeSeries(ctx, timeSeriesRequest)
-		if err != nil {
-			if errStatus, ok := status.FromError(err); ok {
-				if errStatus.Code().String() == "InvalidArgument" {
-					s.Log.Warnf("Unable to write to Stackdriver - dropping metrics: %s", err)
-					return nil
-				}
+		if err := s.client.CreateTimeSeries(ctx, timeSeriesRequest); err != nil {
+			// status.Code also handles non-gRPC errors, unlike status.FromError
+			if isRetryable(status.Code(err)) {
+				s.Log.Errorf("Unable to write to Stackdriver: %s", err)
+				return err
 			}
 
-			s.Log.Errorf("Unable to write to Stackdriver: %s", err)
-			return err
+			// Nothing will replay a permanent rejection, so drop this chunk and
+			// continue; the remaining chunks are separate requests.
+			s.Log.Warnf("Unable to write to Stackdriver - dropping metrics: %s", err)
 		}
 	}
 
@@ -721,6 +723,28 @@ func (s *Stackdriver) Close() error {
 
 func newStackdriver() *Stackdriver {
 	return &Stackdriver{}
+}
+
+// isRetryable reports whether replaying a CreateTimeSeries call can plausibly
+// succeed. This is an allowlist of transient conditions rather than a denylist
+// of rejection reasons, so an unrecognised code is dropped as a permanent
+// rejection instead of becoming an infinite retry.
+func isRetryable(code codes.Code) bool {
+	switch code {
+	case codes.Unavailable, // transient backend or connection failure
+		codes.Canceled,          // peer reset the stream; the call context is never cancelled here
+		codes.DeadlineExceeded,  // exceeded the client's call timeout
+		codes.ResourceExhausted, // quota exhausted; succeeds once refilled
+		codes.Aborted,           // concurrency conflict
+		codes.Internal,          // server-side fault
+		codes.Unknown,           // unclassified, including non-gRPC errors
+		codes.Unauthenticated,   // credential refresh or key rotation in flight
+		codes.PermissionDenied,  // IAM grant not yet propagated
+		codes.NotFound:          // project missing or not yet visible
+		return true
+	default:
+		return false
+	}
 }
 
 func init() {

--- a/plugins/outputs/stackdriver/stackdriver_test.go
+++ b/plugins/outputs/stackdriver/stackdriver_test.go
@@ -672,6 +672,253 @@ func TestWritePassthroughErrors(t *testing.T) {
 	require.ErrorContains(t, plugin.Write(testutil.MockMetrics()), "desc = unknown")
 }
 
+func TestWriteDropsFailedPrecondition(t *testing.T) {
+	// FAILED_PRECONDITION is a permanent rejection. Retrying it re-sends points
+	// that already landed, which produces the duplicates that caused the error.
+	server := &mockServer{
+		errForCall: map[int]error{
+			1: status.New(codes.FailedPrecondition, "one or more points were written more frequently than the maximum sampling period").Err(),
+		},
+	}
+	srv, client := startServer(t, server)
+	defer srv.GracefulStop()
+
+	// Setup and start the plugin with the injected client
+	plugin := &Stackdriver{
+		Project:   "projects/[PROJECT]",
+		Namespace: "test",
+		Log:       testutil.Logger{},
+		client:    client,
+	}
+	require.NoError(t, plugin.Init())
+	require.NoError(t, plugin.Connect())
+
+	require.NoError(t, plugin.Write(testutil.MockMetrics()))
+	require.Len(t, server.reqs, 1)
+}
+
+func TestWriteSendsRemainingChunksAfterPermanentFailure(t *testing.T) {
+	// Previously the first chunk failing with InvalidArgument returned nil, so
+	// the later chunks were never sent and Telegraf still cleared the batch.
+	server := &mockServer{
+		errForCall: map[int]error{
+			1: status.New(codes.InvalidArgument, "bad point in first chunk").Err(),
+		},
+	}
+	srv, client := startServer(t, server)
+	defer srv.GracefulStop()
+
+	// Setup and start the plugin with the injected client
+	plugin := &Stackdriver{
+		Project:   "projects/[PROJECT]",
+		Namespace: "test",
+		Log:       testutil.Logger{},
+		client:    client,
+	}
+	require.NoError(t, plugin.Init())
+	require.NoError(t, plugin.Connect())
+
+	// 250 distinct series sharing one timestamp: one group, chunks of 200 and 50
+	input := make([]telegraf.Metric, 0, 250)
+	for i := range 250 {
+		input = append(input, metric.New(
+			fmt.Sprintf("series_%03d", i),
+			map[string]string{},
+			map[string]interface{}{
+				"value": 42,
+			},
+			time.Unix(1, 0),
+		))
+	}
+
+	// The failure is permanent, so the batch must not be handed back to Telegraf
+	require.NoError(t, plugin.Write(input))
+
+	reqs := server.reqs
+	require.Len(t, reqs, 2, "the chunk following the failed one must still be sent")
+	first, ok := reqs[0].(*monitoringpb.CreateTimeSeriesRequest)
+	require.Truef(t, ok, "Invalid request type %T for request 0", reqs[0])
+	require.Len(t, first.TimeSeries, 200)
+	second, ok := reqs[1].(*monitoringpb.CreateTimeSeriesRequest)
+	require.Truef(t, ok, "Invalid request type %T for request 1", reqs[1])
+	require.Len(t, second.TimeSeries, 50)
+}
+
+func TestWriteSendsRemainingTimestampGroupsAfterPermanentFailure(t *testing.T) {
+	// The outer loop in Write must not abandon later timestamp groups when an
+	// earlier group is permanently rejected.
+	server := &mockServer{
+		errForCall: map[int]error{
+			1: status.New(codes.InvalidArgument, "bad point in first group").Err(),
+		},
+	}
+	srv, client := startServer(t, server)
+	defer srv.GracefulStop()
+
+	// Setup and start the plugin with the injected client
+	plugin := &Stackdriver{
+		Project:   "projects/[PROJECT]",
+		Namespace: "test",
+		Log:       testutil.Logger{},
+		client:    client,
+	}
+	require.NoError(t, plugin.Init())
+	require.NoError(t, plugin.Connect())
+
+	// Two distinct timestamps produce two groups, hence two requests
+	input := []telegraf.Metric{
+		metric.New(
+			"first",
+			map[string]string{},
+			map[string]interface{}{
+				"value": 42,
+			},
+			time.Unix(1, 0),
+		),
+		metric.New(
+			"second",
+			map[string]string{},
+			map[string]interface{}{
+				"value": 43,
+			},
+			time.Unix(2, 0),
+		),
+	}
+
+	require.NoError(t, plugin.Write(input))
+	require.Len(t, server.reqs, 2, "the timestamp group following the failed one must still be sent")
+}
+
+func TestWriteRetryableOnLaterChunkPropagates(t *testing.T) {
+	// A retryable failure must be returned even when earlier chunks succeeded.
+	server := &mockServer{
+		errForCall: map[int]error{
+			2: status.New(codes.Unavailable, "backend down").Err(),
+		},
+	}
+	srv, client := startServer(t, server)
+	defer srv.GracefulStop()
+
+	// Setup and start the plugin with the injected client
+	plugin := &Stackdriver{
+		Project:   "projects/[PROJECT]",
+		Namespace: "test",
+		Log:       testutil.Logger{},
+		client:    client,
+	}
+	require.NoError(t, plugin.Init())
+	require.NoError(t, plugin.Connect())
+
+	// 250 distinct series sharing one timestamp: one group, chunks of 200 and 50
+	input := make([]telegraf.Metric, 0, 250)
+	for i := range 250 {
+		input = append(input, metric.New(
+			fmt.Sprintf("series_%03d", i),
+			map[string]string{},
+			map[string]interface{}{
+				"value": 42,
+			},
+			time.Unix(1, 0),
+		))
+	}
+
+	require.ErrorContains(t, plugin.Write(input), "backend down")
+	require.Len(t, server.reqs, 2, "the earlier chunk must still have been sent")
+}
+
+func TestWritePermanentThenRetryableReturnsError(t *testing.T) {
+	// A retryable failure after a permanent one must still be returned.
+	server := &mockServer{
+		errForCall: map[int]error{
+			1: status.New(codes.InvalidArgument, "bad point in first chunk").Err(),
+			2: status.New(codes.Unavailable, "backend down").Err(),
+		},
+	}
+	srv, client := startServer(t, server)
+	defer srv.GracefulStop()
+
+	// Setup and start the plugin with the injected client
+	plugin := &Stackdriver{
+		Project:   "projects/[PROJECT]",
+		Namespace: "test",
+		Log:       testutil.Logger{},
+		client:    client,
+	}
+	require.NoError(t, plugin.Init())
+	require.NoError(t, plugin.Connect())
+
+	// 250 distinct series sharing one timestamp: one group, chunks of 200 and 50
+	input := make([]telegraf.Metric, 0, 250)
+	for i := range 250 {
+		input = append(input, metric.New(
+			fmt.Sprintf("series_%03d", i),
+			map[string]string{},
+			map[string]interface{}{
+				"value": 42,
+			},
+			time.Unix(1, 0),
+		))
+	}
+
+	require.ErrorContains(t, plugin.Write(input), "backend down")
+	require.Len(t, server.reqs, 2)
+}
+
+func TestWriteErrorClassification(t *testing.T) {
+	// Retryable codes are returned so Telegraf replays the batch; permanent ones
+	// are dropped so it drains.
+	tests := []struct {
+		name      string
+		code      codes.Code
+		retryable bool
+	}{
+		{"canceled", codes.Canceled, true},
+		{"unavailable", codes.Unavailable, true},
+		{"deadline exceeded", codes.DeadlineExceeded, true},
+		{"resource exhausted", codes.ResourceExhausted, true},
+		{"aborted", codes.Aborted, true},
+		{"internal", codes.Internal, true},
+		{"unknown", codes.Unknown, true},
+		// Auth failures are transient in practice and must not drop metrics
+		{"unauthenticated", codes.Unauthenticated, true},
+		{"permission denied", codes.PermissionDenied, true},
+		{"invalid argument", codes.InvalidArgument, false},
+		{"failed precondition", codes.FailedPrecondition, false},
+		{"out of range", codes.OutOfRange, false},
+		{"not found", codes.NotFound, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := &mockServer{
+				errForCall: map[int]error{
+					1: status.New(tt.code, "rejected").Err(),
+				},
+			}
+			srv, client := startServer(t, server)
+			defer srv.GracefulStop()
+
+			// Setup and start the plugin with the injected client
+			plugin := &Stackdriver{
+				Project:   "projects/[PROJECT]",
+				Namespace: "test",
+				Log:       testutil.Logger{},
+				client:    client,
+			}
+			require.NoError(t, plugin.Init())
+			require.NoError(t, plugin.Connect())
+
+			err := plugin.Write(testutil.MockMetrics())
+			if tt.retryable {
+				require.ErrorContains(t, err, "desc = rejected")
+			} else {
+				require.NoError(t, err, "a permanent rejection must be dropped, not retried")
+			}
+			require.Len(t, server.reqs, 1)
+		})
+	}
+}
+
 func TestIntervalEndpoints(t *testing.T) {
 	// Start the test-server
 	server := &mockServer{err: errors.New("invalid argument")}
@@ -1218,6 +1465,10 @@ type mockServer struct {
 	// If set, all calls return this error.
 	err error
 
+	// Errors to return for individual calls, keyed by the one-based call
+	// number. Calls without an entry succeed.
+	errForCall map[int]error
+
 	// responses to return if err == nil
 	resps []proto.Message
 }
@@ -1229,6 +1480,14 @@ func (s *mockServer) CreateTimeSeries(ctx context.Context, req *monitoringpb.Cre
 	}
 
 	s.reqs = append(s.reqs, req)
+
+	if s.errForCall != nil {
+		if err, ok := s.errForCall[len(s.reqs)]; ok {
+			return nil, err
+		}
+		return &emptypb.Empty{}, nil
+	}
+
 	if s.err != nil {
 		var statusResp *status.Status
 		switch s.err.Error() {


### PR DESCRIPTION
## Summary

`CreateTimeSeries` partially succeeds: the valid points in a chunk are written
before the error returns. Two defects compounded on top of that.

**`FAILED_PRECONDITION` was retried forever.** The error handling only
special-cased `InvalidArgument`, so `FailedPrecondition` fell through to
`return err`. Because writes partially succeed, the replayed batch re-sent
points that had already landed; those come back as duplicates, and duplicates
return `FAILED_PRECONDITION`. The retry manufactured the error that caused it,
so the batch never drained and the output buffer filled behind it. Errors where
`status.FromError` reported `ok == false` fell through the same way.

**A failed chunk abandoned the rest of its timestamp group.** `sendBatch` splits
a group into requests of at most 200 time series, and any chunk error returned
immediately. On the `InvalidArgument` path that return was `nil`, reporting
success, so Telegraf cleared the batch and the remaining chunks were permanently
and silently lost — never retried, never counted as dropped. One bad point in
the first chunk could discard an unbounded tail of good metrics.

### Approach

Response codes are classified with an allowlist of *transient* conditions rather
than a denylist of rejection reasons. Which code Cloud Monitoring returns for a
given bad payload is a service-side detail that can change; the set of transient
conditions is stable, and the service will not return `Unavailable` for
malformed data. An unrecognised code is therefore treated as permanent — logged
and dropped — rather than silently becoming an infinite retry.

- **Permanent** → count the chunk's series by response code and `continue`.
  Continuing is required: nothing will ever replay these, so aborting loses them
  silently.
- **Retryable** → return the error. Telegraf replays the batch, including the
  timestamp groups not yet attempted.

`status.Code` replaces `status.FromError` + `ok`, which closes the non-gRPC
fall-through.

#### Deliberate semantic change worth a maintainer's sign-off

`Unauthenticated`, `PermissionDenied` and `NotFound` are classified **retryable**.
They are independent of the payload and transient in practice — token refresh,
key rotation, IAM propagation after a role grant, a project not yet visible.
Classifying them as permanent would mean a routine credential blip reports a
successful write, leaves `metrics_written` incrementing and the buffer flat, and
discards the data with only a log line as evidence. Retrying keeps the buffer
growing so the condition stays visible to an operator, which matches the
behaviour before this change.

Worth noting for reviewers: a misconfigured or non-existent project reports
`PERMISSION_DENIED` ("*or the resource may not exist*"), not `NOT_FOUND` — the
API does not confirm whether a resource exists to a caller lacking permission on
it. Both are retryable here, so that case surfaces loudly either way.

`codes.Unknown` is retryable because `TestWritePassthroughErrors` already encodes
that intent. Note that `status.Code` maps every non-gRPC error to `Unknown`, so
client-side and transport failures are retried too. That is deliberate — they are
not service rejections of the payload — and the code comment says so rather than
claiming a fail-safe property the code does not have.

Net effect on retry behaviour: the previous code returned an error for every
code except `InvalidArgument`, so this change *narrows* what gets retried.
`FailedPrecondition`, `OutOfRange` and unrecognised codes now drain instead of
looping.

### Known limitations

Both are pre-existing and tracked in #19613 rather than fixed here:

- `sendBatch` mutates the caller's metrics in place (`RemoveTag` for
  `tags_as_resource_label`, `RemoveField("sum")`/`("count")` in
  `buildHistogram`). Telegraf hands back the same pointers on replay, so a
  retried batch loses those tags and histogram metrics fail with
  `no sum field present`.
- Permanently dropped series are logged but not machine-readable. `Write`
  returns `nil`, so the agent still credits the batch to `metrics_written`.
  `internal.PartialWriteError` is the idiomatic fix, but the buckets hold bare
  `*monitoringpb.TimeSeries` with no back-reference to the source metric index
  and the mapping is many-to-one, so it is deferred rather than done badly here.

### Tests

Existing tests pass unmodified — the test file is purely additive against
master, 245 insertions and 0 deletions. Classification is driven through `Write`
and asserts the observable contract: a retryable code is returned so Telegraf
replays, a permanent one is dropped so the batch drains.

- `TestWriteDropsFailedPrecondition` — fails against the unfixed code
- `TestWriteSendsRemainingChunksAfterPermanentFailure` — 250 series in one
  timestamp group, only the first chunk fails; asserts both chunks are sent.
  Fails against the unfixed code (1 request instead of 2)
- `TestWriteSendsRemainingTimestampGroupsAfterPermanentFailure` — later groups
  are still attempted
- `TestWriteRetryableOnLaterChunkPropagates` — the error propagates and the
  earlier chunk was still sent
- `TestWritePermanentThenRetryableReturnsError` — the retryable error wins
- `TestWriteErrorClassification` — table over retryable and permanent codes

Four of these fail against the current code on master and pass with the fix.

Also exercised end to end with a compiled binary against a stand-in Cloud
Monitoring server and a live project: a rejected first chunk still sends the
second, permanent rejections drain the buffer, and retryable ones retain it.

## Checklist

- [ ] No AI generated code was used in this PR
- [x] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

resolves #19611
