### PR TITLE
test(outputs.amqp): Assert the connect error when the broker is unavailable

### DIFF
--- a/plugins/outputs/amqp/amqp_test.go
+++ b/plugins/outputs/amqp/amqp_test.go
@@ -183,5 +183,5 @@ func TestWriteReturnsErrorWhenBrokerUnavailable(t *testing.T) {
 	// nil) and gets back a plain error that is not amqp.ErrClosed. Write must
 	// surface that error so the framework keeps the metrics buffered for
 	// retry instead of silently dropping them.
-	require.Error(t, q.Write(testutil.MockMetrics()))
+	require.ErrorContains(t, q.Write(testutil.MockMetrics()), "could not connect to any broker")
 }


### PR DESCRIPTION
## Summary

The broker-unavailable test added in #19464 ends in a bare error assertion, so it also passes if Write fails for an unrelated reason such as a serializer error. Asserting the connect error message makes the test prove that the connect failure is the one surfaced to the framework, which is what the fix was about.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

related to #19464
