### PR TITLE
chore(filter): Cleanup code

### DIFF
--- a/filter/filter.go
+++ b/filter/filter.go
@@ -31,12 +31,11 @@ type Filter interface {
 //
 // Compile will return nil if the filter list is empty.
 func Compile(filters []string, separators ...rune) (Filter, error) {
-	// return if there is nothing to compile
 	if len(filters) == 0 {
 		return nil, nil
 	}
 
-	// check if we can compile a non-glob filter
+	// Check if we can compile a non-glob filter
 	wildcards := len(separators) != 0
 	wildcards = wildcards || slices.ContainsFunc(filters, func(filter string) bool {
 		return strings.ContainsAny(filter, WildcardCharacters)
@@ -50,6 +49,8 @@ func Compile(filters []string, separators ...rune) (Filter, error) {
 	case wildcards && len(filters) == 1:
 		return glob.Compile(filters[0], separators...)
 	default:
+		// Implement this manually as it is significatly faster than using
+		// gobwas/glob's pattern list
 		return newFilterGlobMultiple(filters, separators...)
 	}
 }

--- a/filter/filter_test.go
+++ b/filter/filter_test.go
@@ -121,7 +121,7 @@ func BenchmarkFilterSingleNoGlobFalse(b *testing.B) {
 	f, err := Compile([]string{"cpu"})
 	require.NoError(b, err)
 	var tmp bool
-	for n := 0; n < b.N; n++ {
+	for b.Loop() {
 		tmp = f.Match("network")
 	}
 	benchbool = tmp
@@ -131,7 +131,7 @@ func BenchmarkFilterSingleNoGlobTrue(b *testing.B) {
 	f, err := Compile([]string{"cpu"})
 	require.NoError(b, err)
 	var tmp bool
-	for n := 0; n < b.N; n++ {
+	for b.Loop() {
 		tmp = f.Match("cpu")
 	}
 	benchbool = tmp
@@ -141,7 +141,7 @@ func BenchmarkFilter(b *testing.B) {
 	f, err := Compile([]string{"cpu", "mem", "net*"})
 	require.NoError(b, err)
 	var tmp bool
-	for n := 0; n < b.N; n++ {
+	for b.Loop() {
 		tmp = f.Match("network")
 	}
 	benchbool = tmp
@@ -151,29 +151,33 @@ func BenchmarkFilterNoGlob(b *testing.B) {
 	f, err := Compile([]string{"cpu", "mem", "net"})
 	require.NoError(b, err)
 	var tmp bool
-	for n := 0; n < b.N; n++ {
+	for b.Loop() {
 		tmp = f.Match("net")
 	}
 	benchbool = tmp
 }
 
-func BenchmarkFilter2(b *testing.B) {
-	f, err := Compile([]string{"aa", "bb", "c", "ad", "ar", "at", "aq",
-		"aw", "az", "axxx", "ab", "cpu", "mem", "net*"})
+func BenchmarkFilterMany(b *testing.B) {
+	f, err := Compile([]string{
+		"aa", "bb", "c", "ad", "ar", "at", "aq",
+		"aw", "az", "axxx", "ab", "cpu", "mem", "net*",
+	})
 	require.NoError(b, err)
 	var tmp bool
-	for n := 0; n < b.N; n++ {
+	for b.Loop() {
 		tmp = f.Match("network")
 	}
 	benchbool = tmp
 }
 
-func BenchmarkFilter2NoGlob(b *testing.B) {
-	f, err := Compile([]string{"aa", "bb", "c", "ad", "ar", "at", "aq",
-		"aw", "az", "axxx", "ab", "cpu", "mem", "net"})
+func BenchmarkFilterManyNoGlob(b *testing.B) {
+	f, err := Compile([]string{
+		"aa", "bb", "c", "ad", "ar", "at", "aq",
+		"aw", "az", "axxx", "ab", "cpu", "mem", "net",
+	})
 	require.NoError(b, err)
 	var tmp bool
-	for n := 0; n < b.N; n++ {
+	for b.Loop() {
 		tmp = f.Match("net")
 	}
 	benchbool = tmp


### PR DESCRIPTION
## Summary

This is a small cleanup fallout from (failed) experimenting with returning to use `gobwas/glob`'s pattern list instead of manually implementing the list logic.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues
