### PR TITLE
docs(inputs.cloudwatch): Drop note on removed namespace option

### DIFF
--- a/plugins/inputs/cloudwatch/README.md
+++ b/plugins/inputs/cloudwatch/README.md
@@ -154,9 +154,6 @@ plugin ordering. See [CONFIGURATION.md][CONFIGURATION.md] for more details.
   #    value = "p-example"
 ```
 
-Please note, the `namespace` option is deprecated in favor of the `namespaces`
-list option.
-
 ## Requirements and Terminology
 
 Plugin Configuration utilizes [CloudWatch concepts][concept] and access


### PR DESCRIPTION
## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

`inputs.cloudwatch`'s README says the `namespace` option "is deprecated in favor of the `namespaces` list option". It was removed, not deprecated: the struct only carries `namespaces` (`cloudwatch.go:43`), so setting `namespace` now fails at startup with the unused-fields error from `config/config.go:738` rather than being honoured with a warning. So the note sends a reader towards a config that will not load.

Deleted rather than reworded, per your review on #19654.

There is a migration for this at `migrations/inputs_cloudwatch/migration.go`, and it only runs under `telegraf config migrate`, so pointing at that command instead of dropping the note is also defensible. Happy to do that if you prefer.

Documentation only. `markdownlint --config .markdownlint.jsonc` passes on the file.

No issue for this one: it came out of your review on #19654, where you asked for the two `query_version` blocks and the `source_tag` sentence to be removed rather than corrected, and this is the same class in a third plugin. Glad to open an issue if you would rather have the paper trail.

### AI involvement

The audit that found this, the one-line change and this description were written by Claude Opus 5 running in Claude Code, on my machine and under my direction.

How it was verified: the README claim was checked against the struct tags in `plugins/inputs/cloudwatch/*.go`, and against the changelog entry recording the removal. The same check was run across all 48 removed (plugin, option) pairs in the changelog, against every `sample.conf` and every README outside the generated config block; this was the only stale one left, which is why the diff is one sentence.

On the review requirement behind the checked box: I have read the three-line diff and I confirm it.

## Checklist
<!-- Mandatory
Please confirm at least ONE of the following by replacing the space with an "x"
between the []:
-->

- [ ] No AI generated code was used in this PR
- [x] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
