### PR TITLE
test(secretstores.vault): Cleanup tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -214,7 +214,6 @@ require (
 	github.com/testcontainers/testcontainers-go v0.44.0
 	github.com/testcontainers/testcontainers-go/modules/azure v0.44.0
 	github.com/testcontainers/testcontainers-go/modules/kafka v0.44.0
-	github.com/testcontainers/testcontainers-go/modules/vault v0.44.0
 	github.com/thomasklein94/packer-plugin-libvirt v0.5.0
 	github.com/tidwall/gjson v1.19.0
 	github.com/tidwall/wal v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -1673,8 +1673,6 @@ github.com/hashicorp/packer-plugin-sdk v0.3.2/go.mod h1:XZRvL9kRqJJtB6rf9Lu2zWLJ
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
 github.com/hashicorp/serf v0.10.4 h1:TCQOrJXHZ1Xf80c4WBhMM9OwUFgDaIP0R+YvoQUKadI=
 github.com/hashicorp/serf v0.10.4/go.mod h1:l+s5Q1OSPWU6b9l9m7ODJzTp7mLevSaVzAI03Nka2F0=
-github.com/hashicorp/vault-client-go v0.4.3 h1:zG7STGVgn/VK6rnZc0k8PGbfv2x/sJExRKHSUg3ljWc=
-github.com/hashicorp/vault-client-go v0.4.3/go.mod h1:4tDw7Uhq5XOxS1fO+oMtotHL7j4sB9cp0T7U6m4FzDY=
 github.com/hashicorp/vault/api v1.23.0 h1:gXgluBsSECfRWTSW9niY2jwg2e9mMJc4WoHNv4g3h6A=
 github.com/hashicorp/vault/api v1.23.0/go.mod h1:zransKiB9ftp+kgY8ydjnvCU7Wk8i9L0DYWpXeMj9ko=
 github.com/hashicorp/vault/api/auth/approle v0.12.0 h1:PhF7jrQjydK1DC05EboosXmZg31GDUIKL8bjyilsJ+E=
@@ -2402,8 +2400,6 @@ github.com/testcontainers/testcontainers-go/modules/azure v0.44.0 h1:TdEQKNZcFuQ
 github.com/testcontainers/testcontainers-go/modules/azure v0.44.0/go.mod h1:VF3c5PrpknPYRaOIPIfjAhhMJpOjOCqkfIAhaQRxkPQ=
 github.com/testcontainers/testcontainers-go/modules/kafka v0.44.0 h1:KOyj22XaB0X2RsyQKQKthzcWObKtni0kLrV1HqFVeec=
 github.com/testcontainers/testcontainers-go/modules/kafka v0.44.0/go.mod h1:OP4szEj4BpOH/UZhbtNER1ERRSj4YJ6hu2x+FIBdo5o=
-github.com/testcontainers/testcontainers-go/modules/vault v0.44.0 h1:lrIV4oEPtBeiTYeWtUdhozf4FIktglP8Hb0JVeyssXE=
-github.com/testcontainers/testcontainers-go/modules/vault v0.44.0/go.mod h1:1uXTUa/fbboegLYSLc26pRxt3N4vpcOongjTarasmI8=
 github.com/thomasklein94/packer-plugin-libvirt v0.5.0 h1:aj2HLHZZM/ClGLIwVp9rrgh+2TOU/w4EiaZHAwCpOgs=
 github.com/thomasklein94/packer-plugin-libvirt v0.5.0/go.mod h1:GwN82FQ6KxCNKtS8LNUgLbwTZs90GGhBzCmTNkrTCrY=
 github.com/tidwall/gjson v1.10.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=

--- a/plugins/secretstores/vault/vault_test.go
+++ b/plugins/secretstores/vault/vault_test.go
@@ -2,413 +2,21 @@ package vault
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
-	"fmt"
 	"io"
 	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/testcontainers/testcontainers-go"
-	"github.com/testcontainers/testcontainers-go/modules/vault"
+	"github.com/testcontainers/testcontainers-go/wait"
 
 	"github.com/influxdata/telegraf/config"
+	"github.com/influxdata/telegraf/testutil"
 )
 
