### PR TITLE
fix(inputs.opentelemetry): bounds check profile table indexes

### DIFF
--- a/plugins/inputs/opentelemetry/grpc_service_profile.go
+++ b/plugins/inputs/opentelemetry/grpc_service_profile.go
@@ -10,6 +10,8 @@ import (
 
 	service "go.opentelemetry.io/proto/otlp/collector/profiles/v1development"
 	otlp "go.opentelemetry.io/proto/otlp/profiles/v1development"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/encoding/protojson"
 
 	"github.com/influxdata/telegraf"
@@ -63,52 +65,84 @@ func (s *profileService) Export(_ context.Context, req *service.ExportProfilesSe
 	}
 
 	pd := req.Dictionary
+	if pd == nil {
+		return nil, status.Error(codes.InvalidArgument, "profile dictionary is required")
+	}
 
 	for _, rp := range req.ResourceProfiles {
 		// Extract the requested attributes that should be added as tags
 		attrtags := make(map[string]string)
-		for _, attr := range rp.Resource.Attributes {
-			if s.filter.Match(attr.Key) {
-				attrtags[attr.Key] = attr.GetValue().GetStringValue()
+		if rp.Resource != nil {
+			for _, attr := range rp.Resource.Attributes {
+				if s.filter.Match(attr.Key) {
+					attrtags[attr.Key] = attr.GetValue().GetStringValue()
+				}
 			}
 		}
 
 		for _, sp := range rp.ScopeProfiles {
 			for _, p := range sp.Profiles {
+				// These four are constant for the profile, so resolve them once
+				// and drop the whole profile if any of them cannot be resolved.
+				sampleName, nameOK := tableEntry(pd.StringTable, p.GetPeriodType().GetTypeStrindex())
+				sampleUnit, unitOK := tableEntry(pd.StringTable, p.GetPeriodType().GetUnitStrindex())
+				sampleType, typeOK := tableEntry(pd.StringTable, p.GetSampleType().GetTypeStrindex())
+				sampleTypeUnit, typeUnitOK := tableEntry(pd.StringTable, p.GetSampleType().GetUnitStrindex())
+				if !nameOK || !unitOK || !typeOK || !typeUnitOK {
+					s.logger.Errorf("dropping profile %s: period or sample type names out of range", hex.EncodeToString(p.ProfileId))
+					continue
+				}
+
 				for i, sample := range p.Samples {
-					stack := pd.StackTable[sample.StackIndex]
+					stack, ok := tableEntry(pd.StackTable, sample.StackIndex)
+					if !ok {
+						s.logger.Errorf("dropping sample %d: stack index %d out of range", i, sample.StackIndex)
+						continue
+					}
 					for _, locIdx := range stack.LocationIndices {
-						for validx, value := range sample.Values {
-							loc := pd.LocationTable[locIdx]
-							locations := make([]string, 0, len(loc.Lines))
-							for _, line := range loc.Lines {
-								f := pd.FunctionTable[line.FunctionIndex]
-								fileloc := pd.StringTable[f.FilenameStrindex]
-								if f.StartLine > 0 {
-									if fileloc != "" {
-										fileloc += " "
-									}
-									fileloc += "line " + strconv.FormatInt(f.StartLine, 10)
-								}
-								l := pd.StringTable[f.NameStrindex]
-								if fileloc != "" {
-									l += "(" + fileloc + ")"
-								}
-								locations = append(locations, l)
+						loc, ok := tableEntry(pd.LocationTable, locIdx)
+						if !ok {
+							s.logger.Errorf("dropping sample %d: location index %d out of range", i, locIdx)
+							continue
+						}
+						locations, ok := s.resolveLocation(pd, loc)
+						if !ok {
+							s.logger.Errorf("dropping sample %d: location %d references an out-of-range function or string", i, locIdx)
+							continue
+						}
+						mapping := &otlp.Mapping{}
+						// MappingIndex of 0 means unknown or unapplicable mapping, as the
+						// first entry in the  mapping table is always a null mapping.
+						if loc.MappingIndex != 0 {
+							mapping, ok = tableEntry(pd.MappingTable, loc.MappingIndex)
+							if !ok {
+								s.logger.Errorf("dropping sample %d: mapping index %d out of range", i, loc.MappingIndex)
+								continue
 							}
-							mapping := &otlp.Mapping{}
-							// MappingIndex of 0 means unknown or unapplicable mapping, as the
-							// first entry in the  mapping table is always a null mapping.
-							if loc.MappingIndex != 0 {
-								mapping = pd.MappingTable[loc.MappingIndex]
+						}
+						mappingFilename, ok := tableEntry(pd.StringTable, mapping.FilenameStrindex)
+						if !ok {
+							s.logger.Errorf("dropping sample %d: mapping filename index %d out of range", i, mapping.FilenameStrindex)
+							continue
+						}
+						sampleAttributes, ok := s.resolveAttributes(pd, sample.AttributeIndices)
+						if !ok {
+							s.logger.Errorf("dropping sample %d: attribute index out of range", i)
+							continue
+						}
+						for validx, value := range sample.Values {
+							ts, ok := tableEntry(sample.TimestampsUnixNano, int32(validx))
+							if !ok {
+								s.logger.Errorf("dropping sample %d: no timestamp for value %d", i, validx)
+								continue
 							}
 							tags := map[string]string{
 								"profile_id":       hex.EncodeToString(p.ProfileId),
 								"sample":           strconv.Itoa(i),
-								"sample_name":      pd.StringTable[p.PeriodType.TypeStrindex],
-								"sample_unit":      pd.StringTable[p.PeriodType.UnitStrindex],
-								"sample_type":      pd.StringTable[p.SampleType.TypeStrindex],
-								"sample_type_unit": pd.StringTable[p.SampleType.UnitStrindex],
+								"sample_name":      sampleName,
+								"sample_unit":      sampleUnit,
+								"sample_type":      sampleType,
+								"sample_type_unit": sampleTypeUnit,
 								"address":          "0x" + strconv.FormatUint(loc.Address, 16),
 							}
 							for k, v := range attrtags {
@@ -120,16 +154,13 @@ func (s *profileService) Export(_ context.Context, req *service.ExportProfilesSe
 								"location":             strings.Join(locations, ","),
 								"memory_start":         mapping.MemoryStart,
 								"memory_limit":         mapping.MemoryLimit,
-								"filename":             pd.StringTable[mapping.FilenameStrindex],
+								"filename":             mappingFilename,
 								"file_offset":          mapping.FileOffset,
 								"value":                value,
 							}
-							for _, idx := range sample.AttributeIndices {
-								attr := pd.AttributeTable[idx]
-								key := pd.StringTable[attr.KeyStrindex]
-								fields[key] = attr.GetValue().Value
+							for k, v := range sampleAttributes {
+								fields[k] = v
 							}
-							ts := sample.TimestampsUnixNano[validx]
 							s.acc.AddFields("profiles", fields, tags, time.Unix(0, int64(ts)))
 						}
 					}
@@ -138,4 +169,66 @@ func (s *profileService) Export(_ context.Context, req *service.ExportProfilesSe
 		}
 	}
 	return &service.ExportProfilesServiceResponse{}, nil
+}
+
+// tableEntry reads an entry from one of the cross-reference tables carried in a
+// profile request. Every index in the payload is chosen by the sender, so an
+// out-of-range one is a malformed message rather than a bug in the sender, and
+// it must not reach a slice index expression: the plugin's gRPC server installs
+// no recovery interceptor, so the resulting panic ends the Telegraf process.
+func tableEntry[T any](table []T, index int32) (T, bool) {
+	if index < 0 || int(index) >= len(table) {
+		var zero T
+		return zero, false
+	}
+	return table[index], true
+}
+
+// resolveLocation renders the function names and file positions of a location,
+// reporting false if any index in it is out of range.
+func (s *profileService) resolveLocation(pd *otlp.ProfilesDictionary, loc *otlp.Location) ([]string, bool) {
+	locations := make([]string, 0, len(loc.Lines))
+	for _, line := range loc.Lines {
+		f, ok := tableEntry(pd.FunctionTable, line.FunctionIndex)
+		if !ok {
+			return nil, false
+		}
+		fileloc, ok := tableEntry(pd.StringTable, f.FilenameStrindex)
+		if !ok {
+			return nil, false
+		}
+		if f.StartLine > 0 {
+			if fileloc != "" {
+				fileloc += " "
+			}
+			fileloc += "line " + strconv.FormatInt(f.StartLine, 10)
+		}
+		l, ok := tableEntry(pd.StringTable, f.NameStrindex)
+		if !ok {
+			return nil, false
+		}
+		if fileloc != "" {
+			l += "(" + fileloc + ")"
+		}
+		locations = append(locations, l)
+	}
+	return locations, true
+}
+
+// resolveAttributes reads the sample attributes, reporting false if any index is
+// out of range.
+func (s *profileService) resolveAttributes(pd *otlp.ProfilesDictionary, indices []int32) (map[string]interface{}, bool) {
+	attributes := make(map[string]interface{}, len(indices))
+	for _, idx := range indices {
+		attr, ok := tableEntry(pd.AttributeTable, idx)
+		if !ok {
+			return nil, false
+		}
+		key, ok := tableEntry(pd.StringTable, attr.KeyStrindex)
+		if !ok {
+			return nil, false
+		}
+		attributes[key] = attr.GetValue().Value
+	}
+	return attributes, true
 }

--- a/plugins/inputs/opentelemetry/grpc_service_profile_test.go
+++ b/plugins/inputs/opentelemetry/grpc_service_profile_test.go
@@ -1,0 +1,165 @@
+package opentelemetry
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	service "go.opentelemetry.io/proto/otlp/collector/profiles/v1development"
+	common "go.opentelemetry.io/proto/otlp/common/v1"
+	otlp "go.opentelemetry.io/proto/otlp/profiles/v1development"
+	resource "go.opentelemetry.io/proto/otlp/resource/v1"
+
+	"github.com/influxdata/telegraf/testutil"
+)
+
+// requestWithSample builds a profile request whose tables are all empty apart
+// from the entries a well-formed sample needs, so a test can point a single
+// index past the end of its table and change nothing else.
+func requestWithSample(sample *otlp.Sample, dictionary *otlp.ProfilesDictionary) *service.ExportProfilesServiceRequest {
+	return &service.ExportProfilesServiceRequest{
+		Dictionary: dictionary,
+		ResourceProfiles: []*otlp.ResourceProfiles{{
+			Resource: &resource.Resource{},
+			ScopeProfiles: []*otlp.ScopeProfiles{{
+				Profiles: []*otlp.Profile{{
+					ProfileId:  []byte{1, 2, 3, 4},
+					SampleType: &otlp.ValueType{TypeStrindex: 0, UnitStrindex: 0},
+					PeriodType: &otlp.ValueType{TypeStrindex: 0, UnitStrindex: 0},
+					Samples:    []*otlp.Sample{sample},
+				}},
+			}},
+		}},
+	}
+}
+
+func validDictionary() *otlp.ProfilesDictionary {
+	return &otlp.ProfilesDictionary{
+		StringTable:   []string{"", "main.go", "main"},
+		MappingTable:  []*otlp.Mapping{{}},
+		FunctionTable: []*otlp.Function{{NameStrindex: 2, FilenameStrindex: 1}},
+		LocationTable: []*otlp.Location{{Lines: []*otlp.Line{{FunctionIndex: 0}}}},
+		StackTable:    []*otlp.Stack{{LocationIndices: []int32{0}}},
+		AttributeTable: []*otlp.KeyValueAndUnit{
+			{KeyStrindex: 1, Value: &common.AnyValue{Value: &common.AnyValue_StringValue{StringValue: "v"}}},
+		},
+	}
+}
+
+func TestProfileExportOutOfRangeIndexes(t *testing.T) {
+	tests := []struct {
+		name     string
+		mutate   func(sample *otlp.Sample, dictionary *otlp.ProfilesDictionary)
+		expected int
+	}{
+		{
+			name:     "well formed",
+			mutate:   func(*otlp.Sample, *otlp.ProfilesDictionary) {},
+			expected: 1,
+		},
+		{
+			name: "stack index",
+			mutate: func(sample *otlp.Sample, _ *otlp.ProfilesDictionary) {
+				sample.StackIndex = 999
+			},
+		},
+		{
+			name: "location index",
+			mutate: func(_ *otlp.Sample, dictionary *otlp.ProfilesDictionary) {
+				dictionary.StackTable[0].LocationIndices = []int32{999}
+			},
+		},
+		{
+			name: "function index",
+			mutate: func(_ *otlp.Sample, dictionary *otlp.ProfilesDictionary) {
+				dictionary.LocationTable[0].Lines[0].FunctionIndex = 999
+			},
+		},
+		{
+			name: "function name string index",
+			mutate: func(_ *otlp.Sample, dictionary *otlp.ProfilesDictionary) {
+				dictionary.FunctionTable[0].NameStrindex = 999
+			},
+		},
+		{
+			name: "mapping index",
+			mutate: func(_ *otlp.Sample, dictionary *otlp.ProfilesDictionary) {
+				dictionary.LocationTable[0].MappingIndex = 999
+			},
+		},
+		{
+			name: "sample attribute index",
+			mutate: func(sample *otlp.Sample, _ *otlp.ProfilesDictionary) {
+				sample.AttributeIndices = []int32{999}
+			},
+		},
+		{
+			name: "negative index",
+			mutate: func(sample *otlp.Sample, _ *otlp.ProfilesDictionary) {
+				sample.StackIndex = -1
+			},
+		},
+		{
+			name: "missing timestamp for value",
+			mutate: func(sample *otlp.Sample, _ *otlp.ProfilesDictionary) {
+				sample.TimestampsUnixNano = nil
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sample := &otlp.Sample{
+				StackIndex:         0,
+				Values:             []int64{1},
+				TimestampsUnixNano: []uint64{1234},
+				AttributeIndices:   []int32{0},
+			}
+			dictionary := validDictionary()
+			tt.mutate(sample, dictionary)
+
+			var acc testutil.Accumulator
+			svc, err := newProfileService(&acc, testutil.Logger{}, nil)
+			require.NoError(t, err)
+
+			require.NotPanics(t, func() {
+				_, err = svc.Export(context.Background(), requestWithSample(sample, dictionary))
+			})
+			require.NoError(t, err)
+			require.Len(t, acc.Metrics, tt.expected)
+		})
+	}
+}
+
+func TestProfileExportMissingDictionary(t *testing.T) {
+	var acc testutil.Accumulator
+	svc, err := newProfileService(&acc, testutil.Logger{}, nil)
+	require.NoError(t, err)
+
+	request := requestWithSample(&otlp.Sample{}, nil)
+
+	require.NotPanics(t, func() {
+		_, err = svc.Export(context.Background(), request)
+	})
+	require.Error(t, err)
+	require.Empty(t, acc.Metrics)
+}
+
+func TestProfileExportNilResource(t *testing.T) {
+	sample := &otlp.Sample{
+		Values:             []int64{1},
+		TimestampsUnixNano: []uint64{1234},
+	}
+	request := requestWithSample(sample, validDictionary())
+	request.ResourceProfiles[0].Resource = nil
+
+	var acc testutil.Accumulator
+	svc, err := newProfileService(&acc, testutil.Logger{}, nil)
+	require.NoError(t, err)
+
+	require.NotPanics(t, func() {
+		_, err = svc.Export(context.Background(), request)
+	})
+	require.NoError(t, err)
+	require.Len(t, acc.Metrics, 1)
+}


### PR DESCRIPTION
Closes #19630.

`profileService.Export` indexes straight into the cross-reference tables carried in the request: stack, location, function, string, mapping and attribute. Every one of those indexes is chosen by whoever sent the profile, so an out-of-range value is a malformed message rather than an internal error, and it reaches a slice index expression unchecked.

The plugin builds its gRPC server with `grpc.NewServer(grpcOptions...)` and no recovery interceptor, and grpc-go does not recover handler panics on its own, so the panic is not contained to the request. It ends the Telegraf process and every other input with it. That is what makes this worth more than a tidy-up.

Reads now go through a small `tableEntry` helper that reports whether the index was in range, and the two loops that resolve a location and the sample attributes return a failure flag rather than panicking. A sample that cannot be resolved is logged and dropped; the rest of the payload is still ingested. Negative indexes are rejected too, which matters because these are `int32` fields and a negative one is as reachable as a large one.

Two things turned up while testing that the report does not mention, both the same class and both remotely reachable. A request with no `Dictionary` at all is a nil dereference on the first table read, so that is now rejected with `InvalidArgument`. And a `ResourceProfiles` entry with no `Resource` dereferences nil in the attribute loop before any index is touched.

There is also a small behaviour change worth flagging: the four period and sample type names were resolved inside the innermost loop even though they are constant for the profile. They are resolved once per profile now, which is where the guard naturally belongs.

`grpc_service_profile_test.go` drives `Export` through the real service. It has a well-formed control that passes on the current code and produces one metric, then points one index past the end of its table at a time. On the current code the control passes and the other eleven cases panic, eight with `index out of range` and two with `invalid memory address or nil pointer dereference`. All pass with the change. `go test ./plugins/inputs/opentelemetry/...`, `go vet` and `gofmt` are clean.