### PR TITLE
feat(secretstores.vault): Allow using namespace

### DIFF
--- a/plugins/secretstores/vault/README.md
+++ b/plugins/secretstores/vault/README.md
@@ -46,6 +46,9 @@ store usage.
   ## paths is handled automatically and should not be included.
   secret_path = ""
 
+  ## Namespace of the secrets; no namespace is used when empty
+  # namespace = ""
+
   ## Secret store engine to use.
   ## Supports 'kv-v1' and 'kv-v2' engines.
   ## By default will use the kv-v2 engine.

--- a/plugins/secretstores/vault/README.md
+++ b/plugins/secretstores/vault/README.md
@@ -47,6 +47,7 @@ store usage.
   secret_path = ""
 
   ## Namespace of the secrets; no namespace is used when empty
+  ## Ignored if the server does not support namespaces such as Vault Community
   # namespace = ""
 
   ## Secret store engine to use.

--- a/plugins/secretstores/vault/sample.conf
+++ b/plugins/secretstores/vault/sample.conf
@@ -21,6 +21,9 @@
   ## paths is handled automatically and should not be included.
   secret_path = ""
 
+  ## Namespace of the secrets; no namespace is used when empty
+  # namespace = ""
+
   ## Secret store engine to use.
   ## Supports 'kv-v1' and 'kv-v2' engines.
   ## By default will use the kv-v2 engine.

--- a/plugins/secretstores/vault/sample.conf
+++ b/plugins/secretstores/vault/sample.conf
@@ -22,6 +22,7 @@
   secret_path = ""
 
   ## Namespace of the secrets; no namespace is used when empty
+  ## Ignored if the server does not support namespaces such as Vault Community
   # namespace = ""
 
   ## Secret store engine to use.

--- a/plugins/secretstores/vault/vault.go
+++ b/plugins/secretstores/vault/vault.go
@@ -25,6 +25,7 @@ type Vault struct {
 	Address    string        `toml:"address"`
 	MountPath  string        `toml:"mount_path"`
 	SecretPath string        `toml:"secret_path"`
+	Namespace  string        `toml:"namespace"`
 	Engine     string        `toml:"engine"`
 	Token      config.Secret `toml:"token"`
 	AppRole    *appRole      `toml:"approle"`
@@ -77,6 +78,9 @@ func (v *Vault) Init() error {
 	client, err := vault.NewClient(cfg)
 	if err != nil {
 		return fmt.Errorf("error creating Vault client: %w", err)
+	}
+	if v.Namespace != "" {
+		client.SetNamespace(v.Namespace)
 	}
 
 	v.client = client

--- a/plugins/secretstores/vault/vault_test.go
+++ b/plugins/secretstores/vault/vault_test.go
@@ -420,6 +420,77 @@ func TestIntegrationSetCreatesNewPath(t *testing.T) {
 	}
 }
 
+func TestIntegrationOpenBAONamespace(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	tests := []struct {
+		namespace string
+		expected  string
+	}{
+		{
+			namespace: "namespaceA",
+			expected:  "secret-some-value",
+		},
+		{
+			namespace: "namespaceB",
+			expected:  "secret-another-value",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.namespace, func(t *testing.T) {
+			// Commands for preparing the container
+			commands := []string{
+				// Authenticate
+				"bao login telegraf",
+				// Create namespaces and add secrets
+				"bao namespace create namespaceA",
+				"bao secrets enable -namespace=namespaceA -path=my-mount-path kv-v2",
+				"bao kv put -namespace=namespaceA -mount=my-mount-path my-secret-path secret-some-name=secret-some-value",
+				"bao namespace create namespaceB",
+				"bao secrets enable -namespace=namespaceB -path=my-mount-path kv-v2",
+				"bao kv put -namespace=namespaceB -mount=my-mount-path my-secret-path secret-some-name=secret-another-value",
+			}
+
+			// Setup the container
+			container := &testutil.Container{
+				Image:        "openbao/openbao",
+				ExposedPorts: []string{"8200"},
+				Env: map[string]string{
+					"BAO_ADDR":              "http://localhost:8200",
+					"BAO_DEV_ROOT_TOKEN_ID": "telegraf",
+					"BAO_TOKEN":             "telegraf",
+				},
+				WaitingFor: wait.ForAll(
+					wait.ForHTTP("/v1/sys/health").WithPort("8200"),
+					wait.ForExec([]string{"/bin/sh", "-c", strings.Join(commands, " && ")}),
+				),
+			}
+			require.NoError(t, container.Start(), "failed to start container")
+			defer container.Terminate()
+
+			addr := "http://" + container.Address + ":" + container.Ports["8200"]
+
+			plugin := &Vault{
+				ID:         "test_integration_namespace",
+				Address:    addr,
+				MountPath:  "my-mount-path",
+				SecretPath: "my-secret-path",
+				Namespace:  tt.namespace,
+				Token:      config.NewSecret([]byte("telegraf")),
+			}
+
+			require.NoError(t, plugin.Init())
+
+			secret, err := plugin.Get("secret-some-name")
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, string(secret))
+		})
+	}
+}
+
 func readInfo(container *testutil.Container, command []string) ([]byte, error) {
 	rc, reader, err := container.Exec(command, exec.Multiplexed())
 	if err != nil {


### PR DESCRIPTION
## Summary

This PR adds support for namespaces and also adds a unit-test for the OpenBao container as namespaces are an Enterprise-only feature on Vault.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

resolves #19606
based on #19621 