-func createContainer(t *testing.T, initCommands []string) (*vault.VaultContainer, func()) {
-	// Create container with a default AppRole setup
-	initCommands = append([]string{
-		"auth enable approle",
-		"policy write my-policy /tmp/policy.hcl",
-		"write auth/approle/role/my-role policies=my-policy",
-	}, initCommands...)
-
-	policyPath, err := filepath.Abs("testdata/policy.hcl")
-	require.NoError(t, err)
-
-	container, err := vault.Run(
-		context.Background(),
-		"hashicorp/vault:1.20.4",
-		testcontainers.WithFiles(testcontainers.ContainerFile{
-			HostFilePath:      policyPath,
-			ContainerFilePath: "/tmp/policy.hcl",
-			FileMode:          0644,
-		}),
-		vault.WithToken("SomeToken"),
-		vault.WithInitCommand(initCommands...),
-	)
-
-	require.NoError(t, err)
-
-	state, err := container.State(context.Background())
-	require.NoError(t, err)
-	require.True(t, state.Running)
-
-	return container, func() {
-		//nolint:errcheck // No need to check error on cleanup
-		_ = container.Terminate(context.Background())
-	}
-}
-
-func getRoleID(t *testing.T, container *vault.VaultContainer) string {
-	t.Helper()
-
-	exitCode, reader, err := container.Exec(context.Background(), []string{
-		"vault", "read", "-format=raw", "auth/approle/role/my-role/role-id",
-	})
-	require.NoError(t, err)
-	require.Zero(t, exitCode)
-
-	output, err := io.ReadAll(reader)
-	require.NoError(t, err)
-
-	var resp roleIDResponse
-	require.NoError(t, json.Unmarshal(sanitizeVaultResponse(t, output), &resp))
-	return resp.Data.RoleID
-}
-
-type roleIDResponse struct {
-	Data struct {
-		RoleID string `json:"role_id"`
-	} `json:"data"`
-}
-
-func getSecretID(t *testing.T, container *vault.VaultContainer) string {
-	t.Helper()
-
-	exitCode, reader, err := container.Exec(context.Background(), []string{
-		"vault", "write", "-f", "-format=json", "auth/approle/role/my-role/secret-id",
-	})
-	require.NoError(t, err)
-	require.Zero(t, exitCode)
-
-	output, err := io.ReadAll(reader)
-	require.NoError(t, err)
-
-	var resp SecretIDResponse
-	require.NoError(t, json.Unmarshal(sanitizeVaultResponse(t, output), &resp))
-	return resp.Data.SecretID
-}
-
-type SecretIDResponse struct {
-	Data struct {
-		SecretID string `json:"secret_id"`
-	} `json:"data"`
-}
-
-func getWrappedSecretID(t *testing.T, container *vault.VaultContainer) string {
-	t.Helper()
-
-	exitCode, reader, err := container.Exec(context.Background(), []string{
-		"vault", "write", "-wrap-ttl=60s", "-f", "-format=json", "auth/approle/role/my-role/secret-id",
-	})
-	require.NoError(t, err)
-	require.Zero(t, exitCode)
-
-	output, err := io.ReadAll(reader)
-	require.NoError(t, err)
-
-	var resp WrappedSecretIDResponse
-	require.NoError(t, json.Unmarshal(sanitizeVaultResponse(t, output), &resp))
-	return resp.WrapInfo.Token
-}
-
-type WrappedSecretIDResponse struct {
-	WrapInfo struct {
-		Token string `json:"token"`
-	} `json:"wrap_info"`
-}
-
-func sanitizeVaultResponse(t *testing.T, resp []byte) []byte {
-	t.Helper()
-
-	// Trim some junk characters in the response first.
-	// "json"/"raw" format may still contain some non-JSON prefix/suffix
-	startIndex := bytes.IndexByte(resp, byte('{'))
-	endIndex := bytes.LastIndexByte(resp, byte('}'))
-	return resp[startIndex : endIndex+1]
-}
-
-func TestIntegrationKVv1(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping integration test in short mode")
-	}
-
-	mountPath := "my-mount-path"
-	secretPath := "my-secret-path"
-	secretName := "secret-some-name"
-	secretValue := "secret-some-value"
-
-	container, closer := createContainer(t, []string{
-		fmt.Sprintf("secrets enable -path=%s kv-v1", mountPath),
-		fmt.Sprintf("kv put -mount=%s %s %s=%s", mountPath, secretPath, secretName, secretValue),
-	})
-	defer closer()
-
-	addr, err := container.HttpHostAddress(context.Background())
-	require.NoError(t, err)
-
-	plugin := &Vault{
-		ID:         "test_integration_kv_v1",
-		Address:    addr,
-		MountPath:  mountPath,
-		SecretPath: secretPath,
-		Engine:     "kv-v1",
-		AppRole: &appRole{
-			RoleID: getRoleID(t, container),
-			Secret: config.NewSecret([]byte(getSecretID(t, container))),
-		},
-	}
-
-	require.NoError(t, plugin.Init())
-
-	secret, err := plugin.Get(secretName)
-	require.NoError(t, err)
-	require.Equal(t, secretValue, string(secret))
-}
-
-func TestIntegrationKVv2(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping integration test in short mode")
-	}
-
-	mountPath := "my-mount-path"
-	secretPath := "my-secret-path"
-	secretName := "secret-some-name"
-	secretValue := "secret-some-value"
-
-	container, closer := createContainer(t, []string{
-		fmt.Sprintf("secrets enable -path=%s kv-v2", mountPath),
-		fmt.Sprintf("kv put -mount=%s %s %s=%s", mountPath, secretPath, secretName, secretValue),
-	})
-	defer closer()
-
-	addr, err := container.HttpHostAddress(context.Background())
-	require.NoError(t, err)
-
-	plugin := &Vault{
-		ID:         "test_integration_kv_v2",
-		Address:    addr,
-		MountPath:  mountPath,
-		SecretPath: secretPath,
-		AppRole: &appRole{
-			RoleID: getRoleID(t, container),
-			Secret: config.NewSecret([]byte(getSecretID(t, container))),
-		},
-	}
-
-	require.NoError(t, plugin.Init())
-
-	secret, err := plugin.Get(secretName)
-	require.NoError(t, err)
-	require.Equal(t, secretValue, string(secret))
-}
-
-func TestIntegrationAppRoleSecretWrapped(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping integration test in short mode")
-	}
-
-	mountPath := "my-mount-path"
-	secretPath := "my-secret-path"
-	secretName := "secret-some-name"
-	secretValue := "secret-some-value"
-
-	container, closer := createContainer(t, []string{
-		fmt.Sprintf("secrets enable -path=%s kv-v2", mountPath),
-		fmt.Sprintf("kv put -mount=%s %s %s=%s", mountPath, secretPath, secretName, secretValue),
-	})
-	defer closer()
-
-	addr, err := container.HttpHostAddress(context.Background())
-	require.NoError(t, err)
-
-	plugin := &Vault{
-		ID:         "test_integration_kv_v2",
-		Address:    addr,
-		MountPath:  mountPath,
-		SecretPath: secretPath,
-		AppRole: &appRole{
-			RoleID:          getRoleID(t, container),
-			Secret:          config.NewSecret([]byte(getWrappedSecretID(t, container))),
-			ResponseWrapped: true,
-		},
-	}
-
-	require.NoError(t, plugin.Init())
-
-	secret, err := plugin.Get(secretName)
-	require.NoError(t, err)
-	require.Equal(t, secretValue, string(secret))
-}
-
-func TestIntegrationSetKeepsSiblingsKVv1(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping integration test in short mode")
-	}
-	testSetKeepsSiblings(t, "kv-v1")
-}
-
-func TestIntegrationSetKeepsSiblingsKVv2(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping integration test in short mode")
-	}
-	testSetKeepsSiblings(t, "kv-v2")
-}
-
-func testSetKeepsSiblings(t *testing.T, engine string) {
-	t.Helper()
-
-	mountPath := "my-mount-path"
-	secretPath := "my-secret-path"
-
-	container, closer := createContainer(t, []string{
-		fmt.Sprintf("secrets enable -path=%s %s", mountPath, engine),
-		fmt.Sprintf("kv put -mount=%s %s alpha=one beta=two", mountPath, secretPath),
-	})
-	defer closer()
-
-	addr, err := container.HttpHostAddress(context.Background())
-	require.NoError(t, err)
-
-	plugin := &Vault{
-		ID:         "test_" + engine,
-		Address:    addr,
-		MountPath:  mountPath,
-		SecretPath: secretPath,
-		Engine:     engine,
-		Token:      config.NewSecret([]byte("SomeToken")),
-	}
-	require.NoError(t, plugin.Init())
-
-	require.NoError(t, plugin.Set("gamma", "three"))
-
-	keys, err := plugin.List()
-	require.NoError(t, err)
-	slices.Sort(keys)
-	require.Equal(t, []string{"alpha", "beta", "gamma"}, keys)
-}
-
-func TestIntegrationRemove(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping integration test in short mode")
-	}
-
-	tests := []struct {
-		engine string
-		// Error reported by the engine for a path without any secret
-		expectedEmpty string
-	}{
-		{
-			engine:        "kv-v1",
-			expectedEmpty: "secret not found",
-		},
-		{
-			engine:        "kv-v2",
-			expectedEmpty: "no secret data found",
-		},
-	}
-
-	mountPath := "my-mount-path"
-	secretPath := "my-secret-path"
-
-	for _, tt := range tests {
-		t.Run(tt.engine, func(t *testing.T) {
-			container, closer := createContainer(t, []string{
-				fmt.Sprintf("secrets enable -path=%s %s", mountPath, tt.engine),
-				fmt.Sprintf("kv put -mount=%s %s alpha=one beta=two", mountPath, secretPath),
-			})
-			defer closer()
-
-			addr, err := container.HttpHostAddress(context.Background())
-			require.NoError(t, err)
-
-			plugin := &Vault{
-				ID:         "test_" + tt.engine,
-				Address:    addr,
-				MountPath:  mountPath,
-				SecretPath: secretPath,
-				Engine:     tt.engine,
-				Token:      config.NewSecret([]byte("SomeToken")),
-			}
-			require.NoError(t, plugin.Init())
-
-			// Removing a secret must keep the sibling secrets at the same path
-			require.NoError(t, plugin.Remove("beta"))
-
-			keys, err := plugin.List()
-			require.NoError(t, err)
-			require.Equal(t, []string{"alpha"}, keys)
-
-			value, err := plugin.Get("alpha")
-			require.NoError(t, err)
-			require.Equal(t, "one", string(value))
-
-			// Removing a secret that does not exist must fail
-			require.ErrorContains(t, plugin.Remove("beta"), `secret "beta" not found`)
-
-			// Removing the last secret must remove the secret at the path completely
-			require.NoError(t, plugin.Remove("alpha"))
-			_, err = plugin.List()
-			require.ErrorContains(t, err, tt.expectedEmpty)
-		})
-	}
-}
-
-func TestIntegrationSetCreatesNewPathKVv1(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping integration test in short mode")
-	}
-	testSetCreatesNewPath(t, "kv-v1")
-}
-
-func TestIntegrationSetCreatesNewPathKVv2(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping integration test in short mode")
-	}
-	testSetCreatesNewPath(t, "kv-v2")
-}
-
-func testSetCreatesNewPath(t *testing.T, engine string) {
-	t.Helper()
-
-	mountPath := "my-mount-path"
-	secretPath := "my-secret-path"
-
-	container, closer := createContainer(t, []string{
-		fmt.Sprintf("secrets enable -path=%s %s", mountPath, engine),
-	})
-	defer closer()
-
-	addr, err := container.HttpHostAddress(context.Background())
-	require.NoError(t, err)
-
-	plugin := &Vault{
-		ID:         "test_" + engine,
-		Address:    addr,
-		MountPath:  mountPath,
-		SecretPath: secretPath,
-		Engine:     engine,
-		Token:      config.NewSecret([]byte("SomeToken")),
-	}
-	require.NoError(t, plugin.Init())
-
-	require.NoError(t, plugin.Set("gamma", "three"))
-
-	value, err := plugin.Get("gamma")
-	require.NoError(t, err)
-	require.Equal(t, "three", string(value))
-}
-
-func TestInitAuthValidation(t *testing.T) {
-	base := Vault{
-		ID:         "vault",
-		Address:    "http://localhost:8200",
-		MountPath:  "secret",
-		SecretPath: "my/path",
-	}
+func TestInitFail(t *testing.T) {
 	tests := []struct {
 		name     string
 		token    config.Secret
@@ -432,44 +40,457 @@ func TestInitAuthValidation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			v := base
-			v.Token = tt.token
-			v.AppRole = tt.approle
-			require.ErrorContains(t, v.Init(), tt.expected)
+			plugin := Vault{
+				ID:         "vault",
+				Address:    "http://localhost:8200",
+				MountPath:  "secret",
+				SecretPath: "my/path",
+				Token:      tt.token,
+				AppRole:    tt.approle,
+			}
+			require.ErrorContains(t, plugin.Init(), tt.expected)
 		})
 	}
 }
 
