### PR TITLE
fix(inputs.dns_query): Use correct defaults

### DIFF
--- a/plugins/inputs/dns_query/README.md
+++ b/plugins/inputs/dns_query/README.md
@@ -31,7 +31,7 @@ plugin ordering. See [CONFIGURATION.md][CONFIGURATION.md] for more details.
 
   ## Query record type.
   ## Possible values: A, AAAA, CNAME, MX, NS, PTR, TXT, SOA, SPF, SRV.
-  # record_type = "A"
+  # record_type = "NS"
 
   ## Dns server port.
   # port = 53

--- a/plugins/inputs/dns_query/dns_query.go
+++ b/plugins/inputs/dns_query/dns_query.go
@@ -68,13 +68,8 @@ func (d *DNSQuery) Init() error {
 		d.Network = "udp"
 	}
 
-	if d.RecordType == "" {
-		d.RecordType = "NS"
-	}
-
 	if len(d.Domains) == 0 {
 		d.Domains = []string{"."}
-		d.RecordType = "NS"
 	}
 
 	if d.Port < 1 {
@@ -83,6 +78,8 @@ func (d *DNSQuery) Init() error {
 
 	// Convert the record type
 	switch d.RecordType {
+	case "":
+		d.RecordType = "NS"
 	case "A":
 		d.record = dns.TypeA
 	case "AAAA":

--- a/plugins/inputs/dns_query/dns_query.go
+++ b/plugins/inputs/dns_query/dns_query.go
@@ -80,6 +80,7 @@ func (d *DNSQuery) Init() error {
 	switch d.RecordType {
 	case "":
 		d.RecordType = "NS"
+		d.record = dns.TypeNS
 	case "A":
 		d.record = dns.TypeA
 	case "AAAA":

--- a/plugins/inputs/dns_query/dns_query_test.go
+++ b/plugins/inputs/dns_query/dns_query_test.go
@@ -20,6 +20,28 @@ func TestInit(t *testing.T) {
 		expected *DNSQuery
 	}{
 		{
+			name:   "empty",
+			plugin: &DNSQuery{},
+			expected: &DNSQuery{
+				Network:    "udp",
+				RecordType: "NS",
+				Domains:    []string{"."},
+				Port:       53,
+			},
+		},
+		{
+			name: "record type",
+			plugin: &DNSQuery{
+				RecordType: "A",
+			},
+			expected: &DNSQuery{
+				Network:    "udp",
+				RecordType: "A",
+				Domains:    []string{"."},
+				Port:       53,
+			},
+		},
+		{
 			name: "domain",
 			plugin: &DNSQuery{
 				Domains: []string{"google.com"},
@@ -27,6 +49,19 @@ func TestInit(t *testing.T) {
 			expected: &DNSQuery{
 				Network:    "udp",
 				RecordType: "NS",
+				Domains:    []string{"google.com"},
+				Port:       53,
+			},
+		},
+		{
+			name: "record type and domain",
+			plugin: &DNSQuery{
+				RecordType: "A",
+				Domains:    []string{"google.com"},
+			},
+			expected: &DNSQuery{
+				Network:    "udp",
+				RecordType: "A",
 				Domains:    []string{"google.com"},
 				Port:       53,
 			},
@@ -122,7 +157,6 @@ func TestRecordTypeParser(t *testing.T) {
 func TestRecordTypeParserError(t *testing.T) {
 	plugin := &DNSQuery{
 		Timeout:    config.Duration(2 * time.Second),
-		Domains:    []string{"example.com"},
 		RecordType: "nil",
 	}
 	require.ErrorContains(t, plugin.Init(), "record type \"nil\" not recognized")

--- a/plugins/inputs/dns_query/dns_query_test.go
+++ b/plugins/inputs/dns_query/dns_query_test.go
@@ -96,6 +96,10 @@ func TestRecordTypeParser(t *testing.T) {
 		expected uint16
 	}{
 		{
+			record:   "",
+			expected: dns.TypeNS,
+		},
+		{
 			record:   "A",
 			expected: dns.TypeA,
 		},

--- a/plugins/inputs/dns_query/sample.conf
+++ b/plugins/inputs/dns_query/sample.conf
@@ -11,7 +11,7 @@
 
   ## Query record type.
   ## Possible values: A, AAAA, CNAME, MX, NS, PTR, TXT, SOA, SPF, SRV.
-  # record_type = "A"
+  # record_type = "NS"
 
   ## Dns server port.
   # port = 53


### PR DESCRIPTION
## Summary

This PR fixes the record-type in `sample.conf` to match the code. Furthermore, the PR avoids overriding the record-type if we did not specify a domain effectively stop ignoring the record-type in such cases.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

resolves #19657 
