### PR TITLE
docs(inputs.opcua): Fix default timeout values in sample config

### DIFF
--- a/plugins/inputs/opcua/README.md
+++ b/plugins/inputs/opcua/README.md
@@ -38,10 +38,10 @@ to use them.
   # endpoint = "opc.tcp://localhost:4840"
 
   ## Maximum time allowed to establish a connect to the endpoint.
-  # connect_timeout = "10s"
+  # connect_timeout = "5s"
 
   ## Maximum time allowed for a request over the established connection.
-  # request_timeout = "5s"
+  # request_timeout = "10s"
 
   ## Maximum time that a session shall remain open without activity.
   # session_timeout = "20m"

--- a/plugins/inputs/opcua/sample.conf
+++ b/plugins/inputs/opcua/sample.conf
@@ -7,10 +7,10 @@
   # endpoint = "opc.tcp://localhost:4840"
 
   ## Maximum time allowed to establish a connect to the endpoint.
-  # connect_timeout = "10s"
+  # connect_timeout = "5s"
 
   ## Maximum time allowed for a request over the established connection.
-  # request_timeout = "5s"
+  # request_timeout = "10s"
 
   ## Maximum time that a session shall remain open without activity.
   # session_timeout = "20m"

--- a/plugins/inputs/opcua_listener/README.md
+++ b/plugins/inputs/opcua_listener/README.md
@@ -49,7 +49,7 @@ to use them.
   # endpoint = "opc.tcp://localhost:4840"
   #
   ## Maximum time allowed to establish a connect to the endpoint.
-  # connect_timeout = "10s"
+  # connect_timeout = "5s"
   #
   ## Behavior when we fail to connect to the endpoint on initialization. Valid options are:
   ##     "error": throw an error and exits Telegraf
@@ -58,7 +58,7 @@ to use them.
   # connect_fail_behavior = "error"
   #
   ## Maximum time allowed for a request over the established connection.
-  # request_timeout = "5s"
+  # request_timeout = "10s"
   #
   # Maximum time that a session shall remain open without activity.
   # session_timeout = "20m"

--- a/plugins/inputs/opcua_listener/sample.conf
+++ b/plugins/inputs/opcua_listener/sample.conf
@@ -7,7 +7,7 @@
   # endpoint = "opc.tcp://localhost:4840"
   #
   ## Maximum time allowed to establish a connect to the endpoint.
-  # connect_timeout = "10s"
+  # connect_timeout = "5s"
   #
   ## Behavior when we fail to connect to the endpoint on initialization. Valid options are:
   ##     "error": throw an error and exits Telegraf
@@ -16,7 +16,7 @@
   # connect_fail_behavior = "error"
   #
   ## Maximum time allowed for a request over the established connection.
-  # request_timeout = "5s"
+  # request_timeout = "10s"
   #
   # Maximum time that a session shall remain open without activity.
   # session_timeout = "20m"


### PR DESCRIPTION
## Summary

The sample configs of `inputs.opcua` and `inputs.opcua_listener` document `connect_timeout` as 10s and `request_timeout` as 5s, but both plugins default to 5s and 10s respectively in their `init()` registration since the options were introduced. Users reading the sample config get the two values swapped, which came up while answering a customer question about read timeouts.

This swaps the commented values to match the code and regenerates the READMEs. No code change.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

related to #19663
