### PR TITLE
chore(inputs.dns_query): Cleanup code

### DIFF
--- a/plugins/inputs/dns_query/dns_query.go
+++ b/plugins/inputs/dns_query/dns_query.go
@@ -43,6 +43,8 @@ type DNSQuery struct {
 	IncludeFields []string        `toml:"include_fields"`
 
 	fieldEnabled map[string]bool
+	client       *dns.Client
+	record       uint16
 }
 
 func (*DNSQuery) SampleConfig() string {
@@ -77,6 +79,40 @@ func (d *DNSQuery) Init() error {
 
 	if d.Port < 1 {
 		d.Port = 53
+	}
+
+	// Convert the record type
+	switch d.RecordType {
+	case "A":
+		d.record = dns.TypeA
+	case "AAAA":
+		d.record = dns.TypeAAAA
+	case "ANY":
+		d.record = dns.TypeANY
+	case "CNAME":
+		d.record = dns.TypeCNAME
+	case "MX":
+		d.record = dns.TypeMX
+	case "NS":
+		d.record = dns.TypeNS
+	case "PTR":
+		d.record = dns.TypePTR
+	case "SOA":
+		d.record = dns.TypeSOA
+	case "SPF":
+		d.record = dns.TypeSPF
+	case "SRV":
+		d.record = dns.TypeSRV
+	case "TXT":
+		d.record = dns.TypeTXT
+	default:
+		return fmt.Errorf("record type %q not recognized", d.RecordType)
+	}
+
+	// Create a client for querying
+	d.client = &dns.Client{
+		ReadTimeout: time.Duration(d.Timeout),
+		Net:         d.Network,
 	}
 
 	return nil
@@ -120,22 +156,12 @@ func (d *DNSQuery) query(domain, server string) (map[string]interface{}, map[str
 		"result_code":   uint64(errorResult),
 	}
 
-	c := dns.Client{
-		ReadTimeout: time.Duration(d.Timeout),
-		Net:         d.Network,
-	}
-
-	recordType, err := d.parseRecordType()
-	if err != nil {
-		return fields, tags, err
-	}
-
 	var msg dns.Msg
-	msg.SetQuestion(dns.Fqdn(domain), recordType)
+	msg.SetQuestion(dns.Fqdn(domain), d.record)
 	msg.RecursionDesired = true
 
 	addr := net.JoinHostPort(server, strconv.Itoa(d.Port))
-	r, rtt, err := c.Exchange(&msg, addr)
+	r, rtt, err := d.client.Exchange(&msg, addr)
 	if err != nil {
 		var opErr *net.OpError
 		if errors.As(err, &opErr) && opErr.Timeout() {
@@ -199,40 +225,6 @@ func (d *DNSQuery) query(domain, server string) (map[string]interface{}, map[str
 	}
 
 	return fields, tags, nil
-}
-
-func (d *DNSQuery) parseRecordType() (uint16, error) {
-	var recordType uint16
-	var err error
-
-	switch d.RecordType {
-	case "A":
-		recordType = dns.TypeA
-	case "AAAA":
-		recordType = dns.TypeAAAA
-	case "ANY":
-		recordType = dns.TypeANY
-	case "CNAME":
-		recordType = dns.TypeCNAME
-	case "MX":
-		recordType = dns.TypeMX
-	case "NS":
-		recordType = dns.TypeNS
-	case "PTR":
-		recordType = dns.TypePTR
-	case "SOA":
-		recordType = dns.TypeSOA
-	case "SPF":
-		recordType = dns.TypeSPF
-	case "SRV":
-		recordType = dns.TypeSRV
-	case "TXT":
-		recordType = dns.TypeTXT
-	default:
-		err = fmt.Errorf("record type %s not recognized", d.RecordType)
-	}
-
-	return recordType, err
 }
 
 func extractIP(record dns.RR) (string, bool) {

--- a/plugins/inputs/dns_query/dns_query_test.go
+++ b/plugins/inputs/dns_query/dns_query_test.go
@@ -13,198 +13,46 @@ import (
 	"github.com/influxdata/telegraf/testutil"
 )
 
-var (
-	servers = []string{"8.8.8.8"}
-	domains = []string{"google.com"}
-)
-
-func TestGathering(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping network-dependent test in short mode.")
-	}
-
-	dnsConfig := DNSQuery{
-		Servers: servers,
-		Domains: domains,
-		Timeout: config.Duration(2 * time.Second),
-	}
-
-	var acc testutil.Accumulator
-	require.NoError(t, dnsConfig.Init())
-	require.NoError(t, acc.GatherError(dnsConfig.Gather))
-	m, ok := acc.Get("dns_query")
-	require.True(t, ok)
-	queryTime, ok := m.Fields["query_time_ms"].(float64)
-	require.True(t, ok)
-	require.NotEqual(t, float64(0), queryTime)
-}
-
-func TestGatherInvalid(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping network-dependent test in short mode.")
-	}
-
-	dnsConfig := DNSQuery{
-		Servers: servers,
-		Domains: []string{"qwerty123.example.com"},
-		Timeout: config.Duration(1 * time.Second),
-	}
-
-	var acc testutil.Accumulator
-	require.NoError(t, dnsConfig.Init())
-	require.NoError(t, dnsConfig.Gather(&acc))
-	require.Empty(t, acc.Errors)
-}
-
-func TestGatheringMxRecord(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping network-dependent test in short mode.")
-	}
-
-	dnsConfig := DNSQuery{
-		Servers:    servers,
-		Domains:    domains,
-		RecordType: "MX",
-		Timeout:    config.Duration(2 * time.Second),
-	}
-	var acc testutil.Accumulator
-
-	require.NoError(t, dnsConfig.Init())
-	require.NoError(t, acc.GatherError(dnsConfig.Gather))
-	m, ok := acc.Get("dns_query")
-	require.True(t, ok)
-	queryTime, ok := m.Fields["query_time_ms"].(float64)
-	require.True(t, ok)
-	require.NotEqual(t, float64(0), queryTime)
-	preference, ok := m.Fields["preference"].(uint16)
-	require.True(t, ok)
-	require.NotEqual(t, 0, preference)
-}
-
-func TestGatheringRootDomain(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping network-dependent test in short mode.")
-	}
-
-	dnsConfig := DNSQuery{
-		Servers:    servers,
-		Domains:    []string{"."},
-		RecordType: "MX",
-		Timeout:    config.Duration(2 * time.Second),
-	}
-	require.NoError(t, dnsConfig.Init())
-
-	var acc testutil.Accumulator
-	require.NoError(t, acc.GatherError(dnsConfig.Gather))
-
-	m, ok := acc.Get("dns_query")
-	require.True(t, ok)
-	queryTime, ok := m.Fields["query_time_ms"].(float64)
-	require.True(t, ok)
-
-	expected := []telegraf.Metric{
-		metric.New(
-			"dns_query",
-			map[string]string{
-				"server":      "8.8.8.8",
-				"domain":      ".",
-				"record_type": "MX",
-				"rcode":       "NOERROR",
-				"result":      "success",
+func TestInit(t *testing.T) {
+	tests := []struct {
+		name     string
+		plugin   *DNSQuery
+		expected *DNSQuery
+	}{
+		{
+			name: "domain",
+			plugin: &DNSQuery{
+				Domains: []string{"google.com"},
 			},
-			map[string]interface{}{
-				"rcode_value":   0,
-				"result_code":   uint64(0),
-				"query_time_ms": queryTime,
+			expected: &DNSQuery{
+				Network:    "udp",
+				RecordType: "NS",
+				Domains:    []string{"google.com"},
+				Port:       53,
 			},
-			time.Unix(0, 0),
-		),
-	}
-	testutil.RequireMetricsEqual(t, expected, acc.GetTelegrafMetrics(), testutil.IgnoreTime())
-}
-
-func TestMetricContainsServerAndDomainAndRecordTypeTags(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping network-dependent test in short mode.")
-	}
-
-	dnsConfig := DNSQuery{
-		Servers: servers,
-		Domains: domains,
-		Timeout: config.Duration(2 * time.Second),
-	}
-	require.NoError(t, dnsConfig.Init())
-
-	var acc testutil.Accumulator
-	require.NoError(t, acc.GatherError(dnsConfig.Gather))
-
-	m, ok := acc.Get("dns_query")
-	require.True(t, ok)
-	queryTime, ok := m.Fields["query_time_ms"].(float64)
-	require.True(t, ok)
-	expected := []telegraf.Metric{
-		metric.New(
-			"dns_query",
-			map[string]string{
-				"server":      "8.8.8.8",
-				"domain":      "google.com",
-				"record_type": "NS",
-				"rcode":       "NOERROR",
-				"result":      "success",
+		},
+		{
+			name: "timeout",
+			plugin: &DNSQuery{
+				Timeout: config.Duration(2 * time.Second),
 			},
-			map[string]interface{}{
-				"rcode_value":   0,
-				"result_code":   uint64(0),
-				"query_time_ms": queryTime,
+			expected: &DNSQuery{
+				Network:    "udp",
+				RecordType: "NS",
+				Domains:    []string{"."},
+				Port:       53,
+				Timeout:    config.Duration(2 * time.Second),
 			},
-			time.Unix(0, 0),
-		),
-	}
-	testutil.RequireMetricsEqual(t, expected, acc.GetTelegrafMetrics(), testutil.IgnoreTime())
-}
-
-func TestGatheringTimeout(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping network-dependent test in short mode.")
+		},
 	}
 
-	dnsConfig := DNSQuery{
-		Servers: servers,
-		Domains: domains,
-		Timeout: config.Duration(1 * time.Second),
-		Port:    60054,
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			plugin := tt.plugin
+			require.NoError(t, plugin.Init())
+			require.EqualExportedValues(t, tt.expected, plugin)
+		})
 	}
-	require.NoError(t, dnsConfig.Init())
-
-	var acc testutil.Accumulator
-	channel := make(chan error, 1)
-	go func() {
-		channel <- acc.GatherError(dnsConfig.Gather)
-	}()
-	select {
-	case err := <-channel:
-		require.NoError(t, err)
-	case <-time.After(time.Second * 2):
-		require.Fail(t, "DNS query did not timeout")
-	}
-}
-
-func TestSettingDefaultValues(t *testing.T) {
-	dnsConfig := DNSQuery{
-		Timeout: config.Duration(2 * time.Second),
-	}
-	require.NoError(t, dnsConfig.Init())
-	require.Equal(t, []string{"."}, dnsConfig.Domains, "Default domain not equal \".\"")
-	require.Equal(t, "NS", dnsConfig.RecordType, "Default record type not equal 'NS'")
-	require.Equal(t, 53, dnsConfig.Port, "Default port number not equal 53")
-	require.Equal(t, config.Duration(2*time.Second), dnsConfig.Timeout, "Default timeout not equal 2s")
-
-	dnsConfig = DNSQuery{
-		Domains: []string{"."},
-		Timeout: config.Duration(2 * time.Second),
-	}
-	require.NoError(t, dnsConfig.Init())
-	require.Equal(t, "NS", dnsConfig.RecordType, "Default record type not equal 'NS'")
 }
 
 func TestRecordTypeParser(t *testing.T) {
@@ -260,25 +108,193 @@ func TestRecordTypeParser(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.record, func(t *testing.T) {
-			plugin := DNSQuery{
+			plugin := &DNSQuery{
 				Timeout:    config.Duration(2 * time.Second),
 				Domains:    []string{"example.com"},
 				RecordType: tt.record,
 			}
 			require.NoError(t, plugin.Init())
-			recordType, err := plugin.parseRecordType()
-			require.NoError(t, err)
-			require.Equal(t, tt.expected, recordType)
+			require.Equal(t, tt.expected, plugin.record)
 		})
 	}
 }
 
 func TestRecordTypeParserError(t *testing.T) {
-	plugin := DNSQuery{
+	plugin := &DNSQuery{
 		Timeout:    config.Duration(2 * time.Second),
+		Domains:    []string{"example.com"},
 		RecordType: "nil",
 	}
+	require.ErrorContains(t, plugin.Init(), "record type \"nil\" not recognized")
+}
 
-	_, err := plugin.parseRecordType()
-	require.Error(t, err)
+func TestGathering(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping network-dependent test in short mode.")
+	}
+
+	dnsConfig := &DNSQuery{
+		Servers: []string{"8.8.8.8"},
+		Domains: []string{"google.com"},
+		Timeout: config.Duration(2 * time.Second),
+	}
+
+	var acc testutil.Accumulator
+	require.NoError(t, dnsConfig.Init())
+	require.NoError(t, acc.GatherError(dnsConfig.Gather))
+	m, ok := acc.Get("dns_query")
+	require.True(t, ok)
+	queryTime, ok := m.Fields["query_time_ms"].(float64)
+	require.True(t, ok)
+	require.NotEqual(t, float64(0), queryTime)
+}
+
+func TestGatherInvalid(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping network-dependent test in short mode.")
+	}
+
+	dnsConfig := &DNSQuery{
+		Servers: []string{"8.8.8.8"},
+		Domains: []string{"qwerty123.example.com"},
+		Timeout: config.Duration(1 * time.Second),
+	}
+
+	var acc testutil.Accumulator
+	require.NoError(t, dnsConfig.Init())
+	require.NoError(t, dnsConfig.Gather(&acc))
+	require.Empty(t, acc.Errors)
+}
+
+func TestGatheringMxRecord(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping network-dependent test in short mode.")
+	}
+
+	dnsConfig := &DNSQuery{
+		Servers:    []string{"8.8.8.8"},
+		Domains:    []string{"google.com"},
+		RecordType: "MX",
+		Timeout:    config.Duration(2 * time.Second),
+	}
+	var acc testutil.Accumulator
+
+	require.NoError(t, dnsConfig.Init())
+	require.NoError(t, acc.GatherError(dnsConfig.Gather))
+	m, ok := acc.Get("dns_query")
+	require.True(t, ok)
+	queryTime, ok := m.Fields["query_time_ms"].(float64)
+	require.True(t, ok)
+	require.NotEqual(t, float64(0), queryTime)
+	preference, ok := m.Fields["preference"].(uint16)
+	require.True(t, ok)
+	require.NotEqual(t, 0, preference)
+}
+
+func TestGatheringRootDomain(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping network-dependent test in short mode.")
+	}
+
+	dnsConfig := &DNSQuery{
+		Servers:    []string{"8.8.8.8"},
+		Domains:    []string{"."},
+		RecordType: "MX",
+		Timeout:    config.Duration(2 * time.Second),
+	}
+	require.NoError(t, dnsConfig.Init())
+
+	var acc testutil.Accumulator
+	require.NoError(t, acc.GatherError(dnsConfig.Gather))
+
+	m, ok := acc.Get("dns_query")
+	require.True(t, ok)
+	queryTime, ok := m.Fields["query_time_ms"].(float64)
+	require.True(t, ok)
+
+	expected := []telegraf.Metric{
+		metric.New(
+			"dns_query",
+			map[string]string{
+				"server":      "8.8.8.8",
+				"domain":      ".",
+				"record_type": "MX",
+				"rcode":       "NOERROR",
+				"result":      "success",
+			},
+			map[string]interface{}{
+				"rcode_value":   0,
+				"result_code":   uint64(0),
+				"query_time_ms": queryTime,
+			},
+			time.Unix(0, 0),
+		),
+	}
+	testutil.RequireMetricsEqual(t, expected, acc.GetTelegrafMetrics(), testutil.IgnoreTime())
+}
+
+func TestMetricContainsServerAndDomainAndRecordTypeTags(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping network-dependent test in short mode.")
+	}
+
+	dnsConfig := &DNSQuery{
+		Servers: []string{"8.8.8.8"},
+		Domains: []string{"google.com"},
+		Timeout: config.Duration(2 * time.Second),
+	}
+	require.NoError(t, dnsConfig.Init())
+
+	var acc testutil.Accumulator
+	require.NoError(t, acc.GatherError(dnsConfig.Gather))
+
+	m, ok := acc.Get("dns_query")
+	require.True(t, ok)
+	queryTime, ok := m.Fields["query_time_ms"].(float64)
+	require.True(t, ok)
+	expected := []telegraf.Metric{
+		metric.New(
+			"dns_query",
+			map[string]string{
+				"server":      "8.8.8.8",
+				"domain":      "google.com",
+				"record_type": "NS",
+				"rcode":       "NOERROR",
+				"result":      "success",
+			},
+			map[string]interface{}{
+				"rcode_value":   0,
+				"result_code":   uint64(0),
+				"query_time_ms": queryTime,
+			},
+			time.Unix(0, 0),
+		),
+	}
+	testutil.RequireMetricsEqual(t, expected, acc.GetTelegrafMetrics(), testutil.IgnoreTime())
+}
+
+func TestGatheringTimeout(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping network-dependent test in short mode.")
+	}
+
+	dnsConfig := &DNSQuery{
+		Servers: []string{"8.8.8.8"},
+		Domains: []string{"google.com"},
+		Timeout: config.Duration(1 * time.Second),
+		Port:    60054,
+	}
+	require.NoError(t, dnsConfig.Init())
+
+	var acc testutil.Accumulator
+	channel := make(chan error, 1)
+	go func() {
+		channel <- acc.GatherError(dnsConfig.Gather)
+	}()
+	select {
+	case err := <-channel:
+		require.NoError(t, err)
+	case <-time.After(time.Second * 2):
+		require.Fail(t, "DNS query did not timeout")
+	}
 }


### PR DESCRIPTION
## Summary

This PR cleans the code a bit in preparation of fixing #19657. Furthermore, the PR moves `record_type` evaluation to `Init()` making the config checkable and allow Telegraf to error out on invalid values instead of producing an unrecoverable error in each gather cycle.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

resolves #19657 
