### PR TITLE
chore(build): Only produce symbols for non-distribution packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ tag := $(shell git describe --exact-match --tags 2>/dev/null)
 branch := $(shell git rev-parse --abbrev-ref HEAD)
 commit := $(shell git rev-parse --short=8 HEAD)
 
-RELEASE := false
+RELEASE ?= false
 ifdef NIGHTLY
 	version := $(next_version)
 	rpm_version := nightly
@@ -352,7 +352,7 @@ $(include_packages):
 
 	@mkdir -p $(pkgdir)
 
-	@if [ "$(RELEASE)" = "true" ]; then \
+	@if [ "$(RELEASE)" = "true" ] && [ -n "$(filter %.tar.gz %.zip,$@)" ]; then \
 	    echo "Updating security info for $(version)_$(basename $(basename $@))..." && \
 		$(HOSTGO) install golang.org/x/vuln/cmd/govulncheck@v1.7.0 && \
 		$(MAKE) build && \


### PR DESCRIPTION
## Summary

This PR limits the `govulncheck` symbol extraction to non-distribution binaries as those binaries are equivalent to the ones in the tar and zip packages. The PR furthermore allows to mock a release for testing by setting the `RELEASE` environment variable to `true`.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
