### PR TITLE
chore(inputs.win_eventlog): Inline the startup error retry check

### DIFF
--- a/plugins/inputs/win_eventlog/win_eventlog.go
+++ b/plugins/inputs/win_eventlog/win_eventlog.go
@@ -106,20 +106,15 @@ func (w *WinEventLog) Init() error {
 func (w *WinEventLog) Start(telegraf.Accumulator) error {
 	subscription, err := w.evtSubscribe()
 	if err != nil {
-		startupErr := fmt.Errorf("subscription of Windows Event Log failed: %w", err)
 		return &internal.StartupError{
-			Err:   startupErr,
-			Retry: isRetriableSubscriptionError(err),
+			Err:   fmt.Errorf("subscription of Windows Event Log failed: %w", err),
+			Retry: errors.Is(err, windows.ERROR_EVT_CHANNEL_NOT_FOUND),
 		}
 	}
 	w.subscription = subscription
 	w.Log.Debug("Subscription handle id:", w.subscription)
 
 	return nil
-}
-
-func isRetriableSubscriptionError(err error) bool {
-	return errors.Is(err, windows.ERROR_EVT_CHANNEL_NOT_FOUND)
 }
 
 func (w *WinEventLog) GetState() interface{} {


### PR DESCRIPTION
## Summary

The retry classification of the subscription startup error lives in a one-line helper with a single caller, plus a temporary for the wrapped error. Every other plugin classifying a startup error inlines the predicate in the `StartupError` literal, for example the Kafka consumer and the Docker input, so this does the same and drops the helper. No behavior change.

## Checklist

- [x] No AI generated code was used in this PR
- [ ] AI generated code used in this PR follows the [InfluxData Policy on AI-Generated Code Contributions][policy]

[policy]: https://www.influxdata.com/ai-generated-code-contributions-policy

## Related issues

related to #19321
