### PR TITLE
docs: Update cel-go links to new repository location

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -732,10 +732,10 @@ evaluation is aborted, an error is logged, and the expression is reported as
 > compared to `namepass`/`namedrop` and friends. So consider to use the more
 > restricted filter options where possible in case of high-throughput scenarios.
 
-[CEL]:https://github.com/google/cel-go/tree/master
+[CEL]:https://github.com/cel-expr/cel-go
 [CEL intro]: https://codelabs.developers.google.com/codelabs/cel-go
-[CEL lang]: https://github.com/google/cel-spec/blob/master/doc/langdef.md
-[CEL ext]: https://github.com/google/cel-go/tree/master/ext#readme
+[CEL lang]: https://github.com/cel-expr/cel-spec/blob/master/doc/langdef.md
+[CEL ext]: https://github.com/cel-expr/cel-go/tree/master/ext#readme
 
 ### Modifiers
 

--- a/docs/LICENSE_OF_DEPENDENCIES.md
+++ b/docs/LICENSE_OF_DEPENDENCIES.md
@@ -210,7 +210,7 @@ following works:
 - github.com/golang/groupcache [Apache License 2.0](https://github.com/golang/groupcache/blob/master/LICENSE)
 - github.com/golang/protobuf [BSD 3-Clause "New" or "Revised" License](https://github.com/golang/protobuf/blob/master/LICENSE)
 - github.com/golang/snappy [BSD 3-Clause "New" or "Revised" License](https://github.com/golang/snappy/blob/master/LICENSE)
-- github.com/google/cel-go [Apache License 2.0](https://github.com/google/cel-go/blob/master/LICENSE)
+- github.com/google/cel-go [Apache License 2.0](https://github.com/cel-expr/cel-go/blob/master/LICENSE)
 - github.com/google/flatbuffers [Apache License 2.0](https://github.com/google/flatbuffers/blob/master/LICENSE)
 - github.com/google/gnostic-models [Apache License 2.0](https://github.com/google/gnostic-models/blob/master/LICENSE)
 - github.com/google/gnxi [Apache License 2.0](https://github.com/google/gnxi/blob/master/LICENSE)

--- a/plugins/outputs/heartbeat/README.md
+++ b/plugins/outputs/heartbeat/README.md
@@ -318,6 +318,6 @@ The following functions are available:
 [internal_plugin]: /plugins/inputs/internal/README.md
 
 [cel]: https://cel.dev
-[cel_encoder]: https://github.com/google/cel-go/blob/master/ext/README.md#encoders
-[cel_math]: https://github.com/google/cel-go/blob/master/ext/README.md#math
-[cel_strings]: https://github.com/google/cel-go/blob/master/ext/README.md#strings
+[cel_encoder]: https://github.com/cel-expr/cel-go/blob/master/ext/README.md#encoders
+[cel_math]: https://github.com/cel-expr/cel-go/blob/master/ext/README.md#math
+[cel_strings]: https://github.com/cel-expr/cel-go/blob/master/ext/README.md#strings


### PR DESCRIPTION
## Summary

The `cel-go` and `cel-spec` repositories moved from the google organization to `cel-expr`, and GitHub no longer redirects the old `cel-go` URLs. This updates CEL-related links to use the new organization structure.

## Checklist

- [ ] No AI generated code was used in this PR
- [x] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]