-func TestIntegrationTokenAuth(t *testing.T) {
+func TestIntegrationV1(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
 
-	mountPath := "my-mount-path"
-	secretPath := "my-secret-path"
-	secretName := "secret-some-name"
-	secretValue := "secret-some-value"
+	for _, engine := range []string{"kv-v1", "kv-v2"} {
+		t.Run(engine, func(t *testing.T) {
+			// Commands for preparing the container
+			commands := []string{
+				// Enable authentication via approle
+				"vault auth enable approle",
+				"vault policy write my-policy /tmp/policy.hcl",
+				"vault write auth/approle/role/my-role policies=my-policy",
+				// Enable KV engine and add secrets
+				"vault secrets enable -path=my-mount-path " + engine,
+				"vault kv put -mount=my-mount-path my-secret-path secret-some-name=secret-some-value",
+			}
 
-	container, closer := createContainer(t, []string{
-		fmt.Sprintf("secrets enable -path=%s kv-v2", mountPath),
-		fmt.Sprintf("kv put -mount=%s %s %s=%s", mountPath, secretPath, secretName, secretValue),
-	})
-	defer closer()
+			// Setup the container
+			policyPath, err := filepath.Abs("testdata/policy.hcl")
+			require.NoError(t, err)
+			container := testutil.Container{
+				Image:        "hashicorp/vault:1.21",
+				ExposedPorts: []string{"8200"},
+				Env: map[string]string{
+					"VAULT_ADDR":              "http://localhost:8200",
+					"VAULT_DEV_ROOT_TOKEN_ID": "telegraf",
+					"VAULT_TOKEN":             "telegraf",
+				},
+				Files: map[string]string{"/tmp/policy.hcl": policyPath},
+				WaitingFor: wait.ForAll(
+					wait.ForHTTP("/v1/sys/health").WithPort("8200"),
+					wait.ForExec([]string{"/bin/sh", "-c", strings.Join(commands, " && ")}),
+				),
+			}
+			require.NoError(t, container.Start(), "failed to start container")
+			defer container.Terminate()
 
-	addr, err := container.HttpHostAddress(context.Background())
-	require.NoError(t, err)
+			addr := "http://" + container.Address + ":" + container.Ports["8200"]
 
-	plugin := &Vault{
-		ID:         "test_integration_token",
-		Address:    addr,
-		MountPath:  mountPath,
-		SecretPath: secretPath,
-		Token:      config.NewSecret([]byte("SomeToken")),
+			// Determine credentials from container
+			rc, reader, err := container.Exec([]string{
+				"vault", "read", "-field", "role_id", "auth/approle/role/my-role/role-id",
+			})
+			require.NoError(t, err)
+			require.Zero(t, rc)
+			buf, err := io.ReadAll(reader)
+			require.NoError(t, err)
+			roleId := string(buf[8:])
+
+			rc, reader, err = container.Exec([]string{
+				"vault", "write", "-field", "secret_id", "-force", "auth/approle/role/my-role/secret-id",
+			})
+			require.NoError(t, err)
+			require.Zero(t, rc)
+			buf, err = io.ReadAll(reader)
+			require.NoError(t, err)
+			secretId := config.NewSecret(buf[8:])
+			defer secretId.Destroy()
+
+			// Setup plugin
+			plugin := &Vault{
+				ID:         "test_integration_" + engine,
+				Address:    addr,
+				MountPath:  "my-mount-path",
+				SecretPath: "my-secret-path",
+				Engine:     engine,
+				AppRole: &appRole{
+					RoleID: roleId,
+					Secret: secretId,
+				},
+			}
+			require.NoError(t, plugin.Init())
+
+			// Check if we can retrieve the secret
+			secret, err := plugin.Get("secret-some-name")
+			require.NoError(t, err)
+			require.Equal(t, "secret-some-value", string(secret))
+		})
+	}
+}
+func TestIntegrationV2(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
 	}
 
+	for _, engine := range []string{"kv-v1", "kv-v2"} {
+		t.Run(engine, func(t *testing.T) {
+			// Commands for preparing the container
+			commands := []string{
+				// Enable authentication via approle
+				"vault auth enable approle",
+				"vault policy write my-policy /tmp/policy.hcl",
+				"vault write auth/approle/role/my-role policies=my-policy",
+				// Enable KV engine and add secrets
+				"vault secrets enable -path=my-mount-path " + engine,
+				"vault kv put -mount=my-mount-path my-secret-path secret-some-name=secret-some-value",
+			}
+
+			// Setup the container
+			policyPath, err := filepath.Abs("testdata/policy.hcl")
+			require.NoError(t, err)
+			container := testutil.Container{
+				Image:        "hashicorp/vault:2.1",
+				ExposedPorts: []string{"8200"},
+				Env: map[string]string{
+					"VAULT_ADDR":              "http://localhost:8200",
+					"VAULT_DEV_ROOT_TOKEN_ID": "telegraf",
+					"VAULT_TOKEN":             "telegraf",
+				},
+				Files: map[string]string{"/tmp/policy.hcl": policyPath},
+				WaitingFor: wait.ForAll(
+					wait.ForHTTP("/v1/sys/health").WithPort("8200"),
+					wait.ForExec([]string{"/bin/sh", "-c", strings.Join(commands, " && ")}),
+				),
+			}
+			require.NoError(t, container.Start(), "failed to start container")
+			defer container.Terminate()
+
+			addr := "http://" + container.Address + ":" + container.Ports["8200"]
+
+			// Determine credentials from container
+			rc, reader, err := container.Exec([]string{
+				"vault", "read", "-field", "role_id", "auth/approle/role/my-role/role-id",
+			})
+			require.NoError(t, err)
+			require.Zero(t, rc)
+			buf, err := io.ReadAll(reader)
+			require.NoError(t, err)
+			roleId := string(buf[8:])
+
+			rc, reader, err = container.Exec([]string{
+				"vault", "write", "-field", "secret_id", "-force", "auth/approle/role/my-role/secret-id",
+			})
+			require.NoError(t, err)
+			require.Zero(t, rc)
+			buf, err = io.ReadAll(reader)
+			require.NoError(t, err)
+			secretId := config.NewSecret(buf[8:])
+			defer secretId.Destroy()
+
+			// Setup plugin
+			plugin := &Vault{
+				ID:         "test_integration_" + engine,
+				Address:    addr,
+				MountPath:  "my-mount-path",
+				SecretPath: "my-secret-path",
+				Engine:     engine,
+				AppRole: &appRole{
+					RoleID: roleId,
+					Secret: secretId,
+				},
+			}
+			require.NoError(t, plugin.Init())
+
+			// Check if we can retrieve the secret
+			secret, err := plugin.Get("secret-some-name")
+			require.NoError(t, err)
+			require.Equal(t, "secret-some-value", string(secret))
+		})
+	}
+}
+
+func TestIntegrationAppRoleSecretWrapped(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	// Commands for preparing the container
+	commands := []string{
+		// Enable authentication via approle
+		"vault auth enable approle",
+		"vault policy write my-policy /tmp/policy.hcl",
+		"vault write auth/approle/role/my-role policies=my-policy",
+		// Enable KV engine and add secrets
+		"vault secrets enable -path=my-mount-path kv-v2",
+		"vault kv put -mount=my-mount-path my-secret-path secret-some-name=secret-some-value",
+	}
+
+	// Setup the container
+	policyPath, err := filepath.Abs("testdata/policy.hcl")
+	require.NoError(t, err)
+	container := testutil.Container{
+		Image:        "hashicorp/vault:1.20.4",
+		ExposedPorts: []string{"8200"},
+		Env: map[string]string{
+			"VAULT_ADDR":              "http://localhost:8200",
+			"VAULT_DEV_ROOT_TOKEN_ID": "telegraf",
+			"VAULT_TOKEN":             "telegraf",
+		},
+		Files: map[string]string{"/tmp/policy.hcl": policyPath},
+		WaitingFor: wait.ForAll(
+			wait.ForHTTP("/v1/sys/health").WithPort("8200"),
+			wait.ForExec([]string{"/bin/sh", "-c", strings.Join(commands, " && ")}),
+		),
+	}
+	require.NoError(t, container.Start(), "failed to start container")
+	defer container.Terminate()
+
+	addr := "http://" + container.Address + ":" + container.Ports["8200"]
+
+	// Determine credentials from container
+	rc, reader, err := container.Exec([]string{
+		"vault", "read", "-field", "role_id", "auth/approle/role/my-role/role-id",
+	})
+	require.NoError(t, err)
+	require.Zero(t, rc)
+	buf, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	roleId := string(buf[8:])
+
+	rc, reader, err = container.Exec([]string{
+		"vault", "write", "-wrap-ttl=60s", "-force", "-format=json", "auth/approle/role/my-role/secret-id",
+	})
+	require.NoError(t, err)
+	buf, err = io.ReadAll(reader)
+	require.NoError(t, err)
+
+	// Trim some junk characters in the response first.
+	// "json"/"raw" format may still contain some non-JSON prefix/suffix
+	startIndex := bytes.IndexByte(buf, byte('{'))
+	endIndex := bytes.LastIndexByte(buf, byte('}'))
+	buf = buf[startIndex : endIndex+1]
+
+	var resp struct {
+		WrapInfo struct {
+			Token string `json:"token"`
+		} `json:"wrap_info"`
+	}
+	require.NoError(t, json.Unmarshal(buf, &resp))
+	secretId := config.NewSecret([]byte(resp.WrapInfo.Token))
+	defer secretId.Destroy()
+
+	// Setup plugin
+	plugin := &Vault{
+		ID:         "test_integration_kv_v2",
+		Address:    addr,
+		MountPath:  "my-mount-path",
+		SecretPath: "my-secret-path",
+		AppRole: &appRole{
+			RoleID:          roleId,
+			Secret:          secretId,
+			ResponseWrapped: true,
+		},
+	}
 	require.NoError(t, plugin.Init())
 
-	secret, err := plugin.Get(secretName)
+	// Check if we can retrieve the secret
+	secret, err := plugin.Get("secret-some-name")
 	require.NoError(t, err)
-	require.Equal(t, secretValue, string(secret))
+	require.Equal(t, "secret-some-value", string(secret))
+}
+
+func TestIntegrationSetKeepsSiblings(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	for _, engine := range []string{"kv-v1", "kv-v2"} {
+		t.Run(engine, func(t *testing.T) {
+			// Commands for preparing the container
+			commands := []string{
+				// Enable KV engine and add secrets
+				"vault secrets enable -path=my-mount-path " + engine,
+				"vault kv put -mount=my-mount-path my-secret-path alpha=one beta=two",
+			}
+
+			// Setup the container
+			container := testutil.Container{
+				Image:        "hashicorp/vault:1.20.4",
+				ExposedPorts: []string{"8200"},
+				Env: map[string]string{
+					"VAULT_ADDR":              "http://localhost:8200",
+					"VAULT_DEV_ROOT_TOKEN_ID": "telegraf",
+					"VAULT_TOKEN":             "telegraf",
+				},
+				WaitingFor: wait.ForAll(
+					wait.ForHTTP("/v1/sys/health").WithPort("8200"),
+					wait.ForExec([]string{"/bin/sh", "-c", strings.Join(commands, " && ")}),
+				),
+			}
+			require.NoError(t, container.Start(), "failed to start container")
+			defer container.Terminate()
+
+			addr := "http://" + container.Address + ":" + container.Ports["8200"]
+
+			// Setup plugin
+			plugin := &Vault{
+				ID:         "test_" + engine,
+				Address:    addr,
+				MountPath:  "my-mount-path",
+				SecretPath: "my-secret-path",
+				Engine:     engine,
+				Token:      config.NewSecret([]byte("telegraf")),
+			}
+			require.NoError(t, plugin.Init())
+
+			// Create a new secret and check if it is there
+			require.NoError(t, plugin.Set("gamma", "three"))
+
+			keys, err := plugin.List()
+			require.NoError(t, err)
+			slices.Sort(keys)
+			require.Equal(t, []string{"alpha", "beta", "gamma"}, keys)
+		})
+	}
+}
+
+func TestIntegrationRemove(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	tests := []struct {
+		engine string
+		// Error reported by the engine for a path without any secret
+		expected string
+	}{
+		{
+			engine:   "kv-v1",
+			expected: "secret not found",
+		},
+		{
+			engine:   "kv-v2",
+			expected: "no secret data found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.engine, func(t *testing.T) {
+			// Commands for preparing the container
+			commands := []string{
+				// Enable KV engine and add secrets
+				"vault secrets enable -path=my-mount-path " + tt.engine,
+				"vault kv put -mount=my-mount-path my-secret-path alpha=one beta=two",
+			}
+
+			// Setup the container
+			container := testutil.Container{
+				Image:        "hashicorp/vault:1.20.4",
+				ExposedPorts: []string{"8200"},
+				Env: map[string]string{
+					"VAULT_ADDR":              "http://localhost:8200",
+					"VAULT_DEV_ROOT_TOKEN_ID": "telegraf",
+					"VAULT_TOKEN":             "telegraf",
+				},
+				WaitingFor: wait.ForAll(
+					wait.ForHTTP("/v1/sys/health").WithPort("8200"),
+					wait.ForExec([]string{"/bin/sh", "-c", strings.Join(commands, " && ")}),
+				),
+			}
+			require.NoError(t, container.Start(), "failed to start container")
+			defer container.Terminate()
+
+			addr := "http://" + container.Address + ":" + container.Ports["8200"]
+
+			// Setup plugin
+			plugin := &Vault{
+				ID:         "test_" + tt.engine,
+				Address:    addr,
+				MountPath:  "my-mount-path",
+				SecretPath: "my-secret-path",
+				Engine:     tt.engine,
+				Token:      config.NewSecret([]byte("telegraf")),
+			}
+			require.NoError(t, plugin.Init())
+
+			// Removing a secret must keep the sibling secrets at the same path
+			require.NoError(t, plugin.Remove("beta"))
+
+			keys, err := plugin.List()
+			require.NoError(t, err)
+			require.Equal(t, []string{"alpha"}, keys)
+
+			value, err := plugin.Get("alpha")
+			require.NoError(t, err)
+			require.Equal(t, "one", string(value))
+
+			// Removing a secret that does not exist must fail
+			require.ErrorContains(t, plugin.Remove("beta"), `secret "beta" not found`)
+
+			// Removing the last secret must remove the secret at the path completely
+			require.NoError(t, plugin.Remove("alpha"))
+			_, err = plugin.List()
+			require.ErrorContains(t, err, tt.expected)
+		})
+	}
+}
+
+func TestIntegrationSetCreatesNewPath(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	for _, engine := range []string{"kv-v1", "kv-v2"} {
+		t.Run(engine, func(t *testing.T) {
+			// Commands for preparing the container
+			commands := []string{
+				// Enable KV engine and add secrets
+				"vault secrets enable -path=my-mount-path " + engine,
+			}
+
+			// Setup the container
+			container := testutil.Container{
+				Image:        "hashicorp/vault:1.20.4",
+				ExposedPorts: []string{"8200"},
+				Env: map[string]string{
+					"VAULT_ADDR":              "http://localhost:8200",
+					"VAULT_DEV_ROOT_TOKEN_ID": "telegraf",
+					"VAULT_TOKEN":             "telegraf",
+				},
+				WaitingFor: wait.ForAll(
+					wait.ForHTTP("/v1/sys/health").WithPort("8200"),
+					wait.ForExec([]string{"/bin/sh", "-c", strings.Join(commands, " && ")}),
+				),
+			}
+			require.NoError(t, container.Start(), "failed to start container")
+			defer container.Terminate()
+
+			addr := "http://" + container.Address + ":" + container.Ports["8200"]
+
+			// Setup plugin
+			plugin := &Vault{
+				ID:         "test_" + engine,
+				Address:    addr,
+				MountPath:  "my-mount-path",
+				SecretPath: "my-secret-path",
+				Engine:     engine,
+				Token:      config.NewSecret([]byte("telegraf")),
+			}
+			require.NoError(t, plugin.Init())
+
+			// Add a new secret
+			require.NoError(t, plugin.Set("gamma", "three"))
+
+			value, err := plugin.Get("gamma")
+			require.NoError(t, err)
+			require.Equal(t, "three", string(value))
+		})
+	}
 }

