### PR TITLE
test(outputs.influxdb): Compare gzip bytes written against the received size

### DIFF
--- a/plugins/outputs/influxdb/influxdb_test.go
+++ b/plugins/outputs/influxdb/influxdb_test.go
@@ -2,9 +2,11 @@ package influxdb_test
 
 import (
 	"context"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -313,9 +315,16 @@ func TestBytesWrittenHTTP(t *testing.T) {
 }
 
 func TestBytesWrittenHTTPGzip(t *testing.T) {
-	// Setup a test server
+	// Setup a test server counting the bytes received on the wire
+	var received atomic.Int64
 	ts := httptest.NewServer(
-		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			n, err := io.Copy(io.Discard, r.Body)
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			received.Add(n)
 			w.WriteHeader(http.StatusNoContent)
 		}),
 	)
@@ -364,7 +373,10 @@ func TestBytesWrittenHTTPGzip(t *testing.T) {
 	}
 	require.NoError(t, plugin.Write(input))
 
-	require.Equal(t, int64(53), stat.Get())
+	// The compressed size depends on the compression library so compare
+	// against what the server actually received instead of a fixed value
+	require.Positive(t, received.Load())
+	require.Equal(t, received.Load(), stat.Get())
 }
 
 func TestBytesWrittenUDP(t *testing.T) {


### PR DESCRIPTION
## Summary

The gzip byte-count test asserts the exact compressed size of the written payload, which pins the output of the Go compression library and breaks on toolchain updates touching it, as it did on the 1.27 bump (#19549). The counter's contract is the number of bytes on the wire, so the test server now counts what it receives and the test compares the counter against that. This still catches counting bugs such as reporting the uncompressed size but no longer depends on the compressor's output.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

related to #19549
