### PR TITLE
fix(processors.reverse_dns): Handle NXDOMAIN error correctly

### DIFF
--- a/plugins/processors/reverse_dns/rdnscache.go
+++ b/plugins/processors/reverse_dns/rdnscache.go
@@ -213,8 +213,14 @@ func (d *reverseDNSCache) doLookup(ip string) {
 
 	names, err := d.resolver.LookupAddr(ctx, ip)
 	if err != nil {
-		d.abandonLookup(ip, err)
-		return
+		var dnsErr *net.DNSError
+		if !errors.As(err, &dnsErr) || !dnsErr.IsNotFound {
+			d.abandonLookup(ip, err)
+			return
+		}
+
+		// Treat NXDOMAIN errors for hosts that cannot be resolved as responses without names
+		names = nil
 	}
 
 	d.rwLock.Lock()


### PR DESCRIPTION
## Summary

This PR fixes the handling for IPs that cannot be resolved e.g. returning an NXDOMAIN error. We want to cache those responses to avoid bothering the DNS server repeatedly and avoid logging errors.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

resolves #19616