--- a/plugins/secretstores/vault/vault_test.go
+++ b/plugins/secretstores/vault/vault_test.go
@@ -1,8 +1,7 @@
 package vault
 
 import (
-	"bytes"
-	"encoding/json"
+	"fmt"
 	"io"
 	"path/filepath"
 	"slices"
@@ -10,10 +9,16 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go/exec"
 	"github.com/testcontainers/testcontainers-go/wait"
 
 	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/testutil"
+)
+
+const (
+	vaultImageV1 = "hashicorp/vault:1.20.4"
+	vaultImageV2 = "hashicorp/vault:2.1"
 )
 
 func TestInitFail(t *testing.T) {
@@ -53,13 +58,40 @@ func TestInitFail(t *testing.T) {
 	}
 }
 
-func TestIntegrationV1(t *testing.T) {
+func TestIntegration(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
 
-	for _, engine := range []string{"kv-v1", "kv-v2"} {
-		t.Run(engine, func(t *testing.T) {
+	tests := []struct {
+		name   string
+		image  string
+		engine string
+	}{
+		{
+			name:   "v1.x with kv-v1",
+			image:  vaultImageV1,
+			engine: "kv-v1",
+		},
+		{
+			name:   "v1.x with kv-v2",
+			image:  vaultImageV1,
+			engine: "kv-v2",
+		},
+		{
+			name:   "v2.x with kv-v1",
+			image:  vaultImageV2,
+			engine: "kv-v1",
+		},
+		{
+			name:   "v2.x with kv-v2",
+			image:  vaultImageV2,
+			engine: "kv-v2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
 			// Commands for preparing the container
 			commands := []string{
 				// Enable authentication via approle
@@ -67,15 +99,15 @@ func TestIntegrationV1(t *testing.T) {
 				"vault policy write my-policy /tmp/policy.hcl",
 				"vault write auth/approle/role/my-role policies=my-policy",
 				// Enable KV engine and add secrets
-				"vault secrets enable -path=my-mount-path " + engine,
+				"vault secrets enable -path=my-mount-path " + tt.engine,
 				"vault kv put -mount=my-mount-path my-secret-path secret-some-name=secret-some-value",
 			}
 
 			// Setup the container
 			policyPath, err := filepath.Abs("testdata/policy.hcl")
 			require.NoError(t, err)
-			container := testutil.Container{
-				Image:        "hashicorp/vault:1.21",
+			container := &testutil.Container{
+				Image:        tt.image,
 				ExposedPorts: []string{"8200"},
 				Env: map[string]string{
 					"VAULT_ADDR":              "http://localhost:8200",
@@ -94,113 +126,25 @@ func TestIntegrationV1(t *testing.T) {
 			addr := "http://" + container.Address + ":" + container.Ports["8200"]
 
 			// Determine credentials from container
-			rc, reader, err := container.Exec([]string{
+			buf, err := readInfo(container, []string{
 				"vault", "read", "-field", "role_id", "auth/approle/role/my-role/role-id",
 			})
 			require.NoError(t, err)
-			buf, err := io.ReadAll(reader)
-			require.NoError(t, err)
-			require.Zero(t, rc, string(buf))
-			roleID := string(buf[8:])
-
-			rc, reader, err = container.Exec([]string{
+			roleID := string(buf)
+			buf, err = readInfo(container, []string{
 				"vault", "write", "-field", "secret_id", "-force", "auth/approle/role/my-role/secret-id",
 			})
 			require.NoError(t, err)
-			buf, err = io.ReadAll(reader)
-			require.NoError(t, err)
-			require.Zero(t, rc, string(buf))
-			secretID := config.NewSecret(buf[8:])
+			secretID := config.NewSecret(buf)
 			defer secretID.Destroy()
 
 			// Setup plugin
 			plugin := &Vault{
-				ID:         "test_integration_" + engine,
+				ID:         "test_integration_" + tt.engine,
 				Address:    addr,
 				MountPath:  "my-mount-path",
 				SecretPath: "my-secret-path",
-				Engine:     engine,
-				AppRole: &appRole{
-					RoleID: roleID,
-					Secret: secretID,
-				},
-			}
-			require.NoError(t, plugin.Init())
-
-			// Check if we can retrieve the secret
-			secret, err := plugin.Get("secret-some-name")
-			require.NoError(t, err)
-			require.Equal(t, "secret-some-value", string(secret))
-		})
-	}
-}
-func TestIntegrationV2(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping integration test in short mode")
-	}
-
-	for _, engine := range []string{"kv-v1", "kv-v2"} {
-		t.Run(engine, func(t *testing.T) {
-			// Commands for preparing the container
-			commands := []string{
-				// Enable authentication via approle
-				"vault auth enable approle",
-				"vault policy write my-policy /tmp/policy.hcl",
-				"vault write auth/approle/role/my-role policies=my-policy",
-				// Enable KV engine and add secrets
-				"vault secrets enable -path=my-mount-path " + engine,
-				"vault kv put -mount=my-mount-path my-secret-path secret-some-name=secret-some-value",
-			}
-
-			// Setup the container
-			policyPath, err := filepath.Abs("testdata/policy.hcl")
-			require.NoError(t, err)
-			container := testutil.Container{
-				Image:        "hashicorp/vault:2.1",
-				ExposedPorts: []string{"8200"},
-				Env: map[string]string{
-					"VAULT_ADDR":              "http://localhost:8200",
-					"VAULT_DEV_ROOT_TOKEN_ID": "telegraf",
-					"VAULT_TOKEN":             "telegraf",
-				},
-				Files: map[string]string{"/tmp/policy.hcl": policyPath},
-				WaitingFor: wait.ForAll(
-					wait.ForHTTP("/v1/sys/health").WithPort("8200"),
-					wait.ForExec([]string{"/bin/sh", "-c", strings.Join(commands, " && ")}),
-				),
-			}
-			require.NoError(t, container.Start(), "failed to start container")
-			defer container.Terminate()
-
-			addr := "http://" + container.Address + ":" + container.Ports["8200"]
-
-			// Determine credentials from container
-			rc, reader, err := container.Exec([]string{
-				"vault", "read", "-field", "role_id", "auth/approle/role/my-role/role-id",
-			})
-			require.NoError(t, err)
-			buf, err := io.ReadAll(reader)
-			require.NoError(t, err)
-			require.Zero(t, rc, string(buf))
-			roleID := string(buf[8:])
-
-			rc, reader, err = container.Exec([]string{
-				"vault", "write", "-field", "secret_id", "-force", "auth/approle/role/my-role/secret-id",
-			})
-			require.NoError(t, err)
-			buf, err = io.ReadAll(reader)
-			require.NoError(t, err)
-			require.Zero(t, rc, string(buf))
-			secretID := config.NewSecret(buf[8:])
-			defer secretID.Destroy()
-
-			// Setup plugin
-			plugin := &Vault{
-				ID:         "test_integration_" + engine,
-				Address:    addr,
-				MountPath:  "my-mount-path",
-				SecretPath: "my-secret-path",
-				Engine:     engine,
+				Engine:     tt.engine,
 				AppRole: &appRole{
 					RoleID: roleID,
 					Secret: secretID,
@@ -235,8 +179,8 @@ func TestIntegrationAppRoleSecretWrapped(t *testing.T) {
 	// Setup the container
 	policyPath, err := filepath.Abs("testdata/policy.hcl")
 	require.NoError(t, err)
-	container := testutil.Container{
-		Image:        "hashicorp/vault:1.20.4",
+	container := &testutil.Container{
+		Image:        vaultImageV1,
 		ExposedPorts: []string{"8200"},
 		Env: map[string]string{
 			"VAULT_ADDR":              "http://localhost:8200",
@@ -255,36 +199,16 @@ func TestIntegrationAppRoleSecretWrapped(t *testing.T) {
 	addr := "http://" + container.Address + ":" + container.Ports["8200"]
 
 	// Determine credentials from container
-	rc, reader, err := container.Exec([]string{
+	buf, err := readInfo(container, []string{
 		"vault", "read", "-field", "role_id", "auth/approle/role/my-role/role-id",
 	})
 	require.NoError(t, err)
-	buf, err := io.ReadAll(reader)
-	require.NoError(t, err)
-	require.Zero(t, rc, string(buf))
-	roleID := string(buf[8:])
-
-	rc, reader, err = container.Exec([]string{
-		"vault", "write", "-wrap-ttl=60s", "-force", "-format=json", "auth/approle/role/my-role/secret-id",
+	roleID := string(buf)
+	buf, err = readInfo(container, []string{
+		"vault", "write", "-wrap-ttl=60s", "-force", "-field", "wrapping_token", "auth/approle/role/my-role/secret-id",
 	})
 	require.NoError(t, err)
-	buf, err = io.ReadAll(reader)
-	require.NoError(t, err)
-	require.Zero(t, rc, string(buf))
-
-	// Trim some junk characters in the response first.
-	// "json"/"raw" format may still contain some non-JSON prefix/suffix
-	startIndex := bytes.IndexByte(buf, byte('{'))
-	endIndex := bytes.LastIndexByte(buf, byte('}'))
-	buf = buf[startIndex : endIndex+1]
-
-	var resp struct {
-		WrapInfo struct {
-			Token string `json:"token"`
-		} `json:"wrap_info"`
-	}
-	require.NoError(t, json.Unmarshal(buf, &resp))
-	secretID := config.NewSecret([]byte(resp.WrapInfo.Token))
+	secretID := config.NewSecret(buf)
 	defer secretID.Destroy()
 
 	// Setup plugin
@@ -322,8 +246,8 @@ func TestIntegrationSetKeepsSiblings(t *testing.T) {
 			}
 
 			// Setup the container
-			container := testutil.Container{
-				Image:        "hashicorp/vault:1.20.4",
+			container := &testutil.Container{
+				Image:        vaultImageV1,
 				ExposedPorts: []string{"8200"},
 				Env: map[string]string{
 					"VAULT_ADDR":              "http://localhost:8200",
@@ -392,8 +316,8 @@ func TestIntegrationRemove(t *testing.T) {
 			}
 
 			// Setup the container
-			container := testutil.Container{
-				Image:        "hashicorp/vault:1.20.4",
+			container := &testutil.Container{
+				Image:        vaultImageV1,
 				ExposedPorts: []string{"8200"},
 				Env: map[string]string{
 					"VAULT_ADDR":              "http://localhost:8200",
@@ -457,8 +381,8 @@ func TestIntegrationSetCreatesNewPath(t *testing.T) {
 			}
 
 			// Setup the container
-			container := testutil.Container{
-				Image:        "hashicorp/vault:1.20.4",
+			container := &testutil.Container{
+				Image:        vaultImageV1,
 				ExposedPorts: []string{"8200"},
 				Env: map[string]string{
 					"VAULT_ADDR":              "http://localhost:8200",
@@ -494,4 +418,19 @@ func TestIntegrationSetCreatesNewPath(t *testing.T) {
 			require.Equal(t, "three", string(value))
 		})
 	}
+}
+
+func readInfo(container *testutil.Container, command []string) ([]byte, error) {
+	rc, reader, err := container.Exec(command, exec.Multiplexed())
+	if err != nil {
+		return nil, fmt.Errorf("executing command failed: %w", err)
+	}
+	buf, err := io.ReadAll(reader)
+	if err != nil {
+		return nil, fmt.Errorf("reading output failed: %w", err)
+	}
+	if rc != 0 {
+		return nil, fmt.Errorf("command returned %d: %s", rc, string(buf))
+	}
+	return buf, nil
 }

--- a/plugins/secretstores/vault/vault_test.go
+++ b/plugins/secretstores/vault/vault_test.go
@@ -98,20 +98,20 @@ func TestIntegrationV1(t *testing.T) {
 				"vault", "read", "-field", "role_id", "auth/approle/role/my-role/role-id",
 			})
 			require.NoError(t, err)
-			require.Zero(t, rc)
 			buf, err := io.ReadAll(reader)
 			require.NoError(t, err)
-			roleId := string(buf[8:])
+			require.Zero(t, rc, string(buf))
+			roleID := string(buf[8:])
 
 			rc, reader, err = container.Exec([]string{
 				"vault", "write", "-field", "secret_id", "-force", "auth/approle/role/my-role/secret-id",
 			})
 			require.NoError(t, err)
-			require.Zero(t, rc)
 			buf, err = io.ReadAll(reader)
 			require.NoError(t, err)
-			secretId := config.NewSecret(buf[8:])
-			defer secretId.Destroy()
+			require.Zero(t, rc, string(buf))
+			secretID := config.NewSecret(buf[8:])
+			defer secretID.Destroy()
 
 			// Setup plugin
 			plugin := &Vault{
@@ -121,8 +121,8 @@ func TestIntegrationV1(t *testing.T) {
 				SecretPath: "my-secret-path",
 				Engine:     engine,
 				AppRole: &appRole{
-					RoleID: roleId,
-					Secret: secretId,
+					RoleID: roleID,
+					Secret: secretID,
 				},
 			}
 			require.NoError(t, plugin.Init())
@@ -179,20 +179,20 @@ func TestIntegrationV2(t *testing.T) {
 				"vault", "read", "-field", "role_id", "auth/approle/role/my-role/role-id",
 			})
 			require.NoError(t, err)
-			require.Zero(t, rc)
 			buf, err := io.ReadAll(reader)
 			require.NoError(t, err)
-			roleId := string(buf[8:])
+			require.Zero(t, rc, string(buf))
+			roleID := string(buf[8:])
 
 			rc, reader, err = container.Exec([]string{
 				"vault", "write", "-field", "secret_id", "-force", "auth/approle/role/my-role/secret-id",
 			})
 			require.NoError(t, err)
-			require.Zero(t, rc)
 			buf, err = io.ReadAll(reader)
 			require.NoError(t, err)
-			secretId := config.NewSecret(buf[8:])
-			defer secretId.Destroy()
+			require.Zero(t, rc, string(buf))
+			secretID := config.NewSecret(buf[8:])
+			defer secretID.Destroy()
 
 			// Setup plugin
 			plugin := &Vault{
@@ -202,8 +202,8 @@ func TestIntegrationV2(t *testing.T) {
 				SecretPath: "my-secret-path",
 				Engine:     engine,
 				AppRole: &appRole{
-					RoleID: roleId,
-					Secret: secretId,
+					RoleID: roleID,
+					Secret: secretID,
 				},
 			}
 			require.NoError(t, plugin.Init())
@@ -259,10 +259,10 @@ func TestIntegrationAppRoleSecretWrapped(t *testing.T) {
 		"vault", "read", "-field", "role_id", "auth/approle/role/my-role/role-id",
 	})
 	require.NoError(t, err)
-	require.Zero(t, rc)
 	buf, err := io.ReadAll(reader)
 	require.NoError(t, err)
-	roleId := string(buf[8:])
+	require.Zero(t, rc, string(buf))
+	roleID := string(buf[8:])
 
 	rc, reader, err = container.Exec([]string{
 		"vault", "write", "-wrap-ttl=60s", "-force", "-format=json", "auth/approle/role/my-role/secret-id",
@@ -270,6 +270,7 @@ func TestIntegrationAppRoleSecretWrapped(t *testing.T) {
 	require.NoError(t, err)
 	buf, err = io.ReadAll(reader)
 	require.NoError(t, err)
+	require.Zero(t, rc, string(buf))
 
 	// Trim some junk characters in the response first.
 	// "json"/"raw" format may still contain some non-JSON prefix/suffix
@@ -283,8 +284,8 @@ func TestIntegrationAppRoleSecretWrapped(t *testing.T) {
 		} `json:"wrap_info"`
 	}
 	require.NoError(t, json.Unmarshal(buf, &resp))
-	secretId := config.NewSecret([]byte(resp.WrapInfo.Token))
-	defer secretId.Destroy()
+	secretID := config.NewSecret([]byte(resp.WrapInfo.Token))
+	defer secretID.Destroy()
 
 	// Setup plugin
 	plugin := &Vault{
@@ -293,8 +294,8 @@ func TestIntegrationAppRoleSecretWrapped(t *testing.T) {
 		MountPath:  "my-mount-path",
 		SecretPath: "my-secret-path",
 		AppRole: &appRole{
-			RoleID:          roleId,
-			Secret:          secretId,
+			RoleID:          roleID,
+			Secret:          secretID,
 			ResponseWrapped: true,
 		},
 	}

--- a/testutil/container.go
+++ b/testutil/container.go
@@ -11,6 +11,7 @@ import (
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/client"
 	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/exec"
 	"github.com/testcontainers/testcontainers-go/wait"
 )
 
@@ -136,8 +137,8 @@ func (c *Container) LookupMappedPorts() error {
 	return nil
 }
 
-func (c *Container) Exec(cmds []string) (int, io.Reader, error) {
-	return c.container.Exec(c.ctx, cmds)
+func (c *Container) Exec(cmds []string, options ...exec.ProcessOption) (int, io.Reader, error) {
+	return c.container.Exec(c.ctx, cmds, options...)
 }
 
 func (c *Container) PrintLogs() {


### PR DESCRIPTION
## Summary

This PR cleans the unit-tests and directly uses the testcontainer package for testing instead of the `vault` module. This removes a dependency and gives us more freedom which containers to use. As a side effect the PR now bumps one integration test to the latest 1.x version of vault and adds an integration test for the 2.x version.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

related to #19606 
