### PR TITLE
fix(inputs.opcua): Respect the server's MaxNodesPerRegisterNodes limit

### DIFF
--- a/plugins/inputs/opcua/opcua_test.go
+++ b/plugins/inputs/opcua/opcua_test.go
@@ -7,8 +7,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gopcua/opcua/id"
 	"github.com/gopcua/opcua/server"
 	"github.com/gopcua/opcua/ua"
+	"github.com/gopcua/opcua/uasc"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go/wait"
 
@@ -204,7 +206,7 @@ func TestReadClientIntegration(t *testing.T) {
 	}
 }
 
-func TestReadClientBatchedReads(t *testing.T) {
+func TestReadClientBatchedRequests(t *testing.T) {
 	// Bind a free port up front; close the listener so the server can
 	// claim it.
 	l, err := net.Listen("tcp", "127.0.0.1:0")
@@ -213,7 +215,7 @@ func TestReadClientBatchedReads(t *testing.T) {
 	require.NoError(t, l.Close())
 
 	// The in-process server reports a MaxNodesPerRead limit of 32, so
-	// registering more nodes than that makes the client split the read
+	// configuring more nodes than that makes the client split the read
 	// according to the limit it discovers on connect.
 	srv := server.New(
 		server.EnableSecurity("None", ua.MessageSecurityModeNone),
@@ -222,6 +224,35 @@ func TestReadClientBatchedReads(t *testing.T) {
 	)
 	ns := server.NewNodeNameSpace(srv, "telegraf-test")
 	srv.AddNamespace(ns)
+
+	// The server neither reports nor enforces a MaxNodesPerRegisterNodes
+	// limit on its own, so add the property and a handler rejecting
+	// register requests exceeding it to make sure the client splits them.
+	const maxNodesPerRegisterNodes = 16
+	ns0, err := srv.Namespace(0)
+	require.NoError(t, err)
+	ns0.AddNode(server.NewVariableNode(
+		ua.NewNumericNodeID(0, id.Server_ServerCapabilities_OperationLimits_MaxNodesPerRegisterNodes),
+		"MaxNodesPerRegisterNodes",
+		uint32(maxNodesPerRegisterNodes),
+	))
+	srv.RegisterHandler(id.RegisterNodesRequest_Encoding_DefaultBinary, func(_ *uasc.SecureChannel, r ua.Request, _ uint32) (ua.Response, error) {
+		req := r.(*ua.RegisterNodesRequest)
+		if len(req.NodesToRegister) > maxNodesPerRegisterNodes {
+			return nil, ua.StatusBadTooManyOperations
+		}
+		return &ua.RegisterNodesResponse{
+			// The encoder dereferences the nested header fields, so they
+			// must not be nil
+			ResponseHeader: &ua.ResponseHeader{
+				Timestamp:          time.Now(),
+				RequestHandle:      req.RequestHeader.RequestHandle,
+				ServiceDiagnostics: &ua.DiagnosticInfo{},
+				AdditionalHeader:   ua.NewExtensionObject(nil),
+			},
+			RegisteredNodeIDs: req.NodesToRegister,
+		}, nil
+	})
 
 	const nodes = 40
 	rootNodes := make([]input.NodeSettings, 0, nodes)
@@ -266,6 +297,8 @@ func TestReadClientBatchedReads(t *testing.T) {
 	require.NoError(t, client.connect())
 	defer client.Disconnect(t.Context())
 	require.Equal(t, 32, client.maxNodesPerRead)
+	require.Equal(t, maxNodesPerRegisterNodes, client.maxNodesPerRegisterNodes)
+	require.Len(t, client.reqIDs, nodes)
 
 	// Clear the values received on connect so the assertions below prove the
 	// batched read actually updated every node

--- a/plugins/inputs/opcua/read_client.go
+++ b/plugins/inputs/opcua/read_client.go
@@ -42,10 +42,11 @@ type readClient struct {
 	Workarounds             readClientWorkarounds
 
 	// Internal flags
-	reqIDs          []*ua.ReadValueID
-	maxNodesPerRead int
-	ctx             context.Context
-	forceReconnect  bool
+	reqIDs                   []*ua.ReadValueID
+	maxNodesPerRead          int
+	maxNodesPerRegisterNodes int
+	ctx                      context.Context
+	forceReconnect           bool
 }
 
 func (rc *readClientConfig) createReadClient(log telegraf.Logger) (*readClient, error) {
@@ -101,26 +102,27 @@ func (o *readClient) connect() error {
 		// Continue anyway - this is only needed if using namespace URIs
 	}
 
-	// Query the server-imposed limit on nodes per read request so large node
-	// sets can be split accordingly. The property is optional and zero means
-	// "no limit"; in both cases all nodes are sent in a single request.
-	o.maxNodesPerRead = 0
+	// Query the server-imposed limits on nodes per read and per register
+	// request so large node sets can be split accordingly. The properties are
+	// optional and zero means "no limit"; in both cases all nodes are sent in
+	// a single request.
+	o.maxNodesPerRead, o.maxNodesPerRegisterNodes = 0, 0
 	limits, err := o.Client.Read(o.ctx, &ua.ReadRequest{
-		NodesToRead: []*ua.ReadValueID{{
-			NodeID: ua.NewNumericNodeID(0, id.Server_ServerCapabilities_OperationLimits_MaxNodesPerRead),
-		}},
+		NodesToRead: []*ua.ReadValueID{
+			{NodeID: ua.NewNumericNodeID(0, id.Server_ServerCapabilities_OperationLimits_MaxNodesPerRead)},
+			{NodeID: ua.NewNumericNodeID(0, id.Server_ServerCapabilities_OperationLimits_MaxNodesPerRegisterNodes)},
+		},
 	})
 	switch {
 	case err != nil:
-		o.Log.Debugf("Querying the server's read limit failed: %v", err)
-	case len(limits.Results) == 1 && limits.Results[0].Status == ua.StatusOK && limits.Results[0].Value != nil:
-		if v, ok := limits.Results[0].Value.Value().(uint32); ok && v > 0 {
-			// Clamp to avoid overflowing int on 32-bit platforms
-			o.maxNodesPerRead = int(min(v, math.MaxInt32))
-			o.Log.Debugf("Server limits read requests to %d nodes", v)
-		}
+		o.Log.Debugf("Querying the server's operation limits failed: %v", err)
+	case len(limits.Results) != 2:
+		o.Log.Debugf("Server returned %d results for 2 requested operation limits", len(limits.Results))
 	default:
-		o.Log.Debug("Server does not report a read limit")
+		o.maxNodesPerRead = operationLimit(limits.Results[0])
+		o.maxNodesPerRegisterNodes = operationLimit(limits.Results[1])
+		o.Log.Debugf("Server limits requests to %d nodes per read and %d nodes per register (0 = unlimited)",
+			o.maxNodesPerRead, o.maxNodesPerRegisterNodes)
 	}
 
 	// Browse-based discovery runs on every connect so server-side schema
@@ -148,15 +150,27 @@ func (o *readClient) connect() error {
 			o.reqIDs = append(o.reqIDs, &ua.ReadValueID{NodeID: nid})
 		}
 	} else {
-		regResp, err := o.Client.RegisterNodes(o.ctx, &ua.RegisterNodesRequest{
-			NodesToRegister: o.NodeIDs,
-		})
-		if err != nil {
-			return fmt.Errorf("registering nodes failed: %w", err)
+		// Split the registration into multiple requests if the server limits
+		// the number of nodes per request; a single request holds everything
+		// otherwise.
+		batches := [][]*ua.NodeID{o.NodeIDs}
+		if o.maxNodesPerRegisterNodes > 0 {
+			batches = slices.Collect(slices.Chunk(o.NodeIDs, o.maxNodesPerRegisterNodes))
 		}
-
-		for _, v := range regResp.RegisteredNodeIDs {
-			o.reqIDs = append(o.reqIDs, &ua.ReadValueID{NodeID: v})
+		for _, batch := range batches {
+			regResp, err := o.Client.RegisterNodes(o.ctx, &ua.RegisterNodesRequest{
+				NodesToRegister: batch,
+			})
+			if err != nil {
+				return fmt.Errorf("registering nodes failed: %w", err)
+			}
+			if len(regResp.RegisteredNodeIDs) != len(batch) {
+				return fmt.Errorf("server returned %d registered node IDs for %d requested nodes",
+					len(regResp.RegisteredNodeIDs), len(batch))
+			}
+			for _, v := range regResp.RegisteredNodeIDs {
+				o.reqIDs = append(o.reqIDs, &ua.ReadValueID{NodeID: v})
+			}
 		}
 	}
 
@@ -228,13 +242,9 @@ func (o *readClient) currentValues() ([]telegraf.Metric, error) {
 func (o *readClient) read() error {
 	// Split the nodes into multiple requests if the server limits the number
 	// of nodes per read; a single request holds everything otherwise.
-	var batches [][]*ua.ReadValueID
+	batches := [][]*ua.ReadValueID{o.reqIDs}
 	if o.maxNodesPerRead > 0 {
-		for chunk := range slices.Chunk(o.reqIDs, o.maxNodesPerRead) {
-			batches = append(batches, chunk)
-		}
-	} else {
-		batches = [][]*ua.ReadValueID{o.reqIDs}
+		batches = slices.Collect(slices.Chunk(o.reqIDs, o.maxNodesPerRead))
 	}
 
 	var count uint64
@@ -303,6 +313,20 @@ func (o *readClient) read() error {
 				nodeTypeLabel(o.Workarounds.UseUnregisteredReads), err)
 		}
 	}
+}
+
+// operationLimit extracts a server operation limit from the read result of
+// the corresponding capability property. Zero means "no limit".
+func operationLimit(result *ua.DataValue) int {
+	if result.Status != ua.StatusOK || result.Value == nil {
+		return 0
+	}
+	limit, ok := result.Value.Value().(uint32)
+	if !ok {
+		return 0
+	}
+	// Clamp to avoid overflowing int on 32-bit platforms
+	return int(min(limit, math.MaxInt32))
 }
 
 // Helper function to provide more accurate error messages

--- a/plugins/inputs/opcua/read_client.go
+++ b/plugins/inputs/opcua/read_client.go
@@ -106,7 +106,8 @@ func (o *readClient) connect() error {
 	// request so large node sets can be split accordingly. The properties are
 	// optional and zero means "no limit"; in both cases all nodes are sent in
 	// a single request.
-	o.maxNodesPerRead, o.maxNodesPerRegisterNodes = 0, 0
+	o.maxNodesPerRead = 0
+	o.maxNodesPerRegisterNodes = 0
 	limits, err := o.Client.Read(o.ctx, &ua.ReadRequest{
 		NodesToRead: []*ua.ReadValueID{
 			{NodeID: ua.NewNumericNodeID(0, id.Server_ServerCapabilities_OperationLimits_MaxNodesPerRead)},


### PR DESCRIPTION
## Summary

The read client registers all configured nodes in a single RegisterNodes request on connect, so servers that limit the number of nodes per request reject it with BadTooManyOperations and collection never starts. This is the RegisterNodes counterpart of #19610, which only split the Read.

The client now queries MaxNodesPerRegisterNodes together with MaxNodesPerRead in the existing capability read and splits the registration into requests of that size, checking that the server returns one registered ID per requested node. Servers not reporting the property keep the single-request behavior.

The test extends the batched-read test with an in-process server that reports a register limit of 16 and rejects larger requests, so the 40 configured nodes require three register requests and two read requests.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

resolves #19662
