### PR TITLE
test(testutil): Return scanner errors

### DIFF
--- a/testutil/file.go
+++ b/testutil/file.go
@@ -115,6 +115,10 @@ func ParseMetricsFromFile(filename string, parser telegraf.Parser) ([]telegraf.M
 		}
 	}
 
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("parsing file %q failed: %w", filename, err)
+	}
+
 	return metrics, nil
 }
 
@@ -136,5 +140,8 @@ func ParseLinesFromFile(filename string) ([]string, error) {
 		lines = append(lines, line)
 	}
 
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("parsing file %q failed: %w", filename, err)
+	}
 	return lines, nil
 }


### PR DESCRIPTION
## Summary

This PR returns scanner errors when parsing test-files so those don't go unnoticed.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
